### PR TITLE
feat(addons): add FIRE Planner addon

### DIFF
--- a/addons/fire-planner/manifest.json
+++ b/addons/fire-planner/manifest.json
@@ -1,0 +1,42 @@
+{
+  "id": "fire-planner",
+  "name": "FIRE Planner",
+  "version": "1.0.0",
+  "description": "Financial Independence planning: FIRE projections, Monte Carlo simulations, allocation drift alerts, and sequence-of-returns analysis. Works with any portfolio and any currency.",
+  "author": "Wealthfolio",
+  "main": "dist/addon.js",
+  "sdkVersion": "3.0.0",
+  "enabled": true,
+  "permissions": [
+    {
+      "category": "accounts",
+      "functions": ["getAll"],
+      "purpose": "Read all portfolio accounts to aggregate total portfolio value"
+    },
+    {
+      "category": "portfolio",
+      "functions": ["getHoldings", "getHistoricalValuations", "getLatestValuations"],
+      "purpose": "Read holdings for allocation drift analysis and authoritative portfolio value"
+    },
+    {
+      "category": "activities",
+      "functions": ["getAll"],
+      "purpose": "Read activity history to compute days-since-last-buy for drift monitor"
+    },
+    {
+      "category": "settings",
+      "functions": ["get"],
+      "purpose": "Read base currency from application settings"
+    },
+    {
+      "category": "secrets",
+      "functions": ["get", "set"],
+      "purpose": "Persist FIRE planning settings (target age, SWR, expenses, etc.)"
+    },
+    {
+      "category": "ui",
+      "functions": ["sidebar.addItem", "router.add"],
+      "purpose": "Add FIRE Planner to sidebar navigation and register routes"
+    }
+  ]
+}

--- a/addons/fire-planner/package.json
+++ b/addons/fire-planner/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "fire-planner",
+  "version": "1.0.0",
+  "description": "Financial Independence planning addon for Wealthfolio",
+  "type": "module",
+  "main": "dist/addon.js",
+  "author": "Wealthfolio",
+  "license": "MIT",
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch",
+    "dev:server": "wealthfolio dev",
+    "clean": "rm -rf dist",
+    "package": "mkdir -p dist && zip -r dist/$npm_package_name-$npm_package_version.zip manifest.json dist/ README.md",
+    "bundle": "pnpm clean && pnpm build && pnpm package",
+    "type-check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.90.20",
+    "@wealthfolio/addon-sdk": "workspace:*",
+    "@wealthfolio/ui": "workspace:*",
+    "recharts": "^3.7.0"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.1.18",
+    "@types/node": "^20.19.33",
+    "@types/react": "^19.2.13",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.4",
+    "@wealthfolio/addon-dev-tools": "workspace:*",
+    "rollup-plugin-external-globals": "^0.13.0",
+    "tailwindcss": "^4.1.18",
+    "typescript": "^5.9.3",
+    "vite": "^7.3.1"
+  },
+  "peerDependencies": {
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
+  },
+  "files": [
+    "dist/",
+    "manifest.json"
+  ]
+}

--- a/addons/fire-planner/src/FirePlannerApp.tsx
+++ b/addons/fire-planner/src/FirePlannerApp.tsx
@@ -1,0 +1,127 @@
+import type { AddonContext } from "@wealthfolio/addon-sdk";
+import {
+  Page,
+  PageContent,
+  PageHeader,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@wealthfolio/ui";
+import { useState, useMemo } from "react";
+
+// IANA timezone → ISO 3166-1 alpha-2 country code
+const TZ_TO_COUNTRY: Record<string, string> = {
+  "Europe/Rome": "IT",
+  "Europe/London": "GB",
+  "Europe/Paris": "FR",
+  "Europe/Berlin": "DE",
+  "Europe/Busingen": "DE",
+  "Europe/Madrid": "ES",
+  "Europe/Amsterdam": "NL",
+  "Europe/Brussels": "BE",
+  "Europe/Zurich": "CH",
+  "Europe/Vienna": "AT",
+  "Europe/Stockholm": "SE",
+  "Europe/Oslo": "NO",
+  "Europe/Copenhagen": "DK",
+  "Europe/Helsinki": "FI",
+  "Europe/Warsaw": "PL",
+  "Europe/Lisbon": "PT",
+  "America/New_York": "US",
+  "America/Chicago": "US",
+  "America/Denver": "US",
+  "America/Los_Angeles": "US",
+  "America/Phoenix": "US",
+  "America/Anchorage": "US",
+  "America/Detroit": "US",
+  "Pacific/Honolulu": "US",
+  "America/Toronto": "CA",
+  "America/Vancouver": "CA",
+  "Australia/Sydney": "AU",
+  "Australia/Melbourne": "AU",
+  "Asia/Tokyo": "JP",
+};
+import { useFireSettings } from "./hooks/use-fire-settings";
+import { usePortfolioData } from "./hooks/use-portfolio";
+import DashboardPage from "./pages/DashboardPage";
+import SimulationsPage from "./pages/SimulationsPage";
+import AllocationPage from "./pages/AllocationPage";
+import SettingsPage from "./pages/SettingsPage";
+import GuidePage from "./pages/GuidePage";
+
+interface FirePlannerAppProps {
+  ctx: AddonContext;
+}
+
+export default function FirePlannerApp({ ctx }: FirePlannerAppProps) {
+  const [activeTab, setActiveTab] = useState("dashboard");
+  const {
+    settings,
+    timezone,
+    isLoading: settingsLoading,
+    saveSettings,
+    isSaving,
+  } = useFireSettings(ctx);
+  const portfolioData = usePortfolioData(ctx, settings);
+  const country = useMemo(() => (timezone ? TZ_TO_COUNTRY[timezone] : undefined), [timezone]);
+
+  return (
+    <Page>
+      <PageHeader heading="FIRE Planner" text="Financial Independence · Retire Early" />
+      <PageContent>
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">
+          <TabsList>
+            <TabsTrigger value="dashboard">Dashboard</TabsTrigger>
+            <TabsTrigger value="simulations">Simulations</TabsTrigger>
+            <TabsTrigger value="allocation">Allocation</TabsTrigger>
+            <TabsTrigger value="settings">Settings</TabsTrigger>
+            <TabsTrigger value="guide">Guide</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="dashboard">
+            <DashboardPage
+              settings={settings}
+              portfolioData={portfolioData}
+              isLoading={settingsLoading || portfolioData.isLoading}
+            />
+          </TabsContent>
+
+          <TabsContent value="simulations">
+            <SimulationsPage
+              settings={settings}
+              totalValue={portfolioData.totalValue}
+              isLoading={settingsLoading || portfolioData.isLoading}
+            />
+          </TabsContent>
+
+          <TabsContent value="allocation">
+            <AllocationPage
+              settings={settings}
+              holdings={portfolioData.holdings}
+              activities={portfolioData.activities}
+              isLoading={portfolioData.isLoading}
+              onSetupTargets={() => setActiveTab("settings")}
+            />
+          </TabsContent>
+
+          <TabsContent value="guide">
+            <GuidePage country={country} />
+          </TabsContent>
+
+          <TabsContent value="settings">
+            <SettingsPage
+              ctx={ctx}
+              settings={settings}
+              onSave={saveSettings}
+              isSaving={isSaving}
+              holdings={portfolioData.holdings}
+              activities={portfolioData.activities}
+              accounts={portfolioData.accounts}
+            />
+          </TabsContent>
+        </Tabs>
+      </PageContent>
+    </Page>
+  );
+}

--- a/addons/fire-planner/src/addon.tsx
+++ b/addons/fire-planner/src/addon.tsx
@@ -1,0 +1,55 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { AddonEnableFunction, UnlistenFn } from "@wealthfolio/addon-sdk";
+import { Icons } from "@wealthfolio/ui";
+import React from "react";
+import FirePlannerApp from "./FirePlannerApp";
+
+const enable: AddonEnableFunction = (context) => {
+  context.api.logger.info("FIRE Planner addon enabled");
+
+  const sidebarItem = context.sidebar.addItem({
+    id: "fire-planner",
+    label: "FIRE Planner",
+    icon: <Icons.Target className="h-5 w-5" />,
+    route: "/addons/fire-planner",
+    order: 150,
+  });
+
+  context.router.add({
+    path: "/addons/fire-planner",
+    component: React.lazy(() =>
+      Promise.resolve({
+        default: () => {
+          const queryClient = context.api.query.getClient() as QueryClient;
+          return (
+            <QueryClientProvider client={queryClient}>
+              <FirePlannerApp ctx={context} />
+            </QueryClientProvider>
+          );
+        },
+      }),
+    ),
+  });
+
+  // Invalidate holdings cache when portfolio updates
+  let cleanupEvent: UnlistenFn | undefined;
+  context.api.events.portfolio
+    .onUpdateComplete(() => {
+      const queryClient = context.api.query.getClient() as QueryClient;
+      queryClient.invalidateQueries({ queryKey: ["fire-planner-holdings"] });
+    })
+    .then((unlisten) => {
+      cleanupEvent = unlisten;
+    })
+    .catch(() => {
+      // Event listener not available in this environment
+    });
+
+  context.onDisable(() => {
+    context.api.logger.info("FIRE Planner addon disabled");
+    sidebarItem.remove();
+    cleanupEvent?.();
+  });
+};
+
+export default enable;

--- a/addons/fire-planner/src/hooks/use-fire-settings.ts
+++ b/addons/fire-planner/src/hooks/use-fire-settings.ts
@@ -1,0 +1,58 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { AddonContext } from "@wealthfolio/addon-sdk";
+import type { FireSettings } from "../types";
+import { DEFAULT_SETTINGS, loadSettings, saveSettings } from "../lib/storage";
+
+const QUERY_KEY = ["fire-planner-settings"];
+
+interface QueryResult {
+  settings: FireSettings;
+  timezone?: string;
+}
+
+export function useFireSettings(ctx: AddonContext) {
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: async (): Promise<QueryResult> => {
+      const settings = await loadSettings(ctx);
+      let timezone: string | undefined;
+      try {
+        const appSettings = await ctx.api.settings.get();
+        if (appSettings?.baseCurrency) {
+          settings.currency = appSettings.baseCurrency;
+        }
+        if (appSettings?.timezone) {
+          timezone = appSettings.timezone;
+        }
+      } catch {
+        // ignore — currency and timezone fall back to defaults
+      }
+      return { settings, timezone };
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (updated: FireSettings) => {
+      await saveSettings(ctx, updated);
+      return updated;
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(QUERY_KEY, { ...query.data, settings: data });
+      ctx.api.toast.success("FIRE settings saved");
+    },
+    onError: (error: Error) => {
+      ctx.api.toast.error("Failed to save settings: " + error.message);
+    },
+  });
+
+  return {
+    settings: query.data?.settings ?? DEFAULT_SETTINGS,
+    timezone: query.data?.timezone,
+    isLoading: query.isLoading,
+    saveSettings: mutation.mutate,
+    isSaving: mutation.isPending,
+  };
+}

--- a/addons/fire-planner/src/hooks/use-portfolio.ts
+++ b/addons/fire-planner/src/hooks/use-portfolio.ts
@@ -1,0 +1,82 @@
+import { useQuery } from "@tanstack/react-query";
+import type { AddonContext, Holding, ActivityDetails, Account } from "@wealthfolio/addon-sdk";
+import type { FireSettings } from "../types";
+
+// CASH accounts are bank/current accounts — excluded from the FIRE portfolio by default.
+const INVESTMENT_TYPES = new Set(["SECURITIES", "CRYPTOCURRENCY"]);
+
+export function usePortfolioData(
+  ctx: AddonContext,
+  settings?: Pick<FireSettings, "includedAccountIds">,
+) {
+  const accountsQuery = useQuery({
+    queryKey: ["fire-planner-accounts"],
+    queryFn: async (): Promise<Account[]> => {
+      const data = await ctx.api.accounts.getAll();
+      return data ?? [];
+    },
+    staleTime: 10 * 60 * 1000,
+  });
+
+  const accounts = accountsQuery.data ?? [];
+  const activeAccounts = accounts.filter((a) => a.isActive && !a.isArchived);
+
+  // If user has explicitly chosen accounts, use those; otherwise default to non-CASH accounts.
+  const activeAccountIds = (
+    settings?.includedAccountIds && settings.includedAccountIds.length > 0
+      ? activeAccounts.filter((a) => settings.includedAccountIds!.includes(a.id))
+      : activeAccounts.filter((a) => INVESTMENT_TYPES.has(a.accountType))
+  ).map((a) => a.id);
+
+  const valuationsQuery = useQuery({
+    queryKey: ["fire-planner-valuations", activeAccountIds],
+    queryFn: async () => {
+      const data = await ctx.api.portfolio.getLatestValuations(activeAccountIds);
+      return data ?? [];
+    },
+    enabled: activeAccountIds.length > 0,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+    retry: 3,
+  });
+
+  const holdingsQuery = useQuery({
+    queryKey: ["fire-planner-holdings"],
+    queryFn: async (): Promise<Holding[]> => {
+      const data = await ctx.api.portfolio.getHoldings("TOTAL");
+      return data ?? [];
+    },
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+    retry: 3,
+  });
+
+  const activitiesQuery = useQuery({
+    queryKey: ["fire-planner-activities"],
+    queryFn: async (): Promise<ActivityDetails[]> => {
+      const data = await ctx.api.activities.getAll();
+      return data ?? [];
+    },
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+  });
+
+  // Sum totalValue * fxRateToBase across all accounts for the authoritative base-currency total
+  const totalValue = (valuationsQuery.data ?? []).reduce(
+    (sum, v) => sum + v.totalValue * v.fxRateToBase,
+    0,
+  );
+
+  return {
+    holdings: holdingsQuery.data ?? [],
+    activities: activitiesQuery.data ?? [],
+    accounts,
+    totalValue,
+    isLoading:
+      accountsQuery.isLoading ||
+      valuationsQuery.isLoading ||
+      holdingsQuery.isLoading ||
+      activitiesQuery.isLoading,
+    error: valuationsQuery.error || holdingsQuery.error || activitiesQuery.error,
+  };
+}

