### PR TITLE
Fix fallback quotes using income amounts as asset prices

### DIFF
--- a/crates/core/src/activities/activities_constants.rs
+++ b/crates/core/src/activities/activities_constants.rs
@@ -60,6 +60,15 @@ pub const TRADING_ACTIVITY_TYPES: [&str; 3] =
 /// Income activity types
 pub const INCOME_ACTIVITY_TYPES: [&str; 2] = [ACTIVITY_TYPE_DIVIDEND, ACTIVITY_TYPE_INTEREST];
 
+/// Activity types where `unit_price` represents the asset's per-unit market
+/// price and can be used as a fallback quote. Income activities (DIVIDEND,
+/// INTEREST) store payment amounts, not asset prices.
+pub const PRICE_BEARING_ACTIVITY_TYPES: [&str; 3] = [
+    ACTIVITY_TYPE_BUY,
+    ACTIVITY_TYPE_SELL,
+    ACTIVITY_TYPE_TRANSFER_IN,
+];
+
 /// Activity types that always require a symbol/asset.
 /// Everything else: symbol is optional (cash-only or dual-use like TRANSFER_IN).
 pub const SYMBOL_REQUIRED_TYPES: [&str; 5] = [

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use crate::accounts::{Account, AccountServiceTrait};
 use crate::activities::activities_constants::{
     classify_import_activity, is_garbage_symbol, requires_symbol, ImportSymbolDisposition,
-    ACTIVITY_TYPE_TRANSFER_IN, ACTIVITY_TYPE_TRANSFER_OUT,
+    ACTIVITY_TYPE_TRANSFER_IN, ACTIVITY_TYPE_TRANSFER_OUT, PRICE_BEARING_ACTIVITY_TYPES,
 };
 use crate::activities::activities_errors::ActivityError;
 use crate::activities::activities_model::*;
@@ -626,6 +626,10 @@ impl ActivityService {
     /// Creates a quote from activity data to serve as a price fallback.
     /// Uses `DataSource::Manual` for MANUAL-mode assets (provider sync won't overwrite),
     /// and `DataSource::Broker` for MARKET-mode assets (coexists with provider quotes).
+    ///
+    /// Only called for activity types where `unit_price` represents the asset's
+    /// market price (BUY, SELL, TRANSFER_IN). Income activities (DIVIDEND,
+    /// INTEREST) store payment amounts in `unit_price`, not asset prices.
     async fn create_quote_from_activity(
         &self,
         asset_id: &str,
@@ -1160,26 +1164,28 @@ impl ActivityService {
                 }
             }
 
-            // Create a quote from the activity price as a fallback.
-            // Use the requested mode (if switching) rather than the pre-update asset mode.
-            if let Some(unit_price) = activity.unit_price {
-                let effective_manual = quote_mode
-                    .as_deref()
-                    .map(|m| m.eq_ignore_ascii_case("manual"))
-                    .unwrap_or(asset.quote_mode == QuoteMode::Manual);
-                let source = if effective_manual {
-                    DataSource::Manual
-                } else {
-                    DataSource::Broker
-                };
-                self.create_quote_from_activity(
-                    asset_id,
-                    unit_price,
-                    &currency,
-                    &activity.activity_date,
-                    source,
-                )
-                .await?;
+            // Create a quote from the activity price as a fallback, but only
+            // for activity types where unit_price is a real asset price.
+            if PRICE_BEARING_ACTIVITY_TYPES.contains(&activity.activity_type.as_str()) {
+                if let Some(unit_price) = activity.unit_price {
+                    let effective_manual = quote_mode
+                        .as_deref()
+                        .map(|m| m.eq_ignore_ascii_case("manual"))
+                        .unwrap_or(asset.quote_mode == QuoteMode::Manual);
+                    let source = if effective_manual {
+                        DataSource::Manual
+                    } else {
+                        DataSource::Broker
+                    };
+                    self.create_quote_from_activity(
+                        asset_id,
+                        unit_price,
+                        &currency,
+                        &activity.activity_date,
+                        source,
+                    )
+                    .await?;
+                }
             }
 
             if activity.currency.is_empty() {
@@ -1538,26 +1544,28 @@ impl ActivityService {
                 }
             }
 
-            // Create a quote from the activity price as a fallback.
-            // Use the requested mode (if switching) rather than the pre-update asset mode.
-            if let Some(Some(unit_price)) = activity.unit_price {
-                let effective_manual = quote_mode
-                    .as_deref()
-                    .map(|m| m.eq_ignore_ascii_case("manual"))
-                    .unwrap_or(asset.quote_mode == QuoteMode::Manual);
-                let source = if effective_manual {
-                    DataSource::Manual
-                } else {
-                    DataSource::Broker
-                };
-                self.create_quote_from_activity(
-                    asset_id,
-                    unit_price,
-                    &currency,
-                    &activity.activity_date,
-                    source,
-                )
-                .await?;
+            // Create a quote from the activity price as a fallback, but only
+            // for activity types where unit_price is a real asset price.
+            if PRICE_BEARING_ACTIVITY_TYPES.contains(&activity.activity_type.as_str()) {
+                if let Some(Some(unit_price)) = activity.unit_price {
+                    let effective_manual = quote_mode
+                        .as_deref()
+                        .map(|m| m.eq_ignore_ascii_case("manual"))
+                        .unwrap_or(asset.quote_mode == QuoteMode::Manual);
+                    let source = if effective_manual {
+                        DataSource::Manual
+                    } else {
+                        DataSource::Broker
+                    };
+                    self.create_quote_from_activity(
+                        asset_id,
+                        unit_price,
+                        &currency,
+                        &activity.activity_date,
+                        source,
+                    )
+                    .await?;
+                }
             }
 
             if activity.currency.is_empty() {
@@ -3266,27 +3274,30 @@ impl ActivityService {
                 }
             }
 
-            // 6. Create a quote from the activity price as a fallback
-            if let Some(ref asset_id) = resolved_asset_id {
-                if let Some(unit_price) = activity.unit_price {
-                    let source = ensure_result
-                        .assets
-                        .get(asset_id)
-                        .filter(|a| a.quote_mode == QuoteMode::Manual)
-                        .map_or(DataSource::Broker, |_| DataSource::Manual);
-                    let currency = if !activity.currency.is_empty() {
-                        &activity.currency
-                    } else {
-                        &account_currency
-                    };
-                    self.create_quote_from_activity(
-                        asset_id,
-                        unit_price,
-                        currency,
-                        &activity.activity_date,
-                        source,
-                    )
-                    .await?;
+            // 6. Create a quote from the activity price as a fallback, but only
+            // for activity types where unit_price is a real asset price.
+            if PRICE_BEARING_ACTIVITY_TYPES.contains(&activity.activity_type.as_str()) {
+                if let Some(ref asset_id) = resolved_asset_id {
+                    if let Some(unit_price) = activity.unit_price {
+                        let source = ensure_result
+                            .assets
+                            .get(asset_id)
+                            .filter(|a| a.quote_mode == QuoteMode::Manual)
+                            .map_or(DataSource::Broker, |_| DataSource::Manual);
+                        let currency = if !activity.currency.is_empty() {
+                            &activity.currency
+                        } else {
+                            &account_currency
+                        };
+                        self.create_quote_from_activity(
+                            asset_id,
+                            unit_price,
+                            currency,
+                            &activity.activity_date,
+                            source,
+                        )
+                        .await?;
+                    }
                 }
             }
 

--- a/crates/storage-sqlite/migrations/2026-03-18-000001_remove_income_fallback_quotes/down.sql
+++ b/crates/storage-sqlite/migrations/2026-03-18-000001_remove_income_fallback_quotes/down.sql
@@ -1,0 +1,2 @@
+-- No-op: deleted quotes cannot be restored. They will be recreated
+-- from activities if the code regression is reintroduced.

--- a/crates/storage-sqlite/migrations/2026-03-18-000001_remove_income_fallback_quotes/up.sql
+++ b/crates/storage-sqlite/migrations/2026-03-18-000001_remove_income_fallback_quotes/up.sql
@@ -1,0 +1,13 @@
+-- Remove bogus BROKER quotes that were created from DIVIDEND, INTEREST,
+-- FEE, TAX, and CREDIT activities. These activity types store payment
+-- amounts in unit_price, not asset market prices.
+DELETE FROM quotes
+WHERE source = 'BROKER'
+  AND id IN (
+    SELECT q.id
+    FROM quotes q
+    JOIN activities a ON a.asset_id = q.asset_id
+      AND substr(a.activity_date, 1, 10) = q.day
+    WHERE q.source = 'BROKER'
+      AND a.activity_type IN ('DIVIDEND', 'INTEREST', 'FEE', 'TAX', 'CREDIT')
+  );


### PR DESCRIPTION
## Summary
- `create_quote_from_activity()` creates BROKER-source fallback quotes from
  activity data, but was not filtering by activity type
- DIVIDEND and INTEREST activities store payment amounts in `unit_price`
  (e.g. a coupon payment), not the asset's market price
- Income payment amounts (dividends, interest, fees) were being stored as
  the asset's market price, overwriting or substituting for real quotes
  and corrupting valuations
- Adds `PRICE_BEARING_ACTIVITY_TYPES` constant (BUY, SELL, TRANSFER_IN) and
  gates all three `create_quote_from_activity()` call sites
- Includes a one-time migration to delete existing bogus BROKER quotes created
  from DIVIDEND, INTEREST, FEE, TAX, and CREDIT activities

## Test plan
- [x] All existing tests pass (1,280 passed, 0 failed)
- [x] `cargo clippy` clean, `cargo fmt` clean
- [ ] Verify bond/dividend-paying asset valuations are correct after migration
- [ ] Verify BUY/SELL activities still create fallback quotes as before