### PR TITLE
Fix/nan income sources if income is empty

### DIFF
--- a/src/pages/holdings/components/income-dashboard.tsx
+++ b/src/pages/holdings/components/income-dashboard.tsx
@@ -35,8 +35,8 @@ export function IncomeDashboard() {
   const totalIncome = incomeSummary.total_income;
   const dividendIncome = incomeSummary.by_type['DIVIDEND'] || 0;
   const interestIncome = incomeSummary.by_type['INTEREST'] || 0;
-  const dividendPercentage = (dividendIncome / totalIncome) * 100;
-  const interestPercentage = (interestIncome / totalIncome) * 100;
+  const dividendPercentage = (dividendIncome / totalIncome) * 100 | 0;
+  const interestPercentage = (interestIncome / totalIncome) * 100 | 0;
 
   // Filter out interest and only keep dividend income for top stocks
   const topDividendStocks = Object.entries(incomeSummary.by_symbol)

--- a/src/pages/holdings/components/income-dashboard.tsx
+++ b/src/pages/holdings/components/income-dashboard.tsx
@@ -35,8 +35,8 @@ export function IncomeDashboard() {
   const totalIncome = incomeSummary.total_income;
   const dividendIncome = incomeSummary.by_type['DIVIDEND'] || 0;
   const interestIncome = incomeSummary.by_type['INTEREST'] || 0;
-  const dividendPercentage = (dividendIncome / totalIncome) * 100 | 0;
-  const interestPercentage = (interestIncome / totalIncome) * 100 | 0;
+  const dividendPercentage = (dividendIncome / totalIncome) * 100 || 0;
+  const interestPercentage = (interestIncome / totalIncome) * 100 || 0;
 
   // Filter out interest and only keep dividend income for top stocks
   const topDividendStocks = Object.entries(incomeSummary.by_symbol)


### PR DESCRIPTION
When totalIncome is 0, then the percentages show up as NaN. This sets the percentages to 0 if they could not be calculated.

before
<img width="409" alt="image" src="https://github.com/user-attachments/assets/c96d76f7-add5-4a43-a279-e1baaf74efe0">

after
<img width="409" alt="image" src="https://github.com/user-attachments/assets/610f2be1-cc11-4fd7-aadf-619cbf5b39cc">


Could alternatively do something like this, I see this happens in other places in the code base.
<img width="488" alt="image" src="https://github.com/user-attachments/assets/c37d5874-e52a-41bd-84cf-8bbb8e57ee84">
