### PR TITLE
Normalize OCC option symbols from broker sync to compact format

### DIFF
--- a/crates/core/src/assets/assets_model.rs
+++ b/crates/core/src/assets/assets_model.rs
@@ -382,6 +382,8 @@ impl Asset {
     /// Returns the contract multiplier for this asset.
     ///
     /// For options, this is the number of shares per contract (typically 100).
+    /// For precious metals with a weight suffix (e.g. XAU-1KG), this is the
+    /// weight in troy ounces so that a per-oz spot quote is scaled correctly.
     /// For all other instruments it is 1.
     pub fn contract_multiplier(&self) -> Decimal {
         if let Some(spec) = self.option_spec() {
@@ -389,6 +391,8 @@ impl Asset {
         } else if self.is_option() {
             // Option without metadata — default to standard 100 multiplier
             Decimal::from(100)
+        } else if self.is_metal() {
+            self.metal_weight_oz()
         } else {
             Decimal::ONE
         }


### PR DESCRIPTION
## Summary
- Brokers (via SnapTrade) may return space-padded OCC symbols (e.g. `GE    270115C00340000`) which creates duplicate assets when the same contract also appears in compact form (`GE270115C00340000`)
- Parse incoming option symbols in the broker mapping layer with the existing `parse_occ_symbol()` utility and rebuild in compact format via `build_occ_symbol()` to ensure consistent asset identity

## Test plan
- [ ] Verify existing option positions from Connect sync are not duplicated
- [ ] Verify option symbols from non-Connect sources (CSV import, manual entry) are unaffected
- [ ] All existing tests pass