### PR TITLE
Replace npm with pnpm in dev-server.js

### DIFF
--- a/packages/addon-dev-tools/dev-server.js
+++ b/packages/addon-dev-tools/dev-server.js
@@ -262,7 +262,7 @@ class AddonDevServer {
 
     // Start vite build in watch mode
     const { spawn } = require("child_process");
-    this.viteWatcher = spawn("npm", ["run", "dev"], {
+    this.viteWatcher = spawn("pnpm", ["run", "dev"], {
       cwd: this.config.addonPath,
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -342,7 +342,7 @@ function main() {
     port,
     addonPath: path.resolve(addonPath),
     manifestPath: path.resolve(addonPath, "manifest.json"),
-    buildCommand: "npm run build",
+    buildCommand: "pnpm run build",
     watchPaths: [path.resolve(addonPath, "src"), path.resolve(addonPath, "manifest.json")],
   };
 


### PR DESCRIPTION
Running npm from spawn on Windows seems to be pretty tricky: https://stackoverflow.com/questions/43230346/error-spawn-npm-enoent. In my case even npm.cmd haven't helped - but replacing it with pnpm (which is used everywhere in documentation already) seems to fix the issue.