### PR TITLE
fix(yahoo): treat boundary startDate errors as no-data range

### DIFF
--- a/crates/market-data/src/provider/yahoo/mod.rs
+++ b/crates/market-data/src/provider/yahoo/mod.rs
@@ -114,6 +114,13 @@ impl YahooProvider {
     fn convert_yahoo_error(&self, e: yahoo::YahooError, symbol: &str) -> MarketDataError {
         let error_msg = e.to_string();
 
+        // Detect no-data boundary from Yahoo API error message
+        if error_msg.contains("Data doesn't exist for startDate")
+            || error_msg.contains("No data found, symbol may be delisted")
+        {
+            return MarketDataError::NoDataForRange;
+        }
+
         // Detect rate limiting from error message
         if error_msg.contains("Too many requests")
             || error_msg.contains("rate limit")
@@ -1184,4 +1191,19 @@ mod tests {
         assert_eq!(results[0].name, "BARC.L");
         assert_eq!(results[0].currency, None);
     }
+
+    #[test]
+    fn test_no_data_range_error_message_detection() {
+        let provider = YahooProvider {
+            connector: yahoo::YahooConnector::new().expect("Failed to initialize Yahoo connector"),
+        };
+        let err = yahoo::YahooError::FetchFailed(
+            "yahoo! finance returned api error: YErrorMessage { code: Some(\"Bad Request\") description: Some(\"Data doesn't exist for startDate = 1747094400 endDate = 1750118399\") }"
+                .to_string(),
+        );
+
+        let mapped = provider.convert_yahoo_error(err, "TEST");
+        assert!(matches!(mapped, MarketDataError::NoDataForRange));
+    }
+
 }


### PR DESCRIPTION
## Description

Fixes #586

### Summary
This PR hardens Yahoo error conversion for historical quote fetches by treating Yahoo’s date-boundary API error as a no-data-range condition instead of a generic provider failure.

When Yahoo returns an API error like:

`Data doesn't exist for startDate = ... endDate = ...`

we now map it to `MarketDataError::NoDataForRange`.

### Why
Issue #586 describes backfill windows that can precede an asset’s inception date. In that case, Yahoo correctly reports no data before inception. This should be interpreted as a backfill boundary/no-data scenario, not a hard provider failure.

### Changes
- Updated Yahoo error mapping in:
  - `/crates/market-data/src/provider/yahoo/mod.rs`
- Added message-based detection in `convert_yahoo_error`:
  - `"Data doesn't exist for startDate"`
  - `"No data found, symbol may be delisted"`
  -> maps to `MarketDataError::NoDataForRange`


## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).
