### PR TITLE
Update methods signature and tests (build fix)

### DIFF
--- a/src/pages/account/account-page.tsx
+++ b/src/pages/account/account-page.tsx
@@ -68,7 +68,7 @@ const AccountPage = () => {
 
   // Calculate gainLossAmount and simpleReturn from valuationHistory
   const { gainLossAmount: frontendGainLossAmount, simpleReturn: frontendSimpleReturn } = useMemo(() => {
-    return calculatePerformanceMetrics(valuationHistory, id);
+    return calculatePerformanceMetrics(valuationHistory, false);
   }, [valuationHistory, id]);
 
   const chartData: HistoryChartData[] = useMemo(() => {


### PR DESCRIPTION
@afadil 
running `pnpm tauri build` fails on main right now because #271 introduced a couple of method signature changes.
This PR updates the failing files. 
- fixed gainLossAmount calculation call
- introduced a helper method to convert a `SimplePerformanceMetrics[]` into `AccountValuations[]` for the `Goal` tests.