### PR TITLE
ci(rust): align test feature flags with clippy to enable artifact reuse

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -85,7 +85,7 @@ jobs:
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
       - name: Test
-        run: cargo test --workspace
+        run: cargo test --workspace --all-features
         env:
           # Required for outbox tests in storage-sqlite
           CONNECT_API_URL: http://test.local


### PR DESCRIPTION
Add --all-features flag to the Test step of the rust pr-check. This should trigger asset resuse between the clippy step and the test step.

Resolves #643 
