### PR TITLE
fix(net-worth): fall back to display_code when asset name is empty

### DIFF
--- a/crates/core/src/portfolio/net_worth/net_worth_service.rs
+++ b/crates/core/src/portfolio/net_worth/net_worth_service.rs
@@ -297,7 +297,12 @@ impl NetWorthServiceTrait for NetWorthService {
 
                 // Get asset info to determine category more precisely
                 let asset = asset_map.get(asset_id);
-                let asset_name = asset.and_then(|a| a.name.clone());
+                let asset_name = asset.and_then(|a| {
+                    a.name
+                        .clone()
+                        .filter(|n| !n.is_empty())
+                        .or_else(|| a.display_code.clone())
+                });
 
                 // Determine category: prefer asset kind if available, fallback to account type
                 let category = if let Some(asset) = asset {
@@ -457,7 +462,11 @@ impl NetWorthServiceTrait for NetWorthService {
 
             valuations.push(ValuationInfo {
                 asset_id: asset.id.clone(),
-                name: asset.name.clone(),
+                name: asset
+                    .name
+                    .clone()
+                    .filter(|n| !n.is_empty())
+                    .or_else(|| asset.display_code.clone()),
                 market_value_base,
                 valuation_date,
                 category,


### PR DESCRIPTION
## Summary
- Assets with NULL or empty `name` field (e.g. manually-tracked 529 funds, CUSIP-only bonds) display raw UUIDs in the net worth staleness panel
- When building `ValuationInfo`, fall back to `display_code` when `name` is NULL or empty, for both snapshot-based positions and standalone alternative assets

## Test plan
- [x] Verified with portfolio containing 42 assets with empty names — staleness panel now shows ticker/CUSIP instead of UUIDs
- [x] `cargo test -p wealthfolio-core` passes
- [x] `cargo clippy` and `cargo fmt` clean on changed file