### PR TITLE
fix(frontend): make ticker logos exchange-aware (#623)

### DIFF
--- a/apps/frontend/src/components/ticker-avatar.test.tsx
+++ b/apps/frontend/src/components/ticker-avatar.test.tsx
@@ -1,0 +1,47 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { TickerAvatar } from "./ticker-avatar";
+
+const { mockAvatarImage } = vi.hoisted(() => ({
+  mockAvatarImage: vi.fn(
+    ({ src, alt, className }: { src?: string; alt?: string; className?: string }) => (
+      <img src={src} alt={alt} className={className} />
+    ),
+  ),
+}));
+
+vi.mock("@wealthfolio/ui", () => ({
+  Avatar: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  AvatarFallback: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  AvatarImage: mockAvatarImage,
+}));
+
+describe("TickerAvatar", () => {
+  it("uses an exchange-qualified primary logo and disables ambiguous base fallback for non-US MICs", () => {
+    const { container } = render(<TickerAvatar symbol="DTE" exchangeMic="XETR" />);
+    const images = container.querySelectorAll("img");
+
+    expect(images[0]?.getAttribute("src")).toBe("/ticker-logos/DTE.DE.png");
+    expect(images[1]?.getAttribute("src")).toBeNull();
+  });
+
+  it("keeps base-symbol fallback for unsuffixed US listings", () => {
+    const { container } = render(<TickerAvatar symbol="DTE" exchangeMic="XNYS" />);
+    const images = container.querySelectorAll("img");
+
+    expect(images[0]?.getAttribute("src")).toBe("/ticker-logos/DTE.png");
+    expect(images[1]?.getAttribute("src")).toBe("/ticker-logos/DTE.png");
+  });
+
+  it("preserves already-suffixed symbols", () => {
+    const { container } = render(<TickerAvatar symbol="DTE.DE" exchangeMic="XETR" />);
+    const images = container.querySelectorAll("img");
+
+    expect(images[0]?.getAttribute("src")).toBe("/ticker-logos/DTE.DE.png");
+    expect(images[1]?.getAttribute("src")).toBeNull();
+  });
+});

--- a/apps/frontend/src/components/ticker-avatar.tsx
+++ b/apps/frontend/src/components/ticker-avatar.tsx
@@ -4,21 +4,111 @@ import { Avatar, AvatarFallback, AvatarImage } from "@wealthfolio/ui";
 
 interface TickerAvatarProps {
   symbol: string;
+  exchangeMic?: string;
   className?: string;
 }
 
-export const TickerAvatar = ({ symbol, className = "size-8" }: TickerAvatarProps) => {
+const MIC_TO_YAHOO_SUFFIX: Record<string, string> = {
+  XTSE: "TO",
+  XTSX: "V",
+  XCNQ: "CN",
+  XMEX: "MX",
+  XLON: "L",
+  XDUB: "IR",
+  XETR: "DE",
+  XFRA: "F",
+  XSTU: "SG",
+  XHAM: "HM",
+  XDUS: "DU",
+  XMUN: "MU",
+  XBER: "BE",
+  XHAN: "HA",
+  XPAR: "PA",
+  XAMS: "AS",
+  XBRU: "BR",
+  XLIS: "LS",
+  XMIL: "MI",
+  XMAD: "MC",
+  XATH: "AT",
+  XSTO: "ST",
+  XHEL: "HE",
+  XCSE: "CO",
+  XOSL: "OL",
+  XICE: "IC",
+  XSWX: "SW",
+  XWBO: "VI",
+  XWAR: "WA",
+  XPRA: "PR",
+  XBUD: "BD",
+  XIST: "IS",
+  XSHG: "SS",
+  XSHE: "SZ",
+  XHKG: "HK",
+  XTKS: "T",
+  XKRX: "KS",
+  XKOS: "KQ",
+  XSES: "SI",
+  XBKK: "BK",
+  XIDX: "JK",
+  XKLS: "KL",
+  XBOM: "BO",
+  XNSE: "NS",
+  XTAI: "TW",
+  XASX: "AX",
+  XNZE: "NZ",
+  BVMF: "SA",
+  XBUE: "BA",
+  XSGO: "SN",
+  XTAE: "TA",
+  XSAU: "SAU",
+  XDFM: "AE",
+  DSMD: "QA",
+  XJSE: "JO",
+  XCAI: "CA",
+};
+
+const KNOWN_YAHOO_SUFFIXES = new Set(Object.values(MIC_TO_YAHOO_SUFFIX));
+
+function stripKnownYahooSuffix(symbol: string): { baseSymbol: string; hasKnownSuffix: boolean } {
+  const trimmed = symbol.trim().toUpperCase();
+  const dot = trimmed.lastIndexOf(".");
+  if (dot < 0) {
+    return { baseSymbol: trimmed, hasKnownSuffix: false };
+  }
+
+  const suffix = trimmed.slice(dot + 1);
+  if (!KNOWN_YAHOO_SUFFIXES.has(suffix)) {
+    return { baseSymbol: trimmed, hasKnownSuffix: false };
+  }
+
+  return {
+    baseSymbol: trimmed.slice(0, dot),
+    hasKnownSuffix: true,
+  };
+}
+
+export const TickerAvatar = ({ symbol, exchangeMic, className = "size-8" }: TickerAvatarProps) => {
   // For OCC option symbols (e.g. "AAPL250321C00150000"), use the underlying ticker for logo
   const parsed = symbol ? parseOccSymbol(symbol) : null;
   const logoSymbol = parsed ? parsed.underlying : symbol;
+  const normalizedExchangeMic = exchangeMic?.trim().toUpperCase();
 
-  // Extract the base symbol (before any dot, hyphen, or colon) for fallback
-  const baseSymbol = logoSymbol ? logoSymbol.split(/[.:-]/)[0].toUpperCase() : "";
+  // Extract the base symbol (before any dot, hyphen, or colon) for initials/fallback.
+  const fallbackBaseSymbol = logoSymbol ? logoSymbol.split(/[.:-]/)[0].toUpperCase() : "";
   const fullSymbol = logoSymbol ? logoSymbol.toUpperCase() : "";
+  const { baseSymbol, hasKnownSuffix } = stripKnownYahooSuffix(fullSymbol);
+  const derivedSuffix =
+    !hasKnownSuffix && normalizedExchangeMic
+      ? MIC_TO_YAHOO_SUFFIX[normalizedExchangeMic]
+      : undefined;
+  const primarySymbol = derivedSuffix ? `${baseSymbol}.${derivedSuffix}` : fullSymbol;
+  const allowBaseFallback = !hasKnownSuffix && !derivedSuffix;
 
-  // Try full symbol first, then fallback to base symbol
-  const primaryLogoUrl = fullSymbol ? `/ticker-logos/${fullSymbol}.png` : "";
-  const fallbackLogoUrl = baseSymbol ? `/ticker-logos/${baseSymbol}.png` : "";
+  // Try the exchange-aware symbol first. Only allow a base-ticker fallback when the
+  // exchange is unknown or canonically unsuffixed; otherwise prefer initials to a wrong logo.
+  const primaryLogoUrl = primarySymbol ? `/ticker-logos/${primarySymbol}.png` : "";
+  const fallbackLogoUrl =
+    allowBaseFallback && fallbackBaseSymbol ? `/ticker-logos/${fallbackBaseSymbol}.png` : undefined;
 
   return (
     <Avatar
@@ -30,7 +120,7 @@ export const TickerAvatar = ({ symbol, className = "size-8" }: TickerAvatarProps
           <AvatarImage src={fallbackLogoUrl} alt={fullSymbol} className="object-contain p-2" />
           <AvatarFallback className="bg-transparent text-xs font-medium">
             <span className="p-1" title={fullSymbol}>
-              {baseSymbol ? baseSymbol.slice(0, 4) : "•"}
+              {fallbackBaseSymbol ? fallbackBaseSymbol.slice(0, 4) : "•"}
             </span>
           </AvatarFallback>
         </Avatar>

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -444,6 +444,7 @@ export type ValidationResult = { status: "success" } | { status: "error"; errors
 export interface Instrument {
   id: string;
   symbol: string;
+  exchangeMic?: string | null;
   name?: string | null;
   currency: string;
   notes?: string | null;
@@ -524,6 +525,7 @@ export interface Holding {
 export interface HoldingSummary {
   id: string;
   symbol: string;
+  exchangeMic?: string | null;
   name?: string | null;
   holdingType: HoldingType;
   quantity: number;

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
@@ -84,7 +84,11 @@ export const ActivityTableMobile = ({
                 {(() => {
                   const inner = (
                     <>
-                      <TickerAvatar symbol={avatarSymbol} className="h-10 w-10 flex-shrink-0" />
+                      <TickerAvatar
+                        symbol={avatarSymbol}
+                        exchangeMic={activity.exchangeMic}
+                        className="h-10 w-10 flex-shrink-0"
+                      />
                       <div className="min-w-0 flex-1">
                         <div className="flex items-baseline justify-between gap-2">
                           <p className="truncate font-semibold">{displaySymbol}</p>
@@ -148,7 +152,11 @@ export const ActivityTableMobile = ({
                 {(() => {
                   const inner = (
                     <>
-                      <TickerAvatar symbol={avatarSymbol} className="h-10 w-10" />
+                      <TickerAvatar
+                        symbol={avatarSymbol}
+                        exchangeMic={activity.exchangeMic}
+                        className="h-10 w-10"
+                      />
                       <div>
                         <p className="font-semibold">{displaySymbol}</p>
                         <p className="text-muted-foreground text-xs">

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
@@ -187,7 +187,11 @@ export const ActivityTable = ({
 
           const content = (
             <div className="flex max-w-[220px] items-center gap-2">
-              <TickerAvatar symbol={avatarSymbol} className="h-8 w-8 shrink-0" />
+              <TickerAvatar
+                symbol={avatarSymbol}
+                exchangeMic={row.original.exchangeMic}
+                className="h-8 w-8 shrink-0"
+              />
               <div className="flex min-w-0 flex-col">
                 <span className="flex items-center gap-1 truncate font-medium">
                   <span className="truncate">{displaySymbol}</span>

--- a/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
+++ b/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
@@ -405,7 +405,11 @@ export function AssetEditSheet({
       <SheetContent side="right" className="pb-safe flex h-full w-full flex-col sm:max-w-2xl">
         <SheetHeader className="shrink-0 pb-4">
           <div className="flex items-center gap-3">
-            <TickerAvatar symbol={asset.displayCode ?? ""} className="size-10" />
+            <TickerAvatar
+              symbol={asset.displayCode ?? ""}
+              exchangeMic={asset.instrumentExchangeMic ?? undefined}
+              className="size-10"
+            />
             <div className="min-w-0 flex-1">
               <SheetTitle className="truncate text-lg">
                 {asset.displayCode ?? asset.name ?? "Unknown"}

--- a/apps/frontend/src/pages/asset/asset-profile-page.tsx
+++ b/apps/frontend/src/pages/asset/asset-profile-page.tsx
@@ -965,6 +965,11 @@ export const AssetProfilePage = () => {
                   assetProfile?.displayCode ??
                   assetId
                 }
+                exchangeMic={
+                  assetProfile?.instrumentExchangeMic ??
+                  holding?.instrument?.exchangeMic ??
+                  undefined
+                }
                 className="size-9"
               />
             )

--- a/apps/frontend/src/pages/asset/assets-table-mobile.tsx
+++ b/apps/frontend/src/pages/asset/assets-table-mobile.tsx
@@ -224,7 +224,11 @@ export function AssetsTableMobile({
                   const avatarSymbol = parsedOption ? parsedOption.underlying : rawSymbol;
                   return (
                     <>
-                      <TickerAvatar symbol={avatarSymbol} className="h-10 w-10 flex-shrink-0" />
+                      <TickerAvatar
+                        symbol={avatarSymbol}
+                        exchangeMic={asset.instrumentExchangeMic ?? undefined}
+                        className="h-10 w-10 flex-shrink-0"
+                      />
                       <div className="min-w-0 flex-1">
                         <div className="flex items-center gap-2">
                           <p className="truncate font-semibold">{displaySymbol}</p>

--- a/apps/frontend/src/pages/asset/assets-table.tsx
+++ b/apps/frontend/src/pages/asset/assets-table.tsx
@@ -96,7 +96,11 @@ export function AssetsTable({
               onClick={() => navigate(`/holdings/${encodeURIComponent(asset.id)}`)}
               className="hover:bg-muted/60 focus-visible:ring-ring group flex w-full items-center gap-2.5 rounded-md py-1 text-left transition"
             >
-              <TickerAvatar symbol={avatarSymbol} className="h-8 w-8 shrink-0" />
+              <TickerAvatar
+                symbol={avatarSymbol}
+                exchangeMic={asset.instrumentExchangeMic ?? undefined}
+                className="h-8 w-8 shrink-0"
+              />
               <div className="min-w-0 flex-1">
                 <div className="group-hover:text-primary flex items-center gap-1.5 font-semibold leading-tight transition-colors">
                   {displaySymbol}

--- a/apps/frontend/src/pages/dashboard/top-holdings.test.tsx
+++ b/apps/frontend/src/pages/dashboard/top-holdings.test.tsx
@@ -1,0 +1,77 @@
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import TopHoldings from "./top-holdings";
+import type { Holding } from "@/lib/types";
+
+const { mockTickerAvatar } = vi.hoisted(() => ({
+  mockTickerAvatar: vi.fn(
+    ({ symbol, exchangeMic }: { symbol: string; exchangeMic?: string; className?: string }) => (
+      <div data-testid={`ticker-avatar-${symbol}`}>{exchangeMic ?? ""}</div>
+    ),
+  ),
+}));
+
+vi.mock("@/components/ticker-avatar", () => ({
+  TickerAvatar: mockTickerAvatar,
+}));
+
+vi.mock("@/hooks/use-balance-privacy", () => ({
+  useBalancePrivacy: () => ({ isBalanceHidden: false }),
+}));
+
+const holding: Holding = {
+  id: "holding-1",
+  accountId: "acc-1",
+  holdingType: "security",
+  instrument: {
+    id: "asset-1",
+    symbol: "DTE",
+    exchangeMic: "XETR",
+    name: "Deutsche Telekom AG",
+    currency: "EUR",
+    quoteMode: "MARKET",
+    preferredProvider: null,
+    notes: null,
+    classifications: null,
+  },
+  assetKind: "INVESTMENT",
+  quantity: 10,
+  openDate: null,
+  lots: null,
+  localCurrency: "EUR",
+  baseCurrency: "EUR",
+  fxRate: null,
+  marketValue: { local: 230, base: 230 },
+  costBasis: null,
+  price: 23,
+  unrealizedGain: { local: 10, base: 10 },
+  unrealizedGainPct: 0.045,
+  realizedGain: null,
+  realizedGainPct: null,
+  totalGain: null,
+  totalGainPct: null,
+  dayChange: null,
+  dayChangePct: null,
+  prevCloseValue: null,
+  weight: 1,
+  asOfDate: "2026-03-15",
+};
+
+describe("TopHoldings", () => {
+  it("passes exchangeMic through to ticker avatars", () => {
+    render(
+      <MemoryRouter>
+        <TopHoldings holdings={[holding]} isLoading={false} baseCurrency="EUR" />
+      </MemoryRouter>,
+    );
+
+    expect(mockTickerAvatar).toHaveBeenCalledWith(
+      expect.objectContaining({
+        symbol: "DTE",
+        exchangeMic: "XETR",
+      }),
+      undefined,
+    );
+  });
+});

--- a/apps/frontend/src/pages/dashboard/top-holdings.tsx
+++ b/apps/frontend/src/pages/dashboard/top-holdings.tsx
@@ -47,7 +47,11 @@ function HoldingRow({ holding, baseCurrency, isHidden, onClick }: HoldingRowProp
       onKeyDown={(e) => e.key === "Enter" && onClick?.()}
     >
       <div className="flex items-center gap-3">
-        <TickerAvatar symbol={avatarSymbol} className="size-9" />
+        <TickerAvatar
+          symbol={avatarSymbol}
+          exchangeMic={holding.instrument?.exchangeMic ?? undefined}
+          className="size-9"
+        />
         <div className="flex flex-col">
           <span className="text-sm font-semibold">{displayName}</span>
           <span className="text-muted-foreground text-xs">{subtitle}</span>
@@ -107,7 +111,11 @@ function StackedAvatars({ holdings, totalRemaining, onClick }: StackedAvatarsPro
               className={cn("relative", index > 0 && "-ml-2")}
               style={{ zIndex: displayedHoldings.length - index }}
             >
-              <TickerAvatar symbol={avatarSym} className="ring-background size-8 ring-2" />
+              <TickerAvatar
+                symbol={avatarSym}
+                exchangeMic={holding.instrument?.exchangeMic ?? undefined}
+                className="ring-background size-8 ring-2"
+              />
             </div>
           );
         })}

--- a/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
+++ b/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
@@ -331,7 +331,11 @@ export function AllocationDetailSheet({
                       className="hover:bg-muted/30 flex cursor-pointer items-center gap-3 py-3 transition-colors"
                       onClick={() => handleHoldingClick(holding)}
                     >
-                      <TickerAvatar symbol={holding.symbol} className="h-9 w-9" />
+                      <TickerAvatar
+                        symbol={holding.symbol}
+                        exchangeMic={holding.exchangeMic ?? undefined}
+                        className="h-9 w-9"
+                      />
                       <div className="min-w-0 flex-1">
                         <p className="truncate text-sm font-semibold">{holding.symbol}</p>
                         <p className="text-muted-foreground truncate text-xs">

--- a/apps/frontend/src/pages/holdings/components/holdings-edit-mode.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-edit-mode.tsx
@@ -438,7 +438,11 @@ export const HoldingsEditMode = ({
                         {/* Symbol */}
                         <div className="col-span-5">
                           <div className="flex items-center gap-2">
-                            <TickerAvatar symbol={holding.symbol} className="h-7 w-7 shrink-0" />
+                            <TickerAvatar
+                              symbol={holding.symbol}
+                              exchangeMic={holding.exchangeMic}
+                              className="h-7 w-7 shrink-0"
+                            />
                             <div className="min-w-0">
                               <div className="truncate text-sm font-medium">{holding.symbol}</div>
                               {holding.name && (

--- a/apps/frontend/src/pages/holdings/components/holdings-grouped-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-grouped-table.tsx
@@ -221,7 +221,11 @@ function HoldingRow({
       >
         {/* Symbol/Name Column */}
         <div className="flex min-w-0 flex-1 items-center gap-3">
-          <TickerAvatar symbol={symbol} className="h-8 w-8 flex-shrink-0" />
+          <TickerAvatar
+            symbol={symbol}
+            exchangeMic={holding.instrument?.exchangeMic ?? undefined}
+            className="h-8 w-8 flex-shrink-0"
+          />
           <div className="flex min-w-0 flex-1 flex-col">
             <div className="flex items-center gap-2">
               <span className="truncate font-medium">{symbol}</span>

--- a/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
@@ -184,7 +184,11 @@ export const HoldingsTableMobile = ({
               >
                 <div className="flex items-center justify-between">
                   <div className="flex flex-1 items-center gap-3 overflow-hidden">
-                    <TickerAvatar symbol={avatarSymbol} className="h-10 w-10" />
+                    <TickerAvatar
+                      symbol={avatarSymbol}
+                      exchangeMic={holding.instrument?.exchangeMic ?? undefined}
+                      className="h-10 w-10"
+                    />
                     <div className="flex-1 overflow-hidden">
                       <p className="truncate font-semibold">{displaySymbol}</p>
                       {subtitle && (

--- a/apps/frontend/src/pages/holdings/components/holdings-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table.tsx
@@ -207,6 +207,7 @@ const getColumns = (
         <div className="flex items-center">
           <TickerAvatar
             symbol={parsedOption ? parsedOption.underlying : symbol}
+            exchangeMic={holding.instrument?.exchangeMic ?? undefined}
             className="mr-2 h-8 w-8"
           />
           <div className="flex flex-col">

--- a/apps/tauri/src/commands/portfolio.rs
+++ b/apps/tauri/src/commands/portfolio.rs
@@ -1010,6 +1010,7 @@ pub async fn get_snapshot_by_date(
             id: asset.id.clone(),
             symbol: asset.display_code.clone().unwrap_or_default(),
             name: asset.name.clone(),
+            exchange_mic: asset.instrument_exchange_mic.clone(),
             currency: asset.quote_ccy.clone(),
             notes: asset.notes.clone(),
             pricing_mode: asset.quote_mode.as_db_str().to_string(),

--- a/crates/core/src/portfolio/allocation/allocation_service.rs
+++ b/crates/core/src/portfolio/allocation/allocation_service.rs
@@ -14,6 +14,42 @@ use crate::taxonomies::{Category, TaxonomyServiceTrait};
 
 use super::{AllocationHoldings, CategoryAllocation, PortfolioAllocations, TaxonomyAllocation};
 
+fn holding_summary_from_holding(
+    holding: &Holding,
+    weighted_value: Decimal,
+    total_matched_value: Decimal,
+) -> HoldingSummary {
+    let weight_in_category = if total_matched_value > Decimal::ZERO {
+        (weighted_value / total_matched_value * dec!(100)).round_dp(2)
+    } else {
+        Decimal::ZERO
+    };
+
+    HoldingSummary {
+        // Use instrument.id (the asset ID) for navigation, not holding.id (composite ID)
+        id: holding
+            .instrument
+            .as_ref()
+            .map(|i| i.id.clone())
+            .unwrap_or_else(|| holding.id.clone()),
+        symbol: holding
+            .instrument
+            .as_ref()
+            .map(|i| i.symbol.clone())
+            .unwrap_or_default(),
+        exchange_mic: holding
+            .instrument
+            .as_ref()
+            .and_then(|i| i.exchange_mic.clone()),
+        name: holding.instrument.as_ref().and_then(|i| i.name.clone()),
+        holding_type: holding.holding_type.clone(),
+        quantity: holding.quantity,
+        market_value: weighted_value,
+        currency: holding.base_currency.clone(),
+        weight_in_category,
+    }
+}
+
 /// Trait for allocation service.
 #[async_trait]
 pub trait AllocationServiceTrait: Send + Sync {
@@ -599,31 +635,7 @@ impl AllocationServiceTrait for AllocationService {
             .map(|(holding, weight)| {
                 let weight_decimal = Decimal::from(weight) / dec!(10000);
                 let weighted_value = holding.market_value.base * weight_decimal;
-                let weight_in_category = if total_matched_value > Decimal::ZERO {
-                    (weighted_value / total_matched_value * dec!(100)).round_dp(2)
-                } else {
-                    Decimal::ZERO
-                };
-
-                HoldingSummary {
-                    // Use instrument.id (the asset ID) for navigation, not holding.id (composite ID)
-                    id: holding
-                        .instrument
-                        .as_ref()
-                        .map(|i| i.id.clone())
-                        .unwrap_or_else(|| holding.id.clone()),
-                    symbol: holding
-                        .instrument
-                        .as_ref()
-                        .map(|i| i.symbol.clone())
-                        .unwrap_or_default(),
-                    name: holding.instrument.as_ref().and_then(|i| i.name.clone()),
-                    holding_type: holding.holding_type.clone(),
-                    quantity: holding.quantity,
-                    market_value: weighted_value,
-                    currency: holding.base_currency.clone(),
-                    weight_in_category,
-                }
+                holding_summary_from_holding(&holding, weighted_value, total_matched_value)
             })
             .collect();
 
@@ -640,5 +652,64 @@ impl AllocationServiceTrait for AllocationService {
             total_value: total_matched_value,
             currency: base_currency.to_string(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::portfolio::holdings::{Instrument, MonetaryValue};
+    use chrono::Utc;
+
+    #[test]
+    fn holding_summary_from_holding_preserves_exchange_mic() {
+        let holding = Holding {
+            id: "holding-1".to_string(),
+            account_id: "acc-1".to_string(),
+            holding_type: HoldingType::Security,
+            instrument: Some(Instrument {
+                id: "asset-1".to_string(),
+                symbol: "DTE".to_string(),
+                exchange_mic: Some("XETR".to_string()),
+                name: Some("Deutsche Telekom AG".to_string()),
+                currency: "EUR".to_string(),
+                notes: None,
+                pricing_mode: "MARKET".to_string(),
+                preferred_provider: None,
+                classifications: None,
+            }),
+            asset_kind: None,
+            quantity: dec!(10),
+            open_date: Some(Utc::now()),
+            lots: None,
+            contract_multiplier: Decimal::ONE,
+            local_currency: "EUR".to_string(),
+            base_currency: "EUR".to_string(),
+            fx_rate: None,
+            market_value: MonetaryValue {
+                local: dec!(230),
+                base: dec!(230),
+            },
+            cost_basis: None,
+            price: Some(dec!(23)),
+            purchase_price: None,
+            unrealized_gain: None,
+            unrealized_gain_pct: None,
+            realized_gain: None,
+            realized_gain_pct: None,
+            total_gain: None,
+            total_gain_pct: None,
+            day_change: None,
+            day_change_pct: None,
+            prev_close_value: None,
+            weight: dec!(1),
+            as_of_date: chrono::Utc::now().date_naive(),
+            metadata: None,
+        };
+
+        let summary = holding_summary_from_holding(&holding, dec!(230), dec!(230));
+
+        assert_eq!(summary.symbol, "DTE");
+        assert_eq!(summary.exchange_mic.as_deref(), Some("XETR"));
     }
 }

--- a/crates/core/src/portfolio/allocation/allocation_service.rs
+++ b/crates/core/src/portfolio/allocation/allocation_service.rs
@@ -635,7 +635,7 @@ impl AllocationServiceTrait for AllocationService {
             .map(|(holding, weight)| {
                 let weight_decimal = Decimal::from(weight) / dec!(10000);
                 let weighted_value = holding.market_value.base * weight_decimal;
-                holding_summary_from_holding(&holding, weighted_value, total_matched_value)
+                holding_summary_from_holding(holding, weighted_value, total_matched_value)
             })
             .collect();
 

--- a/crates/core/src/portfolio/holdings/holdings_model.rs
+++ b/crates/core/src/portfolio/holdings/holdings_model.rs
@@ -24,6 +24,7 @@ pub enum HoldingType {
 pub struct Instrument {
     pub id: String,
     pub symbol: String,
+    pub exchange_mic: Option<String>,
     pub name: Option<String>,
     pub currency: String,
     pub notes: Option<String>,
@@ -57,6 +58,7 @@ impl MonetaryValue {
 pub struct HoldingSummary {
     pub id: String,
     pub symbol: String,
+    pub exchange_mic: Option<String>,
     pub name: Option<String>,
     pub holding_type: HoldingType,
     pub quantity: Decimal,

--- a/crates/core/src/portfolio/holdings/holdings_service.rs
+++ b/crates/core/src/portfolio/holdings/holdings_service.rs
@@ -51,6 +51,20 @@ struct AssetInfo {
     purchase_price: Option<Decimal>,
 }
 
+fn instrument_from_asset(asset: &Asset) -> Instrument {
+    Instrument {
+        id: asset.id.clone(),
+        symbol: asset.display_code.clone().unwrap_or_default(),
+        exchange_mic: asset.instrument_exchange_mic.clone(),
+        name: asset.name.clone(),
+        currency: asset.quote_ccy.clone(),
+        notes: asset.notes.clone(),
+        pricing_mode: asset.quote_mode.as_db_str().to_string(),
+        preferred_provider: asset.preferred_provider(),
+        classifications: None,
+    }
+}
+
 impl HoldingsService {
     pub fn new(
         asset_service: Arc<dyn AssetServiceTrait>,
@@ -120,16 +134,7 @@ impl HoldingsService {
                         let purchase_price: Option<Decimal> =
                             metadata.as_ref().and_then(extract_purchase_price);
 
-                        let instrument = Instrument {
-                            id: asset.id.clone(),
-                            symbol: asset.display_code.clone().unwrap_or_default(),
-                            name: asset.name.clone(),
-                            currency: asset.quote_ccy.clone(),
-                            notes: asset.notes.clone(),
-                            pricing_mode: asset.quote_mode.as_db_str().to_string(),
-                            preferred_provider: asset.preferred_provider(),
-                            classifications: None,
-                        };
+                        let instrument = instrument_from_asset(&asset);
 
                         let asset_info = AssetInfo {
                             instrument,
@@ -217,6 +222,7 @@ impl HoldingsService {
             let cash_instrument = Instrument {
                 id: format!("cash:{}", currency),
                 symbol: currency.clone(),
+                exchange_mic: None,
                 name: Some(format!("Cash ({})", currency)),
                 currency: currency.clone(),
                 notes: None,
@@ -587,16 +593,7 @@ impl HoldingsServiceTrait for HoldingsService {
             let purchase_price: Option<Decimal> =
                 asset.metadata.as_ref().and_then(extract_purchase_price);
 
-            let instrument = Instrument {
-                id: asset.id.clone(),
-                symbol: asset.display_code.clone().unwrap_or_default(),
-                name: asset.name.clone(),
-                currency: asset.quote_ccy.clone(),
-                notes: asset.notes.clone(),
-                pricing_mode: asset.quote_mode.as_db_str().to_string(),
-                preferred_provider: asset.preferred_provider(),
-                classifications: None,
-            };
+            let instrument = instrument_from_asset(&asset);
 
             let holding = Holding {
                 id: format!(
@@ -692,10 +689,30 @@ mod tests {
     use crate::utils::time_utils::valuation_date_today;
 
     use super::*;
+    use crate::assets::{InstrumentType, QuoteMode};
     use chrono::Utc;
     use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
     use std::collections::VecDeque;
+
+    #[test]
+    fn instrument_from_asset_preserves_exchange_mic() {
+        let asset = Asset {
+            id: "asset-1".to_string(),
+            display_code: Some("DTE".to_string()),
+            instrument_exchange_mic: Some("XETR".to_string()),
+            name: Some("Deutsche Telekom AG".to_string()),
+            quote_ccy: "EUR".to_string(),
+            quote_mode: QuoteMode::Market,
+            instrument_type: Some(InstrumentType::Equity),
+            ..Default::default()
+        };
+
+        let instrument = instrument_from_asset(&asset);
+
+        assert_eq!(instrument.symbol, "DTE");
+        assert_eq!(instrument.exchange_mic.as_deref(), Some("XETR"));
+    }
 
     #[test]
     fn normalize_holding_currency_converts_minor_security_units() {
@@ -707,6 +724,7 @@ mod tests {
             instrument: Some(Instrument {
                 id: "TEST".to_string(),
                 symbol: "TEST".to_string(),
+                exchange_mic: None,
                 name: Some("Test".to_string()),
                 currency: "GBp".to_string(),
                 notes: None,

--- a/crates/core/src/portfolio/holdings/holdings_service.rs
+++ b/crates/core/src/portfolio/holdings/holdings_service.rs
@@ -593,7 +593,7 @@ impl HoldingsServiceTrait for HoldingsService {
             let purchase_price: Option<Decimal> =
                 asset.metadata.as_ref().and_then(extract_purchase_price);
 
-            let instrument = instrument_from_asset(&asset);
+            let instrument = instrument_from_asset(asset);
 
             let holding = Holding {
                 id: format!(

--- a/crates/core/src/portfolio/holdings/holdings_valuation_service_tests.rs
+++ b/crates/core/src/portfolio/holdings/holdings_valuation_service_tests.rs
@@ -458,6 +458,7 @@ mod tests {
             Some(Instrument {
                 id: symbol_or_cash_code.to_string(), // Use symbol as ID to match mock quote keys
                 symbol: symbol_or_cash_code.to_string(),
+                exchange_mic: None,
                 name: Some(name.unwrap_or(symbol_or_cash_code).to_string()),
                 currency: local_currency.to_string(),
                 notes: None,

--- a/packages/ui/src/components/common/ticker-avatar.tsx
+++ b/packages/ui/src/components/common/ticker-avatar.tsx
@@ -3,17 +3,102 @@ import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
 
 interface TickerAvatarProps {
   symbol: string;
+  exchangeMic?: string;
   className?: string;
 }
 
-export const TickerAvatar = ({ symbol, className = "size-8" }: TickerAvatarProps) => {
-  // Extract the base symbol (before any dot, hyphen, or colon) for fallback
-  const baseSymbol = symbol ? symbol.split(/[.:-]/)[0].toUpperCase() : "";
-  const fullSymbol = symbol ? symbol.toUpperCase() : "";
+const MIC_TO_YAHOO_SUFFIX: Record<string, string> = {
+  XTSE: "TO",
+  XTSX: "V",
+  XCNQ: "CN",
+  XMEX: "MX",
+  XLON: "L",
+  XDUB: "IR",
+  XETR: "DE",
+  XFRA: "F",
+  XSTU: "SG",
+  XHAM: "HM",
+  XDUS: "DU",
+  XMUN: "MU",
+  XBER: "BE",
+  XHAN: "HA",
+  XPAR: "PA",
+  XAMS: "AS",
+  XBRU: "BR",
+  XLIS: "LS",
+  XMIL: "MI",
+  XMAD: "MC",
+  XATH: "AT",
+  XSTO: "ST",
+  XHEL: "HE",
+  XCSE: "CO",
+  XOSL: "OL",
+  XICE: "IC",
+  XSWX: "SW",
+  XWBO: "VI",
+  XWAR: "WA",
+  XPRA: "PR",
+  XBUD: "BD",
+  XIST: "IS",
+  XSHG: "SS",
+  XSHE: "SZ",
+  XHKG: "HK",
+  XTKS: "T",
+  XKRX: "KS",
+  XKOS: "KQ",
+  XSES: "SI",
+  XBKK: "BK",
+  XIDX: "JK",
+  XKLS: "KL",
+  XBOM: "BO",
+  XNSE: "NS",
+  XTAI: "TW",
+  XASX: "AX",
+  XNZE: "NZ",
+  BVMF: "SA",
+  XBUE: "BA",
+  XSGO: "SN",
+  XTAE: "TA",
+  XSAU: "SAU",
+  XDFM: "AE",
+  DSMD: "QA",
+  XJSE: "JO",
+  XCAI: "CA",
+};
 
-  // Try full symbol first, then fallback to base symbol
-  const primaryLogoUrl = fullSymbol ? `/ticker-logos/${fullSymbol}.png` : "";
-  const fallbackLogoUrl = baseSymbol ? `/ticker-logos/${baseSymbol}.png` : "";
+const KNOWN_YAHOO_SUFFIXES = new Set(Object.values(MIC_TO_YAHOO_SUFFIX));
+
+function stripKnownYahooSuffix(symbol: string): { baseSymbol: string; hasKnownSuffix: boolean } {
+  const trimmed = symbol.trim().toUpperCase();
+  const dot = trimmed.lastIndexOf(".");
+  if (dot < 0) {
+    return { baseSymbol: trimmed, hasKnownSuffix: false };
+  }
+
+  const suffix = trimmed.slice(dot + 1);
+  if (!KNOWN_YAHOO_SUFFIXES.has(suffix)) {
+    return { baseSymbol: trimmed, hasKnownSuffix: false };
+  }
+
+  return {
+    baseSymbol: trimmed.slice(0, dot),
+    hasKnownSuffix: true,
+  };
+}
+
+export const TickerAvatar = ({ symbol, exchangeMic, className = "size-8" }: TickerAvatarProps) => {
+  const fallbackBaseSymbol = symbol ? symbol.split(/[.:-]/)[0].toUpperCase() : "";
+  const fullSymbol = symbol ? symbol.toUpperCase() : "";
+  const normalizedExchangeMic = exchangeMic?.trim().toUpperCase();
+  const { baseSymbol, hasKnownSuffix } = stripKnownYahooSuffix(fullSymbol);
+  const derivedSuffix =
+    !hasKnownSuffix && normalizedExchangeMic ? MIC_TO_YAHOO_SUFFIX[normalizedExchangeMic] : undefined;
+  const primarySymbol = derivedSuffix ? `${baseSymbol}.${derivedSuffix}` : fullSymbol;
+  const allowBaseFallback = !hasKnownSuffix && !derivedSuffix;
+
+  const primaryLogoUrl = primarySymbol ? `/ticker-logos/${primarySymbol}.png` : "";
+  const fallbackLogoUrl =
+    allowBaseFallback && fallbackBaseSymbol ? `/ticker-logos/${fallbackBaseSymbol}.png` : undefined;
 
   return (
     <Avatar className={cn("bg-primary/80 dark:bg-primary/20 border-white/20 backdrop-blur-md", className)}>
@@ -23,7 +108,7 @@ export const TickerAvatar = ({ symbol, className = "size-8" }: TickerAvatarProps
           <AvatarImage src={fallbackLogoUrl} alt={fullSymbol} className="object-contain p-2" />
           <AvatarFallback className="bg-transparent text-xs font-medium">
             <span className="p-1" title={fullSymbol}>
-              {baseSymbol ? baseSymbol.slice(0, 4) : "•"}
+              {fallbackBaseSymbol ? fallbackBaseSymbol.slice(0, 4) : "•"}
             </span>
           </AvatarFallback>
         </Avatar>


### PR DESCRIPTION
## Description

Root cause:
- Asset avatars currently resolve logos with a simple `fullSymbol -> baseSymbol` lookup against `/ticker-logos/*.png`.
- For ambiguous tickers like `DTE`, that means a German/Xetra asset with symbol `DTE` falls back to `DTE.png`, which is the US listing logo.
- The rest of the app already carries exchange context (`exchangeMic`), but the logo lookup path was ignoring it.

Lookup method in this PR:
- If the symbol is already exchange-qualified, keep it unchanged.
- If the symbol is unsuffixed and the view has an `exchangeMic`, derive the Yahoo-style suffix from that MIC (for example `XETR -> .DE`, `XFRA -> .F`, `XLON -> .L`) and try the exchange-qualified logo first.
- Only allow the unsuffixed base-symbol fallback when the exchange is unknown or canonically unsuffixed (US-style cases).
- If a non-US exchange-qualified logo asset is missing, fall back to initials instead of showing an incorrect logo.

Fix summary:
- Made `TickerAvatar` exchange-aware in both frontend/shared components.
- Propagated `exchangeMic` through asset, activity, holdings, dashboard, and allocation avatar call sites.
- Added optional `exchangeMic` to holdings `Instrument` and allocation `HoldingSummary` payloads and populated them in core services.
- Added regressions for the avatar lookup, UI wiring, and core payload propagation.

User-visible tradeoff:
- Some non-US assets may now show initials instead of borrowing an incorrect unsuffixed US logo when no exchange-specific logo asset exists. This is intentional to prefer no logo over a wrong-company logo.

Validation:
- `pnpm --filter frontend test -- ticker-avatar`
- `pnpm --filter frontend test -- top-holdings`
- `cargo test -p wealthfolio-core exchange_mic`
- `cargo test -p wealthfolio-core portfolio::holdings`
- `cargo test -p wealthfolio-core allocation_service`
- `pnpm --filter frontend lint` (passes with existing repo warning baseline)
- `cargo fmt --all -- --check`
- `pnpm exec prettier --check ...` on all touched frontend/package files
- `pnpm --filter frontend type-check` still fails on pre-existing unrelated issues in `apps/frontend/src/addons/type-bridge.ts` and `apps/frontend/src/pages/holdings/components/alternative-holdings-table.tsx`

Fixes #623

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).
