### PR TITLE
feat: show download progress in update dialog

### DIFF
--- a/apps/frontend/src/components/update-dialog.tsx
+++ b/apps/frontend/src/components/update-dialog.tsx
@@ -9,6 +9,7 @@ import {
   CarouselNext,
   CarouselPrevious,
 } from "@wealthfolio/ui/components/ui/carousel";
+import { Progress } from "@wealthfolio/ui/components/ui/progress";
 import { toast } from "@wealthfolio/ui/components/ui/use-toast";
 import {
   useCheckUpdateOnStartup,
@@ -25,6 +26,12 @@ interface DismissedUpdate {
 }
 
 const SNOOZE_DURATION_MS = 3 * 24 * 60 * 60 * 1000; // 3 days
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
 
 function isDismissed(dismissed: DismissedUpdate | null, version: string): boolean {
   if (!dismissed || dismissed.version !== version) return false;
@@ -52,7 +59,7 @@ export function UpdateDialog() {
   const { data: updateInfo } = useCheckUpdateOnStartup();
   const clearUpdate = useClearUpdate();
   const [isOpen, setIsOpen] = useState(false);
-  const installMutation = useInstallUpdate();
+  const { install, phase, progress, error, isPending, reset } = useInstallUpdate();
   const isDesktopEnv = isDesktop;
   const [dismissedUpdate, setDismissedUpdate] = usePersistentState<DismissedUpdate | null>(
     UPDATE_DISMISSED_KEY,
@@ -69,37 +76,36 @@ export function UpdateDialog() {
 
   // X button, Escape, backdrop — dismiss for current session only
   const handleDismiss = useCallback(() => {
-    if (installMutation.isPending) return;
+    if (isPending) return;
     setIsOpen(false);
     clearUpdate();
-  }, [installMutation.isPending, clearUpdate]);
+    reset();
+  }, [isPending, clearUpdate, reset]);
 
   // "Remind me later" — snooze for 3 days
   const handleSnooze = useCallback(() => {
-    if (installMutation.isPending) return;
+    if (isPending) return;
     if (updateInfo?.latestVersion) {
       setDismissedUpdate({ version: updateInfo.latestVersion, dismissedAt: Date.now() });
     }
     setIsOpen(false);
     clearUpdate();
-  }, [installMutation.isPending, updateInfo?.latestVersion, setDismissedUpdate, clearUpdate]);
+    reset();
+  }, [isPending, updateInfo?.latestVersion, setDismissedUpdate, clearUpdate, reset]);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (!isOpen || installMutation.isPending) return;
+      if (!isOpen || isPending) return;
       if (e.key === "Escape") {
         handleDismiss();
       }
     };
     window.addEventListener("keydown", handleKeyDown);
     return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [isOpen, installMutation.isPending, handleDismiss]);
