### PR TITLE
Fix symbol routing with slashes

### DIFF
--- a/src/pages/activity/components/activity-table.tsx
+++ b/src/pages/activity/components/activity-table.tsx
@@ -133,11 +133,11 @@ export const ActivityTable = ({
 
           return (
             <div className="w-3/3 flex items-center">
-              {ogSymbol.startsWith('$CASH-') ? (
-                badge
-              ) : (
-                <Link to={`/holdings/${ogSymbol}`}>{badge}</Link>
-              )}
+                {ogSymbol.startsWith('$CASH-') ? (
+                  badge
+                ) : (
+                  <Link to={`/holdings/${encodeURIComponent(ogSymbol)}`}>{badge}</Link>
+                )}
               <span className="ml-2 text-xs">{row.getValue('assetName')}</span>
             </div>
           );

--- a/src/pages/activity/components/editable-activity-table.tsx
+++ b/src/pages/activity/components/editable-activity-table.tsx
@@ -590,7 +590,7 @@ const EditableActivityTable = ({
           if (symbol.startsWith('$CASH')) symbol = symbol.split('-')[0];
           return (
             <div className="flex min-w-[120px] items-center">
-              <Link to={`/holdings/${symbol}`}>
+              <Link to={`/holdings/${encodeURIComponent(symbol)}`}>
                 <Badge className="flex min-w-[60px] cursor-pointer items-center justify-center rounded-sm">
                   {symbol || '-'}
                 </Badge>

--- a/src/pages/asset/asset-profile-page.tsx
+++ b/src/pages/asset/asset-profile-page.tsx
@@ -54,7 +54,8 @@ interface AssetDetailData {
 }
 
 export const AssetProfilePage = () => {
-  const { symbol = '' } = useParams<{ symbol: string }>();
+  const { symbol: encodedSymbol = '' } = useParams<{ symbol: string }>();
+  const symbol = decodeURIComponent(encodedSymbol);
   const location = useLocation();
   const queryParams = new URLSearchParams(location.search);
   const defaultTab = queryParams.get('tab') || 'overview';

--- a/src/pages/holdings/components/composition-chart.tsx
+++ b/src/pages/holdings/components/composition-chart.tsx
@@ -98,7 +98,7 @@ const CustomizedContent = (props: any) => {
       />
       {depth === 1 ? (
         <>
-          <Link to={`/holdings/${symbol}`}>
+          <Link to={`/holdings/${encodeURIComponent(symbol)}`}>
             <text
               x={x + width / 2}
               y={y + height / 2}

--- a/src/pages/holdings/components/holdings-table.tsx
+++ b/src/pages/holdings/components/holdings-table.tsx
@@ -125,7 +125,7 @@ const getColumns = (
 
       const handleNavigate = () => {
         const navSymbol = holding.instrument?.symbol ?? holding.id;
-        navigate(`/holdings/${navSymbol}`, { state: { holding } });
+        navigate(`/holdings/${encodeURIComponent(navSymbol)}`, { state: { holding } });
       };
       return (
         <div className="flex items-center">
@@ -357,7 +357,7 @@ const getColumns = (
       const navigate = useNavigate();
       const handleNavigate = () => {
         const navSymbol = row.original.instrument?.symbol ?? row.original.id;
-        navigate(`/holdings/${navSymbol}`, { state: { holding: row.original } });
+        navigate(`/holdings/${encodeURIComponent(navSymbol)}`, { state: { holding: row.original } });
       };
 
       return (

--- a/src/pages/settings/general/exchange-rates/exchange-rates-settings.tsx
+++ b/src/pages/settings/general/exchange-rates/exchange-rates-settings.tsx
@@ -72,7 +72,7 @@ export function ExchangeRatesSettings() {
       id: 'history',
       enableHiding: false,
       cell: ({ row }) => (
-        <Link to={`/holdings/${row.original.id}`} className="flex items-center justify-center">
+        <Link to={`/holdings/${encodeURIComponent(row.original.id)}`} className="flex items-center justify-center">
           <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
             <Icons.Clock className="h-4 w-4" />
             <span className="sr-only">View history</span>


### PR DESCRIPTION
## Summary
- encode symbol in holdings navigation links
- decode symbol from route params when loading AssetProfilePage

## Testing
- `npm run tsc`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68547504714483248cf70c17a4b63030