### PR TITLE
fix: use base currency to show currency breakdown

### DIFF
--- a/src/pages/holdings/components/currency-chart.tsx
+++ b/src/pages/holdings/components/currency-chart.tsx
@@ -42,7 +42,7 @@ function getCurrencyData(holdings: Holding[] = [], baseCurrency: string): Curren
       if (isNaN(localValue) || isNaN(baseValue)) return acc;
 
       const current = acc.currencies[currency] || 0;
-      acc.currencies[currency] = current + localValue;
+      acc.currencies[currency] = current + baseValue;
       acc.totalBase += baseValue;
 
       return acc;


### PR DESCRIPTION
Fixes currency breakdown currency mismatch on `currency-chart` component
Before this change the displayed value was using asset currency with base currency symbol.
This PR changes it to use the base currency value and symbol. 