### PR TITLE
Fix OCC option symbol classification priority

### DIFF
--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -822,24 +822,40 @@ impl ActivityService {
 
         // Fallback key for OCC option symbols that were previously misclassified
         // as EQUITY due to exchange MIC taking priority over OCC heuristic.
+        // Must mirror the key format the old code would have produced (with MIC when present).
         let fallback_equity_key = if matches!(instrument_type, Some(InstrumentType::Option)) {
-            Some(format!(
-                "{}:{}",
-                InstrumentType::Equity.as_db_str(),
-                upper_symbol
-            ))
+            exchange_mic
+                .filter(|mic| !mic.trim().is_empty())
+                .map(|mic| {
+                    format!(
+                        "{}:{}@{}",
+                        InstrumentType::Equity.as_db_str(),
+                        upper_symbol,
+                        mic.trim().to_uppercase()
+                    )
+                })
+                .or_else(|| {
+                    Some(format!(
+                        "{}:{}",
+                        InstrumentType::Equity.as_db_str(),
+                        upper_symbol,
+                    ))
+                })
         } else {
             None
         };
 
         if let Some(ref key) = expected_key {
+            // Pass 1: exact instrument key match
             for asset in &assets {
-                let asset_key = asset.instrument_key.as_deref();
-                if asset_key == Some(key) {
+                if asset.instrument_key.as_deref() == Some(key) {
                     return Some(asset.id.clone());
                 }
-                if let Some(ref fallback) = fallback_equity_key {
-                    if asset_key == Some(fallback.as_str()) {
+            }
+            // Pass 2: fallback for legacy misclassified options
+            if let Some(ref fallback) = fallback_equity_key {
+                for asset in &assets {
+                    if asset.instrument_key.as_deref() == Some(fallback.as_str()) {
                         return Some(asset.id.clone());
                     }
                 }


### PR DESCRIPTION
## Description

This PR fixes the instrument type classification logic to correctly identify OCC option symbols before checking for exchange MIC. Previously, OCC option symbols (e.g., `AAPL240119C00150000`) were being misclassified as equities when an exchange MIC like "OPRA" was attached by search providers.

### Changes

1. **Reordered classification heuristics**: Moved the OCC option symbol check (step 3) before the exchange MIC check (now step 4). This ensures options are correctly identified even when they have an exchange MIC attached.

2. **Added fallback lookup logic**: When resolving asset IDs, the code now includes a fallback mechanism to find previously misclassified OCC options that were stored with an EQUITY instrument type key. This maintains backward compatibility with existing data.

3. **Updated step numbering**: Adjusted comments to reflect the new order (steps 4-6).

### Why This Matters

Search providers may attach exchange MICs (like "OPRA" for options) to symbols, which would cause the old logic to classify them as equities. By checking the OCC symbol pattern first, we ensure options are correctly identified regardless of whether an exchange MIC is present.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

https://claude.ai/code/session_01398hEBBYCG9Jwjms4wzSJP