### PR TITLE
Fix privacy toggle layout shift and improve chart readability

### DIFF
--- a/src/pages/account/account-page.tsx
+++ b/src/pages/account/account-page.tsx
@@ -14,6 +14,7 @@ import {
   PrivacyAmount,
 } from "@wealthfolio/ui";
 import { useMemo, useState } from "react";
+import { usePersistentState } from "@/hooks/use-persistent-state";
 
 import { PrivacyToggle } from "@/components/privacy-toggle";
 import { Button } from "@/components/ui/button";
@@ -58,13 +59,6 @@ import { AccountContributionLimit } from "./account-contribution-limit";
 import AccountHoldings from "./account-holdings";
 import AccountMetrics from "./account-metrics";
 
-interface HistoryChartData {
-  date: string;
-  totalValue: number;
-  netContribution: number;
-  currency: string;
-}
-
 // Map account types to icons for visual distinction
 const accountTypeIcons: Record<AccountType, Icon> = {
   SECURITIES: Icons.Briefcase,
@@ -84,7 +78,10 @@ const INITIAL_INTERVAL_CODE: TimePeriod = "3M";
 const AccountPage = () => {
   const { id = "" } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const [dateRange, setDateRange] = useState<DateRange | undefined>(getInitialDateRange());
+  const [dateRange, setDateRange] = usePersistentState<DateRange | undefined>(
+    "global:dateRange",
+    getInitialDateRange(),
+  );
   const [selectedIntervalCode, setSelectedIntervalCode] =
     useState<TimePeriod>(INITIAL_INTERVAL_CODE);
   const [desktopSelectorOpen, setDesktopSelectorOpen] = useState(false);
@@ -143,7 +140,7 @@ const AccountPage = () => {
       return calculatePerformanceMetrics(valuationHistory, false);
     }, [valuationHistory, id]);
 
-  const chartData: HistoryChartData[] = useMemo(() => {
+  const chartData = useMemo(() => {
     if (!valuationHistory) return [];
     return valuationHistory.map((valuation: AccountValuation) => ({
       date: valuation.valuationDate,

--- a/src/pages/dashboard/dashboard-page.tsx
+++ b/src/pages/dashboard/dashboard-page.tsx
@@ -2,7 +2,9 @@ import { HistoryChart } from "@/components/history-chart";
 import { PrivacyToggle } from "@/components/privacy-toggle";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useHoldings } from "@/hooks/use-holdings";
+import { usePersistentState } from "@/hooks/use-persistent-state";
 import { useValuationHistory } from "@/hooks/use-valuation-history";
+
 import { PORTFOLIO_ACCOUNT_ID } from "@/lib/constants";
 import { useSettingsContext } from "@/lib/settings-provider";
 import { DateRange, TimePeriod } from "@/lib/types";
@@ -39,7 +41,10 @@ const getInitialDateRange = (): DateRange => ({
 const INITIAL_INTERVAL_CODE: TimePeriod = "3M";
 
 export default function DashboardPage() {
-  const [dateRange, setDateRange] = useState<DateRange | undefined>(getInitialDateRange());
+  const [dateRange, setDateRange] = usePersistentState<DateRange | undefined>(
+    "global:dateRange",
+    getInitialDateRange(),
+  );
   const [selectedIntervalDescription, setSelectedIntervalDescription] =
     useState<string>("Last 3 months");
   const [isAllTime, setIsAllTime] = useState<boolean>(false);
@@ -97,16 +102,16 @@ export default function DashboardPage() {
       <div data-ptr-content className="flex min-h-screen flex-col">
         <div className="px-4 pt-22 pb-6 md:px-6 md:pt-10 md:pb-8 lg:px-8 lg:pt-12">
           <PortfolioUpdateTrigger lastCalculatedAt={currentValuation?.calculatedAt}>
-            <div className="flex items-start gap-2">
+            <div className="flex items-start gap-2 pt-3">
+              <PrivacyToggle />
               <div>
-                <div className="flex items-center gap-3">
+                <div className="min-h-[3rem] flex items-center">
                   <Balance
                     isLoading={isHoldingsLoading}
                     targetValue={totalValue}
                     currency={baseCurrency}
                     displayCurrency={true}
                   />
-                  <PrivacyToggle />
                 </div>
                 <div className="text-md flex space-x-3">
                   <GainAmount
@@ -114,13 +119,13 @@ export default function DashboardPage() {
                     value={gainLossAmount}
                     currency={baseCurrency}
                     displayCurrency={false}
-                  ></GainAmount>
+                  />
                   <div className="border-secondary my-1 border-r pr-2" />
                   <GainPercent
                     className="lg:text-md text-sm font-light"
                     value={simpleReturn}
                     animated={true}
-                  ></GainPercent>
+                  />
                   {selectedIntervalDescription && (
                     <span className="lg:text-md text-muted-foreground ml-1 text-sm font-light">
                       {selectedIntervalDescription}
@@ -135,7 +140,10 @@ export default function DashboardPage() {
         <div className="h-[300px]">
           {valuationHistory && chartData.length > 0 ? (
             <>
-              <HistoryChart data={chartData} />
+              <HistoryChart
+                data={chartData}
+                isLoading={isValuationHistoryLoading}
+              />
               <div className="flex w-full justify-center">
                 <IntervalSelector
                   className="pointer-events-auto relative z-20 w-full max-w-screen-sm sm:max-w-screen-md md:max-w-2xl lg:max-w-3xl"

--- a/src/pages/performance/performance-page.tsx
+++ b/src/pages/performance/performance-page.tsx
@@ -218,7 +218,7 @@ export default function PerformancePage() {
     null,
   );
   const [dateRange, setDateRange] = usePersistentState<DateRange | undefined>(
-    "performance:dateRange",
+    "global:dateRange",
     {
       from: subMonths(new Date(), 12),
       to: new Date(),


### PR DESCRIPTION
- Move privacy toggle left of balance to eliminate jump on hide/show
- Add min-height to balance container for stable layout
- Show Y-axis labels inside chart (mirrored) with K/M formatting
- Remove hover cursor line for cleaner interaction
- Improve tooltip hierarchy with bold labels and visual separator
- Export HistoryChartData type for reusability
- Sync date range globally across dashboard, account, and performance pages
