### PR TITLE
Add price and quantity fields to dividend DRIP form

### DIFF
--- a/apps/frontend/src/pages/activity/components/forms/dividend-form.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/dividend-form.tsx
@@ -1,5 +1,5 @@
 import { useSettings } from "@/hooks/use-settings";
-import { ActivityType } from "@/lib/constants";
+import { ACTIVITY_SUBTYPES, ActivityType } from "@/lib/constants";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@wealthfolio/ui/components/ui/button";
 import { Card, CardContent } from "@wealthfolio/ui/components/ui/card";
@@ -14,6 +14,7 @@ import {
   createValidatedSubmit,
   DatePicker,
   NotesInput,
+  QuantityInput,
   SymbolSearch,
   type AccountSelectOption,
 } from "./fields";
@@ -40,6 +41,19 @@ export const dividendFormSchema = z.object({
     .positive({ message: "FX Rate must be positive." })
     .optional(),
   subtype: z.string().optional().nullable(),
+  // DRIP fields (price & quantity of reinvested shares)
+  unitPrice: z.coerce
+    .number({
+      invalid_type_error: "Price must be a number.",
+    })
+    .positive({ message: "Price must be greater than 0." })
+    .optional(),
+  quantity: z.coerce
+    .number({
+      invalid_type_error: "Quantity must be a number.",
+    })
+    .positive({ message: "Quantity must be greater than 0." })
+    .optional(),
   symbolQuoteCcy: z.string().nullable().optional(),
   symbolInstrumentType: z.string().nullable().optional(),
 });
@@ -98,6 +112,8 @@ export function DividendForm({
   const { watch } = form;
   const accountId = watch("accountId");
   const currency = watch("currency");
+  const subtype = watch("subtype");
+  const isDrip = subtype === ACTIVITY_SUBTYPES.DRIP;
 
   // Get account currency from selected account
   const selectedAccount = useMemo(
@@ -146,7 +162,21 @@ export function DividendForm({
               assetCurrency={assetCurrency}
               accountCurrency={accountCurrency}
               baseCurrency={baseCurrency}
+              defaultOpen={isDrip}
             />
+
+            {/* DRIP: Price & Quantity of reinvested shares */}
+            {isDrip && (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <AmountInput
+                  name="unitPrice"
+                  label="Price"
+                  maxDecimalPlaces={4}
+                  currency={currency}
+                />
+                <QuantityInput name="quantity" label="Quantity" />
+              </div>
+            )}
 
             {/* Notes */}
             <NotesInput name="comment" label="Notes" placeholder="Add an optional note..." />

--- a/apps/frontend/src/pages/activity/components/forms/schemas.ts
+++ b/apps/frontend/src/pages/activity/components/forms/schemas.ts
@@ -162,6 +162,7 @@ export const incomeActivitySchema = baseActivitySchema.extend({
   activityType: z.enum([ActivityType.DIVIDEND, ActivityType.INTEREST]),
   assetId: z.string().min(1, { message: "Please select a security" }).optional(),
   quantity: z.coerce.number().default(0),
+  unitPrice: z.coerce.number().positive().optional(),
   amount: z.coerce
     .number({
       required_error: "Please enter a valid amount.",

--- a/apps/frontend/src/pages/activity/components/mobile-forms/mobile-details-step.tsx
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/mobile-details-step.tsx
@@ -1,7 +1,7 @@
 import { ScrollArea } from "@wealthfolio/ui/components/ui/scroll-area";
 import { Textarea } from "@wealthfolio/ui/components/ui/textarea";
 import { AnimatedToggleGroup } from "@wealthfolio/ui/components/ui/animated-toggle-group";
-import { QuoteMode, type ActivityType } from "@/lib/constants";
+import { ACTIVITY_SUBTYPES, QuoteMode, type ActivityType } from "@/lib/constants";
 import { useSettingsContext } from "@/lib/settings-provider";
 import {
   AdvancedOptionsSection,
@@ -88,6 +88,9 @@ export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileD
   const isSecuritiesTransfer = isTransfer && transferMode === "securities";
   const isCashTransfer = isTransfer && transferMode === "cash";
   const [toAccountSheetOpen, setToAccountSheetOpen] = useState(false);
+
+  const subtype = watch("subtype");
+  const isDrip = activityType === "DIVIDEND" && subtype === ACTIVITY_SUBTYPES.DRIP;
 
   const isFeeActivity = activityType === "FEE";
   const isTaxActivity = activityType === "TAX";
@@ -553,7 +556,56 @@ export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileD
             assetCurrency={assetCurrency}
             accountCurrency={accountCurrency}
             baseCurrency={baseCurrency}
+            defaultOpen={isDrip}
           />
+
+          {/* DRIP: Price & Quantity of reinvested shares */}
+          {isDrip && (
+            <div className="grid grid-cols-1 gap-4">
+              <FormField
+                control={control}
+                name="unitPrice"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="text-base font-medium">Price</FormLabel>
+                    <FormControl>
+                      <MoneyInput
+                        ref={field.ref}
+                        name={field.name}
+                        value={field.value}
+                        onValueChange={field.onChange}
+                        placeholder="0.00"
+                        maxDecimalPlaces={4}
+                        className="h-12 text-base sm:text-sm"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={control}
+                name="quantity"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="text-base font-medium">Quantity</FormLabel>
+                    <FormControl>
+                      <QuantityInput
+                        ref={field.ref}
+                        name={field.name}
+                        value={field.value}
+                        onValueChange={field.onChange}
+                        placeholder="0.00"
+                        maxDecimalPlaces={8}
+                        className="h-12 text-base sm:text-sm"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          )}
 
           {/* Comment */}
           <FormField

--- a/apps/frontend/src/pages/activity/config/activity-form-config.ts
+++ b/apps/frontend/src/pages/activity/config/activity-form-config.ts
@@ -306,6 +306,8 @@ export const ACTIVITY_FORM_CONFIG: Record<
       ...getBaseDefaults(activity, accounts),
       symbol: activity?.assetSymbol ?? activity?.assetId ?? "",
       amount: absNum(activity?.amount),
+      unitPrice: absNum(activity?.unitPrice),
+      quantity: absNum(activity?.quantity),
       // Advanced options
       currency: activity?.currency,
       fxRate: activity?.fxRate ?? undefined,
@@ -319,6 +321,8 @@ export const ACTIVITY_FORM_CONFIG: Record<
         activityDate: d.activityDate,
         assetId: d.symbol,
         amount: d.amount,
+        unitPrice: d.unitPrice,
+        quantity: d.quantity,
         comment: d.comment,
         subtype: d.subtype ?? undefined,
         currency: d.currency,


### PR DESCRIPTION
### Changes

- Added `unitPrice` and `quantity` fields to dividend form schema for tracking reinvested shares in DRIP transactions
- Updated `DividendForm` component to conditionally display price and quantity inputs when DRIP subtype is selected
- Added corresponding UI in `MobileDetailsStep` for mobile form support
- Updated `incomeActivitySchema` to include `unitPrice` field validation
- Modified `activity-form-config` to map and persist these new fields during form submission and initialization

### Details

These fields are now conditionally rendered only for DRIP (Dividend Reinvestment Plan) subtypes, allowing users to track the price per share and quantity of shares acquired through dividend reinvestment.