### PR TITLE
Add missing percentage sign

### DIFF
--- a/src/components/gain-percent.tsx
+++ b/src/components/gain-percent.tsx
@@ -61,7 +61,7 @@ export function GainPercent({
       {animated ? (
         <>
           {showSign && (value > 0 ? '+' : value < 0 ? '-' : null)}
-          <AnimatedNumber value={value} />
+          <AnimatedNumber value={value} /> %
         </>
       ) : (
         <>


### PR DESCRIPTION
The new GainPercent implementation doesn't show the % sign any more.
This adds it back