### PR TITLE
fix: enable message editing in AI assistant thread

### DIFF
--- a/apps/frontend/src/features/ai-assistant/hooks/use-chat-runtime.ts
+++ b/apps/frontend/src/features/ai-assistant/hooks/use-chat-runtime.ts
@@ -384,6 +384,9 @@ export function useChatRuntime(config?: ChatModelConfig) {
   // Thread ID ref - persists across streaming calls
   const threadIdRef = useRef<string | null>(null);
 
+  // Parent message ID ref - set during edit to truncate AI context
+  const editParentIdRef = useRef<string | null>(null);
+
   // Abort controller for cancelling streams
   const abortControllerRef = useRef<AbortController | null>(null);
 
@@ -557,6 +560,7 @@ export function useChatRuntime(config?: ChatModelConfig) {
             content: contentForAi,
             config,
             threadId: threadIdRef.current ?? undefined,
+            parentMessageId: editParentIdRef.current ?? undefined,
           },
           signal,
         )) {
@@ -752,7 +756,9 @@ export function useChatRuntime(config?: ChatModelConfig) {
         const parentIndex = prev.findIndex((m) => m.id === message.parentId);
         return parentIndex >= 0 ? prev.slice(0, parentIndex + 1) : [];
       });
+      editParentIdRef.current = message.parentId ?? null;
       await handleNew(message);
+      editParentIdRef.current = null;
     },
     [handleNew],
   );

--- a/apps/frontend/src/features/ai-assistant/types.ts
+++ b/apps/frontend/src/features/ai-assistant/types.ts
@@ -144,6 +144,8 @@ export interface AiSendMessageRequest {
   modelId?: string;
   /** Tool allowlist for this request (uses all if not specified). */
   allowedTools?: string[];
+  /** Parent message ID for edit operations. When set, AI context is truncated to this message. */
+  parentMessageId?: string;
 }
 
 /**

--- a/crates/ai/src/chat.rs
+++ b/crates/ai/src/chat.rs
@@ -194,7 +194,15 @@ impl<E: AiEnvironment + 'static> ChatService<E> {
         info!("Processing message for thread {}", thread_id);
 
         // Load previous messages for context (history)
-        let previous_messages = repo.get_messages_by_thread(&thread_id)?;
+        let mut previous_messages = repo.get_messages_by_thread(&thread_id)?;
+
+        // When editing a message, truncate context to the parent message (inclusive)
+        if let Some(ref parent_id) = request.parent_message_id {
+            if let Some(parent_pos) = previous_messages.iter().position(|m| m.id == *parent_id) {
+                previous_messages.truncate(parent_pos + 1);
+            }
+        }
+
         let history_messages: Vec<SimpleChatMessage> = previous_messages
             .iter()
             .filter_map(|msg| {

--- a/crates/ai/src/types.rs
+++ b/crates/ai/src/types.rs
@@ -866,6 +866,10 @@ pub struct SendMessageRequest {
     /// Tool allowlist for this request (uses all if not specified).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_tools: Option<Vec<String>>,
+    /// Parent message ID for edit operations.
+    /// When set, AI context is truncated to this message (inclusive).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_message_id: Option<String>,
 }
 
 impl SendMessageRequest {


### PR DESCRIPTION
## Description

The edit button in the AI assistant's `UserMessage` component was clickable but had no effect.

Root cause: `@assistant-ui/react`'s `useExternalStoreRuntime` requires an `onEdit` handler in the adapter to enable the edit feature — without it, `ActionBarPrimitive.Edit` silently does nothing.

Added a `handleEdit` callback to `useChatRuntime` that:
- Truncates the message history to the parent of the edited message (drops the old message and everything after it)
- Delegates to the existing `handleNew` to stream a new assistant response

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).