### PR TITLE
Encode query before querying Yahoo API

### DIFF
--- a/src-core/Cargo.lock
+++ b/src-core/Cargo.lock
@@ -3199,6 +3199,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3354,6 +3360,7 @@ dependencies = [
  "serde_with",
  "thiserror 1.0.69",
  "tokio",
+ "urlencoding",
  "uuid",
  "yahoo_finance_api",
 ]

--- a/src-core/Cargo.toml
+++ b/src-core/Cargo.toml
@@ -34,5 +34,6 @@ futures = "0.3"
 serde_with = "3.4"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync"] }
 keyring = "2"
+urlencoding = "2"
 
 [dev-dependencies]

--- a/src-core/src/market_data/providers/yahoo_provider.rs
+++ b/src-core/src/market_data/providers/yahoo_provider.rs
@@ -13,6 +13,7 @@ use reqwest::{header, Client};
 use serde_json::json;
 use yahoo::{YQuoteItem, YahooError};
 use yahoo_finance_api as yahoo;
+use urlencoding::encode;
 
 #[derive(Debug, Clone)]
 pub struct CrumbData {
@@ -66,7 +67,8 @@ impl YahooProvider {
     }
 
     pub async fn search_ticker(&self, query: &str) -> Result<Vec<QuoteSummary>, yahoo::YahooError> {
-        let result = self.provider.search_ticker(query).await?;
+        let encoded_query = encode(query);
+        let result = self.provider.search_ticker(&encoded_query).await?;
 
         let asset_profiles = result.quotes.iter().map(QuoteSummary::from).collect();
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6007,6 +6007,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "urlpattern"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6333,6 +6339,7 @@ dependencies = [
  "serde_with",
  "thiserror 1.0.69",
  "tokio",
+ "urlencoding",
  "uuid",
  "yahoo_finance_api",
 ]


### PR DESCRIPTION
This PR fixes #390

When searching for the ticker `M&M.NS` https://finance.yahoo.com/quote/M&M.NS/ 

The current implementation does a query:

https://query2.finance.yahoo.com/v1/finance/search?q=M&M.NS

The `&` in the URL is getting treated as a query parameter delimiter thus the `GET` request results to `q=M`

This PR url encodes the query before querying Yahoo API thus the `GET` request is

https://query2.finance.yahoo.com/v1/finance/search?q=M%26M.NS

Screenshot of the correct ticker in the UI:

<img width="1147" height="507" alt="Screenshot 2025-09-23 at 3 21 44 PM" src="https://github.com/user-attachments/assets/e8013faf-b151-4c1a-8236-efdf82efce73" />
<img width="332" height="121" alt="Screenshot 2025-09-23 at 3 23 11 PM" src="https://github.com/user-attachments/assets/2059bb04-a58d-4017-87e1-999378242b2b" />

