### PR TITLE
fix(frontend): download SQLite backup/export in web mode (#688)

### DIFF
--- a/apps/frontend/src/pages/settings/exports/backup-restore-form.tsx
+++ b/apps/frontend/src/pages/settings/exports/backup-restore-form.tsx
@@ -17,8 +17,8 @@ const desktopNotes = [
 ] as const;
 
 const webNotes = [
-  "Backups include WAL and SHM files and are stored in the server data directory.",
-  "Download or copy backup files directly from the host environment when needed.",
+  "Backups include WAL and SHM files and are downloaded directly to your browser.",
+  "Store downloaded backups somewhere safe so they can be restored later in desktop or iOS.",
   "Restores are only available in the desktop application.",
   "Create backups regularly, especially before bulk imports or migrations.",
 ] as const;
@@ -132,7 +132,7 @@ const WebBackupPanel = ({ performBackup, isBackingUp }: WebPanelProps) => {
 
       <BackupCard
         title="Create Backup"
-        description="Create a complete backup with WAL and SHM files stored automatically in the server data directory for safekeeping."
+        description="Create a complete backup with WAL and SHM files and download it directly to your device."
         isLoading={isBackingUp}
         disabled={isBackingUp}
         actionLabel="Backup Database"

--- a/apps/frontend/src/pages/settings/exports/exports-form.tsx
+++ b/apps/frontend/src/pages/settings/exports/exports-form.tsx
@@ -85,7 +85,7 @@ const dataTypes = {
       key: "full",
       name: "Export the full SQLite Database",
       icon: Icons.Database,
-      description: "Complete database backup with WAL/SHM files - choose your backup location",
+      description: "Complete database backup with WAL/SHM files",
     },
   ],
 };

--- a/apps/frontend/src/pages/settings/exports/use-backup-restore.test.tsx
+++ b/apps/frontend/src/pages/settings/exports/use-backup-restore.test.tsx
@@ -1,0 +1,81 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useBackupRestore } from "./use-backup-restore";
+
+const mocks = vi.hoisted(() => ({
+  backupDatabase: vi.fn(),
+  backupDatabaseToPath: vi.fn(),
+  openDatabaseFileDialog: vi.fn(),
+  openFileSaveDialog: vi.fn(),
+  openFolderDialog: vi.fn(),
+  restoreDatabase: vi.fn(),
+  getPlatform: vi.fn(),
+  usePlatform: vi.fn(),
+  toast: vi.fn(),
+  loggerError: vi.fn(),
+}));
+
+vi.mock("@/adapters", () => ({
+  backupDatabase: mocks.backupDatabase,
+  backupDatabaseToPath: mocks.backupDatabaseToPath,
+  isWeb: true,
+  logger: { error: mocks.loggerError },
+  openDatabaseFileDialog: mocks.openDatabaseFileDialog,
+  openFileSaveDialog: mocks.openFileSaveDialog,
+  openFolderDialog: mocks.openFolderDialog,
+  restoreDatabase: mocks.restoreDatabase,
+}));
+
+vi.mock("@/hooks/use-platform", () => ({
+  getPlatform: mocks.getPlatform,
+  usePlatform: mocks.usePlatform,
+}));
+
+vi.mock("@wealthfolio/ui/components/ui/use-toast", () => ({
+  toast: mocks.toast,
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useBackupRestore (web)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.usePlatform.mockReturnValue({ platform: null });
+    mocks.backupDatabase.mockResolvedValue({
+      filename: "wealthfolio_backup_20260309_120000.db",
+      data: new Uint8Array([4, 5, 6]),
+    });
+    mocks.openFileSaveDialog.mockResolvedValue(true);
+  });
+
+  it("downloads backup file locally in web mode", async () => {
+    const { result } = renderHook(() => useBackupRestore(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.performBackup();
+    });
+
+    expect(mocks.backupDatabase).toHaveBeenCalledTimes(1);
+    expect(mocks.openFileSaveDialog).toHaveBeenCalledWith(
+      new Uint8Array([4, 5, 6]),
+      "wealthfolio_backup_20260309_120000.db",
+    );
+
+    await waitFor(() => {
+      expect(mocks.toast).toHaveBeenCalledWith({
+        title: "Backup completed successfully",
+        description: "Backup saved as wealthfolio_backup_20260309_120000.db",
+        variant: "success",
+      });
+    });
+  });
+});

