### PR TITLE
fix: make contribution limits page responsive on mobile

### DIFF
--- a/apps/frontend/src/pages/settings/contribution-limits/components/contribution-limit-edit-modal.tsx
+++ b/apps/frontend/src/pages/settings/contribution-limits/components/contribution-limit-edit-modal.tsx
@@ -15,7 +15,7 @@ export function ContributionLimitEditModal({
 }: ContributionLimitEditModalProps) {
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="max-h-[90vh] w-[50vw] max-w-5xl overflow-y-auto">
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[650px]">
         <ContributionLimitForm
           defaultValues={
             limit ?? {

--- a/apps/frontend/src/pages/settings/contribution-limits/contribution-limits-page.tsx
+++ b/apps/frontend/src/pages/settings/contribution-limits/contribution-limits-page.tsx
@@ -107,15 +107,15 @@ const SettingsContributionLimitPage = () => {
           {previousYearsLimits.length > 0 && (
             <div className="mt-8">
               <div className="flex items-center justify-center">
-                <Separator className="w-1/3" />
+                <Separator className="flex-1" />
                 <Button
                   variant="outline"
-                  className="mx-4 rounded-full"
+                  className="mx-4 shrink-0 rounded-full"
                   onClick={() => setShowPreviousYears(!showPreviousYears)}
                 >
                   {showPreviousYears ? "Hide" : "Show"} Previous Years
                 </Button>
-                <Separator className="w-1/3" />
+                <Separator className="flex-1" />
               </div>
 
               {showPreviousYears && (


### PR DESCRIPTION
## Changes

- **contribution-limit-edit-modal.tsx**: Updated DialogContent className to use responsive `sm:max-w-[650px]` instead of fixed `w-[50vw] max-w-5xl` for better mobile compatibility
- **contribution-limits-page.tsx**: 
  - Changed Separator widths from `w-1/3` to `flex-1` for flexible spacing
  - Added `shrink-0` to toggle button to prevent unwanted shrinking on smaller screens

These changes improve the responsiveness of the contribution limits settings page on mobile devices.