### PR TITLE
Fix average monthly income calculation

### DIFF
--- a/src-core/src/models.rs
+++ b/src-core/src/models.rs
@@ -1,6 +1,7 @@
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+
 #[derive(Queryable, Identifiable, AsChangeset, Serialize, Deserialize, Debug)]
 #[diesel(table_name= crate::schema::platforms)]
 #[serde(rename_all = "camelCase")]
@@ -476,6 +477,15 @@ pub struct GoalsAllocation {
 }
 
 #[derive(Debug, Serialize, QueryableByName)]
+#[diesel(table_name = crate::schema::activities)]
+#[diesel(check_for_backend(diesel::sqlite::Sqlite))]
+#[serde(rename_all = "camelCase")]
+pub struct MinDate {
+    pub activity_date: chrono::NaiveDateTime,
+}
+
+
+#[derive(Debug, Serialize, QueryableByName)]
 #[serde(rename_all = "camelCase")]
 #[diesel(table_name = crate::schema::activities)]
 pub struct IncomeData {
@@ -492,6 +502,7 @@ pub struct IncomeData {
     #[diesel(sql_type = diesel::sql_types::Double)]
     pub amount: f64,
 }
+
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src-core/src/models.rs
+++ b/src-core/src/models.rs
@@ -533,10 +533,10 @@ impl IncomeSummary {
         self.total_income += converted_amount;
     }
 
-    pub fn calculate_monthly_average(&mut self, num_months: Option<f64>) {
-        let months = num_months.unwrap_or_else(|| self.by_month.len() as f64);
-        if months > 0.0 {
-            self.monthly_average = self.total_income / months;
+    pub fn calculate_monthly_average(&mut self, num_months: Option<u32>) {
+        let months = num_months.unwrap_or_else(|| self.by_month.len() as u32);
+        if months > 0 {
+            self.monthly_average = self.total_income / (months as f64);
         }
     }
 }


### PR DESCRIPTION
The number of months for monthly average income calculation only takes into account the months where there is an actual income. So if there is a month with no income (for example last year), the 'monthly average' gets artificially bumped up.

This simplifies the calculation to use the actual number of months in the given year (current month number for the current year, 12 for previous years) rather than only the months where there was some income