### PR TITLE
Add new belarusian ruble currency

### DIFF
--- a/packages/ui/src/lib/currencies.ts
+++ b/packages/ui/src/lib/currencies.ts
@@ -37,6 +37,7 @@ export const worldCurrencies = [
   { label: "Bangladeshi taka (BDT)", value: "BDT" },
   { label: "Barbadian dollar (BBD)", value: "BBD" },
   { label: "Belarusian ruble (BYR)", value: "BYR" },
+  { label: "Belarusian ruble (BYN)", value: "BYN" },
   { label: "Belize dollar (BZD)", value: "BZD" },
   { label: "Bermudian dollar (BMD)", value: "BMD" },
   { label: "Bhutanese ngultrum (BTN)", value: "BTN" },


### PR DESCRIPTION
This adds a BYN - currency code for Belarusian Ruble which is commonly used now instead of legacy BYR.