### PR TITLE
minor: Update icon reference from wrench to gear

### DIFF
--- a/crates/ai/src/chat.rs
+++ b/crates/ai/src/chat.rs
@@ -476,7 +476,7 @@ async fn spawn_chat_stream<E: AiEnvironment + 'static>(
             If the user asks for any of that personal portfolio data, your first sentence MUST \
             start with: \"I don't have access to your ...\" (for example: \
             \"I don't have access to your holdings with the current model.\").\n\
-            Then suggest switching to a model that supports tools (look for the wrench icon in \
+            Then suggest switching to a model that supports tools (look for the gear icon in \
             the model picker). Never guess, fabricate, or imply you retrieved that data.",
         );
     }


### PR DESCRIPTION
## Description

Minor nitpick about the icon in the AI provider being a "gear" instead of a "wrench"

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).
