### PR TITLE
Issue fix: private asset portfolio history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ out
 # Testing
 coverage
 .nyc_output
+src-core/tests/output/
 
 # Environment files
 .env

--- a/src-core/Cargo.lock
+++ b/src-core/Cargo.lock
@@ -54,6 +54,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1690,6 +1712,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1951,6 +1997,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+ "tokio-test",
  "uuid",
  "yahoo_finance_api",
 ]

--- a/src-core/Cargo.toml
+++ b/src-core/Cargo.toml
@@ -30,3 +30,6 @@ async-trait = "0.1"
 bigdecimal = { version = "0.4", features = ["serde"] }
 num-traits = "0.2"
 log = "0.4"
+
+[dev-dependencies]
+tokio-test = "*"

--- a/src-core/tests/common/mod.rs
+++ b/src-core/tests/common/mod.rs
@@ -1,0 +1,20 @@
+use wealthfolio_core::errors::Result;
+use chrono::Local;
+use std::sync::Arc;
+use wealthfolio_core::db;
+use diesel::sqlite::SqliteConnection;
+use diesel::r2d2::{self, ConnectionManager};
+
+type DbPool = r2d2::Pool<ConnectionManager<SqliteConnection>>;
+
+pub fn get_db_connection_pool() -> Result<Arc<DbPool>> {
+	let now = Local::now();
+
+	let formatted_date_path = now.format("./tests/output/%Y%m%d/%H%M%S/").to_string();
+
+	let db_path = db::init(&formatted_date_path).expect("Failed to initialize database");
+
+    let pool = db::create_pool(&db_path).expect("Failed to create database pool");
+
+	Ok(pool)
+}

--- a/src-core/tests/portfolio_history_test.rs
+++ b/src-core/tests/portfolio_history_test.rs
@@ -1,0 +1,91 @@
+
+use wealthfolio_core::account::account_service::AccountService;
+use wealthfolio_core::models::NewAccount;
+use wealthfolio_core::activity::activity_service::ActivityService;
+use wealthfolio_core::models::NewActivity;
+use wealthfolio_core::market_data::market_data_service::MarketDataService;
+use wealthfolio_core::models::QuoteUpdate;
+use wealthfolio_core::portfolio::portfolio_service::PortfolioService;
+mod common;
+
+#[test]
+fn test_historical_private_asset_portfolio_value(){
+	
+	// Get a connection to the DB
+	let pool = common::get_db_connection_pool().unwrap();
+	let mut conn = pool.get().unwrap();
+
+	// Set a base currency
+	let base_currency = "CAD";
+	let account_service = AccountService::new(base_currency.to_string());
+
+	// Create a new account
+	let account =  NewAccount {
+		id: Some("RealEstate".to_string()),
+		name: "Real Estate".to_string(),
+		account_type: "CASH".to_string(),
+		group: None,
+		currency: base_currency.to_string(),
+		is_default: false,
+		is_active: true,
+		platform_id: None,
+	};
+	
+	let account = tokio_test::block_on(account_service.
+		create_account(&mut conn, account)).unwrap();
+
+	// Create a new activity for a new private asset with a value of $900K
+	let activity_service = ActivityService::new(base_currency.to_string());
+
+	let activity =  NewActivity {
+		id: None,
+		account_id: account.id.clone(),
+		asset_id: "Condo".to_string(),
+		activity_type: "BUY".to_string(),
+		activity_date: chrono::DateTime::parse_from_rfc3339("2024-02-01T00:00:00Z").unwrap().to_string(),
+		quantity: 1.0,
+		unit_price: 900000.0,
+		currency: base_currency.to_string(),
+		fee: 0.0,
+		is_draft: false,
+		comment: Some("New condo purchase".to_string()),
+	};
+
+	tokio_test::block_on(activity_service
+		.create_activity(&mut conn, activity)).unwrap();
+
+	// Add a manual quote for the private asset, valuing it a month after purchase at $1M
+	let market_data_service = MarketDataService::new();
+
+	let quote_update = QuoteUpdate {
+		date: "2024-03-01".to_string(),
+		symbol: "Condo".to_string(),
+		open: 1000000.0,
+		high: 1000000.0,
+		low: 1000000.0,
+		volume: 1.0,
+		close: 1000000.0,
+		data_source: "MANUAL".to_string(),
+	};
+
+	tokio_test::block_on(market_data_service).update_quote(&mut conn, quote_update).unwrap();
+
+	// Calculate the historical portfolio value
+	let portfolio_service = tokio_test::block_on( PortfolioService::new(base_currency.to_string())).unwrap();
+	let account_ids = vec![account.id.clone()];
+	tokio_test::block_on(portfolio_service
+		.calculate_historical_data(&mut conn, Some(account_ids), false)).unwrap();
+	
+	// Get the portfolio history
+	let account_history = portfolio_service
+		.get_portfolio_history(&mut conn, Some(&account.id.clone()))
+		.unwrap();
+	
+	// Get the portfolio value on the day four months after the purchase
+	let portfolio_value_on_day = account_history
+		.iter()
+		.find(|x| x.date == "2024-06-01").unwrap();
+
+	// Check that the portfolio value is $1M
+	assert_eq!(portfolio_value_on_day.market_value, 1000000.0);
+}


### PR DESCRIPTION
Issue: After a creating a private asset and adding a quote, the portfolio history value can be incorrect. This is caused by the history value calculation which assumes there is a quote at least every 30 days. Private assets often won't have quotes at least every 30 days.

Steps to recreate

* Create a cash account
* Add a buy activity on that account for a private (manual) asset with the activity date set to one year ago. As an example, set the asset value to $900K
* Add a quote for 11 months ago with a value greater than the orginal value (ex. $1000K).
* Recalculate the portfolio history
EXPECTED: The portfolio value for the account will be $1000K and the total gain will be $100K for every day subsequent to the added quote.
ACTUAL: The portfolio value shows value of 0 for the from one year ago to 11 months ago, then the expected value for 30 days, then a value of 0 again after the 30 days of correct values.