--- a/addons/fire-planner/src/lib/auto-config.ts
+++ b/addons/fire-planner/src/lib/auto-config.ts
@@ -1,0 +1,233 @@
+import type { AddonContext, ActivityDetails, Holding, Account } from "@wealthfolio/addon-sdk";
+import type { FireSettings } from "../types";
+
+export interface AutoConfigResult {
+  monthlyContribution: number | null;
+  expectedAnnualReturn: number | null;
+  targetAllocations: Record<string, number> | null;
+  currency: string | null;
+  // Human-readable notes explaining how each value was derived
+  notes: {
+    monthlyContribution?: string;
+    expectedAnnualReturn?: string;
+    targetAllocations?: string;
+  };
+}
+
+// ─── Monthly Contribution ───────────────────────────────────────────────────────
+
+/**
+ * Derive average monthly contribution from the last 12 months of BUY and DEPOSIT
+ * activities. Uses |amount| in the activity's own currency as an approximation
+ * (works well when accounts are mostly in base currency).
+ */
+export function deriveMonthlyContribution(activities: ActivityDetails[]): {
+  value: number | null;
+  note: string;
+} {
+  const now = new Date();
+  const oneYearAgo = new Date(now.getFullYear() - 1, now.getMonth(), now.getDate());
+
+  const relevant = activities.filter((a) => {
+    const date = a.date instanceof Date ? a.date : new Date(a.date as unknown as string);
+    const isRecent = date >= oneYearAgo;
+    const isBuyOrDeposit =
+      a.activityType === "BUY" || a.activityType === "DEPOSIT" || a.activityType === "TRANSFER_IN";
+    return isRecent && isBuyOrDeposit;
+  });
+
+  if (relevant.length === 0) {
+    return { value: null, note: "No BUY/DEPOSIT activities found in the last 12 months." };
+  }
+
+  // Group by year-month and sum amounts
+  const monthlyTotals = new Map<string, number>();
+  let skipped = 0;
+
+  relevant.forEach((a) => {
+    const amount = parseFloat(a.amount ?? "0");
+    if (isNaN(amount) || amount === 0) {
+      skipped++;
+      return;
+    }
+    const date = a.date instanceof Date ? a.date : new Date(a.date as unknown as string);
+    const key = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
+    // Use fxRate to convert to base currency (fxRate = 1 activity currency → fxRate base currency)
+    const fxRate = parseFloat(a.fxRate ?? "1") || 1;
+    const baseAmount = Math.abs(amount) * fxRate;
+    monthlyTotals.set(key, (monthlyTotals.get(key) ?? 0) + baseAmount);
+  });
+
+  if (monthlyTotals.size === 0) {
+    return { value: null, note: "Activities found but amounts could not be parsed." };
+  }
+
+  const average =
+    Array.from(monthlyTotals.values()).reduce((sum, v) => sum + v, 0) / monthlyTotals.size;
+
+  const note = `Average of ${monthlyTotals.size} months with ${relevant.length} activities (last 12 months).`;
+  return { value: Math.round(average), note };
+}
+
+// ─── Expected Annual Return ─────────────────────────────────────────────────────
+
+/**
+ * Estimate expected annual return from historical performance across all accounts.
+ * Uses the annualized simple return from the performance API over the longest
+ * available window (up to 5 years).
+ */
+export async function deriveExpectedReturn(
+  accounts: Account[],
+  ctx: AddonContext,
+): Promise<{ value: number | null; note: string }> {
+  const activeAccounts = accounts.filter((a) => a.isActive && !a.isArchived);
+  if (activeAccounts.length === 0) {
+    return { value: null, note: "No active accounts found." };
+  }
+
+  const endDate = new Date().toISOString().split("T")[0];
+  // Try 5 years first, fall back to 3 years if no data
+  const windows = [
+    { years: 5, label: "5-year" },
+    { years: 3, label: "3-year" },
+    { years: 1, label: "1-year" },
+  ];
+
+  for (const { years, label } of windows) {
+    const startDate = new Date(
+      new Date().getFullYear() - years,
+      new Date().getMonth(),
+      new Date().getDate(),
+    )
+      .toISOString()
+      .split("T")[0];
+
+    try {
+      const results = await Promise.all(
+        activeAccounts.map((a) =>
+          ctx.api.performance
+            .calculateSummary({ itemType: "account", itemId: a.id, startDate, endDate })
+            .catch(() => null),
+        ),
+      );
+
+      const validReturns = results
+        .filter((r) => r !== null && r.annualizedSimpleReturn != null)
+        .map((r) => r!.annualizedSimpleReturn!);
+
+      if (validReturns.length === 0) continue;
+
+      // Weight average by number of valid accounts
+      const avg = validReturns.reduce((sum, r) => sum + r, 0) / validReturns.length;
+
+      // Sanity check: ignore implausible values (< -50% or > 100% annualized)
+      if (avg < -0.5 || avg > 1.0) continue;
+
+      return {
+        value: Math.round(avg * 1000) / 1000, // round to 0.1%
+        note: `Annualized simple return over ${label} across ${validReturns.length} account(s).`,
+      };
+    } catch {
+      continue;
+    }
+  }
+
+  return {
+    value: null,
+    note: "Could not retrieve performance data. Check account history.",
+  };
+}
+
+// ─── Target Allocations ─────────────────────────────────────────────────────────
+
+/**
+ * Derive target allocations from current portfolio holdings.
+ * Returns weights rounded to the nearest 0.5% with a minimum threshold of 1%.
+ */
+export function deriveTargetAllocations(holdings: Holding[]): {
+  value: Record<string, number> | null;
+  note: string;
+} {
+  const relevant = holdings.filter(
+    (h) => h.holdingType !== "cash" && (h.marketValue?.base ?? 0) > 0,
+  );
+
+  if (relevant.length === 0) {
+    return { value: null, note: "No holdings found to derive allocations." };
+  }
+
+  const total = relevant.reduce((sum, h) => sum + (h.marketValue?.base ?? 0), 0);
+  if (total === 0) return { value: null, note: "Total portfolio value is zero." };
+
+  const allocs: Record<string, number> = {};
+  relevant.forEach((h) => {
+    const sym = h.instrument?.symbol ?? "";
+    if (!sym) return;
+    const weight = (h.marketValue?.base ?? 0) / total;
+    if (weight >= 0.01) {
+      // Round to nearest 0.5%
+      allocs[sym] = Math.round(weight * 200) / 200;
+    }
+  });
+
+  // Normalize so weights sum to 1.0
+  const allocTotal = Object.values(allocs).reduce((sum, w) => sum + w, 0);
+  if (allocTotal > 0) {
+    Object.keys(allocs).forEach((k) => {
+      allocs[k] = Math.round((allocs[k] / allocTotal) * 1000) / 1000;
+    });
+  }
+
+  const count = Object.keys(allocs).length;
+  return {
+    value: allocs,
+    note: `Derived from ${count} holding${count !== 1 ? "s" : ""} based on current market weights.`,
+  };
+}
+
+// ─── Full Auto-Config ───────────────────────────────────────────────────────────
+
+export async function runAutoConfig(
+  activities: ActivityDetails[],
+  holdings: Holding[],
+  accounts: Account[],
+  ctx: AddonContext,
+): Promise<AutoConfigResult> {
+  const [contribution, expectedReturn, appSettings] = await Promise.all([
+    Promise.resolve(deriveMonthlyContribution(activities)),
+    deriveExpectedReturn(accounts, ctx),
+    ctx.api.settings.get().catch(() => null),
+  ]);
+
+  const allocResult = deriveTargetAllocations(holdings);
+
+  return {
+    monthlyContribution: contribution.value,
+    expectedAnnualReturn: expectedReturn.value,
+    targetAllocations: allocResult.value,
+    currency: appSettings?.baseCurrency ?? null,
+    notes: {
+      monthlyContribution: contribution.note,
+      expectedAnnualReturn: expectedReturn.note,
+      targetAllocations: allocResult.note,
+    },
+  };
+}
+
+/**
+ * Apply auto-config results to a settings draft, keeping existing values
+ * where auto-config returns null.
+ */
+export function applyAutoConfig(current: FireSettings, result: AutoConfigResult): FireSettings {
+  return {
+    ...current,
+    ...(result.monthlyContribution !== null
+      ? { monthlyContribution: result.monthlyContribution }
+      : {}),
+    ...(result.expectedAnnualReturn !== null
+      ? { expectedAnnualReturn: result.expectedAnnualReturn }
+      : {}),
+    ...(result.targetAllocations !== null ? { targetAllocations: result.targetAllocations } : {}),
+    ...(result.currency !== null ? { currency: result.currency } : {}),
+  };
+}

--- a/addons/fire-planner/src/lib/fire-math.ts
+++ b/addons/fire-planner/src/lib/fire-math.ts
@@ -1,0 +1,552 @@
+import type {
+  FireSettings,
+  FireProjection,
+  YearlySnapshot,
+  MonteCarloResult,
+  ScenarioResult,
+  SorrScenario,
+  AllocationHealth,
+  SensitivityMatrix,
+  SensitivitySWRMatrix,
+} from "../types";
+
+// ─── Helpers ───────────────────────────────────────────────────────────────────
+
+function gaussianRandom(mean: number, std: number): number {
+  let u = 0,
+    v = 0;
+  while (u === 0) u = Math.random();
+  while (v === 0) v = Math.random();
+  return mean + std * Math.sqrt(-2.0 * Math.log(u)) * Math.cos(2.0 * Math.PI * v);
+}
+
+// Two-regime fat-tailed return distribution.
+// 85% normal years: μ+1.5%, σ×0.8 — 15% stress years: μ−8.5%, σ×1.8
+// Long-run mean preserved: 0.85×(μ+0.015) + 0.15×(μ−0.085) = μ
+function sampleReturn(mean: number, std: number): number {
+  if (Math.random() < 0.15) {
+    return gaussianRandom(mean - 0.085, std * 1.8);
+  }
+  return gaussianRandom(mean + 0.015, std * 0.8);
+}
+
+function additionalIncomeAtAge(
+  streams: FireSettings["additionalIncomeStreams"],
+  age: number,
+  yearsFromNow: number,
+  inflationRate: number,
+): number {
+  return streams
+    .filter((s) => age >= s.startAge)
+    .reduce((sum, s) => {
+      const annual = s.monthlyAmount * 12;
+      const rate =
+        s.annualGrowthRate !== undefined
+          ? s.annualGrowthRate
+          : s.adjustForInflation
+            ? inflationRate
+            : 0;
+      return sum + annual * Math.pow(1 + rate, yearsFromNow);
+    }, 0);
+}
+
+function percentile(sorted: number[], p: number): number {
+  const idx = Math.floor(sorted.length * p);
+  return sorted[Math.min(idx, sorted.length - 1)];
+}
+
+// ─── Core FIRE Calculations ────────────────────────────────────────────────────
+
+// Gross FIRE target — ignores income streams. Used for display / SWR label.
+export function calculateFireTarget(settings: FireSettings): number {
+  return (settings.monthlyExpensesAtFire * 12) / settings.safeWithdrawalRate;
+}
+
+// Net FIRE target — subtracts income available from day-1 of FIRE (startAge <= targetFireAge).
+// Deferred streams (e.g. INPS at 67 when FIRE at 55) are NOT subtracted here;
+// the portfolio needs to bridge that gap on its own.
+export function calculateNetFireTarget(settings: FireSettings): number {
+  const incomeAtFireAge = settings.additionalIncomeStreams
+    .filter((s) => s.startAge <= settings.targetFireAge)
+    .reduce((sum, s) => sum + s.monthlyAmount, 0);
+  const netMonthly = Math.max(0, settings.monthlyExpensesAtFire - incomeAtFireAge);
+  return (netMonthly * 12) / settings.safeWithdrawalRate;
+}
+
+export function calculateCoastFireAmount(settings: FireSettings): number {
+  const fireTarget = calculateNetFireTarget(settings);
+  const yearsToGrow = settings.targetFireAge - settings.currentAge;
+  if (yearsToGrow <= 0) return fireTarget;
+  // Inflate real target to nominal value at FIRE age, then discount back at nominal return
+  return (
+    (fireTarget * Math.pow(1 + settings.inflationRate, yearsToGrow)) /
+    Math.pow(1 + settings.expectedAnnualReturn, yearsToGrow)
+  );
+}
+
+// ─── Deterministic Projection ──────────────────────────────────────────────────
+
+// Track pension fund balances year by year (separate from main portfolio).
+// Three phases:
+//   1. Pre-FIRE (still employed): fund grows + contributions (TFR) are added
+//   2. Post-FIRE, pre-payout: fund grows on investment return only (no more TFR)
+//   3. Payout (age >= startAge): fund is fixed; monthly income drawn from it
+function stepPensionFunds(
+  streams: FireSettings["additionalIncomeStreams"],
+  balances: Map<string, number>,
+  age: number,
+  inFire: boolean,
+): number {
+  let total = 0;
+  for (const s of streams) {
+    const hasAccumulation = (s.currentValue ?? 0) > 0 || (s.monthlyContribution ?? 0) > 0;
+    if (!hasAccumulation) continue;
+
+    const current = balances.get(s.id) ?? s.currentValue ?? 0;
+
+    if (age < s.startAge) {
+      const r = s.accumulationReturn ?? 0.04;
+      // Contributions (TFR) only while still employed — stop at FIRE
+      const contributions = inFire ? 0 : (s.monthlyContribution ?? 0) * 12;
+      const next = current * (1 + r) + contributions;
+      balances.set(s.id, next);
+      total += next;
+    } else {
+      // Payout age reached: fund converted to annuity — zero out for subsequent snapshots.
+      // The snapshot for this year already captured the peak balance (read before this step).
+      balances.set(s.id, 0);
+    }
+  }
+  return total;
+}
+
+export function projectFireDate(settings: FireSettings, currentPortfolio: number): FireProjection {
+  // Real (today's €) target for display; each loop year inflates it to nominal for the trigger
+  const realFireTarget = calculateNetFireTarget(settings);
+  const coastAmount = calculateCoastFireAmount(settings);
+  const startYear = new Date().getFullYear();
+  const horizonYears = Math.max(1, settings.planningHorizonAge - settings.currentAge);
+  const r = settings.expectedAnnualReturn;
+  const contribGrowth = settings.salaryGrowthRate ?? settings.contributionGrowthRate;
+
+  let portfolio = currentPortfolio;
+  let fireAge: number | null = null;
+  let fireYear: number | null = null;
+  let portfolioAtFire = 0;
+  let inFire = false;
+  const yearByYear: YearlySnapshot[] = [];
+
+  // Initialise pension fund balances from currentValue of each stream
+  const pensionBalances = new Map<string, number>(
+    settings.additionalIncomeStreams.map((s) => [s.id, s.currentValue ?? 0]),
+  );
+
+  for (let i = 0; i <= horizonYears; i++) {
+    const age = settings.currentAge + i;
+    const year = startYear + i;
+
+    // Snapshot uses start-of-year pension value (before stepping for this year)
+    const pensionAssets = [...pensionBalances.values()].reduce((s, v) => s + v, 0);
+
+    // Trigger FIRE when nominal portfolio ≥ nominal target (real target × (1+inf)^i)
+    const nominalFireTarget = realFireTarget * Math.pow(1 + settings.inflationRate, i);
+    if (!inFire && (portfolio >= nominalFireTarget || age >= settings.targetFireAge)) {
+      inFire = true;
+      fireAge = age;
+      fireYear = year;
+      portfolioAtFire = portfolio;
+    }
+
+    if (inFire) {
+      const annualExpenses =
+        settings.monthlyExpensesAtFire * 12 * Math.pow(1 + settings.inflationRate, i);
+      const annualIncome = additionalIncomeAtAge(
+        settings.additionalIncomeStreams,
+        age,
+        i,
+        settings.inflationRate,
+      );
+
+      const netWithdrawal =
+        (settings.withdrawalStrategy ?? "constant-dollar") === "constant-percentage"
+          ? settings.safeWithdrawalRate * portfolio
+          : Math.max(0, annualExpenses - annualIncome);
+
+      yearByYear.push({
+        age,
+        year,
+        phase: "fire",
+        portfolioValue: Math.max(0, portfolio),
+        annualContribution: 0,
+        annualWithdrawal: annualExpenses,
+        annualIncome,
+        netWithdrawalFromPortfolio: netWithdrawal,
+        pensionAssets,
+      });
+
+      portfolio = Math.max(0, portfolio * (1 + r) - netWithdrawal);
+    } else {
+      const annualContribution = settings.monthlyContribution * 12 * Math.pow(1 + contribGrowth, i);
+
+      yearByYear.push({
+        age,
+        year,
+        phase: "accumulation",
+        portfolioValue: portfolio,
+        annualContribution,
+        annualWithdrawal: 0,
+        annualIncome: 0,
+        netWithdrawalFromPortfolio: 0,
+        pensionAssets,
+      });
+
+      portfolio = portfolio * (1 + r) + annualContribution;
+    }
+
+    // Advance pension balances for the next iteration (contributions stop once in FIRE)
+    stepPensionFunds(settings.additionalIncomeStreams, pensionBalances, age, inFire);
+  }
+
+  return {
+    fireAge,
+    fireYear,
+    portfolioAtFire,
+    coastFireAmount: coastAmount,
+    coastFireReached: currentPortfolio >= coastAmount,
+    yearByYear,
+  };
+}
+
+// ─── Monte Carlo ───────────────────────────────────────────────────────────────
+
+export function runMonteCarlo(
+  settings: FireSettings,
+  currentPortfolio: number,
+  nSims = 1000,
+): MonteCarloResult {
+  const realFireTarget = calculateNetFireTarget(settings); // real (today's €); inflated per year for trigger
+  const horizonYears = Math.max(1, settings.planningHorizonAge - settings.currentAge);
+  const contribGrowth = settings.salaryGrowthRate ?? settings.contributionGrowthRate;
+
+  // paths[simIndex][yearIndex] = portfolio value
+  const paths: number[][] = [];
+  let survivedCount = 0;
+  const fireAges: number[] = [];
+
+  const useConstantPct =
+    (settings.withdrawalStrategy ?? "constant-dollar") === "constant-percentage";
+
+  for (let sim = 0; sim < nSims; sim++) {
+    let portfolio = currentPortfolio;
+    let inFire = false;
+    let simFireAge: number | null = null;
+    const path: number[] = [];
+    let cumulativeInflation = 1.0;
+
+    for (let i = 0; i <= horizonYears; i++) {
+      const age = settings.currentAge + i;
+      path.push(Math.max(0, portfolio));
+
+      const nominalFireTarget = realFireTarget * Math.pow(1 + settings.inflationRate, i);
+      if (!inFire && (portfolio >= nominalFireTarget || age >= settings.targetFireAge)) {
+        inFire = true;
+        simFireAge = age;
+      }
+
+      const annualReturn = sampleReturn(
+        settings.expectedAnnualReturn,
+        settings.expectedReturnStdDev,
+      );
+
+      if (inFire) {
+        const annualExpenses = settings.monthlyExpensesAtFire * 12 * cumulativeInflation;
+        const annualIncome = additionalIncomeAtAge(
+          settings.additionalIncomeStreams,
+          age,
+          i,
+          settings.inflationRate,
+        );
+        const netWithdrawal = useConstantPct
+          ? settings.safeWithdrawalRate * portfolio
+          : Math.max(0, annualExpenses - annualIncome);
+        portfolio = Math.max(0, portfolio * (1 + annualReturn) - netWithdrawal);
+      } else {
+        const annualContribution =
+          settings.monthlyContribution * 12 * Math.pow(1 + contribGrowth, i);
+        portfolio = portfolio * (1 + annualReturn) + annualContribution;
+      }
+
+      // Stochastic inflation: update cumulative factor for the next year
+      cumulativeInflation *= 1 + gaussianRandom(settings.inflationRate, 0.01);
+    }
+
+    paths.push(path);
+    if (portfolio > 0) survivedCount++;
+    if (simFireAge !== null) fireAges.push(simFireAge);
+  }
+
+  // Compute percentile paths across all simulations at each year
+  const yearCount = horizonYears + 1;
+  const p10: number[] = [];
+  const p25: number[] = [];
+  const p50: number[] = [];
+  const p75: number[] = [];
+  const p90: number[] = [];
+  const ageAxis: number[] = [];
+
+  for (let i = 0; i < yearCount; i++) {
+    const vals = paths.map((p) => p[i]).sort((a, b) => a - b);
+    p10.push(percentile(vals, 0.1));
+    p25.push(percentile(vals, 0.25));
+    p50.push(percentile(vals, 0.5));
+    p75.push(percentile(vals, 0.75));
+    p90.push(percentile(vals, 0.9));
+    ageAxis.push(settings.currentAge + i);
+  }
+
+  const finalVals = paths.map((p) => p[yearCount - 1]).sort((a, b) => a - b);
+
+  fireAges.sort((a, b) => a - b);
+  const medianFireAge =
+    fireAges.length > 0 ? fireAges[Math.floor(fireAges.length / 2)] : settings.targetFireAge;
+
+  return {
+    successRate: survivedCount / nSims,
+    medianFireAge,
+    percentiles: { p10, p25, p50, p75, p90 },
+    ageAxis,
+    finalPortfolioAtHorizon: {
+      p10: percentile(finalVals, 0.1),
+      p25: percentile(finalVals, 0.25),
+      p50: percentile(finalVals, 0.5),
+      p75: percentile(finalVals, 0.75),
+      p90: percentile(finalVals, 0.9),
+    },
+    nSimulations: nSims,
+  };
+}
+
+// ─── Scenario Analysis ─────────────────────────────────────────────────────────
+
+export function runScenarioAnalysis(
+  settings: FireSettings,
+  currentPortfolio: number,
+): ScenarioResult[] {
+  const scenarios = [
+    { label: "Pessimistic", delta: -0.02 },
+    { label: "Base case", delta: 0 },
+    { label: "Optimistic", delta: +0.015 },
+  ];
+
+  return scenarios.map(({ label, delta }) => {
+    const adjusted: FireSettings = {
+      ...settings,
+      expectedAnnualReturn: settings.expectedAnnualReturn + delta,
+    };
+    const proj = projectFireDate(adjusted, currentPortfolio);
+    const lastSnapshot = proj.yearByYear[proj.yearByYear.length - 1];
+    return {
+      label,
+      annualReturn: adjusted.expectedAnnualReturn,
+      fireAge: proj.fireAge,
+      portfolioAtHorizon: lastSnapshot?.portfolioValue ?? 0,
+      yearByYear: proj.yearByYear,
+    };
+  });
+}
+
+// ─── Sequence of Returns Risk ──────────────────────────────────────────────────
+
+export function runSequenceOfReturnsRisk(
+  settings: FireSettings,
+  portfolioAtFire: number,
+): SorrScenario[] {
+  const r = settings.expectedAnnualReturn;
+  const years = Math.max(10, settings.planningHorizonAge - settings.targetFireAge);
+  // yearsToFire offsets the inflation/income-growth index so it is always
+  // "years from today" (currentAge), not "years from FIRE date".
+  const yearsToFire = Math.max(0, settings.targetFireAge - settings.currentAge);
+
+  const useConstantPct =
+    (settings.withdrawalStrategy ?? "constant-dollar") === "constant-percentage";
+
+  const scenarios: { label: string; returnsFactory: () => number[] }[] = [
+    {
+      label: "Base (constant)",
+      returnsFactory: () => Array(years).fill(r),
+    },
+    {
+      label: "Crash Year 1 (−30%)",
+      returnsFactory: () => [-0.3, ...Array(years - 1).fill(r + 0.01)],
+    },
+    {
+      label: "Crash Year 5 (−30%)",
+      returnsFactory: () => [...Array(4).fill(r), -0.3, ...Array(years - 5).fill(r + 0.01)],
+    },
+    {
+      label: "Double Crash",
+      returnsFactory: () => [-0.25, r, r, r, -0.2, ...Array(years - 5).fill(r)],
+    },
+    {
+      label: "Lost Decade",
+      returnsFactory: () => [...Array(10).fill(0), ...Array(years - 10).fill(r + 0.02)],
+    },
+  ];
+
+  return scenarios.map(({ label, returnsFactory }) => {
+    const returns = returnsFactory();
+    const path: number[] = [];
+    let portfolio = portfolioAtFire;
+
+    for (let i = 0; i < years; i++) {
+      path.push(Math.max(0, portfolio));
+      const age = settings.targetFireAge + i;
+      // yearsFromNow must be relative to currentAge (not FIRE date) so that
+      // expenses and inflation-linked income are correctly priced in future money.
+      const yearsFromNow = yearsToFire + i;
+      const annualExpenses =
+        settings.monthlyExpensesAtFire * 12 * Math.pow(1 + settings.inflationRate, yearsFromNow);
+      const annualIncome = additionalIncomeAtAge(
+        settings.additionalIncomeStreams,
+        age,
+        yearsFromNow,
+        settings.inflationRate,
+      );
+      const netWithdrawal = useConstantPct
+        ? settings.safeWithdrawalRate * portfolio
+        : Math.max(0, annualExpenses - annualIncome);
+      portfolio = Math.max(0, portfolio * (1 + returns[i]) - netWithdrawal);
+    }
+    path.push(Math.max(0, portfolio));
+
+    return {
+      label,
+      returns,
+      portfolioPath: path,
+      finalValue: portfolio,
+      survived: portfolio > 0,
+    };
+  });
+}
+
+// ─── Allocation Drift ──────────────────────────────────────────────────────────
+
+export interface HoldingInput {
+  symbol: string;
+  name: string;
+  marketValue: number;
+}
+
+export interface ActivityInput {
+  symbol: string;
+  activityType: string;
+  date: string; // ISO date string
+}
+
+export function checkAllocationDrift(
+  holdings: HoldingInput[],
+  targetAllocations: Record<string, number>,
+  activities: ActivityInput[],
+): AllocationHealth[] {
+  const totalValue = holdings.reduce((sum, h) => sum + h.marketValue, 0);
+  if (totalValue === 0) return [];
+
+  const today = new Date();
+
+  return Object.entries(targetAllocations)
+    .filter(([, target]) => target > 0)
+    .map(([symbol, targetWeight]) => {
+      const holding = holdings.find((h) => h.symbol === symbol || h.name === symbol);
+      const currentValue = holding?.marketValue ?? 0;
+      const currentWeight = currentValue / totalValue;
+      const drift = currentWeight - targetWeight;
+
+      // Find last BUY for this symbol
+      const buys = activities
+        .filter(
+          (a) => (a.symbol === symbol || a.symbol === holding?.symbol) && a.activityType === "BUY",
+        )
+        .map((a) => new Date(a.date).getTime())
+        .filter((t) => !isNaN(t));
+
+      const lastBuy = buys.length > 0 ? Math.max(...buys) : null;
+      const daysSinceLastBuy = lastBuy
+        ? Math.floor((today.getTime() - lastBuy) / (1000 * 60 * 60 * 24))
+        : null;
+
+      const status: AllocationHealth["status"] =
+        drift < -0.02 ? "underweight" : drift > 0.02 ? "overweight" : "ok";
+
+      return {
+        symbol,
+        name: holding?.name ?? symbol,
+        currentWeight,
+        targetWeight,
+        drift,
+        status,
+        currentValue,
+        daysSinceLastBuy,
+      };
+    });
+}
+
+// ─── Strategy Comparison ───────────────────────────────────────────────────────
+
+export function runStrategyComparison(
+  settings: FireSettings,
+  currentPortfolio: number,
+  nSims = 1000,
+): { constantDollar: MonteCarloResult; constantPercentage: MonteCarloResult } {
+  return {
+    constantDollar: runMonteCarlo(
+      { ...settings, withdrawalStrategy: "constant-dollar" },
+      currentPortfolio,
+      nSims,
+    ),
+    constantPercentage: runMonteCarlo(
+      { ...settings, withdrawalStrategy: "constant-percentage" },
+      currentPortfolio,
+      nSims,
+    ),
+  };
+}
+
+// ─── Sensitivity Analysis ──────────────────────────────────────────────────────
+
+export function runSensitivityAnalysis(
+  settings: FireSettings,
+  currentPortfolio: number,
+): { contribution: SensitivityMatrix; swr: SensitivitySWRMatrix } {
+  const contributionMultipliers = [0.5, 0.75, 1.0, 1.25, 1.5];
+  const returnValues = [0.04, 0.05, 0.06, 0.07, 0.08, 0.09];
+  const swrValues = [0.03, 0.035, 0.04, 0.045, 0.05];
+
+  const contributionRows = contributionMultipliers.map((m) => settings.monthlyContribution * m);
+
+  const fireAges: (number | null)[][] = contributionRows.map((contribution) =>
+    returnValues.map((ret) => {
+      const s: FireSettings = {
+        ...settings,
+        monthlyContribution: contribution,
+        expectedAnnualReturn: ret,
+      };
+      return projectFireDate(s, currentPortfolio).fireAge;
+    }),
+  );
+
+  const fireAgesBySwr: (number | null)[][] = swrValues.map((swr) =>
+    returnValues.map((ret) => {
+      const s: FireSettings = {
+        ...settings,
+        safeWithdrawalRate: swr,
+        expectedAnnualReturn: ret,
+      };
+      return projectFireDate(s, currentPortfolio).fireAge;
+    }),
+  );
+
+  return {
+    contribution: { contributionRows, returnColumns: returnValues, fireAges },
+    swr: { swrRows: swrValues, returnColumns: returnValues, fireAges: fireAgesBySwr },
+  };
+}

