### PR TITLE
Add a risk attribute to assets

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,7 +37,7 @@
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[json]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "vscode.json-language-features"
   },
   "[jsonc]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/src-core/migrations/2025-12-03-000000_add_risk_to_assets/down.sql
+++ b/src-core/migrations/2025-12-03-000000_add_risk_to_assets/down.sql
@@ -1,0 +1,2 @@
+-- Remove risk column from assets table
+ALTER TABLE assets DROP COLUMN risk;

--- a/src-core/migrations/2025-12-03-000000_add_risk_to_assets/up.sql
+++ b/src-core/migrations/2025-12-03-000000_add_risk_to_assets/up.sql
@@ -1,0 +1,2 @@
+-- Add risk column to assets table
+ALTER TABLE assets ADD COLUMN risk TEXT;

--- a/src-core/src/assets/assets_model.rs
+++ b/src-core/src/assets/assets_model.rs
@@ -32,6 +32,7 @@ pub struct Asset {
     pub data_source: String,
     pub sectors: Option<String>,
     pub url: Option<String>,
+    pub risk: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -84,6 +85,7 @@ pub struct NewAsset {
     pub data_source: String,
     pub sectors: Option<String>,
     pub url: Option<String>,
+    pub risk: Option<String>,
 }
 
 impl NewAsset {
@@ -161,6 +163,7 @@ impl From<crate::market_data::providers::models::AssetProfile> for NewAsset {
             data_source: profile.data_source,
             sectors: profile.sectors,
             url: profile.url,
+            risk: None,
         }
     }
 }
@@ -176,6 +179,7 @@ pub struct UpdateAssetProfile {
     pub notes: String,
     pub asset_sub_class: Option<String>,
     pub asset_class: Option<String>,
+    pub risk: Option<String>,
 }
 
 impl UpdateAssetProfile {
@@ -226,6 +230,7 @@ pub struct AssetDB {
     pub data_source: String,
     pub sectors: Option<String>,
     pub url: Option<String>,
+    pub risk: Option<String>,
 }
 
 // Conversion implementations
@@ -251,6 +256,7 @@ impl From<AssetDB> for Asset {
             data_source: db.data_source,
             sectors: db.sectors,
             url: db.url,
+            risk: db.risk,
         }
     }
 }
@@ -278,6 +284,7 @@ impl From<NewAsset> for AssetDB {
             data_source: domain.data_source,
             sectors: domain.sectors,
             url: domain.url,
+            risk: domain.risk,
         }
     }
 }

--- a/src-core/src/assets/assets_repository.rs
+++ b/src-core/src/assets/assets_repository.rs
@@ -108,6 +108,7 @@ impl AssetRepositoryTrait for AssetRepository {
                         assets::notes.eq(&payload_owned.notes),
                         assets::asset_sub_class.eq(&payload_owned.asset_sub_class),
                         assets::asset_class.eq(&payload_owned.asset_class),
+                        assets::risk.eq(&payload_owned.risk),
                     ))
                     .get_result::<AssetDB>(conn)?;
                 Ok(result_db.into())

--- a/src-core/src/portfolio/holdings/holdings_model.rs
+++ b/src-core/src/portfolio/holdings/holdings_model.rs
@@ -45,6 +45,7 @@ pub struct Instrument {
     // Display categorization
     pub countries: Option<Vec<Country>>,
     pub sectors: Option<Vec<Sector>>,
+    pub risk: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/src-core/src/portfolio/holdings/holdings_service.rs
+++ b/src-core/src/portfolio/holdings/holdings_service.rs
@@ -197,6 +197,7 @@ impl HoldingsServiceTrait for HoldingsService {
                                     })
                                     .collect()
                             }),
+                            risk: asset.risk,
                         };
                         (asset.id, instrument)
                     })
@@ -461,6 +462,7 @@ impl HoldingsServiceTrait for HoldingsService {
                     })
                     .collect()
             }),
