### PR TITLE
Fix ctx.api.activities.getAll with accountId

### DIFF
--- a/src/commands/activity.ts
+++ b/src/commands/activity.ts
@@ -10,8 +10,8 @@ import {
 import { getRunEnv, RUN_ENV, invokeTauri, invokeWeb, logger } from "@/adapters";
 
 interface Filters {
-  accountId?: string;
-  activityType?: string;
+  accountIds?: string[];
+  activityTypes?: string[];
   symbol?: string;
 }
 
@@ -25,7 +25,7 @@ export const getActivities = async (accountId?: string): Promise<ActivityDetails
     const response = await searchActivities(
       0,
       Number.MAX_SAFE_INTEGER,
-      accountId ? { accountId } : {},
+      accountId ? { accountIds: [accountId] } : {},
       "",
       {
         id: "date",
@@ -52,8 +52,8 @@ export const searchActivities = async (
         return invokeTauri("search_activities", {
           page,
           pageSize,
-          accountIdFilter: filters?.accountId,
-          activityTypeFilter: filters?.activityType,
+          accountIdFilter: filters?.accountIds,
+          activityTypeFilter: filters?.activityTypes,
           assetIdKeyword: searchKeyword,
           sort,
         });
@@ -61,8 +61,8 @@ export const searchActivities = async (
         return invokeWeb("search_activities", {
           page,
           pageSize,
-          accountIdFilter: filters?.accountId,
-          activityTypeFilter: filters?.activityType,
+          accountIdFilter: filters?.accountIds,
+          activityTypeFilter: filters?.activityTypes,
           assetIdKeyword: searchKeyword,
           sort,
         });

--- a/src/pages/activity/hooks/use-activity-search.ts
+++ b/src/pages/activity/hooks/use-activity-search.ts
@@ -40,14 +40,14 @@ export function useActivitySearch({
 }: UseActivitySearchOptions): UseActivitySearchResult {
   const normalizedFilters = useMemo(() => {
     return {
-      accountId: filters.accountIds.length > 0 ? filters.accountIds : undefined,
-      activityType: filters.activityTypes.length > 0 ? filters.activityTypes : undefined,
-    } as Record<string, unknown>;
+      accountIds: filters.accountIds.length > 0 ? filters.accountIds : undefined,
+      activityTypes: filters.activityTypes.length > 0 ? filters.activityTypes : undefined
+    };
   }, [filters.accountIds, filters.activityTypes]);
 
   const primarySort =
     sorting.length > 0 && sorting[0]?.id
-      ? ({ id: sorting[0]!.id, desc: sorting[0]!.desc ?? false } as {
+      ? ({ id: sorting[0].id, desc: sorting[0].desc ?? false } as {
           id: string;
           desc: boolean;
         })


### PR DESCRIPTION
Fixes #446

Issue was hidden due to type removal in `use-activity-search.ts`. I've also updated the names in struct to represent that they contain arrays now.

I wonder if maybe this argument should be required alltogether and empty array will mean the same as undefined now.