--- a/apps/frontend/src/pages/settings/exports/use-backup-restore.ts
+++ b/apps/frontend/src/pages/settings/exports/use-backup-restore.ts
@@ -21,13 +21,17 @@ export function useBackupRestore() {
       : "desktop";
 
   const { mutateAsync: backupWithDirectorySelection, isPending: isBackingUp } = useMutation<{
-    location: "local" | "server";
+    location: "local";
     value: string;
   } | null>({
     mutationFn: async () => {
       if (isWeb) {
-        const { filename } = await backupDatabase();
-        return { location: "server" as const, value: filename };
+        const { filename, data } = await backupDatabase();
+        const saved = await openFileSaveDialog(data, filename);
+        if (!saved) {
+          return null;
+        }
+        return { location: "local" as const, value: filename };
       }
 
       const runtimePlatform = await getRuntimePlatform();
@@ -59,14 +63,9 @@ export function useBackupRestore() {
         return;
       }
 
-      const description =
-        result.location === "server"
-          ? `Backup created on the server as ${result.value}`
-          : `Backup saved as ${result.value}`;
-
       toast({
         title: "Backup completed successfully",
-        description,
+        description: `Backup saved as ${result.value}`,
         variant: "success",
       });
     },

--- a/apps/frontend/src/pages/settings/exports/use-export-data.test.tsx
+++ b/apps/frontend/src/pages/settings/exports/use-export-data.test.tsx
@@ -1,0 +1,85 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { useExportData } from "./use-export-data";
+
+const mocks = vi.hoisted(() => ({
+  backupDatabase: vi.fn(),
+  backupDatabaseToPath: vi.fn(),
+  getAccounts: vi.fn(),
+  getActivities: vi.fn(),
+  getGoals: vi.fn(),
+  getHistoricalValuations: vi.fn(),
+  openFileSaveDialog: vi.fn(),
+  openFolderDialog: vi.fn(),
+  getPlatform: vi.fn(),
+  toast: vi.fn(),
+  loggerError: vi.fn(),
+}));
+
+vi.mock("@/adapters", () => ({
+  backupDatabase: mocks.backupDatabase,
+  backupDatabaseToPath: mocks.backupDatabaseToPath,
+  getAccounts: mocks.getAccounts,
+  getActivities: mocks.getActivities,
+  getGoals: mocks.getGoals,
+  getHistoricalValuations: mocks.getHistoricalValuations,
+  isWeb: true,
+  logger: { error: mocks.loggerError },
+  openFileSaveDialog: mocks.openFileSaveDialog,
+  openFolderDialog: mocks.openFolderDialog,
+}));
+
+vi.mock("@/hooks/use-platform", () => ({
+  getPlatform: mocks.getPlatform,
+}));
+
+vi.mock("@wealthfolio/ui/components/ui/use-toast", () => ({
+  toast: mocks.toast,
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useExportData (web SQLite)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.backupDatabase.mockResolvedValue({
+      filename: "wealthfolio_backup_20260309_120000.db",
+      data: new Uint8Array([1, 2, 3]),
+    });
+    mocks.openFileSaveDialog.mockResolvedValue(true);
+  });
+
+  it("downloads SQLite backup bytes in web mode", async () => {
+    const { result } = renderHook(() => useExportData(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.exportData({
+        format: "SQLite",
+        data: "accounts",
+      });
+    });
+
+    expect(mocks.backupDatabase).toHaveBeenCalledTimes(1);
+    expect(mocks.openFileSaveDialog).toHaveBeenCalledWith(
+      new Uint8Array([1, 2, 3]),
+      "wealthfolio_backup_20260309_120000.db",
+    );
+
+    await waitFor(() => {
+      expect(mocks.toast).toHaveBeenCalledWith({
+        title: "Database backup completed successfully.",
+        description: "Backup saved as wealthfolio_backup_20260309_120000.db",
+        variant: "success",
+      });
+    });
+  });
+});

--- a/apps/frontend/src/pages/settings/exports/use-export-data.ts
+++ b/apps/frontend/src/pages/settings/exports/use-export-data.ts
@@ -31,7 +31,7 @@ interface ExportParams {
 
 interface SQLiteBackupResult {
   mode: "sqlite";
-  target: "local" | "server";
+  target: "local";
   value: string;
 }
 
@@ -68,8 +68,12 @@ export function useExportData() {
       const { format, data: desiredData } = params;
       if (format === "SQLite") {
         if (isWeb) {
-          const { filename } = await backupDatabase();
-          return { mode: "sqlite", target: "server" as const, value: filename };
+          const { filename, data } = await backupDatabase();
+          const saved = await openFileSaveDialog(data, filename);
+          if (!saved) {
+            return null;
+          }
+          return { mode: "sqlite", target: "local" as const, value: filename };
         }
 
         const runtimePlatform = await getRuntimePlatform();
@@ -144,14 +148,9 @@ export function useExportData() {
       }
 
       if (result && typeof result === "object" && "mode" in result && result.mode === "sqlite") {
-        const description =
-          result.target === "server"
-            ? `Backup created on the server as ${result.value}`
-            : `Backup saved as ${result.value}`;
-
         toast({
           title: "Database backup completed successfully.",
-          description,
+          description: `Backup saved as ${result.value}`,
           variant: "success",
         });
       } else {

--- a/crates/core/src/addons/tests.rs
+++ b/crates/core/src/addons/tests.rs
@@ -613,8 +613,8 @@ fn test_parse_manifest_json_metadata_service() {
 #[cfg(test)]
 mod service_tests {
     use super::*;
-    use std::env;
     use crate::addons::addon_traits::AddonServiceTrait;
+    use std::env;
 
     #[test]
     fn test_ensure_addons_directory_service() {
@@ -694,10 +694,14 @@ mod service_tests {
             ]
         }"#;
 
-        std::fs::write(addon_dir.join("manifest.json"), manifest_json).expect("Failed to write manifest");
-        std::fs::write(addon_dir.join("addon.js"), "console.log('test')").expect("Failed to write js");
+        std::fs::write(addon_dir.join("manifest.json"), manifest_json)
+            .expect("Failed to write manifest");
+        std::fs::write(addon_dir.join("addon.js"), "console.log('test')")
+            .expect("Failed to write js");
 
-        let installed = service.list_installed_addons().expect("Failed to list installed addons");
+        let installed = service
+            .list_installed_addons()
+            .expect("Failed to list installed addons");
         assert_eq!(installed.len(), 1, "AddonService should load the manifest");
 
         let permissions = installed[0].metadata.permissions.as_ref().unwrap();


### PR DESCRIPTION
## Description

Fixes self-hosted web backup/export flow for SQLite so users receive a browser download instead of only a server-side filename.

Root cause:
- Web `backup_database` already returned `{ filename, data }` from backend.
- Frontend web paths (`useExportData` and `useBackupRestore`) ignored `data` and treated result as server-only save.

Fix summary:
- Web SQLite paths now call `openFileSaveDialog(data, filename)` and treat success as local save.
- Updated web backup/export copy to match actual behavior.
- Added regression tests for both hooks covering web SQLite download behavior.
- Includes rustfmt baseline fix for unrelated upstream file (`crates/core/src/addons/tests.rs`) to satisfy current Rust Check gate.

Note: Backend/API unchanged (`POST /utilities/database/backup` already returns data and filename).

## Test Evidence

- `cargo fmt --all -- --check` ✅
- `pnpm --filter frontend test -- use-export-data` ✅
- `pnpm --filter frontend test -- use-backup-restore` ✅
- `pnpm run build:types && pnpm --filter frontend type-check` ✅

Fixes #688

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).
