### PR TITLE
Detect enoding while loading CSV file

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@tauri-apps/plugin-updater": "~2.9.0",
     "@tauri-apps/plugin-window-state": "~2.4.1",
     "@wealthfolio/ui": "workspace:*",
+    "chardet": "^2.1.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@wealthfolio/ui':
         specifier: workspace:*
         version: link:packages/ui
+      chardet:
+        specifier: ^2.1.1
+        version: 2.1.1
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -3288,6 +3291,9 @@ packages:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
+  chardet@2.1.1:
+    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
@@ -5897,6 +5903,7 @@ packages:
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
@@ -9210,6 +9217,8 @@ snapshots:
       supports-color: 7.2.0
 
   chalk@5.6.2: {}
+
+  chardet@2.1.1: {}
 
   check-error@2.1.1: {}
 

--- a/src/pages/activity/import/hooks/use-csv-parser.ts
+++ b/src/pages/activity/import/hooks/use-csv-parser.ts
@@ -218,6 +218,25 @@ export function useCsvParser() {
         },
       });
       };
+
+      reader.onerror = () => {
+        const errorMessage = 'Failed to read file for encoding detection';
+        logger.error(errorMessage, { file: file.name });
+
+        const fileReadError: CsvRowError = {
+          type: "FieldMismatch",
+          code: "UndetectableDelimiter",
+          message: errorMessage,
+          row: 0,
+        };
+
+        setState((prev) => ({
+          ...prev,
+          isParsing: false,
+          errors: [fileReadError],
+        }));
+      };
+
       reader.readAsArrayBuffer(file);
     },
     [resetParserStates], // Keep resetParserStates dependency

--- a/src/pages/activity/import/hooks/use-csv-parser.ts
+++ b/src/pages/activity/import/hooks/use-csv-parser.ts
@@ -229,7 +229,7 @@ export function useCsvParser() {
 
         const fileReadError: CsvRowError = {
           type: "FieldMismatch",
-          code: "TooFewFields",
+          code: "FileReadError",
           message: errorMessage,
           row: 0,
         };


### PR DESCRIPTION
Some brokers provide CSV files in non-UTF-8 encodings. This MR adds automatic encoding detection to handle such files correctly. 


Before:
<img width="1316" height="115" alt="before" src="https://github.com/user-attachments/assets/a8bae4b2-83b7-43fa-8f5a-3bc5104b7938" />


After:
<img width="1316" height="115" alt="after" src="https://github.com/user-attachments/assets/945466fe-7b04-4fe4-ab98-de99bcb93cdf" />


```sh
[2026-01-05][09:49:19][webview][DEBUG] Detected CSV file encoding: Shift_JIS
```

The screenshots above are based on a CSV provided by Rakuten Securities.
