### PR TITLE
fix(docs): update Argon2 password hash generation instructions for cl…

### DIFF
--- a/.env.web.example
+++ b/.env.web.example
@@ -52,7 +52,9 @@ WF_SECRET_KEY=
 # Windows PS:   $env:WF_SECRET_KEY=$(openssl rand -base64 32)
 
 # Authentication for web mode (required to enable login)
-# Provide an Argon2id PHC string (see README for generation instructions)
+# Provide an Argon2id PHC string. Generate with argon2.online or:
+#   printf 'your-password' | argon2 yoursalt16chars! -id -e
+# For Docker Compose, double every $ in the hash ($$argon2id$$...)
 WF_AUTH_PASSWORD_HASH=
 
 # Optional JWT access token lifetime in minutes (default: 60)

--- a/README.md
+++ b/README.md
@@ -262,11 +262,18 @@ All configuration is done via environment variables in `.env.web`.
   before accessing the Web App.
 
   You can generate the hash with online tools like
-  [argon2.online](argon2.online) or the following command:
+  [argon2.online](https://argon2.online) or the CLI (`argon2-utils` package):
 
   ```bash
-  argon2 "your-password" -id -e
+  printf 'your-password' | argon2 yoursalt16chars! -id -e
   ```
+
+  > **Tips:**
+  >
+  > - The first argument is the **salt** (use 16+ characters); the password is
+  >   read from stdin.
+  > - Use `printf` instead of `echo -n` to avoid hidden newline issues.
+  > - For Docker Compose, double every `$` in the hash (`$$argon2id$$...`).
 
   Copy the full output (starting with `$argon2id$...`) into `.env.web`.
 

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -24,10 +24,13 @@ Key environment variables
   - 32-byte ASCII string: Must be exactly 32 characters (less secure if contains only printable characters)
   Example: `WF_SECRET_KEY=$(openssl rand -base64 32)`.
 - `WF_AUTH_PASSWORD_HASH`: Enables password-only authentication for web mode when set to an Argon2id PHC string.
-  Generate via online tools like [argon2.online](https://argon2.online/) or the following command:
+  Generate via online tools like [argon2.online](https://argon2.online/) or the CLI (`argon2-utils` package):
   ```bash
-  argon2 "your-password" -id -e
+  printf 'your-password' | argon2 yoursalt16chars! -id -e
   ```
+  The first argument is the **salt** (use 16+ characters); the password is read from stdin.
+  Use `printf` instead of `echo -n` to avoid hidden newline issues.
+  For Docker Compose, double every `$` in the hash (`$$argon2id$$...`).
   When unset, authentication is disabled.
 - `WF_AUTH_TOKEN_TTL_MINUTES`: Optional JWT access token lifetime (minutes). Defaults to `60`.
 - `WF_SECRET_FILE`: Optional override for where encrypted secrets are stored. Defaults to `<data-root>/secrets.json`.


### PR DESCRIPTION
This pull request updates the documentation and example environment files to clarify and improve instructions for generating the `WF_AUTH_PASSWORD_HASH` environment variable. The changes emphasize correct usage of the Argon2id hash generation process, provide more secure and reliable command examples, and offer tips for avoiding common pitfalls, especially in Docker Compose environments.

**Documentation improvements for Argon2id password hash:**

* Updated the example command for generating an Argon2id hash to use `printf 'your-password' | argon2 yoursalt16chars! -id -e` for better compatibility and security, replacing the previous usage of `argon2 "your-password" -id -e` in both `README.md` and `apps/server/README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L265-R277) [[2]](diffhunk://#diff-48427da47bcffeb297d96bc2e98c287eceff9282eac2628e5a095fe868cbb890L27-R33)
* Added detailed tips about salt usage, input handling (using `printf` to avoid newline issues), and the need to double ` characters in the hash when using Docker Compose in both documentation files. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L265-R277) [[2]](diffhunk://#diff-48427da47bcffeb297d96bc2e98c287eceff9282eac2628e5a095fe868cbb890L27-R33)

**Example environment file update:**

* Updated the `.env.web.example` file to match the improved documentation, including the new hash generation command and Docker Compose note.