+            risk: asset_details.risk,
         };
 
         let holding_view = Holding {

--- a/src-core/src/schema.rs
+++ b/src-core/src/schema.rs
@@ -74,6 +74,7 @@ diesel::table! {
         data_source -> Text,
         sectors -> Nullable<Text>,
         url -> Nullable<Text>,
+        risk -> Nullable<Text>,
     }
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -3,13 +3,13 @@ import * as z from "zod";
 import { AccountType, ActivityType, DataSource, HoldingType } from "./constants";
 
 export {
-  AccountType,
-  ActivityType,
-  DataSource,
-  ExportDataType,
-  ExportedFileFormat,
-  HoldingType,
-  ImportFormat,
+    AccountType,
+    ActivityType,
+    DataSource,
+    ExportDataType,
+    ExportedFileFormat,
+    HoldingType,
+    ImportFormat
 } from "./constants";
 
 export type { ImportRequiredField } from "./constants";
@@ -226,6 +226,7 @@ export interface Instrument {
   assetSubclass?: string | null;
   countries?: Country[] | null;
   sectors?: Sector[] | null;
+  risk?: string | null;
 }
 
 export interface MonetaryValue {
@@ -310,6 +311,7 @@ export interface Asset {
   dataSource: string;
   sectors?: string | null;
   url?: string | null;
+  risk?: string | null;
 }
 
 export interface Quote {
@@ -522,6 +524,7 @@ export interface UpdateAssetProfile {
   notes: string;
   assetClass: string;
   assetSubClass: string;
+  risk?: string;
 }
 
 // Rename ComparisonItem to TrackedItem

--- a/src/pages/asset/asset-profile-page.tsx
+++ b/src/pages/asset/asset-profile-page.tsx
@@ -35,6 +35,7 @@ interface AssetProfileFormData {
   assetSubClass: string;
   notes: string;
   dataSource: DataSource;
+  risk: string;
 }
 
 interface AssetDetailData {
@@ -81,6 +82,7 @@ export const AssetProfilePage = () => {
     assetSubClass: "",
     notes: "",
     dataSource: DataSource.MANUAL,
+    risk: "",
   });
 
   const {
@@ -157,6 +159,7 @@ export const AssetProfilePage = () => {
       assetClass: instrument?.assetClass ?? asset?.assetClass ?? "",
       notes: instrument?.notes ?? asset?.notes ?? "",
       dataSource: (instrument?.dataSource ?? asset?.dataSource ?? DataSource.YAHOO) as DataSource,
+      risk: instrument?.risk ?? asset?.risk ?? "",
     });
   }, [holding, assetProfile]);
 
@@ -251,6 +254,7 @@ export const AssetProfilePage = () => {
       notes: formData.notes,
       assetSubClass: formData.assetSubClass,
       assetClass: formData.assetClass,
+      risk: formData.risk || undefined,
     });
     setIsEditing(false);
   }, [profile, symbol, formData, updateAssetProfileMutation]);
@@ -265,6 +269,7 @@ export const AssetProfilePage = () => {
       notes: formData.notes,
       assetSubClass: formData.assetSubClass,
       assetClass: formData.assetClass,
+      risk: formData.risk || undefined,
     });
   }, [profile, symbol, formData, updateAssetProfileMutation]);
 
@@ -306,6 +311,7 @@ export const AssetProfilePage = () => {
       assetClass: instrument?.assetClass ?? asset?.assetClass ?? "",
       notes: instrument?.notes ?? asset?.notes ?? "",
       dataSource: (instrument?.dataSource ?? asset?.dataSource ?? DataSource.YAHOO) as DataSource,
+      risk: instrument?.risk ?? asset?.risk ?? "",
     });
   }, [holding, assetProfile]);
 
@@ -397,7 +403,34 @@ export const AssetProfilePage = () => {
                     </Badge>
                   )
                 )}
