### PR TITLE
Track Short Position

### DIFF
--- a/addons/swingfolio-addon/src/lib/trade-matcher.ts
+++ b/addons/swingfolio-addon/src/lib/trade-matcher.ts
@@ -47,7 +47,12 @@ export class TradeMatcher {
     const parsedActivities = this.parseActivities(activities)
     
     // Separate trading activities from dividends
-    const tradingActivities = parsedActivities.filter(a => a.activityType === "BUY" || a.activityType === "SELL")
+    const tradingActivities = parsedActivities.filter(
+      a => a.activityType === "BUY" || 
+           a.activityType === "SELL" || 
+           a.activityType === "SELL_SHORT" || 
+           a.activityType === "BUY_COVER"
+    )
     const dividendActivities = parsedActivities.filter(a => a.activityType === "DIVIDEND")
     
     // Group activities by symbol

--- a/packages/ui/src/components/financial/quantity-input.tsx
+++ b/packages/ui/src/components/financial/quantity-input.tsx
@@ -13,7 +13,7 @@ const QuantityInput = React.forwardRef<HTMLInputElement, QuantityInputProps>(
     {
       className,
       maxDecimalPlaces = 8,
-      allowNegative = false,
+      allowNegative = true,
       value,
       defaultValue,
       onChange,

--- a/packages/ui/src/components/financial/quantity-input.tsx
+++ b/packages/ui/src/components/financial/quantity-input.tsx
@@ -13,7 +13,7 @@ const QuantityInput = React.forwardRef<HTMLInputElement, QuantityInputProps>(
     {
       className,
       maxDecimalPlaces = 8,
-      allowNegative = true,
+      allowNegative = false,
       value,
       defaultValue,
       onChange,

--- a/src-core/src/activities/activities_constants.rs
+++ b/src-core/src/activities/activities_constants.rs
@@ -9,6 +9,12 @@ pub const ACTIVITY_TYPE_BUY: &str = "BUY";
 /// Disposal of a security or other asset. Increases cash and decreases quantity.
 pub const ACTIVITY_TYPE_SELL: &str = "SELL";
 
+/// Short sale of a security or other asset. Increases cash and increases quantity (liability).
+pub const ACTIVITY_TYPE_SELL_SHORT: &str = "SELL_SHORT";
+
+/// Buy back an asset to close a short position. Decreases cash balance and decreases quantity (liability).
+pub const ACTIVITY_TYPE_BUY_COVER: &str = "BUY_COVER";
+
 /// Cash dividend paid into the account. Increases cash.
 pub const ACTIVITY_TYPE_DIVIDEND: &str = "DIVIDEND";
 

--- a/src-core/src/activities/activities_model.rs
+++ b/src-core/src/activities/activities_model.rs
@@ -415,6 +415,8 @@ impl ImportMapping {
 pub enum ActivityType {
     Buy,
     Sell,
+    SellShort,
+    BuyCover,
     Dividend,
     Interest,
     Deposit,
@@ -434,6 +436,8 @@ impl ActivityType {
         match self {
             ActivityType::Buy => ACTIVITY_TYPE_BUY,
             ActivityType::Sell => ACTIVITY_TYPE_SELL,
+            ActivityType::SellShort => ACTIVITY_TYPE_SELL_SHORT,
+            ActivityType::BuyCover => ACTIVITY_TYPE_BUY_COVER,
             ActivityType::Dividend => ACTIVITY_TYPE_DIVIDEND,
             ActivityType::Interest => ACTIVITY_TYPE_INTEREST,
             ActivityType::Deposit => ACTIVITY_TYPE_DEPOSIT,
@@ -457,6 +461,8 @@ impl FromStr for ActivityType {
         match s {
             s if s == ACTIVITY_TYPE_BUY => Ok(ActivityType::Buy),
             s if s == ACTIVITY_TYPE_SELL => Ok(ActivityType::Sell),
+            s if s == ACTIVITY_TYPE_SELL_SHORT => Ok(ActivityType::SellShort),
+            s if s == ACTIVITY_TYPE_BUY_COVER => Ok(ActivityType::BuyCover),
             s if s == ACTIVITY_TYPE_DIVIDEND => Ok(ActivityType::Dividend),
             s if s == ACTIVITY_TYPE_INTEREST => Ok(ActivityType::Interest),
             s if s == ACTIVITY_TYPE_DEPOSIT => Ok(ActivityType::Deposit),

--- a/src-core/src/activities/activities_model.rs
+++ b/src-core/src/activities/activities_model.rs
@@ -364,6 +364,8 @@ impl Default for ImportMappingData {
         let mut activity_mappings = std::collections::HashMap::new();
         activity_mappings.insert("BUY".to_string(), vec!["BUY".to_string()]);
         activity_mappings.insert("SELL".to_string(), vec!["SELL".to_string()]);
+        activity_mappings.insert("SELL_SHORT".to_string(), vec!["SELL_SHORT".to_string()]);
+        activity_mappings.insert("BUY_COVER".to_string(), vec!["BUY_COVER".to_string()]);
         activity_mappings.insert("DIVIDEND".to_string(), vec!["DIVIDEND".to_string()]);
         activity_mappings.insert("INTEREST".to_string(), vec!["INTEREST".to_string()]);
         activity_mappings.insert("DEPOSIT".to_string(), vec!["DEPOSIT".to_string()]);

--- a/src-core/src/portfolio/holdings/holdings_service.rs
+++ b/src-core/src/portfolio/holdings/holdings_service.rs
@@ -274,7 +274,7 @@ impl HoldingsServiceTrait for HoldingsService {
             .map(|holding_view| holding_view.market_value.base)
             .sum();
 
-        if total_portfolio_value_base > dec!(0) {
+        if total_portfolio_value_base != dec!(0) {
             for holding_view in &mut holdings {
                 holding_view.weight =
                     (holding_view.market_value.base / total_portfolio_value_base).round_dp(4);

--- a/src-core/src/portfolio/snapshot/holdings_calculator.rs
+++ b/src-core/src/portfolio/snapshot/holdings_calculator.rs
@@ -353,12 +353,12 @@ pub struct HoldingsCalculator {
              }
         };
         
-        let total_proceed_acct = activity.quantity * unit_price_acct + fee_acct;
+        let total_proceed_acct = activity.quantity.abs() * unit_price_acct - fee_acct;
         
         *state
             .cash_balances
             .entry(account_currency.to_string())
-            .or_insert(Decimal::ZERO) += total_proceed_acct.abs();
+            .or_insert(Decimal::ZERO) += total_proceed_acct;
         
         Ok(())
     }
@@ -389,7 +389,7 @@ pub struct HoldingsCalculator {
             }
         };
 
-        let total_cost_acct = (activity.quantity * unit_price_acct) - fee_acct;
+        let total_cost_acct = activity.quantity * unit_price_acct + fee_acct;
 
         if let Some(position) = state.positions.get_mut(&activity.asset_id) {
             // Check if currency conversion is needed and handle accordingly

--- a/src-core/src/portfolio/snapshot/holdings_calculator.rs
+++ b/src-core/src/portfolio/snapshot/holdings_calculator.rs
@@ -175,6 +175,8 @@ pub struct HoldingsCalculator {
         match activity_type {
             ActivityType::Buy => self.handle_buy(activity, state, account_currency, fee_acct),
             ActivityType::Sell => self.handle_sell(activity, state, account_currency, fee_acct),
+            ActivityType::SellShort => self.handle_short_sell(activity, state, account_currency, fee_acct),
+            ActivityType::BuyCover => self.handle_buy_cover(activity, state, account_currency, fee_acct),
             ActivityType::Deposit => self.handle_deposit(activity, state, account_currency, amount_acct, fee_acct),
             ActivityType::Withdrawal => self.handle_withdrawal(activity, state, account_currency, amount_acct, fee_acct),
             ActivityType::Dividend | ActivityType::Interest => self.handle_income(state, account_currency, amount_acct, fee_acct),
@@ -300,6 +302,121 @@ pub struct HoldingsCalculator {
                 .cash_balances
                 .entry(account_currency.to_string())
                 .or_insert(Decimal::ZERO) += total_proceeds_acct;
+        }
+        Ok(())
+    }
+
+    fn handle_short_sell(
+        &self,
+        activity: &Activity,
+        state: &mut AccountStateSnapshot,
+        account_currency: &str,
+        fee_acct: Decimal, // Already converted using activity date
+    ) -> Result<()> {
+        let activity_currency = &activity.currency;
+        let activity_date = activity.activity_date.naive_utc().date();
+
+        let position = self.get_or_create_position_mut(
+            state,
+            &activity.asset_id,
+            activity_currency, 
+            activity.activity_date,
+        )?;
+
+        // Check if currency conversion is needed and handle accordingly
+        let converted_activity;
+        let activity_to_use = if position.currency.is_empty() || position.currency == activity.currency {
+            // No conversion needed, use original activity directly
+            activity
+        } else {
+            // Conversion needed, convert and store in local variable
+            converted_activity = self.convert_activity_to_position_currency(activity, position, &ActivityType::Buy)?;
+            &converted_activity
+        };
+
+        let _cost_basis_sold_asset_curr = position.add_short_lot(activity_to_use)?;
+
+        // Calculate total cost in Account Currency for cash adjustment
+        let unit_price_acct = match self.fx_service.convert_currency_for_date(
+            activity.unit_price, 
+            activity_currency, 
+            account_currency, 
+            activity_date
+        ) {
+             Ok(converted) => converted,
+             Err(e) => {
+                  warn!(
+                    "Holdings Calc (Buy Unit Price {}): Failed conversion {} {}->{} on {}: {}. Using original price.",
+                    activity.id, activity.unit_price, activity_currency, account_currency, activity_date, e
+                 );
+                 activity.unit_price // Fallback
+             }
+        };
+        
+        let total_proceed_acct = activity.quantity * unit_price_acct + fee_acct;
+        
+        *state
+            .cash_balances
+            .entry(account_currency.to_string())
+            .or_insert(Decimal::ZERO) += total_proceed_acct.abs();
+        
+        Ok(())
+    }
+
+    fn handle_buy_cover(
+        &self,
+        activity: &Activity,
+        state: &mut AccountStateSnapshot,
+        account_currency: &str,
+        fee_acct: Decimal, // Already converted using activity date
+    ) -> Result<()> {
+        let activity_currency = &activity.currency;
+        let activity_date = activity.activity_date.naive_utc().date();
+
+        let unit_price_acct = match self.fx_service.convert_currency_for_date(
+            activity.unit_price, 
+            activity_currency, 
+            account_currency, 
+            activity_date
+        ) {
+            Ok(converted) => converted,
+            Err(e) => {
+                 warn!(
+                    "Holdings Calc (Sell Unit Price {}): Failed conversion {} {}->{} on {}: {}. Using original price.",
+                    activity.id, activity.unit_price, activity_currency, account_currency, activity_date, e
+                 );
+                 activity.unit_price // Fallback
+            }
+        };
+
+        let total_cost_acct = (activity.quantity * unit_price_acct) - fee_acct;
+
+        if let Some(position) = state.positions.get_mut(&activity.asset_id) {
+            // Check if currency conversion is needed and handle accordingly
+            let converted_activity;
+            let activity_to_use = if position.currency.is_empty() || position.currency == activity.currency {
+                // No conversion needed, use original activity directly
+                activity
+            } else {
+                // Conversion needed, convert and store in local variable
+                converted_activity = self.convert_activity_to_position_currency(activity, position, &ActivityType::Sell)?;
+                &converted_activity
+            };
+
+            let (_qty_reduced, _cost_basis_asset_curr) = 
+                position.cover_short_lots_fifo(activity_to_use.quantity)?;
+            
+            *state
+                .cash_balances
+                .entry(account_currency.to_string())
+                .or_insert(Decimal::ZERO) -= total_cost_acct;
+        } else {
+            warn!("Attempted to Sell non-existent/zero position {} via activity {}. Applying cash effect.",
+                     activity.asset_id, activity.id);
+            *state
+                .cash_balances
+                .entry(account_currency.to_string())
+                .or_insert(Decimal::ZERO) -= total_cost_acct;
         }
         Ok(())
     }

--- a/src/lib/activity-utils.ts
+++ b/src/lib/activity-utils.ts
@@ -133,7 +133,15 @@ export const calculateActivityValue = (activity: ActivityDetails): number => {
   if (activityType === ActivityType.SELL) {
     return Number(activityAmount) - Number(fee); // Net proceeds after fees
   }
-  
+
+  if (activityType === ActivityType.SELL_SHORT) {
+    
+    return Number(activityAmount) - Number(fee); // Net proceeds after fees
+  }
+
+  if (activityType === ActivityType.BUY_COVER) {
+    return Number(activityAmount) + Number(fee); // Total cost including fees
+  }
   // Default case - just return the activity amount
   return Number(activityAmount);
 };

--- a/src/lib/activity-utils.ts
+++ b/src/lib/activity-utils.ts
@@ -34,7 +34,12 @@ export const isCashTransfer = (activityType: string, assetSymbol: string): boole
 
 // Helper to check if activity is a trade type
 export const isTradeActivity = (type: string): boolean => {
-  return type === ActivityType.BUY || type === ActivityType.SELL;
+  return (
+    type === ActivityType.BUY ||
+    type === ActivityType.SELL ||
+    type === ActivityType.SELL_SHORT ||
+    type === ActivityType.BUY_COVER
+  );
 }
 
 // Helper to check if activity is a fee type

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -109,6 +109,8 @@ export const exportedFileFormatSchema = z.enum([
 export const ActivityType = {
   BUY: 'BUY',
   SELL: 'SELL',
+  SELL_SHORT: 'SELL_SHORT',
+  BUY_COVER: 'BUY_COVER',
   DIVIDEND: 'DIVIDEND',
   INTEREST: 'INTEREST',
   DEPOSIT: 'DEPOSIT',
@@ -127,6 +129,8 @@ export type ActivityType = (typeof ActivityType)[keyof typeof ActivityType];
 export const TRADING_ACTIVITY_TYPES = [
   ActivityType.BUY,
   ActivityType.SELL,
+  ActivityType.SELL_SHORT,
+  ActivityType.BUY_COVER,
   ActivityType.SPLIT,
   ActivityType.ADD_HOLDING,
   ActivityType.REMOVE_HOLDING,
@@ -151,6 +155,8 @@ export const INCOME_ACTIVITY_TYPES = [
 export const activityTypeSchema = z.enum([
   ActivityType.BUY,
   ActivityType.SELL,
+  ActivityType.SELL_SHORT,
+  ActivityType.BUY_COVER,
   ActivityType.DIVIDEND,
   ActivityType.INTEREST,
   ActivityType.DEPOSIT,
@@ -167,6 +173,8 @@ export const activityTypeSchema = z.enum([
 export const ActivityTypeNames: Record<ActivityType, string> = {
   [ActivityType.BUY]: 'Buy',
   [ActivityType.SELL]: 'Sell',
+  [ActivityType.SELL_SHORT]: 'Sell Short',
+  [ActivityType.BUY_COVER]: 'Buy to Cover',
   [ActivityType.DIVIDEND]: 'Dividend',
   [ActivityType.INTEREST]: 'Interest',
   [ActivityType.DEPOSIT]: 'Deposit',

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -81,7 +81,6 @@ export const importActivitySchema = z.object({
       required_error: 'Please enter a valid quantity.',
       invalid_type_error: 'Quantity must be a number.',
     })
-    .min(0, { message: 'Quantity must be a non-negative number.' })
     .optional(),
   unitPrice: z.coerce
     .number({
@@ -176,6 +175,21 @@ export const importActivitySchema = z.object({
     message: "Quantity must be positive for non-cash activities",
     path: ["quantity"]
   }
+).refine(
+  (data) => {
+    //check activityType if other than SELL_SHORT 'Quantity must be a non-negative number.'
+    const isShortSell = data.activityType === ActivityType.SELL_SHORT;
+    const tradeActivity = isTradeActivity(data.activityType as string);
+
+    if (tradeActivity && !isShortSell) {
+      return data.quantity !== undefined && data.quantity >= 0;
+    }
+    return true;
+  },
+  {
+    message: "Quantity must be a non-negative number.",
+    path: ["quantity"]
+  },
 );
 
 export const newContributionLimitSchema = z.object({

--- a/src/pages/activity/components/activity-form.tsx
+++ b/src/pages/activity/components/activity-form.tsx
@@ -42,6 +42,8 @@ interface ActivityFormProps {
 const ACTIVITY_TYPE_TO_TAB: Record<string, string> = {
   BUY: 'trade',
   SELL: 'trade',
+  SELL_SHORT: 'trade',
+  BUY_COVER: 'trade',
   DEPOSIT: 'cash',
   WITHDRAWAL: 'cash',
   INTEREST: 'income',

--- a/src/pages/activity/components/activity-form.tsx
+++ b/src/pages/activity/components/activity-form.tsx
@@ -122,6 +122,18 @@ export function ActivityForm({ accounts, activity, open, onClose }: ActivityForm
         }
       }
 
+      // Ensure quantity is negative for short activities
+      if (
+        ['SELL_SHORT'].includes(
+          submitData.activityType,
+        ) &&
+        'quantity' in submitData &&
+        submitData.quantity &&
+        submitData.quantity > 0
+      ) {
+        submitData.quantity = -submitData.quantity;
+      }
+
       if ('assetDataSource' in submitData && submitData.assetDataSource === DataSource.MANUAL && account) {
         submitData.currency = submitData.currency || account.currency;
       }

--- a/src/pages/activity/components/activity-table.tsx
+++ b/src/pages/activity/components/activity-table.tsx
@@ -132,6 +132,7 @@ export const ActivityTable = ({
           const activityType = row.getValue('activityType') as string;
           const badgeVariant =
             activityType === 'BUY' ||
+            activityType === 'BUY_COVER' ||
             activityType === 'DEPOSIT' ||
             activityType === 'DIVIDEND' ||
             activityType === 'INTEREST' ||

--- a/src/pages/activity/components/editable-activity-table.tsx
+++ b/src/pages/activity/components/editable-activity-table.tsx
@@ -450,6 +450,15 @@ const EditableActivityTable = ({
       if (activityToSave.hasOwnProperty('amount')) payloadForBackend.amount = amount;
       if (activityToSave.hasOwnProperty('fee')) payloadForBackend.fee = fee;
 
+      // For SELL_SHORT, ensure quantity is negative before sending to backend
+      if (
+        payloadForBackend.activityType === ActivityType.SELL_SHORT &&
+        payloadForBackend.quantity &&
+        payloadForBackend.quantity > 0
+      ) {
+        payloadForBackend.quantity = -payloadForBackend.quantity;
+      }
+
       try {
         let mutationPromise;
 

--- a/src/pages/activity/components/forms/schemas.ts
+++ b/src/pages/activity/components/forms/schemas.ts
@@ -59,8 +59,7 @@ export const tradeActivitySchema = baseActivitySchema.extend({
     .number({
       required_error: 'Please enter a valid quantity.',
       invalid_type_error: 'Quantity must be a number.',
-    })
-    .positive(),
+    }),
   unitPrice: z.coerce
     .number({
       required_error: 'Please enter a valid unit price.',

--- a/src/pages/activity/components/forms/schemas.ts
+++ b/src/pages/activity/components/forms/schemas.ts
@@ -53,7 +53,7 @@ export const bulkHoldingsFormSchema = baseActivitySchema.extend({
 });
 
 export const tradeActivitySchema = baseActivitySchema.extend({
-  activityType: z.enum([ActivityType.BUY, ActivityType.SELL]),
+  activityType: z.enum([ActivityType.BUY, ActivityType.SELL, ActivityType.SELL_SHORT, ActivityType.BUY_COVER]),
   assetId: z.string().min(1, { message: 'Please select a security' }),
   quantity: z.coerce
     .number({

--- a/src/pages/activity/components/forms/schemas.ts
+++ b/src/pages/activity/components/forms/schemas.ts
@@ -59,7 +59,8 @@ export const tradeActivitySchema = baseActivitySchema.extend({
     .number({
       required_error: 'Please enter a valid quantity.',
       invalid_type_error: 'Quantity must be a number.',
-    }),
+    })
+    .positive(),
   unitPrice: z.coerce
     .number({
       required_error: 'Please enter a valid unit price.',

--- a/src/pages/activity/components/forms/trade-form.tsx
+++ b/src/pages/activity/components/forms/trade-form.tsx
@@ -25,13 +25,15 @@ export const TradeForm = ({ accounts }: { accounts: AccountSelectOption[] }) => 
   const tradeTypes: ActivityTypeUI[] = [
     { value: 'BUY', label: 'Buy', icon: 'ArrowDown', description: 'Purchase an asset. This increases your holding quantity and decreases your cash balance.' },
     { value: 'SELL', label: 'Sell', icon: 'ArrowUp', description: 'Sell an asset. This decreases your holding quantity and increases your cash balance.' },
+    { value: 'SELL_SHORT', label: 'Sell Short', icon: 'ArrowDown', description: 'Sell an asset you do not own. This increases your cash balance and increases your holding liability.' },
+    { value: 'BUY_COVER', label: 'Buy to Cover', icon: 'ArrowUp', description: 'Buy back an asset to close a short position. This decreases your cash balance and decreases your holding liability.' },
   ];
 
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <div className="flex-1">
-          <ActivityTypeSelector control={control} types={tradeTypes} columns={2} />
+          <ActivityTypeSelector control={control} types={tradeTypes} columns={4} />
         </div>
       </div>
       <CashBalanceWarning />

--- a/src/pages/activity/import/import-help.tsx
+++ b/src/pages/activity/import/import-help.tsx
@@ -61,6 +61,8 @@ export function ImportHelpPopover() {
                 <pre className="mt-2 overflow-x-auto bg-muted p-4 text-xs">
                   <ul className="list-inside list-disc space-y-1">
                     <li>BUY</li>
+                    <li>SELL_SHORT (Opens a short position)</li>
+                    <li>BUY_COVER (Closes a short position)</li>
                     <li>SELL</li>
                     <li>DIVIDEND</li>
                     <li>INTEREST</li>


### PR DESCRIPTION
Feature: Enable Short Position Tracking via Negative Quantity
This PR introduces the ability to track short positions within the portfolio by allowing SELL_SHORT transaction quantities to be negative.
https://github.com/afadil/wealthfolio/issues/339

Implementation Details
I've updated the relevant logic to handle negative quantities, treating them as short sales. This allows users to accurately represent short positions in their holdings data.

Testing and Scope
I've performed testing across key areas, and confirmed the following components are functioning correctly with negative quantities:

Performance Chart: Calculations correctly reflect P/L and value changes for short positions.

Data Import: Importing transactions with negative quantities works as expected.

Holdings View: Displays short positions and current values accurately.
Holdings View: Limitation on displaying short position for Country Allocation and Sector Allocation (showing 0%)

Design Discussion: Negative Quantity Direction
I noticed existing guarding code against negative quantities. This implementation uses the negative quantity as the primary signal for a short position. While functional, this might conflict with existing architectural assumptions or planned future features. I am completely open to discussing alternative approaches. Do let me know your thoughts!