### PR TITLE
fix(sync): fall through to preferred_provider when data_source is empty

### DIFF
--- a/crates/core/src/quotes/sync.rs
+++ b/crates/core/src/quotes/sync.rs
@@ -420,6 +420,7 @@ where
             let provider = existing_states
                 .get(&asset.id)
                 .map(|s| s.data_source.clone())
+                .filter(|s| !s.is_empty())
                 .or_else(|| asset.preferred_provider())
                 .unwrap_or_else(|| DATA_SOURCE_YAHOO.to_string());
             assets_by_provider
@@ -1352,6 +1353,7 @@ where
             let provider = existing_states
                 .get(&asset.id)
                 .map(|s| s.data_source.clone())
+                .filter(|s| !s.is_empty())
                 .or_else(|| asset.preferred_provider())
                 .unwrap_or_else(|| DATA_SOURCE_YAHOO.to_string());
             assets_by_provider
@@ -1372,6 +1374,7 @@ where
             let data_source = state
                 .as_ref()
                 .map(|s| s.data_source.clone())
+                .filter(|s| !s.is_empty())
                 .or_else(|| asset.preferred_provider())
                 .unwrap_or_else(|| DATA_SOURCE_YAHOO.to_string());
             let effective_today =


### PR DESCRIPTION
## Summary
- New sync states are initialized with an empty `data_source` string (intended to be populated after first successful sync)
- The provider resolution chain uses `.map(|s| s.data_source.clone()).or_else(|| asset.preferred_provider())`, but `.map()` converts `""` to `Some("")`, so `.or_else()` never fires
- This traps affected assets in a permanent failure loop: provider `""` is tried, fails, error_count increments, repeat forever
- Fix: add `.filter(|s| !s.is_empty())` at all 3 call sites so empty `data_source` falls through to the asset's `preferred_provider` or the Yahoo default

## Test plan
- [ ] Create a METAL-type asset with `preferred_provider = METAL_PRICE_API`
- [ ] Verify sync state has empty `data_source` initially
- [ ] Trigger a sync — should now use METAL_PRICE_API instead of failing
- [ ] Verify `data_source` is populated after successful sync