### PR TITLE
Enhance account summary to display total value in account currency

### DIFF
--- a/src/pages/dashboard/accounts-summary.tsx
+++ b/src/pages/dashboard/accounts-summary.tsx
@@ -92,7 +92,7 @@ const AccountSummaryComponent = React.memo(
         ? `${item.accountCurrency} • ${item.accountCount} ${item.accountCount === 1 ? "account" : "accounts"}`
         : `${item.accountCount} ${item.accountCount === 1 ? "account" : "accounts"}`
       : useAccountCurrency
-        ? item.accountCurrency
+        ? (item.accountCurrency ?? item.baseCurrency)
         : item.baseCurrency;
 
     const totalValue = useAccountCurrency


### PR DESCRIPTION
This pull request enhances the account summary display logic to more accurately represent account groups in their respective currencies when possible, improving clarity for users. The main changes focus on determining when a group of accounts should be displayed in a single account currency and updating the summary and calculation logic accordingly.

**Account group currency display improvements:**

* Added the `displayInAccountCurrency` property to the `AccountSummaryDisplayData` interface to indicate when a group or account should be displayed in its account currency.
* Implemented logic to detect if all accounts in a group share the same account currency, and set `displayInAccountCurrency` and the display currency appropriately for the group summary.

**Calculation and summary logic updates:**

* Updated the calculation of total value, gain/loss, and net contribution for account groups to use account currency when applicable, and adjusted the computation of return percentages accordingly.
* Modified the rendering of account and group summaries to use the correct currency and display text, reflecting whether account currency or base currency is used. [[1]](diffhunk://#diff-7caa52a5c10a9ff527209673b43095faccbba36e7eaa5cecfd18a54e348a3537L66-R68) [[2]](diffhunk://#diff-7caa52a5c10a9ff527209673b43095faccbba36e7eaa5cecfd18a54e348a3537L88-L91)

**Component usage updates:**

* Updated component props to pass `displayInAccountCurrency` to account summary components, ensuring consistent currency display across individual and grouped accounts. [[1]](diffhunk://#diff-7caa52a5c10a9ff527209673b43095faccbba36e7eaa5cecfd18a54e348a3537L418-R463) [[2]](diffhunk://#diff-7caa52a5c10a9ff527209673b43095faccbba36e7eaa5cecfd18a54e348a3537L433-R478)