### PR TITLE
Allow bulk transactions import into multiple accounts

### DIFF
--- a/src-core/migrations/2025-06-11-133126_account_import_mapping/down.sql
+++ b/src-core/migrations/2025-06-11-133126_account_import_mapping/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE activity_import_profiles DROP COLUMN account_mappings;

--- a/src-core/migrations/2025-06-11-133126_account_import_mapping/up.sql
+++ b/src-core/migrations/2025-06-11-133126_account_import_mapping/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE activity_import_profiles ADD COLUMN account_mappings TEXT NOT NULL default "{}";

--- a/src-core/src/activities/activities_model.rs
+++ b/src-core/src/activities/activities_model.rs
@@ -330,6 +330,7 @@ pub struct ImportMapping {
     pub field_mappings: String,
     pub activity_mappings: String,
     pub symbol_mappings: String,
+    pub account_mappings: String,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
 }
@@ -342,6 +343,7 @@ pub struct ImportMappingData {
     pub field_mappings: std::collections::HashMap<String, String>,
     pub activity_mappings: std::collections::HashMap<String, Vec<String>>,
     pub symbol_mappings: std::collections::HashMap<String, String>,
+    pub account_mappings: std::collections::HashMap<String, String>,
 }
 
 impl Default for ImportMappingData {
@@ -356,6 +358,8 @@ impl Default for ImportMappingData {
         field_mappings.insert("comment".to_string(), "comment".to_string());
         field_mappings.insert("currency".to_string(), "currency".to_string());
         field_mappings.insert("fee".to_string(), "fee".to_string());
+        field_mappings.insert("account".to_string(), "account".to_string());
+
 
         let mut activity_mappings = std::collections::HashMap::new();
         activity_mappings.insert("BUY".to_string(), vec!["BUY".to_string()]);
@@ -377,6 +381,7 @@ impl Default for ImportMappingData {
             field_mappings,
             activity_mappings,
             symbol_mappings: std::collections::HashMap::new(),
+            account_mappings: std::collections::HashMap::new(),
         }
     }
 }
@@ -388,6 +393,7 @@ impl ImportMapping {
             field_mappings: serde_json::from_str(&self.field_mappings)?,
             activity_mappings: serde_json::from_str(&self.activity_mappings)?,
             symbol_mappings: serde_json::from_str(&self.symbol_mappings)?,
+            account_mappings: serde_json::from_str(&self.account_mappings)?,
         })
     }
 
@@ -397,6 +403,7 @@ impl ImportMapping {
             field_mappings: serde_json::to_string(&data.field_mappings)?,
             activity_mappings: serde_json::to_string(&data.activity_mappings)?,
             symbol_mappings: serde_json::to_string(&data.symbol_mappings)?,
+            account_mappings: serde_json::to_string(&data.account_mappings)?,
             created_at: chrono::Utc::now().naive_utc(),
             updated_at: chrono::Utc::now().naive_utc(),
         })

--- a/src-core/src/schema.rs
+++ b/src-core/src/schema.rs
@@ -40,6 +40,7 @@ diesel::table! {
         field_mappings -> Text,
         activity_mappings -> Text,
         symbol_mappings -> Text,
+        account_mappings -> Text,
         created_at -> Timestamp,
         updated_at -> Timestamp,
     }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -46,6 +46,7 @@ export const ImportFormat = {
   AMOUNT: 'amount',
   CURRENCY: 'currency',
   FEE: 'fee',
+  ACCOUNT: 'account',
   COMMENT: 'comment',
 } as const;
 
