### PR TITLE
Allow scrolling through the list of accounts in manual activity add

### DIFF
--- a/src/pages/activity/components/forms/common.tsx
+++ b/src/pages/activity/components/forms/common.tsx
@@ -106,7 +106,7 @@ export const CommonFields = ({ accounts }: { accounts: AccountSelectOption[] }) 
                 <SelectTrigger>
                   <SelectValue placeholder="Select an account" />
                 </SelectTrigger>
-                <SelectContent>
+                <SelectContent className="max-h-[500px] overflow-y-auto">
                   {accounts.map((account) => (
                     <SelectItem value={account.value} key={account.value}>
                       {account.label}


### PR DESCRIPTION
If you manage a lot of accounts, the account selector in the manual activity add overflows without the ability to scroll:
<img width="630" alt="Screenshot 2025-06-09 at 4 51 29 PM" src="https://github.com/user-attachments/assets/031c1a1b-616b-47d4-9bb2-26f59280f91c" />
^^^ you can see that the list only shows the last accounts

This change simply adds back the ability to scroll; I picked 500px as a max height so it doesn't quite reach the top of the window:
<img width="630" alt="Screenshot 2025-06-09 at 5 36 57 PM" src="https://github.com/user-attachments/assets/07a0da34-bd60-466b-8a83-4d2f5e82f1be" />


^^^ The list shows the first accounts, and is scroll-able
