### PR TITLE
Update activity page layout to position import buttons on the right of the viewable window

### DIFF
--- a/src/pages/activity/activity-page.tsx
+++ b/src/pages/activity/activity-page.tsx
@@ -49,7 +49,7 @@ const ActivityPage = () => {
   return (
     <div className="flex flex-col p-6">
       <ApplicationHeader heading="Activity">
-        <div className="flex items-center space-x-2">
+        <div className="flex items-center space-x-2 absolute right-6">
           <Button size="sm" title="Import" asChild>
             <Link to={'/import'}>
               <Icons.Import className="mr-2 h-4 w-4" />


### PR DESCRIPTION
If the window is resized to fill up only half of the screen (which I frequently do when adding activities on a single machine), the buttons to add activities are not visible.