--- a/addons/fire-planner/src/lib/storage.ts
+++ b/addons/fire-planner/src/lib/storage.ts
@@ -1,0 +1,35 @@
+import type { AddonContext } from "@wealthfolio/addon-sdk";
+import type { FireSettings } from "../types";
+
+const SETTINGS_KEY = "fire-planner-settings";
+
+export const DEFAULT_SETTINGS: FireSettings = {
+  monthlyExpensesAtFire: 3000,
+  safeWithdrawalRate: 0.035,
+  withdrawalStrategy: "constant-dollar",
+  expectedAnnualReturn: 0.07,
+  expectedReturnStdDev: 0.12,
+  inflationRate: 0.02,
+  currentAge: 30,
+  targetFireAge: 50,
+  monthlyContribution: 1000,
+  contributionGrowthRate: 0.02,
+  planningHorizonAge: 90,
+  additionalIncomeStreams: [],
+  targetAllocations: {},
+  currency: "USD",
+};
+
+export async function loadSettings(ctx: AddonContext): Promise<FireSettings> {
+  try {
+    const raw = await ctx.api.secrets.get(SETTINGS_KEY);
+    if (!raw) return DEFAULT_SETTINGS;
+    return { ...DEFAULT_SETTINGS, ...JSON.parse(raw) };
+  } catch {
+    return DEFAULT_SETTINGS;
+  }
+}
+
+export async function saveSettings(ctx: AddonContext, settings: FireSettings): Promise<void> {
+  await ctx.api.secrets.set(SETTINGS_KEY, JSON.stringify(settings));
+}