@@ -60,6 +61,7 @@ export const importFormatSchema = z.enum([
   ImportFormat.AMOUNT,
   ImportFormat.CURRENCY,
   ImportFormat.FEE,
+  ImportFormat.ACCOUNT,
   ImportFormat.COMMENT,
 ]);
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -19,6 +19,7 @@ export const importMappingSchema = z.object({
   fieldMappings: z.record(z.string(), z.string()),
   activityMappings: z.record(z.string(), z.array(z.string())),
   symbolMappings: z.record(z.string(), z.string()),
+  accountMappings: z.record(z.string(), z.string()),
 });
 
 export const newAccountSchema = z.object({

--- a/src/pages/activity/import/activity-import-page.tsx
+++ b/src/pages/activity/import/activity-import-page.tsx
@@ -15,6 +15,9 @@ import { DataPreviewStep } from './steps/preview-step';
 import { ResultStep } from './steps/result-step';
 import { logger } from '@/adapters';
 import { useNavigate } from 'react-router-dom';
+import { getAccounts } from '@/commands/account';
+import { QueryKeys } from '@/lib/query-keys';
+import { useQuery } from '@tanstack/react-query';
 
 // Define the steps in the wizard
 const STEPS = [
@@ -32,6 +35,14 @@ const ActivityImportPage = () => {
   const [activities, setActivities] = useState<ActivityImport[]>([]);
   const [processedActivities, setProcessedActivities] = useState<ActivityImport[]>([]);
 
+
+  const { data: accountsData } = useQuery<Account[], Error>({
+    queryKey: [QueryKeys.ACCOUNTS],
+    queryFn: getAccounts,
+  });
+  const accounts = accountsData || [];
+
+  
   // 1. CSV Parsing Hook - Focus on parsing and structure validation
   const { 
     headers, 
@@ -129,6 +140,7 @@ const ActivityImportPage = () => {
           <MappingStep
             headers={headers}
             data={data}
+            accounts={accounts}
             accountId={selectedAccount?.id}
             onNext={handleMappingComplete}
             onBack={goToPreviousStep}
@@ -139,6 +151,7 @@ const ActivityImportPage = () => {
           <DataPreviewStep
             data={data}
             headers={headers}
+            accounts={accounts}
             activities={activities}
             onNext={handlePreviewComplete}
             onBack={goToPreviousStep}
@@ -148,6 +161,7 @@ const ActivityImportPage = () => {
         return (
           <ResultStep
             activities={processedActivities}
+            accounts={accounts}
             onBack={goToPreviousStep}
             onReset={resetImportProcess}
           />

--- a/src/pages/activity/import/components/mapping-editor.tsx
+++ b/src/pages/activity/import/components/mapping-editor.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { ImportFormat, ActivityType, ImportMappingData, CsvRowData } from '@/lib/types';
+import { ImportFormat, ActivityType, ImportMappingData, CsvRowData, Account } from '@/lib/types';
 
 import { MappingTable } from './mapping-table';
 import { CardContent } from '@/components/ui/card';
@@ -11,10 +11,13 @@ interface CsvMappingEditorProps {
   mapping: ImportMappingData;
   headers: string[];
   data: CsvRowData[];
+  accounts: Account[];
   handleColumnMapping: (field: ImportFormat, value: string) => void;
   handleActivityTypeMapping: (csvActivity: string, activityType: ActivityType) => void;
   handleSymbolMapping: (csvSymbol: string, newSymbol: string) => void;
   getMappedValue: (row: CsvRowData, field: ImportFormat) => string;
+  handleAccountIdMapping: (csvAccountId: string, accountId: string) => void;
+  distinctAccountIds: string[];
   mappedFieldsCount: number;
   totalFields: number;
   requiredFieldsMapped: boolean;
@@ -97,6 +100,50 @@ export function CsvMappingEditor(props: CsvMappingEditorProps) {
     };
   }, [props.data, props.getMappedValue, invalidSymbols, props.mapping.symbolMappings]);
 
+  const distinctAccounts = useMemo(() => {
+    return Array.from(
+      new Set(props.data.map((row) => props.getMappedValue(row, ImportFormat.ACCOUNT))),
+    ).filter(Boolean);
+  }, [props.data, props.getMappedValue]);
+
+  const invalidAccounts = useMemo(() => {
+    return distinctAccounts.filter((account) => !props.mapping.accountMappings?.[account]);    
+  }, [distinctAccounts, props.mapping.accountMappings]);
+
+
+  const { distinctAccountRows } = useMemo(() => {
+    const accountMap = new Map<string, { row: CsvRowData; count: number }>();
+
+    props.data.forEach((row) => {
+      const account = props.getMappedValue(row, ImportFormat.ACCOUNT);
+      if (!account) return;
+
+      if (!accountMap.has(account)) {
+        accountMap.set(account, {
+          row,
+          count: 1,
+        });
+      } else {
+        const current = accountMap.get(account)!;
+        accountMap.set(account, {
+          ...current,
+          count: current.count + 1,
+        });
+      }
+    });
+    
+    return {
+      distinctAccountRows: Array.from(accountMap.entries()).map(([account, data]) => ({
+        accountId: account,
+        row: data.row,
+        count: data.count,
+        isValid: !invalidAccounts.includes(account),
+        mappedAccount: props.mapping.symbolMappings[account],
+      })),
+    };
+  }, [props.data, props.getMappedValue, invalidAccounts, props.mapping.accountMappings]);
+
+
   const dataToMap = useMemo(() => {
     // Create a Set of rows that need mapping
     const rowsNeedingMapping = new Set<CsvRowData>();
@@ -121,6 +168,16 @@ export function CsvMappingEditor(props: CsvMappingEditorProps) {
       }
     });
 
+    distinctAccountRows.forEach(({ row, isValid, mappedAccount }) => {
+        const lineNumber = row.lineNumber;
+        processedRows.set(lineNumber, row);
+        if (!isValid && !mappedAccount) {
+          rowsNeedingMapping.add(row);
+        }
+    });
+
+    console.log
+
     // Convert to array and sort
     return Array.from(processedRows.values()).sort((a, b) => {
       const aNeedsMapping = rowsNeedingMapping.has(a);
@@ -132,7 +189,7 @@ export function CsvMappingEditor(props: CsvMappingEditorProps) {
 
       return parseInt(a.lineNumber) - parseInt(b.lineNumber);
     });
-  }, [distinctActivityTypes, distinctSymbolRows]);
+  }, [distinctActivityTypes, distinctSymbolRows, distinctAccountRows]);
 
   function findAppTypeForCsvType(
     csvType: string,
@@ -201,7 +258,9 @@ export function CsvMappingEditor(props: CsvMappingEditorProps) {
             <MappingTable
               {...props}
               data={dataToMap}
+              accounts={props.accounts}
               invalidSymbols={invalidSymbols}
+              invalidAccounts={invalidAccounts}
               className="max-h-[50vh]"
             />
           </TabsContent>

--- a/src/pages/activity/import/components/mapping-editor.tsx
+++ b/src/pages/activity/import/components/mapping-editor.tsx
@@ -138,7 +138,7 @@ export function CsvMappingEditor(props: CsvMappingEditorProps) {
         row: data.row,
         count: data.count,
         isValid: !invalidAccounts.includes(account),
-        mappedAccount: props.mapping.symbolMappings[account],
+        mappedAccount: props.mapping.accountMappings[account],
       })),
     };
   }, [props.data, props.getMappedValue, invalidAccounts, props.mapping.accountMappings]);
@@ -175,8 +175,6 @@ export function CsvMappingEditor(props: CsvMappingEditorProps) {
           rowsNeedingMapping.add(row);
         }
     });
