### PR TITLE
fix(market-data): support Boerse Frankfurt ETF ISIN quotes

### DIFF
--- a/crates/core/src/assets/assets_model.rs
+++ b/crates/core/src/assets/assets_model.rs
@@ -427,6 +427,17 @@ impl Asset {
             .and_then(|v| serde_json::from_value(v.clone()).ok())
     }
 
+    /// Get an ISIN identifier from generic asset metadata when present.
+    pub fn identifier_isin(&self) -> Option<String> {
+        self.metadata
+            .as_ref()
+            .and_then(|m| m.get("identifiers"))
+            .and_then(|v| v.get("isin"))
+            .and_then(|v| v.as_str())
+            .filter(|isin| !isin.is_empty())
+            .map(|isin| isin.to_uppercase())
+    }
+
     /// Convert to canonical instrument for market data resolution.
     /// Returns None for asset kinds that are not resolvable to market data.
     pub fn to_instrument_id(&self) -> Option<InstrumentId> {

--- a/crates/core/src/quotes/client.rs
+++ b/crates/core/src/quotes/client.rs
@@ -40,9 +40,9 @@ use wealthfolio_market_data::{
     mic_to_currency, mic_to_exchange_name, yahoo_exchange_to_mic, yahoo_suffix_to_mic,
     AlphaVantageProvider, AssetProfile as MarketAssetProfile, BoerseFrankfurtProvider,
     BondQuoteMetadata, FinnhubProvider, MarketDataAppProvider, MetalPriceApiProvider,
-    OpenFigiProvider, ProviderId, ProviderRegistry, Quote as MarketQuote, QuoteContext,
-    ResolverChain, SearchResult as MarketSearchResult, SplitEvent, UsTreasuryCalcProvider,
-    YahooProvider,
+    OpenFigiProvider, ProviderId, ProviderInstrument, ProviderOverrides, ProviderRegistry,
+    Quote as MarketQuote, QuoteContext, ResolverChain, SearchResult as MarketSearchResult,
+    SplitEvent, UsTreasuryCalcProvider, YahooProvider,
 };
 
 /// Market data error types.
@@ -339,9 +339,28 @@ impl MarketDataClient {
         })?;
 
         // Build provider overrides from asset.provider_config JSON
-        let overrides = asset
+        let mut overrides = asset
             .provider_overrides()
             .and_then(|json| wealthfolio_market_data::ProviderOverrides::from_json(json).ok());
+
+        // BF supports ISIN-based lookup for Frankfurt/Xetra-listed ETFs/equities.
+        // Synthesize an internal provider override when we already have a stable ISIN.
+        if asset.instrument_type == Some(crate::assets::InstrumentType::Equity)
+            && matches!(
+                asset.instrument_exchange_mic.as_deref(),
+                Some("XFRA" | "XETR")
+            )
+        {
+            if let Some(isin) = asset.identifier_isin() {
+                let overrides_ref = overrides.get_or_insert_with(ProviderOverrides::new);
+                if !overrides_ref.contains(DATA_SOURCE_BOERSE_FRANKFURT) {
+                    overrides_ref.insert(
+                        DATA_SOURCE_BOERSE_FRANKFURT.to_string(),
+                        ProviderInstrument::Isin { isin: isin.into() },
+                    );
+                }
+            }
+        }
 
         // Currency hint: prefer asset.quote_ccy, fall back to MIC-derived currency
         let currency_hint: Option<Cow<'static, str>> = if !asset.quote_ccy.is_empty() {
@@ -1045,6 +1064,62 @@ mod tests {
             context.bond_metadata.is_none(),
             "bond_metadata should be None when no bond spec exists"
         );
