### PR TITLE
First step to support dynamic platform commands

### DIFF
--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -2,13 +2,20 @@ import { invoke } from '@tauri-apps/api';
 import * as z from 'zod';
 import { Account } from '@/lib/types';
 import { newAccountSchema } from '@/lib/schemas';
+import { invokeTauri, isDesktop } from '@/commands/utils';
 
 type NewAccount = z.infer<typeof newAccountSchema>;
 
 export const getAccounts = async (): Promise<Account[]> => {
   try {
-    const accounts = await invoke('get_accounts');
-    return accounts as Account[];
+    if (isDesktop()) {
+      const accounts = await invokeTauri('get_accounts');
+      return accounts as Account[];
+    } else {
+      // TODO: Implement more platform-specific logic here
+      // e.g. web standalone with localForage
+      throw new Error('Not implemented');
+    }
   } catch (error) {
     console.error('Error fetching accounts:', error);
     throw error;

--- a/src/commands/utils.ts
+++ b/src/commands/utils.ts
@@ -1,0 +1,8 @@
+export const isDesktop = () => {
+    return !!window.__TAURI__;
+}
+
+export const invokeTauri = async (command: string, payload?: Record<string, unknown>) => {
+    const invoke = await import('@tauri-apps/api').then((mod) => mod.invoke);
+    return await invoke(command, payload);
+}


### PR DESCRIPTION
# Summary
- Extend `src/commands` to support multiple platforms
- e.g.
  - in desktop mode, call Tauri
  - in web standalone, use localForage in web browser like IndexedDB