-                {(formData.assetClass || formData.assetSubClass) && formData.sectors.length > 0 && (
+                {isEditing ? (
+                  <Input
+                    value={formData.risk}
+                    onChange={(e) =>
+                      setFormData((prev) => ({ ...prev, risk: e.target.value }))
+                    }
+                    placeholder="Risk (Low/Medium/High)"
+                    className="w-[180px]"
+                  />
+                ) : (
+                  formData.risk && (
+                    <Badge
+                      variant="secondary"
+                      className={`flex-none uppercase ${
+                        formData.risk.toLowerCase() === "low"
+                          ? "bg-success text-success-foreground"
+                          : formData.risk.toLowerCase() === "medium"
+                            ? "bg-warning text-warning-foreground"
+                            : formData.risk.toLowerCase() === "high"
+                              ? "bg-destructive text-destructive-foreground"
+                              : ""
+                      }`}
+                    >
+                      {formData.risk}
+                    </Badge>
+                  )
+                )}
+                {(formData.assetClass || formData.assetSubClass || formData.risk) && formData.sectors.length > 0 && (
                   <Separator orientation="vertical" />
                 )}
                 {isEditing ? (
@@ -874,7 +907,34 @@ export const AssetProfilePage = () => {
                         </Badge>
                       )
                     )}
-                    {(formData.assetClass || formData.assetSubClass) &&
+                    {isEditing ? (
+                      <Input
+                        value={formData.risk}
+                        onChange={(e) =>
+                          setFormData((prev) => ({ ...prev, risk: e.target.value }))
+                        }
+                        placeholder="Risk (Low/Medium/High)"
+                        className="w-[180px]"
+                      />
+                    ) : (
+                      formData.risk && (
+                        <Badge
+                          variant="secondary"
+                          className={`flex-none uppercase ${
+                            formData.risk.toLowerCase() === "low"
+                              ? "bg-success text-success-foreground"
+                              : formData.risk.toLowerCase() === "medium"
+                                ? "bg-warning text-warning-foreground"
+                                : formData.risk.toLowerCase() === "high"
+                                  ? "bg-destructive text-destructive-foreground"
+                                  : ""
+                          }`}
+                        >
+                          {formData.risk}
+                        </Badge>
+                      )
+                    )}
+                    {(formData.assetClass || formData.assetSubClass || formData.risk) &&
                       formData.sectors.length > 0 && <Separator orientation="vertical" />}
                     {isEditing ? (
                       <InputTags

--- a/src/pages/performance/components/risk-categories-card.tsx
+++ b/src/pages/performance/components/risk-categories-card.tsx
@@ -1,0 +1,152 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EmptyPlaceholder } from "@/components/ui/empty-placeholder";
+import { Icons } from "@/components/ui/icons";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Holding } from "@/lib/types";
+import { Badge, formatPercent, PrivacyAmount } from "@wealthfolio/ui";
+import { useMemo } from "react";
+
+interface RiskData {
+  name: string;
+  value: number;
+  count: number;
+}
+
+function getRiskData(holdings: Holding[]): { data: RiskData[]; currency: string } {
+  if (!holdings || holdings.length === 0) return { data: [], currency: "USD" };
+
+  const baseCurrency = holdings[0]?.baseCurrency || "USD";
+
+  const riskMap = holdings.reduce(
+    (acc, holding) => {
+      const risk = holding.instrument?.risk || "Unknown";
+      const marketValue = Number(holding.marketValue?.base) || 0;
+
+      if (!acc[risk]) {
+        acc[risk] = { value: 0, count: 0 };
+      }
+
+      acc[risk].value += marketValue;
+      acc[risk].count += 1;
+
+      return acc;
+    },
+    {} as Record<string, { value: number; count: number }>,
+  );
+
+  const data = Object.entries(riskMap)
+    .map(([name, data]) => ({ name, value: data.value, count: data.count }))
+    .sort((a, b) => b.value - a.value);
+
+  return { data, currency: baseCurrency };
+}
+
+interface RiskCategoriesCardProps {
+  holdings: Holding[];
+  isLoading?: boolean;
+}
+
+const riskColors: Record<string, string> = {
+  Low: "bg-success text-success-foreground",
+  Medium: "bg-warning text-warning-foreground",
+  High: "bg-destructive text-destructive-foreground",
+  Unknown: "bg-muted text-muted-foreground",
+};
+
+export function RiskCategoriesCard({ holdings, isLoading }: RiskCategoriesCardProps) {
+  const { data: riskData, currency } = useMemo(() => getRiskData(holdings), [holdings]);
+  const total = riskData.reduce((sum, r) => sum + r.value, 0);
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-muted-foreground text-sm font-medium tracking-wider uppercase">
+            Risk Categories
+          </CardTitle>
+        </div>
+      </CardHeader>
+      <CardContent className="relative w-full">
+        <TooltipProvider>
+          {isLoading ? (
+            <div className="space-y-2">
+              {[...Array(3)].map((_, i) => (
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
+            </div>
+          ) : riskData.length > 0 ? (
+            <div className="space-y-3">
+              {riskData.map((risk) => {
+                const percentage = total > 0 ? (risk.value / total) * 100 : 0;
+                return (
+                  <div key={risk.name} className="space-y-1.5">
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center gap-2">
+                        <Badge
+                          variant="secondary"
+                          className={riskColors[risk.name] || riskColors.Unknown}
+                        >
+                          {risk.name}
+                        </Badge>
+                        <span className="text-muted-foreground text-xs">
+                          ({risk.count} asset{risk.count !== 1 ? "s" : ""})
+                        </span>
+                      </div>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <div className="flex items-center gap-2">
+                            <PrivacyAmount
+                              value={risk.value}
+                              currency={currency}
+                              className="text-sm font-medium"
+                            />
+                            <span className="text-muted-foreground text-xs">
+                              ({formatPercent(percentage / 100)})
+                            </span>
+                          </div>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <div className="space-y-1">
+                            <div className="text-xs">
+                              <span className="font-medium">{risk.name} Risk:</span>{" "}
+                              <PrivacyAmount value={risk.value} currency={currency} />
+                            </div>
+                            <div className="text-xs text-muted-foreground">
+                              {formatPercent(percentage / 100)} of total portfolio
+                            </div>
+                          </div>
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                    <div className="bg-secondary h-2 w-full overflow-hidden rounded-full">
+                      <div
+                        className={`h-full rounded-full transition-all ${
+                          risk.name === "Low"
+                            ? "bg-success"
+                            : risk.name === "Medium"
+                              ? "bg-warning"
+                              : risk.name === "High"
+                                ? "bg-destructive"
+                                : "bg-muted-foreground"
+                        }`}
+                        style={{ width: `${percentage}%` }}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <EmptyPlaceholder
+              icon={<Icons.TrendingUp className="text-muted-foreground h-8 w-8" />}
+              title="No risk data"
+              description="Risk information will appear here when assets have risk classifications."
+              className="py-8"
+            />
+          )}
+        </TooltipProvider>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/performance/performance-page.tsx
+++ b/src/pages/performance/performance-page.tsx
@@ -11,6 +11,7 @@ import { PerformanceChartMobile } from "@/components/performance-chart-mobile";
 
 import { PERFORMANCE_CHART_COLORS } from "@/components/performance-chart-colors";
 import { EmptyPlaceholder } from "@/components/ui/empty-placeholder";
+import { useHoldings } from "@/hooks/use-holdings";
 import { usePersistentState } from "@/hooks/use-persistent-state";
 import { useIsMobileViewport } from "@/hooks/use-platform";
 import { PORTFOLIO_ACCOUNT_ID } from "@/lib/constants";
@@ -43,6 +44,7 @@ import { useMemo, useState } from "react";
 import { AccountSelector } from "../../components/account-selector";
 import { AccountSelectorMobile } from "../../components/account-selector-mobile";
 import { BenchmarkSymbolSelectorMobile } from "../../components/benchmark-symbol-selector-mobile";
+import { RiskCategoriesCard } from "./components/risk-categories-card";
 import { useCalculatePerformanceHistory } from "./hooks/use-performance-data";
 
 const PORTFOLIO_TOTAL: TrackedItem = {
@@ -249,6 +251,9 @@ export default function PerformancePage() {
     selectedItems,
     dateRange,
   });
+
+  // Fetch holdings for risk categories display
+  const { holdings, isLoading: isLoadingHoldings } = useHoldings(PORTFOLIO_ACCOUNT_ID);
 
   // Calculate derived chart data
   const chartData = useMemo(() => {
@@ -478,21 +483,22 @@ export default function PerformancePage() {
           className="hidden"
         />
 
-        <div className="flex h-[calc(100vh-19rem)] flex-col md:h-[calc(100vh-12rem)]">
-          <Card className="flex min-h-0 flex-1 flex-col">
-            <CardHeader className={cn("pb-2", isMobile ? "px-3 py-3" : "pb-1")}>
-              <div className={cn("space-y-3", isMobile ? "space-y-2" : "sm:space-y-4")}>
-                <div className="flex flex-col space-y-3 sm:flex-row sm:items-center sm:justify-between sm:space-y-0">
-                  <div>
-                    <CardTitle className={cn("text-lg sm:text-xl", isMobile && "text-sm")}>
-                      Performance
-                    </CardTitle>
-                    <CardDescription
-                      className={cn("text-xs sm:text-sm", isMobile && "text-[10px]")}
-                    >
-                      {displayDateRange}
-                    </CardDescription>
-                  </div>
+        <div className="flex flex-col gap-4">
+          <div className="flex h-[calc(100vh-23rem)] flex-col md:h-[calc(100vh-16rem)]">
+            <Card className="flex min-h-0 flex-1 flex-col">
+              <CardHeader className={cn("pb-2", isMobile ? "px-3 py-3" : "pb-1")}>
+                <div className={cn("space-y-3", isMobile ? "space-y-2" : "sm:space-y-4")}>
+                  <div className="flex flex-col space-y-3 sm:flex-row sm:items-center sm:justify-between sm:space-y-0">
+                    <div>
+                      <CardTitle className={cn("text-lg sm:text-xl", isMobile && "text-sm")}>
+                        Performance
+                      </CardTitle>
+                      <CardDescription
+                        className={cn("text-xs sm:text-sm", isMobile && "text-[10px]")}
+                      >
+                        {displayDateRange}
+                      </CardDescription>
+                    </div>
                   {performanceData && performanceData.length > 0 && (
                     <>
                       {/* Mobile compact metrics - horizontal scroll */}
@@ -679,6 +685,10 @@ export default function PerformancePage() {
             </CardContent>
           </Card>
         </div>
+
+        {/* Risk Categories Section */}
+        <RiskCategoriesCard holdings={holdings} isLoading={isLoadingHoldings} />
+      </div>
       </div>
     </>
   );


### PR DESCRIPTION
This PR introduces a risk classification system for portfolio assets, enabling users to categorize holdings based on risk.
The implementation spans the full stack with database schema updates, backend models, and frontend UI components, including a new Risk Categories visualization on the Performance page.

Are you interested in including this feature in the Wealthfolio?
If you have feedback can make adjustments, let me know.

### Backend
- Migration: Added `risk` column to `assets` table (nullable TEXT)
- Models: Extended `Asset`, `NewAsset`, `UpdateAssetProfile`, `AssetDB`, and `Instrument` with optional `risk` field
- Repository: Updated asset repository to persist risk values during profile updates
- Service: Modified holdings service to propagate risk data from assets to instruments

### Frontend
- **Asset Profile Page**: Added editable risk field with color-coded badges
  - Edit mode: text input accepting risk classification
  - View mode: color-coded badges (Low, Medium, High)
- **Risk Categories Card**: New component on Performance page showing:
  - Portfolio risk distribution with visual progress bars
  - Asset counts per risk category
  - Market values and percentages
  - Interactive tooltips with detailed breakdowns
  - Empty state for portfolios without risk data

### Testing
1. **Edit Asset Risk:**
   - Navigate to any asset (Holdings → click asset)
   - Click "Edit" and enter a risk value (e.g., "Low", "Medium", "High")
   - Save and verify color-coded badge appears

2. **View Risk Distribution:**
   - Go to Performance page
   - Scroll to "Risk Categories" card
   - Verify visualization shows correct data, percentages, and colors
   - Hover over values to see detailed tooltips

### Notes
- No breaking change, the `risk` field is optional throughout the stack, maintaining full backward compatibility
- Risk field accepts free-form text; UI suggests "Low/Medium/High" but doesn't enforce strict validation
- Color scheme uses existing theme tokens (`success`, `warning`, `destructive`)
- Design patterns follow existing Performance page components
- Migration includes both `up.sql` and `down.sql` for easy rollback
- Not included in export functionality
- No filtering by risk category in Holdings view

### Screenshots
Performance
<img width="957" height="1036" alt="image" src="https://github.com/user-attachments/assets/7bda4dcd-cbc5-4af4-9f56-73ff99341924" />
Assert view
<img width="744" height="159" alt="image" src="https://github.com/user-attachments/assets/8c164536-741d-440c-92eb-b8acaad945ff" />
Asset edit
<img width="1024" height="253" alt="image" src="https://github.com/user-attachments/assets/6a608847-2968-447f-98b7-54e97a07f484" />

