### PR TITLE
Add keyring-based API key storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,12 @@ wealthfolio/
 └── vite.config.ts       # Vite build tool configuration
 ```
 
+### API Keys
+
+API credentials are stored using the operating system keyring through the
+`keyring` crate. Use the `set_api_key` and `get_api_key` commands to manage
+keys for external services without writing them to disk.
+
 ## Contributing
 
 Contributions are welcome! Please follow these steps:

--- a/src-core/Cargo.toml
+++ b/src-core/Cargo.toml
@@ -33,5 +33,6 @@ log = "0.4"
 futures = "0.3"
 serde_with = "3.4"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
+keyring = "2"
 
 [dev-dependencies]

--- a/src-core/src/errors.rs
+++ b/src-core/src/errors.rs
@@ -48,6 +48,9 @@ pub enum Error {
     #[error("Holdings calculation failed: {0}")]
     Calculation(#[from] CalculatorError),
 
+    #[error("Secret store error: {0}")]
+    Secret(String),
+
     #[error("Unexpected error: {0}")]
     Unexpected(String),
 
@@ -185,6 +188,12 @@ impl From<r2d2::Error> for Error {
 impl From<diesel::ConnectionError> for Error {
     fn from(err: diesel::ConnectionError) -> Self {
         Error::Database(DatabaseError::ConnectionFailed(err))
+    }
+}
+
+impl From<keyring::Error> for Error {
+    fn from(err: keyring::Error) -> Self {
+        Error::Secret(err.to_string())
     }
 }
 

--- a/src-core/src/lib.rs
+++ b/src-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod market_data;
 pub mod portfolio;
 pub mod schema;
 pub mod settings;
+pub mod secrets;
 pub mod utils;
 pub use portfolio::*;
 pub use assets::*;

--- a/src-core/src/secrets/mod.rs
+++ b/src-core/src/secrets/mod.rs
@@ -1,0 +1,25 @@
+use keyring::Entry;
+use crate::errors::{Error, Result};
+
+const USERNAME: &str = "default";
+
+/// Provides simple API key storage using the operating system keyring.
+pub struct SecretManager;
+
+impl SecretManager {
+    /// Store an API key for the given service.
+    pub fn set_api_key(service: &str, api_key: &str) -> Result<()> {
+        let entry = Entry::new(service, USERNAME).map_err(Error::from)?;
+        entry.set_password(api_key).map_err(Error::from)
+    }
+
+    /// Retrieve an API key for the given service.
+    pub fn get_api_key(service: &str) -> Result<Option<String>> {
+        let entry = Entry::new(service, USERNAME).map_err(Error::from)?;
+        match entry.get_password() {
+            Ok(value) => Ok(Some(value)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(e) => Err(Error::from(e)),
+        }
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -7,3 +7,4 @@ pub mod market_data;
 pub mod portfolio;
 pub mod settings;
 pub mod utilities;
+pub mod secrets;

--- a/src-tauri/src/commands/secrets.rs
+++ b/src-tauri/src/commands/secrets.rs
@@ -1,0 +1,21 @@
+use std::sync::Arc;
+use tauri::State;
+use crate::context::ServiceContext;
+use wealthfolio_core::secrets::SecretManager;
+
+#[tauri::command]
+pub async fn set_api_key(
+    service: String,
+    api_key: String,
+    _state: State<'_, Arc<ServiceContext>>, // keep signature consistent
+) -> Result<(), String> {
+    SecretManager::set_api_key(&service, &api_key).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn get_api_key(
+    service: String,
+    _state: State<'_, Arc<ServiceContext>>,
+) -> Result<Option<String>, String> {
+    SecretManager::get_api_key(&service).map_err(|e| e.to_string())
+}

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -138,6 +138,8 @@ pub fn main() {
             commands::market_data::delete_quote,
             commands::market_data::get_quote_history,
             commands::market_data::get_market_data_providers,
+            commands::secrets::set_api_key,
+            commands::secrets::get_api_key,
         ])
         .build(tauri::generate_context!())
         .expect("error while running wealthfolio application");


### PR DESCRIPTION
## Summary
- add new `SecretManager` for handling secrets with `keyring`
- expose `secrets` module from core crate
- add Tauri commands `set_api_key` and `get_api_key`
- register new commands in the application
- document API key storage in README

## Testing
- `cargo test --test-threads=1` in `src-core`
- `cargo test --test-threads=1` in `src-tauri` *(fails: glib-2.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea42f05c8832487ce278a6e320fae