### PR TITLE
Replace "primary" with "addons" for addon dynamic items

### DIFF
--- a/src/pages/layouts/navigation/app-navigation.tsx
+++ b/src/pages/layouts/navigation/app-navigation.tsx
@@ -51,7 +51,7 @@ const staticNavigation: NavigationProps = {
 };
 
 export function useNavigation() {
-  const [dynamicItems, setDynamicItems] = useState<NavigationProps["primary"]>([]);
+  const [dynamicItems, setDynamicItems] = useState<NavigationProps["addons"]>([]);
 
   // Subscribe to navigation updates from addons
   useEffect(() => {


### PR DESCRIPTION
They are of course the same interfaces, but logically these "dynamic items" refer to addons