### PR TITLE
feat(ai): add file attachments & history windowing

### DIFF
--- a/apps/frontend/src/features/ai-assistant/hooks/use-chat-runtime.ts
+++ b/apps/frontend/src/features/ai-assistant/hooks/use-chat-runtime.ts
@@ -18,7 +18,7 @@ import { useMemo, useCallback, useRef, useState } from "react";
 import { useQueryClient, type InfiniteData } from "@tanstack/react-query";
 
 import { streamChatResponse, type ChatModelConfig } from "../api";
-import type { AiThread, ChatMessage, ChatThread, ThreadPage } from "../types";
+import type { AiMessageAttachment, AiThread, ChatMessage, ChatThread, ThreadPage } from "../types";
 import { QueryKeys } from "@/lib/query-keys";
 import { generateId } from "@/lib/id";
 import { AI_THREADS_KEY } from "./use-threads";
@@ -205,40 +205,79 @@ interface ThreadListItemData {
   title?: string;
 }
 
+/** Maximum attachment size in bytes (10 MB). */
+const MAX_ATTACHMENT_SIZE = 10 * 1024 * 1024;
+
+/** Accepted file types for the AI assistant. */
+const ACCEPTED_FILE_TYPES =
+  ".csv,text/csv,application/csv,image/png,image/jpeg,image/jpg,application/pdf";
+
+/** Read a File as a base64 string (without the data: prefix). */
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const dataUrl = reader.result as string;
+      resolve(dataUrl.split(",")[1] ?? "");
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
 /**
- * CSV attachment adapter for importing activity data.
- * Accepts CSV files and reads content as text for AI processing.
+ * Unified file attachment adapter for CSV, images, and PDFs.
  */
