### PR TITLE
Setup adapters for commands

### DIFF
--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -5,7 +5,7 @@ export enum RUN_ENV {
   UNSUPPORTED = 'unsupported',
 };
 
-export const getRunEnv = () => {
+export const getRunEnv = (): RUN_ENV => {
   if (typeof window !== 'undefined' && window.__TAURI__) {
     return RUN_ENV.DESKTOP;
   }

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,0 +1,30 @@
+export enum RUN_ENV {
+  DESKTOP = 'desktop',
+  BROWSER = 'browser',
+  UNSUPPORTED = 'unsupported',
+};
+
+export const getRunEnv = () => {
+  if (typeof window !== 'undefined' && window.__TAURI__) {
+    return RUN_ENV.DESKTOP;
+  }
+  if (typeof window !== 'undefined' && window.indexedDB) {
+    return RUN_ENV.BROWSER;
+  }
+  return RUN_ENV.UNSUPPORTED;
+}
+
+export type {
+  EventCallback,
+  UnlistenFn,
+} from './tauri';
+
+export {
+  invokeTauri,
+  openCsvFileDialogTauri,
+  listenFileDropHoverTauri,
+  listenFileDropTauri,
+  listenFileDropCancelledTauri,
+  listenQuotesSyncStartTauri,
+  listenQuotesSyncCompleteTauri,
+} from './tauri';

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,5 +1,6 @@
 export enum RUN_ENV {
   DESKTOP = 'desktop',
+  MOBILE = 'mobile',
   BROWSER = 'browser',
   UNSUPPORTED = 'unsupported',
 };

--- a/src/adapters/tauri.ts
+++ b/src/adapters/tauri.ts
@@ -1,0 +1,38 @@
+import type { EventCallback, UnlistenFn } from '@tauri-apps/api/event';
+
+export type { EventCallback, UnlistenFn };
+
+export const invokeTauri = async <T>(command: string, payload?: Record<string, unknown>) => {
+  const invoke = await import('@tauri-apps/api').then((mod) => mod.invoke);
+  return await invoke<T>(command, payload);
+}
+
+export const openCsvFileDialogTauri = async (): Promise<null | string | string[]> => {
+  const open = await import('@tauri-apps/api/dialog').then((mod) => mod.open);
+  return open({ filters: [{ name: 'CSV', extensions: ['csv'] }] });
+}
+
+export const listenFileDropHoverTauri = async <T>(handler: EventCallback<T>): Promise<UnlistenFn> => {
+  const { listen } = await import('@tauri-apps/api/event');
+  return listen<T>('tauri://file-drop-hover', handler);
+}
+
+export const listenFileDropTauri = async <T>(handler: EventCallback<T>): Promise<UnlistenFn> => {
+  const { listen } = await import('@tauri-apps/api/event');
+  return listen<T>('tauri://file-drop', handler);
+}
+
+export const listenFileDropCancelledTauri = async <T>(handler: EventCallback<T>): Promise<UnlistenFn> => {
+  const { listen } = await import('@tauri-apps/api/event');
+  return listen<T>('tauri://file-drop-cancelled', handler);
+}
+
+export const listenQuotesSyncStartTauri = async <T>(handler: EventCallback<T>): Promise<UnlistenFn> => {
+  const { listen } = await import('@tauri-apps/api/event');
+  return listen<T>('QUOTES_SYNC_START', handler);
+}
+
+export const listenQuotesSyncCompleteTauri = async <T>(handler: EventCallback<T>): Promise<UnlistenFn> => {
+  const { listen } = await import('@tauri-apps/api/event');
+  return listen<T>('QUOTES_SYNC_COMPLETE', handler);
+}

--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -1,14 +1,18 @@
-import { invoke } from '@tauri-apps/api';
-import * as z from 'zod';
+import z from 'zod';
 import { Account } from '@/lib/types';
 import { newAccountSchema } from '@/lib/schemas';
+import { getRunEnv, RUN_ENV, invokeTauri } from '@/adapters';
 
 type NewAccount = z.infer<typeof newAccountSchema>;
 
 export const getAccounts = async (): Promise<Account[]> => {
   try {
-    const accounts = await invoke('get_accounts');
-    return accounts as Account[];
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return invokeTauri('get_accounts');
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error fetching accounts:', error);
     throw error;
@@ -18,8 +22,12 @@ export const getAccounts = async (): Promise<Account[]> => {
 // createAccount
 export const createAccount = async (account: NewAccount): Promise<Account> => {
   try {
-    const createdAccount = await invoke('create_account', { account });
-    return createdAccount as Account;
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return invokeTauri('create_account', { account });
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error creating account:', error);
     throw error;
@@ -29,9 +37,13 @@ export const createAccount = async (account: NewAccount): Promise<Account> => {
 // updateAccount
 export const updateAccount = async (account: NewAccount): Promise<Account> => {
   try {
-    const { currency, ...updatedAccountData } = account;
-    const updatedAccount = await invoke('update_account', { account: updatedAccountData });
-    return updatedAccount as Account;
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        const { currency, ...updatedAccountData } = account;
+        return invokeTauri('update_account', { account: updatedAccountData });
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error updating account:', error);
     throw error;
@@ -41,7 +53,13 @@ export const updateAccount = async (account: NewAccount): Promise<Account> => {
 // deleteAccount
 export const deleteAccount = async (accountId: string): Promise<void> => {
   try {
-    await invoke('delete_account', { accountId });
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        await invokeTauri('delete_account', { accountId });
+        return;
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error deleting account:', error);
     throw error;

--- a/src/commands/activity.ts
+++ b/src/commands/activity.ts
@@ -1,7 +1,7 @@
-import { invoke } from '@tauri-apps/api';
-import * as z from 'zod';
+import z from 'zod';
 import { Activity, ActivityDetails, ActivityImport, ActivitySearchResponse } from '@/lib/types';
 import { newActivitySchema } from '@/lib/schemas';
+import { getRunEnv, RUN_ENV, invokeTauri } from '@/adapters';
 
 export type NewActivity = z.infer<typeof newActivitySchema>;
 
@@ -18,8 +18,12 @@ interface Sort {
 
 export const getActivities = async (): Promise<ActivityDetails[]> => {
   try {
-    const activities = await invoke('get_activities');
-    return activities as ActivityDetails[];
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return invokeTauri('get_activities');
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error fetching activities:', error);
     throw error;
@@ -34,15 +38,19 @@ export const searchActivities = async (
   sort: Sort,
 ): Promise<ActivitySearchResponse> => {
   try {
-    const result = await invoke('search_activities', {
-      page,
-      pageSize,
-      accountIdFilter: filters?.accountId,
-      activityTypeFilter: filters?.activityType,
-      assetIdKeyword: searchKeyword,
-      sort,
-    });
-    return result as ActivitySearchResponse;
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return invokeTauri('search_activities', {
+          page,
+          pageSize,
+          accountIdFilter: filters?.accountId,
+          activityTypeFilter: filters?.activityType,
+          assetIdKeyword: searchKeyword,
+          sort,
+        });
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error fetching activities:', error);
     throw error;
@@ -52,8 +60,12 @@ export const searchActivities = async (
 // createActivity
 export const createActivity = async (activity: NewActivity): Promise<Activity> => {
   try {
-    const newActivity = await invoke('create_activity', { activity });
-    return newActivity as Activity;
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return invokeTauri('create_activity', { activity });
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error creating activity:', error);
     throw error;
@@ -63,8 +75,12 @@ export const createActivity = async (activity: NewActivity): Promise<Activity> =
 // updateActivity
 export const updateActivity = async (activity: NewActivity): Promise<Activity> => {
   try {
-    const updatedActivity = await invoke('update_activity', { activity });
-    return updatedActivity as Activity;
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return invokeTauri('update_activity', { activity });
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error updating activity:', error);
     throw error;
@@ -74,7 +90,13 @@ export const updateActivity = async (activity: NewActivity): Promise<Activity> =
 // deleteActivity
 export const deleteActivity = async (activityId: string): Promise<void> => {
   try {
-    await invoke('delete_activity', { activityId });
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        await invokeTauri('delete_activity', { activityId });
+        return;
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error deleting activity:', error);
     throw error;
@@ -90,11 +112,15 @@ export const checkActivitiesImport = async ({
   file_path: string;
 }): Promise<ActivityImport[]> => {
   try {
-    const result: ActivityImport[] = await invoke('check_activities_import', {
-      accountId: account_id,
-      filePath: file_path,
-    });
-    return result;
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return invokeTauri('check_activities_import', {
+          accountId: account_id,
+          filePath: file_path,
+        });
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error checking activities import:', error);
     throw error;
@@ -104,8 +130,12 @@ export const checkActivitiesImport = async ({
 // importActivities
 export const createActivities = async (activities: NewActivity[]): Promise<Number> => {
   try {
-    const importResult: Number = await invoke('create_activities', { activities });
-    return importResult;
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return invokeTauri('create_activities', { activities });
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error importing activities:', error);
     throw error;

--- a/src/commands/file.ts
+++ b/src/commands/file.ts
@@ -1,9 +1,14 @@
-import { open } from '@tauri-apps/api/dialog';
+import { getRunEnv, openCsvFileDialogTauri, RUN_ENV } from '@/adapters';
 
-// openCsvFile
+// openCsvFileDialog
 export const openCsvFileDialog = async (): Promise<null | string | string[]> => {
   try {
-    return open({ filters: [{ name: 'CSV', extensions: ['csv'] }] });
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return openCsvFileDialogTauri();
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error open csv file', error);
     throw error;

--- a/src/commands/goal.ts
+++ b/src/commands/goal.ts
@@ -1,14 +1,18 @@
-import { invoke } from '@tauri-apps/api';
-import * as z from 'zod';
+import z from 'zod';
 import { Goal, GoalAllocation } from '@/lib/types';
 import { newGoalSchema } from '@/lib/schemas';
+import { getRunEnv, RUN_ENV, invokeTauri } from '@/adapters';
 
 type NewGoal = z.infer<typeof newGoalSchema>;
 
 export const getGoals = async (): Promise<Goal[]> => {
   try {
-    const goals = await invoke('get_goals');
-    return goals as Goal[];
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return invokeTauri('get_goals');
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error fetching goals:', error);
     throw error;
@@ -23,8 +27,12 @@ export const createGoal = async (goal: NewGoal): Promise<Goal> => {
     isAchieved: false,
   };
   try {
-    const createdGoal = await invoke('create_goal', { goal: newGoal });
-    return createdGoal as Goal;
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return invokeTauri('create_goal', { goal: newGoal });
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error creating goal:', error);
     throw error;
@@ -33,8 +41,12 @@ export const createGoal = async (goal: NewGoal): Promise<Goal> => {
 
 export const updateGoal = async (goal: Goal): Promise<Goal> => {
   try {
-    const updatedGoal = await invoke('update_goal', { goal });
-    return updatedGoal as Goal;
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return invokeTauri('update_goal', { goal });
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error updating goal:', error);
     throw error;
@@ -43,7 +55,13 @@ export const updateGoal = async (goal: Goal): Promise<Goal> => {
 
 export const deleteGoal = async (goalId: string): Promise<void> => {
   try {
-    await invoke('delete_goal', { goalId });
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        await invokeTauri('delete_goal', { goalId });
+        return;
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error deleting goal:', error);
     throw error;
@@ -52,7 +70,13 @@ export const deleteGoal = async (goalId: string): Promise<void> => {
 
 export const updateGoalsAllocations = async (allocations: GoalAllocation[]): Promise<void> => {
   try {
-    await invoke('update_goal_allocations', { allocations });
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        await invokeTauri('update_goal_allocations', { allocations });
+        return;
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error saving goals allocations:', error);
     throw error;
@@ -61,8 +85,12 @@ export const updateGoalsAllocations = async (allocations: GoalAllocation[]): Pro
 
 export const getGoalsAllocation = async (): Promise<GoalAllocation[]> => {
   try {
-    const allocations = await invoke('load_goals_allocations');
-    return allocations as GoalAllocation[];
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return invokeTauri('load_goals_allocations');
+      default:
+        throw new Error(`Unsupported`);
+    };
   } catch (error) {
     console.error('Error fetching goals allocations:', error);
     throw error;

--- a/src/commands/import-listener.ts
+++ b/src/commands/import-listener.ts
@@ -1,9 +1,15 @@
-import { listen, EventCallback, UnlistenFn } from '@tauri-apps/api/event';
+import type { EventCallback, UnlistenFn } from '@/adapters';
+import { getRunEnv, RUN_ENV, listenFileDropCancelledTauri, listenFileDropHoverTauri, listenFileDropTauri } from "@/adapters";
 
 // listenImportFileDropHover
 export const listenImportFileDropHover = async <T>(handler: EventCallback<T>): Promise<UnlistenFn> => {
   try {
-    return listen<T>('tauri://file-drop-hover', handler);
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return listenFileDropHoverTauri<T>(handler);
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error listen tauri://file-drop-hover:', error);
     throw error;
@@ -13,7 +19,12 @@ export const listenImportFileDropHover = async <T>(handler: EventCallback<T>): P
 // listenImportFileDrop
 export const listenImportFileDrop = async <T>(handler: EventCallback<T>): Promise<UnlistenFn> => {
   try {
-    return listen<T>('tauri://file-drop', handler);
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return listenFileDropTauri<T>(handler);
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error listen tauri://file-drop:', error);
     throw error;
@@ -23,7 +34,12 @@ export const listenImportFileDrop = async <T>(handler: EventCallback<T>): Promis
 // listenImportFileDropCancelled
 export const listenImportFileDropCancelled = async <T>(handler: EventCallback<T>): Promise<UnlistenFn> => {
   try {
-    return listen<T>('tauri://file-drop-cancelled', handler);
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return listenFileDropCancelledTauri<T>(handler);
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error listen tauri://file-drop-cancelled:', error);
     throw error;

--- a/src/commands/portfolio.ts
+++ b/src/commands/portfolio.ts
@@ -1,10 +1,14 @@
-import { invoke } from '@tauri-apps/api';
 import { FinancialHistory, Holding, IncomeSummary } from '@/lib/types';
+import { getRunEnv, RUN_ENV, invokeTauri } from '@/adapters';
 
 export const getHistorical = async (): Promise<FinancialHistory[]> => {
   try {
-    const result = await invoke('get_historical');
-    return result as FinancialHistory[];
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return invokeTauri('get_historical');
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error fetching accounts:', error);
     throw error;
@@ -13,8 +17,12 @@ export const getHistorical = async (): Promise<FinancialHistory[]> => {
 
 export const computeHoldings = async (): Promise<Holding[]> => {
   try {
-    const result = await invoke('compute_holdings');
-    return result as Holding[];
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return invokeTauri('compute_holdings');
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error computing holdings:', error);
     throw error;
@@ -23,8 +31,12 @@ export const computeHoldings = async (): Promise<Holding[]> => {
 
 export const getIncomeSummary = async (): Promise<IncomeSummary> => {
   try {
-    const result = await invoke('get_income_summary');
-    return result as IncomeSummary;
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return invokeTauri('get_income_summary');
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error fetching income summary:', error);
     throw error;

--- a/src/commands/quote-listener.ts
+++ b/src/commands/quote-listener.ts
@@ -1,9 +1,15 @@
-import { listen, EventCallback, UnlistenFn } from '@tauri-apps/api/event';
+import type { EventCallback, UnlistenFn } from '@/adapters';
+import { getRunEnv, RUN_ENV, listenQuotesSyncStartTauri, listenQuotesSyncCompleteTauri } from "@/adapters";
 
 // listenQuotesSyncStart
 export const listenQuotesSyncStart = async <T>(handler: EventCallback<T>): Promise<UnlistenFn> => {
   try {
-    return listen<T>('QUOTES_SYNC_START', handler);
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return listenQuotesSyncStartTauri<T>(handler);
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error listen QUOTES_SYNC_START:', error);
     throw error;
@@ -13,7 +19,12 @@ export const listenQuotesSyncStart = async <T>(handler: EventCallback<T>): Promi
 // listenQuotesSyncComplete
 export const listenQuotesSyncComplete = async <T>(handler: EventCallback<T>): Promise<UnlistenFn> => {
   try {
-    return listen<T>('QUOTES_SYNC_COMPLETE', handler);
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return listenQuotesSyncCompleteTauri<T>(handler);
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error listen QUOTES_SYNC_COMPLETE:', error);
     throw error;

--- a/src/commands/setting.ts
+++ b/src/commands/setting.ts
@@ -1,11 +1,15 @@
-import { invoke } from '@tauri-apps/api';
 import { Settings } from '@/lib/types';
+import { getRunEnv, RUN_ENV, invokeTauri } from '@/adapters';
 
 // getSettings
 export const getSettings = async (): Promise<Settings> => {
   try {
-    const settings = await invoke('get_settings');
-    return settings as Settings;
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return invokeTauri('get_settings');
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error fetching settings:', error);
     return {} as Settings;
@@ -15,8 +19,12 @@ export const getSettings = async (): Promise<Settings> => {
 // saveSettings
 export const saveSettings = async (settings: Settings): Promise<Settings> => {
   try {
-    const updatedSettings = await invoke('update_settings', { settings });
-    return updatedSettings as Settings;
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return invokeTauri('update_settings', { settings });
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error updating settings:', error);
     throw error;

--- a/src/commands/symbol.ts
+++ b/src/commands/symbol.ts
@@ -1,10 +1,14 @@
-import { invoke } from '@tauri-apps/api';
 import { AssetData, QuoteSummary } from '@/lib/types';
+import { getRunEnv, RUN_ENV, invokeTauri } from '@/adapters';
 
 export const searchTicker = async (query: string): Promise<QuoteSummary[]> => {
   try {
-    const searchResult = await invoke('search_ticker', { query });
-    return searchResult as QuoteSummary[];
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return invokeTauri('search_ticker', { query });
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error searching for ticker:', error);
     throw error;
@@ -13,7 +17,13 @@ export const searchTicker = async (query: string): Promise<QuoteSummary[]> => {
 
 export const syncHistoryQuotes = async (): Promise<void> => {
   try {
-    await invoke('synch_quotes');
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        await invokeTauri('synch_quotes');
+        return;
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error syncing history quotes:', error);
     throw error;
@@ -22,8 +32,12 @@ export const syncHistoryQuotes = async (): Promise<void> => {
 
 export const getAssetData = async (assetId: string): Promise<AssetData> => {
   try {
-    const result = await invoke('get_asset_data', { assetId });
-    return result as AssetData;
+    switch (getRunEnv()) {
+      case RUN_ENV.DESKTOP:
+        return invokeTauri('get_asset_data', { assetId });
+      default:
+        throw new Error(`Unsupported`);
+    }
   } catch (error) {
     console.error('Error loading asset data:', error);
     throw error;


### PR DESCRIPTION
# Summary
- Previously, in frontend code, we have centralized all tauri commands into a single dir at `src/commands`. Now we continue to improve this to centralize all tauri commands into a single file at `src/adapters/tauri.ts`
- We also introduce the `RUN_ENV` enum, and `getRunEnv` helper to determine the running env, e.g. desktop, browser, mobile
- This helps cleaning the code with these things
  - preparing for new running env
  - use generic type from `invoke` function instead of manual type casting