### PR TITLE
Fix CSV re-import dedup to use raw symbol for stable keys

### DIFF
--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -306,6 +306,21 @@ impl ActivityService {
             .ok()
     }
 
+    /// Build a symbol-based asset identifier for idempotency key computation.
+    /// Uses raw symbol text + exchange MIC instead of resolved UUID so that
+    /// keys are stable across imports and match between the review step
+    /// (`build_import_idempotency_key`) and the import step.
+    fn symbol_based_asset_id(
+        symbol_code: Option<&str>,
+        exchange_mic: Option<&str>,
+    ) -> Option<String> {
+        let symbol = symbol_code.map(|s| s.trim()).filter(|s| !s.is_empty())?;
+        match exchange_mic {
+            Some(mic) => Some(format!("{}@{}", symbol, mic)),
+            None => Some(symbol.to_string()),
+        }
+    }
+
     fn build_import_idempotency_key(
         activity: &ActivityImport,
         default_account_id: &str,
@@ -317,14 +332,10 @@ impl ActivityService {
         } else {
             activity.currency.as_str()
         };
-        let symbol = activity.symbol.trim();
-        let asset_id = if symbol.is_empty() {
-            None
-        } else if let Some(exchange_mic) = activity.exchange_mic.as_deref() {
-            Some(format!("{}@{}", symbol, exchange_mic))
-        } else {
-            Some(symbol.to_string())
-        };
+        let asset_id = Self::symbol_based_asset_id(
+            Some(activity.symbol.as_str()),
+            activity.exchange_mic.as_deref(),
+        );
 
         Some(compute_idempotency_key(
             account_id,
@@ -2619,11 +2630,17 @@ impl ActivityServiceTrait for ActivityService {
                     .ok();
 
                 if let Some(date) = date {
+                    // Build asset_id from symbol+MIC (not UUID) to match
+                    // build_import_idempotency_key used in the review step.
+                    let asset_id_for_key = Self::symbol_based_asset_id(
+                        activity.get_symbol_code(),
+                        activity.get_exchange_mic(),
+                    );
                     let key = compute_idempotency_key(
                         &activity.account_id,
                         &activity.activity_type,
                         &date,
-                        activity.get_symbol_id(),
+                        asset_id_for_key.as_deref(),
                         activity.quantity,
                         activity.unit_price,
                         activity.amount,

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -661,12 +661,29 @@ impl ActivityRepositoryTrait for ActivityRepository {
 
         self.writer
             .exec_tx(move |tx| -> Result<usize> {
-                let num_inserted = diesel::insert_into(activities::table)
-                    .values(&activities_db_owned)
-                    .execute(tx.conn())
-                    .map_err(StorageError::from)?;
+                let mut num_inserted = 0usize;
                 for activity_db in &activities_db_owned {
-                    tx.insert(activity_db)?;
+                    match diesel::insert_into(activities::table)
+                        .values(activity_db)
+                        .execute(tx.conn())
+                    {
+                        Ok(count) => {
+                            if count > 0 {
+                                tx.insert(activity_db)?;
+                                num_inserted += count;
+                            }
+                        }
+                        Err(diesel::result::Error::DatabaseError(
+                            diesel::result::DatabaseErrorKind::UniqueViolation,
+                            _,
+                        )) => {
+                            log::debug!(
+                                "Skipping duplicate activity {} (idempotency_key constraint)",
+                                activity_db.id
+                            );
+                        }
+                        Err(e) => return Err(StorageError::from(e).into()),
+                    }
                 }
                 Ok(num_inserted)
             })


### PR DESCRIPTION
## Problem
CSV re-imports were using resolved asset UUIDs for idempotency key computation, causing keys to differ between the review step and import step, breaking deduplication.

## Solution
- Extract symbol-based asset identifier logic into `symbol_based_asset_id()` helper that uses raw symbol + exchange MIC instead of UUID
- Update `build_import_idempotency_key()` to use the new helper for consistent key generation
- Update CSV import deduplication in repository to call the same helper, ensuring keys match across steps
- Improve duplicate handling with explicit error catching for `UniqueViolation` constraints with debug logging

## Changes
- **activities_service.rs**: Add `symbol_based_asset_id()` helper and refactor key building logic
- **repository.rs**: Switch from bulk insert to per-activity insert with duplicate detection and logging