-
-    console.log
 
     // Convert to array and sort
     return Array.from(processedRows.values()).sort((a, b) => {

--- a/src/pages/activity/import/components/mapping-table.tsx
+++ b/src/pages/activity/import/components/mapping-table.tsx
@@ -13,6 +13,7 @@ import {
   ImportMappingData,
   CsvRowData,
   ImportRequiredField,
+  Account,
 } from '@/lib/types';
 import { renderHeaderCell, renderCell } from './mapping-table-cells';
 import { cn } from '@/lib/utils';
@@ -23,11 +24,14 @@ interface MappingTableProps {
   mapping: ImportMappingData;
   headers: string[];
   data: CsvRowData[];
+  accounts: Account[];
   handleColumnMapping: (field: ImportFormat, value: string) => void;
   handleActivityTypeMapping: (csvActivity: string, activityType: ActivityType) => void;
   handleSymbolMapping: (csvSymbol: string, newSymbol: string) => void;
+  handleAccountIdMapping: (csvAccountId: string, accountId: string) => void;
   getMappedValue: (row: CsvRowData, field: ImportFormat) => string;
   invalidSymbols: string[];
+  invalidAccounts: string[];
   className?: string;
 }
 
@@ -37,11 +41,14 @@ export function MappingTable({
   mapping,
   headers,
   data,
+  accounts,
   handleColumnMapping,
   handleActivityTypeMapping,
   handleSymbolMapping,
+  handleAccountIdMapping,
   getMappedValue,
   invalidSymbols,
+  invalidAccounts,
   className,
 }: MappingTableProps) {
   // Check if a field is mapped
@@ -111,10 +118,13 @@ export function MappingTable({
                             field,
                             row,
                             mapping,
+                            accounts,
                             getMappedValue,
                             handleActivityTypeMapping,
                             handleSymbolMapping,
+                            handleAccountIdMapping,
                             invalidSymbols,
+                            invalidAccounts
                           })}
                         </TableCell>
                       );

--- a/src/pages/activity/import/hooks/use-import-mapping.ts
+++ b/src/pages/activity/import/hooks/use-import-mapping.ts
@@ -27,6 +27,7 @@ const initialMapping: ImportMappingData = {
   fieldMappings: {},
   activityMappings: {},
   symbolMappings: {},
+  accountMappings: {},
 };
 
 interface UseImportMappingProps {
@@ -91,6 +92,7 @@ export function useImportMapping({
         fieldMappings: { ...prev.fieldMappings, ...(fetchedMappingData.fieldMappings || {}) },
         activityMappings: { ...prev.activityMappings, ...(fetchedMappingData.activityMappings || {}) },
         symbolMappings: { ...prev.symbolMappings, ...(fetchedMappingData.symbolMappings || {}) },
+        accountMappings: { ...prev.accountMappings, ...(fetchedMappingData.accountMappings || {}) },
       }));
       setHasInitializedFromHeaders(false);
     }
