### PR TITLE
Refactor code to improve simplicity and efficiency

### DIFF
--- a/src-tauri/src/account/account_commands.rs
+++ b/src-tauri/src/account/account_commands.rs
@@ -19,7 +19,7 @@ pub fn create_account(account: NewAccount, state: State<AppState>) -> Result<Acc
     let mut conn = state.conn.lock().unwrap();
     let service = account_service::AccountService::new();
     service
-        .create_account(&mut *conn, account)
+        .create_account(&mut conn, account)
         .map_err(|e| format!("Failed to add new account: {}", e))
 }
 
@@ -29,7 +29,7 @@ pub fn update_account(account: AccountUpdate, state: State<AppState>) -> Result<
     let mut conn = state.conn.lock().unwrap();
     let service = account_service::AccountService::new();
     service
-        .update_account(&mut *conn, account)
+        .update_account(&mut conn, account)
         .map_err(|e| format!("Failed to update account: {}", e))
 }
 
@@ -39,6 +39,6 @@ pub fn delete_account(account_id: String, state: State<AppState>) -> Result<usiz
     let mut conn = state.conn.lock().unwrap();
     let service = account_service::AccountService::new();
     service
-        .delete_account(&mut *conn, account_id)
+        .delete_account(&mut conn, account_id)
         .map_err(|e| format!("Failed to delete account: {}", e))
 }

--- a/src-tauri/src/activity/activity_commands.rs
+++ b/src-tauri/src/activity/activity_commands.rs
@@ -40,7 +40,7 @@ pub fn create_activity(activity: NewActivity, state: State<AppState>) -> Result<
     let result = tauri::async_runtime::block_on(async {
         let mut conn = state.conn.lock().unwrap();
         let service = activity_service::ActivityService::new();
-        service.create_activity(&mut *conn, activity).await
+        service.create_activity(&mut conn, activity).await
     });
 
     result.map_err(|e| format!("Failed to add new activity: {}", e))
@@ -61,7 +61,7 @@ pub fn check_activities_import(
         let mut conn = state.conn.lock().unwrap();
         let service = activity_service::ActivityService::new();
         service
-            .check_activities_import(&mut *conn, account_id, file_path)
+            .check_activities_import(&mut conn, account_id, file_path)
             .await
     });
 
@@ -78,7 +78,7 @@ pub fn create_activities(
     let mut conn = state.conn.lock().unwrap();
     let service = activity_service::ActivityService::new();
     service
-        .create_activities(&mut *conn, activities)
+        .create_activities(&mut conn, activities)
         .map_err(|err| format!("Failed to import activities: {}", err))
         .map(|count| count) // You can directly return the count here
 }
@@ -92,7 +92,7 @@ pub fn update_activity(
     let mut conn = state.conn.lock().unwrap();
     let service = activity_service::ActivityService::new();
     service
-        .update_activity(&mut *conn, activity)
+        .update_activity(&mut conn, activity)
         .map_err(|e| format!("Failed to update activity: {}", e))
 }
 
@@ -103,6 +103,6 @@ pub fn delete_activity(activity_id: String, state: State<AppState>) -> Result<us
     let mut conn = state.conn.lock().unwrap();
     let service = activity_service::ActivityService::new();
     service
-        .delete_activity(&mut *conn, activity_id)
+        .delete_activity(&mut conn, activity_id)
         .map_err(|e| format!("Failed to delete activity: {}", e))
 }

--- a/src-tauri/src/asset/asset_service.rs
+++ b/src-tauri/src/asset/asset_service.rs
@@ -54,7 +54,6 @@ impl AssetService {
         assets::table
             .find(asset_id)
             .first::<Asset>(conn)
-            .map_err(|e| e.into())
     }
 
     pub fn get_asset_data(
@@ -256,7 +255,6 @@ impl AssetService {
                     .values(&fetched_profile)
                     .returning(Asset::as_returning())
                     .get_result(conn)
-                    .map_err(|e| e.into())
             }
             Err(e) => Err(e),
         }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -69,5 +69,5 @@ fn get_db_path() -> String {
     let database_url = database_path
         .to_str()
         .expect("Failed to convert path to string");
-    return database_url.to_string();
+    database_url.to_string()
 }

--- a/src-tauri/src/goal/goal_commands.rs
+++ b/src-tauri/src/goal/goal_commands.rs
@@ -19,7 +19,7 @@ pub fn create_goal(goal: NewGoal, state: State<AppState>) -> Result<Goal, String
     let mut conn = state.conn.lock().unwrap();
     let service = goal_service::GoalService::new();
     service
-        .create_goal(&mut *conn, goal)
+        .create_goal(&mut conn, goal)
         .map_err(|e| format!("Failed to add new goal: {}", e))
 }
 
@@ -29,7 +29,7 @@ pub fn update_goal(goal: Goal, state: State<AppState>) -> Result<Goal, String> {
     let mut conn = state.conn.lock().unwrap();
     let service = goal_service::GoalService::new();
     service
-        .update_goal(&mut *conn, goal)
+        .update_goal(&mut conn, goal)
         .map_err(|e| format!("Failed to update goal: {}", e))
 }
 
