### PR TITLE
docs: expand CLAUDE.md with architecture, Docker, logs, and IPC guide

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,15 +1,23 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 ## Project Overview
 
-Wealthfolio - Desktop investment tracker with local-first data. React + Vite
-frontend, Tauri/Rust backend, SQLite storage.
+Wealthfolio — local-first desktop investment tracker. React + Vite frontend,
+Tauri/Rust backend, SQLite storage. Runs in two modes: **desktop** (Tauri
+native app) and **web** (Axum HTTP server + browser).
 
-Key directories:
+## Key Directories
 
-- `apps/frontend/` — React app (pages, components, commands, hooks)
-- `apps/tauri/` — Tauri desktop/mobile app (IPC commands)
-- `apps/server/` — Axum HTTP server (web mode)
-- `crates/` — Rust crates (core logic, storage, market-data, connect,
-  device-sync)
+- `apps/frontend/` — React app (pages, components, adapters, hooks)
+- `apps/tauri/` — Tauri desktop app (IPC command handlers, app lifecycle)
+- `apps/server/` — Axum HTTP server (web mode route handlers)
+- `crates/wealthfolio-core` — Database-agnostic domain logic, service traits, domain models
+- `crates/wealthfolio-storage-sqlite` — Diesel/SQLite implementations of core traits
+- `crates/wealthfolio-market-data` — Provider-agnostic quote fetching (Yahoo, Alpha Vantage, etc.)
+- `crates/wealthfolio-connect` — Cloud broker sync (feature-gated: `connect-sync`)
+- `crates/wealthfolio-device-sync` — E2EE device pairing/sync (feature-gated: `device-sync`)
 - `packages/` — Shared TS packages (addon-sdk, ui, addon-dev-tools)
 - `addons/` — Distributable addon plugins
 
@@ -18,16 +26,110 @@ Key directories:
 - Dev desktop: `pnpm tauri dev`
 - Dev web: `pnpm run dev:web`
 - Tests: `pnpm test` | `cargo test`
+- Single Rust test: `cargo test -p wealthfolio-core test_name`
 - Type check: `pnpm type-check`
 - Lint: `pnpm lint`
 
-## Plan Mode
+## Docker (web mode only)
 
