### PR TITLE
fix: map InstrumentType::Metal to AssetKind::Investment

### DIFF
--- a/apps/frontend/src/pages/activity/import/utils/asset-review-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/asset-review-utils.ts
@@ -120,8 +120,7 @@ export function buildNewAssetFromSearchResult(
   fallbackCurrency: string,
 ): NewAsset {
   const instrumentType = mapQuoteTypeToInstrumentType(result.quoteType);
-  const kind =
-    instrumentType === "METAL" ? "PRECIOUS_METAL" : instrumentType === "FX" ? "FX" : "INVESTMENT";
+  const kind = instrumentType === "FX" ? "FX" : "INVESTMENT";
   const quoteMode = result.dataSource === "MANUAL" ? "MANUAL" : "MARKET";
 
   return {
@@ -143,12 +142,7 @@ export function buildNewAssetFromDraft(draft: DraftActivity): NewAsset | null {
   }
 
   const normalizedInstrumentType = draft.instrumentType.toUpperCase();
-  const kind =
-    normalizedInstrumentType === "METAL"
-      ? "PRECIOUS_METAL"
-      : normalizedInstrumentType === "FX"
-        ? "FX"
-        : "INVESTMENT";
+  const kind = normalizedInstrumentType === "FX" ? "FX" : "INVESTMENT";
 
   return {
     kind,

--- a/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
+++ b/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
@@ -98,7 +98,7 @@ const EDIT_INSTRUMENT_TYPE_OPTIONS = [
   { value: "CRYPTO", label: "Cryptocurrency" },
   { value: "BOND", label: "Bond" },
   { value: "OPTION", label: "Option" },
-  { value: "METAL", label: "Precious Metal" },
+  { value: "METAL", label: "Metal (Commodity)" },
 ] as const;
 
 // Parse provider overrides from config JSON (supports nested and flat formats)

--- a/apps/frontend/src/pages/asset/create-security-dialog.tsx
+++ b/apps/frontend/src/pages/asset/create-security-dialog.tsx
@@ -42,7 +42,7 @@ const INSTRUMENT_TYPE_OPTIONS = [
   { value: "BOND", label: "Bond" },
   { value: "OPTION", label: "Option" },
   { value: "FX", label: "Foreign Exchange" },
-  { value: "METAL", label: "Precious Metal" },
+  { value: "METAL", label: "Metal (Commodity)" },
 ] as const;
 
 const QUOTE_MODE_OPTIONS = [
@@ -188,12 +188,7 @@ export function CreateSecurityDialog({
   );
 
   const handleSubmit = (values: CreateSecurityFormValues) => {
-    const kind =
-      values.instrumentType === "METAL"
-        ? "PRECIOUS_METAL"
-        : values.instrumentType === "FX"
-          ? "FX"
-          : "INVESTMENT";
+    const kind = values.instrumentType === "FX" ? "FX" : "INVESTMENT";
 
     const payload: NewAsset = {
       kind,

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -216,7 +216,7 @@ impl ActivityService {
     fn kind_from_instrument_type(instrument_type: &InstrumentType) -> AssetKind {
         match instrument_type {
             InstrumentType::Fx => AssetKind::Fx,
-            InstrumentType::Metal => AssetKind::PreciousMetal,
+            InstrumentType::Metal => AssetKind::Investment,
             _ => AssetKind::Investment,
         }
     }
@@ -978,7 +978,7 @@ impl ActivityService {
                 "OPTION" | "OPT" => return (AssetKind::Investment, Some(InstrumentType::Option)),
                 "BOND" => return (AssetKind::Investment, Some(InstrumentType::Bond)),
                 "COMMODITY" | "CMDTY" | "METAL" => {
-                    return (AssetKind::PreciousMetal, Some(InstrumentType::Metal))
+                    return (AssetKind::Investment, Some(InstrumentType::Metal))
                 }
                 "PROPERTY" | "PROP" => return (AssetKind::Property, None),
                 "VEHICLE" | "VEH" => return (AssetKind::Vehicle, None),


### PR DESCRIPTION
## Summary

- Metal instrument types (XAU, XAG spot prices) now map to `AssetKind::Investment` instead of `PreciousMetal`
- This gives metal instruments automatic market quote fetching (`QuoteMode::Market`) by default
- Physical precious metals (gold bars in a safe) remain as `AssetKind::PreciousMetal` via the alternative assets path
- Frontend: removes hardcoded `METAL→PRECIOUS_METAL` overrides in create-security dialog and CSV import review; updates dropdown labels to "Metal (Commodity)"

## Motivation

Per the intended design, `InstrumentType::Metal` represents market-priced spot commodities traded through brokerages, while `AssetKind::PreciousMetal` represents physical holdings tracked manually. The previous mapping conflated both into `PreciousMetal`, which defaulted to `QuoteMode::Manual` and excluded metals from the investments view.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [x] `cargo test --workspace` — 1,305 tests pass, 0 failures
- [x] `pnpm format:check` passes