@@ -39,7 +39,7 @@ pub fn delete_goal(goal_id: String, state: State<AppState>) -> Result<usize, Str
     let mut conn = state.conn.lock().unwrap();
     let service = goal_service::GoalService::new();
     service
-        .delete_goal(&mut *conn, goal_id)
+        .delete_goal(&mut conn, goal_id)
         .map_err(|e| format!("Failed to delete goal: {}", e))
 }
 
@@ -52,7 +52,7 @@ pub fn update_goal_allocations(
     let mut conn = state.conn.lock().unwrap();
     let service = goal_service::GoalService::new();
     service
-        .upsert_goal_allocations(&mut *conn, allocations)
+        .upsert_goal_allocations(&mut conn, allocations)
         .map_err(|e| e.to_string())
 }
 
@@ -62,6 +62,6 @@ pub fn load_goals_allocations(state: State<AppState>) -> Result<Vec<GoalsAllocat
     let mut conn = state.conn.lock().unwrap();
     let service = goal_service::GoalService::new();
     service
-        .load_goals_allocations(&mut *conn)
+        .load_goals_allocations(&mut conn)
         .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -107,18 +107,18 @@ fn main() {
         let asset_service = asset_service::AssetService::new();
         // Synchronize history quotes
         app_handle
-            .emit_all("QUOTES_SYNC_START", {})
+            .emit_all("QUOTES_SYNC_START", ())
             .expect("Failed to emit event");
         match asset_service.initialize_and_sync_quotes().await {
             Ok(_) => {
                 app_handle
-                    .emit_all("QUOTES_SYNC_COMPLETE", {})
+                    .emit_all("QUOTES_SYNC_COMPLETE", ())
                     .expect("Failed to emit event");
             }
             Err(e) => {
                 eprintln!("Failed to sync history quotes: {}", e);
                 app_handle
-                    .emit_all("QUOTES_SYNC_ERROR", {})
+                    .emit_all("QUOTES_SYNC_ERROR", ())
                     .expect("Failed to emit event");
             }
         }

--- a/src-tauri/src/models.rs
+++ b/src-tauri/src/models.rs
@@ -76,6 +76,7 @@ pub struct AccountUpdate {
     Deserialize,
     Clone,
     Debug,
+    Default,
 )]
 #[diesel(table_name = crate::schema::assets)]
 #[serde(rename_all = "camelCase")]

--- a/src-tauri/src/portfolio/portfolio_service.rs
+++ b/src-tauri/src/portfolio/portfolio_service.rs
@@ -47,7 +47,7 @@ impl PortfolioService {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let settings_service = SettingsService::new();
         let settings = settings_service.get_settings(conn)?;
-        self.base_currency = settings.base_currency.clone();
+        self.base_currency.clone_from(&settings.base_currency);
         self.exchange_rates = self
             .asset_service
             .load_exchange_rates(conn, &settings.base_currency)?;

--- a/src-tauri/src/providers/yahoo_provider.rs
+++ b/src-tauri/src/providers/yahoo_provider.rs
@@ -1,6 +1,6 @@
 use std::{sync::RwLock, time::SystemTime};
 
-use crate::models::{Asset, CrumbData, NewAsset, QuoteSummary};
+use crate::models::{CrumbData, NewAsset, QuoteSummary};
 use lazy_static::lazy_static;
 use reqwest::{header, Client};
 use serde_json::json;
@@ -40,32 +40,6 @@ impl From<&YQuoteItem> for NewAsset {
             symbol: item.symbol.clone(),
             data_source: "YAHOO".to_string(),
             ..Default::default() // Use default for the rest
-        }
-    }
-}
-
-impl Default for Asset {
-    fn default() -> Self {
-        Asset {
-            id: Default::default(),
-            isin: Default::default(),
-            name: Default::default(),
-            asset_type: Default::default(),
-            symbol: Default::default(),
-            symbol_mapping: Default::default(),
-            asset_class: Default::default(),
-            asset_sub_class: Default::default(),
-            comment: Default::default(),
-            countries: Default::default(),
-            categories: Default::default(),
-            classes: Default::default(),
-            attributes: Default::default(),
-            created_at: Default::default(),
-            currency: Default::default(),
-            data_source: Default::default(),
-            updated_at: Default::default(),
-            sectors: Default::default(),
-            url: Default::default(),
         }
     }
 }

--- a/src-tauri/src/providers/yahoo_provider.rs
+++ b/src-tauri/src/providers/yahoo_provider.rs
@@ -119,7 +119,7 @@ impl YahooProvider {
         let asset_profiles = result
             .quotes
             .iter()
-            .map(|ticker_info| QuoteSummary::from(ticker_info)) // No need to dereference or clone
+            .map(QuoteSummary::from) // No need to dereference or clone
             .collect();
 
         Ok(asset_profiles)


### PR DESCRIPTION
Key Changes:

1. Remove unnecessary dereferences
2. Refactor manual implementation of `std::default::Default`
3. Use unit type instead of empty block