### PR TITLE
Make ticker symbol regexp more tolerant

### DIFF
--- a/src/pages/activity/import/utils/csvValidation.ts
+++ b/src/pages/activity/import/utils/csvValidation.ts
@@ -81,7 +81,7 @@ const CASH_ACTIVITY_TYPES = new Set([
 ]);
 
 // Add a simple regex for ticker validation
-const tickerRegex = /^(\$CASH-[A-Z]{3}|[A-Z0-9]{1,5}([.-][A-Z0-9]+)?)$/;
+const tickerRegex = /^(\$CASH-[A-Z]{3}|[A-Z0-9]{1,10}([\.-][A-Z0-9]+){0,2})$/;
 
 export const activityImportValidationSchema = z
   .object({


### PR DESCRIPTION
The new CSV import regexp for symbols is too restrictive.

Some symbols are incorrectly recognized as invalid, 2 examples:
- `RCI-B.TO` https://ca.finance.yahoo.com/quote/RCI-B.TO/ 
- `0P0000UF8O.TO` https://ca.finance.yahoo.com/quote/0P0000UF8O.TO/

I updated the regular expression to handle between 0 and 2 suffixes in `-` or `.`  to handle the first case
I increased the size of the base ticker from 5 to 10 characters to handle the second case

I'm a bit skeptical of the approach to add this regexp rather than lookup an actual symbol from the list of existing symbols (and offer to map unknown symbols maybe), but I'm keeping the change small for now