@@ -158,12 +160,31 @@ export function useImportMapping({
     }));
   }, []);
 
+  const handleAccountIdMapping = useCallback((csvAccountId: string, accountId: string) => {
+    setMapping((prev) => {
+      const updatedMappings = { ...prev.accountMappings };
+      
+      if (accountId.trim() === '') {
+        // Remove mapping if accountId is empty
+        delete updatedMappings[csvAccountId.trim()];
+      } else {
+        // Add or update mapping
+        updatedMappings[csvAccountId.trim()] = accountId.trim();
+      }
+      return {
+        ...prev,
+        accountMappings: updatedMappings,
+      };
+    });
+  }, []);
+
   return {
     mapping,
     updateMapping,
     handleColumnMapping,
     handleActivityTypeMapping,
     handleSymbolMapping,
+    handleAccountIdMapping,
     saveMapping,
     isMappingLoading,
     saveMappingMutation,

--- a/src/pages/activity/import/steps/preview-step.tsx
+++ b/src/pages/activity/import/steps/preview-step.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import { ActivityImport, CsvRowData } from '@/lib/types';
+import { Account, ActivityImport, CsvRowData } from '@/lib/types';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { CSVFileViewer } from '../components/csv-file-viewer';
 import { ImportPreviewTable } from '../import-preview-table';
@@ -15,6 +15,7 @@ interface DataPreviewStepProps {
   data: CsvRowData[] | null;
   headers: string[];
   activities?: ActivityImport[];
+  accounts: Account[];
   onNext: (processedActivities: ActivityImport[]) => void;
   onBack: () => void;
   onError?: () => void;
@@ -23,6 +24,7 @@ interface DataPreviewStepProps {
 export const DataPreviewStep = ({
   headers,
   data,
+  accounts,
   activities = [],
   onNext,
   onBack,
@@ -223,7 +225,7 @@ export const DataPreviewStep = ({
             </div>
             <CardContent className="overflow-hidden p-0 pt-5">
               <TabsContent value="preview" className="m-0 overflow-x-auto">
-                <ImportPreviewTable activities={activities} />
+                <ImportPreviewTable activities={activities} accounts={accounts}/>
               </TabsContent>
               <TabsContent value="raw" className="m-0 overflow-x-auto">
                 <div className="space-y-2">

--- a/src/pages/activity/import/steps/result-step.tsx
+++ b/src/pages/activity/import/steps/result-step.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import { ActivityImport } from '@/lib/types';
+import { Account, ActivityImport } from '@/lib/types';
 import { Icons } from '@/components/icons';
 import { ImportPreviewTable } from '../import-preview-table';
 import { ImportAlert } from '../components/import-alert';
@@ -10,11 +10,12 @@ import { motion } from 'framer-motion';
 
 interface ResultStepProps {
   activities: ActivityImport[];
+  accounts: Account[];
   onBack: () => void;
   onReset: () => void;
 }
 
-export const ResultStep = ({ activities, onBack, onReset }: ResultStepProps) => {
+export const ResultStep = ({ activities, accounts, onBack, onReset }: ResultStepProps) => {
   // Use navigate directly in the component
   const navigate = useNavigate();
 
@@ -144,7 +145,7 @@ export const ResultStep = ({ activities, onBack, onReset }: ResultStepProps) => 
           
           <Card>
             <CardContent className="pt-6">
-              <ImportPreviewTable activities={activities} />
+              <ImportPreviewTable activities={activities} accounts={accounts} />
             </CardContent>
           </Card>
         </div>

--- a/src/pages/activity/import/utils/validation-utils.ts
+++ b/src/pages/activity/import/utils/validation-utils.ts
@@ -166,6 +166,12 @@ function transformRowToActivity(
     return typeof value === 'string' ? value.trim() : undefined;
   };
 
+  // Handle account ID mapping
+  const csvAccountId = getMappedValue(ImportFormat.ACCOUNT);
+  activity.accountId = csvAccountId && mapping.accountMappings?.[csvAccountId.trim()]
+    ? mapping.accountMappings[csvAccountId.trim()] // Use mapped account ID if available
+    : accountId; // Fall back to default account ID 
+
   // 1. Map Raw Values & Basic Parsing
   const rawDate = getMappedValue(ImportFormat.DATE);
   activity.date = rawDate ? tryParseDate(rawDate)?.toISOString() : undefined;
@@ -291,6 +297,7 @@ export function validateActivityImport(
 
         if (schemaValidation.success) {
           const activity = schemaValidation.data as ActivityImport;
+          activity.accountId = transformedActivity.accountId ?? accountId
           activity.isValid = true;
           allActivities.push(activity);
         } else {


### PR DESCRIPTION
It's pretty common for a single broker to hold multiple kinds of accounts, for example in Canada you can have a RRSP, TFSA, RESP and a taxable investment account. Unfortunately, the current CSV import workflow only allows importing transactions one account at a time, even though the broker may be able to export all transactions at once in a single CSV file, which makes it a pain if you manage a lot of accounts.

This PR adds the ability to optionally override the account ID for every row of the CSV. It does not fundamentally change the flow (where the CSV import mapping is stored per account), but allows combining imports for multiple accounts in a single shot.  Ideally the CSV import mapping would be stored per broker, not per account, but this seems to big of a change and I'm not sure it brings anything. The downside of this approach is that you have to select the same account every time you want to import from the same broker.

This flow is very much modelled after the symbols mapping import: if the import is set to use an account column, and an account mapping is not found for a given value of the account column, the row is added to the mapping table to select an account to map to.

A migration was added to add the account mapping to the activity import profile (defaulting to empty).

Just for completeness sake, the account name is displayed in the import screen (even when not overriding it) for every transaction in the preview.

