### PR TITLE
fix: cookie-based web auth and cloud auth 401/403 separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,13 @@ All configuration is done via environment variables in `.env.web`.
   (default `60`)
 - `WF_AUTH_REQUIRED` - Set to `false` to allow starting on non-loopback
   addresses without authentication (e.g. when a reverse proxy handles auth)
+- `WF_COOKIE_SECURE` - Controls the `Secure` attribute on session cookies
+  (default: `auto`)
+  - `auto` - set `Secure` only when `X-Forwarded-Proto: https` is present
+    (recommended for most reverse-proxy setups)
+  - `true` - always set `Secure` (use when TLS is guaranteed but the header is
+    absent)
+  - `false` - never set `Secure` (plain HTTP without a reverse proxy)
 - `WF_SECRET_FILE` - **Optional** path to secrets storage file (default:
   `<data-root>/secrets.json`)
 - `WF_ADDONS_DIR` - **Optional** path to addons directory (default: derived from
@@ -277,8 +284,15 @@ All configuration is done via environment variables in `.env.web`.
 
   Copy the full output (starting with `$argon2id$...`) into `.env.web`.
 
-- Tokens are short-lived (default 60 minutes) and stored in memory on the
-  client; refresh the page to re-authenticate.
+- Sessions are cookie-based (`HttpOnly`, `SameSite=Lax`, `Path=/api`). The login
+  endpoint sets the session cookie automatically — no token is exposed to
+  client-side JavaScript. Sessions last 60 minutes by default (see
+  `WF_AUTH_TOKEN_TTL_MINUTES`).
+
+- **Reverse proxy (HTTPS):** If your reverse proxy terminates TLS, ensure it
+  forwards `X-Forwarded-Proto: https` so the server sets the `Secure` cookie
+  attribute correctly. Alternatively, set `WF_COOKIE_SECURE=true` to always set
+  `Secure`. See `WF_COOKIE_SECURE` above.
 
 #### Notes
 

--- a/apps/frontend/src/adapters/web/activities.ts
+++ b/apps/frontend/src/adapters/web/activities.ts
@@ -1,5 +1,4 @@
 // Web-specific activity commands
-import { getAuthToken } from "@/lib/auth-token";
 import type { ParseConfig, ParsedCsvResult } from "@/lib/types";
 import { API_PREFIX, logger } from "./core";
 
@@ -41,15 +40,8 @@ export const parseCsv = async (file: File, config: ParseConfig): Promise<ParsedC
     formData.append("file", file);
     formData.append("config", JSON.stringify(config));
 
-    const headers: HeadersInit = {};
-    const token = getAuthToken();
-    if (token) {
-      headers.Authorization = `Bearer ${token}`;
-    }
-
     const response = await fetch(`${API_PREFIX}/activities/import/parse`, {
       method: "POST",
-      headers,
       body: formData,
       credentials: "same-origin",
     });

--- a/apps/frontend/src/adapters/web/ai-streaming.ts
+++ b/apps/frontend/src/adapters/web/ai-streaming.ts
@@ -1,6 +1,5 @@
 // Web adapter - AI Chat Streaming (platform-specific HTTP implementation)
 
-import { getAuthToken } from "@/lib/auth-token";
 import { logger, AI_CHAT_STREAM_ENDPOINT } from "./core";
 import type { AiSendMessageRequest, AiStreamEvent } from "@/features/ai-assistant/types";
 
@@ -17,18 +16,9 @@ export async function* streamAiChat(
   request: AiSendMessageRequest,
   signal?: AbortSignal,
 ): AsyncGenerator<AiStreamEvent, void, undefined> {
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-  };
-
-  const token = getAuthToken();
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
-  }
-
   const response = await fetch(AI_CHAT_STREAM_ENDPOINT, {
     method: "POST",
-    headers,
+    headers: { "Content-Type": "application/json" },
     body: JSON.stringify(request),
     signal,
     credentials: "same-origin",

--- a/apps/frontend/src/adapters/web/core.ts
+++ b/apps/frontend/src/adapters/web/core.ts
@@ -1,7 +1,7 @@
 // Web adapter core - Internal invoke function, COMMANDS map, and helpers
 // This module exports invoke, logger, and platform constants for shared modules
 
-import { getAuthToken, notifyUnauthorized } from "@/lib/auth-token";
+import { notifyUnauthorized } from "@/lib/auth-token";
 import type { Logger } from "../types";
 
 /** True when running in the desktop (Tauri) environment */
@@ -1212,10 +1212,6 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
   if (body !== undefined) {
     headers["Content-Type"] = "application/json";
   }
-  const token = getAuthToken();
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
-  }
   if (command === "get_health_status" || command === "run_health_checks") {
     const payloadTimezone =
       typeof payload === "object" && payload !== null && "clientTimezone" in payload
@@ -1234,41 +1230,8 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
     credentials: "same-origin",
   });
 
