### PR TITLE
fix: use `parse_manifest_json_metadata` for addon manifest parsing

### DIFF
--- a/crates/core/src/addons/service.rs
+++ b/crates/core/src/addons/service.rs
@@ -1317,7 +1317,7 @@ impl AddonService {
         }
         let content = fs::read_to_string(&manifest_path)
             .map_err(|e| format!("Failed to read manifest {}: {}", manifest_path.display(), e))?;
-        let manifest = serde_json::from_str::<AddonManifest>(&content).map_err(|e| {
+        let manifest = parse_manifest_json_metadata(&content).map_err(|e| {
             format!(
                 "Failed to parse manifest {}: {}",
                 manifest_path.display(),

--- a/crates/core/src/addons/tests.rs
+++ b/crates/core/src/addons/tests.rs
@@ -614,6 +614,7 @@ fn test_parse_manifest_json_metadata_service() {
 mod service_tests {
     use super::*;
     use std::env;
+    use crate::addons::addon_traits::AddonServiceTrait;
 
     #[test]
     fn test_ensure_addons_directory_service() {
@@ -658,6 +659,51 @@ mod service_tests {
         // Verify the parent directory is the addons directory
         let parent = addon_path.parent().unwrap();
         assert_eq!(parent.file_name().unwrap(), "addons");
+
+        // Clean up
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    fn test_addon_service_load_manifest() {
+        // Test that AddonService can load an installed addo
+        let temp_dir = env::temp_dir().join("wealthfolio_test_manifest_service");
+        let app_data_path = temp_dir.to_str().unwrap();
+
+        if temp_dir.exists() {
+            std::fs::remove_dir_all(&temp_dir).ok();
+        }
+
+        let service = AddonService::new(app_data_path, "test-instance");
+
+        // Create addon directory structure manually
+        let addon_dir = temp_dir.join("addons").join("addon");
+        std::fs::create_dir_all(&addon_dir).expect("Failed to create addon dir");
+
+        let manifest_json = r#"{
+            "id": "addon",
+            "name": "Addon",
+            "version": "1.0.0",
+            "main": "addon.js",
+            "permissions": [
+                {
+                    "category": "api",
+                    "purpose": "Network calls",
+                    "functions": ["fetch"]
+                }
+            ]
+        }"#;
+
+        std::fs::write(addon_dir.join("manifest.json"), manifest_json).expect("Failed to write manifest");
+        std::fs::write(addon_dir.join("addon.js"), "console.log('test')").expect("Failed to write js");
+
+        let installed = service.list_installed_addons().expect("Failed to list installed addons");
+        assert_eq!(installed.len(), 1, "AddonService should load the manifest");
+
+        let permissions = installed[0].metadata.permissions.as_ref().unwrap();
+        assert_eq!(permissions.len(), 1);
+        assert_eq!(permissions[0].functions[0].name, "fetch");
+        assert!(permissions[0].functions[0].is_declared);
 
         // Clean up
         std::fs::remove_dir_all(&temp_dir).ok();


### PR DESCRIPTION
## Description

When running Wealthfolio with `WF_ADDONS_DIR=.
VITE_ENABLE_ADDON_DEV_MODE=true pnpm run dev:web` no addons load due to manifests containing stringified function call permissions e.g. `"functions": ["getAll"],`.

This is due to `AddonService` expecting a stricter format conforming to `AddonManifest` struct.

There exists more lenient `parse_manifest_json_metadata` function that should be used and using that makes addons load fine.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).