-const csvAttachmentAdapter: AttachmentAdapter = {
-  accept: ".csv,text/csv,application/csv",
+const fileAttachmentAdapter: AttachmentAdapter = {
+  accept: ACCEPTED_FILE_TYPES,
 
   async add({ file }): Promise<PendingAttachment> {
+    if (file.size > MAX_ATTACHMENT_SIZE) {
+      throw new Error(`File "${file.name}" is too large (max 10 MB)`);
+    }
+
+    const isImage = file.type.startsWith("image/");
     return {
       id: generateId(),
-      type: "document",
+      type: isImage ? "image" : "document",
       name: file.name,
-      contentType: file.type || "text/csv",
+      contentType: file.type || "application/octet-stream",
       file,
       status: { type: "requires-action", reason: "composer-send" },
     };
   },
 
-  async remove(): Promise<void> {
-    // No cleanup needed for local file references
-  },
+  async remove(): Promise<void> {},
 
   async send(attachment: PendingAttachment): Promise<CompleteAttachment> {
-    // Read CSV file content as text
-    const csvContent = await attachment.file.text();
+    const file = attachment.file;
+    const isCsv =
+      file.type === "text/csv" || file.type === "application/csv" || file.name.endsWith(".csv");
+    const isImage = file.type.startsWith("image/");
 
+    if (isCsv) {
+      const csvText = await file.text();
+      return {
+        id: attachment.id,
+        type: "document",
+        name: attachment.name,
+        contentType: "text/csv",
+        status: { type: "complete" },
+        content: [{ type: "text" as const, text: csvText }],
+      };
+    }
+
+    // Images and PDFs: read as base64
+    const base64 = await fileToBase64(file);
     return {
       id: attachment.id,
-      type: "document",
+      type: isImage ? "image" : "document",
       name: attachment.name,
       contentType: attachment.contentType,
       status: { type: "complete" },
-      // Store CSV content as text part for AI to process
-      content: [{ type: "text", text: csvContent }],
+      content: isImage
+        ? [{ type: "image" as const, image: `data:${file.type};base64,${base64}` }]
+        : [{ type: "text" as const, text: base64 }],
     };
   },
 };
@@ -447,36 +486,68 @@ export function useChatRuntime(config?: ChatModelConfig) {
         .map((part) => part.text)
         .join("\n");
 
-      // Extract CSV attachment content if present
-      // Attachments are processed by csvAttachmentAdapter.send() which stores content as text parts
-      let attachmentContent = "";
+      // Build structured attachment payloads for the backend
+      const attachmentPayloads: AiMessageAttachment[] = [];
       const attachmentNames: string[] = [];
-      let hasCsvAttachment = false;
       if (message.attachments && message.attachments.length > 0) {
         for (const attachment of message.attachments) {
           attachmentNames.push(attachment.name);
-          if (attachment.content) {
+          if (!attachment.content) continue;
+
+          const isCsv =
+            attachment.contentType === "text/csv" ||
+            attachment.contentType === "application/csv" ||
+            attachment.name.endsWith(".csv");
+          const isImage = attachment.contentType?.startsWith("image/");
+
+          if (isCsv) {
+            // CSV: content stored as text part (plain text)
             const csvText = attachment.content
-              .filter((part): part is { type: "text"; text: string } => part.type === "text")
-              .map((part) => part.text)
+              .filter((c): c is { type: "text"; text: string } => c.type === "text")
+              .map((c) => c.text)
               .join("\n");
             if (csvText) {
-              hasCsvAttachment = true;
-              // Format attachment content with metadata for AI
-              attachmentContent += `\n\n[Attached CSV file: ${attachment.name}]\n${csvText}`;
+              attachmentPayloads.push({
+                name: attachment.name,
+                contentType: "text/csv",
+                data: csvText,
+              });
+            }
+          } else if (isImage) {
+            // Image: content stored as image part (data URL with base64)
+            const imgContent = attachment.content.find(
+              (c): c is { type: "image"; image: string } => c.type === "image",
+            );
+            if (imgContent) {
+              const raw = imgContent.image.includes(",")
+                ? imgContent.image.split(",")[1]!
+                : imgContent.image;
+              attachmentPayloads.push({
+                name: attachment.name,
+                contentType: attachment.contentType ?? "image/png",
+                data: raw,
+              });
+            }
+          } else {
+            // PDF and other binary: content stored as text part (base64)
+            const b64Content = attachment.content.find(
+              (c): c is { type: "text"; text: string } => c.type === "text",
+            );
+            if (b64Content) {
+              attachmentPayloads.push({
+                name: attachment.name,
+                contentType: attachment.contentType ?? "application/octet-stream",
+                data: b64Content.text,
+              });
             }
           }
         }
       }
 
-      // Content for AI includes both text and attachment content
-      // For CSV files, prepend explicit tool instruction for smaller models
-      let contentForAi = textContent + attachmentContent;
-      if (hasCsvAttachment) {
-        contentForAi = `[INSTRUCTION: A CSV file is attached. You MUST call the import_csv tool with the full CSV content in csvContent parameter. Do NOT analyze or summarize the data yourself - use the tool.]\n\n${contentForAi}`;
-      }
-
-      if (!contentForAi.trim()) return;
+      // Text content only — attachments sent separately in structured field
+      const contentForAi = textContent;
+      const hasContent = contentForAi.trim() || attachmentPayloads.length > 0;
+      if (!hasContent) return;
       const initialThreadTitle = deriveInitialThreadTitle(
         textContent || attachmentNames[0] || "New chat",
       );
@@ -561,6 +632,7 @@ export function useChatRuntime(config?: ChatModelConfig) {
             config,
             threadId: threadIdRef.current ?? undefined,
             parentMessageId: editParentIdRef.current ?? undefined,
+            attachments: attachmentPayloads.length > 0 ? attachmentPayloads : undefined,
           },
           signal,
         )) {
@@ -839,7 +911,7 @@ export function useChatRuntime(config?: ChatModelConfig) {
       onEdit: handleEdit,
       onCancel: handleCancel,
       adapters: {
-        attachments: csvAttachmentAdapter,
+        attachments: fileAttachmentAdapter,
         threadList: {
           threadId: currentThreadId ?? undefined,
           isLoading: isThreadListLoading,

--- a/apps/frontend/src/features/ai-assistant/types.ts
+++ b/apps/frontend/src/features/ai-assistant/types.ts
@@ -146,6 +146,20 @@ export interface AiSendMessageRequest {
   allowedTools?: string[];
   /** Parent message ID for edit operations. When set, AI context is truncated to this message. */
   parentMessageId?: string;
+  /** File attachments (CSV, images, PDFs). */
+  attachments?: AiMessageAttachment[];
+}
+
+/**
+ * A file attachment sent with an AI chat message.
+ */
+export interface AiMessageAttachment {
+  /** Original filename. */
+  name: string;
+  /** MIME type (e.g., "text/csv", "image/png", "application/pdf"). */
+  contentType: string;
+  /** File content: plain text for CSV, base64-encoded for images/PDFs. */
+  data: string;
 }
 
 /**

--- a/apps/frontend/src/pages/income/income-page.tsx
+++ b/apps/frontend/src/pages/income/income-page.tsx
@@ -105,29 +105,29 @@ export default function IncomePage() {
             setSelectedAccount={setSelectedAccount}
             variant="dropdown"
             includePortfolio
+            className="h-9"
           />
           <IncomePeriodSelector
             selectedPeriod={selectedPeriod}
             onPeriodSelect={setSelectedPeriod}
           />
         </div>
-        <div className="flex items-center justify-between md:hidden">
-          <Button
-            variant="outline"
-            size="sm"
-            className="bg-secondary/30 relative rounded-full border-none"
-            onClick={() => setIsFilterSheetOpen(true)}
-          >
-            <Icons.ListFilter className="mr-1.5 h-4 w-4" />
-            {selectedAccount?.id !== PORTFOLIO_ACCOUNT_ID && (
-              <span className="bg-destructive absolute -right-1 -top-1 h-2 w-2 rounded-full" />
-            )}
-            Filter
-          </Button>
+        <div className="flex items-center justify-end gap-2 md:hidden">
           <IncomePeriodSelector
             selectedPeriod={selectedPeriod}
             onPeriodSelect={setSelectedPeriod}
           />
+          <Button
+            variant="outline"
+            size="icon"
+            className="bg-secondary/30 relative h-9 w-9 rounded-full border-none"
+            onClick={() => setIsFilterSheetOpen(true)}
+          >
+            <Icons.ListFilter className="h-4 w-4" />
+            {selectedAccount?.id !== PORTFOLIO_ACCOUNT_ID && (
+              <span className="bg-destructive absolute -right-1 -top-1 h-2 w-2 rounded-full" />
+            )}
+          </Button>
         </div>
         <EmptyPlaceholder
           className="mx-auto flex max-w-[420px] items-center justify-center pt-12"
@@ -215,29 +215,29 @@ export default function IncomePage() {
           setSelectedAccount={setSelectedAccount}
           variant="dropdown"
           includePortfolio
+          className="h-9"
         />
         <IncomePeriodSelector selectedPeriod={selectedPeriod} onPeriodSelect={setSelectedPeriod} />
       </div>
 
       <div className="space-y-6">
-        {/* Mobile: filter button + period toggle */}
-        <div className="flex items-center justify-between md:hidden">
-          <Button
-            variant="outline"
-            size="sm"
-            className="bg-secondary/30 relative rounded-full border-none"
-            onClick={() => setIsFilterSheetOpen(true)}
-          >
-            <Icons.ListFilter className="mr-1.5 h-4 w-4" />
-            {selectedAccount?.id !== PORTFOLIO_ACCOUNT_ID && (
-              <span className="bg-destructive absolute -right-1 -top-1 h-2 w-2 rounded-full" />
-            )}
-            Filter
-          </Button>
+        {/* Mobile: filter icon button + period toggle */}
+        <div className="flex items-center justify-end gap-2 md:hidden">
           <IncomePeriodSelector
             selectedPeriod={selectedPeriod}
             onPeriodSelect={setSelectedPeriod}
           />
+          <Button
+            variant="outline"
+            size="icon"
+            className="bg-secondary/30 relative h-9 w-9 rounded-full border-none"
+            onClick={() => setIsFilterSheetOpen(true)}
+          >
+            <Icons.ListFilter className="h-4 w-4" />
+            {selectedAccount?.id !== PORTFOLIO_ACCOUNT_ID && (
+              <span className="bg-destructive absolute -right-1 -top-1 h-2 w-2 rounded-full" />
+            )}
+          </Button>
         </div>
         <div className="grid gap-6 md:grid-cols-3">
           <Card className="border-yellow-500/10 bg-yellow-500/10">

--- a/crates/ai/src/chat.rs
+++ b/crates/ai/src/chat.rs
@@ -189,14 +189,24 @@ impl<E: AiEnvironment + 'static> ChatService<E> {
             }
             let mut total_size: usize = 0;
             for att in &attachments {
-                if att.data.len() > MAX_ATTACHMENT_SIZE_BYTES {
+                // For base64-encoded payloads (images/PDFs), estimate the
+                // decoded byte size (~75% of encoded length) so limits stay
+                // consistent with the frontend's raw file.size check.
+                let is_binary =
+                    att.content_type.starts_with("image/") || att.content_type == "application/pdf";
+                let effective_size = if is_binary {
+                    att.data.len() * 3 / 4
+                } else {
+                    att.data.len()
+                };
+                if effective_size > MAX_ATTACHMENT_SIZE_BYTES {
                     return Err(AiError::InvalidInput(format!(
                         "Attachment '{}' too large (max {} MB)",
                         att.name,
                         MAX_ATTACHMENT_SIZE_BYTES / (1024 * 1024)
                     )));
                 }
-                total_size += att.data.len();
+                total_size += effective_size;
             }
             if total_size > MAX_TOTAL_ATTACHMENTS_BYTES {
                 return Err(AiError::InvalidInput(format!(
@@ -620,6 +630,20 @@ async fn spawn_chat_stream<E: AiEnvironment + 'static>(
         provider_id: provider_id.clone(),
         model_id: model_id.clone(),
     };
+
+    // Reject image/PDF attachments when the model doesn't support vision
+    if !capabilities.vision {
+        if let Some(att) = attachments
+            .iter()
+            .find(|a| a.content_type.starts_with("image/") || a.content_type == "application/pdf")
+        {
+            return Err(AiError::InvalidInput(format!(
+                "The current model does not support image/PDF attachments ({}). \
+                 Please switch to a vision-capable model.",
+                att.name
+            )));
+        }
+    }
 
     // Build multimodal user content from text + attachments
     let prompt = build_user_prompt(&user_message, &attachments);

--- a/crates/ai/src/chat.rs
+++ b/crates/ai/src/chat.rs
@@ -39,7 +39,8 @@ use crate::providers::ProviderService;
 use crate::title_generator::truncate_to_title;
 use crate::title_generator::{TitleGenerator, TitleGeneratorConfig, TitleGeneratorTrait};
 use crate::tools::constants::{
-    MAX_ATTACHMENTS_COUNT, MAX_ATTACHMENT_SIZE_BYTES, MAX_TOTAL_ATTACHMENTS_BYTES,
+    MAX_ATTACHMENTS_COUNT, MAX_ATTACHMENT_SIZE_BYTES, MAX_HISTORY_CHARS,
+    MAX_TOTAL_ATTACHMENTS_BYTES,
 };
 use crate::tools::ToolSet;
 use crate::types::{
@@ -235,20 +236,27 @@ impl<E: AiEnvironment + 'static> ChatService<E> {
             }
         }
 
-        let history_messages: Vec<SimpleChatMessage> = previous_messages
-            .iter()
-            .filter_map(|msg| {
-                let text = msg.content.get_text_content();
-                if text.is_empty() {
-                    return None;
-                }
-                match msg.role {
-                    ChatMessageRole::User => Some(SimpleChatMessage::user(&text)),
-                    ChatMessageRole::Assistant => Some(SimpleChatMessage::assistant(&text)),
-                    _ => None, // Skip system/tool messages in history
-                }
-            })
-            .collect();
+        // Build history with a reverse character-budget window:
+        // take messages from most recent backwards until the budget is exhausted.
+        let mut history_messages: Vec<SimpleChatMessage> = Vec::new();
+        let mut budget = MAX_HISTORY_CHARS;
+        for msg in previous_messages.iter().rev() {
+            let text = msg.content.get_text_content();
+            if text.is_empty() {
+                continue;
+            }
+            let simple = match msg.role {
+                ChatMessageRole::User => SimpleChatMessage::user(&text),
+                ChatMessageRole::Assistant => SimpleChatMessage::assistant(&text),
+                _ => continue,
+            };
+            if text.len() > budget {
+                break;
+            }
+            budget -= text.len();
+            history_messages.push(simple);
+        }
+        history_messages.reverse();
 
         // Save user message with attachment placeholders (no binary data stored)
         let mut persist_text = request.content.clone();

--- a/crates/ai/src/chat.rs
+++ b/crates/ai/src/chat.rs
@@ -16,8 +16,8 @@ use rig::{
     client::{CompletionClient, Nothing},
     completion::{CompletionModel, Message},
     message::{
-        AssistantContent, Reasoning, Text, ToolCall as RigToolCall, ToolChoice, ToolResultContent,
-        UserContent,
+        AssistantContent, Document, DocumentMediaType, DocumentSourceKind, Image, ImageMediaType,
+        Reasoning, Text, ToolCall as RigToolCall, ToolChoice, ToolResultContent, UserContent,
     },
     providers::{
         anthropic, gemini, groq,
@@ -38,11 +38,14 @@ use crate::error::AiError;
 use crate::providers::ProviderService;
 use crate::title_generator::truncate_to_title;
 use crate::title_generator::{TitleGenerator, TitleGeneratorConfig, TitleGeneratorTrait};
+use crate::tools::constants::{
+    MAX_ATTACHMENTS_COUNT, MAX_ATTACHMENT_SIZE_BYTES, MAX_TOTAL_ATTACHMENTS_BYTES,
+};
 use crate::tools::ToolSet;
 use crate::types::{
     AiStreamEvent, ChatMessage, ChatMessageContent, ChatMessagePart, ChatMessageRole,
-    ChatRepositoryTrait, ChatThread, ListThreadsRequest, SendMessageRequest, SimpleChatMessage,
-    ThreadPage, ToolCall, ToolResultData,
+    ChatRepositoryTrait, ChatThread, ListThreadsRequest, MessageAttachment, SendMessageRequest,
+    SimpleChatMessage, ThreadPage, ToolCall, ToolResultData,
 };
 
 fn derive_initial_thread_title(first_user_message: &str) -> Option<String> {
@@ -173,6 +176,35 @@ impl<E: AiEnvironment + 'static> ChatService<E> {
     ) -> Result<BoxStream<'static, AiStreamEvent>, AiError> {
         let repo = self.env.chat_repository();
 
+        // Validate attachments
+        let attachments = request.attachments.clone().unwrap_or_default();
+        if !attachments.is_empty() {
+            if attachments.len() > MAX_ATTACHMENTS_COUNT {
+                return Err(AiError::InvalidInput(format!(
+                    "Too many attachments: {} (max {})",
+                    attachments.len(),
+                    MAX_ATTACHMENTS_COUNT
+                )));
+            }
+            let mut total_size: usize = 0;
+            for att in &attachments {
+                if att.data.len() > MAX_ATTACHMENT_SIZE_BYTES {
+                    return Err(AiError::InvalidInput(format!(
+                        "Attachment '{}' too large (max {} MB)",
+                        att.name,
+                        MAX_ATTACHMENT_SIZE_BYTES / (1024 * 1024)
+                    )));
+                }
+                total_size += att.data.len();
+            }
+            if total_size > MAX_TOTAL_ATTACHMENTS_BYTES {
+                return Err(AiError::InvalidInput(format!(
+                    "Total attachment size too large (max {} MB)",
+                    MAX_TOTAL_ATTACHMENTS_BYTES / (1024 * 1024)
+                )));
+            }
+        }
+
         // Get or create thread
         let (thread, is_new_thread, initial_title) = match &request.thread_id {
             Some(id) => {
@@ -218,8 +250,12 @@ impl<E: AiEnvironment + 'static> ChatService<E> {
             })
             .collect();
 
-        // Save user message immediately to repository
-        let user_message = ChatMessage::user(&thread_id, &request.content);
+        // Save user message with attachment placeholders (no binary data stored)
+        let mut persist_text = request.content.clone();
+        for att in &attachments {
+            persist_text.push_str(&format!("\n[Attached: {}]", att.name));
+        }
+        let user_message = ChatMessage::user(&thread_id, &persist_text);
         repo.create_message(user_message).await?;
 
         // Get provider settings
@@ -262,6 +298,7 @@ impl<E: AiEnvironment + 'static> ChatService<E> {
                 tx.clone(),
                 content,
                 history_messages,
+                attachments,
                 provider_id,
                 model_id,
                 thread_id_clone.clone(),
@@ -413,6 +450,80 @@ struct TitleContext<E: AiEnvironment> {
     model_id: String,
 }
 
+/// Build a multimodal `Message::User` from text content and file attachments.
+fn build_user_prompt(user_message: &str, attachments: &[MessageAttachment]) -> Message {
+    if attachments.is_empty() {
+        return Message::User {
+            content: OneOrMany::one(UserContent::Text(Text {
+                text: user_message.to_string(),
+            })),
+        };
+    }
+
+    let mut parts: Vec<UserContent> = Vec::new();
+    let has_csv = attachments
+        .iter()
+        .any(|a| a.content_type == "text/csv" || a.content_type == "application/csv");
+    let has_image_or_pdf = attachments
+        .iter()
+        .any(|a| a.content_type.starts_with("image/") || a.content_type == "application/pdf");
+
+    // Build instruction-prefixed text
+    let mut text = String::new();
+    if has_csv {
+        text.push_str("[INSTRUCTION: A CSV file is attached. You MUST call the import_csv tool with the full CSV content in csvContent parameter. Do NOT analyze or summarize the data yourself - use the tool.]\n\n");
+    }
+    if has_image_or_pdf {
+        text.push_str("[INSTRUCTION: Image or PDF file(s) attached. Examine for financial transaction data and use record_activities to create drafts for all extracted transactions.]\n\n");
+    }
+    text.push_str(user_message);
+    parts.push(UserContent::Text(Text { text }));
+
+    // Add attachment content parts
+    for att in attachments {
+        match att.content_type.as_str() {
+            "text/csv" | "application/csv" => {
+                parts.push(UserContent::Text(Text {
+                    text: format!("[Attached CSV file: {}]\n{}", att.name, att.data),
+                }));
+            }
+            ct if ct.starts_with("image/") => {
+                let media_type = match ct {
+                    "image/png" => Some(ImageMediaType::PNG),
+                    "image/jpeg" | "image/jpg" => Some(ImageMediaType::JPEG),
+                    "image/webp" => Some(ImageMediaType::WEBP),
+                    "image/gif" => Some(ImageMediaType::GIF),
+                    _ => None,
+                };
+                parts.push(UserContent::Image(Image {
+                    data: DocumentSourceKind::Base64(att.data.clone()),
+                    media_type,
+                    detail: None,
+                    additional_params: None,
+                }));
+            }
+            "application/pdf" => {
+                parts.push(UserContent::Document(Document {
+                    data: DocumentSourceKind::Base64(att.data.clone()),
+                    media_type: Some(DocumentMediaType::PDF),
+                    additional_params: None,
+                }));
+            }
+            _ => {
+                debug!("Skipping unsupported attachment type: {}", att.content_type);
+            }
+        }
+    }
+
+    Message::User {
+        content: OneOrMany::many(parts).unwrap_or_else(|_| {
+            OneOrMany::one(UserContent::Text(Text {
+                text: user_message.to_string(),
+            }))
+        }),
+    }
+}
+
 /// Spawn a chat stream with the appropriate provider.
 #[allow(clippy::too_many_arguments)]
 async fn spawn_chat_stream<E: AiEnvironment + 'static>(
@@ -420,6 +531,7 @@ async fn spawn_chat_stream<E: AiEnvironment + 'static>(
     tx: mpsc::Sender<AiStreamEvent>,
     user_message: String,
     history_messages: Vec<SimpleChatMessage>,
+    attachments: Vec<MessageAttachment>,
     provider_id: String,
     model_id: String,
     thread_id: String,
@@ -501,9 +613,8 @@ async fn spawn_chat_stream<E: AiEnvironment + 'static>(
         model_id: model_id.clone(),
     };
 
-    let prompt = Message::User {
-        content: OneOrMany::one(UserContent::Text(Text { text: user_message })),
-    };
+    // Build multimodal user content from text + attachments
+    let prompt = build_user_prompt(&user_message, &attachments);
 
     // Build history from previous messages
     let history: Vec<Message> = history_messages

--- a/crates/ai/src/system_prompt.txt
+++ b/crates/ai/src/system_prompt.txt
@@ -115,4 +115,12 @@ RECORD_ACTIVITY RULES:
 - Use the base currency from context when user mentions amounts without currency symbol.
 - Use `record_activities` instead of `record_activity` when recording 2 or more transactions in one user request.
 
+IMAGE/PDF ATTACHMENT RULES:
+- When the user attaches images or PDF pages, examine them for financial transaction data.
+- Extract: dates, symbols/tickers, quantities, prices, amounts, fees, activity types.
+- Use record_activities to create drafts for all extracted transactions.
+- If image shows a brokerage statement or trade confirmation, extract ALL visible transactions.
+- If you cannot read or extract data from an image, tell the user clearly.
+- Ask the user which account to use if not specified and multiple accounts exist.
+
 Be helpful and conversational. If you cannot answer something, say so clearly.

--- a/crates/ai/src/tools/constants.rs
+++ b/crates/ai/src/tools/constants.rs
@@ -41,3 +41,7 @@ pub const MAX_TOTAL_ATTACHMENTS_BYTES: usize = 20 * 1024 * 1024;
 
 /// Maximum number of attachments per message.
 pub const MAX_ATTACHMENTS_COUNT: usize = 10;
+
+/// Maximum total characters of history sent to the LLM (~25K tokens).
+/// Messages are taken from most-recent backwards until this budget is exhausted.
+pub const MAX_HISTORY_CHARS: usize = 100_000;

--- a/crates/ai/src/tools/constants.rs
+++ b/crates/ai/src/tools/constants.rs
@@ -32,3 +32,12 @@ pub const MAX_ACCOUNTS: usize = 50;
 
 /// Maximum number of rows to import from CSV per tool call.
 pub const MAX_IMPORT_ROWS: usize = 500;
+
+/// Maximum size per attachment in bytes (10 MB).
+pub const MAX_ATTACHMENT_SIZE_BYTES: usize = 10 * 1024 * 1024;
+
+/// Maximum total attachment payload in bytes (20 MB).
+pub const MAX_TOTAL_ATTACHMENTS_BYTES: usize = 20 * 1024 * 1024;
+
+/// Maximum number of attachments per message.
+pub const MAX_ATTACHMENTS_COUNT: usize = 10;

--- a/crates/ai/src/types.rs
+++ b/crates/ai/src/types.rs
@@ -871,6 +871,21 @@ pub struct SendMessageRequest {
     /// When set, AI context is truncated to this message (inclusive).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parent_message_id: Option<String>,
+    /// File attachments (CSV, images, PDFs).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attachments: Option<Vec<MessageAttachment>>,
+}
+
+/// A file attachment sent with a chat message.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MessageAttachment {
+    /// Original filename (e.g., "statement.pdf", "trades.csv").
+    pub name: String,
+    /// MIME type (e.g., "text/csv", "image/png", "application/pdf").
+    pub content_type: String,
+    /// File content: plain text for CSV, base64-encoded for images/PDFs.
+    pub data: String,
 }
 
 impl SendMessageRequest {


### PR DESCRIPTION
## Summary

Add support for multimodal file attachments (CSV, images, PDFs) and implement history windowing to prevent context overflow.

## Changes

### Frontend (`use-chat-runtime.ts`)
- Replace CSV-only adapter with unified `fileAttachmentAdapter` supporting CSV, images (PNG/JPG), and PDFs
- Add file size validation (max 10 MB per file)
- Convert files to appropriate formats: plain text for CSV, base64 for images/PDFs
- Send structured attachment payloads separately from text content
- Add `AiMessageAttachment` type for attachment metadata

### Backend (`chat.rs`)
- Validate attachments: count (max 10), individual size (10 MB), and total size (20 MB)
- Implement `MAX_HISTORY_CHARS` windowing: include recent messages up to ~100K characters (~25K tokens)
- Add `build_user_prompt()` to construct multimodal messages with images and documents
- Store attachment placeholders in history, not raw binary data
- Add conditional instructions for CSV and image/PDF processing

### Configuration
- Add attachment constants: `MAX_ATTACHMENT_SIZE_BYTES`, `MAX_TOTAL_ATTACHMENTS_BYTES`, `MAX_ATTACHMENTS_COUNT`, `MAX_HISTORY_CHARS`
- Update system prompt with image/PDF extraction rules
- Add new `MessageAttachment` type to request/response structs

## Benefits
- Users can now attach images and PDFs for financial data extraction
- Context windowing prevents token limit errors on long conversations
- Backward-compatible: existing text-only messages still work