-  // Only notify unauthorized for app auth failures, not for connect cloud token issues
-  // Connect endpoints return 401 when cloud token isn't configured - that's not an app auth failure
-  const connectCommands = [
-    "get_subscription_plans",
-    "get_subscription_plans_public",
-    "get_user_info",
-    "get_connect_portal",
-    "sync_broker_connections",
-    "sync_broker_accounts",
-    "sync_broker_activities",
-    "list_broker_connections",
-    "list_broker_accounts",
-    "get_broker_sync_states",
-    "get_broker_ingest_states",
-    "get_import_runs",
-    "get_data_import_runs",
-    "get_synced_accounts",
-    "get_platforms",
-    "sync_broker_data",
-    "broker_ingest_run",
-    "device_sync_engine_status",
-    "device_sync_bootstrap_overwrite_check",
-    "device_sync_reconcile_ready_state",
-    "device_sync_bootstrap_snapshot_if_needed",
-    "device_sync_trigger_cycle",
-    "device_sync_start_background_engine",
-    "device_sync_stop_background_engine",
-    "device_sync_generate_snapshot_now",
-    "device_sync_cancel_snapshot_upload",
-    "store_sync_session",
-    "clear_sync_session",
-    "get_sync_session_status",
-    "restore_sync_session",
-  ];
-  if (res.status === 401 && !connectCommands.includes(command)) {
+  // 401 = app auth failure (JWT expired/invalid). Cloud auth failures return 403.
+  if (res.status === 401) {
     notifyUnauthorized();
   }
   if (!res.ok) {

--- a/apps/frontend/src/adapters/web/crypto.ts
+++ b/apps/frontend/src/adapters/web/crypto.ts
@@ -1,23 +1,14 @@
 // Web adapter - Sync Crypto Commands
 // These call the REST API endpoints for E2EE cryptographic operations.
 
-import { getAuthToken } from "@/lib/auth-token";
 import type { EphemeralKeyPair } from "../types";
 import { API_PREFIX } from "./core";
 
 // Helper to make authenticated POST requests to crypto endpoints
 async function cryptoPost<T>(endpoint: string, body?: Record<string, unknown>): Promise<T> {
-  const headers: HeadersInit = {
-    "Content-Type": "application/json",
-  };
-  const token = getAuthToken();
-  if (token) {
-    headers.Authorization = `Bearer ${token}`;
-  }
-
   const res = await fetch(`${API_PREFIX}/sync/crypto/${endpoint}`, {
     method: "POST",
-    headers,
+    headers: { "Content-Type": "application/json" },
     body: body ? JSON.stringify(body) : undefined,
     credentials: "same-origin",
   });

--- a/apps/frontend/src/context/auth-context.tsx
+++ b/apps/frontend/src/context/auth-context.tsx
@@ -1,5 +1,5 @@
 import { isWeb } from "@/adapters";
-import { getAuthToken, setAuthToken, setUnauthorizedHandler } from "@/lib/auth-token";
+import { setUnauthorizedHandler } from "@/lib/auth-token";
 import {
   createContext,
   useCallback,
@@ -27,16 +27,10 @@ const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [requiresAuth, setRequiresAuth] = useState(false);
   const [statusLoading, setStatusLoading] = useState(isWeb);
-  const [token, setToken] = useState<string | null>(() => getAuthToken());
   const [cookieSession, setCookieSession] = useState(false);
   const [loginLoading, setLoginLoading] = useState(false);
   const [loginError, setLoginError] = useState<string | null>(null);
-  const tokenRef = useRef<string | null>(null);
   const cookieSessionRef = useRef(false);
-
-  useEffect(() => {
-    tokenRef.current = token;
-  }, [token]);
 
   useEffect(() => {
     cookieSessionRef.current = cookieSession;
@@ -94,9 +88,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     const handler = () => {
-      const hadSession = Boolean(tokenRef.current) || cookieSessionRef.current;
-      setToken(null);
-      setAuthToken(null);
+      const hadSession = cookieSessionRef.current;
       setCookieSession(false);
       if (hadSession) {
         setLoginError("Session expired. Please sign in again.");
@@ -131,18 +123,12 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         }
         throw new Error(message);
       }
-      const body = (await response.json()) as { accessToken: string };
-      const accessToken = body?.accessToken;
-      if (!accessToken) {
-        throw new Error("Login response did not contain an access token");
-      }
-      setToken(accessToken);
-      setAuthToken(accessToken);
+      // Cookie is set by the server via Set-Cookie header
+      setCookieSession(true);
       setLoginError(null);
     } catch (error) {
       const message = error instanceof Error ? error.message : "Login failed";
-      setToken(null);
-      setAuthToken(null);
+      setCookieSession(false);
       setLoginError(message);
       throw error;
     } finally {
@@ -158,8 +144,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         credentials: "same-origin",
       }).catch(() => {});
     }
-    setToken(null);
-    setAuthToken(null);
     setCookieSession(false);
     setLoginError(null);
   }, []);
@@ -169,7 +153,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const value = useMemo<AuthContextValue>(
     () => ({
       requiresAuth,
-      isAuthenticated: !requiresAuth || Boolean(token) || cookieSession,
+      isAuthenticated: !requiresAuth || cookieSession,
       statusLoading,
       loginLoading,
       loginError,
@@ -179,7 +163,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }),
     [
       requiresAuth,
-      token,
       cookieSession,
       statusLoading,
       loginLoading,

--- a/apps/frontend/src/lib/auth-token.ts
+++ b/apps/frontend/src/lib/auth-token.ts
@@ -1,11 +1,4 @@
-let authToken: string | null = null;
 let unauthorizedHandler: (() => void) | null = null;
-
-export const setAuthToken = (token: string | null) => {
-  authToken = token;
-};
-
-export const getAuthToken = () => authToken;
 
 export const setUnauthorizedHandler = (handler: (() => void) | null) => {
   unauthorizedHandler = handler;

--- a/apps/server/src/api/connect.rs
+++ b/apps/server/src/api/connect.rs
@@ -330,7 +330,7 @@ async fn restore_sync_session(
         .secret_store
         .get_secret(CLOUD_REFRESH_TOKEN_KEY)
         .map_err(|e| ApiError::Internal(format!("Failed to read refresh token: {}", e)))?
-        .ok_or_else(|| ApiError::Unauthorized("No sync session configured".to_string()))?;
+        .ok_or_else(|| ApiError::Forbidden("No sync session configured".to_string()))?;
 
     Ok(Json(RestoreSyncSessionResponse {
         access_token,
@@ -356,7 +356,7 @@ pub(crate) async fn mint_access_token(state: &AppState) -> ApiResult<String> {
 
 fn map_token_lifecycle_error(err: TokenLifecycleError) -> ApiError {
     match err {
-        TokenLifecycleError::Unauthorized(message) => ApiError::Unauthorized(message),
+        TokenLifecycleError::Unauthorized(message) => ApiError::Forbidden(message),
         TokenLifecycleError::NotConfigured(message)
         | TokenLifecycleError::RefreshFailed(message)
         | TokenLifecycleError::Internal(message) => ApiError::Internal(message),

--- a/apps/server/src/auth.rs
+++ b/apps/server/src/auth.rs
@@ -10,7 +10,7 @@ use axum::{
     extract::State,
     http::{
         header::{AUTHORIZATION, COOKIE, SET_COOKIE},
-        HeaderValue, Request, StatusCode,
+        HeaderMap, HeaderValue, Request, StatusCode,
     },
     middleware::Next,
     response::{IntoResponse, Response},
@@ -22,12 +22,34 @@ use serde::{Deserialize, Serialize};
 
 use crate::main_lib::AppState;
 
+/// Controls when the `Secure` attribute is set on session cookies.
+///
+/// - `Auto`: set `Secure` only when `X-Forwarded-Proto: https` is present (default).
+/// - `Always`: always set `Secure` (use when TLS is guaranteed but the header is absent).
+/// - `Never`: never set `Secure` (plain HTTP without a reverse proxy).
+#[derive(Clone, Debug)]
+pub enum CookieSecurePolicy {
+    Auto,
+    Always,
+    Never,
+}
+
+impl std::fmt::Display for CookieSecurePolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Auto => write!(f, "auto (Secure only when X-Forwarded-Proto: https)"),
+            Self::Always => write!(f, "always (Secure flag always set)"),
+            Self::Never => write!(f, "never (Secure flag never set)"),
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct AuthConfig {
     pub password_hash: String,
     pub jwt_secret: Vec<u8>,
     pub access_token_ttl: Duration,
-    pub secure_cookie: bool,
+    pub cookie_secure: CookieSecurePolicy,
 }
 
 pub struct AuthManager {
@@ -36,7 +58,7 @@ pub struct AuthManager {
     decoding_key: DecodingKey,
     validation: Validation,
     token_ttl: Duration,
-    secure_cookie: bool,
+    cookie_secure: CookieSecurePolicy,
 }
 
 #[derive(Debug)]
@@ -68,8 +90,7 @@ pub struct LoginRequest {
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct LoginResponse {
-    pub access_token: String,
-    pub token_type: String,
+    pub authenticated: bool,
     pub expires_in: u64,
 }
 
@@ -92,7 +113,7 @@ impl AuthManager {
             decoding_key,
             validation,
             token_ttl: config.access_token_ttl,
-            secure_cookie: config.secure_cookie,
+            cookie_secure: config.cookie_secure.clone(),
         })
     }
 
@@ -140,8 +161,20 @@ impl AuthManager {
         self.token_ttl
     }
 
-    pub fn secure_cookie(&self) -> bool {
-        self.secure_cookie
+    /// Resolve whether the `Secure` cookie attribute should be set for this request.
+    pub fn should_secure_cookie(&self, headers: &HeaderMap) -> bool {
+        match &self.cookie_secure {
+            CookieSecurePolicy::Always => true,
+            CookieSecurePolicy::Never => false,
+            CookieSecurePolicy::Auto => headers
+                .get("x-forwarded-proto")
+                .and_then(|v| v.to_str().ok())
+                .is_some_and(|v| {
+                    v.split(',')
+                        .next()
+                        .is_some_and(|p| p.trim().eq_ignore_ascii_case("https"))
+                }),
+        }
     }
 }
 
@@ -203,23 +236,26 @@ pub fn decode_secret_key(raw: &str) -> anyhow::Result<Vec<u8>> {
 
 const SESSION_COOKIE_NAME: &str = "wf_session";
 
+fn build_session_cookie(token: &str, max_age_secs: u64, secure: bool) -> String {
+    let secure_attr = if secure { "; Secure" } else { "" };
+    format!(
+        "{SESSION_COOKIE_NAME}={token}; HttpOnly; SameSite=Lax; Path=/api; Max-Age={max_age_secs}{secure_attr}"
+    )
+}
+
 pub async fn login(
     axum::extract::State(state): axum::extract::State<Arc<AppState>>,
+    headers: HeaderMap,
     Json(payload): Json<LoginRequest>,
 ) -> Result<Response, AuthError> {
     let auth = state.auth.as_ref().ok_or(AuthError::NotConfigured)?.clone();
     auth.verify_password(&payload.password)?;
     let token = auth.issue_token()?;
     let ttl_secs = auth.expires_in().as_secs();
-
-    let secure_attr = if auth.secure_cookie { "; Secure" } else { "" };
-    let cookie_value = format!(
-        "{SESSION_COOKIE_NAME}={token}; HttpOnly; SameSite=Strict; Path=/api; Max-Age={ttl_secs}{secure_attr}"
-    );
+    let cookie_value = build_session_cookie(&token, ttl_secs, auth.should_secure_cookie(&headers));
 
     let body = LoginResponse {
-        access_token: token,
-        token_type: "Bearer".to_string(),
+        authenticated: true,
         expires_in: ttl_secs,
     };
 
@@ -232,17 +268,14 @@ pub async fn login(
     Ok(response)
 }
 
-pub async fn logout(State(state): State<Arc<AppState>>) -> Response {
-    let secure_attr = if state.auth.as_ref().is_some_and(|a| a.secure_cookie()) {
-        "; Secure"
-    } else {
-        ""
-    };
-    let clear_cookie = format!(
-        "{SESSION_COOKIE_NAME}=; HttpOnly; SameSite=Strict; Path=/api; Max-Age=0{secure_attr}"
-    );
+pub async fn logout(State(state): State<Arc<AppState>>, headers: HeaderMap) -> Response {
+    let secure = state
+        .auth
+        .as_ref()
+        .is_some_and(|a| a.should_secure_cookie(&headers));
+    let cookie_value = build_session_cookie("", 0, secure);
     let mut response = StatusCode::NO_CONTENT.into_response();
-    if let Ok(val) = HeaderValue::from_str(&clear_cookie) {
+    if let Ok(val) = HeaderValue::from_str(&cookie_value) {
         response.headers_mut().insert(SET_COOKIE, val);
     }
     response
@@ -323,4 +356,85 @@ fn extract_token(request: &Request<Body>) -> Result<String, AuthError> {
     }
 
     Err(AuthError::Unauthorized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_manager(policy: CookieSecurePolicy) -> AuthManager {
+        let config = AuthConfig {
+            password_hash: "$argon2i$v=19$m=16,t=2,p=1$MTIzMjMyMzIz$/5nvsvwbwLNOxDtDae5XMQ".into(),
+            jwt_secret: vec![0u8; 32],
+            access_token_ttl: Duration::from_secs(3600),
+            cookie_secure: policy,
+        };
+        AuthManager::new(&config).unwrap()
+    }
+
+    fn headers_with_proto(value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert("x-forwarded-proto", HeaderValue::from_str(value).unwrap());
+        h
+    }
+
+    #[test]
+    fn auto_no_header_is_not_secure() {
+        let mgr = make_manager(CookieSecurePolicy::Auto);
+        assert!(!mgr.should_secure_cookie(&HeaderMap::new()));
+    }
+
+    #[test]
+    fn auto_http_is_not_secure() {
+        let mgr = make_manager(CookieSecurePolicy::Auto);
+        assert!(!mgr.should_secure_cookie(&headers_with_proto("http")));
+    }
+
+    #[test]
+    fn auto_https_is_secure() {
+        let mgr = make_manager(CookieSecurePolicy::Auto);
+        assert!(mgr.should_secure_cookie(&headers_with_proto("https")));
+    }
+
+    #[test]
+    fn auto_https_case_insensitive() {
+        let mgr = make_manager(CookieSecurePolicy::Auto);
+        assert!(mgr.should_secure_cookie(&headers_with_proto("HTTPS")));
+    }
+
+    #[test]
+    fn auto_multi_value_https_first() {
+        let mgr = make_manager(CookieSecurePolicy::Auto);
+        assert!(mgr.should_secure_cookie(&headers_with_proto("https, http")));
+    }
+
+    #[test]
+    fn auto_multi_value_http_first() {
+        let mgr = make_manager(CookieSecurePolicy::Auto);
+        assert!(!mgr.should_secure_cookie(&headers_with_proto("http, https")));
+    }
+
+    #[test]
+    fn always_without_header() {
+        let mgr = make_manager(CookieSecurePolicy::Always);
+        assert!(mgr.should_secure_cookie(&HeaderMap::new()));
+    }
+
+    #[test]
+    fn always_with_http_header() {
+        let mgr = make_manager(CookieSecurePolicy::Always);
+        assert!(mgr.should_secure_cookie(&headers_with_proto("http")));
+    }
+
+    #[test]
+    fn never_without_header() {
+        let mgr = make_manager(CookieSecurePolicy::Never);
+        assert!(!mgr.should_secure_cookie(&HeaderMap::new()));
+    }
+
+    #[test]
+    fn never_with_https_header() {
+        let mgr = make_manager(CookieSecurePolicy::Never);
+        assert!(!mgr.should_secure_cookie(&headers_with_proto("https")));
+    }
 }

--- a/apps/server/src/config.rs
+++ b/apps/server/src/config.rs
@@ -1,6 +1,6 @@
 use std::{net::SocketAddr, time::Duration};
 
-use crate::auth::{decode_secret_key, derive_keys, AuthConfig};
+use crate::auth::{decode_secret_key, derive_keys, AuthConfig, CookieSecurePolicy};
 
 pub struct Config {
     pub listen_addr: SocketAddr,
@@ -64,11 +64,22 @@ impl Config {
                     .and_then(|value| value.parse::<u64>().ok())
                     .filter(|value| *value > 0)
                     .unwrap_or(60);
+                let cookie_secure_raw =
+                    std::env::var("WF_COOKIE_SECURE").unwrap_or_else(|_| "auto".into());
+                let cookie_secure = match cookie_secure_raw.trim().to_ascii_lowercase().as_str() {
+                    "auto" => CookieSecurePolicy::Auto,
+                    "true" | "1" | "yes" => CookieSecurePolicy::Always,
+                    "false" | "0" | "no" => CookieSecurePolicy::Never,
+                    other => panic!(
+                        "Invalid WF_COOKIE_SECURE value: \"{other}\". \
+                         Expected one of: auto, true, false"
+                    ),
+                };
                 AuthConfig {
                     password_hash,
                     jwt_secret: jwt_key.to_vec(),
                     access_token_ttl: Duration::from_secs(ttl_minutes.saturating_mul(60)),
-                    secure_cookie: !listen_addr.ip().is_loopback(),
+                    cookie_secure,
                 }
             });
         // When auth is enabled, wildcard CORS is incompatible with credentials

--- a/apps/server/src/error.rs
+++ b/apps/server/src/error.rs
@@ -22,6 +22,8 @@ pub enum ApiError {
     #[error("{0}")]
     Unauthorized(String),
     #[error("{0}")]
+    Forbidden(String),
+    #[error("{0}")]
     Internal(String),
     // Surface the underlying error message to help debugging during development
     #[error("{0}")]
@@ -46,6 +48,7 @@ impl IntoResponse for ApiError {
             ApiError::NotImplemented(reason) => (StatusCode::NOT_IMPLEMENTED, reason.clone()),
             ApiError::BadRequest(reason) => (StatusCode::BAD_REQUEST, reason.clone()),
             ApiError::Unauthorized(reason) => (StatusCode::UNAUTHORIZED, reason.clone()),
+            ApiError::Forbidden(reason) => (StatusCode::FORBIDDEN, reason.clone()),
             ApiError::Internal(reason) => (StatusCode::INTERNAL_SERVER_ERROR, reason.clone()),
             ApiError::Anyhow(_) => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -23,7 +23,7 @@ use wealthfolio_device_sync::SyncState;
 #[cfg(feature = "device-sync")]
 fn is_expected_startup_token_warmup_error(err: &crate::error::ApiError) -> bool {
     match err {
-        crate::error::ApiError::Unauthorized(_) => true,
+        crate::error::ApiError::Unauthorized(_) | crate::error::ApiError::Forbidden(_) => true,
         crate::error::ApiError::Internal(message) => {
             message.contains("No refresh token configured")
                 || message.contains("Auth refresh configuration is missing")
@@ -40,7 +40,7 @@ mod tests {
 
     #[test]
     fn startup_token_warmup_treats_unauthorized_as_expected() {
-        let err = ApiError::Unauthorized("No refresh token configured".to_string());
+        let err = ApiError::Forbidden("No refresh token configured".to_string());
         assert!(is_expected_startup_token_warmup_error(&err));
     }
 
@@ -108,6 +108,14 @@ async fn main() -> anyhow::Result<()> {
     let index_file = static_dir.join("index.html");
     let static_service = ServeDir::new(static_dir).fallback(ServeFile::new(index_file));
     let router = app_router(state, &config).fallback_service(static_service);
+    if let Some(ref auth) = config.auth {
+        tracing::info!(
+            "Authentication enabled, cookie secure policy: {}",
+            auth.cookie_secure
+        );
+    } else {
+        tracing::info!("Authentication disabled");
+    }
     tracing::info!("Listening on {}", config.listen_addr);
     let listener = tokio::net::TcpListener::bind(config.listen_addr).await?;
     axum::serve(

--- a/apps/server/tests/auth.rs
+++ b/apps/server/tests/auth.rs
@@ -101,7 +101,8 @@ async fn login_and_access_protected_route() {
         .get(header::SET_COOKIE)
         .expect("login should set a cookie")
         .to_str()
-        .unwrap();
+        .unwrap()
+        .to_owned();
     assert!(
         set_cookie.contains("wf_session="),
         "cookie should contain wf_session"
@@ -111,14 +112,26 @@ async fn login_and_access_protected_route() {
         .await
         .unwrap();
     let login_json: serde_json::Value = serde_json::from_slice(&login_bytes).unwrap();
-    let token = login_json["accessToken"].as_str().unwrap();
+    assert_eq!(login_json["authenticated"], true);
+    assert!(login_json["expiresIn"].as_u64().unwrap() > 0);
+    assert!(
+        login_json.get("accessToken").is_none(),
+        "login should not expose accessToken"
+    );
 
-    // Access with token succeeds
+    // Extract session cookie from Set-Cookie header
+    let cookie_token = set_cookie
+        .split(';')
+        .next()
+        .unwrap()
+        .trim_start_matches("wf_session=");
+
+    // Access with cookie succeeds
     let authed_response = app
         .oneshot(
             Request::builder()
                 .uri("/api/v1/accounts")
-                .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                .header(header::COOKIE, format!("wf_session={cookie_token}"))
                 .body(Body::empty())
                 .unwrap(),
         )


### PR DESCRIPTION
## Summary

Fixes #686 (login screen on every page load in Docker self-hosted deployments).

- **Cookie `Secure` policy**: Replace bind-address heuristic (`!is_loopback`) with per-request `X-Forwarded-Proto` detection via new `WF_COOKIE_SECURE` env var (`auto`/`true`/`false`). Docker containers binding to `0.0.0.0` over plain HTTP no longer force `Secure` cookies that the browser rejects.
- **Cookie-only web auth**: Login response no longer exposes JWT in the response body. Frontend relies entirely on `HttpOnly` cookie via `credentials: "same-origin"`. Removed in-memory token storage and `Authorization: Bearer` header attachment from all web adapters.
- **401/403 separation**: Cloud auth failures (Connect/device-sync token issues) now return HTTP 403 (`ApiError::Forbidden`) instead of 401. Frontend only triggers app logout on 401, so Connect token problems no longer cause "Session expired" on the login screen.
- **Cookie builder**: Extracted `build_session_cookie()` helper for login/logout cookie generation.
- **`SameSite=Lax`**: Changed from `Strict` to `Lax` (industry standard for session cookies — allows top-level navigations from external links).
- **Docs**: Added `WF_COOKIE_SECURE` and cookie session documentation to README.

## Changed files

### Server
- `auth.rs` — `CookieSecurePolicy` enum, `should_secure_cookie()`, `build_session_cookie()`, updated login/logout handlers, 10 unit tests
- `config.rs` — `WF_COOKIE_SECURE` env parsing with strict validation
- `error.rs` — `ApiError::Forbidden` variant → `StatusCode::FORBIDDEN`
- `connect.rs` — `map_token_lifecycle_error` returns `Forbidden` for cloud auth; `restore_sync_session` uses `Forbidden`
- `main.rs` — Startup warmup matches `Forbidden`; updated test
- `tests/auth.rs` — Verifies cookie-only auth flow, no `accessToken` in response

### Frontend
- `auth-token.ts` — Removed `authToken`/`setAuthToken`/`getAuthToken`; only unauthorized handler remains
- `auth-context.tsx` — Removed token state; login sets `cookieSession` on HTTP success
- `web/core.ts` — Removed bearer header and 60-line `connectCommands` allowlist; simple `401` check
- `web/activities.ts`, `web/ai-streaming.ts`, `web/crypto.ts` — Removed bearer header attachment

### Docs
- `README.md` — `WF_COOKIE_SECURE` config reference, updated auth section

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` — 30 tests pass (including 10 new cookie policy tests + updated auth integration test)
- [x] `pnpm type-check` passes
- [ ] Manual: Docker HTTP deployment — verify login persists across page reload
- [ ] Manual: HTTPS reverse proxy — verify `Secure` cookie set via `X-Forwarded-Proto`
- [ ] Manual: Connect page — verify cloud auth 403 does not trigger app logout