+  }, [isOpen, isPending, handleDismiss]);
 
   const handleInstall = () => {
-    // Close dialog - backend will handle everything with native dialogs
-    setIsOpen(false);
-    clearUpdate();
-    installMutation.mutate();
+    install();
   };
 
   const handleOpenStore = async () => {
@@ -210,36 +216,79 @@ export function UpdateDialog() {
         </div>
 
         {/* Footer actions */}
-        <div className="border-border bg-secondary/30 flex shrink-0 items-center justify-between gap-4 border-t px-6 py-4">
-          <Button variant="ghost" onClick={handleSnooze}>
-            Remind me later
-          </Button>
-          <div className="flex items-center gap-3">
-            {updateInfo.changelogUrl && (
-              <Button variant="outline" onClick={handleOpenChangelog}>
-                View Changelog
-              </Button>
-            )}
-            {isDesktopEnv ? (
-              // Desktop: Show App Store or direct install button
-              updateInfo.isAppStoreBuild ? (
-                <Button onClick={handleOpenStore} disabled={!updateInfo.storeUrl}>
-                  Open App Store
-                </Button>
+        <div className="border-border bg-secondary/30 flex shrink-0 flex-col gap-3 border-t px-6 py-4">
+          {isPending ? (
+            // Download / install progress
+            <div className="flex flex-col gap-2">
+              {phase === "downloading" ? (
+                <>
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-muted-foreground">Downloading update...</span>
+                    <span className="text-muted-foreground tabular-nums">
+                      {progress.total
+                        ? `${formatBytes(progress.downloaded)} / ${formatBytes(progress.total)}`
+                        : formatBytes(progress.downloaded)}
+                    </span>
+                  </div>
+                  <Progress
+                    value={
+                      progress.total ? (progress.downloaded / progress.total) * 100 : undefined
+                    }
+                    className="h-2"
+                  />
+                </>
               ) : (
-                <Button onClick={handleInstall}>
-                  <Icons.Download className="mr-2 h-4 w-4" />
-                  Update Now
+                <div className="flex items-center gap-2 text-sm">
+                  <Icons.Spinner className="h-4 w-4 animate-spin" />
+                  <span className="text-muted-foreground">Installing update...</span>
+                </div>
+              )}
+            </div>
+          ) : phase === "error" ? (
+            // Error state with retry
+            <div className="flex items-center justify-between gap-4">
+              <p className="text-destructive text-sm">
+                {error || "Update failed. Please try again."}
+              </p>
+              <div className="flex items-center gap-3">
+                <Button variant="ghost" onClick={handleDismiss}>
+                  Close
                 </Button>
-              )
-            ) : (
-              // Web: Show download link (opens GitHub releases or Docker instructions)
-              <Button onClick={handleOpenStore} disabled={!updateInfo.storeUrl}>
-                <Icons.ExternalLink className="mr-2 h-4 w-4" />
-                View Release
+                <Button onClick={handleInstall}>Retry</Button>
+              </div>
+            </div>
+          ) : (
+            // Default actions
+            <div className="flex items-center justify-between gap-4">
+              <Button variant="ghost" onClick={handleSnooze}>
+                Remind me later
               </Button>
-            )}
-          </div>
+              <div className="flex items-center gap-3">
+                {updateInfo.changelogUrl && (
+                  <Button variant="outline" onClick={handleOpenChangelog}>
+                    View Changelog
+                  </Button>
+                )}
+                {isDesktopEnv ? (
+                  updateInfo.isAppStoreBuild ? (
+                    <Button onClick={handleOpenStore} disabled={!updateInfo.storeUrl}>
+                      Open App Store
+                    </Button>
+                  ) : (
+                    <Button onClick={handleInstall}>
+                      <Icons.Download className="mr-2 h-4 w-4" />
+                      Update Now
+                    </Button>
+                  )
+                ) : (
+                  <Button onClick={handleOpenStore} disabled={!updateInfo.storeUrl}>
+                    <Icons.ExternalLink className="mr-2 h-4 w-4" />
+                    View Release
+                  </Button>
+                )}
+              </div>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/apps/frontend/src/hooks/use-updater.ts
+++ b/apps/frontend/src/hooks/use-updater.ts
@@ -8,7 +8,7 @@ import {
 import { toast } from "@wealthfolio/ui/components/ui/use-toast";
 import type { UpdateInfo } from "@/lib/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 const UPDATE_QUERY_KEY = ["app-update"];
 export const UPDATE_DISMISSED_KEY = "update-dismissed";
@@ -110,11 +110,72 @@ export function useClearUpdate() {
   return () => queryClient.setQueryData(UPDATE_QUERY_KEY, null);
 }
 
+export type UpdatePhase = "idle" | "downloading" | "installing" | "error";
+
+export interface UpdateProgress {
+  downloaded: number;
+  total: number | null;
+}
+
+interface DownloadProgressEvent {
+  downloaded: number;
+  total: number | null;
+  phase: "downloading" | "installing";
+}
+
 /**
  * Hook to install an available update (desktop only).
+ * Tracks download progress and install phase via Tauri events.
  */
 export function useInstallUpdate() {
-  return useMutation({
+  const [phase, setPhase] = useState<UpdatePhase>("idle");
+  const [progress, setProgress] = useState<UpdateProgress>({ downloaded: 0, total: null });
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isDesktop) return;
+
+    let unlisten: (() => void) | undefined;
+
+    import("@tauri-apps/api/event").then(({ listen }) => {
+      listen<DownloadProgressEvent>("app:update-download-progress", (event) => {
+        setPhase(event.payload.phase);
+        if (event.payload.phase === "downloading") {
+          setProgress({ downloaded: event.payload.downloaded, total: event.payload.total });
+        }
+      }).then((fn) => {
+        unlisten = fn;
+      });
+    });
+
+    return () => unlisten?.();
+  }, []);
+
+  const mutation = useMutation({
     mutationFn: installUpdate,
+    onMutate: () => {
+      setPhase("downloading");
+      setProgress({ downloaded: 0, total: null });
+      setError(null);
+    },
+    onError: (err: Error) => {
+      setPhase("error");
+      setError(err.message);
+    },
   });
+
+  const reset = () => {
+    setPhase("idle");
+    setProgress({ downloaded: 0, total: null });
+    setError(null);
+  };
+
+  return {
+    install: () => mutation.mutate(),
+    phase,
+    progress,
+    error,
+    isPending: phase === "downloading" || phase === "installing",
+    reset,
+  };
 }

--- a/apps/tauri/src/commands/utilities.rs
+++ b/apps/tauri/src/commands/utilities.rs
@@ -78,11 +78,11 @@ pub async fn check_for_updates(app_handle: AppHandle) -> Result<Option<serde_jso
     }
 }
 
-/// Download and install an available update. Shows native dialogs and restarts the app.
+/// Download and install an available update. Emits progress events and restarts the app.
 #[tauri::command]
 pub async fn install_app_update(app_handle: AppHandle) -> Result<(), String> {
     #[cfg(desktop)]
-    install_update(app_handle).await;
+    install_update(app_handle).await?;
     Ok(())
 }
 

--- a/apps/tauri/src/updater.rs
+++ b/apps/tauri/src/updater.rs
@@ -1,8 +1,7 @@
 use chrono::DateTime;
 use log::{error, info, warn};
 use serde::Serialize;
-use tauri::AppHandle;
-use tauri_plugin_dialog::{DialogExt, MessageDialogKind};
+use tauri::{AppHandle, Emitter};
 use tauri_plugin_updater::UpdaterExt;
 
 // Helper function to detect if this is an App Store build
@@ -113,44 +112,34 @@ pub async fn check_for_update(
     }
 }
 
+/// Progress payload emitted during update download/install.
+#[derive(Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct UpdateDownloadProgress {
+    downloaded: u64,
+    total: Option<u64>,
+    /// "downloading" or "installing"
+    phase: String,
+}
+
 /// Download and install an available update, then restart the app.