+    }
+
+    #[test]
+    fn test_build_quote_context_adds_boerse_frankfurt_isin_override_for_xetra_equity() {
+        let mut asset = create_test_asset(AssetKind::Investment, "XMME", "EUR");
+        asset.instrument_exchange_mic = Some("XETR".to_string());
+        asset.metadata = Some(serde_json::json!({
+            "identifiers": {
+                "isin": "IE00BTJRMP35"
+            }
+        }));
+
+        let client = create_test_client();
+        let context = client.build_quote_context(&asset).unwrap();
+        let instrument = context
+            .overrides
+            .as_ref()
+            .and_then(|o| o.get(DATA_SOURCE_BOERSE_FRANKFURT))
+            .expect("expected synthesized BF override");
+
+        match instrument {
+            ProviderInstrument::Isin { isin } => assert_eq!(isin.as_ref(), "IE00BTJRMP35"),
+            other => panic!("expected ISIN override, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_build_quote_context_preserves_existing_boerse_frankfurt_override() {
+        let mut asset = create_test_asset(AssetKind::Investment, "XMME", "EUR");
+        asset.instrument_exchange_mic = Some("XFRA".to_string());
+        asset.metadata = Some(serde_json::json!({
+            "identifiers": {
+                "isin": "IE00BTJRMP35"
+            }
+        }));
+        asset.provider_config = Some(serde_json::json!({
+            "overrides": {
+                "BOERSE_FRANKFURT": {
+                    "type": "equity_symbol",
+                    "symbol": "XMME"
+                }
+            }
+        }));
+
+        let client = create_test_client();
+        let context = client.build_quote_context(&asset).unwrap();
+        let instrument = context
+            .overrides
+            .as_ref()
+            .and_then(|o| o.get(DATA_SOURCE_BOERSE_FRANKFURT))
+            .expect("expected BF override");
+
+        match instrument {
+            ProviderInstrument::EquitySymbol { symbol } => assert_eq!(symbol.as_ref(), "XMME"),
+            other => panic!("expected existing equity override, got {:?}", other),
+        }
     }
 
     // =========================================================================

--- a/crates/market-data/src/models/provider_params.rs
+++ b/crates/market-data/src/models/provider_params.rs
@@ -33,6 +33,9 @@ pub enum ProviderInstrument {
         quote: Currency,
     },
 
+    /// Generic security identified by ISIN
+    Isin { isin: ProviderSymbol },
+
     /// Bond identified by ISIN
     BondIsin { isin: ProviderSymbol },
 }
@@ -50,6 +53,7 @@ impl ProviderInstrument {
             ProviderInstrument::FxSymbol { symbol } => symbol.to_string(),
             ProviderInstrument::FxPair { from, to } => format!("{}{}=X", from, to),
             ProviderInstrument::MetalSymbol { symbol, .. } => symbol.to_string(),
+            ProviderInstrument::Isin { isin } => isin.to_string(),
             ProviderInstrument::BondIsin { isin } => isin.to_string(),
         }
     }
@@ -133,6 +137,16 @@ mod tests {
         assert!(json.contains("fx_pair"));
         assert!(json.contains("EUR"));
         assert!(json.contains("USD"));
+    }
+
+    #[test]
+    fn test_isin_serialization() {
+        let instrument = ProviderInstrument::Isin {
+            isin: Arc::from("IE00BTJRMP35"),
+        };
+        let json = serde_json::to_string(&instrument).unwrap();
+        assert!(json.contains("isin"));
+        assert!(json.contains("IE00BTJRMP35"));
     }
 
     #[test]

--- a/crates/market-data/src/provider/alpha_vantage/mod.rs
+++ b/crates/market-data/src/provider/alpha_vantage/mod.rs
@@ -1109,6 +1109,11 @@ impl MarketDataProvider for AlphaVantageProvider {
                     "Alpha Vantage does not support metals".to_string(),
                 ));
             }
