### PR TITLE
fix: show quantity for asset transfer activities

### DIFF
--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
@@ -91,7 +91,7 @@ export const ActivityTableMobile = ({
                         <p className="text-muted-foreground text-xs">{activityTypeLabel}</p>
                         <div className="text-muted-foreground mt-0.5 flex items-center gap-1.5 text-xs">
                           <span>{formattedDate.date}</span>
-                          {!(isCashActivity(activity.activityType) && !isAssetBackedIncome) &&
+                          {!isCash &&
                             !(isIncomeActivity(activity.activityType) && !isAssetBackedIncome) &&
                             !isSplitActivity(activity.activityType) &&
                             !isFeeActivity(activity.activityType) &&
@@ -183,7 +183,7 @@ export const ActivityTableMobile = ({
                 </div>
 
                 {/* Quantity (if applicable) */}
-                {!(isCashActivity(activity.activityType) && !isAssetBackedIncome) &&
+                {!isCash &&
                   !(isIncomeActivity(activity.activityType) && !isAssetBackedIncome) &&
                   !isSplitActivity(activity.activityType) &&
                   !isFeeActivity(activity.activityType) &&

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
@@ -227,9 +227,15 @@ export const ActivityTable = ({
             assetSymbol,
             row.original.assetId,
           );
+          const isTransfer =
+            activityType === ActivityType.TRANSFER_IN || activityType === ActivityType.TRANSFER_OUT;
+          const hasAsset = Boolean(row.original.assetId?.trim());
+          const isCash = isTransfer
+            ? !hasAsset || isCashTransfer(activityType, assetSymbol)
+            : isCashActivity(activityType) && !isAssetBackedIncome;
 
           if (
-            (isCashActivity(activityType) && !isAssetBackedIncome) ||
+            isCash ||
             (isIncomeActivity(activityType) && !isAssetBackedIncome) ||
             isSplitActivity(activityType) ||
             isFeeActivity(activityType)


### PR DESCRIPTION
## Summary
- Asset transfers were incorrectly treated as cash transfers, causing the quantity column to display empty on the activity page
- Fixed both desktop and mobile activity tables to properly distinguish asset transfers from cash transfers

## Test plan
- [ ] Create a TRANSFER_IN activity for a stock (e.g. AAPL) with a quantity — verify quantity is displayed
- [ ] Create a TRANSFER_OUT activity for a stock with a quantity — verify quantity is displayed
- [ ] Verify cash transfers (TRANSFER_IN/OUT without an asset) still show "-" for quantity
- [ ] Verify on mobile view as well