### PR TITLE
fix(core): harden addon ZIP extraction paths

### DIFF
--- a/apps/tauri/src/commands/addon.rs
+++ b/apps/tauri/src/commands/addon.rs
@@ -37,7 +37,8 @@ pub async fn install_addon_zip(
 
     // Write all addon files
     for file in &extracted.files {
-        let file_path = addon_dir.join(&file.name);
+        let relative_path = addons::validated_addon_archive_path(&file.name)?;
+        let file_path = addon_dir.join(relative_path);
         if let Some(parent) = file_path.parent() {
             fs::create_dir_all(parent)
                 .map_err(|e| format!("Failed to create file directory: {}", e))?;

--- a/crates/core/src/addons/service.rs
+++ b/crates/core/src/addons/service.rs
@@ -1,6 +1,6 @@
 use std::fs;
 use std::io::Read;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use async_trait::async_trait;
 
@@ -87,6 +87,62 @@ pub fn ensure_addons_directory(base_dir: impl AsRef<Path>) -> Result<PathBuf, St
 pub fn get_addon_path(base_dir: impl AsRef<Path>, addon_id: &str) -> Result<PathBuf, String> {
     let addons_dir = ensure_addons_directory(base_dir)?;
     Ok(addons_dir.join(addon_id))
+}
+
+pub fn validated_addon_archive_path(file_name: &str) -> Result<PathBuf, String> {
+    if file_name.is_empty() {
+        return Err("Unsafe addon archive path: path is empty".to_string());
+    }
+
+    if file_name.contains('\\') {
+        return Err(format!(
+            "Unsafe addon archive path '{}': backslashes are not allowed",
+            file_name
+        ));
+    }
+
+    if file_name.len() >= 2
+        && file_name.as_bytes()[1] == b':'
+        && file_name.as_bytes()[0].is_ascii_alphabetic()
+    {
+        return Err(format!(
+            "Unsafe addon archive path '{}': Windows drive prefixes are not allowed",
+            file_name
+        ));
+    }
+
+    let path = Path::new(file_name);
+    if path.is_absolute() {
+        return Err(format!(
+            "Unsafe addon archive path '{}': absolute paths are not allowed",
+            file_name
+        ));
+    }
+
+    let mut has_normal_component = false;
+    for component in path.components() {
+        match component {
+            Component::Normal(_) => has_normal_component = true,
+            Component::ParentDir => {
+                return Err(format!(
+                    "Unsafe addon archive path '{}': parent traversal is not allowed",
+                    file_name
+                ));
+            }
+            Component::RootDir | Component::CurDir | Component::Prefix(_) => {
+                return Err(format!("Unsafe addon archive path '{}'", file_name));
+            }
+        }
+    }
+
+    if !has_normal_component {
+        return Err(format!(
+            "Unsafe addon archive path '{}': no file components found",
+            file_name
+        ));
+    }
+
+    Ok(path.to_path_buf())
 }
 
 /// Simple permission detection based on common API function patterns
@@ -440,6 +496,7 @@ pub fn extract_addon_zip_internal(zip_data: Vec<u8>) -> Result<ExtractedAddon, S
         }
 
         let file_name = file.name().to_string();
+        validated_addon_archive_path(&file_name)?;
         let mut contents = String::new();
 
         file.read_to_string(&mut contents)
@@ -1334,7 +1391,8 @@ impl AddonService {
 
     fn write_addon_files(&self, addon_dir: &Path, files: &[AddonFile]) -> Result<(), String> {
         for file in files {
-            let file_path = addon_dir.join(&file.name);
+            let relative_path = validated_addon_archive_path(&file.name)?;
+            let file_path = addon_dir.join(relative_path);
             if let Some(parent) = file_path.parent() {
                 fs::create_dir_all(parent)
                     .map_err(|e| format!("Failed to create directory: {}", e))?;

--- a/crates/core/src/addons/tests.rs
+++ b/crates/core/src/addons/tests.rs
@@ -1,5 +1,26 @@
 use crate::addons::models::*;
 use crate::addons::service::*;
+use std::io::Write;
+use zip::write::SimpleFileOptions;
+
+fn build_test_addon_zip(entries: &[(&str, &str)]) -> Vec<u8> {
+    let mut cursor = std::io::Cursor::new(Vec::new());
+    {
+        let mut zip = zip::ZipWriter::new(&mut cursor);
+        let options = SimpleFileOptions::default();
+
+        for (name, content) in entries {
+            zip.start_file(name, options)
+                .expect("failed to start zip file");
+            zip.write_all(content.as_bytes())
+                .expect("failed to write zip file");
+        }
+
+        zip.finish().expect("failed to finish zip");
+    }
+
+    cursor.into_inner()
+}
 
 #[test]
 fn test_detect_addon_permissions_hello_world() {
@@ -610,6 +631,107 @@ fn test_parse_manifest_json_metadata_service() {
     assert!(!permissions[0].functions[0].is_detected);
 }
 
+#[test]
+fn test_extract_addon_zip_rejects_parent_traversal_path() {
+    let zip_data = build_test_addon_zip(&[
+        (
+            "manifest.json",
+            r#"{"id":"test-addon","name":"Test Addon","version":"1.0.0","main":"dist/addon.js"}"#,
+        ),
+        ("dist/addon.js", "console.log('ok');"),
+        ("../evil.js", "console.log('bad');"),
+    ]);
+
+    let err = match extract_addon_zip_internal(zip_data) {
+        Ok(_) => panic!("zip should be rejected"),
+        Err(err) => err,
+    };
+    assert!(err.contains("Unsafe addon archive path"));
+}
+
+#[test]
+fn test_extract_addon_zip_rejects_nested_parent_traversal_path() {
+    let zip_data = build_test_addon_zip(&[
+        (
+            "manifest.json",
+            r#"{"id":"test-addon","name":"Test Addon","version":"1.0.0","main":"dist/addon.js"}"#,
+        ),
+        ("dist/addon.js", "console.log('ok');"),
+        ("dist/../../evil.js", "console.log('bad');"),
+    ]);
+
+    let err = match extract_addon_zip_internal(zip_data) {
+        Ok(_) => panic!("zip should be rejected"),
+        Err(err) => err,
+    };
+    assert!(err.contains("Unsafe addon archive path"));
+}
+
+#[test]
+fn test_extract_addon_zip_rejects_absolute_path() {
+    let zip_data = build_test_addon_zip(&[
+        (
+            "manifest.json",
+            r#"{"id":"test-addon","name":"Test Addon","version":"1.0.0","main":"dist/addon.js"}"#,
+        ),
+        ("dist/addon.js", "console.log('ok');"),
+        ("/tmp/evil.js", "console.log('bad');"),
+    ]);
+
+    let err = match extract_addon_zip_internal(zip_data) {
+        Ok(_) => panic!("zip should be rejected"),
+        Err(err) => err,
+    };
+    assert!(err.contains("Unsafe addon archive path"));
+}
+
+#[test]
+fn test_extract_addon_zip_rejects_windows_drive_path() {
+    let zip_data = build_test_addon_zip(&[
+        (
+            "manifest.json",
+            r#"{"id":"test-addon","name":"Test Addon","version":"1.0.0","main":"dist/addon.js"}"#,
+        ),
+        ("dist/addon.js", "console.log('ok');"),
+        ("C:/evil.js", "console.log('bad');"),
+    ]);
+
+    let err = match extract_addon_zip_internal(zip_data) {
+        Ok(_) => panic!("zip should be rejected"),
+        Err(err) => err,
+    };
+    assert!(err.contains("Unsafe addon archive path"));
+}
+
+#[test]
+fn test_extract_addon_zip_accepts_valid_nested_paths() {
+    let zip_data = build_test_addon_zip(&[
+        (
+            "manifest.json",
+            r#"{"id":"test-addon","name":"Test Addon","version":"1.0.0","main":"dist/addon.js"}"#,
+        ),
+        ("dist/addon.js", "console.log('ok');"),
+        ("dist/helpers/util.js", "export const value = 1;"),
+    ]);
+
+    let extracted = extract_addon_zip_internal(zip_data).expect("zip should extract");
+    assert_eq!(extracted.metadata.id, "test-addon");
+    assert!(
+        extracted
+            .files
+            .iter()
+            .any(|file| file.name == "dist/addon.js" && file.is_main),
+        "main file should be preserved"
+    );
+    assert!(
+        extracted
+            .files
+            .iter()
+            .any(|file| file.name == "dist/helpers/util.js"),
+        "nested helper file should be preserved"
+    );
+}
+
 #[cfg(test)]
 mod service_tests {
     use super::*;
@@ -710,6 +832,42 @@ mod service_tests {
         assert!(permissions[0].functions[0].is_declared);
 
         // Clean up
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[tokio::test]
+    async fn test_install_addon_zip_rejects_unsafe_paths_without_writing_files() {
+        let temp_dir = env::temp_dir().join("wealthfolio_test_addon_zip_traversal");
+        if temp_dir.exists() {
+            std::fs::remove_dir_all(&temp_dir).ok();
+        }
+
+        let zip_data = build_test_addon_zip(&[
+            (
+                "manifest.json",
+                r#"{"id":"test-addon","name":"Test Addon","version":"1.0.0","main":"dist/addon.js"}"#,
+            ),
+            ("dist/addon.js", "console.log('ok');"),
+            ("../evil.js", "console.log('bad');"),
+        ]);
+
+        let service = AddonService::new(&temp_dir, "test-instance");
+        let result = service.install_addon_zip(zip_data, true).await;
+        let addon_dir = temp_dir.join("addons").join("test-addon");
+
+        assert!(result.is_err(), "unsafe zip install should fail");
+        assert!(
+            result
+                .err()
+                .unwrap_or_default()
+                .contains("Unsafe addon archive path"),
+            "install should fail with unsafe path error"
+        );
+        assert!(
+            !addon_dir.exists(),
+            "addon directory should not be populated on failed install"
+        );
+
         std::fs::remove_dir_all(&temp_dir).ok();
     }
 }


### PR DESCRIPTION
## Description

Root cause:
- addon ZIP extraction/install trusted archive entry names and joined them directly into the addon directory
- malicious paths such as `../evil.js`, absolute paths, or Windows drive-prefixed paths could escape the addon root and write arbitrary files writable by the app

Fix summary:
- add a shared addon archive path validator in the core addon service
- reject unsafe archive paths during ZIP extraction before any `AddonFile` is accepted
- reuse the same validation in addon file writes and the Tauri direct-install path
- preserve valid nested addon paths and hard-fail malformed archives with a clear error

Validation:
- `pnpm install --frozen-lockfile`
- `pnpm run build:types`
- `pnpm format:check`
- `pnpm lint`
- `pnpm type-check`
- `pnpm test`
- `pnpm build`
- `CONNECT_API_URL=http://test.local cargo fmt --all -- --check`
- `CONNECT_API_URL=http://test.local cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `CONNECT_API_URL=http://test.local cargo test --workspace`
- `CONNECT_API_URL=http://test.local cargo build -p wealthfolio-server --release`

Security coverage added:
- reject `../evil.js`
- reject `dist/../../evil.js`
- reject `/tmp/evil.js`
- reject `C:/evil.js`
- accept valid nested paths like `dist/addon.js`
- verify service install fails before populating the addon directory for unsafe archives

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).
