### PR TITLE
fix: import mapping improvements and version bump to 3.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8002,7 +8002,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-ai"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8026,7 +8026,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-app"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8075,7 +8075,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-connect"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8093,7 +8093,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-core"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8138,7 +8138,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-device-sync"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8162,7 +8162,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-market-data"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8184,7 +8184,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-server"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8231,7 +8231,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-storage-sqlite"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.2.0"
+version = "3.2.1"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/addons/goal-progress-tracker/package.json
+++ b/addons/goal-progress-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goal-progress-tracker-addon",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "An addon for tracking investment progress towards target amounts with progress visualization",
   "type": "module",
   "main": "dist/addon.js",

--- a/addons/investment-fees-tracker/package.json
+++ b/addons/investment-fees-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "investment-fees-tracker-addon",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "An addon for tracking and analyzing investment fees across your portfolio",
   "type": "module",
   "main": "dist/addon.js",

--- a/addons/swingfolio-addon/package.json
+++ b/addons/swingfolio-addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swingfolio-addon",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A simple swing stock trading tracker with performance analytics and calendar views",
   "type": "module",
   "main": "dist/addon.js",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "3.2.0",
+  "version": "3.2.1",
   "type": "module",
   "scripts": {
     "dev": "cross-env BUILD_TARGET=web vite",

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -858,8 +858,6 @@ export interface DepositsCalculation {
   byAccount: Record<string, AccountDeposit>;
 }
 
-export const ACTIVITY_TYPE_PREFIX_LENGTH = 12;
-
 // Renamed from CumulativeReturn to match Rust struct ReturnData
 export interface ReturnData {
   date: string; // Changed from CumulativeReturn

--- a/apps/frontend/src/pages/activity/import/activity-import-page.tsx
+++ b/apps/frontend/src/pages/activity/import/activity-import-page.tsx
@@ -4,7 +4,6 @@ import { isCashSymbol, needsImportAssetResolution } from "@/lib/activity-utils";
 import { canImportCSV } from "@/lib/activity-restrictions";
 import { QueryKeys } from "@/lib/query-keys";
 import type { Account } from "@/lib/types";
-import { ImportType } from "@/lib/types";
 import { useQuery } from "@tanstack/react-query";
 import { AlertFeedback, Page, PageContent, PageHeader } from "@wealthfolio/ui";
 import { Button } from "@wealthfolio/ui/components/ui/button";
@@ -25,6 +24,7 @@ import {
   type ImportStep,
 } from "./context";
 import { createDraftActivities } from "./utils/draft-utils";
+import { createDefaultActivityMapping } from "./utils/default-activity-template";
 
 // Components
 import { CancelConfirmationDialog } from "./components/cancel-confirmation-dialog";
@@ -213,7 +213,7 @@ function useStepValidation(isHoldingsMode: boolean, accounts?: Account[]) {
               const symbol = row[symbolHeaderIndex]?.trim();
               if (!symbol) return;
 
-              // Resolve activity type with fallback
+              // Resolve activity type using explicit mappings only
               let csvActivityType: string | undefined;
               for (const idx of atCols) {
                 const val = row[idx]?.trim();
@@ -369,16 +369,7 @@ function ImportWizardContent() {
             : existingAccountMappings;
         dispatch(
           setMapping({
-            ...(state.mapping ?? {
-              accountId: state.accountId || "",
-              importType: ImportType.ACTIVITY,
-              name: "",
-              fieldMappings: {},
-              activityMappings: {},
-              symbolMappings: {},
-              accountMappings: {},
-              symbolMappingMeta: {},
-            }),
+            ...(state.mapping ?? createDefaultActivityMapping(state.accountId || "")),
             fieldMappings: mergedFieldMappings,
             accountMappings,
           }),

--- a/apps/frontend/src/pages/activity/import/components/mapping-editor.tsx
+++ b/apps/frontend/src/pages/activity/import/components/mapping-editor.tsx
@@ -1,5 +1,5 @@
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@wealthfolio/ui/components/ui/tabs";
-import { Account, ActivityType, CsvRowData, ImportFormat, ImportMappingData } from "@/lib/types";
+import { Account, CsvRowData, ImportFormat, ImportMappingData } from "@/lib/types";
 import { useMemo } from "react";
 
 import { CardContent } from "@wealthfolio/ui/components/ui/card";
@@ -14,7 +14,7 @@ interface CsvMappingEditorProps {
   data: CsvRowData[];
   accounts: Account[];
   handleColumnMapping: (field: ImportFormat, value: string) => void;
-  handleActivityTypeMapping: (csvActivity: string, activityType: ActivityType) => void;
+  handleActivityTypeMapping: (csvActivity: string, activityType: string) => void;
   handleSymbolMapping: (csvSymbol: string, newSymbol: string) => void;
   getMappedValue: (row: CsvRowData, field: ImportFormat) => string;
   handleAccountIdMapping: (csvAccountId: string, accountId: string) => void;

--- a/apps/frontend/src/pages/activity/import/components/mapping-table-cells.tsx
+++ b/apps/frontend/src/pages/activity/import/components/mapping-table-cells.tsx
@@ -114,7 +114,7 @@ interface ActivityTypeDisplayCellProps {
   csvType: string;
   appType: string | null;
   subtype?: string;
-  handleActivityTypeMapping: (csvActivity: string, activityType: ActivityType) => void;
+  handleActivityTypeMapping: (csvActivity: string, activityType: string) => void;
 }
 function ActivityTypeDisplayCell({
   csvType,
@@ -355,7 +355,7 @@ export function MappingCell({
   mapping: ImportMappingData;
   accounts: Account[];
   getMappedValue: (row: CsvRowData, field: ImportFormat) => string;
-  handleActivityTypeMapping: (csvActivity: string, activityType: ActivityType) => void;
+  handleActivityTypeMapping: (csvActivity: string, activityType: string) => void;
   handleSymbolMapping: (
     csvSymbol: string,
     newSymbol: string,

--- a/apps/frontend/src/pages/activity/import/components/mapping-table.tsx
+++ b/apps/frontend/src/pages/activity/import/components/mapping-table.tsx
@@ -10,7 +10,6 @@ import { TooltipProvider } from "@wealthfolio/ui/components/ui/tooltip";
 import { IMPORT_REQUIRED_FIELDS } from "@/lib/constants";
 import {
   Account,
-  ActivityType,
   CsvRowData,
   ImportFormat,
   ImportMappingData,
@@ -27,7 +26,7 @@ interface MappingTableProps {
   data: CsvRowData[];
   accounts: Account[];
   handleColumnMapping: (field: ImportFormat, value: string) => void;
-  handleActivityTypeMapping: (csvActivity: string, activityType: ActivityType) => void;
+  handleActivityTypeMapping: (csvActivity: string, activityType: string) => void;
   handleSymbolMapping: (
     csvSymbol: string,
     newSymbol: string,

--- a/apps/frontend/src/pages/activity/import/context/import-actions.ts
+++ b/apps/frontend/src/pages/activity/import/context/import-actions.ts
@@ -217,3 +217,10 @@ export function setSelectedTemplate(
 ): ImportAction {
   return { type: "SET_SELECTED_TEMPLATE", payload: { id, scope } };
 }
+
+/**
+ * Suppress auto-applying account-linked templates for the current import session.
+ */
+export function setSuppressLinkedTemplate(value: boolean): ImportAction {
+  return { type: "SET_SUPPRESS_LINKED_TEMPLATE", payload: value };
+}

--- a/apps/frontend/src/pages/activity/import/context/import-context.tsx
+++ b/apps/frontend/src/pages/activity/import/context/import-context.tsx
@@ -120,6 +120,7 @@ export interface ImportState {
   pendingImportAssets: Record<string, PendingImportAsset>;
   selectedTemplateId: string | null;
   selectedTemplateScope: ImportTemplateScope | null;
+  suppressLinkedTemplate: boolean;
   duplicates: Record<string, string>; // idempotencyKey -> existingActivityId
   importResult: ImportResult | null;
   accountId: string;
@@ -161,6 +162,7 @@ const INITIAL_STATE: ImportState = {
   pendingImportAssets: {},
   selectedTemplateId: null,
   selectedTemplateScope: null,
+  suppressLinkedTemplate: false,
   duplicates: {},
   importResult: null,
   accountId: "",
@@ -202,6 +204,7 @@ export type ImportAction =
       type: "SET_SELECTED_TEMPLATE";
       payload: { id: string | null; scope: ImportTemplateScope | null };
     }
+  | { type: "SET_SUPPRESS_LINKED_TEMPLATE"; payload: boolean }
   | { type: "SET_DUPLICATES"; payload: Record<string, string> }
   | { type: "SET_IMPORT_RESULT"; payload: ImportResult }
   | { type: "SET_HOLDINGS_CHECK_PASSED"; payload: boolean }
@@ -371,6 +374,12 @@ function importReducer(state: ImportState, action: ImportAction): ImportState {
         ...state,
         selectedTemplateId: action.payload.id,
         selectedTemplateScope: action.payload.scope,
+      };
+
+    case "SET_SUPPRESS_LINKED_TEMPLATE":
+      return {
+        ...state,
+        suppressLinkedTemplate: action.payload,
       };
 
     case "SET_DUPLICATES":

--- a/apps/frontend/src/pages/activity/import/hooks/use-import-mapping.test.tsx
+++ b/apps/frontend/src/pages/activity/import/hooks/use-import-mapping.test.tsx
@@ -1,0 +1,95 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it } from "vitest";
+import { ActivityType, ImportType } from "@/lib/types";
+import { useImportMapping } from "./use-import-mapping";
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useImportMapping activity type mappings", () => {
+  it("starts with exact identity mappings for canonical activity types", () => {
+    const { result } = renderHook(() => useImportMapping(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.mapping.activityMappings[ActivityType.BUY]).toEqual(["BUY"]);
+    expect(result.current.mapping.activityMappings[ActivityType.WITHDRAWAL]).toEqual([
+      "WITHDRAWAL",
+    ]);
+  });
+
+  it("stores full normalized labels and clears mappings without leaving empty keys", () => {
+    const { result } = renderHook(
+      () =>
+        useImportMapping({
+          defaultMapping: {
+            accountId: "acc-1",
+            importType: ImportType.ACTIVITY,
+            name: "",
+            fieldMappings: {},
+            activityMappings: {},
+            symbolMappings: {},
+            accountMappings: {},
+            symbolMappingMeta: {},
+          },
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    act(() => {
+      result.current.handleActivityTypeMapping("Dividend Qualified", ActivityType.DIVIDEND);
+    });
+
+    expect(result.current.mapping.activityMappings[ActivityType.DIVIDEND]).toEqual([
+      "DIVIDEND_QUALIFIED",
+    ]);
+
+    act(() => {
+      result.current.handleActivityTypeMapping("Dividend Qualified", "");
+    });
+
+    expect(result.current.mapping.activityMappings[ActivityType.DIVIDEND]).toBeUndefined();
+    expect(result.current.mapping.activityMappings[""]).toBeUndefined();
+  });
+
+  it("remaps one csv label without colliding with a different longer label", () => {
+    const { result } = renderHook(
+      () =>
+        useImportMapping({
+          defaultMapping: {
+            accountId: "acc-1",
+            importType: ImportType.ACTIVITY,
+            name: "",
+            fieldMappings: {},
+            activityMappings: {},
+            symbolMappings: {},
+            accountMappings: {},
+            symbolMappingMeta: {},
+          },
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    act(() => {
+      result.current.handleActivityTypeMapping("Transfer Out Fee", ActivityType.FEE);
+    });
+
+    act(() => {
+      result.current.handleActivityTypeMapping("Transfer Out", ActivityType.TRANSFER_OUT);
+    });
+
+    expect(result.current.mapping.activityMappings[ActivityType.FEE]).toEqual(["TRANSFER_OUT_FEE"]);
+    expect(result.current.mapping.activityMappings[ActivityType.TRANSFER_OUT]).toEqual([
+      "TRANSFER_OUT",
+    ]);
+  });
+});

--- a/apps/frontend/src/pages/activity/import/hooks/use-import-mapping.ts
+++ b/apps/frontend/src/pages/activity/import/hooks/use-import-mapping.ts
@@ -1,16 +1,11 @@
 import { useState, useCallback } from "react";
-import {
-  ImportFormat,
-  ActivityType,
-  ImportMappingData,
-  ImportType,
-  type SymbolSearchResult,
-} from "@/lib/types";
-import { ACTIVITY_TYPE_PREFIX_LENGTH } from "@/lib/types";
+import { ImportFormat, ImportMappingData, type SymbolSearchResult } from "@/lib/types";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { saveAccountImportMapping, logger } from "@/adapters";
 import { QueryKeys } from "@/lib/query-keys";
 import { toast } from "@wealthfolio/ui/components/ui/use-toast";
+import { createDefaultActivityMapping } from "../utils/default-activity-template";
+import { normalizeActivityLabel } from "../utils/activity-type-mapping";
 
 /**
  * Common column name aliases for each ImportFormat field.
@@ -353,16 +348,7 @@ export function computeFieldMappings(
   return result;
 }
 
-const emptyMapping: ImportMappingData = {
-  accountId: "",
-  importType: ImportType.ACTIVITY,
-  name: "",
-  fieldMappings: {},
-  activityMappings: {},
-  symbolMappings: {},
-  accountMappings: {},
-  symbolMappingMeta: {},
-};
+const emptyMapping: ImportMappingData = createDefaultActivityMapping();
 
 interface UseImportMappingProps {
   defaultMapping?: ImportMappingData;
@@ -422,29 +408,33 @@ export function useImportMapping({
     }));
   }, []);
 
-  const handleActivityTypeMapping = useCallback(
-    (csvActivity: string, activityType: ActivityType) => {
-      const trimmedCsvType = csvActivity.trim().toUpperCase();
-      const compareValue = trimmedCsvType.substring(0, ACTIVITY_TYPE_PREFIX_LENGTH);
+  const handleActivityTypeMapping = useCallback((csvActivity: string, activityType: string) => {
+    const normalizedCsvType = normalizeActivityLabel(csvActivity);
+    const legacyPrefix = normalizedCsvType.slice(0, 12);
 
-      setMapping((prev) => {
-        const updatedMappings = { ...prev.activityMappings };
-        Object.keys(updatedMappings).forEach((key) => {
-          updatedMappings[key] = (updatedMappings[key] ?? []).filter(
-            (type) => type.substring(0, ACTIVITY_TYPE_PREFIX_LENGTH) !== compareValue,
-          );
-        });
-        if (!updatedMappings[activityType]) {
-          updatedMappings[activityType] = [];
-        }
-        if (!updatedMappings[activityType]?.includes(compareValue)) {
-          updatedMappings[activityType]?.push(compareValue);
-        }
+    setMapping((prev) => {
+      const updatedMappings = Object.fromEntries(
+        Object.entries(prev.activityMappings).flatMap(([key, values]) => {
+          const nextValues = (values ?? []).filter((value) => {
+            const normalizedValue = normalizeActivityLabel(value);
+            return normalizedValue !== normalizedCsvType && normalizedValue !== legacyPrefix;
+          });
+          return nextValues.length > 0 ? [[key, nextValues]] : [];
+        }),
+      );
+
+      if (!activityType.trim()) {
         return { ...prev, activityMappings: updatedMappings };
-      });
-    },
-    [],
-  );
+      }
+
+      const nextValues = updatedMappings[activityType] ?? [];
+      if (!nextValues.includes(normalizedCsvType)) {
+        updatedMappings[activityType] = [...nextValues, normalizedCsvType];
+      }
+
+      return { ...prev, activityMappings: updatedMappings };
+    });
+  }, []);
 
   const handleSymbolMapping = useCallback(
     (csvSymbol: string, newSymbol: string, searchResult?: SymbolSearchResult) => {

--- a/apps/frontend/src/pages/activity/import/steps/holdings-mapping-step.tsx
+++ b/apps/frontend/src/pages/activity/import/steps/holdings-mapping-step.tsx
@@ -19,6 +19,7 @@ import { setMapping } from "../context/import-actions";
 import { ImportAlert } from "../components/import-alert";
 import type { ImportMappingData } from "@/lib/types";
 import { ImportType } from "@/lib/types";
+import { shouldUseSavedHoldingsMapping } from "../utils/import-flow-utils";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Holdings Format Fields
@@ -182,8 +183,7 @@ export function HoldingsMappingStep() {
   const { state, dispatch } = useImportContext();
   const { headers, parsedRows, mapping, accountId } = state;
   const hasAutoInitialized = useRef(false);
-  const shouldUseSavedMapping =
-    !state.suppressLinkedTemplate && !(mapping && !state.selectedTemplateId);
+  const shouldUseSavedMapping = shouldUseSavedHoldingsMapping(state.suppressLinkedTemplate);
 
   // Fetch saved mapping from backend
   const { data: savedMapping } = useQuery({

--- a/apps/frontend/src/pages/activity/import/steps/holdings-mapping-step.tsx
+++ b/apps/frontend/src/pages/activity/import/steps/holdings-mapping-step.tsx
@@ -182,12 +182,14 @@ export function HoldingsMappingStep() {
   const { state, dispatch } = useImportContext();
   const { headers, parsedRows, mapping, accountId } = state;
   const hasAutoInitialized = useRef(false);
+  const shouldUseSavedMapping =
+    !state.suppressLinkedTemplate && !(mapping && !state.selectedTemplateId);
 
   // Fetch saved mapping from backend
   const { data: savedMapping } = useQuery({
     queryKey: [QueryKeys.IMPORT_MAPPING, accountId],
     queryFn: () => (accountId ? getAccountImportMapping(accountId, ImportType.HOLDINGS) : null),
-    enabled: !!accountId,
+    enabled: !!accountId && shouldUseSavedMapping,
   });
 
   // Local state for the field mappings being edited
@@ -205,7 +207,7 @@ export function HoldingsMappingStep() {
     const merged: Record<string, string> = {};
 
     // 1. Apply saved field mappings (only valid HoldingsFormat keys with headers in this CSV)
-    if (savedMapping?.fieldMappings) {
+    if (shouldUseSavedMapping && savedMapping?.fieldMappings) {
       for (const [field, value] of Object.entries(savedMapping.fieldMappings)) {
         const header = Array.isArray(value) ? value[0] : value;
         if (validHoldingsFields.has(field) && header && headers.includes(header)) {
@@ -227,7 +229,10 @@ export function HoldingsMappingStep() {
     }
 
     // 3. Merge saved symbol mappings into context
-    if (savedMapping?.symbolMappings || savedMapping?.symbolMappingMeta) {
+    if (
+      shouldUseSavedMapping &&
+      (savedMapping?.symbolMappings || savedMapping?.symbolMappingMeta)
+    ) {
       const currentMapping = mapping || {
         accountId,
         importType: ImportType.HOLDINGS,
@@ -253,7 +258,15 @@ export function HoldingsMappingStep() {
     }
 
     hasAutoInitialized.current = true;
-  }, [headers, savedMapping, mapping, accountId, dispatch, validHoldingsFields]);
+  }, [
+    headers,
+    savedMapping,
+    mapping,
+    accountId,
+    dispatch,
+    shouldUseSavedMapping,
+    validHoldingsFields,
+  ]);
 
   // ───────────────────────────────────────────────────────────────────────────
   // Derived data

--- a/apps/frontend/src/pages/activity/import/steps/mapping-step-unified.tsx
+++ b/apps/frontend/src/pages/activity/import/steps/mapping-step-unified.tsx
@@ -22,12 +22,19 @@ import {
   setParseConfig,
   setParsedData,
   setSelectedTemplate,
+  setSuppressLinkedTemplate,
   useImportContext,
 } from "../context";
 import { TemplatePicker } from "../components/template-picker";
 import { computeFieldMappings, useImportMapping } from "../hooks/use-import-mapping";
 import { isFieldMapped } from "../utils/draft-utils";
 import { validateTickerSymbol, findMappedActivityType } from "../utils/validation-utils";
+import {
+  createDefaultActivityMapping,
+  createDefaultParseConfig,
+  isDefaultActivityTemplateId,
+  prependDefaultActivityTemplate,
+} from "../utils/default-activity-template";
 
 import { isCashSymbol, needsImportAssetResolution } from "@/lib/activity-utils";
 import { IMPORT_REQUIRED_FIELDS, ImportFormat } from "@/lib/constants";
@@ -47,15 +54,25 @@ export function MappingStepUnified() {
     queryKey: [QueryKeys.ACCOUNTS],
     queryFn: () => getAccounts(),
   });
+  const selectedAccount = useMemo(
+    () => accounts.find((account) => account.id === accountId) ?? null,
+    [accountId, accounts],
+  );
+  const baselineParseConfig = useMemo(
+    () => createDefaultParseConfig(selectedAccount?.currency),
+    [selectedAccount?.currency],
+  );
 
   const { data: allTemplates = [] } = useQuery<ImportTemplateData[], Error>({
     queryKey: [QueryKeys.IMPORT_TEMPLATES],
     queryFn: listImportTemplates,
   });
   const templates = useMemo(
-    () => allTemplates.filter((t) => t.kind === ImportType.ACTIVITY),
+    () =>
+      prependDefaultActivityTemplate(allTemplates.filter((t) => t.kind === ImportType.ACTIVITY)),
     [allTemplates],
   );
+  const effectiveSelectedTemplateId = state.selectedTemplateId ?? templates[0]?.id ?? null;
 
   // Convert string[][] to CsvRowData[]
   const data: CsvRowData[] = useMemo(() => {
@@ -78,16 +95,7 @@ export function MappingStepUnified() {
     handleAccountIdMapping,
   } = useImportMapping({
     accountId,
-    defaultMapping: mapping || {
-      accountId: accountId || "",
-      importType: ImportType.ACTIVITY,
-      name: "",
-      fieldMappings: {},
-      activityMappings: {},
-      symbolMappings: {},
-      accountMappings: {},
-      symbolMappingMeta: {},
-    },
+    defaultMapping: mapping || createDefaultActivityMapping(accountId || ""),
   });
 
   // Sync localMapping to context whenever it changes (covers auto-detection, user edits, etc.)
@@ -456,6 +464,7 @@ export function MappingStepUnified() {
   const applyTemplate = useCallback(
     async (templateId: string) => {
       try {
+        const isDefaultTemplate = isDefaultActivityTemplateId(templateId);
         if (templateId === "__custom__") {
           dispatch(setSelectedTemplate(null, null));
           setTemplateError(null);
@@ -471,10 +480,14 @@ export function MappingStepUnified() {
         setTemplateError(null);
 
         let nextHeaders = headers;
-        let nextParseConfig: typeof state.parseConfig = {
-          ...state.parseConfig,
-          ...(template.parseConfig ?? {}),
-        };
+        let nextParseConfig: typeof state.parseConfig = isDefaultTemplate
+          ? baselineParseConfig
+          : template.parseConfig
+            ? ({ ...state.parseConfig, ...template.parseConfig } as typeof state.parseConfig)
+            : state.parseConfig;
+
+        dispatch(setParseConfig(nextParseConfig));
+        dispatch(setSuppressLinkedTemplate(false));
 
         if (state.file) {
           const parsed = await parseCsv(state.file, nextParseConfig);
@@ -486,15 +499,14 @@ export function MappingStepUnified() {
           dispatch(setParsedData(parsed.headers, parsed.rows));
         }
 
-        dispatch(setParseConfig(nextParseConfig));
         updateMapping({
           accountId: accountId || "",
-          name: template.name,
+          name: isDefaultActivityTemplateId(template.id) ? "" : template.name,
           fieldMappings: computeFieldMappings(nextHeaders, template.fieldMappings),
           activityMappings: template.activityMappings,
           symbolMappings: template.symbolMappings,
-          accountMappings: template.accountMappings,
-          symbolMappingMeta: template.symbolMappingMeta,
+          accountMappings: template.accountMappings || {},
+          symbolMappingMeta: template.symbolMappingMeta || {},
           parseConfig: template.parseConfig,
         });
         dispatch(setSelectedTemplate(template.id, template.scope));
@@ -504,7 +516,16 @@ export function MappingStepUnified() {
         );
       }
     },
-    [accountId, dispatch, headers, state.file, state.parseConfig, templates, updateMapping],
+    [
+      accountId,
+      baselineParseConfig,
+      dispatch,
+      headers,
+      state.file,
+      state.parseConfig,
+      templates,
+      updateMapping,
+    ],
   );
 
   const buildTemplatePayload = useCallback(
@@ -589,7 +610,7 @@ export function MappingStepUnified() {
             <Label>Template</Label>
             <TemplatePicker
               templates={templates}
-              selectedTemplateId={state.selectedTemplateId}
+              selectedTemplateId={effectiveSelectedTemplateId}
               onSelect={(id) => void applyTemplate(id)}
             />
           </div>
@@ -615,7 +636,9 @@ export function MappingStepUnified() {
             >
               {saveTemplateMutation.isPending
                 ? "Saving..."
-                : state.selectedTemplateId && state.selectedTemplateScope === "USER"
+                : state.selectedTemplateId &&
+                    !isDefaultActivityTemplateId(state.selectedTemplateId) &&
+                    state.selectedTemplateScope === "USER"
                   ? "Update Template"
                   : "Save Template"}
             </Button>

--- a/apps/frontend/src/pages/activity/import/steps/mapping-step-unified.tsx
+++ b/apps/frontend/src/pages/activity/import/steps/mapping-step-unified.tsx
@@ -35,6 +35,7 @@ import {
   isDefaultActivityTemplateId,
   prependDefaultActivityTemplate,
 } from "../utils/default-activity-template";
+import { mergeDetectedParseConfig } from "../utils/import-flow-utils";
 
 import { isCashSymbol, needsImportAssetResolution } from "@/lib/activity-utils";
 import { IMPORT_REQUIRED_FIELDS, ImportFormat } from "@/lib/constants";
@@ -492,11 +493,9 @@ export function MappingStepUnified() {
         if (state.file) {
           const parsed = await parseCsv(state.file, nextParseConfig);
           nextHeaders = parsed.headers;
-          nextParseConfig = {
-            ...nextParseConfig,
-            ...parsed.detectedConfig,
-          };
+          nextParseConfig = mergeDetectedParseConfig(nextParseConfig, parsed.detectedConfig);
           dispatch(setParsedData(parsed.headers, parsed.rows));
+          dispatch(setParseConfig(nextParseConfig));
         }
 
         updateMapping({
@@ -507,7 +506,7 @@ export function MappingStepUnified() {
           symbolMappings: template.symbolMappings,
           accountMappings: template.accountMappings || {},
           symbolMappingMeta: template.symbolMappingMeta || {},
-          parseConfig: template.parseConfig,
+          parseConfig: nextParseConfig,
         });
         dispatch(setSelectedTemplate(template.id, template.scope));
       } catch (error) {

--- a/apps/frontend/src/pages/activity/import/steps/upload-step.tsx
+++ b/apps/frontend/src/pages/activity/import/steps/upload-step.tsx
@@ -46,8 +46,16 @@ import {
   setParseConfig,
   setParsedData,
   setSelectedTemplate,
+  setSuppressLinkedTemplate,
 } from "../context/import-actions";
 import { useImportContext, type ParseConfig } from "../context/import-context";
+import {
+  createDefaultParseConfig,
+  createDefaultActivityTemplate,
+  createEmptyHoldingsMapping,
+  isDefaultActivityTemplateId,
+  prependDefaultActivityTemplate,
+} from "../utils/default-activity-template";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // CSV Preview Component
@@ -310,7 +318,7 @@ interface TemplateSelectorProps {
   templates: ImportTemplateData[];
   selectedTemplateId: string | null;
   onSelect: (templateId: string) => void;
-  onClear: () => void;
+  onClear?: () => void;
   config: ParseConfig;
   onConfigChange: (updates: Partial<ParseConfig>) => void;
   hasConfigErrors?: boolean;
@@ -486,6 +494,10 @@ export function UploadStep() {
   );
   const importType =
     selectedAccount?.trackingMode === "HOLDINGS" ? ImportType.HOLDINGS : ImportType.ACTIVITY;
+  const baselineParseConfig = useMemo(
+    () => createDefaultParseConfig(selectedAccount?.currency),
+    [selectedAccount?.currency],
+  );
 
   // Templates — filtered by the active import kind
   const { data: allTemplates = [] } = useQuery<ImportTemplateData[], Error>({
@@ -493,19 +505,28 @@ export function UploadStep() {
     queryFn: listImportTemplates,
   });
   const templates = useMemo(
-    () => allTemplates.filter((t) => t.kind === importType),
+    () =>
+      importType === ImportType.ACTIVITY
+        ? prependDefaultActivityTemplate(allTemplates.filter((t) => t.kind === importType))
+        : allTemplates.filter((t) => t.kind === importType),
     [allTemplates, importType],
   );
+  const effectiveSelectedTemplateId =
+    importType === ImportType.ACTIVITY
+      ? (state.selectedTemplateId ?? templates[0]?.id ?? null)
+      : state.selectedTemplateId;
 
   const applyTemplate = useCallback(
-    async (template: ImportTemplateData) => {
-      const nextParseConfig = template.parseConfig
-        ? { ...state.parseConfig, ...template.parseConfig }
-        : state.parseConfig;
+    async (template: ImportTemplateData, options?: { selectTemplate?: boolean }) => {
+      const selectTemplate = options?.selectTemplate ?? true;
+      const nextParseConfig =
+        importType === ImportType.ACTIVITY && isDefaultActivityTemplateId(template.id)
+          ? baselineParseConfig
+          : template.parseConfig
+            ? { ...state.parseConfig, ...template.parseConfig }
+            : state.parseConfig;
 
-      if (template.parseConfig) {
-        dispatch(setParseConfig(template.parseConfig));
-      }
+      dispatch(setParseConfig(nextParseConfig));
 
       // Re-parse with the template's config to get fresh headers, then compute mappings
       // so auto-detected columns (e.g., ISIN) are merged with the saved template mappings.
@@ -526,7 +547,7 @@ export function UploadStep() {
         setMapping({
           accountId: state.accountId || "",
           importType,
-          name: template.name,
+          name: isDefaultActivityTemplateId(template.id) ? "" : template.name,
           fieldMappings: computeFieldMappings(headers, template.fieldMappings),
           activityMappings: template.activityMappings,
           symbolMappings: template.symbolMappings,
@@ -535,17 +556,28 @@ export function UploadStep() {
           parseConfig: template.parseConfig,
         }),
       );
-      dispatch(setSelectedTemplate(template.id, template.scope));
+      if (selectTemplate) {
+        dispatch(setSelectedTemplate(template.id, template.scope));
+      }
     },
-    [dispatch, importType, state.accountId, state.file, state.parseConfig, state.headers],
+    [
+      baselineParseConfig,
+      dispatch,
+      importType,
+      state.accountId,
+      state.file,
+      state.parseConfig,
+      state.headers,
+    ],
   );
 
   const handleTemplateSelect = useCallback(
     async (templateId: string) => {
       const template = templates.find((t) => t.id === templateId);
       if (!template) return;
+      dispatch(setSuppressLinkedTemplate(false));
       await applyTemplate(template);
-      if (state.accountId) {
+      if (state.accountId && !isDefaultActivityTemplateId(template.id)) {
         linkAccountTemplate(state.accountId, templateId, importType).catch(() => {
           /* non-critical */
         });
@@ -555,8 +587,28 @@ export function UploadStep() {
   );
 
   const handleTemplateClear = useCallback(() => {
+    dispatch(setSuppressLinkedTemplate(true));
     dispatch(setSelectedTemplate(null, null));
-  }, [dispatch]);
+
+    if (importType === ImportType.ACTIVITY) {
+      void applyTemplate(createDefaultActivityTemplate(), { selectTemplate: false });
+      return;
+    }
+
+    dispatch(setParseConfig(baselineParseConfig));
+    dispatch(setMapping(createEmptyHoldingsMapping(state.accountId || "")));
+    if (state.file) {
+      parseCsv(state.file, baselineParseConfig)
+        .then((result) => {
+          setParseError(null);
+          dispatch(setParsedData(result.headers, result.rows));
+          dispatch(setParseConfig(result.detectedConfig));
+        })
+        .catch((error) => {
+          setParseError(error instanceof Error ? error.message : "Failed to parse CSV file");
+        });
+    }
+  }, [applyTemplate, baselineParseConfig, dispatch, importType, state.accountId, state.file]);
 
   // Auto-suggest linked template when account changes.
   // Two-phase approach: fetch the linked template ID, then apply once templates are loaded.
@@ -569,9 +621,33 @@ export function UploadStep() {
       setPendingLinkedTemplateId(null);
       // Clear the previous account's template so the new account's linked template can apply
       dispatch(setSelectedTemplate(null, null));
+      dispatch(setSuppressLinkedTemplate(false));
+      if (importType === ImportType.ACTIVITY) {
+        void applyTemplate(createDefaultActivityTemplate(), { selectTemplate: false });
+      } else {
+        dispatch(setParseConfig(baselineParseConfig));
+        dispatch(setMapping(createEmptyHoldingsMapping(state.accountId || "")));
+        if (state.file) {
+          parseCsv(state.file, baselineParseConfig)
+            .then((result) => {
+              setParseError(null);
+              dispatch(setParsedData(result.headers, result.rows));
+              dispatch(setParseConfig(result.detectedConfig));
+            })
+            .catch((error) => {
+              setParseError(error instanceof Error ? error.message : "Failed to parse CSV file");
+            });
+        }
+      }
     }
     // Skip if no account, or if a template is already selected and the account hasn't changed
-    if (!state.accountId || (state.selectedTemplateId && !accountChanged)) return;
+    if (
+      !state.accountId ||
+      state.suppressLinkedTemplate ||
+      (state.selectedTemplateId && !accountChanged)
+    ) {
+      return;
+    }
     getAccountImportMapping(state.accountId, importType)
       .then((mapping) => {
         setPendingLinkedTemplateId(mapping?.templateId ?? null);
@@ -580,7 +656,16 @@ export function UploadStep() {
         /* no saved mapping — ignore */
       });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state.accountId, importType]);
+  }, [
+    applyTemplate,
+    baselineParseConfig,
+    dispatch,
+    importType,
+    state.accountId,
+    state.file,
+    state.selectedTemplateId,
+    state.suppressLinkedTemplate,
+  ]);
 
   // Apply the pending linked template once the template list is available
   const applyTemplateRef = useRef(applyTemplate);
@@ -764,9 +849,13 @@ export function UploadStep() {
         </div>
         <TemplateSelector
           templates={templates}
-          selectedTemplateId={state.selectedTemplateId}
+          selectedTemplateId={effectiveSelectedTemplateId}
           onSelect={handleTemplateSelect}
-          onClear={handleTemplateClear}
+          onClear={
+            isDefaultActivityTemplateId(effectiveSelectedTemplateId)
+              ? undefined
+              : handleTemplateClear
+          }
           config={state.parseConfig}
           onConfigChange={handleConfigChange}
           hasConfigErrors={hasParseErrors}

--- a/apps/frontend/src/pages/activity/import/utils/activity-type-mapping.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/activity-type-mapping.test.ts
@@ -1,23 +1,44 @@
 import { describe, expect, it } from "vitest";
 import { ActivityType } from "@/lib/constants";
-import { findMappedActivityType, getSmartDefault } from "./activity-type-mapping";
+import { createDefaultActivityTemplate } from "./default-activity-template";
+import { findMappedActivityType } from "./activity-type-mapping";
 
 describe("activity-type-mapping", () => {
-  it("maps transfer out labels to TRANSFER_OUT before generic TRANSFER", () => {
-    expect(getSmartDefault("TRANSFER OUT")).toBe(ActivityType.TRANSFER_OUT);
-    expect(getSmartDefault("TRANSFER-OUT")).toBe(ActivityType.TRANSFER_OUT);
-    expect(getSmartDefault("TRANSFER_OUT")).toBe(ActivityType.TRANSFER_OUT);
+  it.each(Object.values(ActivityType).filter((type) => type !== ActivityType.UNKNOWN))(
+    "treats exact canonical %s labels as explicit identity mappings",
+    (type) => {
+      expect(findMappedActivityType(type, createDefaultActivityTemplate().activityMappings)).toBe(
+        type,
+      );
+    },
+  );
+
+  it("does not infer non-canonical labels without explicit mappings", () => {
+    expect(findMappedActivityType("TRANSFER OUT", {})).toBeNull();
+    expect(findMappedActivityType("PURCHASE", {})).toBeNull();
+    expect(findMappedActivityType("DIV", {})).toBeNull();
   });
 
-  it("keeps generic transfer mapping for ambiguous transfer labels", () => {
-    expect(getSmartDefault("TRANSFER")).toBe(ActivityType.TRANSFER_IN);
-    expect(getSmartDefault("TRANSFER BETWEEN ACCOUNTS")).toBe(ActivityType.TRANSFER_IN);
+  it("requires exact explicit label matches", () => {
+    expect(
+      findMappedActivityType("DIVIDEND QUALIFIED", {
+        [ActivityType.DIVIDEND]: ["DIVIDEND"],
+      }),
+    ).toBeNull();
   });
 
-  it("prioritizes explicit mappings over smart defaults", () => {
+  it("lets explicit mappings override matching labels", () => {
     const mapped = findMappedActivityType("TRANSFER OUT", {
       [ActivityType.DEPOSIT]: ["TRANSFER OUT"],
     });
     expect(mapped).toBe(ActivityType.DEPOSIT);
+  });
+
+  it("treats the selected template as the source of truth", () => {
+    expect(
+      findMappedActivityType("BUY", {
+        [ActivityType.DIVIDEND]: ["DIV"],
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/frontend/src/pages/activity/import/utils/activity-type-mapping.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/activity-type-mapping.test.ts
@@ -34,6 +34,22 @@ describe("activity-type-mapping", () => {
     expect(mapped).toBe(ActivityType.DEPOSIT);
   });
 
+  it("preserves legacy truncated mappings when the old prefix cuts mid-label", () => {
+    expect(
+      findMappedActivityType("DIVIDEND QUALIFIED", {
+        [ActivityType.DIVIDEND]: ["DIVIDEND_QUA"],
+      }),
+    ).toBe(ActivityType.DIVIDEND);
+  });
+
+  it("does not treat exact 12-character labels as legacy prefixes", () => {
+    expect(
+      findMappedActivityType("TRANSFER OUT FEE", {
+        [ActivityType.TRANSFER_OUT]: ["TRANSFER_OUT"],
+      }),
+    ).toBeNull();
+  });
+
   it("treats the selected template as the source of truth", () => {
     expect(
       findMappedActivityType("BUY", {

--- a/apps/frontend/src/pages/activity/import/utils/activity-type-mapping.ts
+++ b/apps/frontend/src/pages/activity/import/utils/activity-type-mapping.ts
@@ -1,83 +1,15 @@
 import { ActivityType } from "@/lib/constants";
 
-/**
- * Maps common CSV activity type labels to canonical Wealthfolio activity types.
- * Used for auto-detection during CSV import mapping.
- * Keys must be UPPERCASE.
- */
-export const ACTIVITY_TYPE_SMART_DEFAULTS: Record<string, ActivityType> = {
-  // BUY
-  BUY: ActivityType.BUY,
-  PURCHASE: ActivityType.BUY,
-  BOUGHT: ActivityType.BUY,
-  COVER: ActivityType.BUY,
-
-  // SELL
-  SELL: ActivityType.SELL,
-  SOLD: ActivityType.SELL,
-
-  // DIVIDEND
-  DIVIDEND: ActivityType.DIVIDEND,
-  DIV: ActivityType.DIVIDEND,
-  REINVEST: ActivityType.DIVIDEND,
-  REINVESTMENT: ActivityType.DIVIDEND,
-
-  // DEPOSIT
-  DEPOSIT: ActivityType.DEPOSIT,
-  CONTRIBUTION: ActivityType.DEPOSIT,
-
-  // WITHDRAWAL
-  WITHDRAWAL: ActivityType.WITHDRAWAL,
-  WITHDRAW: ActivityType.WITHDRAWAL,
-  SPEND: ActivityType.WITHDRAWAL,
-
-  // FEE
-  FEE: ActivityType.FEE,
-  COMMISSION: ActivityType.FEE,
-
-  // TAX
-  TAX: ActivityType.TAX,
-  WITHHOLDING: ActivityType.TAX,
-
-  // TRANSFER
-  TRANSFER_IN: ActivityType.TRANSFER_IN,
-  TRANSFER: ActivityType.TRANSFER_IN,
-  JOURNAL: ActivityType.TRANSFER_IN,
-  TRANSFER_OUT: ActivityType.TRANSFER_OUT,
-
-  // INTEREST
-  INTEREST: ActivityType.INTEREST,
-  INT: ActivityType.INTEREST,
-
-  // SPLIT
-  SPLIT: ActivityType.SPLIT,
-
-  // CREDIT
-  CREDIT: ActivityType.CREDIT,
-  BONUS: ActivityType.CREDIT,
-  CASHBACK: ActivityType.CREDIT,
-  REFUND: ActivityType.CREDIT,
-  REBATE: ActivityType.CREDIT,
-
-  // ADJUSTMENT
-  ADJUSTMENT: ActivityType.ADJUSTMENT,
-};
-
-function normalizeActivityLabel(value: string): string {
+export function normalizeActivityLabel(value: string): string {
   return value
     .trim()
     .toUpperCase()
     .replace(/[\s-]+/g, "_");
 }
 
-const SMART_DEFAULT_ENTRIES = Object.entries(ACTIVITY_TYPE_SMART_DEFAULTS);
-const PARTIAL_SMART_DEFAULT_ENTRIES = [...SMART_DEFAULT_ENTRIES].sort(
-  ([a], [b]) => b.length - a.length,
-);
-
 /**
  * Find the best activity type match for a CSV value.
- * Priority: explicit user mappings -> exact smart default -> partial smart default.
+ * Only explicit user/template mappings count as resolved.
  */
 export function findMappedActivityType(
   csvValue: string,
@@ -85,43 +17,9 @@ export function findMappedActivityType(
 ): ActivityType | null {
   const normalized = normalizeActivityLabel(csvValue);
 
-  // 1. Check explicit user mappings first
   for (const [activityType, csvValues] of Object.entries(activityMappings)) {
-    if (csvValues?.some((v) => normalized.startsWith(normalizeActivityLabel(v)))) {
+    if (csvValues?.some((v) => normalized === normalizeActivityLabel(v))) {
       return activityType as ActivityType;
-    }
-  }
-
-  // 2. Exact smart default match
-  if (ACTIVITY_TYPE_SMART_DEFAULTS[normalized]) {
-    return ACTIVITY_TYPE_SMART_DEFAULTS[normalized];
-  }
-
-  // 3. Partial smart default match (e.g., "BUY - MARKET" contains "BUY")
-  for (const [key, value] of PARTIAL_SMART_DEFAULT_ENTRIES) {
-    if (normalized.startsWith(key) || normalized.includes(key)) {
-      return value;
-    }
-  }
-
-  return null;
-}
-
-/**
- * Find activity type using only smart defaults (no explicit mappings).
- * Useful for auto-detection UI where you want to distinguish
- * "auto-detected" from "explicitly mapped".
- */
-export function getSmartDefault(csvValue: string): ActivityType | null {
-  const normalized = normalizeActivityLabel(csvValue);
-
-  if (ACTIVITY_TYPE_SMART_DEFAULTS[normalized]) {
-    return ACTIVITY_TYPE_SMART_DEFAULTS[normalized];
-  }
-
-  for (const [key, value] of PARTIAL_SMART_DEFAULT_ENTRIES) {
-    if (normalized.startsWith(key) || normalized.includes(key)) {
-      return value;
     }
   }
 

--- a/apps/frontend/src/pages/activity/import/utils/activity-type-mapping.ts
+++ b/apps/frontend/src/pages/activity/import/utils/activity-type-mapping.ts
@@ -1,5 +1,7 @@
 import { ActivityType } from "@/lib/constants";
 
+export const LEGACY_ACTIVITY_MAPPING_PREFIX_LENGTH = 12;
+
 export function normalizeActivityLabel(value: string): string {
   return value
     .trim()
@@ -7,21 +9,48 @@ export function normalizeActivityLabel(value: string): string {
     .replace(/[\s-]+/g, "_");
 }
 
+function isLegacyActivityLabelMatch(
+  normalizedCsvValue: string,
+  normalizedMappedValue: string,
+): boolean {
+  return (
+    normalizedMappedValue.length === LEGACY_ACTIVITY_MAPPING_PREFIX_LENGTH &&
+    normalizedCsvValue.length > LEGACY_ACTIVITY_MAPPING_PREFIX_LENGTH &&
+    normalizedCsvValue.startsWith(normalizedMappedValue) &&
+    !normalizedMappedValue.endsWith("_") &&
+    normalizedCsvValue[LEGACY_ACTIVITY_MAPPING_PREFIX_LENGTH] !== "_"
+  );
+}
+
 /**
  * Find the best activity type match for a CSV value.
  * Only explicit user/template mappings count as resolved.
+ * A narrow legacy fallback keeps old 12-character truncated mappings working
+ * without reintroducing broad prefix collisions like TRANSFER_OUT vs TRANSFER_OUT_FEE.
  */
 export function findMappedActivityType(
   csvValue: string,
   activityMappings: Record<string, string[]>,
 ): ActivityType | null {
   const normalized = normalizeActivityLabel(csvValue);
+  let legacyMatch: ActivityType | null = null;
 
   for (const [activityType, csvValues] of Object.entries(activityMappings)) {
-    if (csvValues?.some((v) => normalized === normalizeActivityLabel(v))) {
-      return activityType as ActivityType;
+    for (const value of csvValues ?? []) {
+      const normalizedValue = normalizeActivityLabel(value);
+
+      if (normalized === normalizedValue) {
+        return activityType as ActivityType;
+      }
+
+      if (isLegacyActivityLabelMatch(normalized, normalizedValue)) {
+        if (legacyMatch && legacyMatch !== activityType) {
+          return null;
+        }
+        legacyMatch = activityType as ActivityType;
+      }
     }
   }
 
-  return null;
+  return legacyMatch;
 }

--- a/apps/frontend/src/pages/activity/import/utils/default-activity-template.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/default-activity-template.test.ts
@@ -18,6 +18,12 @@ describe("default-activity-template", () => {
     },
   );
 
+  it("includes SPLIT in the code-defined default baseline", () => {
+    expect(createDefaultActivityTemplate().activityMappings[ActivityType.SPLIT]).toEqual([
+      ActivityType.SPLIT,
+    ]);
+  });
+
   it("creates a clean default activity mapping state", () => {
     expect(createDefaultActivityMapping("acc-1")).toMatchObject({
       accountId: "acc-1",

--- a/apps/frontend/src/pages/activity/import/utils/default-activity-template.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/default-activity-template.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { ActivityType } from "@/lib/constants";
+import type { ImportTemplateData } from "@/lib/types";
+import {
+  DEFAULT_ACTIVITY_TEMPLATE_ID,
+  createDefaultActivityMapping,
+  createDefaultParseConfig,
+  createDefaultActivityTemplate,
+  createEmptyHoldingsMapping,
+  prependDefaultActivityTemplate,
+} from "./default-activity-template";
+
+describe("default-activity-template", () => {
+  it.each(Object.values(ActivityType).filter((type) => type !== ActivityType.UNKNOWN))(
+    "includes canonical %s identity mappings",
+    (type) => {
+      expect(createDefaultActivityTemplate().activityMappings[type]).toEqual([type]);
+    },
+  );
+
+  it("creates a clean default activity mapping state", () => {
+    expect(createDefaultActivityMapping("acc-1")).toMatchObject({
+      accountId: "acc-1",
+      name: "",
+      fieldMappings: {},
+      symbolMappings: {},
+      accountMappings: {},
+    });
+  });
+
+  it("creates the baseline parse config for no-template imports", () => {
+    expect(createDefaultParseConfig("CAD")).toMatchObject({
+      delimiter: "auto",
+      dateFormat: "auto",
+      skipTopRows: 0,
+      skipBottomRows: 0,
+      defaultCurrency: "CAD",
+    });
+  });
+
+  it("creates an empty holdings mapping for template clear/reset", () => {
+    expect(createEmptyHoldingsMapping("acc-1")).toMatchObject({
+      accountId: "acc-1",
+      importType: "CSV_HOLDINGS",
+      fieldMappings: {},
+      symbolMappings: {},
+    });
+  });
+
+  it("prepends the code-defined default template once", () => {
+    const templates: ImportTemplateData[] = [
+      createDefaultActivityTemplate(),
+      {
+        id: "user-template",
+        name: "Broker CSV",
+        scope: "USER",
+        kind: "CSV_ACTIVITY",
+        fieldMappings: {},
+        activityMappings: {},
+        symbolMappings: {},
+        accountMappings: {},
+        symbolMappingMeta: {},
+      },
+    ];
+
+    const merged = prependDefaultActivityTemplate(templates);
+
+    expect(merged[0]?.id).toBe(DEFAULT_ACTIVITY_TEMPLATE_ID);
+    expect(merged.filter((template) => template.id === DEFAULT_ACTIVITY_TEMPLATE_ID)).toHaveLength(
+      1,
+    );
+  });
+});

--- a/apps/frontend/src/pages/activity/import/utils/default-activity-template.ts
+++ b/apps/frontend/src/pages/activity/import/utils/default-activity-template.ts
@@ -1,0 +1,82 @@
+import { ActivityType } from "@/lib/constants";
+import type { ImportMappingData, ImportTemplateData } from "@/lib/types";
+import { ImportType } from "@/lib/types";
+import type { ParseConfig } from "../context";
+
+export const DEFAULT_ACTIVITY_TEMPLATE_ID = "system_default_activity";
+
+export function createDefaultParseConfig(defaultCurrency = "USD"): ParseConfig {
+  return {
+    hasHeaderRow: true,
+    headerRowIndex: 0,
+    delimiter: "auto",
+    skipTopRows: 0,
+    skipBottomRows: 0,
+    skipEmptyRows: true,
+    dateFormat: "auto",
+    decimalSeparator: "auto",
+    thousandsSeparator: "auto",
+    defaultCurrency,
+  };
+}
+
+function createCanonicalActivityMappings(): Record<string, string[]> {
+  return Object.fromEntries(
+    Object.values(ActivityType)
+      .filter((type) => type !== ActivityType.UNKNOWN)
+      .map((type) => [type, [type]]),
+  );
+}
+
+export function createDefaultActivityTemplate(): ImportTemplateData {
+  return {
+    id: DEFAULT_ACTIVITY_TEMPLATE_ID,
+    name: "Default",
+    scope: "SYSTEM",
+    kind: ImportType.ACTIVITY,
+    fieldMappings: {},
+    activityMappings: createCanonicalActivityMappings(),
+    symbolMappings: {},
+    accountMappings: {},
+    symbolMappingMeta: {},
+  };
+}
+
+export function createDefaultActivityMapping(accountId = ""): ImportMappingData {
+  return {
+    accountId,
+    importType: ImportType.ACTIVITY,
+    name: "",
+    fieldMappings: {},
+    activityMappings: createDefaultActivityTemplate().activityMappings,
+    symbolMappings: {},
+    accountMappings: {},
+    symbolMappingMeta: {},
+  };
+}
+
+export function createEmptyHoldingsMapping(accountId = ""): ImportMappingData {
+  return {
+    accountId,
+    importType: ImportType.HOLDINGS,
+    name: "",
+    fieldMappings: {},
+    activityMappings: {},
+    symbolMappings: {},
+    accountMappings: {},
+    symbolMappingMeta: {},
+  };
+}
+
+export function prependDefaultActivityTemplate(
+  templates: ImportTemplateData[],
+): ImportTemplateData[] {
+  return [
+    createDefaultActivityTemplate(),
+    ...templates.filter((template) => template.id !== DEFAULT_ACTIVITY_TEMPLATE_ID),
+  ];
+}
+
+export function isDefaultActivityTemplateId(templateId: string | null): boolean {
+  return templateId === DEFAULT_ACTIVITY_TEMPLATE_ID;
+}

--- a/apps/frontend/src/pages/activity/import/utils/draft-utils.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/draft-utils.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { ActivityType, ImportFormat } from "@/lib/constants";
+import { createDraftActivities } from "./draft-utils";
+
+const headers = [
+  ImportFormat.DATE,
+  ImportFormat.ACTIVITY_TYPE,
+  ImportFormat.AMOUNT,
+  ImportFormat.CURRENCY,
+];
+
+const baseMapping = {
+  fieldMappings: {
+    [ImportFormat.DATE]: ImportFormat.DATE,
+    [ImportFormat.ACTIVITY_TYPE]: ImportFormat.ACTIVITY_TYPE,
+    [ImportFormat.AMOUNT]: ImportFormat.AMOUNT,
+    [ImportFormat.CURRENCY]: ImportFormat.CURRENCY,
+  },
+  activityMappings: {},
+  symbolMappings: {},
+  accountMappings: {},
+};
+
+const parseConfig = {
+  dateFormat: "auto",
+  decimalSeparator: "auto",
+  thousandsSeparator: "auto",
+  defaultCurrency: "USD",
+};
+
+function createSingleDraft(row: string[]) {
+  const [draft] = createDraftActivities([row], headers, baseMapping, parseConfig, "account-1");
+  expect(draft).toBeDefined();
+  return draft;
+}
+
+function createSingleDraftWithMapping(row: string[], activityMappings: Record<string, string[]>) {
+  const [draft] = createDraftActivities(
+    [row],
+    headers,
+    { ...baseMapping, activityMappings },
+    parseConfig,
+    "account-1",
+  );
+  expect(draft).toBeDefined();
+  return draft;
+}
+
+describe("createDraftActivities explicit activity mapping", () => {
+  it("keeps explicitly mapped withdrawal labels when amount is positive", () => {
+    const draft = createSingleDraftWithMapping(["2024-03-15", "WITHDRAWAL", "1000.00", "USD"], {
+      [ActivityType.WITHDRAWAL]: ["WITHDRAWAL"],
+    });
+
+    expect(draft.activityType).toBe(ActivityType.WITHDRAWAL);
+    expect(draft.amount).toBe("1000.00");
+  });
+
+  it("keeps explicitly mapped deposit labels when amount is negative", () => {
+    const draft = createSingleDraftWithMapping(["2024-03-15", "DEPOSIT", "-1000.00", "USD"], {
+      [ActivityType.DEPOSIT]: ["DEPOSIT"],
+    });
+
+    expect(draft.activityType).toBe(ActivityType.DEPOSIT);
+    expect(draft.amount).toBe("1000.00");
+  });
+
+  it("does not infer transfer direction from sign", () => {
+    const draft = createSingleDraftWithMapping(["2024-03-15", "TRANSFER", "-250.00", "USD"], {
+      [ActivityType.TRANSFER_IN]: ["TRANSFER"],
+    });
+
+    expect(draft.activityType).toBe(ActivityType.TRANSFER_IN);
+    expect(draft.amount).toBe("250.00");
+  });
+
+  it("marks rows as invalid until the activity type is explicitly mapped", () => {
+    const draft = createSingleDraft(["2024-03-15", "WITHDRAWAL", "1000.00", "USD"]);
+
+    expect(draft.activityType).toBeUndefined();
+    expect(draft.status).toBe("error");
+    expect(draft.errors.activityType).toContain("Activity type is required");
+  });
+});

--- a/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
@@ -25,6 +25,9 @@ import type { DraftActivity, DraftActivityStatus } from "../context";
 
 /** Sentinel value for activity types the user chooses to skip during import. */
 export const ACTIVITY_SKIP = "_SKIP_";
+const IMPORTABLE_ACTIVITY_TYPES = new Set<string>(
+  Object.values(ActivityType).filter((type) => type !== ActivityType.UNKNOWN),
+);
 
 // ---------------------------------------------------------------------------
 // Fallback-column helpers — support `string | string[]` in fieldMappings
@@ -108,14 +111,14 @@ export function parseDateValue(value: string | undefined, dateFormat: string): s
 
 /**
  * Map a CSV activity type value to a Wealthfolio activity type.
- * Uses findMappedActivityType which checks explicit mappings + smart defaults.
+ * Returns only explicit user/template mappings.
  */
 export function mapActivityType(
   csvValue: string | undefined,
   activityMappings: Record<string, string[]>,
 ): string | undefined {
   if (!csvValue) return undefined;
-  return findMappedActivityType(csvValue, activityMappings) ?? csvValue.trim();
+  return findMappedActivityType(csvValue, activityMappings) ?? undefined;
 }
 
 /**
@@ -178,6 +181,8 @@ export function validateDraft(draft: Partial<DraftActivity>): {
 
   if (!draft.activityType) {
     errors.activityType = ["Activity type is required"];
+  } else if (!IMPORTABLE_ACTIVITY_TYPES.has(draft.activityType.toUpperCase() as ActivityType)) {
+    errors.activityType = ["Map the CSV activity type before continuing"];
   }
 
   // SPLIT is a ratio event — currency is not meaningful
@@ -335,7 +340,6 @@ export function validateDraft(draft: Partial<DraftActivity>): {
 
   return { status, errors, warnings };
 }
-
 /**
  * Create DraftActivity objects from parsed CSV data and mapping
  */
@@ -414,22 +418,7 @@ export function createDraftActivities(
 
     // Parse and normalize values
     const activityDate = parseDateValue(rawDate, dateFormat);
-    let activityType = mapActivityType(rawType, activityMappings);
-
-    // Sign-based direction inference: peek at raw amount before sign is stripped.
-    // Flip DEPOSIT↔WITHDRAWAL when the CSV amount sign disagrees with the mapped type.
-    // Safe for all brokers — explicit labels already resolve correctly (no-op).
-    const rawAmountTrimmed = rawAmount?.trim();
-    const isNegativeRaw = rawAmountTrimmed?.startsWith("-") || rawAmountTrimmed?.startsWith("(");
-    if (isNegativeRaw && activityType === ActivityType.DEPOSIT) {
-      activityType = ActivityType.WITHDRAWAL;
-    } else if (!isNegativeRaw && rawAmountTrimmed && activityType === ActivityType.WITHDRAWAL) {
-      activityType = ActivityType.DEPOSIT;
-    } else if (isNegativeRaw && activityType === ActivityType.TRANSFER_IN) {
-      activityType = ActivityType.TRANSFER_OUT;
-    } else if (!isNegativeRaw && rawAmountTrimmed && activityType === ActivityType.TRANSFER_OUT) {
-      activityType = ActivityType.TRANSFER_IN;
-    }
+    const activityType = mapActivityType(rawType, activityMappings);
     const {
       symbol: mappedSymbol,
       exchangeMic: mappedExchangeMic,

--- a/apps/frontend/src/pages/activity/import/utils/import-flow-utils.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/import-flow-utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { mergeDetectedParseConfig, shouldUseSavedHoldingsMapping } from "./import-flow-utils";
+
+describe("import-flow-utils", () => {
+  it("keeps the final detected parse config after a template re-parse", () => {
+    expect(
+      mergeDetectedParseConfig(
+        {
+          hasHeaderRow: true,
+          headerRowIndex: 0,
+          delimiter: ",",
+          skipTopRows: 2,
+          skipBottomRows: 0,
+          skipEmptyRows: true,
+          dateFormat: "DD/MM/YYYY",
+          decimalSeparator: ",",
+          thousandsSeparator: ".",
+          defaultCurrency: "CAD",
+        },
+        {
+          delimiter: ";",
+          dateFormat: "YYYY-MM-DD",
+        },
+      ),
+    ).toMatchObject({
+      delimiter: ";",
+      dateFormat: "YYYY-MM-DD",
+      skipTopRows: 2,
+      decimalSeparator: ",",
+      defaultCurrency: "CAD",
+    });
+  });
+
+  it("restores saved holdings mappings unless the user explicitly cleared templates", () => {
+    expect(shouldUseSavedHoldingsMapping(false)).toBe(true);
+    expect(shouldUseSavedHoldingsMapping(true)).toBe(false);
+  });
+});

--- a/apps/frontend/src/pages/activity/import/utils/import-flow-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/import-flow-utils.ts
@@ -1,0 +1,15 @@
+import type { ParseConfig } from "../context";
+
+export function mergeDetectedParseConfig(
+  currentConfig: ParseConfig,
+  detectedConfig?: Partial<ParseConfig>,
+): ParseConfig {
+  return {
+    ...currentConfig,
+    ...(detectedConfig ?? {}),
+  };
+}
+
+export function shouldUseSavedHoldingsMapping(suppressLinkedTemplate: boolean): boolean {
+  return !suppressLinkedTemplate;
+}

--- a/apps/frontend/src/pages/activity/import/utils/validation-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/validation-utils.ts
@@ -12,6 +12,7 @@ import { logger } from "@/adapters";
 import { SUBTYPES_BY_ACTIVITY_TYPE, SUBTYPE_DISPLAY_NAMES } from "@/lib/constants";
 import { looksLikeOccSymbol, normalizeOptionSymbol } from "@/lib/occ-symbol";
 import { looksLikeIsin } from "@/lib/isin";
+import { findMappedActivityType } from "./activity-type-mapping";
 import { normalizeInstrumentType, splitInstrumentPrefixedSymbol } from "./instrument-type";
 
 // Ticker symbol validation regex
@@ -36,7 +37,7 @@ export function validateTickerSymbol(symbol: string): boolean {
 }
 
 // Re-export shared activity type mapping utilities
-export { ACTIVITY_TYPE_SMART_DEFAULTS, findMappedActivityType } from "./activity-type-mapping";
+export { findMappedActivityType };
 
 // Build reverse lookup from display names to subtype codes
 const DISPLAY_NAME_TO_SUBTYPE: Record<string, string> = {};
@@ -478,13 +479,8 @@ function transformRowToActivity(
 
   // 2. Determine Activity Type
   if (csvActivityType) {
-    const trimmedCsvType = csvActivityType.trim().toUpperCase();
-    for (const [appType, csvTypes] of Object.entries(mapping.activityMappings)) {
-      if (csvTypes?.some((ct) => trimmedCsvType.startsWith(ct.trim().toUpperCase()))) {
-        activity.activityType = appType as ActivityType;
-        break;
-      }
-    }
+    activity.activityType =
+      findMappedActivityType(csvActivityType, mapping.activityMappings) ?? activity.activityType;
   }
 
   // Validate subtype against allowed subtypes for the determined activity type

--- a/apps/tauri/tauri.conf.json
+++ b/apps/tauri/tauri.conf.json
@@ -32,7 +32,7 @@
   },
   "productName": "Wealthfolio",
   "mainBinaryName": "Wealthfolio",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "identifier": "com.teymz.wealthfolio",
   "plugins": {
     "updater": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wealthfolio-app",
   "private": true,
-  "version": "3.2.0",
+  "version": "3.2.1",
   "type": "module",
   "workspaces": [
     "apps/frontend",

--- a/packages/addon-dev-tools/package.json
+++ b/packages/addon-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/addon-dev-tools",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Development tools for Wealthfolio addons - hot reload server and CLI",
   "main": "index.js",
   "bin": {

--- a/packages/addon-sdk/package.json
+++ b/packages/addon-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/addon-sdk",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "type": "module",
   "description": "TypeScript SDK for building Wealthfolio addons with enhanced functionality and type safety",
   "main": "dist/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/ui",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "type": "module",
   "description": "Wealthfolio UI components based on shadcn/ui and Tailwind CSS",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Refactor activity type mapping: extract default mapping utility, normalize labels, simplify type signatures
- Add `suppressLinkedTemplate` to prevent auto-applying account-linked templates during import
- Add tests for default activity template, draft utils, and import mapping hook
- Bump version to 3.2.1 across all packages (Cargo, npm, Tauri)

## Test plan
- [x] `pnpm format:check` — passes
- [x] `pnpm type-check` — passes
- [x] `pnpm test` — 499 tests pass
- [x] `cargo fmt --check` — passes
- [x] `cargo clippy` — passes
- [x] `cargo test --workspace` — all tests pass
- [x] `pnpm build` — builds successfully