### PR TITLE
Improve authentication setup documentation and error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,16 @@ All configuration is done via environment variables in `.env.web`.
 
   Copy the full output (starting with `$argon2id$...`) into `.env.web`.
 
+  **Dollar-sign (`$`) escaping cheat-sheet** — Argon2 hashes contain `$`
+  characters that shells and Compose interpret as variable references:
+
+  | Context                     | Syntax                                 | Notes                                          |
+  | --------------------------- | -------------------------------------- | ---------------------------------------------- |
+  | `.env` file                 | `WF_AUTH_PASSWORD_HASH=$argon2id$...`  | No quotes, no escaping needed                  |
+  | Docker Compose YAML inline  | `HASH: '$$argon2id$$v=19$$...'`        | Double every `$` to escape Compose interpolation|
+  | `docker run` (single quotes)| `-e HASH='$argon2id$...'`              | Single quotes prevent shell expansion          |
+  | `docker run` (double quotes)| `-e HASH="\$argon2id\$..."`            | Backslash-escape each `$`                      |
+
 - Sessions are cookie-based (`HttpOnly`, `SameSite=Lax`, `Path=/api`). The login
   endpoint sets the session cookie automatically — no token is exposed to
   client-side JavaScript. Sessions last 60 minutes by default (see

--- a/apps/server/src/auth.rs
+++ b/apps/server/src/auth.rs
@@ -102,7 +102,14 @@ pub struct AuthStatusResponse {
 
 impl AuthManager {
     pub fn new(config: &AuthConfig) -> anyhow::Result<Self> {
-        PasswordHash::new(&config.password_hash)?;
+        PasswordHash::new(&config.password_hash).map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to parse WF_AUTH_PASSWORD_HASH: {e}. \
+                 The hash must be a valid Argon2id PHC string starting with '$argon2id$'. \
+                 If using Docker Compose YAML, double every '$' (e.g. '$$argon2id$$v=19$$...'). \
+                 If using a .env file, no escaping is needed."
+            )
+        })?;
         let encoding_key = EncodingKey::from_secret(&config.jwt_secret);
         let decoding_key = DecodingKey::from_secret(&config.jwt_secret);
         let mut validation = Validation::new(Algorithm::HS256);

--- a/apps/server/src/config.rs
+++ b/apps/server/src/config.rs
@@ -99,8 +99,16 @@ impl Config {
             if auth_required {
                 panic!(
                     "Refusing to start: listening on non-loopback address {listen_addr} without \
-                     authentication. Set WF_AUTH_PASSWORD_HASH to enable auth, or set \
-                     WF_AUTH_REQUIRED=false if a reverse proxy handles authentication."
+                     authentication.\n\
+                     \n\
+                     To fix this, do one of the following:\n\
+                     \n\
+                     1. Set WF_AUTH_PASSWORD_HASH to an Argon2id hash of your password.\n\
+                        Generate one with: printf 'your-password' | argon2 yoursalt16chars! -id -e\n\
+                        In a .env file, no escaping is needed.\n\
+                        In Docker Compose YAML, double every $ sign: '$$argon2id$$v=19$$...'\n\
+                     \n\
+                     2. Set WF_AUTH_REQUIRED=false if a reverse proxy handles authentication."
                 );
             }
         }

--- a/compose.yml
+++ b/compose.yml
@@ -20,10 +20,25 @@ services:
       WF_DB_PATH: "/data/wealthfolio.db"
       # Required — generate with: openssl rand -base64 32
       WF_SECRET_KEY: "${WF_SECRET_KEY:?Set WF_SECRET_KEY}"
-      # Recommended for internet-facing deployments (Argon2id PHC hash)
-      # Set in .env (no quotes needed) or shell. If inlining in YAML, double every $: '$$argon2id$$...'
+
+      # ── Authentication ────────────────────────────────────────────────
+      # Required when listening on 0.0.0.0 (the default for Docker).
+      # Provide an Argon2id PHC hash of your password.
+      #
+      # IMPORTANT — the hash contains "$" signs that need escaping:
+      #   .env file  → WF_AUTH_PASSWORD_HASH=$argon2id$v=19$...  (no quotes, no escaping)
+      #   YAML inline → WF_AUTH_PASSWORD_HASH: '$$argon2id$$v=19$$...'  (double every $)
+      #
+      # Generate a hash:
+      #   printf 'your-password' | argon2 yoursalt16chars! -id -e
+      #
+      # If a reverse proxy handles auth instead, set WF_AUTH_REQUIRED: "false"
+      # and leave WF_AUTH_PASSWORD_HASH empty.
       WF_AUTH_PASSWORD_HASH: "${WF_AUTH_PASSWORD_HASH:-}"
       WF_AUTH_TOKEN_TTL_MINUTES: "${WF_AUTH_TOKEN_TTL_MINUTES:-60}"
+      # Set to "false" to skip the auth requirement (e.g. reverse proxy handles auth)
+      # WF_AUTH_REQUIRED: "true"
+
       # Required when auth is enabled — set to your app's origin, e.g. https://wealthfolio.example.com
       WF_CORS_ALLOW_ORIGINS: "${WF_CORS_ALLOW_ORIGINS}"
       WF_REQUEST_TIMEOUT_MS: "${WF_REQUEST_TIMEOUT_MS:-30000}"


### PR DESCRIPTION
## Description

This PR enhances the authentication setup experience by providing clearer documentation and more helpful error messages for users configuring password-based authentication.

### Changes

**Documentation improvements:**
- Added a comprehensive "Dollar-sign escaping cheat-sheet" in README.md with examples for `.env` files, Docker Compose YAML, and `docker run` commands
- Expanded `compose.yml` comments with detailed authentication setup instructions, including password hash generation command and escaping guidance
- Clarified the purpose of `WF_AUTH_REQUIRED` configuration option

**Error message improvements:**
- Enhanced the startup panic message in `config.rs` when authentication is required but not configured, breaking it into numbered steps with specific instructions
- Added detailed error handling in `auth.rs` when `WF_AUTH_PASSWORD_HASH` fails to parse, explaining the expected format and escaping requirements for different contexts

### Motivation

Users frequently struggle with:
1. Understanding how to generate Argon2id password hashes
2. Properly escaping `$` characters in different configuration contexts (`.env`, YAML, shell)
3. Knowing what to do when authentication setup fails

These changes provide clear, actionable guidance at the point of configuration and failure, reducing setup friction.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

https://claude.ai/code/session_01AKRG2muLKf4dFxgjs3qE4M