-- Make the plan extremely concise. Sacrifice grammar for the sake of concision.
-- At the end of each plan, give me a list of unresolved questions to answer, if
-  any.
+Docker targets the **web mode** only — the desktop Tauri app requires native OS
+access. The Dockerfile is a multi-stage production build (not a dev environment).
+
+```bash
+docker build -t wealthfolio-web .
+docker run -e WF_LISTEN_ADDR=0.0.0.0:8080 -p 8080:8080 -v wf-data:/data wealthfolio-web
+```
+
+For development, use `pnpm run dev:web` (Vite + Axum with hot reload).
+Copy `.env.web.example` → `.env.web`. Required vars: `WF_SECRET_KEY`
+(`openssl rand -base64 32`) and `WF_AUTH_PASSWORD_HASH` (Argon2id hash).
+
+## Logs
+
+**Dev:** Rust logs print to the terminal; frontend logs go to browser DevTools.  
+**Tauri production:** macOS `~/Library/Logs/com.wealthfolio.app/`, Linux
+`~/.local/share/com.wealthfolio.app/logs/`, Windows `%APPDATA%\com.wealthfolio.app\logs\`  
+**Docker:** `docker logs <container>`
+
+## Architecture
+
+### Desktop vs Web modes
+
+Both modes share the same Rust service layer (`ServiceContext` / `AppState`),
+crates, and domain logic. Only the transport layer differs:
+
+| | Desktop | Web |
+|---|---|---|
+| Transport | Tauri IPC (`invoke()`) | HTTP REST (`/api/v1/*`) |
+| Events | Tauri events → `listen()` | SSE stream |
+| Auth | Keyring (local) | JWT cookies |
+| DB path | OS app-data dir | `WF_DB_PATH` env var |
+
+### Frontend adapter pattern
+
+`apps/frontend/src/adapters/` abstracts the transport. Vite's `resolve.alias`
+swaps the adapter at build time:
+- `adapters/tauri/` — wraps `invoke()` with 120s timeout
+- `adapters/web/` — wraps `fetch()` using a `COMMANDS → HTTP route` map
+
+Never call `invoke()` or `fetch()` directly from components — always go through
+adapters.
+
+### IPC: adding a new command
+
+1. Define the Rust handler in `apps/tauri/src/commands/<domain>.rs`:
+   ```rust
+   #[tauri::command]
+   pub async fn my_command(state: State<'_, Arc<ServiceContext>>) -> Result<T, String>
+   ```
+2. Register it in `apps/tauri/src/lib.rs` (`invoke_handler`)
+3. Add the Axum route in `apps/server/src/api/<domain>.rs`
+4. Add the adapter call in both `adapters/tauri/<domain>.ts` and
+   `adapters/web/<domain>.ts`
+
+### Rust crate boundaries
+
+- **core** — no database, no Diesel. Only traits, models, and business logic.
+- **storage-sqlite** — only crate with Diesel. Implements core traits.
+- **market-data** — stateless provider chain; no persistence.
+- **connect / device-sync** — optional via feature flags; depend on core only.
+
+Services are injected into `ServiceContext` at startup. Database writes go
+through a `WriteHandle` actor to prevent SQLite deadlocks.
+
+### Domain events
+
+Service mutations emit `DomainEvent` → async event sink → debounced queue
+worker → portfolio recalc + frontend notification (Tauri events or SSE).
+Frontend doesn't receive direct mutation results for state; it re-queries
+after events.
+
+### Key data model notes
+
+- All monetary values use `Decimal` (not `f64`)
+- `ActivityType`, `TrackingMode`, etc. are enums — not strings
+- `Activity.status = PENDING_REVIEW` blocks portfolio calculations
+- Holdings are derived from activities, not stored independently
+
+## Frontend Conventions
+
+- Component files: PascalCase. Directories: lowercase-with-dashes.
+- File order: component export → subcomponents → helpers → static content → types
+- State: TanStack Query for server state; no duplication into client stores
+- Router: TanStack Router
+
+## Rust Conventions
+
+- Error handling: `thiserror` for custom errors, `?` operator throughout
+- Async: `#[tokio::test]` for async tests
+- No `unwrap()` in production paths
 
 ---
+
+## Plan Mode
+
+Make plans extremely concise. Sacrifice grammar for concision. End each plan
+with a list of unresolved questions, if any.
 
 ## Behavioral Guidelines
 
@@ -36,69 +138,25 @@ tasks, use judgment.
 
 ### 1. Think Before Coding
 
-**Don't assume. Don't hide confusion. Surface tradeoffs.**
-
-Before implementing:
-
-- State your assumptions explicitly. If uncertain, ask.
-- If multiple interpretations exist, present them - don't pick silently.
-- If a simpler approach exists, say so. Push back when warranted.
-- If something is unclear, stop. Name what's confusing. Ask.
+Before implementing: state assumptions explicitly. If multiple interpretations
+exist, present them. If simpler approach exists, say so. If unclear, stop and ask.
 
 ### 2. Simplicity First
 
-**Minimum code that solves the problem. Nothing speculative.**
-
-- No features beyond what was asked.
-- No abstractions for single-use code.
-- No "flexibility" or "configurability" that wasn't requested.
-- No error handling for impossible scenarios.
-- If you write 200 lines and it could be 50, rewrite it.
-
-Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes,
-simplify.
+Minimum code that solves the problem. No speculative features, abstractions for
+single-use code, or error handling for impossible scenarios. If you write 200
+lines and it could be 50, rewrite it.
 
 ### 3. Surgical Changes
 
-**Touch only what you must. Clean up only your own mess.**
-
-When editing existing code:
-
-- Don't "improve" adjacent code, comments, or formatting.
-- Don't refactor things that aren't broken.
-- Match existing style, even if you'd do it differently.
-- If you notice unrelated dead code, mention it - don't delete it.
-
-When your changes create orphans:
-
-- Remove imports/variables/functions that YOUR changes made unused.
-- Don't remove pre-existing dead code unless asked.
-
-The test: Every changed line should trace directly to the user's request.
+Touch only what you must. Don't improve adjacent code. Match existing style.
+Remove imports/variables YOUR changes made unused, but not pre-existing dead code.
 
 ### 4. Goal-Driven Execution
 
-**Define success criteria. Loop until verified.**
-
-Transform tasks into verifiable goals:
-
-- "Add validation" → "Write tests for invalid inputs, then make them pass"
-- "Fix the bug" → "Write a test that reproduces it, then make it pass"
-- "Refactor X" → "Ensure tests pass before and after"
-
-For multi-step tasks, state a brief plan:
+Transform tasks into verifiable goals. For multi-step tasks:
 
 ```
 1. [Step] → verify: [check]
 2. [Step] → verify: [check]
-3. [Step] → verify: [check]
 ```
-
-Strong success criteria let you loop independently. Weak criteria ("make it
-work") require constant clarification.
-
----
-
-**These guidelines are working if:** fewer unnecessary changes in diffs, fewer
-rewrites due to overcomplication, and clarifying questions come before
-implementation rather than after mistakes.


### PR DESCRIPTION
## Summary

Expands `.claude/CLAUDE.md` with missing technical context that helps AI assistants (and new contributors) understand the project faster.

- Document each Rust crate's responsibility and boundaries (`core`, `storage-sqlite`, `market-data`, `connect`, `device-sync`)
- Add frontend adapter pattern explanation and step-by-step guide for adding a new IPC command
- Add desktop vs web mode comparison table (transport, events, auth, DB path)
- Add Docker section (web mode only, production builds, required env vars)
- Add logs section (dev, Tauri production paths per OS, Docker)
- Add frontend and Rust conventions (naming, file order, TanStack Query, `thiserror`, no `unwrap()`)
- Condense behavioral guidelines for brevity while preserving intent

Closes #823

## Test plan

- [ ] Read through the updated CLAUDE.md and verify all information is accurate
- [ ] Verify Docker commands work against the existing Dockerfile
- [ ] Verify log paths are correct per platform