### PR TITLE
use nonnegative() for quantity for other type

### DIFF
--- a/src/pages/activity/components/forms/schemas.ts
+++ b/src/pages/activity/components/forms/schemas.ts
@@ -128,7 +128,7 @@ export const otherActivitySchema = baseActivitySchema.extend({
   ]),
   assetId: z.string().min(1, { message: 'Please select a security' }).optional(),
   amount: z.coerce.number().min(0).optional(),
-  quantity: z.coerce.number().positive().optional(),
+  quantity: z.coerce.number().nonnegative().optional(),
   fee: z.coerce
     .number({
       invalid_type_error: 'Fee must be a positive number.',


### PR DESCRIPTION
fixes: #402

Updating an activity that is of type "other" is currently erroring out due to `quantity` having a value of zero. 

<img width="790" height="366" alt="Screenshot 2025-10-22 at 7 12 16 PM" src="https://github.com/user-attachments/assets/15507f33-11fc-45d8-b85a-ff0215fc36c6" />

The "other" activities (split/fee/tax) doesn't  have a "quantity" input field so upon creating a new one, "quantity" is defaulted to zero. On edit, zod fails validation because the `quantity` value is 0 and `positive() requires the value to be strictly greater than zero (greater than 0).`

This PR changes the `quantity` to be `.nonnegative() ensures the value is greater than or equal to zero (0 or more)` so zod doesn't error out on submit

