### PR TITLE
Fix bulk import

### DIFF
--- a/src-core/src/activities/activities_service.rs
+++ b/src-core/src/activities/activities_service.rs
@@ -180,9 +180,13 @@ impl ActivityServiceTrait for ActivityService {
 
         for mut activity in activities {
             activity.id = Some(Uuid::new_v4().to_string());
-            activity.account_name = Some(account.name.clone());
-            activity.account_id = Some(account_id.clone());
-
+            if activity.account_name.is_none() {
+                activity.account_name = Some(account.name.clone());
+            }
+            if activity.account_id.is_none() {
+                activity.account_id = Some(account_id.clone());
+            }
+        
             // Determine context currency for potential asset creation during check
             let asset_context_currency = if !activity.currency.is_empty() {
                 activity.currency.clone()


### PR DESCRIPTION
Fixes #315 

When doing a bulk import, the account specified in the transaction was being overridden by the account for the import.