-/// Shows native dialogs for success/failure and handles restart.
-pub async fn install_update(app_handle: AppHandle) {
+/// Emits `app:update-download-progress` events so the frontend can show progress.
+/// Returns `Err` on failure so the frontend can display the error inline.
+pub async fn install_update(app_handle: AppHandle) -> Result<(), String> {
     info!("Starting update download and installation");
 
-    // Check for updates
     let update = match app_handle.updater_builder().build() {
         Ok(updater) => match updater.check().await {
             Ok(Some(update)) => update,
-            Ok(None) => {
-                app_handle
-                    .dialog()
-                    .message("No update available.")
-                    .title("Update")
-                    .kind(MessageDialogKind::Info)
-                    .blocking_show();
-                return;
-            }
+            Ok(None) => return Err("No update available.".to_string()),
             Err(e) => {
                 error!("Failed to check for updates: {}", e);
-                app_handle
-                    .dialog()
-                    .message(format!("Failed to check for updates: {}", e))
-                    .title("Update Failed")
-                    .kind(MessageDialogKind::Error)
-                    .blocking_show();
-                return;
+                return Err(format!("Failed to check for updates: {}", e));
             }
         },
         Err(e) => {
             error!("Failed to build updater: {}", e);
-            app_handle
-                .dialog()
-                .message(format!("Failed to initialize updater: {}", e))
-                .title("Update Failed")
-                .kind(MessageDialogKind::Error)
-                .blocking_show();
-            return;
+            return Err(format!("Failed to initialize updater: {}", e));
         }
     };
 
@@ -159,29 +148,45 @@ pub async fn install_update(app_handle: AppHandle) {
         update.current_version, update.version
     );
 
-    // Download and install
-    match update.download_and_install(|_, _| {}, || {}).await {
+    let handle_chunk = app_handle.clone();
+    let handle_finish = app_handle.clone();
+    let mut downloaded: u64 = 0;
+
+    match update
+        .download_and_install(
+            move |chunk_len, content_len| {
+                downloaded += chunk_len as u64;
+                let _ = handle_chunk.emit(
+                    "app:update-download-progress",
+                    UpdateDownloadProgress {
+                        downloaded,
+                        total: content_len,
+                        phase: "downloading".to_string(),
+                    },
+                );
+            },
+            move || {
+                let _ = handle_finish.emit(
+                    "app:update-download-progress",
+                    UpdateDownloadProgress {
+                        downloaded: 0,
+                        total: None,
+                        phase: "installing".to_string(),
+                    },
+                );
+            },
+        )
+        .await
+    {
         Ok(_) => {
-            info!("Update installed successfully, showing dialog and restarting");
-
-            app_handle
-                .dialog()
-                .message("Update installed successfully. The application will now restart.")
-                .title("Update Complete")
-                .kind(MessageDialogKind::Info)
-                .blocking_show();
-
+            info!("Update installed successfully, restarting");
             app_handle.restart();
+            #[allow(unreachable_code)]
+            Ok(())
         }
         Err(e) => {
             error!("Failed to download and install update: {}", e);
-
-            app_handle
-                .dialog()
-                .message(format!("Failed to install update: {}", e))
-                .title("Update Failed")
-                .kind(MessageDialogKind::Error)
-                .blocking_show();
+            Err(format!("Failed to install update: {}", e))
         }
     }
 }


### PR DESCRIPTION
## Summary
- Keep the update dialog open when clicking "Update Now" and show real-time download progress (progress bar + byte counts) and install status (spinner)
- Emit `app:update-download-progress` events from Rust's `download_and_install` callbacks instead of using native OS dialogs
- Show errors inline with a retry option instead of native error dialogs
- Block dismiss/escape/backdrop click while update is in progress

## Test plan
- [x] Set version to 3.0.4 in tauri.conf.json, run `pnpm tauri dev`, trigger update dialog
- [x] Click "Update Now" — verify progress bar appears with byte counts
- [x] Verify dialog cannot be dismissed during download/install
- [ ] Verify error state shows with retry button (simulate by disconnecting network mid-download)
- [ ] Verify app restarts after successful install