### PR TITLE
fix: fallback amount to quantity * unit_price when NULL in DB

### DIFF
--- a/crates/storage-sqlite/src/activities/model.rs
+++ b/crates/storage-sqlite/src/activities/model.rs
@@ -250,6 +250,14 @@ impl From<ActivityDetailsDB> for wealthfolio_core::activities::ActivityDetails {
             _ => ActivityStatus::Posted, // Default to Posted for unknown values
         };
 
+        let amount = db.amount.or_else(|| {
+            let q = db.quantity.as_ref()?;
+            let p = db.unit_price.as_ref()?;
+            let qty = parse_decimal_string_tolerant(q, "quantity");
+            let price = parse_decimal_string_tolerant(p, "unit_price");
+            Some((qty * price).to_string())
+        });
+
         Self {
             id: db.id,
             account_id: db.account_id,
@@ -262,7 +270,7 @@ impl From<ActivityDetailsDB> for wealthfolio_core::activities::ActivityDetails {
             unit_price: db.unit_price,
             currency: db.currency,
             fee: db.fee,
-            amount: db.amount,
+            amount,
             needs_review: db.needs_review != 0,
             comment: db.notes,
             fx_rate: db.fx_rate,


### PR DESCRIPTION
## Description

Activity details were showing `0` for the amount field on activities created before the `2025-03-18-222805_add_amount_field_and_use_decimal` migration. That migration added the `amount` column with `DEFAULT NULL`, so pre-existing rows have `amount = NULL`. The frontend converts this via `Number(activity.amount)` which returns `0` for null.

**Root cause**: `crates/storage-sqlite/src/activities/model.rs` passed `db.amount` straight through with no fallback.

**Fix**: In the `From<ActivityDetailsDB> for ActivityDetails` conversion, compute `quantity * unit_price` as a fallback when `amount` is `NULL`. This only triggers when both `quantity` and `unit_price` are non-null, so CASH activities without those fields are unaffected.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).