### PR TITLE
Allow INTEREST activities to preserve custom symbols

### DIFF
--- a/src/pages/activity/activity-manager-page.tsx
+++ b/src/pages/activity/activity-manager-page.tsx
@@ -159,7 +159,7 @@ const ActivityManagerPage = () => {
 
       // For cash activities and fees, set assetId to $CASH-accountCurrency
       if (
-        ["DEPOSIT", "WITHDRAWAL", "INTEREST", "FEE", "TAX", "TRANSFER_IN", "TRANSFER_OUT"].includes(
+        ["DEPOSIT", "WITHDRAWAL", "FEE", "TAX", "TRANSFER_IN", "TRANSFER_OUT"].includes(
           submitData.activityType,
         )
       ) {

--- a/src/pages/activity/components/activity-form.tsx
+++ b/src/pages/activity/components/activity-form.tsx
@@ -120,7 +120,7 @@ export function ActivityForm({ accounts, activity, open, onClose }: ActivityForm
       const account = accounts.find((a) => a.value === submitData.accountId);
       // For cash activities and fees, set assetId to $CASH-accountCurrency
       if (
-        ["DEPOSIT", "WITHDRAWAL", "INTEREST", "FEE", "TAX", "TRANSFER_IN", "TRANSFER_OUT"].includes(
+        ["DEPOSIT", "WITHDRAWAL", "FEE", "TAX", "TRANSFER_IN", "TRANSFER_OUT"].includes(
           submitData.activityType,
         )
       ) {

--- a/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
+++ b/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
@@ -97,7 +97,7 @@ export function MobileActivityForm({ accounts, activity, open, onClose }: Mobile
 
       // For cash activities and fees, set assetId to $CASH-accountCurrency
       if (
-        ["DEPOSIT", "WITHDRAWAL", "INTEREST", "FEE", "TAX", "TRANSFER_IN", "TRANSFER_OUT"].includes(
+        ["DEPOSIT", "WITHDRAWAL", "FEE", "TAX", "TRANSFER_IN", "TRANSFER_OUT"].includes(
           submitData.activityType,
         )
       ) {

--- a/src/pages/activity/import/utils/validation-utils.ts
+++ b/src/pages/activity/import/utils/validation-utils.ts
@@ -174,9 +174,10 @@ const activityLogicMap: Partial<Record<ActivityType, ActivityLogicConfig>> = {
         : Math.abs(calculateCashActivityAmount(activity.quantity, activity.unitPrice)),
     calculateFee: (activity) => (activity.fee ? Math.abs(activity.fee) : 0),
   },
+
   [ActivityType.INTEREST]: {
     calculateSymbol: (activity, accountCurrency) =>
-      `$CASH-${(activity.currency || accountCurrency).toUpperCase()}`,
+      activity.symbol || `$CASH-${(activity.currency || accountCurrency).toUpperCase()}`,
     calculateAmount: (activity) =>
       activity.amount
         ? Math.abs(activity.amount)


### PR DESCRIPTION
- Remove INTEREST from $CASH symbol forcing in activity forms
- Update CSV import validation to support custom symbols for INTEREST
- Maintain backward compatibility: empty symbols still default to $CASH
- Enables tracking bond coupon payments with specific bond symbols