### PR TITLE
Fix quote creation for manual symbols

### DIFF
--- a/src/pages/activity/hooks/use-activity-mutations.ts
+++ b/src/pages/activity/hooks/use-activity-mutations.ts
@@ -76,17 +76,19 @@ export function useActivityMutations(onSuccess?: (activity: { accountId?: string
 
   const addActivityMutation = useMutation({
     mutationFn: async (data: NewActivityFormValues) => {
-      await createQuoteFromActivity(data);
       const { ...rest } = data;
-      return createActivity(rest);
+      const activity = await createActivity(rest);
+      await createQuoteFromActivity(data);
+      return activity;
     },
     ...createMutationOptions('adding'),
   });
 
   const updateActivityMutation = useMutation({
     mutationFn: async (data: NewActivityFormValues & { id: string }) => {
+      const activity = await updateActivity(data);
       await createQuoteFromActivity(data);
-      return updateActivity(data);
+      return activity;
     },
     ...createMutationOptions('updating'),
   });


### PR DESCRIPTION
## Summary
- adjust order of actions when adding or updating activities so the related asset exists before saving quotes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68547bbfff048324accce31a3d713663