### PR TITLE
Refactor formatAmount function to improve currency formatting

### DIFF
--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -8,31 +8,51 @@ export function cn(...inputs: ClassValue[]) {
 /**
  * Format amount with currency support, including special handling for pence (GBp/GBX)
  */
-export function formatAmount(amount: number, currency: string, displayCurrency = true) {
-  // Handle pence (GBp) specially
-  if (currency === "GBp" || currency === "GBX") {
-    if (!displayCurrency) {
-      return new Intl.NumberFormat("en-US", {
-        minimumFractionDigits: 2,
-        maximumFractionDigits: 2,
-      }).format(amount);
-    }
+const DECIMAL_FORMAT_OPTIONS: Intl.NumberFormatOptions = {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+};
 
-    // For pence, format as "123.45p" or "1,234.56p"
-    const formattedNumber = new Intl.NumberFormat("en-US", {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    }).format(amount);
+const decimalFormatter = new Intl.NumberFormat("en-US", DECIMAL_FORMAT_OPTIONS);
+const currencyFormatterCache = new Map<string, Intl.NumberFormat>();
 
-    return `${formattedNumber}p`;
+const getCurrencyFormatter = (currency: string) => {
+  const normalizedCurrency = currency?.toUpperCase?.() ?? "USD";
+  const cacheKey = normalizedCurrency;
+
+  if (currencyFormatterCache.has(cacheKey)) {
+    return currencyFormatterCache.get(cacheKey)!;
   }
 
-  return new Intl.NumberFormat("en-US", {
-    style: displayCurrency ? "currency" : undefined,
-    currency: currency,
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(amount);
+  let formatter: Intl.NumberFormat;
+  try {
+    formatter = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: normalizedCurrency,
+      ...DECIMAL_FORMAT_OPTIONS,
+    });
+  } catch {
+    formatter = decimalFormatter;
+  }
+
+  currencyFormatterCache.set(cacheKey, formatter);
+  return formatter;
+};
+
+export function formatAmount(amount: number, currency: string, displayCurrency = true) {
+  const rawCurrency = currency ?? "USD";
+  const isPenceCurrency = rawCurrency === "GBp" || rawCurrency === "GBX";
+
+  if (isPenceCurrency) {
+    const formattedNumber = decimalFormatter.format(amount);
+    return displayCurrency ? `${formattedNumber}p` : formattedNumber;
+  }
+
+  if (!displayCurrency) {
+    return decimalFormatter.format(amount);
+  }
+
+  return getCurrencyFormatter(rawCurrency).format(amount);
 }
 
 /**


### PR DESCRIPTION
This pull request refactors the `formatAmount` utility function in both `packages/ui/src/lib/utils.ts` and `src/lib/utils.ts` for better performance