### PR TITLE
Skip empty lines in CSV import

### DIFF
--- a/src/pages/activity/import/hooks/useCsvParser.ts
+++ b/src/pages/activity/import/hooks/useCsvParser.ts
@@ -31,6 +31,7 @@ export function useCsvParser() {
       setSelectedFile(file);
 
       Papa.parse<string[]>(file, {
+        skipEmptyLines: true,
         complete: (results) => {
           if (results.data && results.data.length > 0) {
             setCsvData(results.data);


### PR DESCRIPTION
Fixes https://github.com/afadil/wealthfolio/issues/162

The Papa parser seems to have trouble with a CSV that seems valid (like the one in attachment)
[wealthfolio-error.csv](https://github.com/user-attachments/files/17720065/wealthfolio-error.csv)


Adding` skipEmptyLines: true` to the options improves the situation, and is probably a safe default anyway.