--- a/addons/fire-planner/src/pages/AllocationPage.tsx
+++ b/addons/fire-planner/src/pages/AllocationPage.tsx
@@ -1,0 +1,309 @@
+import type { Holding, ActivityDetails } from "@wealthfolio/addon-sdk";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Skeleton,
+  formatAmount,
+} from "@wealthfolio/ui";
+import { Cell, Legend, Pie, PieChart, ResponsiveContainer, Tooltip } from "@wealthfolio/ui/chart";
+import { useMemo } from "react";
+import type { FireSettings } from "../types";
+import { checkAllocationDrift } from "../lib/fire-math";
+
+interface Props {
+  settings: FireSettings;
+  holdings: Holding[];
+  activities: ActivityDetails[];
+  isLoading: boolean;
+  onSetupTargets?: () => void;
+}
+
+const DRIFT_COLORS = {
+  underweight: "bg-red-100 text-red-700 dark:bg-red-950/40 dark:text-red-400",
+  overweight: "bg-yellow-100 text-yellow-700 dark:bg-yellow-950/40 dark:text-yellow-400",
+  ok: "bg-green-100 text-green-700 dark:bg-green-950/40 dark:text-green-400",
+};
+
+const CHART_COLORS = [
+  "#3b82f6",
+  "#22c55e",
+  "#f59e0b",
+  "#ef4444",
+  "#8b5cf6",
+  "#06b6d4",
+  "#f97316",
+  "#ec4899",
+  "#14b8a6",
+  "#84cc16",
+];
+
+function pct(value: number) {
+  return (value * 100).toFixed(1) + "%";
+}
+
+export default function AllocationPage({
+  settings,
+  holdings,
+  activities,
+  isLoading,
+  onSetupTargets,
+}: Props) {
+  const { targetAllocations, currency } = settings;
+  const hasTargets = Object.keys(targetAllocations).length > 0;
+
+  const holdingInputs = useMemo(
+    () =>
+      holdings
+        .filter((h) => h.holdingType !== "cash")
+        .map((h) => ({
+          symbol: h.instrument?.symbol ?? "",
+          name: h.instrument?.name ?? h.instrument?.symbol ?? "",
+          marketValue: h.marketValue?.base ?? 0,
+        })),
+    [holdings],
+  );
+
+  const activityInputs = useMemo(
+    () =>
+      activities.map((a) => ({
+        symbol: a.assetSymbol ?? "",
+        activityType: a.activityType,
+        date: typeof a.date === "string" ? a.date : a.date.toISOString(),
+      })),
+    [activities],
+  );
+
+  const driftData = useMemo(
+    () =>
+      hasTargets ? checkAllocationDrift(holdingInputs, targetAllocations, activityInputs) : [],
+    [holdingInputs, targetAllocations, activityInputs, hasTargets],
+  );
+
+  const totalValue = holdingInputs.reduce((sum, h) => sum + (h.marketValue ?? 0), 0);
+
+  // Pie chart data: current vs target
+  const currentPieData = holdingInputs
+    .filter((h) => (h.marketValue ?? 0) > 0)
+    .sort((a, b) => (b.marketValue ?? 0) - (a.marketValue ?? 0))
+    .slice(0, 10)
+    .map((h) => ({
+      name: h.symbol,
+      value: Math.round(((h.marketValue ?? 0) / totalValue) * 1000) / 10,
+    }));
+
+  const targetPieData = Object.entries(targetAllocations)
+    .filter(([, w]) => w > 0)
+    .map(([sym, weight]) => ({
+      name: sym,
+      value: Math.round(weight * 1000) / 10,
+    }));
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-48 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  if (!hasTargets) {
+    return (
+      <div className="space-y-6">
+        <Card>
+          <CardContent className="py-10 text-center">
+            <p className="text-muted-foreground mb-4 text-sm">
+              Set your target allocation to enable drift monitoring.
+              <br />
+              Go to <strong>Settings → Target Allocations</strong>.
+            </p>
+            {onSetupTargets && (
+              <Button variant="outline" size="sm" onClick={onSetupTargets}>
+                Go to Settings
+              </Button>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Still show current portfolio composition */}
+        {currentPieData.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-sm">Current Portfolio Composition</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ResponsiveContainer width="100%" height={280}>
+                <PieChart>
+                  <Pie
+                    data={currentPieData}
+                    dataKey="value"
+                    nameKey="name"
+                    cx="50%"
+                    cy="50%"
+                    outerRadius={100}
+                    label={({ name, value }: { name?: string; value?: number }) =>
+                      `${name ?? ""} ${value ?? 0}%`
+                    }
+                  >
+                    {currentPieData.map((_, i) => (
+                      <Cell key={i} fill={CHART_COLORS[i % CHART_COLORS.length]} />
+                    ))}
+                  </Pie>
+                  <Tooltip formatter={(v: number | undefined) => `${v ?? 0}%`} />
+                  <Legend />
+                </PieChart>
+              </ResponsiveContainer>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Drift Monitor */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Allocation Drift Monitor</CardTitle>
+        </CardHeader>
+        <CardContent className="overflow-x-auto">
+          {driftData.length === 0 ? (
+            <p className="text-muted-foreground text-sm">
+              No matching holdings found for your target allocations. Check that your target symbols
+              match your holding symbols.
+            </p>
+          ) : (
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="text-muted-foreground border-b">
+                  <th className="pb-2 text-left">Asset</th>
+                  <th className="pb-2 text-right">Current %</th>
+                  <th className="pb-2 text-right">Target %</th>
+                  <th className="pb-2 text-right">Drift</th>
+                  <th className="pb-2 text-center">Status</th>
+                  <th className="pb-2 text-right">Value</th>
+                  <th className="pb-2 text-right">Days since buy</th>
+                  <th className="pb-2 text-left">Action</th>
+                </tr>
+              </thead>
+              <tbody>
+                {driftData.map((item) => (
+                  <tr key={item.symbol} className="border-b last:border-0">
+                    <td className="py-1.5 font-medium">
+                      {item.symbol}
+                      {item.name !== item.symbol && (
+                        <span className="text-muted-foreground ml-1 font-normal">{item.name}</span>
+                      )}
+                    </td>
+                    <td className="py-1.5 text-right">{pct(item.currentWeight)}</td>
+                    <td className="py-1.5 text-right">{pct(item.targetWeight)}</td>
+                    <td
+                      className={`py-1.5 text-right font-medium ${
+                        item.drift < -0.02
+                          ? "text-red-500"
+                          : item.drift > 0.02
+                            ? "text-yellow-600"
+                            : "text-green-600"
+                      }`}
+                    >
+                      {item.drift > 0 ? "+" : ""}
+                      {pct(item.drift)}
+                    </td>
+                    <td className="py-1.5 text-center">
+                      <span
+                        className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${DRIFT_COLORS[item.status]}`}
+                      >
+                        {item.status === "underweight" && "↓ Under"}
+                        {item.status === "overweight" && "↑ Over"}
+                        {item.status === "ok" && "✓ OK"}
+                      </span>
+                    </td>
+                    <td className="py-1.5 text-right">
+                      {formatAmount(item.currentValue, currency)}
+                    </td>
+                    <td className="py-1.5 text-right">
+                      {item.daysSinceLastBuy !== null ? `${item.daysSinceLastBuy}d` : "—"}
+                    </td>
+                    <td className="text-muted-foreground py-1.5 text-left">
+                      {item.status === "underweight" && "Consider buying"}
+                      {item.status === "overweight" && "Skip next contribution"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Side-by-side pie charts */}
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm">Current Allocation</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {currentPieData.length > 0 ? (
+              <ResponsiveContainer width="100%" height={240}>
+                <PieChart>
+                  <Pie
+                    data={currentPieData}
+                    dataKey="value"
+                    nameKey="name"
+                    cx="50%"
+                    cy="50%"
+                    outerRadius={90}
+                  >
+                    {currentPieData.map((_, i) => (
+                      <Cell key={i} fill={CHART_COLORS[i % CHART_COLORS.length]} />
+                    ))}
+                  </Pie>
+                  <Tooltip formatter={(v: number | undefined) => `${v ?? 0}%`} />
+                  <Legend />
+                </PieChart>
+              </ResponsiveContainer>
+            ) : (
+              <p className="text-muted-foreground py-6 text-center text-sm">No holdings found</p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm">Target Allocation</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {targetPieData.length > 0 ? (
+              <ResponsiveContainer width="100%" height={240}>
+                <PieChart>
+                  <Pie
+                    data={targetPieData}
+                    dataKey="value"
+                    nameKey="name"
+                    cx="50%"
+                    cy="50%"
+                    outerRadius={90}
+                  >
+                    {targetPieData.map((_, i) => (
+                      <Cell key={i} fill={CHART_COLORS[i % CHART_COLORS.length]} />
+                    ))}
+                  </Pie>
+                  <Tooltip formatter={(v: number | undefined) => `${v ?? 0}%`} />
+                  <Legend />
+                </PieChart>
+              </ResponsiveContainer>
+            ) : (
+              <p className="text-muted-foreground py-6 text-center text-sm">
+                No target allocations set
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/addons/fire-planner/src/pages/DashboardPage.tsx
+++ b/addons/fire-planner/src/pages/DashboardPage.tsx
@@ -1,0 +1,496 @@
+import type { Holding, ActivityDetails } from "@wealthfolio/addon-sdk";
+import {
+  Badge,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Skeleton,
+  formatAmount,
+} from "@wealthfolio/ui";
+import { useMemo } from "react";
+import type { FireSettings, IncomeStream } from "../types";
+import {
+  calculateFireTarget,
+  calculateNetFireTarget,
+  calculateCoastFireAmount,
+  projectFireDate,
+} from "../lib/fire-math";
+
+interface Props {
+  settings: FireSettings;
+  portfolioData: {
+    holdings: Holding[];
+    activities: ActivityDetails[];
+    totalValue: number;
+    isLoading: boolean;
+    error: Error | null;
+  };
+  isLoading: boolean;
+}
+
+function fmt(value: number, currency: string) {
+  return formatAmount(value, currency);
+}
+
+function pct(value: number) {
+  return (value * 100).toFixed(1) + "%";
+}
+
+function singleStreamIncome(
+  s: IncomeStream,
+  age: number,
+  yearsFromStart: number,
+  inflationRate: number,
+): number {
+  if (age < s.startAge) return 0;
+  const rate =
+    s.annualGrowthRate !== undefined
+      ? s.annualGrowthRate
+      : s.adjustForInflation
+        ? inflationRate
+        : 0;
+  return s.monthlyAmount * 12 * Math.pow(1 + rate, yearsFromStart);
+}
+
+export default function DashboardPage({ settings, portfolioData, isLoading }: Props) {
+  const { totalValue, error } = portfolioData;
+  const currency = settings.currency;
+
+  const fireTarget = useMemo(() => calculateFireTarget(settings), [settings]);
+  const netFireTarget = useMemo(() => calculateNetFireTarget(settings), [settings]);
+  const coastAmount = useMemo(() => calculateCoastFireAmount(settings), [settings]);
+  const projection = useMemo(() => projectFireDate(settings, totalValue), [settings, totalValue]);
+
+  const progress = netFireTarget > 0 ? Math.min(1, totalValue / netFireTarget) : 0;
+
+  const fireAgeForBudget = projection.fireAge ?? settings.targetFireAge;
+
+  // Streams active from day-1 of FIRE (payout age <= FIRE age)
+  const activeStreams = settings.additionalIncomeStreams.filter(
+    (s) => s.startAge <= fireAgeForBudget && s.monthlyAmount > 0,
+  );
+  // Streams that kick in later
+  const deferredStreams = settings.additionalIncomeStreams
+    .filter((s) => s.startAge > fireAgeForBudget && s.monthlyAmount > 0)
+    .sort((a, b) => a.startAge - b.startAge);
+
+  const totalActiveIncome = activeStreams.reduce((sum, s) => sum + s.monthlyAmount, 0);
+  const portfolioWithdrawalAtFire = Math.max(0, settings.monthlyExpensesAtFire - totalActiveIncome);
+  const totalBudget = settings.monthlyExpensesAtFire;
+
+  const hasPensionFunds = settings.additionalIncomeStreams.some(
+    (s) => (s.currentValue ?? 0) > 0 || (s.monthlyContribution ?? 0) > 0,
+  );
+
+  // Key snapshots to show in table
+  const keyAges = new Set<number>();
+  keyAges.add(settings.currentAge);
+  keyAges.add(settings.currentAge + 5);
+  keyAges.add(settings.currentAge + 10);
+  if (projection.fireAge) {
+    keyAges.add(projection.fireAge);
+    keyAges.add(projection.fireAge + 5);
+    keyAges.add(projection.fireAge + 10);
+    keyAges.add(projection.fireAge + 15);
+  }
+  settings.additionalIncomeStreams.forEach((s) => keyAges.add(s.startAge));
+
+  const tableSnapshots = projection.yearByYear.filter((y) => keyAges.has(y.age));
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          {[...Array(4)].map((_, i) => (
+            <Card key={i}>
+              <CardHeader className="pb-2">
+                <Skeleton className="h-4 w-24" />
+              </CardHeader>
+              <CardContent>
+                <Skeleton className="h-7 w-32" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+        <Skeleton className="h-40 w-full" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-destructive p-4 text-sm">
+        Failed to load portfolio data: {error.message}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* KPI Cards */}
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+              FIRE Target
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-xl font-bold">{fmt(netFireTarget, currency)}</p>
+            {netFireTarget < fireTarget ? (
+              <p className="text-muted-foreground text-xs">
+                Gross {fmt(fireTarget, currency)} − {fmt(totalActiveIncome, currency)}/mo income
+                already covers {fmt(fireTarget - netFireTarget, currency)}
+              </p>
+            ) : (
+              <p className="text-muted-foreground text-xs">
+                {pct(settings.safeWithdrawalRate)} SWR ·{" "}
+                {fmt(settings.monthlyExpensesAtFire, currency)}/mo
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+              Portfolio Value
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-xl font-bold">{fmt(totalValue, currency)}</p>
+            <p
+              className={`text-xs ${totalValue >= netFireTarget ? "text-green-600" : "text-muted-foreground"}`}
+            >
+              {totalValue >= netFireTarget
+                ? `${fmt(totalValue - netFireTarget, currency)} above target`
+                : `${fmt(netFireTarget - totalValue, currency)} to go`}
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+              Progress
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-xl font-bold">{pct(progress)}</p>
+            <p className="text-muted-foreground text-xs">toward FIRE target</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+              Est. FIRE Age
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-xl font-bold">{projection.fireAge ?? "Not reached"}</p>
+            <p className="text-muted-foreground text-xs">
+              {projection.fireAge != null
+                ? projection.fireAge < settings.targetFireAge
+                  ? `${settings.targetFireAge - projection.fireAge} yrs ahead of target`
+                  : projection.fireAge === settings.targetFireAge
+                    ? `on target (age ${settings.targetFireAge})`
+                    : `target age ${settings.targetFireAge}`
+                : `not reached by age ${settings.planningHorizonAge}`}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Progress Bars */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">FIRE Progress</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <div className="mb-1 flex justify-between text-xs">
+              <span>Portfolio vs FIRE Target</span>
+              <span>{pct(progress)}</span>
+            </div>
+            <div className="bg-muted h-3 w-full overflow-hidden rounded-full">
+              <div
+                className="bg-primary h-full rounded-full transition-all"
+                style={{ width: `${Math.min(100, progress * 100)}%` }}
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Coast FIRE Card */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-sm">
+            Coast FIRE
+            {projection.coastFireReached ? (
+              <Badge variant="default" className="bg-green-600 text-xs">
+                Reached ✓
+              </Badge>
+            ) : (
+              <Badge variant="secondary" className="text-xs">
+                Not yet
+              </Badge>
+            )}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 gap-4 text-sm md:grid-cols-3">
+            <div>
+              <p className="text-muted-foreground text-xs">Coast FIRE amount needed today</p>
+              <p className="font-semibold">{fmt(coastAmount, currency)}</p>
+            </div>
+            <div>
+              <p className="text-muted-foreground text-xs">Current portfolio</p>
+              <p className="font-semibold">{fmt(totalValue, currency)}</p>
+            </div>
+            <div>
+              <p className="text-muted-foreground text-xs">
+                {projection.coastFireReached ? "Surplus" : "Gap"}
+              </p>
+              <p
+                className={`font-semibold ${projection.coastFireReached ? "text-green-600" : "text-red-500"}`}
+              >
+                {fmt(Math.abs(totalValue - coastAmount), currency)}
+              </p>
+            </div>
+          </div>
+          <p className="text-muted-foreground mt-3 text-xs">
+            Coast FIRE means your current portfolio, growing at your expected return with no further
+            contributions, would reach your FIRE target by age {settings.targetFireAge}.
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Monthly Budget at FIRE */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Monthly Budget at FIRE</CardTitle>
+          <p className="text-muted-foreground text-xs">
+            How your {fmt(totalBudget, currency)}/mo is funded at each phase of retirement
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Phase 1: at FIRE age */}
+          <div>
+            <p className="mb-2 text-xs font-medium">
+              At FIRE age {fireAgeForBudget} — {fmt(totalBudget, currency)}/mo total
+            </p>
+
+            {/* Visual bar */}
+            <div className="mb-3 flex h-5 w-full overflow-hidden rounded-full">
+              {activeStreams.map((s, i) => {
+                const pctVal = totalBudget > 0 ? (s.monthlyAmount / totalBudget) * 100 : 0;
+                const colors = ["#3b82f6", "#22c55e", "#f97316", "#a855f7", "#ec4899"];
+                return (
+                  <div
+                    key={s.id}
+                    style={{ width: `${pctVal}%`, background: colors[i % colors.length] }}
+                    title={`${s.label}: ${fmt(s.monthlyAmount, currency)}/mo`}
+                  />
+                );
+              })}
+              {portfolioWithdrawalAtFire > 0 && (
+                <div
+                  style={{
+                    width: `${totalBudget > 0 ? (portfolioWithdrawalAtFire / totalBudget) * 100 : 100}%`,
+                  }}
+                  className="bg-muted-foreground/30"
+                  title={`Portfolio: ${fmt(portfolioWithdrawalAtFire, currency)}/mo`}
+                />
+              )}
+            </div>
+
+            {/* Breakdown rows */}
+            <div className="space-y-1">
+              {activeStreams.map((s, i) => {
+                const pctVal = totalBudget > 0 ? (s.monthlyAmount / totalBudget) * 100 : 0;
+                const colors = ["#3b82f6", "#22c55e", "#f97316", "#a855f7", "#ec4899"];
+                return (
+                  <div key={s.id} className="flex items-center justify-between text-xs">
+                    <span className="flex items-center gap-2">
+                      <span
+                        className="inline-block h-2.5 w-2.5 rounded-full"
+                        style={{ background: colors[i % colors.length] }}
+                      />
+                      {s.label || "Income stream"}
+                    </span>
+                    <span className="text-muted-foreground">
+                      {fmt(s.monthlyAmount, currency)}/mo{" "}
+                      <span className="text-foreground ml-1 font-medium">{pctVal.toFixed(0)}%</span>
+                    </span>
+                  </div>
+                );
+              })}
+              <div className="flex items-center justify-between text-xs">
+                <span className="flex items-center gap-2">
+                  <span className="bg-muted-foreground/30 inline-block h-2.5 w-2.5 rounded-full" />
+                  Portfolio withdrawal
+                </span>
+                <span className="text-muted-foreground">
+                  {fmt(portfolioWithdrawalAtFire, currency)}/mo{" "}
+                  <span className="text-foreground ml-1 font-medium">
+                    {totalBudget > 0
+                      ? ((portfolioWithdrawalAtFire / totalBudget) * 100).toFixed(0)
+                      : 0}
+                    %
+                  </span>
+                </span>
+              </div>
+            </div>
+          </div>
+
+          {/* Deferred phases */}
+          {deferredStreams.length > 0 && (
+            <div className="space-y-3 border-t pt-3">
+              <p className="text-muted-foreground text-xs">How the mix evolves over time:</p>
+              {deferredStreams.map((s) => {
+                // Cumulative income available from this stream's start age onwards
+                const cumulativeIncome =
+                  totalActiveIncome +
+                  deferredStreams
+                    .filter((d) => d.startAge <= s.startAge)
+                    .reduce((sum, d) => sum + d.monthlyAmount, 0);
+                const newPortfolioWithdrawal = Math.max(0, totalBudget - cumulativeIncome);
+                const extraBudget = Math.max(0, cumulativeIncome - totalBudget);
+
+                return (
+                  <div key={s.id} className="bg-muted/40 rounded p-2 text-xs">
+                    <p className="font-medium">
+                      From age {s.startAge}: +{fmt(s.monthlyAmount, currency)}/mo ({s.label})
+                    </p>
+                    {extraBudget > 0 ? (
+                      <p className="text-muted-foreground mt-0.5">
+                        Income exceeds base expenses — portfolio withdrawal drops to{" "}
+                        <span className="font-medium text-green-600">€0</span> and you have{" "}
+                        <span className="font-medium text-green-600">
+                          {fmt(extraBudget, currency)}/mo
+                        </span>{" "}
+                        extra spending power
+                      </p>
+                    ) : (
+                      <p className="text-muted-foreground mt-0.5">
+                        Portfolio withdrawal drops to{" "}
+                        <span className="font-medium text-green-600">
+                          {fmt(newPortfolioWithdrawal, currency)}/mo
+                        </span>{" "}
+                        (was {fmt(portfolioWithdrawalAtFire, currency)}/mo at FIRE)
+                      </p>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {settings.additionalIncomeStreams.length === 0 && (
+            <p className="text-muted-foreground text-xs">
+              No income streams configured. Add pension, part-time work, or annuity streams in
+              Settings to see how they reduce your portfolio withdrawal.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Yearly Snapshot Table */}
+      {tableSnapshots.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm">Year-by-Year Snapshot</CardTitle>
+          </CardHeader>
+          <CardContent className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="text-muted-foreground border-b">
+                  <th className="pb-2 text-left">Age</th>
+                  <th className="pb-2 text-left">Year</th>
+                  <th className="pb-2 text-left">Phase</th>
+                  <th className="pb-2 text-right">Portfolio</th>
+                  {hasPensionFunds && <th className="pb-2 text-right">Pension Fund</th>}
+                  <th className="pb-2 text-right">Contribution/yr</th>
+                  {settings.additionalIncomeStreams.map((s) => (
+                    <th key={s.id} className="whitespace-nowrap pb-2 text-right">
+                      {s.label || "Income"}/yr
+                    </th>
+                  ))}
+                  <th className="pb-2 text-right">Net Withdrawal/yr</th>
+                </tr>
+              </thead>
+              <tbody>
+                {tableSnapshots.map((snap) => {
+                  const isFire = snap.phase === "fire";
+                  const isFireRow = snap.age === projection.fireAge;
+                  const isIncomeRow = settings.additionalIncomeStreams.some(
+                    (s) => s.startAge === snap.age,
+                  );
+                  return (
+                    <tr
+                      key={snap.age}
+                      className={`border-b last:border-0 ${
+                        isFireRow
+                          ? "bg-green-50 font-semibold dark:bg-green-950/20"
+                          : isIncomeRow
+                            ? "bg-blue-50 dark:bg-blue-950/20"
+                            : ""
+                      }`}
+                    >
+                      <td className="py-1.5">{snap.age}</td>
+                      <td className="py-1.5">{snap.year}</td>
+                      <td className="py-1.5">
+                        <Badge variant={isFire ? "default" : "secondary"} className="text-xs">
+                          {isFire ? "FIRE" : "Acc."}
+                        </Badge>
+                      </td>
+                      <td className="py-1.5 text-right">{fmt(snap.portfolioValue, currency)}</td>
+                      {hasPensionFunds && (
+                        <td className="py-1.5 text-right">
+                          {snap.pensionAssets > 0 ? fmt(snap.pensionAssets, currency) : "—"}
+                        </td>
+                      )}
+                      <td className="py-1.5 text-right">
+                        {snap.annualContribution > 0 ? fmt(snap.annualContribution, currency) : "—"}
+                      </td>
+                      {settings.additionalIncomeStreams.map((s) => {
+                        const income = singleStreamIncome(
+                          s,
+                          snap.age,
+                          snap.age - settings.currentAge,
+                          settings.inflationRate,
+                        );
+                        return (
+                          <td key={s.id} className="py-1.5 text-right">
+                            {income > 0 ? fmt(income, currency) : "—"}
+                          </td>
+                        );
+                      })}
+                      <td className="py-1.5 text-right">
+                        {snap.netWithdrawalFromPortfolio > 0
+                          ? fmt(snap.netWithdrawalFromPortfolio, currency)
+                          : "—"}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+      )}
+
+      {totalValue === 0 && (
+        <Card>
+          <CardContent className="text-muted-foreground py-8 text-center text-sm">
+            No portfolio data found. Add accounts and holdings in Wealthfolio to see your FIRE
+            projection.
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/addons/fire-planner/src/pages/GuidePage.tsx
+++ b/addons/fire-planner/src/pages/GuidePage.tsx
@@ -1,0 +1,194 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@wealthfolio/ui";
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="text-sm leading-relaxed">{children}</CardContent>
+    </Card>
+  );
+}
+
+function Step({ n, title, children }: { n: number; title: string; children: React.ReactNode }) {
+  return (
+    <div className="flex gap-3">
+      <span className="bg-primary text-primary-foreground mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-xs font-bold">
+        {n}
+      </span>
+      <div>
+        <p className="font-medium">{title}</p>
+        <p className="text-muted-foreground text-xs">{children}</p>
+      </div>
+    </div>
+  );
+}
+
+function Term({ t, children }: { t: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <p className="font-medium">{t}</p>
+      <p className="text-muted-foreground text-xs">{children}</p>
+    </div>
+  );
+}
+
+export default function GuidePage({ country }: { country?: string }) {
+  return (
+    <div className="space-y-6 pb-8">
+      <Section title="Quick start — 5 steps">
+        <div className="space-y-4">
+          <Step n={1} title="Set your FIRE Parameters (Settings tab)">
+            Enter your current age, your target FIRE age, and how much you plan to spend per month
+            once retired. Use today's money — inflation is handled automatically.
+          </Step>
+          <Step n={2} title="Set your monthly contribution and expected return">
+            Enter how much you invest each month and your expected annual portfolio return (7% is a
+            common historical figure for a diversified equity portfolio). If you enter your annual
+            salary, the planner will show your savings rate and can grow contributions with your
+            raises.
+          </Step>
+          <Step n={3} title="Add income streams (pension, part-time, annuity…)">
+            Each stream has a monthly amount and a payout start age. Streams active at your FIRE age
+            reduce how much your portfolio needs to cover. Streams that start later (e.g. state
+            pension at 67) are modelled as deferred phases.
+          </Step>
+          <Step n={4} title="For pension funds with accumulation (fondo pensione, TFR)">
+            Enable the "Has accumulation fund" toggle on the stream. Enter the current fund balance,
+            monthly contribution (TFR), and the fund's annual return. Link it to the matching
+            Wealthfolio account to pull the live balance with one click.
+          </Step>
+          <Step n={5} title="Read the Dashboard, then explore Simulations">
+            The Dashboard shows your FIRE target, progress, budget breakdown by source, and a
+            year-by-year table. Simulations runs Monte Carlo (1,000 paths), scenarios, and
+            crash-stress tests.
+          </Step>
+        </div>
+      </Section>
+
+      <Section title="Understanding the Dashboard">
+        <div className="space-y-4">
+          <Term t="FIRE Target (net)">
+            The portfolio you need to accumulate, after subtracting income available from day one of
+            FIRE. A €1,200/mo pension that starts at your FIRE age reduces your target by €1,200 ×
+            12 / SWR. Deferred streams (e.g. state pension at 67) do NOT reduce this number — your
+            portfolio must bridge that gap on its own.
+          </Term>
+          <Term t="Coast FIRE amount">
+            If you stopped contributing today, this is the minimum portfolio needed to grow to your
+            FIRE target by your target age, purely on investment returns. Once you pass this number,
+            every additional contribution is accelerating retirement, not enabling it.
+          </Term>
+          <Term t="Monthly Budget at FIRE">
+            Your total monthly spend broken down by funding source. Income streams active from FIRE
+            age appear as coloured segments; the grey segment is what the portfolio must cover. Each
+            deferred stream then shows how the mix shifts at the age it starts.
+          </Term>
+          <Term t="Year-by-Year table">
+            The accumulation phase shows annual contributions and portfolio growth. The FIRE phase
+            shows annual expenses, income from each stream, and the net withdrawal from the
+            portfolio. The highlighted row is when FIRE is reached; blue rows mark when a new income
+            stream kicks in.
+          </Term>
+        </div>
+      </Section>
+
+      <Section title="Understanding Simulations">
+        <div className="space-y-4">
+          <Term t="Monte Carlo (1,000 simulations)">
+            Runs your plan 1,000 times using a two-regime fat-tailed return distribution (85% of
+            years draw from a shifted-up normal, 15% are stress years with heavier downside), with
+            stochastic per-year inflation. The fan chart shows percentile bands P10–P90. Success
+            rate = % of simulations where the portfolio survives to your planning horizon age. Aim
+            for ≥ 90%.
+          </Term>
+          <Term t="Scenario Analysis">
+            The same plan run with three different return assumptions: pessimistic (−2%), base case,
+            and optimistic (+1.5%). Shows how sensitive your FIRE date is to return assumptions.
+            Income streams are fully reflected — the lines diverge in the FIRE phase where
+            withdrawals differ.
+          </Term>
+          <Term t="Income Streams Projection">
+            Shows each income stream as a stacked area growing over time, versus your
+            inflation-adjusted expense line. The gap between the areas and the line is the portfolio
+            withdrawal needed each year. Coverage % in the table tells you how much of expenses are
+            self-funded at each key age.
+          </Term>
+          <Term t="Sequence of Returns Risk (SORR)">
+            Tests five crash scenarios starting from your FIRE date. A crash in year 1 is far more
+            dangerous than the same crash in year 10 because early withdrawals lock in losses.
+            Substantial income streams reduce SORR significantly — the green banner appears if your
+            streams cover more than 30% of expenses.
+          </Term>
+          <Term t="Sensitivity Analysis">
+            Two heatmaps: FIRE age across contribution levels × return rates, and FIRE target across
+            SWR × return rates. Your current settings are highlighted in blue. Use this to
+            understand what levers matter most for your timeline.
+          </Term>
+        </div>
+      </Section>
+
+      {country === "IT" && (
+        <Section title="Italian FIRE setup (fondo pensione, TFR, INPS)">
+          <div className="space-y-4">
+            <Term t="Portafoglio investito (Golden Butterfly, All-Weather…)">
+              This is your main portfolio — the value Wealthfolio tracks. Set your expected return
+              and monthly contribution here. This is the primary engine of your FIRE plan.
+            </Term>
+            <Term t="Fondo pensione integrativo">
+              Add it as an income stream. Enable "Has accumulation fund". Set the current fund
+              balance (or link the Wealthfolio account and click Sync), the monthly TFR
+              contribution, and the fund's net return (check your fund's factsheet — 3–5% is common
+              after fees). Set the payout start age to when you plan to draw it (typically pension
+              age, 65–67). The planner will accumulate TFR until you FIRE, then let the fund grow
+              without new contributions until payout age.
+            </Term>
+            <Term t="Pensione INPS (previdenza obbligatoria)">
+              Add it as a pure income stream (no accumulation toggle). Enter your estimated monthly
+              net pension in <strong>today's euros</strong> (real value) and set the payout start
+              age (typically 67 for contributivo). Enable "Inflation-adjusted" since INPS is linked
+              to cost-of-living indexation. Use the INPS simulator (inps.it) to estimate your amount
+              — the simulator gives a future nominal value, so divide it by (1 + inflation)^years to
+              convert to today's euros. Example: simulator says €1,500 at age 67 in 35 years at 2%
+              inflation → enter €1,500 / 1.02^35 ≈ €750.
+            </Term>
+            <Term t="TFR (Trattamento di Fine Rapporto)">
+              TFR is typically paid into your fondo pensione — model it as the monthly contribution
+              on that stream. Rough estimate: gross monthly salary × 6.91% / 12. If you keep TFR in
+              azienda instead, it grows at 1.5% + 75% of ISTAT inflation — use a lower
+              accumulationReturn (≈ 2–3%) and no monthly contribution.
+            </Term>
+          </div>
+        </Section>
+      )}
+
+      <Section title="Key concepts">
+        <div className="space-y-4">
+          <Term t="Safe Withdrawal Rate (SWR)">
+            The % of your portfolio you withdraw annually in retirement. The classic 4% rule (from
+            the Trinity Study) means a €1M portfolio supports €40k/year. This planner defaults to
+            3.5% — more conservative and appropriate for early retirees with longer horizons. Lower
+            SWR = larger required portfolio = more safety.
+          </Term>
+          <Term t="Inflation rate">
+            All projections grow expenses and inflation-linked income at this rate year over year.
+            The default 2% matches the ECB target. Use 2.5–3% if you want a more conservative
+            assumption for Italian CPI.
+          </Term>
+          <Term t="Expected return and volatility">
+            Expected return is the average annual growth of your portfolio. For a diversified global
+            equity portfolio, 6–8% real (after inflation) is a common long-term assumption.
+            Volatility (std dev) is used only in Monte Carlo — higher values produce a wider fan of
+            outcomes. 12% is typical for a mixed equity/bond portfolio.
+          </Term>
+          <Term t="Net FIRE target vs gross">
+            The gross target (spese × 12 / SWR) ignores income streams. The net target subtracts
+            income available from day-one of FIRE, giving the actual amount your portfolio needs to
+            cover. The Dashboard card shows the net target as the main figure.
+          </Term>
+        </div>
+      </Section>
+    </div>
+  );
+}

--- a/addons/fire-planner/src/pages/SettingsPage.tsx
+++ b/addons/fire-planner/src/pages/SettingsPage.tsx
@@ -1,0 +1,915 @@
+import type { AddonContext, Holding, ActivityDetails, Account } from "@wealthfolio/addon-sdk";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+  Switch,
+} from "@wealthfolio/ui";
+import { useState, useEffect } from "react";
+import type { FireSettings, IncomeStream } from "../types";
+import { DEFAULT_SETTINGS } from "../lib/storage";
+import { runAutoConfig, applyAutoConfig, type AutoConfigResult } from "../lib/auto-config";
+
+interface Props {
+  ctx: AddonContext;
+  settings: FireSettings;
+  onSave: (settings: FireSettings) => void;
+  isSaving: boolean;
+  holdings: Holding[];
+  activities: ActivityDetails[];
+  accounts: Account[];
+}
+
+function generateId() {
+  return Math.random().toString(36).slice(2, 9);
+}
+
+function SliderField({
+  label,
+  value,
+  min,
+  max,
+  step,
+  displayValue,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  displayValue: string;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center justify-between">
+        <Label className="text-xs">{label}</Label>
+        <span className="text-xs font-medium">{displayValue}</span>
+      </div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        className="w-full accent-blue-600"
+      />
+    </div>
+  );
+}
+
+function NumberField({
+  label,
+  value,
+  onChange,
+  prefix,
+  suffix,
+  min,
+}: {
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+  prefix?: string;
+  suffix?: string;
+  min?: number;
+}) {
+  return (
+    <div className="space-y-1">
+      <Label className="text-xs">{label}</Label>
+      <div className="flex items-center gap-1">
+        {prefix && <span className="text-muted-foreground text-xs">{prefix}</span>}
+        <Input
+          type="number"
+          value={value}
+          min={min}
+          onChange={(e) => {
+            const v = parseFloat(e.target.value);
+            if (!isNaN(v)) onChange(v);
+          }}
+          className="h-8 text-sm"
+        />
+        {suffix && <span className="text-muted-foreground text-xs">{suffix}</span>}
+      </div>
+    </div>
+  );
+}
+
+export default function SettingsPage({
+  ctx,
+  settings,
+  onSave,
+  isSaving,
+  holdings,
+  activities,
+  accounts,
+}: Props) {
+  const [draft, setDraft] = useState<FireSettings>(settings);
+  const [showResetConfirm, setShowResetConfirm] = useState(false);
+  const [autoConfigResult, setAutoConfigResult] = useState<AutoConfigResult | null>(null);
+  const [autoConfigLoading, setAutoConfigLoading] = useState(false);
+  const [syncingStreamId, setSyncingStreamId] = useState<string | null>(null);
+
+  // Sync when settings load from storage
+  useEffect(() => {
+    setDraft(settings);
+  }, [settings]);
+
+  async function handleAutoConfig() {
+    setAutoConfigLoading(true);
+    setAutoConfigResult(null);
+    try {
+      const result = await runAutoConfig(activities, holdings, accounts, ctx);
+      setAutoConfigResult(result);
+    } catch (e) {
+      ctx.api.toast.error("Auto-config failed: " + (e as Error).message);
+    } finally {
+      setAutoConfigLoading(false);
+    }
+  }
+
+  function applyDetected() {
+    if (!autoConfigResult) return;
+    setDraft((prev) => applyAutoConfig(prev, autoConfigResult));
+    setAutoConfigResult(null);
+    ctx.api.toast.success("Auto-config applied — review and save when ready.");
+  }
+
+  function update<K extends keyof FireSettings>(key: K, value: FireSettings[K]) {
+    setDraft((prev) => ({ ...prev, [key]: value }));
+  }
+
+  // ─── Income streams ──────────────────────────────────────────────────────────
+
+  function addStream() {
+    update("additionalIncomeStreams", [
+      ...draft.additionalIncomeStreams,
+      {
+        id: generateId(),
+        label: "",
+        monthlyAmount: 0,
+        startAge: draft.targetFireAge,
+        adjustForInflation: false,
+      },
+    ]);
+  }
+
+  function updateStream(id: string, patch: Partial<IncomeStream>) {
+    update(
+      "additionalIncomeStreams",
+      draft.additionalIncomeStreams.map((s) => (s.id === id ? { ...s, ...patch } : s)),
+    );
+  }
+
+  async function syncStreamFromAccount(streamId: string, accountId: string) {
+    setSyncingStreamId(streamId);
+    try {
+      const valuations = await ctx.api.portfolio.getLatestValuations([accountId]);
+      const v = valuations?.[0];
+      if (v) {
+        const value = Math.round(v.totalValue * v.fxRateToBase);
+        updateStream(streamId, { currentValue: value });
+        ctx.api.toast.success(`Synced: ${value.toLocaleString()} ${draft.currency}`);
+      } else {
+        ctx.api.toast.error("No valuation found for this account.");
+      }
+    } catch {
+      ctx.api.toast.error("Sync failed.");
+    } finally {
+      setSyncingStreamId(null);
+    }
+  }
+
+  function removeStream(id: string) {
+    update(
+      "additionalIncomeStreams",
+      draft.additionalIncomeStreams.filter((s) => s.id !== id),
+    );
+  }
+
+  // ─── Target allocations ──────────────────────────────────────────────────────
+
+  const allocEntries = Object.entries(draft.targetAllocations);
+  const totalAllocPct = allocEntries.reduce((sum, [, w]) => sum + w, 0);
+  const allocDiff = Math.abs(totalAllocPct - 1);
+  const allocWarning = allocEntries.length > 0 && allocDiff > 0.01;
+
+  function addAllocation() {
+    update("targetAllocations", { ...draft.targetAllocations, "": 0 });
+  }
+
+  function updateAllocation(oldKey: string, newKey: string, weight: number) {
+    const next = { ...draft.targetAllocations };
+    if (oldKey !== newKey) delete next[oldKey];
+    next[newKey] = weight;
+    update("targetAllocations", next);
+  }
+
+  function removeAllocation(key: string) {
+    const next = { ...draft.targetAllocations };
+    delete next[key];
+    update("targetAllocations", next);
+  }
+
+  // Auto-detect from buy activities (approximate from holdings)
+  function autoDetectAllocations() {
+    const totalValue = holdings.reduce((sum, h) => sum + (h.marketValue?.base ?? 0), 0);
+    if (totalValue === 0) return;
+    const allocs: Record<string, number> = {};
+    holdings
+      .filter((h) => h.holdingType !== "cash" && (h.marketValue?.base ?? 0) > 0)
+      .forEach((h) => {
+        const sym = h.instrument?.symbol ?? "";
+        if (sym) {
+          allocs[sym] = Math.round(((h.marketValue?.base ?? 0) / totalValue) * 100) / 100;
+        }
+      });
+    update("targetAllocations", allocs);
+  }
+
+  function handleReset() {
+    setDraft({ ...DEFAULT_SETTINGS, currency: draft.currency });
+    setShowResetConfirm(false);
+  }
+
+  function handleSave() {
+    // Resolve auto payout ages: startAgeIsAuto streams always use targetFireAge
+    const resolved: FireSettings = {
+      ...draft,
+      additionalIncomeStreams: draft.additionalIncomeStreams.map((s) =>
+        s.startAgeIsAuto ? { ...s, startAge: draft.targetFireAge } : s,
+      ),
+    };
+    onSave(resolved);
+  }
+
+  return (
+    <div className="space-y-6 pb-8">
+      {/* Auto-configure from portfolio */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <div>
+            <CardTitle className="text-sm">Auto-configure from portfolio</CardTitle>
+            <p className="text-muted-foreground mt-1 text-xs">
+              Detect monthly contribution, expected return, and target allocations from your
+              portfolio data.
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleAutoConfig}
+            disabled={autoConfigLoading}
+          >
+            {autoConfigLoading ? "Analyzing…" : "Detect from portfolio"}
+          </Button>
+        </CardHeader>
+
+        {autoConfigResult && (
+          <CardContent className="space-y-3">
+            <div className="space-y-2 rounded border p-3 text-xs">
+              {autoConfigResult.monthlyContribution !== null && (
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <span className="font-medium">Monthly contribution</span>
+                    <p className="text-muted-foreground">
+                      {autoConfigResult.notes.monthlyContribution}
+                    </p>
+                  </div>
+                  <span className="shrink-0 font-semibold text-green-600">
+                    {autoConfigResult.monthlyContribution.toLocaleString(undefined, {
+                      maximumFractionDigits: 0,
+                    })}{" "}
+                    {autoConfigResult.currency ?? draft.currency}
+                  </span>
+                </div>
+              )}
+              {autoConfigResult.expectedAnnualReturn !== null && (
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <span className="font-medium">Expected annual return</span>
+                    <p className="text-muted-foreground">
+                      {autoConfigResult.notes.expectedAnnualReturn}
+                    </p>
+                  </div>
+                  <span className="shrink-0 font-semibold text-green-600">
+                    {(autoConfigResult.expectedAnnualReturn * 100).toFixed(1)}%
+                  </span>
+                </div>
+              )}
+              {autoConfigResult.targetAllocations !== null && (
+                <div>
+                  <span className="font-medium">Target allocations</span>
+                  <p className="text-muted-foreground">
+                    {autoConfigResult.notes.targetAllocations}
+                  </p>
+                  <p className="mt-1">
+                    {Object.entries(autoConfigResult.targetAllocations)
+                      .map(([sym, w]) => `${sym} ${(w * 100).toFixed(1)}%`)
+                      .join(" · ")}
+                  </p>
+                </div>
+              )}
+              {autoConfigResult.monthlyContribution === null &&
+                autoConfigResult.expectedAnnualReturn === null &&
+                autoConfigResult.targetAllocations === null && (
+                  <p className="text-muted-foreground">
+                    No data could be detected. Add activities and holdings to Wealthfolio first.
+                  </p>
+                )}
+            </div>
+            {(autoConfigResult.monthlyContribution !== null ||
+              autoConfigResult.expectedAnnualReturn !== null ||
+              autoConfigResult.targetAllocations !== null) && (
+              <div className="flex gap-2">
+                <Button size="sm" onClick={applyDetected}>
+                  Apply detected values
+                </Button>
+                <Button variant="ghost" size="sm" onClick={() => setAutoConfigResult(null)}>
+                  Dismiss
+                </Button>
+              </div>
+            )}
+          </CardContent>
+        )}
+      </Card>
+
+      {/* FIRE Parameters */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">FIRE Parameters</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <NumberField
+              label={`Monthly expenses in FIRE (${draft.currency})`}
+              value={draft.monthlyExpensesAtFire}
+              onChange={(v) => update("monthlyExpensesAtFire", v)}
+              min={0}
+            />
+            <NumberField
+              label="Current age"
+              value={draft.currentAge}
+              onChange={(v) => update("currentAge", v)}
+              min={1}
+            />
+            <NumberField
+              label="Target FIRE age"
+              value={draft.targetFireAge}
+              onChange={(v) => update("targetFireAge", v)}
+              min={1}
+            />
+            <NumberField
+              label="Planning horizon age (life expectancy)"
+              value={draft.planningHorizonAge}
+              onChange={(v) => update("planningHorizonAge", v)}
+              min={draft.targetFireAge + 1}
+            />
+          </div>
+          <SliderField
+            label="Safe Withdrawal Rate"
+            value={draft.safeWithdrawalRate}
+            min={0.025}
+            max={0.06}
+            step={0.0025}
+            displayValue={(draft.safeWithdrawalRate * 100).toFixed(2) + "%"}
+            onChange={(v) => update("safeWithdrawalRate", v)}
+          />
+          <div className="space-y-2">
+            <Label className="text-xs">Withdrawal Strategy</Label>
+            <div className="flex flex-col gap-2 sm:flex-row sm:gap-6">
+              {(["constant-dollar", "constant-percentage"] as const).map((s) => (
+                <label key={s} className="flex cursor-pointer items-center gap-2 text-xs">
+                  <input
+                    type="radio"
+                    name="withdrawalStrategy"
+                    value={s}
+                    checked={(draft.withdrawalStrategy ?? "constant-dollar") === s}
+                    onChange={() => update("withdrawalStrategy", s)}
+                  />
+                  {s === "constant-dollar"
+                    ? "Constant dollar (fixed real spending)"
+                    : "Constant percentage (% of portfolio)"}
+                </label>
+              ))}
+            </div>
+            <p className="text-muted-foreground text-xs">
+              {(draft.withdrawalStrategy ?? "constant-dollar") === "constant-dollar"
+                ? "Withdraw a fixed inflation-adjusted amount each year. Spending is stable but the portfolio can deplete."
+                : `Withdraw ${(draft.safeWithdrawalRate * 100).toFixed(1)}% of the portfolio each year. Spending varies with market performance; the portfolio never fully depletes.`}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Investment Parameters */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Investment Parameters</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <NumberField
+              label={`Monthly contribution (${draft.currency})`}
+              value={draft.monthlyContribution}
+              onChange={(v) => update("monthlyContribution", v)}
+              min={0}
+            />
+            <NumberField
+              label={`Net annual salary / take-home (${draft.currency}) — optional`}
+              value={draft.currentAnnualSalary ?? 0}
+              onChange={(v) =>
+                update("currentAnnualSalary", v > 0 ? v : (undefined as unknown as number))
+              }
+              min={0}
+            />
+          </div>
+          {(draft.currentAnnualSalary ?? 0) > 0 && (
+            <p className="text-muted-foreground text-xs">
+              Implied savings rate:{" "}
+              <span className="text-foreground font-medium">
+                {(((draft.monthlyContribution * 12) / draft.currentAnnualSalary!) * 100).toFixed(1)}
+                %
+              </span>{" "}
+              of net salary (take-home)
+            </p>
+          )}
+          <SliderField
+            label={
+              (draft.salaryGrowthRate !== undefined
+                ? "Salary growth rate (per year)"
+                : "Contribution growth rate (per year)") + " — drives annual contribution increase"
+            }
+            value={draft.salaryGrowthRate ?? draft.contributionGrowthRate}
+            min={0}
+            max={0.1}
+            step={0.005}
+            displayValue={
+              ((draft.salaryGrowthRate ?? draft.contributionGrowthRate) * 100).toFixed(1) + "%"
+            }
+            onChange={(v) => {
+              if (draft.currentAnnualSalary) {
+                update("salaryGrowthRate", v);
+              } else {
+                update("contributionGrowthRate", v);
+              }
+            }}
+          />
+          {draft.currentAnnualSalary && (
+            <p className="text-muted-foreground text-xs">
+              Salary growth rate is active — your monthly contribution will grow at this rate each
+              year, mirroring salary raises.
+            </p>
+          )}
+          <SliderField
+            label="Expected annual portfolio return"
+            value={draft.expectedAnnualReturn}
+            min={0.03}
+            max={0.12}
+            step={0.005}
+            displayValue={(draft.expectedAnnualReturn * 100).toFixed(1) + "%"}
+            onChange={(v) => update("expectedAnnualReturn", v)}
+          />
+          <SliderField
+            label="Return standard deviation (volatility)"
+            value={draft.expectedReturnStdDev}
+            min={0.05}
+            max={0.25}
+            step={0.005}
+            displayValue={(draft.expectedReturnStdDev * 100).toFixed(1) + "%"}
+            onChange={(v) => update("expectedReturnStdDev", v)}
+          />
+          <p className="text-muted-foreground text-xs">
+            Volatility is used only for Monte Carlo simulation. Higher values produce a wider fan of
+            outcomes.
+          </p>
+          <SliderField
+            label="Inflation rate"
+            value={draft.inflationRate}
+            min={0.01}
+            max={0.05}
+            step={0.0025}
+            displayValue={(draft.inflationRate * 100).toFixed(2) + "%"}
+            onChange={(v) => update("inflationRate", v)}
+          />
+        </CardContent>
+      </Card>
+
+      {/* Portfolio Accounts */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">Portfolio Accounts</CardTitle>
+          <p className="text-muted-foreground mt-1 text-xs">
+            Choose which accounts count toward your FIRE portfolio. Cash / bank accounts are
+            excluded by default.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {accounts.filter((a) => a.isActive && !a.isArchived).length === 0 ? (
+            <p className="text-muted-foreground text-xs">
+              No active accounts found in Wealthfolio.
+            </p>
+          ) : (
+            accounts
+              .filter((a) => a.isActive && !a.isArchived)
+              .map((a) => {
+                const isInvestment =
+                  a.accountType === "SECURITIES" || a.accountType === "CRYPTOCURRENCY";
+                // If includedAccountIds is not set, default selection = investment accounts
+                const included =
+                  draft.includedAccountIds != null
+                    ? draft.includedAccountIds.includes(a.id)
+                    : isInvestment;
+                return (
+                  <div key={a.id} className="flex items-center gap-3 text-sm">
+                    <input
+                      type="checkbox"
+                      id={`acc-${a.id}`}
+                      checked={included}
+                      onChange={(e) => {
+                        // Materialise the selection list from the current effective set
+                        const currentSet =
+                          draft.includedAccountIds ??
+                          accounts
+                            .filter(
+                              (x) =>
+                                x.isActive &&
+                                !x.isArchived &&
+                                (x.accountType === "SECURITIES" ||
+                                  x.accountType === "CRYPTOCURRENCY"),
+                            )
+                            .map((x) => x.id);
+                        const next = e.target.checked
+                          ? [...currentSet, a.id]
+                          : currentSet.filter((id) => id !== a.id);
+                        update("includedAccountIds", next.length > 0 ? next : []);
+                      }}
+                    />
+                    <label htmlFor={`acc-${a.id}`} className="flex-1 cursor-pointer">
+                      {a.name}
+                    </label>
+                    <span className="text-muted-foreground text-xs">{a.accountType}</span>
+                  </div>
+                );
+              })
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Additional Income Streams */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <CardTitle className="text-sm">Additional Income Streams</CardTitle>
+          <Button variant="outline" size="sm" onClick={addStream}>
+            + Add
+          </Button>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {draft.additionalIncomeStreams.length === 0 && (
+            <p className="text-muted-foreground text-xs">
+              No income streams added. Examples: state pension, rental income, part-time work. Enter
+              amounts as net (after tax).
+            </p>
+          )}
+          {draft.additionalIncomeStreams.map((stream) => {
+            const hasPension =
+              (stream.currentValue ?? 0) > 0 ||
+              (stream.monthlyContribution ?? 0) > 0 ||
+              (stream.accumulationReturn ?? 0) > 0;
+            return (
+              <div key={stream.id} className="rounded border p-3">
+                <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
+                  <div className="col-span-2 sm:col-span-1">
+                    <Label className="text-xs">Label</Label>
+                    <Input
+                      value={stream.label}
+                      onChange={(e) => updateStream(stream.id, { label: e.target.value })}
+                      placeholder="e.g. State Pension"
+                      className="mt-1 h-8 text-sm"
+                    />
+                  </div>
+                  <div>
+                    <Label className="text-xs">
+                      Monthly amount — today's {draft.currency} (real)
+                    </Label>
+                    <Input
+                      type="number"
+                      value={stream.monthlyAmount}
+                      min={0}
+                      onChange={(e) =>
+                        updateStream(stream.id, { monthlyAmount: parseFloat(e.target.value) || 0 })
+                      }
+                      className="mt-1 h-8 text-sm"
+                    />
+                  </div>
+                  <div>
+                    <div className="flex items-center justify-between gap-2">
+                      <Label className="text-xs">Payout start age</Label>
+                      <label className="text-muted-foreground flex cursor-pointer items-center gap-1 text-xs">
+                        <input
+                          type="checkbox"
+                          checked={stream.startAgeIsAuto ?? false}
+                          onChange={(e) =>
+                            updateStream(stream.id, { startAgeIsAuto: e.target.checked })
+                          }
+                        />
+                        Auto
+                      </label>
+                    </div>
+                    {stream.startAgeIsAuto ? (
+                      <p className="mt-1 flex h-8 items-center text-sm font-medium">
+                        {draft.targetFireAge}
+                        <span className="text-muted-foreground ml-1 text-xs">(= FIRE age)</span>
+                      </p>
+                    ) : (
+                      <Input
+                        type="number"
+                        value={stream.startAge}
+                        min={1}
+                        onChange={(e) =>
+                          updateStream(stream.id, { startAge: parseInt(e.target.value) || 0 })
+                        }
+                        className="mt-1 h-8 text-sm"
+                      />
+                    )}
+                  </div>
+                  <div className="flex flex-col items-start gap-1">
+                    <Label className="text-xs">Inflation-adjusted</Label>
+                    <Switch
+                      checked={stream.annualGrowthRate === undefined && stream.adjustForInflation}
+                      disabled={stream.annualGrowthRate !== undefined}
+                      onCheckedChange={(v) => updateStream(stream.id, { adjustForInflation: v })}
+                    />
+                  </div>
+                  <div>
+                    <Label className="text-xs">
+                      Custom growth rate (%/yr){" "}
+                      <span className="text-muted-foreground">— overrides inflation flag</span>
+                    </Label>
+                    <div className="mt-1 flex items-center gap-1">
+                      <Input
+                        type="number"
+                        value={
+                          stream.annualGrowthRate !== undefined
+                            ? Math.round(stream.annualGrowthRate * 1000) / 10
+                            : ""
+                        }
+                        placeholder="e.g. 1.5"
+                        min={0}
+                        max={20}
+                        step={0.1}
+                        onChange={(e) => {
+                          const raw = e.target.value;
+                          updateStream(stream.id, {
+                            annualGrowthRate: raw === "" ? undefined : (parseFloat(raw) || 0) / 100,
+                          });
+                        }}
+                        className="h-8 text-sm"
+                      />
+                      <span className="text-muted-foreground text-xs">%</span>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Pension fund accumulation toggle */}
+                <div className="mt-3 flex items-center gap-2">
+                  <Switch
+                    checked={hasPension}
+                    onCheckedChange={(v) => {
+                      if (v) {
+                        updateStream(stream.id, {
+                          currentValue: 0,
+                          monthlyContribution: 0,
+                          accumulationReturn: 0.04,
+                          startAgeIsAuto: true,
+                        });
+                      } else {
+                        updateStream(stream.id, {
+                          currentValue: undefined,
+                          monthlyContribution: undefined,
+                          accumulationReturn: undefined,
+                        });
+                      }
+                    }}
+                  />
+                  <Label className="text-muted-foreground cursor-pointer text-xs">
+                    Has accumulation fund (pension fund, TFR…)
+                  </Label>
+                </div>
+
+                {hasPension && (
+                  <div className="bg-muted/40 mt-3 grid grid-cols-1 gap-3 rounded p-3 sm:grid-cols-3">
+                    <div>
+                      <Label className="text-xs">Current fund value ({draft.currency})</Label>
+                      <Input
+                        type="number"
+                        value={stream.currentValue ?? 0}
+                        min={0}
+                        onChange={(e) =>
+                          updateStream(stream.id, {
+                            currentValue: parseFloat(e.target.value) || 0,
+                          })
+                        }
+                        className="mt-1 h-8 text-sm"
+                      />
+                    </div>
+                    <div>
+                      <Label className="text-xs">Monthly contribution ({draft.currency})</Label>
+                      <Input
+                        type="number"
+                        value={stream.monthlyContribution ?? 0}
+                        min={0}
+                        onChange={(e) =>
+                          updateStream(stream.id, {
+                            monthlyContribution: parseFloat(e.target.value) || 0,
+                          })
+                        }
+                        className="mt-1 h-8 text-sm"
+                      />
+                    </div>
+                    <div>
+                      <Label className="text-xs">Accumulation return (%/yr)</Label>
+                      <Input
+                        type="number"
+                        value={Math.round((stream.accumulationReturn ?? 0.04) * 1000) / 10}
+                        min={0}
+                        max={20}
+                        step={0.1}
+                        onChange={(e) =>
+                          updateStream(stream.id, {
+                            accumulationReturn: (parseFloat(e.target.value) || 0) / 100,
+                          })
+                        }
+                        className="mt-1 h-8 text-sm"
+                      />
+                    </div>
+                    {/* Account link */}
+                    <div className="col-span-full space-y-1">
+                      <Label className="text-xs">
+                        Link to Wealthfolio account{" "}
+                        <span className="text-muted-foreground">
+                          (optional — syncs current value)
+                        </span>
+                      </Label>
+                      <div className="flex gap-2">
+                        <select
+                          value={stream.linkedAccountId ?? ""}
+                          onChange={(e) =>
+                            updateStream(stream.id, {
+                              linkedAccountId: e.target.value || undefined,
+                            })
+                          }
+                          className="border-input bg-background h-8 flex-1 rounded-md border px-2 text-sm"
+                        >
+                          <option value="">— Not linked —</option>
+                          {accounts
+                            .filter((a) => a.isActive && !a.isArchived)
+                            .map((a) => (
+                              <option key={a.id} value={a.id}>
+                                {a.name} ({a.currency})
+                              </option>
+                            ))}
+                        </select>
+                        {stream.linkedAccountId && (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="h-8 text-xs"
+                            disabled={syncingStreamId === stream.id}
+                            onClick={() =>
+                              syncStreamFromAccount(stream.id, stream.linkedAccountId!)
+                            }
+                          >
+                            {syncingStreamId === stream.id ? "Syncing…" : "Sync value"}
+                          </Button>
+                        )}
+                      </div>
+                      {stream.linkedAccountId && (
+                        <p className="text-muted-foreground text-xs">
+                          Current value pulled from this account. Click "Sync value" to refresh from
+                          live data.
+                        </p>
+                      )}
+                    </div>
+
+                    <p className="text-muted-foreground col-span-full text-xs">
+                      Phase 1 (now → FIRE): fund grows with contributions + investment return. Phase
+                      2 (FIRE → payout age): contributions stop (no more TFR), fund keeps growing on
+                      return only. Phase 3 (payout age+): pays out as monthly income.
+                    </p>
+                  </div>
+                )}
+
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="mt-2 h-6 text-xs text-red-500 hover:text-red-600"
+                  onClick={() => removeStream(stream.id)}
+                >
+                  Remove
+                </Button>
+              </div>
+            );
+          })}
+        </CardContent>
+      </Card>
+
+      {/* Target Allocations */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0">
+          <div>
+            <CardTitle className="text-sm">Target Allocations</CardTitle>
+            {allocEntries.length > 0 && (
+              <p
+                className={`mt-1 text-xs ${allocWarning ? "text-red-500" : "text-muted-foreground"}`}
+              >
+                Total: {(totalAllocPct * 100).toFixed(1)}%{allocWarning && " — must equal 100%"}
+              </p>
+            )}
+          </div>
+          <div className="flex gap-2">
+            {holdings.length > 0 && (
+              <Button variant="ghost" size="sm" className="text-xs" onClick={autoDetectAllocations}>
+                Auto-detect from holdings
+              </Button>
+            )}
+            <Button variant="outline" size="sm" onClick={addAllocation}>
+              + Add
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {allocEntries.length === 0 && (
+            <p className="text-muted-foreground text-xs">
+              Add target weights to enable drift monitoring in the Allocation tab.
+            </p>
+          )}
+          {allocEntries.map(([sym, weight]) => (
+            <div key={sym} className="flex items-center gap-2">
+              <Input
+                value={sym}
+                placeholder="Ticker / symbol"
+                className="h-8 flex-1 text-sm"
+                onChange={(e) => updateAllocation(sym, e.target.value, weight)}
+              />
+              <Input
+                type="number"
+                value={Math.round(weight * 1000) / 10}
+                min={0}
+                max={100}
+                step={0.1}
+                className="h-8 w-24 text-sm"
+                onChange={(e) =>
+                  updateAllocation(sym, sym, (parseFloat(e.target.value) || 0) / 100)
+                }
+              />
+              <span className="text-muted-foreground text-xs">%</span>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-red-500 hover:text-red-600"
+                onClick={() => removeAllocation(sym)}
+              >
+                ×
+              </Button>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      {/* Actions */}
+      <div className="flex items-center justify-between">
+        <div>
+          {showResetConfirm ? (
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground text-xs">Reset all settings to defaults?</span>
+              <Button variant="destructive" size="sm" onClick={handleReset}>
+                Yes, reset
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => setShowResetConfirm(false)}>
+                Cancel
+              </Button>
+            </div>
+          ) : (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-muted-foreground text-xs"
+              onClick={() => setShowResetConfirm(true)}
+            >
+              Reset to defaults
+            </Button>
+          )}
+        </div>
+        <Button onClick={handleSave} disabled={isSaving}>
+          {isSaving ? "Saving…" : "Save Settings"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/addons/fire-planner/src/pages/SimulationsPage.tsx
+++ b/addons/fire-planner/src/pages/SimulationsPage.tsx
@@ -1,0 +1,898 @@
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Skeleton,
+  formatAmount,
+} from "@wealthfolio/ui";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "@wealthfolio/ui/chart";
+import { useState, useMemo, useEffect } from "react";
+import type { FireSettings, MonteCarloResult } from "../types";
+import {
+  calculateNetFireTarget,
+  runMonteCarlo,
+  runStrategyComparison,
+  runScenarioAnalysis,
+  runSequenceOfReturnsRisk,
+  runSensitivityAnalysis,
+  projectFireDate,
+} from "../lib/fire-math";
+
+interface Props {
+  settings: FireSettings;
+  totalValue: number;
+  isLoading: boolean;
+}
+
+function fmt(value: number, currency: string) {
+  return formatAmount(value, currency);
+}
+
+function fmtCompact(value: number) {
+  if (value >= 1_000_000) return (value / 1_000_000).toFixed(1) + "M";
+  if (value >= 1_000) return (value / 1_000).toFixed(0) + "k";
+  return value.toFixed(0);
+}
+
+// ─── Monte Carlo Section ───────────────────────────────────────────────────────
+
+function MonteCarloSection({
+  settings,
+  totalValue,
+}: {
+  settings: FireSettings;
+  totalValue: number;
+}) {
+  const [result, setResult] = useState<MonteCarloResult | null>(null);
+  const [running, setRunning] = useState(false);
+  const [compResult, setCompResult] = useState<{
+    constantDollar: MonteCarloResult;
+    constantPercentage: MonteCarloResult;
+  } | null>(null);
+  const [comparing, setComparing] = useState(false);
+  const fireTarget = useMemo(() => calculateNetFireTarget(settings), [settings]);
+  const strategy = settings.withdrawalStrategy ?? "constant-dollar";
+
+  // Invalidate stale results whenever settings change
+  useEffect(() => {
+    setResult(null);
+    setCompResult(null);
+  }, [settings]);
+
+  const run = () => {
+    setRunning(true);
+    // Run asynchronously to allow the spinner to render
+    setTimeout(() => {
+      const res = runMonteCarlo(settings, totalValue, 1000);
+      setResult(res);
+      setRunning(false);
+    }, 0);
+  };
+
+  const compare = () => {
+    setComparing(true);
+    setTimeout(() => {
+      const res = runStrategyComparison(settings, totalValue, 500);
+      setCompResult(res);
+      setComparing(false);
+    }, 0);
+  };
+
+  const chartData = result
+    ? result.ageAxis.map((age, i) => ({
+        age,
+        p10: result.percentiles.p10[i],
+        p25: result.percentiles.p25[i],
+        p50: result.percentiles.p50[i],
+        p75: result.percentiles.p75[i],
+        p90: result.percentiles.p90[i],
+      }))
+    : [];
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0">
+        <div>
+          <CardTitle className="text-sm">Monte Carlo Simulation</CardTitle>
+          <p className="text-muted-foreground mt-1 text-xs">
+            1,000 simulations · fat-tailed two-regime returns (μ={" "}
+            {(settings.expectedAnnualReturn * 100).toFixed(1)}%, σ={" "}
+            {(settings.expectedReturnStdDev * 100).toFixed(1)}%) · stochastic inflation ·{" "}
+            <span className="font-medium">
+              {strategy === "constant-dollar" ? "constant-dollar" : "constant-%"} strategy
+            </span>
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button onClick={compare} disabled={comparing || running} variant="outline" size="sm">
+            {comparing ? "Comparing…" : "Compare Strategies"}
+          </Button>
+          <Button onClick={run} disabled={running || comparing} size="sm">
+            {running ? "Running…" : result ? "Re-run" : "Run Simulation"}
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {running && (
+          <div className="space-y-2 py-4">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-[200px] w-full" />
+          </div>
+        )}
+
+        {!running && result && (
+          <div className="space-y-4">
+            {/* Summary stats */}
+            <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+              <div>
+                <p className="text-muted-foreground text-xs">Success Rate</p>
+                <p
+                  className={`text-lg font-bold ${
+                    result.successRate >= 0.9
+                      ? "text-green-600"
+                      : result.successRate >= 0.7
+                        ? "text-yellow-600"
+                        : "text-red-500"
+                  }`}
+                >
+                  {(result.successRate * 100).toFixed(0)}%
+                </p>
+              </div>
+              <div className="rounded border border-amber-300 bg-amber-50 px-3 py-2 dark:border-amber-700 dark:bg-amber-950/30">
+                <p className="text-muted-foreground text-xs">Median FIRE Age</p>
+                <p className="text-lg font-bold text-amber-600 dark:text-amber-400">
+                  {result.medianFireAge}
+                </p>
+                <p className="text-xs text-amber-600 dark:text-amber-400">
+                  {new Date().getFullYear() + (result.medianFireAge - settings.currentAge)}
+                </p>
+              </div>
+              <div>
+                <p className="text-muted-foreground text-xs">P50 Portfolio at Horizon</p>
+                <p className="text-lg font-bold">
+                  {fmt(result.finalPortfolioAtHorizon.p50, settings.currency)}
+                </p>
+              </div>
+              <div>
+                <p className="text-muted-foreground text-xs">P10 Portfolio at Horizon</p>
+                <p className="text-lg font-bold">
+                  {fmt(result.finalPortfolioAtHorizon.p10, settings.currency)}
+                </p>
+              </div>
+            </div>
+
+            {/* Fan chart */}
+            <div>
+              <ResponsiveContainer width="100%" height={300}>
+                <LineChart data={chartData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis
+                    dataKey="age"
+                    label={{ value: "Age", position: "insideBottom", offset: -2 }}
+                  />
+                  <YAxis tickFormatter={fmtCompact} />
+                  <Tooltip
+                    formatter={(value: number | undefined) => fmt(value ?? 0, settings.currency)}
+                    labelFormatter={(age) => `Age ${age}`}
+                  />
+                  <Legend />
+                  <ReferenceLine
+                    y={fireTarget}
+                    stroke="orange"
+                    strokeDasharray="6 3"
+                    label={{ value: "FIRE Target", position: "right", fontSize: 10 }}
+                  />
+                  <ReferenceLine
+                    x={settings.targetFireAge}
+                    stroke="#94a3b8"
+                    strokeDasharray="4 2"
+                    label={{
+                      value: "Target",
+                      position: "insideTopRight",
+                      fontSize: 9,
+                      fill: "#94a3b8",
+                    }}
+                  />
+                  <ReferenceLine
+                    x={result.medianFireAge}
+                    stroke="#f59e0b"
+                    strokeWidth={2.5}
+                    label={{
+                      value: `FIRE: ${result.medianFireAge}`,
+                      position: "insideTopLeft",
+                      fontSize: 11,
+                      fontWeight: 700,
+                      fill: "#f59e0b",
+                    }}
+                  />
+                  <Line dataKey="p90" name="P90" stroke="#22c55e" dot={false} strokeWidth={1.5} />
+                  <Line dataKey="p75" name="P75" stroke="#86efac" dot={false} strokeWidth={1} />
+                  <Line
+                    dataKey="p50"
+                    name="P50 (Median)"
+                    stroke="#3b82f6"
+                    dot={false}
+                    strokeWidth={2}
+                  />
+                  <Line dataKey="p25" name="P25" stroke="#fca5a5" dot={false} strokeWidth={1} />
+                  <Line dataKey="p10" name="P10" stroke="#ef4444" dot={false} strokeWidth={1.5} />
+                </LineChart>
+              </ResponsiveContainer>
+              <p className="text-muted-foreground mt-1 text-center text-xs">
+                Portfolio value from age {settings.currentAge} to {settings.planningHorizonAge}{" "}
+                across 1,000 simulations
+              </p>
+            </div>
+          </div>
+        )}
+
+        {!running && !result && (
+          <p className="text-muted-foreground py-8 text-center text-sm">
+            Click "Run Simulation" to model 1,000 possible retirement paths.
+          </p>
+        )}
+
+        {comparing && (
+          <div className="space-y-2 py-4">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-3/4" />
+          </div>
+        )}
+
+        {!comparing && compResult && (
+          <div className="border-t pt-4">
+            <p className="mb-2 text-xs font-semibold">Strategy Comparison (500 simulations each)</p>
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="text-muted-foreground border-b">
+                  <th className="pb-2 text-left">Metric</th>
+                  <th className="pb-2 text-right">Constant Dollar</th>
+                  <th className="pb-2 text-right">Constant %</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="border-b">
+                  <td className="py-1.5">Success Rate</td>
+                  <td className="py-1.5 text-right">
+                    {(compResult.constantDollar.successRate * 100).toFixed(0)}%
+                  </td>
+                  <td className="py-1.5 text-right">
+                    {(compResult.constantPercentage.successRate * 100).toFixed(0)}%
+                  </td>
+                </tr>
+                <tr className="border-b">
+                  <td className="py-1.5">Median FIRE Age</td>
+                  <td className="py-1.5 text-right">{compResult.constantDollar.medianFireAge}</td>
+                  <td className="py-1.5 text-right">
+                    {compResult.constantPercentage.medianFireAge}
+                  </td>
+                </tr>
+                <tr className="border-b">
+                  <td className="py-1.5">Median portfolio at horizon</td>
+                  <td className="py-1.5 text-right">
+                    {fmt(compResult.constantDollar.finalPortfolioAtHorizon.p50, settings.currency)}
+                  </td>
+                  <td className="py-1.5 text-right">
+                    {fmt(
+                      compResult.constantPercentage.finalPortfolioAtHorizon.p50,
+                      settings.currency,
+                    )}
+                  </td>
+                </tr>
+                <tr>
+                  <td className="py-1.5">P10 portfolio at horizon</td>
+                  <td className="py-1.5 text-right">
+                    {fmt(compResult.constantDollar.finalPortfolioAtHorizon.p10, settings.currency)}
+                  </td>
+                  <td className="py-1.5 text-right">
+                    {fmt(
+                      compResult.constantPercentage.finalPortfolioAtHorizon.p10,
+                      settings.currency,
+                    )}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+            <p className="text-muted-foreground mt-2 text-xs">
+              Constant %: the portfolio mathematically never depletes (high success rate expected),
+              but annual spending varies with market performance.
+            </p>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Scenario Analysis Section ─────────────────────────────────────────────────
+
+function ScenarioSection({ settings, totalValue }: { settings: FireSettings; totalValue: number }) {
+  const scenarios = useMemo(
+    () => runScenarioAnalysis(settings, totalValue),
+    [settings, totalValue],
+  );
+
+  const COLORS = ["#ef4444", "#3b82f6", "#22c55e"];
+
+  const chartData = useMemo(() => {
+    const maxLen = Math.max(...scenarios.map((s) => s.yearByYear.length));
+    return Array.from({ length: maxLen }, (_, i) => {
+      const entry: Record<string, number | string> = {
+        age: settings.currentAge + i,
+      };
+      scenarios.forEach((s) => {
+        entry[s.label] = s.yearByYear[i]?.portfolioValue ?? 0;
+      });
+      return entry;
+    });
+  }, [scenarios, settings.currentAge]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm">Scenario Analysis</CardTitle>
+        <p className="text-muted-foreground text-xs">Same settings, three return assumptions</p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <ResponsiveContainer width="100%" height={260}>
+          <LineChart data={chartData}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="age" />
+            <YAxis tickFormatter={fmtCompact} />
+            <Tooltip
+              formatter={(value: number | undefined) => fmt(value ?? 0, settings.currency)}
+              labelFormatter={(age) => `Age ${age}`}
+            />
+            <Legend />
+            {scenarios.map((s, i) =>
+              s.fireAge != null ? (
+                <ReferenceLine
+                  key={`fire-${s.label}`}
+                  x={s.fireAge}
+                  stroke={COLORS[i]}
+                  strokeWidth={2}
+                  strokeDasharray="5 3"
+                  label={{
+                    value: `${s.fireAge}`,
+                    position: i === 0 ? "insideTopRight" : i === 1 ? "top" : "insideTopLeft",
+                    fontSize: 11,
+                    fontWeight: 700,
+                    fill: COLORS[i],
+                  }}
+                />
+              ) : null,
+            )}
+            {scenarios.map((s, i) => (
+              <Line
+                key={s.label}
+                dataKey={s.label}
+                stroke={COLORS[i]}
+                dot={false}
+                strokeWidth={2}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="text-muted-foreground border-b">
+              <th className="pb-2 text-left">Scenario</th>
+              <th className="pb-2 text-right">Return</th>
+              <th className="pb-2 text-right">FIRE Age</th>
+              <th className="pb-2 text-right">Portfolio at Horizon</th>
+            </tr>
+          </thead>
+          <tbody>
+            {scenarios.map((s, i) => (
+              <tr key={s.label} className="border-b last:border-0">
+                <td className="py-1.5 font-medium" style={{ color: COLORS[i] }}>
+                  {s.label}
+                </td>
+                <td className="py-1.5 text-right">{(s.annualReturn * 100).toFixed(1)}%</td>
+                <td
+                  className="py-1.5 text-right font-semibold"
+                  style={{ color: s.fireAge ? COLORS[i] : undefined }}
+                >
+                  {s.fireAge ?? "—"}
+                </td>
+                <td className="py-1.5 text-right">
+                  {fmt(s.portfolioAtHorizon, settings.currency)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Income Streams Projection Section ────────────────────────────────────────
+
+const STREAM_COLORS = ["#3b82f6", "#22c55e", "#f97316", "#a855f7", "#ec4899", "#14b8a6"];
+
+function IncomeProjectionSection({
+  settings,
+  actualFireAge,
+}: {
+  settings: FireSettings;
+  actualFireAge: number;
+}) {
+  const streams = settings.additionalIncomeStreams;
+  if (streams.length === 0) return null;
+
+  const horizonYears = Math.max(1, settings.planningHorizonAge - settings.currentAge);
+  const fireAge = actualFireAge;
+
+  // Real value (today's euros): deflate nominal future value back by inflation.
+  // This means inflation-indexed streams appear as flat lines matching what the user entered.
+  // Non-indexed streams slowly decline in real purchasing power.
+  function realStreamValue(s: (typeof streams)[number], i: number): number {
+    const rate =
+      s.annualGrowthRate !== undefined
+        ? s.annualGrowthRate
+        : s.adjustForInflation
+          ? settings.inflationRate
+          : 0;
+    const nominal = s.monthlyAmount * 12 * Math.pow(1 + rate, i);
+    return nominal / Math.pow(1 + settings.inflationRate, i);
+  }
+
+  // Expenses in today's euros are always flat = monthlyExpensesAtFire × 12
+  const realExpenses = settings.monthlyExpensesAtFire * 12;
+
+  const chartData = useMemo(() => {
+    return Array.from({ length: horizonYears + 1 }, (_, i) => {
+      const age = settings.currentAge + i;
+      const entry: Record<string, number | null> = {
+        age,
+        expenses: age >= fireAge ? realExpenses : null,
+      };
+      for (const s of streams) {
+        entry[s.id] = age >= s.startAge ? realStreamValue(s, i) : 0;
+      }
+      return entry;
+    });
+  }, [settings, streams, fireAge, horizonYears, realExpenses]);
+
+  // Key ages for coverage table
+  const keyAges = useMemo(() => {
+    const ages = new Set<number>([fireAge, fireAge + 5, fireAge + 10, fireAge + 20]);
+    streams.forEach((s) => ages.add(s.startAge));
+    return [...ages]
+      .filter((a) => a >= settings.currentAge && a <= settings.planningHorizonAge)
+      .sort((a, b) => a - b);
+  }, [streams, fireAge, settings.currentAge, settings.planningHorizonAge]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm">Income Streams Projection</CardTitle>
+        <p className="text-muted-foreground text-xs">
+          All amounts in today's euros (real terms). Inflation-indexed streams appear flat;
+          non-indexed streams lose purchasing power over time. The gap between total income and the
+          expense line is what the portfolio must cover each year.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <ResponsiveContainer width="100%" height={280}>
+          <AreaChart data={chartData}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="age" />
+            <YAxis tickFormatter={fmtCompact} />
+            <Tooltip
+              formatter={(value: number | undefined, name: string | undefined) => {
+                const stream = streams.find((s) => s.id === name);
+                const label = stream ? stream.label || "Stream" : (name ?? "");
+                return [fmt(value ?? 0, settings.currency), label];
+              }}
+              labelFormatter={(age) => `Age ${age} (today's €)`}
+            />
+            <Legend
+              formatter={(value) => {
+                const stream = streams.find((s) => s.id === value);
+                return stream ? stream.label || "Stream" : value;
+              }}
+            />
+            {streams.map((s, i) => (
+              <Area
+                key={s.id}
+                type="monotone"
+                dataKey={s.id}
+                name={s.id}
+                stackId="income"
+                stroke={STREAM_COLORS[i % STREAM_COLORS.length]}
+                fill={STREAM_COLORS[i % STREAM_COLORS.length]}
+                fillOpacity={0.35}
+                dot={false}
+              />
+            ))}
+            <Line
+              dataKey="expenses"
+              name="FIRE Expenses"
+              stroke="#ef4444"
+              dot={false}
+              strokeWidth={2}
+              strokeDasharray="5 3"
+              connectNulls={false}
+            />
+            <ReferenceLine
+              x={fireAge}
+              stroke="#94a3b8"
+              strokeDasharray="4 2"
+              label={{ value: "FIRE", position: "top", fontSize: 10 }}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+
+        {/* Coverage table at key ages */}
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="text-muted-foreground border-b">
+              <th className="pb-2 text-left">Age</th>
+              {streams.map((s) => (
+                <th key={s.id} className="pb-2 text-right">
+                  {s.label || "Stream"}
+                </th>
+              ))}
+              <th className="pb-2 text-right">Total income/yr</th>
+              <th className="pb-2 text-right">Expenses/yr</th>
+              <th className="pb-2 text-right">Coverage</th>
+            </tr>
+          </thead>
+          <tbody>
+            {keyAges.map((age) => {
+              const i = age - settings.currentAge;
+              const totalIncome = streams.reduce((sum, s) => {
+                if (age < s.startAge) return sum;
+                return sum + realStreamValue(s, i);
+              }, 0);
+              const expenses = age >= fireAge ? realExpenses : null;
+              const coverage = expenses && expenses > 0 ? totalIncome / expenses : null;
+              const isFireRow = age === fireAge;
+
+              return (
+                <tr
+                  key={age}
+                  className={`border-b last:border-0 ${isFireRow ? "font-semibold" : ""}`}
+                >
+                  <td className="py-1.5">
+                    {age}
+                    {isFireRow && (
+                      <span className="text-muted-foreground ml-1 font-normal">(FIRE)</span>
+                    )}
+                  </td>
+                  {streams.map((s) => {
+                    if (age < s.startAge)
+                      return (
+                        <td key={s.id} className="text-muted-foreground py-1.5 text-right">
+                          —
+                        </td>
+                      );
+                    return (
+                      <td key={s.id} className="py-1.5 text-right">
+                        {fmt(realStreamValue(s, i), settings.currency)}
+                      </td>
+                    );
+                  })}
+                  <td className="py-1.5 text-right">{fmt(totalIncome, settings.currency)}</td>
+                  <td className="py-1.5 text-right">
+                    {expenses !== null ? fmt(expenses, settings.currency) : "—"}
+                  </td>
+                  <td
+                    className={`py-1.5 text-right font-medium ${
+                      coverage === null
+                        ? ""
+                        : coverage >= 1
+                          ? "text-green-600"
+                          : coverage >= 0.5
+                            ? "text-yellow-600"
+                            : "text-muted-foreground"
+                    }`}
+                  >
+                    {coverage !== null ? (coverage * 100).toFixed(0) + "%" : "—"}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Sensitivity Analysis Section ─────────────────────────────────────────────
+
+function SensitivitySection({
+  settings,
+  totalValue,
+}: {
+  settings: FireSettings;
+  totalValue: number;
+}) {
+  const sensitivity = useMemo(
+    () => runSensitivityAnalysis(settings, totalValue),
+    [settings, totalValue],
+  );
+
+  const { contribution, swr } = sensitivity;
+
+  function cellBg(fireAge: number | null): string {
+    if (fireAge === null) return "bg-red-100 dark:bg-red-950/30";
+    if (fireAge <= settings.targetFireAge - 5) return "bg-green-100 dark:bg-green-950/30";
+    if (fireAge <= settings.targetFireAge) return "bg-blue-100 dark:bg-blue-950/30";
+    if (fireAge <= settings.targetFireAge + 5) return "bg-yellow-50 dark:bg-yellow-950/20";
+    return "bg-red-50 dark:bg-red-950/20";
+  }
+
+  function isCurrentContrib(contrib: number) {
+    return Math.abs(contrib - settings.monthlyContribution) < 1;
+  }
+  function isCurrentReturn(ret: number) {
+    return Math.abs(ret - settings.expectedAnnualReturn) < 0.001;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm">Sensitivity Analysis</CardTitle>
+        <p className="text-muted-foreground text-xs">
+          FIRE age by monthly contribution × expected return.{" "}
+          <span className="text-blue-600">Blue = your settings.</span>
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-6 overflow-x-auto">
+        {/* Contribution × Return table */}
+        <div>
+          <p className="mb-2 text-xs font-semibold">FIRE Age (monthly contribution × return)</p>
+          <table className="text-xs">
+            <thead>
+              <tr>
+                <th className="text-muted-foreground pr-2 text-left font-normal">
+                  Monthly ↓ / Return →
+                </th>
+                {contribution.returnColumns.map((r) => (
+                  <th
+                    key={r}
+                    className={`px-2 py-1 text-center ${isCurrentReturn(r) ? "font-bold text-blue-600" : "text-muted-foreground font-normal"}`}
+                  >
+                    {(r * 100).toFixed(0)}%
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {contribution.contributionRows.map((contrib, ri) => (
+                <tr key={contrib}>
+                  <td
+                    className={`py-1 pr-2 ${isCurrentContrib(contrib) ? "font-bold text-blue-600" : "text-muted-foreground"}`}
+                  >
+                    {formatAmount(contrib, settings.currency)}
+                  </td>
+                  {contribution.returnColumns.map((r, ci) => {
+                    const age = contribution.fireAges[ri][ci];
+                    const highlight = isCurrentContrib(contrib) && isCurrentReturn(r);
+                    return (
+                      <td
+                        key={r}
+                        className={`px-2 py-1 text-center ${cellBg(age)} ${highlight ? "ring-2 ring-blue-500" : ""}`}
+                      >
+                        {age ?? `>${settings.planningHorizonAge}`}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* SWR × Return table */}
+        <div>
+          <p className="mb-2 text-xs font-semibold">FIRE Age (SWR × return)</p>
+          <table className="text-xs">
+            <thead>
+              <tr>
+                <th className="text-muted-foreground pr-2 text-left font-normal">
+                  SWR ↓ / Return →
+                </th>
+                {swr.returnColumns.map((r) => (
+                  <th
+                    key={r}
+                    className={`px-2 py-1 text-center ${isCurrentReturn(r) ? "font-bold text-blue-600" : "text-muted-foreground font-normal"}`}
+                  >
+                    {(r * 100).toFixed(0)}%
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {swr.swrRows.map((rate, ri) => {
+                const isCurrentSWR = Math.abs(rate - settings.safeWithdrawalRate) < 0.001;
+                return (
+                  <tr key={rate}>
+                    <td
+                      className={`py-1 pr-2 ${isCurrentSWR ? "font-bold text-blue-600" : "text-muted-foreground"}`}
+                    >
+                      {(rate * 100).toFixed(1)}%
+                    </td>
+                    {swr.returnColumns.map((r, ci) => {
+                      const age = swr.fireAges[ri][ci];
+                      const highlight = isCurrentSWR && isCurrentReturn(r);
+                      return (
+                        <td
+                          key={r}
+                          className={`px-2 py-1 text-center ${cellBg(age)} ${highlight ? "ring-2 ring-blue-500" : ""}`}
+                        >
+                          {age ?? `>${settings.planningHorizonAge}`}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Sequence of Returns Risk Section ─────────────────────────────────────────
+
+function SorrSection({ settings, totalValue }: { settings: FireSettings; totalValue: number }) {
+  const proj = useMemo(() => projectFireDate(settings, totalValue), [settings, totalValue]);
+  const fireReached = proj.portfolioAtFire > 0;
+  // When FIRE hasn't been reached in the projection, fall back to current portfolio so SORR
+  // doesn't show a misleadingly large starting value.
+  const portfolioAtFire = fireReached ? proj.portfolioAtFire : totalValue;
+
+  const scenarios = useMemo(
+    () => runSequenceOfReturnsRisk(settings, portfolioAtFire),
+    [settings, portfolioAtFire],
+  );
+
+  const COLORS = ["#3b82f6", "#ef4444", "#f97316", "#a855f7", "#64748b"];
+
+  const chartData = useMemo(() => {
+    const maxLen = Math.max(...scenarios.map((s) => s.portfolioPath.length));
+    return Array.from({ length: maxLen }, (_, i) => {
+      const entry: Record<string, number | string> = {
+        year: i,
+        age: settings.targetFireAge + i,
+      };
+      scenarios.forEach((s) => {
+        entry[s.label] = s.portfolioPath[i] ?? 0;
+      });
+      return entry;
+    });
+  }, [scenarios, settings.targetFireAge]);
+
+  const annualExpenses = settings.monthlyExpensesAtFire * 12;
+  const annualIncomeAtFire = settings.additionalIncomeStreams
+    .filter((s) => settings.targetFireAge >= s.startAge)
+    .reduce((sum, s) => sum + s.monthlyAmount * 12, 0);
+  const incomeRatio = annualExpenses > 0 ? annualIncomeAtFire / annualExpenses : 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm">Sequence of Returns Risk</CardTitle>
+        <p className="text-muted-foreground text-xs">
+          A market crash in the first years of FIRE is more dangerous than the same crash later.
+          Starting portfolio: {fmt(portfolioAtFire, settings.currency)}
+          {!fireReached && " (current portfolio — FIRE not yet reached in projection)"}.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {!fireReached && (
+          <div className="rounded bg-yellow-50 p-3 text-xs dark:bg-yellow-950/20">
+            FIRE has not been reached within your planning horizon. Results below show crash
+            scenarios starting from your current portfolio — they are illustrative only.
+          </div>
+        )}
+        {incomeRatio > 0.3 && (
+          <div className="rounded bg-green-50 p-3 text-xs dark:bg-green-950/20">
+            Your additional income ({fmt(annualIncomeAtFire / 12, settings.currency)}/mo) covers{" "}
+            {(incomeRatio * 100).toFixed(0)}% of your FIRE expenses, significantly reducing
+            sequence-of-returns risk.
+          </div>
+        )}
+
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="text-muted-foreground border-b">
+              <th className="pb-2 text-left">Scenario</th>
+              <th className="pb-2 text-right">Final Value</th>
+              <th className="pb-2 text-center">Survived to age {settings.planningHorizonAge}?</th>
+            </tr>
+          </thead>
+          <tbody>
+            {scenarios.map((s, i) => (
+              <tr key={s.label} className="border-b last:border-0">
+                <td className="py-1.5 font-medium" style={{ color: COLORS[i] }}>
+                  {s.label}
+                </td>
+                <td className="py-1.5 text-right">{fmt(s.finalValue, settings.currency)}</td>
+                <td className="py-1.5 text-center">
+                  <Badge variant={s.survived ? "default" : "destructive"} className="text-xs">
+                    {s.survived ? "Yes" : "No"}
+                  </Badge>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        <ResponsiveContainer width="100%" height={260}>
+          <LineChart data={chartData}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="age" label={{ value: "Age", position: "insideBottom", offset: -2 }} />
+            <YAxis tickFormatter={fmtCompact} />
+            <Tooltip
+              formatter={(value: number | undefined) => fmt(value ?? 0, settings.currency)}
+              labelFormatter={(age) => `Age ${age}`}
+            />
+            <Legend />
+            {scenarios.map((s, i) => (
+              <Line
+                key={s.label}
+                dataKey={s.label}
+                stroke={COLORS[i]}
+                dot={false}
+                strokeWidth={s.label === "Base (constant)" ? 2 : 1.5}
+                strokeDasharray={s.label === "Base (constant)" ? undefined : "4 2"}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Main Page ─────────────────────────────────────────────────────────────────
+
+export default function SimulationsPage({ settings, totalValue, isLoading }: Props) {
+  // Compute once so child sections can share the actual FIRE age
+  const projection = useMemo(() => projectFireDate(settings, totalValue), [settings, totalValue]);
+  const actualFireAge = projection.fireAge ?? settings.targetFireAge;
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-64 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <MonteCarloSection settings={settings} totalValue={totalValue} />
+      <ScenarioSection settings={settings} totalValue={totalValue} />
+      <IncomeProjectionSection settings={settings} actualFireAge={actualFireAge} />
+      <SensitivitySection settings={settings} totalValue={totalValue} />
+      <SorrSection settings={settings} totalValue={totalValue} />
+    </div>
+  );
+}

--- a/addons/fire-planner/src/types.ts
+++ b/addons/fire-planner/src/types.ts
@@ -1,0 +1,143 @@
+// All monetary values in the user's base currency (from Wealthfolio settings)
+// All rates as decimals (0.065 = 6.5%)
+
+export type WithdrawalStrategy = "constant-dollar" | "constant-percentage";
+
+export interface FireSettings {
+  // Core FIRE parameters
+  monthlyExpensesAtFire: number; // Monthly spending needed in FIRE
+  safeWithdrawalRate: number; // Default: 0.035 (3.5%)
+  withdrawalStrategy: WithdrawalStrategy; // Default: "constant-dollar"
+  expectedAnnualReturn: number; // Portfolio expected return. Default: 0.07
+  expectedReturnStdDev: number; // Volatility for Monte Carlo. Default: 0.12
+  inflationRate: number; // Default: 0.02
+  currentAge: number;
+  targetFireAge: number;
+
+  // Monthly contributions
+  monthlyContribution: number;
+  contributionGrowthRate: number; // Annual growth rate of contribution. Default: 0.02
+
+  // Salary model (optional) — when set, salaryGrowthRate overrides contributionGrowthRate
+  currentAnnualSalary?: number;
+  salaryGrowthRate?: number; // Annual salary raise %. Default: same as contributionGrowthRate
+
+  // Additional income in FIRE (pension, part-time, annuity, etc.)
+  additionalIncomeStreams: IncomeStream[];
+
+  // Planning horizon — used to size the simulation window and SORR test
+  planningHorizonAge: number; // Default: 90
+
+  // Which accounts to include in the FIRE portfolio total.
+  // If undefined, defaults to all SECURITIES + CRYPTOCURRENCY accounts (excludes CASH).
+  includedAccountIds?: string[];
+
+  // Target allocation per asset for drift detection
+  // Key: asset symbol or name, Value: target weight 0–1
+  targetAllocations: Record<string, number>;
+
+  // Currency auto-read from Wealthfolio settings
+  currency: string;
+}
+
+export interface IncomeStream {
+  id: string;
+  label: string; // e.g. "State Pension", "Part-time work"
+  monthlyAmount: number;
+  startAge: number;
+  startAgeIsAuto?: boolean; // if true, startAge is always set to targetFireAge at save time
+  adjustForInflation: boolean;
+  annualGrowthRate?: number; // explicit per-stream growth rate; overrides adjustForInflation when set
+
+  // Optional link to a Wealthfolio account — used to sync currentValue from live data
+  linkedAccountId?: string;
+
+  // Accumulation phase — for assets like private pension funds (fondo pensione, TFR)
+  // Leave at 0 / undefined for pure income streams like INPS state pension
+  currentValue?: number; // Current balance of the pension fund
+  monthlyContribution?: number; // Monthly contribution during accumulation (e.g. TFR)
+  accumulationReturn?: number; // Annual growth rate during accumulation (e.g. 0.04)
+}
+
+export interface FireProjection {
+  fireAge: number | null; // null = not reached in horizon
+  fireYear: number | null;
+  portfolioAtFire: number;
+  coastFireAmount: number;
+  coastFireReached: boolean;
+  yearByYear: YearlySnapshot[];
+}
+
+export interface YearlySnapshot {
+  age: number;
+  year: number;
+  phase: "accumulation" | "fire";
+  portfolioValue: number;
+  annualContribution: number;
+  annualWithdrawal: number;
+  annualIncome: number; // From additional income streams
+  netWithdrawalFromPortfolio: number;
+  pensionAssets: number; // Total value of all accumulating pension funds this year
+}
+
+export interface MonteCarloResult {
+  successRate: number; // 0–1, % of simulations where portfolio survives
+  medianFireAge: number;
+  percentiles: {
+    p10: number[];
+    p25: number[];
+    p50: number[];
+    p75: number[];
+    p90: number[];
+  };
+  ageAxis: number[];
+  finalPortfolioAtHorizon: {
+    p10: number;
+    p25: number;
+    p50: number;
+    p75: number;
+    p90: number;
+  };
+  nSimulations: number;
+}
+
+export interface AllocationHealth {
+  symbol: string;
+  name: string;
+  currentWeight: number;
+  targetWeight: number;
+  drift: number; // currentWeight - targetWeight
+  status: "underweight" | "overweight" | "ok";
+  currentValue: number;
+  daysSinceLastBuy: number | null;
+}
+
+export interface ScenarioResult {
+  label: string;
+  annualReturn: number;
+  fireAge: number | null;
+  portfolioAtHorizon: number;
+  yearByYear: YearlySnapshot[];
+}
+
+export interface SorrScenario {
+  label: string;
+  returns: number[]; // Year-by-year returns starting at FIRE
+  portfolioPath: number[];
+  finalValue: number;
+  survived: boolean;
+}
+
+export interface SensitivityMatrix {
+  contributionRows: number[];
+  returnColumns: number[];
+  // fireAges[i][j] = fire age for contribution[i] and return[j]
+  fireAges: (number | null)[][];
+}
+
+export interface SensitivitySWRMatrix {
+  swrRows: number[];
+  returnColumns: number[];
+  // fireAges[i][j] = FIRE age for swr[i] and return[j]
+  fireAges: (number | null)[][];
+}

--- a/addons/fire-planner/tsconfig.json
+++ b/addons/fire-planner/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@wealthfolio/addon-sdk": ["../../packages/addon-sdk/src"],
+      "@wealthfolio/ui": ["../../packages/ui/src"],
+      "@wealthfolio/ui/*": ["../../packages/ui/src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "./tsconfig.node.json" },
+    { "path": "../../packages/ui" },
+    { "path": "../../packages/addon-sdk" }
+  ]
+}

--- a/addons/fire-planner/tsconfig.node.json
+++ b/addons/fire-planner/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/addons/fire-planner/vite.config.ts
+++ b/addons/fire-planner/vite.config.ts
@@ -1,0 +1,36 @@
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import externalGlobals from "rollup-plugin-external-globals";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  define: {
+    "process.env.NODE_ENV": JSON.stringify("production"),
+  },
+  build: {
+    lib: {
+      entry: "src/addon.tsx",
+      fileName: () => "addon.js",
+      formats: ["es"],
+    },
+    rollupOptions: {
+      external: ["react", "react-dom"],
+      plugins: [
+        externalGlobals({
+          react: "React",
+          "react-dom": "ReactDOM",
+        }),
+      ],
+      output: {
+        globals: {
+          react: "React",
+          "react-dom": "ReactDOM",
+        },
+      },
+    },
+    outDir: "dist",
+    minify: false,
+    sourcemap: true,
+  },
+});


### PR DESCRIPTION
Adds a FIRE Planner addon — a financial independence planning tool that integrates with Wealthfolio's live portfolio data.

# Features

## Dashboard
- Net FIRE target (gross target minus day-1 income streams), Coast FIRE, portfolio progress
- Monthly budget breakdown by funding source (stacked bar per income stream + portfolio withdrawal)
- Year-by-year snapshot table with per-stream income columns and separate pension fund tracking

## Simulations
- Monte Carlo (1,000 paths) with fat-tailed two-regime return distribution and stochastic inflation
- Constant-dollar vs constant-percentage withdrawal strategy toggle (affects MC, SORR, deterministic projection)
- Scenario analysis (pessimistic / base / optimistic) with per-scenario FIRE age markers on chart
- Income streams projection in real terms (stacked area vs expense line, coverage % table)
- Sequence of Returns Risk: 5 crash scenarios starting from FIRE date
- Sensitivity heatmaps: FIRE age × contribution × return, and FIRE age × SWR × return

## Settings
- Income streams with optional accumulation fund (pension, TFR) — auto payout age tied to FIRE age, account sync for live
balance
- Portfolio account inclusion filter (excludes pension fund accounts from main portfolio to avoid double-counting)
- Auto-configure from portfolio data (detects monthly contribution and expected return from activity history)
- Target allocations with drift monitoring (Allocation tab)

## Guide
- Concept explanations (SWR, Coast FIRE, SORR, Monte Carlo)
- Italian FIRE setup walkthrough (pensione fund, INPS) with real-vs-nominal conversion note

## Math correctness

- FIRE trigger uses nominal portfolio vs nominal target (realTarget × (1+inf)^i) to avoid real/nominal mismatch
- Coast FIRE: (realTarget × (1+inf)^n) / (1+r)^n for consistent nominal discounting
- Pension fund off-by-one fixed: yearly snapshot shows start-of-year balance, not post-step
- Pension fund correctly zeroed at annuitization (payout start) rather than frozen
- SWR sensitivity heatmap now shows FIRE age (varies with both SWR and return) — previously showed FIRE target which is
return-independent and produced identical columns

## Checklist

- I have read and agree to the Contributor License Agreement.

## Demo screenshots:

<img width="1187" height="1397" alt="image" src="https://github.com/user-attachments/assets/cceb528c-7e1c-4a83-950d-2cf90c1609ac" />
<img width="1116" height="1380" alt="image" src="https://github.com/user-attachments/assets/16c0d9e7-6aba-4f76-bb2c-7365d4b5f804" />


---