### PR TITLE
feat(income): add "By Account" stacked chart view

### DIFF
--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -676,12 +676,20 @@ export interface IncomeByAsset {
   income: number;
 }
 
+export interface IncomeByAccount {
+  accountId: string;
+  accountName: string;
+  byMonth: Record<string, number>;
+  total: number;
+}
+
 export interface IncomeSummary {
   period: string;
   byMonth: Record<string, number>;
   byType: Record<string, number>;
   byAsset: Record<string, IncomeByAsset>;
   byCurrency: Record<string, number>;
+  byAccount: Record<string, IncomeByAccount>;
   totalIncome: number;
   currency: string;
   monthlyAverage: number;

--- a/apps/frontend/src/pages/income/income-history-chart.tsx
+++ b/apps/frontend/src/pages/income/income-history-chart.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@/lib/utils";
-import { formatAmount } from "@wealthfolio/ui";
+import type { IncomeByAccount } from "@/lib/types";
+import { AnimatedToggleGroup, formatAmount } from "@wealthfolio/ui";
 import {
   Card,
   CardContent,
@@ -17,8 +18,8 @@ import {
 import { EmptyPlaceholder } from "@wealthfolio/ui/components/ui/empty-placeholder";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
 import { format, parseISO } from "date-fns";
-import React from "react";
-import { Bar, CartesianGrid, ComposedChart, Line, XAxis, YAxis } from "recharts";
+import React, { useMemo, useState } from "react";
+import { Bar, BarChart, CartesianGrid, ComposedChart, Line, XAxis, YAxis } from "recharts";
 
 interface IncomeHistoryChartProps {
   monthlyIncomeData: [string, number][];
@@ -26,7 +27,13 @@ interface IncomeHistoryChartProps {
   selectedPeriod: "TOTAL" | "YTD" | "LAST_YEAR";
   currency: string;
   isBalanceHidden: boolean;
+  byAccount?: Record<string, IncomeByAccount>;
 }
+
+const viewModes = [
+  { value: "combined" as const, label: "Combined" },
+  { value: "byAccount" as const, label: "By Account" },
+];
 
 export const IncomeHistoryChart: React.FC<IncomeHistoryChartProps> = ({
   monthlyIncomeData,
@@ -34,8 +41,10 @@ export const IncomeHistoryChart: React.FC<IncomeHistoryChartProps> = ({
   selectedPeriod,
   currency,
   isBalanceHidden,
+  byAccount,
 }) => {
   const [isMobile, setIsMobile] = React.useState(false);
+  const [viewMode, setViewMode] = useState<"combined" | "byAccount">("combined");
 
   React.useEffect(() => {
     const checkMobile = () => {
@@ -62,6 +71,36 @@ export const IncomeHistoryChart: React.FC<IncomeHistoryChartProps> = ({
     return dataPoint;
   });
 
+  const accounts = useMemo(
+    () => (byAccount ? Object.values(byAccount).sort((a, b) => b.total - a.total) : []),
+    [byAccount],
+  );
+
+  const showToggle = accounts.length > 1;
+  const effectiveViewMode = showToggle ? viewMode : "combined";
+
+  const byAccountChartData = useMemo(() => {
+    if (!byAccount || accounts.length === 0) return [];
+    return monthlyIncomeData.map(([month]) => {
+      const point: Record<string, string | number> = { month };
+      for (const acc of accounts) {
+        point[acc.accountId] = acc.byMonth[month] ?? 0;
+      }
+      return point;
+    });
+  }, [monthlyIncomeData, byAccount, accounts]);
+
+  const accountChartConfig = useMemo(
+    () =>
+      Object.fromEntries(
+        accounts.map((acc, i) => [
+          acc.accountId,
+          { label: acc.accountName, color: `var(--chart-${(i % 9) + 1})` },
+        ]),
+      ),
+    [accounts],
+  );
+
   const periodDescription =
     selectedPeriod === "TOTAL"
       ? "All Time"
@@ -69,11 +108,67 @@ export const IncomeHistoryChart: React.FC<IncomeHistoryChartProps> = ({
         ? "Year to Date"
         : "Last Year";
 
+  const xAxisProps = {
+    dataKey: "month" as const,
+    tickLine: false,
+    tickMargin: 8,
+    axisLine: false,
+    tick: { fontSize: isMobile ? 11 : 12 },
+    tickFormatter: (value: string) => {
+      const date = parseISO(`${value}-01`);
+      return isMobile ? format(date, "MMM") : format(date, "MMM yy");
+    },
+  };
+
+  const yAxisProps = {
+    tickLine: false,
+    axisLine: false,
+    tick: { fontSize: isMobile ? 10 : 12 },
+    width: isMobile ? 45 : 60,
+    tickFormatter: (value: number) => {
+      if (value >= 1000) {
+        return `${(value / 1000).toFixed(0)}k`;
+      }
+      return value.toString();
+    },
+  };
+
+  const tooltipLabelFormatter = (label: unknown) => {
+    if (typeof label !== "string") return "";
+    return format(parseISO(`${label}-01`), isMobile ? "MMM yyyy" : "MMMM yyyy");
+  };
+
   return (
     <Card className="md:col-span-2">
       <CardHeader className="pb-4 md:pb-6">
-        <CardTitle className="text-sm font-medium">Income History</CardTitle>
-        <CardDescription className="text-xs md:text-sm">{periodDescription}</CardDescription>
+        <div className="flex items-center justify-between">
+          <div>
+            <CardTitle className="text-sm font-medium">Income History</CardTitle>
+            <CardDescription className="text-xs md:text-sm">{periodDescription}</CardDescription>
+          </div>
+          {showToggle && (
+            <>
+              <div className="hidden sm:block">
+                <AnimatedToggleGroup
+                  variant="secondary"
+                  size="sm"
+                  items={viewModes}
+                  value={viewMode}
+                  onValueChange={setViewMode}
+                />
+              </div>
+              <div className="block sm:hidden">
+                <AnimatedToggleGroup
+                  variant="secondary"
+                  size="xs"
+                  items={viewModes}
+                  value={viewMode}
+                  onValueChange={setViewMode}
+                />
+              </div>
+            </>
+          )}
+        </div>
       </CardHeader>
       <CardContent className="px-4 pt-0 md:px-6">
         {chartData.length === 0 ? (
@@ -83,6 +178,75 @@ export const IncomeHistoryChart: React.FC<IncomeHistoryChartProps> = ({
             title="No income history available"
             description="There is no income history for the selected period. Try selecting a different time range or check back later."
           />
+        ) : effectiveViewMode === "byAccount" ? (
+          <ChartContainer
+            config={accountChartConfig}
+            className={cn("h-[280px] w-full md:h-[380px]")}
+          >
+            <BarChart
+              data={byAccountChartData}
+              margin={{
+                left: isMobile ? -16 : 0,
+                right: isMobile ? 4 : 8,
+                top: 12,
+                bottom: 4,
+              }}
+            >
+              <CartesianGrid vertical={false} strokeDasharray="3 3" opacity={0.3} />
+              <XAxis {...xAxisProps} />
+              <YAxis {...yAxisProps} />
+              <ChartTooltip
+                content={
+                  <ChartTooltipContent
+                    className="min-w-[150px] md:min-w-[180px]"
+                    formatter={(value, name, entry) => {
+                      const formattedValue = isBalanceHidden
+                        ? "••••"
+                        : formatAmount(Number(value), currency);
+                      const label = accountChartConfig[name as string]?.label ?? String(name);
+                      return (
+                        <>
+                          <div
+                            className="border-border bg-(--color-bg) h-2.5 w-2.5 shrink-0 rounded-[2px]"
+                            style={
+                              {
+                                "--color-bg": entry.color,
+                                "--color-border": entry.color,
+                              } as React.CSSProperties
+                            }
+                          />
+                          <div className="flex flex-1 items-center justify-between gap-2">
+                            <span className="text-muted-foreground text-xs md:text-sm">
+                              {label}
+                            </span>
+                            <span className="text-foreground font-mono text-xs font-medium tabular-nums md:text-sm">
+                              {formattedValue}
+                            </span>
+                          </div>
+                        </>
+                      );
+                    }}
+                    labelFormatter={tooltipLabelFormatter}
+                  />
+                }
+              />
+              {!isMobile && <ChartLegend content={<ChartLegendContent />} />}
+              {accounts.map((acc, i) => (
+                <Bar
+                  key={acc.accountId}
+                  dataKey={acc.accountId}
+                  stackId="income"
+                  fill={`var(--chart-${(i % 9) + 1})`}
+                  barSize={isMobile ? 16 : 25}
+                  radius={
+                    i === accounts.length - 1
+                      ? [isMobile ? 4 : 8, isMobile ? 4 : 8, 0, 0]
+                      : [0, 0, 0, 0]
+                  }
+                />
+              ))}
+            </BarChart>
+          </ChartContainer>
         ) : (
           <ChartContainer
             config={{
@@ -111,30 +275,8 @@ export const IncomeHistoryChart: React.FC<IncomeHistoryChartProps> = ({
               }}
             >
               <CartesianGrid vertical={false} strokeDasharray="3 3" opacity={0.3} />
-              <XAxis
-                dataKey="month"
-                tickLine={false}
-                tickMargin={8}
-                axisLine={false}
-                tick={{ fontSize: isMobile ? 11 : 12 }}
-                tickFormatter={(value) => {
-                  const date = parseISO(`${value}-01`);
-                  return isMobile ? format(date, "MMM") : format(date, "MMM yy");
-                }}
-              />
-              <YAxis
-                yAxisId="left"
-                tickLine={false}
-                axisLine={false}
-                tick={{ fontSize: isMobile ? 10 : 12 }}
-                width={isMobile ? 45 : 60}
-                tickFormatter={(value: number) => {
-                  if (value >= 1000) {
-                    return `${(value / 1000).toFixed(0)}k`;
-                  }
-                  return value.toString();
-                }}
-              />
+              <XAxis {...xAxisProps} />
+              <YAxis yAxisId="left" {...yAxisProps} />
               {!isMobile && (
                 <YAxis yAxisId="right" orientation="right" tickLine={false} axisLine={false} />
               )}
@@ -176,10 +318,7 @@ export const IncomeHistoryChart: React.FC<IncomeHistoryChartProps> = ({
                         </>
                       );
                     }}
-                    labelFormatter={(label) => {
-                      if (typeof label !== "string") return "";
-                      return format(parseISO(`${label}-01`), isMobile ? "MMM yyyy" : "MMMM yyyy");
-                    }}
+                    labelFormatter={tooltipLabelFormatter}
                   />
                 }
               />

--- a/apps/frontend/src/pages/income/income-page.tsx
+++ b/apps/frontend/src/pages/income/income-page.tsx
@@ -396,6 +396,7 @@ export default function IncomePage() {
             selectedPeriod={selectedPeriod}
             currency={currency}
             isBalanceHidden={isBalanceHidden}
+            byAccount={periodSummary.byAccount}
           />
           <Card className="flex flex-col">
             <CardHeader>

--- a/crates/core/src/activities/activities_model.rs
+++ b/crates/core/src/activities/activities_model.rs
@@ -1005,6 +1005,8 @@ pub struct IncomeData {
     pub symbol_name: String,
     pub currency: String,
     pub amount: Decimal,
+    pub account_id: String,
+    pub account_name: String,
 }
 
 /// Result of importing activities, includes import run metadata

--- a/crates/core/src/portfolio/income/income_model.rs
+++ b/crates/core/src/portfolio/income/income_model.rs
@@ -13,6 +13,15 @@ pub struct IncomeByAsset {
     pub income: Decimal,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IncomeByAccount {
+    pub account_id: String,
+    pub account_name: String,
+    pub by_month: HashMap<String, Decimal>,
+    pub total: Decimal,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IncomeSummary {
@@ -21,6 +30,7 @@ pub struct IncomeSummary {
     pub by_type: HashMap<String, Decimal>,
     pub by_asset: HashMap<String, IncomeByAsset>,
     pub by_currency: HashMap<String, Decimal>,
+    pub by_account: HashMap<String, IncomeByAccount>,
     pub total_income: Decimal,
     pub currency: String,
     pub monthly_average: Decimal,
@@ -35,6 +45,7 @@ impl IncomeSummary {
             by_type: HashMap::new(),
             by_asset: HashMap::new(),
             by_currency: HashMap::new(),
+            by_account: HashMap::new(),
             total_income: Decimal::ZERO,
             currency,
             monthly_average: Decimal::ZERO,
@@ -65,6 +76,25 @@ impl IncomeSummary {
             .by_currency
             .entry(data.currency.clone())
             .or_insert_with(|| Decimal::ZERO) += &data.amount;
+        self.by_account
+            .entry(data.account_id.clone())
+            .and_modify(|entry| {
+                *entry
+                    .by_month
+                    .entry(data.date.clone())
+                    .or_insert(Decimal::ZERO) += converted_amount;
+                entry.total += converted_amount;
+            })
+            .or_insert_with(|| {
+                let mut by_month = HashMap::new();
+                by_month.insert(data.date.clone(), converted_amount);
+                IncomeByAccount {
+                    account_id: data.account_id.clone(),
+                    account_name: data.account_name.clone(),
+                    by_month,
+                    total: converted_amount,
+                }
+            });
         self.total_income += &converted_amount;
     }
 

--- a/crates/core/src/portfolio/income/income_service.rs
+++ b/crates/core/src/portfolio/income/income_service.rs
@@ -168,7 +168,9 @@ impl IncomeServiceTrait for IncomeService {
                 symbol: activity.symbol.clone(),
                 symbol_name: activity.symbol_name.clone(),
                 currency: activity.currency.clone(),
-                amount: activity.amount, // Keep original amount in activity_copy if needed elsewhere
+                amount: activity.amount,
+                account_id: activity.account_id.clone(),
+                account_name: activity.account_name.clone(),
             };
 
             total_summary.add_income(&activity_copy, converted_amount);
@@ -232,6 +234,12 @@ impl IncomeServiceTrait for IncomeService {
                 }
                 for val in summary.by_currency.values_mut() {
                     *val = val.round_dp(DISPLAY_DECIMAL_PRECISION);
+                }
+                for entry in summary.by_account.values_mut() {
+                    entry.total = entry.total.round_dp(DISPLAY_DECIMAL_PRECISION);
+                    for val in entry.by_month.values_mut() {
+                        *val = val.round_dp(DISPLAY_DECIMAL_PRECISION);
+                    }
                 }
                 summary
             })

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -776,6 +776,8 @@ impl ActivityRepositoryTrait for ActivityRepository {
              COALESCE(ast.display_code, 'CASH') as symbol,
              COALESCE(ast.name, 'Cash') as symbol_name,
              a.currency,
+             a.account_id,
+             acc.name as account_name,
              CASE
                  WHEN a.subtype IN ('STAKING_REWARD', 'DRIP', 'DIVIDEND_IN_KIND')
                       AND (a.amount IS NULL OR CAST(a.amount AS REAL) = 0)
@@ -817,6 +819,10 @@ impl ActivityRepositoryTrait for ActivityRepository {
             #[diesel(sql_type = diesel::sql_types::Text)]
             pub currency: String,
             #[diesel(sql_type = diesel::sql_types::Text)]
+            pub account_id: String,
+            #[diesel(sql_type = diesel::sql_types::Text)]
+            pub account_name: String,
+            #[diesel(sql_type = diesel::sql_types::Text)]
             pub amount: String,
         }
 
@@ -845,6 +851,8 @@ impl ActivityRepositoryTrait for ActivityRepository {
                     symbol_name: raw.symbol_name,
                     currency: raw.currency,
                     amount,
+                    account_id: raw.account_id,
+                    account_name: raw.account_name,
                 })
             })
             .collect::<Result<Vec<IncomeData>>>()?; // Collect into Result


### PR DESCRIPTION
## Changes

- **Frontend**: Add toggle between "Combined" and "By Account" views in income history chart
  - New `IncomeByAccount` type to track income by account and month
  - Add stacked bar chart visualization for account-level income breakdown
  - Add responsive toggle control (hidden on mobile)
  - Refactor chart axis/tooltip props for reusability

- **Backend**: Extend income summary with account-level aggregation
  - Add `account_id` and `account_name` to `IncomeData` model
  - Add `IncomeByAccount` struct with monthly breakdown and totals
  - Populate `by_account` in `IncomeSummary` during income aggregation
  - Update SQL query to fetch account information
  - Apply decimal rounding to account-level data

## Types Updated
- `IncomeByAccount`: accountId, accountName, byMonth, total
- `IncomeSummary`: Added `byAccount` field