+            ProviderInstrument::Isin { .. } => {
+                return Err(MarketDataError::UnsupportedAssetType(
+                    "Alpha Vantage does not support ISIN-based securities".to_string(),
+                ));
+            }
             ProviderInstrument::BondIsin { .. } => {
                 return Err(MarketDataError::UnsupportedAssetType(
                     "Alpha Vantage does not support bonds".to_string(),
@@ -1176,6 +1181,11 @@ impl MarketDataProvider for AlphaVantageProvider {
             ProviderInstrument::MetalSymbol { .. } => {
                 return Err(MarketDataError::UnsupportedAssetType(
                     "Alpha Vantage does not support metals".to_string(),
+                ));
+            }
+            ProviderInstrument::Isin { .. } => {
+                return Err(MarketDataError::UnsupportedAssetType(
+                    "Alpha Vantage does not support ISIN-based securities".to_string(),
                 ));
             }
             ProviderInstrument::BondIsin { .. } => {

--- a/crates/market-data/src/provider/boerse_frankfurt/mod.rs
+++ b/crates/market-data/src/provider/boerse_frankfurt/mod.rs
@@ -1,8 +1,8 @@
-//! Boerse Frankfurt (Deutsche Boerse) provider for bond market data.
+//! Boerse Frankfurt (Deutsche Boerse) provider for ISIN-backed securities.
 //!
-//! Fetches bond price history from the Deutsche Boerse live API (XFRA exchange).
-//! Prices are quoted as percentage-of-par and converted to decimal fractions
-//! (e.g., 97.025 -> 0.97025).
+//! Fetches price history from the Deutsche Boerse live API (XFRA exchange).
+//! Bond prices may be quoted as percentage-of-par and are converted to decimal
+//! fractions when `tradedInPercent` is true.
 //!
 //! No API key required. Authentication uses a salt scraped from the frontend JS bundle
 //! to compute per-request headers (`x-security`, `x-client-traceid`).
@@ -73,7 +73,7 @@ struct InstrumentName {
     original_value: Option<String>,
 }
 
-/// Boerse Frankfurt provider for bond market data.
+/// Boerse Frankfurt provider for ISIN-backed securities.
 pub struct BoerseFrankfurtProvider {
     client: Client,
     salt: Arc<RwLock<Option<String>>>,
@@ -209,7 +209,7 @@ impl BoerseFrankfurtProvider {
         headers
     }
 
-    /// Fetch the instrument name for a bond ISIN.
+    /// Fetch the instrument name for an ISIN-backed security.
     async fn fetch_instrument_name(&self, isin: &str) -> Result<String, MarketDataError> {
         let salt = self.get_salt().await?;
 
@@ -258,7 +258,26 @@ impl BoerseFrankfurtProvider {
             })
     }
 
-    /// Fetch price history for a bond ISIN.
+    fn extract_isin(instrument: &ProviderInstrument) -> Result<String, MarketDataError> {
+        match instrument {
+            ProviderInstrument::Isin { isin } | ProviderInstrument::BondIsin { isin } => {
+                Ok(isin.to_string())
+            }
+            _ => Err(MarketDataError::UnsupportedAssetType(format!(
+                "{:?}",
+                instrument
+            ))),
+        }
+    }
+
+    fn convert_price(raw: f64, traded_in_percent: bool) -> Result<Decimal, MarketDataError> {
+        let normalized = if traded_in_percent { raw / 100.0 } else { raw };
+        Decimal::try_from(normalized).map_err(|_| MarketDataError::ValidationFailed {
+            message: format!("Failed to convert price {} to decimal", raw),
+        })
+    }
+
+    /// Fetch price history for an ISIN-backed security.
     async fn fetch_price_history(
         &self,
         isin: &str,
@@ -312,6 +331,8 @@ impl BoerseFrankfurtProvider {
             return Err(MarketDataError::SymbolNotFound(isin.to_string()));
         }
 
+        let traded_in_percent = body.traded_in_percent.unwrap_or(false);
+
         // Use the asset's quote_ccy from context, or default to EUR for XFRA
         let currency = currency_hint.unwrap_or("EUR").to_string();
 
@@ -324,21 +345,21 @@ impl BoerseFrankfurtProvider {
                 }
             })?;
 
-            let close_pct = match point.close {
+            let close_raw = match point.close {
                 Some(c) => c,
                 None => continue,
             };
 
-            // Prices are %-of-par: 97.025 means 97.025% → 0.97025
-            let close = Decimal::try_from(close_pct / 100.0).map_err(|_| {
-                MarketDataError::ValidationFailed {
-                    message: format!("Failed to convert close {} to decimal", close_pct),
-                }
-            })?;
-
-            let open = point.open.and_then(|v| Decimal::try_from(v / 100.0).ok());
-            let high = point.high.and_then(|v| Decimal::try_from(v / 100.0).ok());
-            let low = point.low.and_then(|v| Decimal::try_from(v / 100.0).ok());
+            let close = Self::convert_price(close_raw, traded_in_percent)?;
+            let open = point
+                .open
+                .and_then(|v| Self::convert_price(v, traded_in_percent).ok());
+            let high = point
+                .high
+                .and_then(|v| Self::convert_price(v, traded_in_percent).ok());
+            let low = point
+                .low
+                .and_then(|v| Self::convert_price(v, traded_in_percent).ok());
             let volume = point
                 .turnover_pieces
                 .and_then(|v| Decimal::try_from(v).ok());
@@ -408,7 +429,7 @@ impl MarketDataProvider for BoerseFrankfurtProvider {
 
     fn capabilities(&self) -> ProviderCapabilities {
         ProviderCapabilities {
-            instrument_kinds: &[InstrumentKind::Bond],
+            instrument_kinds: &[InstrumentKind::Bond, InstrumentKind::Equity],
             coverage: Coverage::global_best_effort(),
             supports_latest: true,
             supports_historical: true,
@@ -430,15 +451,7 @@ impl MarketDataProvider for BoerseFrankfurtProvider {
         context: &QuoteContext,
         instrument: ProviderInstrument,
     ) -> Result<Quote, MarketDataError> {
-        let isin = match &instrument {
-            ProviderInstrument::BondIsin { isin } => isin.to_string(),
-            _ => {
-                return Err(MarketDataError::UnsupportedAssetType(format!(
-                    "{:?}",
-                    instrument
-                )))
-            }
-        };
+        let isin = Self::extract_isin(&instrument)?;
 
         let currency_hint = context.currency_hint.as_deref();
 
@@ -465,15 +478,7 @@ impl MarketDataProvider for BoerseFrankfurtProvider {
         start: DateTime<Utc>,
         end: DateTime<Utc>,
     ) -> Result<Vec<Quote>, MarketDataError> {
-        let isin = match &instrument {
-            ProviderInstrument::BondIsin { isin } => isin.to_string(),
-            _ => {
-                return Err(MarketDataError::UnsupportedAssetType(format!(
-                    "{:?}",
-                    instrument
-                )))
-            }
-        };
+        let isin = Self::extract_isin(&instrument)?;
 
         let currency_hint = context.currency_hint.as_deref();
         let min_date = start.format("%Y-%m-%d").to_string();
@@ -509,7 +514,10 @@ mod tests {
     fn test_capabilities() {
         let provider = BoerseFrankfurtProvider::new();
         let caps = provider.capabilities();
-        assert_eq!(caps.instrument_kinds, &[InstrumentKind::Bond]);
+        assert_eq!(
+            caps.instrument_kinds,
+            &[InstrumentKind::Bond, InstrumentKind::Equity]
+        );
         assert!(caps.supports_latest);
         assert!(caps.supports_historical);
         assert!(!caps.supports_search);
@@ -612,5 +620,39 @@ mod tests {
         let pct = 100.0_f64;
         let decimal = Decimal::try_from(pct / 100.0).unwrap();
         assert_eq!(decimal.to_string(), "1");
+    }
+
+    #[test]
+    fn test_convert_price_preserves_absolute_prices_for_etfs() {
+        let price = BoerseFrankfurtProvider::convert_price(68.71, false).unwrap();
+        assert_eq!(price.to_string(), "68.71");
+    }
+
+    #[test]
+    fn test_extract_isin_accepts_generic_isin_and_bond_isin() {
+        let generic = ProviderInstrument::Isin {
+            isin: Arc::from("IE00BTJRMP35"),
+        };
+        let bond = ProviderInstrument::BondIsin {
+            isin: Arc::from("XS2530331413"),
+        };
+
+        assert_eq!(
+            BoerseFrankfurtProvider::extract_isin(&generic).unwrap(),
+            "IE00BTJRMP35"
+        );
+        assert_eq!(
+            BoerseFrankfurtProvider::extract_isin(&bond).unwrap(),
+            "XS2530331413"
+        );
+    }
+
+    #[test]
+    fn test_extract_isin_rejects_non_isin_instruments() {
+        let instrument = ProviderInstrument::EquitySymbol {
+            symbol: Arc::from("XMME"),
+        };
+        let error = BoerseFrankfurtProvider::extract_isin(&instrument).unwrap_err();
+        assert!(matches!(error, MarketDataError::UnsupportedAssetType(_)));
     }
 }

--- a/crates/market-data/src/provider/finnhub/mod.rs
+++ b/crates/market-data/src/provider/finnhub/mod.rs
@@ -277,6 +277,9 @@ impl FinnhubProvider {
             ProviderInstrument::MetalSymbol { .. } => Err(MarketDataError::UnsupportedAssetType(
                 "Finnhub does not support metals directly".to_string(),
             )),
+            ProviderInstrument::Isin { .. } => Err(MarketDataError::UnsupportedAssetType(
+                "Finnhub does not support ISIN-based securities directly".to_string(),
+            )),
             ProviderInstrument::BondIsin { .. } => Err(MarketDataError::UnsupportedAssetType(
                 "Finnhub does not support bonds directly".to_string(),
             )),

--- a/crates/market-data/src/provider/us_treasury_calc/mod.rs
+++ b/crates/market-data/src/provider/us_treasury_calc/mod.rs
@@ -523,6 +523,7 @@ impl MarketDataProvider for UsTreasuryCalcProvider {
 
 fn extract_isin(instrument: &ProviderInstrument) -> Result<String, MarketDataError> {
     match instrument {
+        ProviderInstrument::Isin { isin } => Ok(isin.to_string()),
         ProviderInstrument::BondIsin { isin } => Ok(isin.to_string()),
         _ => Err(MarketDataError::UnsupportedAssetType(format!(
             "{:?}",

--- a/crates/market-data/src/provider/yahoo/mod.rs
+++ b/crates/market-data/src/provider/yahoo/mod.rs
@@ -115,6 +115,7 @@ impl YahooProvider {
             }
             ProviderInstrument::FxPair { from, to } => Ok(format!("{}{}=X", from, to)),
             ProviderInstrument::MetalSymbol { symbol, .. } => Ok(symbol.to_string()),
+            ProviderInstrument::Isin { isin } => Ok(isin.to_string()),
             ProviderInstrument::BondIsin { isin } => Ok(isin.to_string()),
         }
     }

--- a/crates/market-data/src/resolver/asset_resolver.rs
+++ b/crates/market-data/src/resolver/asset_resolver.rs
@@ -151,4 +151,39 @@ mod tests {
         // Should return None when no override for this provider
         assert!(result.is_none());
     }
+
+    #[test]
+    fn test_resolve_isin_override() {
+        let resolver = AssetResolver::new();
+
+        let mut overrides = ProviderOverrides::new();
+        overrides.insert(
+            "BOERSE_FRANKFURT".to_string(),
+            ProviderInstrument::Isin {
+                isin: Arc::from("IE00BTJRMP35"),
+            },
+        );
+
+        let context = QuoteContext {
+            instrument: InstrumentId::Equity {
+                ticker: Arc::from("XMME"),
+                mic: Some("XETR".into()),
+            },
+            overrides: Some(overrides),
+            currency_hint: Some("EUR".into()),
+            preferred_provider: None,
+            bond_metadata: None,
+        };
+
+        let result = resolver.resolve(&"BOERSE_FRANKFURT".into(), &context);
+
+        assert!(result.is_some());
+        let resolved = result.unwrap().unwrap();
+        assert_eq!(resolved.source, ResolutionSource::Override);
+
+        match resolved.instrument {
+            ProviderInstrument::Isin { isin } => assert_eq!(isin.as_ref(), "IE00BTJRMP35"),
+            _ => panic!("Expected ISIN override"),
+        }
+    }
 }


### PR DESCRIPTION
## Description

Fixes Boerse Frankfurt quote sync for ISIN-backed ETFs/equities such as `IE00BTJRMP35`.

Root cause:
- `BOERSE_FRANKFURT` was implemented as bond-only, so Frankfurt/Xetra ETFs resolved away from the provider even though Deutsche Boerse serves them by ISIN.
- The provider also treated all returned prices as percent-of-par, which would misprice ETFs/equities that return absolute prices with `tradedInPercent: false`.

What changed:
- synthesize an internal Boerse Frankfurt ISIN override for `XFRA`/`XETR` equities that already have `metadata.identifiers.isin`
- add generic ISIN provider-instrument support for internal provider routing
- extend Boerse Frankfurt capability support to equity instruments
- honor `tradedInPercent` when converting Deutsche Boerse price history so bond behavior is preserved and ETF/equity prices are not divided by `100`
- add regression tests for the ISIN override path and BF ISIN/price parsing behavior

Validation:
- `cargo test -p wealthfolio-market-data boerse_frankfurt`
- `cargo test -p wealthfolio-market-data asset_resolver`
- `cargo test -p wealthfolio-core quotes::client`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`

Fixes #729

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).
