### PR TITLE
Percentages fixes

### DIFF
--- a/src/components/gain-percent.tsx
+++ b/src/components/gain-percent.tsx
@@ -26,9 +26,10 @@ function AnimatedNumber({ value }: { value: number }) {
   const Component = NumberFlow;
   return (
     <Component
-      value={Math.abs(value * 100)}
-      animated={true}
+      value={value}
+      animated={true}      
       format={{
+        style: "percent",
         minimumFractionDigits: 2,
         maximumFractionDigits: 2,
       }}

--- a/src/pages/asset/asset-history-card.tsx
+++ b/src/pages/asset/asset-history-card.tsx
@@ -85,7 +85,7 @@ const AssetHistoryCard: React.FC<AssetHistoryProps> = ({
           : 0,
       percentage:
         isValidStartValue && typeof endValue === 'number'
-          ? ((endValue - startValue) / startValue) * 100
+          ? ((endValue - startValue) / startValue)
           : 0,
       calculatedAt: lastFilteredDate,
     };


### PR DESCRIPTION
I noticed a couple of problems in the latest main:
- the dashboard gain percentage is always positive, and doesn't display percent.
- the assets history gain percentage is multiplied by 100

This PR fixes both