### PR TITLE
feat(ai): add Claude Subscription provider via local Claude Code

### DIFF
--- a/apps/frontend/src/features/ai-assistant/components/model-picker.tsx
+++ b/apps/frontend/src/features/ai-assistant/components/model-picker.tsx
@@ -30,6 +30,12 @@ export const ModelPicker: FC = () => {
     const favoriteIds = currentProvider.favoriteModels ?? [];
     const allModels: MergedModel[] = currentProvider.models ?? [];
 
+    // Subscription providers (e.g. Claude via Claude Code) have a small fixed
+    // model set — always show all of them regardless of favorites.
+    if (currentProvider.type === "subscription") {
+      return allModels;
+    }
+
     // If no favorites set, fall back to all catalog models
     if (favoriteIds.length === 0) {
       return allModels;

--- a/apps/frontend/src/features/ai-assistant/components/provider-settings-card.tsx
+++ b/apps/frontend/src/features/ai-assistant/components/provider-settings-card.tsx
@@ -39,6 +39,12 @@ interface ProviderSettingsCardProps {
   onSetCapabilityOverride?: (modelId: string, overrides: ModelCapabilityOverrides | null) => void;
   onToolsAllowlistChange?: (tools: string[] | null) => void;
   isLast?: boolean;
+  /**
+   * For the Anthropic provider card, the related "Claude (Subscription)"
+   * provider state, surfaced as an embedded sub-mode toggle.
+   */
+  subscriptionProvider?: MergedProvider | null;
+  onToggleSubscription?: (enabled: boolean) => void;
   // Model fetching props (controlled by parent via React Query)
   modelComboboxOpen?: boolean;
   onModelComboboxOpenChange?: (open: boolean) => void;
@@ -85,6 +91,9 @@ export function ProviderSettingsCard({
   onSetCapabilityOverride,
   onToolsAllowlistChange,
   isLast = false,
+  // Embedded sub-provider (Claude Subscription inside Anthropic)
+  subscriptionProvider,
+  onToggleSubscription,
   // Model fetching props
   modelComboboxOpen: controlledComboboxOpen,
   onModelComboboxOpenChange,
@@ -390,6 +399,61 @@ export function ProviderSettingsCard({
                         Save
                       </Button>
                     </div>
+                  </div>
+                </div>
+              )}
+
+              {/* Claude Code Subscription — embedded sub-mode of Anthropic.
+                  Lets the user authenticate Claude through their local Claude Code
+                  (Pro/Max) install instead of, or alongside, an API key. */}
+              {provider.id === "anthropic" && subscriptionProvider && (
+                <div className="border-primary/15 bg-primary/5 rounded-lg border border-dashed p-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1 space-y-1.5">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Label
+                          htmlFor="claude-subscription-toggle"
+                          className="text-sm font-medium"
+                        >
+                          Claude Code Subscription
+                        </Label>
+                        <Badge
+                          variant="outline"
+                          className="h-5 px-1.5 text-[10px] font-normal"
+                        >
+                          Alternative to API key
+                        </Badge>
+                        {subscriptionProvider.enabled && (
+                          <Badge
+                            variant="outline"
+                            className="border-success/30 bg-success/10 text-success h-5 px-1.5 text-[10px] font-normal"
+                          >
+                            Active
+                          </Badge>
+                        )}
+                      </div>
+                      <p className="text-muted-foreground text-xs leading-relaxed">
+                        Use Claude through your local Claude Code (Pro / Max)
+                        subscription. No API key required, no per-token billing —
+                        usage is covered by your existing Claude plan. Requires
+                        Claude Code to be installed and logged in on this machine.
+                      </p>
+                      {subscriptionProvider.enabled && (
+                        <p className="text-muted-foreground flex items-center gap-1.5 pt-1 text-xs">
+                          <Icons.Sparkles className="h-3 w-3" />
+                          Selectable in chat as{" "}
+                          <span className="text-foreground font-medium">
+                            Claude (Subscription)
+                          </span>
+                        </p>
+                      )}
+                    </div>
+                    <Switch
+                      id="claude-subscription-toggle"
+                      checked={subscriptionProvider.enabled}
+                      onCheckedChange={(enabled) => onToggleSubscription?.(enabled)}
+                      className="data-[state=checked]:bg-success mt-1 shrink-0"
+                    />
                   </div>
                 </div>
               )}

--- a/apps/frontend/src/features/ai-assistant/hooks/use-chat-model.ts
+++ b/apps/frontend/src/features/ai-assistant/hooks/use-chat-model.ts
@@ -109,8 +109,11 @@ export function useChatModel(): ChatModelState {
   // Ensure resolved model is accessible in the provider's favorites.
   // ModelPicker filters by favorites — if the resolved model isn't among them,
   // the picker shows "No model" while the hook sends a different model to the backend.
+  // Subscription providers show all catalog models (not filtered by favorites),
+  // so skip the adjustment for them.
   const adjustedModelId = useMemo(() => {
     if (!currentModelId) return currentModelId;
+    if (currentProvider?.type === "subscription") return currentModelId;
     if (!currentProvider?.favoriteModels?.length) return currentModelId;
     if (currentProvider.favoriteModels.includes(currentModelId)) return currentModelId;
     return currentProvider.favoriteModels[0];

--- a/apps/frontend/src/features/ai-assistant/hooks/use-chat-model.ts
+++ b/apps/frontend/src/features/ai-assistant/hooks/use-chat-model.ts
@@ -50,6 +50,9 @@ export function useChatModel(): ChatModelState {
         if (!p.enabled) return false;
         // Local providers don't need API keys
         if (p.type === "local") return true;
+        // Subscription providers (e.g. Claude via Claude Code) authenticate
+        // through the host environment, not an API key.
+        if (p.type === "subscription") return true;
         // API providers require an API key
         return p.hasApiKey;
       }) ?? []

--- a/apps/frontend/src/features/ai-assistant/hooks/use-provider-picker.ts
+++ b/apps/frontend/src/features/ai-assistant/hooks/use-provider-picker.ts
@@ -35,6 +35,9 @@ export function useProviderPicker(): UseProviderPickerResult {
         if (!p.enabled) return false;
         // Local providers don't need API keys
         if (p.type === "local") return true;
+        // Subscription providers (e.g. Claude via Claude Code) authenticate
+        // through the host environment, not an API key.
+        if (p.type === "subscription") return true;
         // API providers require an API key
         return p.hasApiKey;
       }) ?? []

--- a/apps/frontend/src/pages/settings/ai-providers/ai-providers-page.tsx
+++ b/apps/frontend/src/pages/settings/ai-providers/ai-providers-page.tsx
@@ -25,6 +25,23 @@ export default function AiProvidersPage() {
 
   const providers = useMemo(() => data?.providers ?? [], [data?.providers]);
 
+  // The `claude-subscription` provider is rendered as an embedded sub-mode
+  // inside the Anthropic card, so it's filtered out of the top-level list and
+  // surfaced to the Anthropic card via props.
+  const { sortedProviders, claudeSubscriptionProvider } = useMemo(() => {
+    let claudeSubscription: (typeof providers)[number] | null = null;
+    const visible: typeof providers = [];
+    for (const p of providers) {
+      if (p.id === "claude-subscription") {
+        claudeSubscription = p;
+      } else {
+        visible.push(p);
+      }
+    }
+    visible.sort((a, b) => a.priority - b.priority);
+    return { sortedProviders: visible, claudeSubscriptionProvider: claudeSubscription };
+  }, [providers]);
+
   const handleCustomUrlChange = (providerId: string, customUrl: string) => {
     updateSettings({ providerId, customUrl });
   };
@@ -110,8 +127,6 @@ export default function AiProvidersPage() {
     );
   }
 
-  const sortedProviders = [...providers].sort((a, b) => a.priority - b.priority);
-
   return (
     <div className="text-foreground space-y-6">
       <SettingsHeader
@@ -144,6 +159,15 @@ export default function AiProvidersPage() {
                   handleSetCapabilityOverride(provider.id, modelId, overrides)
                 }
                 onToolsAllowlistChange={(tools) => handleToolsAllowlistChange(provider.id, tools)}
+                subscriptionProvider={
+                  provider.id === "anthropic" ? claudeSubscriptionProvider : null
+                }
+                onToggleSubscription={
+                  provider.id === "anthropic"
+                    ? (enabled) =>
+                        updateSettings({ providerId: "claude-subscription", enabled })
+                    : undefined
+                }
               />
             ))}
           </div>
@@ -166,6 +190,8 @@ function ProviderSettingsCardWrapper({
   onSetFavoriteModels,
   onSetCapabilityOverride,
   onToolsAllowlistChange,
+  subscriptionProvider,
+  onToggleSubscription,
 }: {
   provider: Parameters<typeof ProviderSettingsCard>[0]["provider"];
   isLast: boolean;
@@ -176,6 +202,8 @@ function ProviderSettingsCardWrapper({
   onSetFavoriteModels: (modelIds: string[]) => void;
   onSetCapabilityOverride: (modelId: string, overrides: ModelCapabilityOverrides | null) => void;
   onToolsAllowlistChange: (tools: string[] | null) => void;
+  subscriptionProvider?: Parameters<typeof ProviderSettingsCard>[0]["provider"] | null;
+  onToggleSubscription?: (enabled: boolean) => void;
 }) {
   const { setApiKey, deleteApiKey, revealApiKey } = useAiProviderApiKey(provider.id);
   const [modelComboboxOpen, setModelComboboxOpen] = useState(false);
@@ -209,6 +237,8 @@ function ProviderSettingsCardWrapper({
       onSetFavoriteModels={onSetFavoriteModels}
       onSetCapabilityOverride={onSetCapabilityOverride}
       onToolsAllowlistChange={onToolsAllowlistChange}
+      subscriptionProvider={subscriptionProvider}
+      onToggleSubscription={onToggleSubscription}
       modelComboboxOpen={modelComboboxOpen}
       onModelComboboxOpenChange={setModelComboboxOpen}
       fetchedModels={fetchedModels}

--- a/apps/tauri/sidecars/claude-agent-bridge/bridge.mjs
+++ b/apps/tauri/sidecars/claude-agent-bridge/bridge.mjs
@@ -1,0 +1,502 @@
+// Wealthfolio Claude Subscription Bridge
+//
+// A long-running Node sidecar process. Reads NDJSON commands from stdin,
+// writes NDJSON events to stdout. Talks to Claude via @anthropic-ai/claude-agent-sdk,
+// which uses the user's locally-installed, logged-in Claude Code as the auth
+// source — no API key needed.
+//
+// === Protocol ===
+//
+// Each line on stdin is a JSON object with a `type` field. Lines on stdout
+// are also JSON objects with a `type` field.
+//
+// Commands (stdin):
+//   {type:"ping", id}
+//   {type:"start_query", threadId, prompt, systemPrompt?, toolDefs?, maxTurns?, cwd?}
+//   {type:"tool_result", threadId, toolCallId, ok, content?, error?}
+//   {type:"cancel", threadId}
+//   {type:"shutdown"}
+//
+// Events (stdout):
+//   {type:"pong", id}
+//   {type:"system",   threadId, sessionId, model, tools}
+//   {type:"text_delta",       threadId, text}
+//   {type:"reasoning_delta",  threadId, text}
+//   {type:"tool_call",        threadId, toolCallId, name, args}     // parent must reply with tool_result
+//   {type:"tool_result_ack",  threadId, toolCallId}                 // sidecar acknowledges receipt
+//   {type:"rate_limit",       threadId, status, resetsAt}
+//   {type:"usage",            threadId, inputTokens, outputTokens, estimatedCostUsd}
+//   {type:"error",            threadId|null, message, recoverable}
+//   {type:"done",             threadId, sessionId, ok, totalTokens, totalCostUsd}
+//
+// === Tool bridging ===
+//
+// The parent (Rust) supplies a list of tool definitions in `start_query.toolDefs`.
+// Each one becomes an in-process MCP tool registered with the Agent SDK via
+// createSdkMcpServer/tool(). When Claude calls one, the sidecar emits a
+// `tool_call` event to stdout and AWAITS a matching `tool_result` from stdin
+// (correlated by toolCallId). The result is returned to Claude.
+//
+// The sidecar passes `tools: []` to query() so the default Claude Code tools
+// (Bash, Edit, etc.) are NOT exposed — only the Wealthfolio MCP tools.
+
+import readline from 'node:readline';
+import { randomUUID } from 'node:crypto';
+import {
+  query,
+  createSdkMcpServer,
+  tool,
+} from '@anthropic-ai/claude-agent-sdk';
+import { z } from 'zod';
+
+// ───────────────────────────────────────────────────────────────────────────
+// I/O helpers
+// ───────────────────────────────────────────────────────────────────────────
+
+const stdoutLock = { busy: false, queue: [] };
+
+function send(obj) {
+  // Serialize writes so concurrent emitters can't interleave a single line.
+  const line = JSON.stringify(obj) + '\n';
+  if (stdoutLock.busy) {
+    stdoutLock.queue.push(line);
+    return;
+  }
+  stdoutLock.busy = true;
+  process.stdout.write(line, () => {
+    stdoutLock.busy = false;
+    if (stdoutLock.queue.length > 0) {
+      const next = stdoutLock.queue.shift();
+      stdoutLock.busy = true;
+      process.stdout.write(next, () => {
+        stdoutLock.busy = false;
+      });
+    }
+  });
+}
+
+function logErr(...args) {
+  // stderr is for sidecar diagnostics only — never used for protocol.
+  process.stderr.write('[bridge] ' + args.map(String).join(' ') + '\n');
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// State
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * threadId -> {
+ *   abortController: AbortController,
+ *   pendingTools: Map<toolCallId, { resolve, reject }>,
+ * }
+ */
+const activeThreads = new Map();
+
+function getThread(threadId) {
+  return activeThreads.get(threadId);
+}
+
+function endThread(threadId) {
+  const t = activeThreads.get(threadId);
+  if (!t) return;
+  // Reject any tool calls still waiting on the parent.
+  for (const [, pending] of t.pendingTools) {
+    pending.reject(new Error('thread ended before tool result arrived'));
+  }
+  t.pendingTools.clear();
+  activeThreads.delete(threadId);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Tool bridging
+// ───────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build an MCP tool object that, when called by Claude, sends a tool_call
+ * event to the parent and awaits a matching tool_result.
+ *
+ * @param {string} threadId
+ * @param {{name: string, description: string, inputSchema: object}} def
+ */
+function buildBridgedTool(threadId, def) {
+  // The Agent SDK's tool() helper takes a Zod schema. Since the parent already
+  // supplies a JSON Schema (from rig-core's ToolDefinition), we accept any
+  // shape and rely on the parent (which knows the real schema) to validate.
+  // Zod's z.any() satisfies the SDK's type requirement without constraining input.
+  const inputZod = z.any();
+
+  return tool(
+    def.name,
+    def.description ?? '',
+    // The SDK expects an object whose values are Zod schemas (a "shape").
+    // Wrap everything under a single passthrough field that captures the raw args.
+    { args: inputZod },
+    async (input) => {
+      // input is `{args: <whatever Claude passed>}`. Unwrap it.
+      const args = input?.args ?? input ?? {};
+      const t = getThread(threadId);
+      if (!t) {
+        return {
+          content: [
+            { type: 'text', text: 'error: thread is no longer active' },
+          ],
+          isError: true,
+        };
+      }
+
+      const toolCallId = randomUUID();
+      const promise = new Promise((resolve, reject) => {
+        t.pendingTools.set(toolCallId, { resolve, reject });
+      });
+
+      send({
+        type: 'tool_call',
+        threadId,
+        toolCallId,
+        name: def.name,
+        args,
+      });
+
+      try {
+        const result = await promise;
+        // result: { ok: bool, content?: string|object, error?: string }
+        if (result.ok === false) {
+          return {
+            content: [
+              { type: 'text', text: String(result.error ?? 'tool failed') },
+            ],
+            isError: true,
+          };
+        }
+        const content = result.content;
+        const text =
+          typeof content === 'string'
+            ? content
+            : JSON.stringify(content ?? null);
+        return { content: [{ type: 'text', text }] };
+      } catch (err) {
+        return {
+          content: [{ type: 'text', text: 'tool bridge error: ' + (err?.message ?? err) }],
+          isError: true,
+        };
+      }
+    }
+  );
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Commands
+// ───────────────────────────────────────────────────────────────────────────
+
+async function handlePing(cmd) {
+  send({ type: 'pong', id: cmd.id });
+}
+
+async function handleStartQuery(cmd) {
+  const { threadId, prompt, systemPrompt, toolDefs = [], maxTurns, cwd } = cmd;
+
+  if (!threadId || typeof prompt !== 'string') {
+    send({
+      type: 'error',
+      threadId: threadId ?? null,
+      message: 'start_query requires threadId and prompt',
+      recoverable: false,
+    });
+    return;
+  }
+
+  if (activeThreads.has(threadId)) {
+    send({
+      type: 'error',
+      threadId,
+      message: 'thread already active',
+      recoverable: false,
+    });
+    return;
+  }
+
+  const abortController = new AbortController();
+  const state = {
+    abortController,
+    pendingTools: new Map(),
+  };
+  activeThreads.set(threadId, state);
+
+  // Build in-process MCP server with the parent's tool definitions.
+  const bridgedTools = toolDefs.map((def) => buildBridgedTool(threadId, def));
+  const mcpServer =
+    bridgedTools.length > 0
+      ? createSdkMcpServer({
+          name: 'wealthfolio-tools',
+          version: '0.1.0',
+          tools: bridgedTools,
+        })
+      : null;
+
+  // Built-in Claude Code tools we expose to the model.
+  // SAFE for a finance app:
+  //   - WebSearch / WebFetch are read-only network reads (look up tickers, news, etc.)
+  // EXPLICITLY EXCLUDED for safety:
+  //   - Bash, Read, Write, Edit, Glob, Grep (filesystem / shell access)
+  //   - Agent (could spawn subagents that transitively access dangerous tools)
+  //   - AskUserQuestion (would prompt the host CC terminal, not our chat UI)
+  const SAFE_BUILTIN_TOOLS = ['WebSearch', 'WebFetch'];
+
+  // The MCP server registers tools under names prefixed by `mcp__<server>__<toolName>`.
+  // We must explicitly allowlist them or the SDK won't expose them to the model.
+  const mcpToolNames = bridgedTools.length > 0
+    ? toolDefs.map((d) => `mcp__wealthfolio-tools__${d.name}`)
+    : [];
+  const allowedTools = [...SAFE_BUILTIN_TOOLS, ...mcpToolNames];
+
+  const options = {
+    // Whitelist only safe read-only built-in tools (web access). Bash, Edit,
+    // Read, Write, Glob, Grep, Agent, AskUserQuestion are dropped.
+    tools: SAFE_BUILTIN_TOOLS,
+    allowedTools,
+    settingSources: [],
+    // Pre-approved allowlist model: any tool not on `allowedTools` is denied.
+    permissionMode: 'dontAsk',
+    abortController,
+  };
+
+  if (mcpServer) {
+    options.mcpServers = { 'wealthfolio-tools': mcpServer };
+  }
+  if (systemPrompt) {
+    options.systemPrompt = systemPrompt;
+  }
+  if (typeof maxTurns === 'number') {
+    options.maxTurns = maxTurns;
+  }
+  if (cwd) {
+    options.cwd = cwd;
+  }
+
+  let sessionId = null;
+  let totalTokens = 0;
+  let totalCostUsd = 0;
+  let ok = false;
+  let lastError = null;
+
+  try {
+    const stream = query({ prompt, options });
+
+    for await (const message of stream) {
+      if (!activeThreads.has(threadId)) break; // cancelled
+
+      switch (message?.type) {
+        case 'system': {
+          if (message.subtype === 'init') {
+            sessionId = message.session_id ?? null;
+            send({
+              type: 'system',
+              threadId,
+              sessionId,
+              model: message.model ?? null,
+              tools: Array.isArray(message.tools) ? message.tools : [],
+            });
+          }
+          break;
+        }
+
+        case 'assistant': {
+          // Streamed assistant content blocks.
+          const blocks = message?.message?.content;
+          if (Array.isArray(blocks)) {
+            for (const block of blocks) {
+              if (block?.type === 'text' && typeof block.text === 'string') {
+                send({ type: 'text_delta', threadId, text: block.text });
+              } else if (block?.type === 'thinking' && typeof block.thinking === 'string') {
+                send({ type: 'reasoning_delta', threadId, text: block.thinking });
+              }
+              // tool_use blocks are NOT forwarded as text — the SDK invokes
+              // the bridged MCP tool directly, which emits its own tool_call event.
+            }
+          }
+          // Per-message usage hints.
+          const usage = message?.message?.usage;
+          if (usage) {
+            send({
+              type: 'usage',
+              threadId,
+              inputTokens: usage.input_tokens ?? 0,
+              outputTokens: usage.output_tokens ?? 0,
+              estimatedCostUsd: 0, // final cost arrives in the result message
+            });
+          }
+          break;
+        }
+
+        case 'rate_limit_event': {
+          const info = message.rate_limit_info ?? {};
+          send({
+            type: 'rate_limit',
+            threadId,
+            status: info.status ?? 'unknown',
+            resetsAt: info.resetsAt ?? null,
+          });
+          break;
+        }
+
+        case 'result': {
+          ok = !message.is_error;
+          sessionId = message.session_id ?? sessionId;
+          totalCostUsd = message.total_cost_usd ?? 0;
+          if (message.usage) {
+            totalTokens =
+              (message.usage.input_tokens ?? 0) +
+              (message.usage.output_tokens ?? 0);
+          }
+          if (message.is_error) {
+            lastError = message.error?.message ?? 'query failed';
+          }
+          break;
+        }
+
+        default:
+          // Unknown message types are ignored — keeps us forward-compatible.
+          break;
+      }
+    }
+  } catch (err) {
+    lastError = err?.message ?? String(err);
+    logErr('start_query error:', lastError);
+  } finally {
+    if (lastError) {
+      send({
+        type: 'error',
+        threadId,
+        message: lastError,
+        recoverable: false,
+      });
+    }
+    send({
+      type: 'done',
+      threadId,
+      sessionId,
+      ok,
+      totalTokens,
+      totalCostUsd,
+    });
+    endThread(threadId);
+  }
+}
+
+function handleToolResult(cmd) {
+  const { threadId, toolCallId } = cmd;
+  const t = getThread(threadId);
+  if (!t) {
+    send({
+      type: 'error',
+      threadId,
+      message: `tool_result for unknown thread ${threadId}`,
+      recoverable: true,
+    });
+    return;
+  }
+  const pending = t.pendingTools.get(toolCallId);
+  if (!pending) {
+    send({
+      type: 'error',
+      threadId,
+      message: `tool_result for unknown toolCallId ${toolCallId}`,
+      recoverable: true,
+    });
+    return;
+  }
+  t.pendingTools.delete(toolCallId);
+  pending.resolve({
+    ok: cmd.ok !== false,
+    content: cmd.content,
+    error: cmd.error,
+  });
+  send({ type: 'tool_result_ack', threadId, toolCallId });
+}
+
+function handleCancel(cmd) {
+  const t = getThread(cmd.threadId);
+  if (!t) return;
+  try {
+    t.abortController.abort();
+  } catch (err) {
+    logErr('abort failed:', err?.message ?? err);
+  }
+  endThread(cmd.threadId);
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Main loop
+// ───────────────────────────────────────────────────────────────────────────
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  crlfDelay: Infinity,
+});
+
+rl.on('line', (line) => {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+  let cmd;
+  try {
+    cmd = JSON.parse(trimmed);
+  } catch (err) {
+    send({
+      type: 'error',
+      threadId: null,
+      message: 'invalid json on stdin: ' + (err?.message ?? err),
+      recoverable: true,
+    });
+    return;
+  }
+
+  switch (cmd.type) {
+    case 'ping':
+      handlePing(cmd);
+      break;
+    case 'start_query':
+      handleStartQuery(cmd).catch((err) =>
+        send({
+          type: 'error',
+          threadId: cmd.threadId ?? null,
+          message: err?.message ?? String(err),
+          recoverable: false,
+        })
+      );
+      break;
+    case 'tool_result':
+      handleToolResult(cmd);
+      break;
+    case 'cancel':
+      handleCancel(cmd);
+      break;
+    case 'shutdown':
+      logErr('shutdown requested');
+      process.exit(0);
+      break;
+    default:
+      send({
+        type: 'error',
+        threadId: null,
+        message: 'unknown command type: ' + cmd.type,
+        recoverable: true,
+      });
+  }
+});
+
+rl.on('close', () => {
+  logErr('stdin closed, exiting');
+  process.exit(0);
+});
+
+process.on('uncaughtException', (err) => {
+  logErr('uncaughtException:', err?.stack ?? err);
+  send({
+    type: 'error',
+    threadId: null,
+    message: 'sidecar uncaughtException: ' + (err?.message ?? err),
+    recoverable: false,
+  });
+});
+
+logErr('ready (node ' + process.version + ')');

--- a/apps/tauri/sidecars/claude-agent-bridge/bridge.mjs
+++ b/apps/tauri/sidecars/claude-agent-bridge/bridge.mjs
@@ -12,7 +12,7 @@
 //
 // Commands (stdin):
 //   {type:"ping", id}
-//   {type:"start_query", threadId, prompt, systemPrompt?, toolDefs?, maxTurns?, cwd?}
+//   {type:"start_query", threadId, prompt, systemPrompt?, toolDefs?, maxTurns?, cwd?, model?}
 //   {type:"tool_result", threadId, toolCallId, ok, content?, error?}
 //   {type:"cancel", threadId}
 //   {type:"shutdown"}
@@ -193,7 +193,7 @@ async function handlePing(cmd) {
 }
 
 async function handleStartQuery(cmd) {
-  const { threadId, prompt, systemPrompt, toolDefs = [], maxTurns, cwd } = cmd;
+  const { threadId, prompt, systemPrompt, toolDefs = [], maxTurns, cwd, model } = cmd;
 
   if (!threadId || typeof prompt !== 'string') {
     send({
@@ -271,6 +271,9 @@ async function handleStartQuery(cmd) {
   }
   if (cwd) {
     options.cwd = cwd;
+  }
+  if (model) {
+    options.model = model;
   }
 
   let sessionId = null;

--- a/apps/tauri/sidecars/claude-agent-bridge/package-lock.json
+++ b/apps/tauri/sidecars/claude-agent-bridge/package-lock.json
@@ -1,0 +1,1521 @@
+{
+  "name": "claude-agent-bridge",
+  "version": "0.0.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "claude-agent-bridge",
+      "version": "0.0.1",
+      "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.2.84",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.2.92",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.92.tgz",
+      "integrity": "sha512-loYyxVUC5gBwHjGi9Fv0b84mduJTp9Z3Pum+y/7IVQDb4NynKfVQl6l4VeDKZaW+1QTQtd25tY4hwUznD7Krqw==",
+      "license": "SEE LICENSE IN README.md",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.80.0",
+        "@modelcontextprotocol/sdk": "^1.27.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "^0.34.2",
+        "@img/sharp-darwin-x64": "^0.34.2",
+        "@img/sharp-linux-arm": "^0.34.2",
+        "@img/sharp-linux-arm64": "^0.34.2",
+        "@img/sharp-linux-x64": "^0.34.2",
+        "@img/sharp-linuxmusl-arm64": "^0.34.2",
+        "@img/sharp-linuxmusl-x64": "^0.34.2",
+        "@img/sharp-win32-arm64": "^0.34.2",
+        "@img/sharp-win32-x64": "^0.34.2"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.80.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.80.0.tgz",
+      "integrity": "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
+      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.11",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.11.tgz",
+      "integrity": "sha512-r4xbIa3mGGGoH9nN4A14DOg2wx7y2oQyJEb5O57C/xzETG/qx4c7CVDQ5WMeKHZ7ORk2W0hZ/sQKXTav3cmYBA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/apps/tauri/sidecars/claude-agent-bridge/package-lock.json
+++ b/apps/tauri/sidecars/claude-agent-bridge/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.84",
-        "zod": "^3.23.8"
+        "zod": "^4.0.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
@@ -1499,9 +1499,9 @@
       "license": "ISC"
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/apps/tauri/sidecars/claude-agent-bridge/package.json
+++ b/apps/tauri/sidecars/claude-agent-bridge/package.json
@@ -11,6 +11,6 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.84",
-    "zod": "^3.23.8"
+    "zod": "^4.0.0"
   }
 }

--- a/apps/tauri/sidecars/claude-agent-bridge/package.json
+++ b/apps/tauri/sidecars/claude-agent-bridge/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "claude-agent-bridge",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "Node sidecar that bridges Wealthfolio's Rust backend to @anthropic-ai/claude-agent-sdk, enabling Claude access via the user's Claude Code subscription instead of an API key.",
+  "main": "bridge.mjs",
+  "scripts": {
+    "start": "node bridge.mjs",
+    "smoke": "node smoke-test.mjs"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.2.84",
+    "zod": "^3.23.8"
+  }
+}

--- a/apps/tauri/sidecars/claude-agent-bridge/smoke-test.mjs
+++ b/apps/tauri/sidecars/claude-agent-bridge/smoke-test.mjs
@@ -1,0 +1,156 @@
+// Smoke test for bridge.mjs
+//
+// Spawns the bridge as a child process, exercises:
+//   1. ping/pong
+//   2. start_query with a bridged tool — verifies that
+//      - the SDK invokes the tool
+//      - the bridge emits tool_call to stdout
+//      - this test sends back tool_result via stdin
+//      - the SDK feeds the result back to Claude
+//      - the final assistant text references the tool's return value
+//
+// Pass criterion: the test sees a `done` event with ok=true and observed
+// at least one tool_call/tool_result round-trip and at least one text_delta.
+
+import { spawn } from 'node:child_process';
+import readline from 'node:readline';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import process from 'node:process';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const bridgePath = path.join(__dirname, 'bridge.mjs');
+
+const env = { ...process.env };
+delete env.ANTHROPIC_API_KEY;
+
+const child = spawn('node', [bridgePath], {
+  stdio: ['pipe', 'pipe', 'inherit'],
+  env,
+});
+
+const rl = readline.createInterface({ input: child.stdout });
+
+function send(obj) {
+  child.stdin.write(JSON.stringify(obj) + '\n');
+}
+
+const observed = {
+  pong: false,
+  textDeltas: 0,
+  toolCalls: 0,
+  done: null,
+  errors: [],
+};
+
+const PING_ID = 'ping-1';
+const THREAD_ID = 'smoke-thread-1';
+
+const TIMEOUT_MS = 90_000;
+const timer = setTimeout(() => {
+  console.error('[smoke] TIMEOUT — killing bridge');
+  child.kill();
+  process.exit(2);
+}, TIMEOUT_MS);
+
+rl.on('line', (line) => {
+  let evt;
+  try {
+    evt = JSON.parse(line);
+  } catch {
+    console.error('[smoke] non-json on stdout:', line);
+    return;
+  }
+  console.log('[smoke] <-', JSON.stringify(evt).slice(0, 220));
+
+  switch (evt.type) {
+    case 'pong':
+      if (evt.id === PING_ID) {
+        observed.pong = true;
+        // Now start the actual query.
+        send({
+          type: 'start_query',
+          threadId: THREAD_ID,
+          prompt:
+            'Use the get_lucky_number tool to fetch the lucky number, then reply with exactly: "Lucky number is N." where N is the value returned by the tool. Do not say anything else.',
+          systemPrompt:
+            'You are a test harness. Always call the tool when instructed.',
+          maxTurns: 3,
+          toolDefs: [
+            {
+              name: 'get_lucky_number',
+              description:
+                'Returns a fixed lucky number for the test harness. Takes no arguments.',
+              inputSchema: {
+                type: 'object',
+                properties: {},
+                additionalProperties: false,
+              },
+            },
+          ],
+        });
+      }
+      break;
+
+    case 'system':
+      // session started
+      break;
+
+    case 'text_delta':
+      observed.textDeltas += 1;
+      break;
+
+    case 'tool_call':
+      observed.toolCalls += 1;
+      // Reply with the lucky number.
+      send({
+        type: 'tool_result',
+        threadId: evt.threadId,
+        toolCallId: evt.toolCallId,
+        ok: true,
+        content: '42',
+      });
+      break;
+
+    case 'error':
+      observed.errors.push(evt.message);
+      break;
+
+    case 'done':
+      observed.done = evt;
+      finish();
+      break;
+  }
+});
+
+function finish() {
+  clearTimeout(timer);
+  send({ type: 'shutdown' });
+  setTimeout(() => child.kill(), 500);
+
+  console.log('---');
+  console.log('observed:', observed);
+
+  const passed =
+    observed.pong &&
+    observed.toolCalls >= 1 &&
+    observed.textDeltas >= 1 &&
+    observed.done &&
+    observed.done.ok === true &&
+    observed.errors.length === 0;
+
+  if (passed) {
+    console.log('\n[smoke] PASS — bridge protocol works end-to-end with tool round-trip.');
+    process.exit(0);
+  } else {
+    console.error('\n[smoke] FAIL — see observed counters above.');
+    process.exit(1);
+  }
+}
+
+child.on('exit', (code) => {
+  console.log('[smoke] bridge exited code=' + code);
+});
+
+// Kick off with a ping.
+send({ type: 'ping', id: PING_ID });

--- a/crates/ai/Cargo.toml
+++ b/crates/ai/Cargo.toml
@@ -12,7 +12,7 @@ default = []
 
 [dependencies]
 # Workspace dependencies
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["process", "io-util"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }

--- a/crates/ai/src/ai_providers.json
+++ b/crates/ai/src/ai_providers.json
@@ -167,6 +167,26 @@
       "titleModelId": "claude-haiku-4-5-20251001",
       "documentationUrl": "https://docs.anthropic.com/en/api/getting-started"
     },
+    "claude-subscription": {
+      "name": "Claude (Subscription)",
+      "type": "subscription",
+      "icon": "LogoAnthropic",
+      "description": "Use Claude via your local Claude Code subscription (Pro/Max). Requires Claude Code installed and logged in.",
+      "envKey": "",
+      "defaultConfig": {
+        "enabled": false,
+        "priority": 55
+      },
+      "connectionFields": [],
+      "models": {
+        "claude-code-default": {
+          "capabilities": { "tools": true, "thinking": true, "vision": true }
+        }
+      },
+      "defaultModel": "claude-code-default",
+      "titleModelId": "claude-code-default",
+      "documentationUrl": "https://docs.claude.com/en/docs/claude-code"
+    },
     "openai": {
       "name": "OpenAI",
       "type": "api",

--- a/crates/ai/src/ai_providers.json
+++ b/crates/ai/src/ai_providers.json
@@ -181,6 +181,15 @@
       "models": {
         "claude-code-default": {
           "capabilities": { "tools": true, "thinking": true, "vision": true }
+        },
+        "claude-sonnet-4-6": {
+          "capabilities": { "tools": true, "thinking": true, "vision": true }
+        },
+        "claude-opus-4-6": {
+          "capabilities": { "tools": true, "thinking": true, "vision": true }
+        },
+        "claude-haiku-4-5-20251001": {
+          "capabilities": { "tools": true, "thinking": false, "vision": true }
         }
       },
       "defaultModel": "claude-code-default",

--- a/crates/ai/src/chat.rs
+++ b/crates/ai/src/chat.rs
@@ -565,6 +565,41 @@ async fn spawn_chat_stream<E: AiEnvironment + 'static>(
         .await
         .map_err(|e| AiError::Internal(e.to_string()))?;
 
+    // The Claude Subscription provider bypasses rig-core entirely; it streams
+    // through a Node sidecar that wraps the Claude Agent SDK and uses the
+    // user's local Claude Code login instead of an API key.
+    if provider_id == crate::claude_subscription::SUBSCRIPTION_PROVIDER_ID {
+        let provider_service = ProviderService::new(env.clone());
+        let tools_allowlist = provider_service.get_tools_allowlist(&provider_id);
+
+        let base_preamble = include_str!("system_prompt.txt").trim();
+        let base_currency = env.base_currency();
+        let current_datetime = chrono::Local::now().format("%Y-%m-%d %H:%M").to_string();
+        let preamble = format!(
+            "{}\n\n## Current Context\n- Current datetime: {}\n- Base currency: {}\n\n\
+            ## Web Access\n\
+            You have read-only web access via the `WebSearch` and `WebFetch` tools. \
+            Use them to look up current stock prices, ticker information, recent \
+            financial news, or any other up-to-date market data the user asks about. \
+            Do not invent prices or news — fetch them. Always cite the URL or source \
+            you fetched.",
+            base_preamble, current_datetime, base_currency
+        );
+
+        return crate::claude_subscription::subscription_chat_stream(
+            env,
+            tx,
+            user_message,
+            history_messages,
+            preamble,
+            tools_allowlist,
+            thread_id,
+            run_id,
+            message_id,
+        )
+        .await;
+    }
+
     // Get provider settings and model capabilities
     let provider_service = ProviderService::new(env.clone());
     let api_key = provider_service.get_api_key(&provider_id)?;
@@ -699,49 +734,11 @@ async fn spawn_chat_stream<E: AiEnvironment + 'static>(
         };
         ($client:expr, $thinking_params:expr, $max_tokens:expr) => {{
             let tool_set = ToolSet::new(env.clone(), env.base_currency());
-
-            // Build filtered tool list based on provider allowlist
-            let is_allowed = |name: &str| -> bool {
-                match &tools_allowlist {
-                    None => true, // None = all tools allowed
-                    Some(list) => list.iter().any(|t| t == name),
-                }
-            };
-
-            let mut allowed_tools: Vec<Box<dyn ToolDyn>> = Vec::new();
-            if is_allowed("get_holdings") {
-                allowed_tools.push(Box::new(tool_set.holdings));
-            }
-            if is_allowed("get_accounts") {
-                allowed_tools.push(Box::new(tool_set.accounts));
-            }
-            if is_allowed("search_activities") {
-                allowed_tools.push(Box::new(tool_set.activities));
-            }
-            if is_allowed("get_goals") {
-                allowed_tools.push(Box::new(tool_set.goals));
-            }
-            if is_allowed("get_valuation_history") {
-                allowed_tools.push(Box::new(tool_set.valuation));
-            }
-            if is_allowed("get_income") {
-                allowed_tools.push(Box::new(tool_set.income));
-            }
-            if is_allowed("get_asset_allocation") {
-                allowed_tools.push(Box::new(tool_set.allocation));
-            }
-            if is_allowed("get_performance") {
-                allowed_tools.push(Box::new(tool_set.performance));
-            }
-            if is_allowed("record_activity") {
-                allowed_tools.push(Box::new(tool_set.record_activity));
-            }
-            if is_allowed("record_activities") {
-                allowed_tools.push(Box::new(tool_set.record_activities));
-            }
-            if is_allowed("import_csv") {
-                allowed_tools.push(Box::new(tool_set.import_csv));
-            }
+            let allowed_tools: Vec<Box<dyn ToolDyn>> = tool_set
+                .into_allowed_tools(tools_allowlist.as_deref())
+                .into_iter()
+                .map(|(_, t)| t)
+                .collect();
 
             let mut builder = $client
                 .agent(&model_id)

--- a/crates/ai/src/chat.rs
+++ b/crates/ai/src/chat.rs
@@ -586,6 +586,13 @@ async fn spawn_chat_stream<E: AiEnvironment + 'static>(
             base_preamble, current_datetime, base_currency
         );
 
+        // Forward model_id so the user can pick a specific Claude model.
+        let sub_model = if model_id == "claude-code-default" {
+            None
+        } else {
+            Some(model_id)
+        };
+
         return crate::claude_subscription::subscription_chat_stream(
             env,
             tx,
@@ -596,6 +603,7 @@ async fn spawn_chat_stream<E: AiEnvironment + 'static>(
             thread_id,
             run_id,
             message_id,
+            sub_model,
         )
         .await;
     }

--- a/crates/ai/src/claude_subscription.rs
+++ b/crates/ai/src/claude_subscription.rs
@@ -1,0 +1,676 @@
+//! Claude Subscription provider — talks to Claude via the user's locally
+//! installed Claude Code (Pro/Max plan) instead of the per-token API.
+//!
+//! Architecture:
+//!
+//! ```text
+//! ChatService ──► subscription_chat_stream() ──► SidecarProcess
+//!                                                       │
+//!                                                       ▼
+//!                                              node bridge.mjs
+//!                                              (NDJSON over stdio)
+//!                                                       │
+//!                                                       ▼
+//!                                              @anthropic-ai/claude-agent-sdk
+//!                                                       │
+//!                                                       ▼
+//!                                              Local Claude Code (authed)
+//! ```
+//!
+//! When the model wants to call a Wealthfolio tool, the sidecar emits a
+//! `tool_call` event on stdout. We dispatch it to the existing rig-core
+//! `ToolDyn` registry (no duplication) and send the result back via
+//! `tool_result` on stdin.
+
+use std::collections::HashMap;
+use std::env;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::Arc;
+
+use log::{debug, error, warn};
+use once_cell::sync::OnceCell;
+use rig::tool::ToolDyn;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, ChildStdout, Command};
+use tokio::sync::{mpsc, Mutex};
+
+use crate::env::AiEnvironment;
+use crate::error::AiError;
+use crate::tools::ToolSet;
+use crate::types::{
+    AiStreamEvent, ChatMessage, ChatMessageContent, ChatMessagePart, ChatMessageRole,
+    SimpleChatMessage, ToolCall as DomainToolCall, ToolResultData, UsageStats,
+};
+
+pub const SUBSCRIPTION_PROVIDER_ID: &str = "claude-subscription";
+
+/// Maximum tokens per conversation as a runaway-loop safety. Configurable
+/// later via provider settings; for now a generous default.
+const DEFAULT_MAX_TOKENS_PER_QUERY: u64 = 100_000;
+
+// ───────────────────────────────────────────────────────────────────────────
+// Sidecar protocol — must match bridge.mjs
+// ───────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type")]
+enum SidecarCommand<'a> {
+    #[serde(rename = "start_query")]
+    StartQuery {
+        #[serde(rename = "threadId")]
+        thread_id: &'a str,
+        prompt: String,
+        #[serde(rename = "systemPrompt", skip_serializing_if = "Option::is_none")]
+        system_prompt: Option<String>,
+        #[serde(rename = "toolDefs")]
+        tool_defs: Vec<ToolDefWire>,
+        #[serde(rename = "maxTurns", skip_serializing_if = "Option::is_none")]
+        max_turns: Option<u32>,
+    },
+    #[serde(rename = "tool_result")]
+    ToolResult {
+        #[serde(rename = "threadId")]
+        thread_id: &'a str,
+        #[serde(rename = "toolCallId")]
+        tool_call_id: &'a str,
+        ok: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        content: Option<Value>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+    },
+    #[serde(rename = "cancel")]
+    Cancel {
+        #[serde(rename = "threadId")]
+        thread_id: &'a str,
+    },
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct ToolDefWire {
+    name: String,
+    description: String,
+    #[serde(rename = "inputSchema")]
+    input_schema: Value,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum SidecarEvent {
+    /// Sent once per query when the SDK reports session init. Currently
+    /// unused on the Rust side (the chat service emits its own `system`
+    /// event upstream) but accepted so it doesn't trigger an "unknown event"
+    /// warning.
+    System {},
+    TextDelta {
+        text: String,
+    },
+    ReasoningDelta {
+        text: String,
+    },
+    ToolCall {
+        #[serde(rename = "toolCallId")]
+        tool_call_id: String,
+        name: String,
+        args: Value,
+    },
+    ToolResultAck {},
+    RateLimit {
+        status: String,
+        #[serde(rename = "resetsAt")]
+        resets_at: Option<i64>,
+    },
+    Usage {
+        #[serde(rename = "inputTokens")]
+        input_tokens: u32,
+        #[serde(rename = "outputTokens")]
+        output_tokens: u32,
+    },
+    Error {
+        message: String,
+    },
+    Done {
+        ok: bool,
+        #[serde(rename = "totalTokens", default)]
+        total_tokens: u32,
+        #[serde(rename = "totalCostUsd", default)]
+        total_cost_usd: f64,
+    },
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Sidecar process
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Owns a Node sidecar process and a serialized writer to its stdin.
+/// The reader half (stdout) is returned separately by `spawn()` so the
+/// chat loop can own it without contention with `send`.
+pub struct SidecarHandle {
+    child: Child,
+    stdin: Mutex<ChildStdin>,
+}
+
+impl SidecarHandle {
+    /// Spawn a new sidecar. Resolves the bridge.mjs path from, in order:
+    ///   1. `WEALTHFOLIO_CLAUDE_BRIDGE_PATH` env var
+    ///   2. next to the current executable (production / Tauri externalBin)
+    ///   3. workspace dev path (debug builds only)
+    ///
+    /// NOTE(perf): Today this is called per chat message, so each user turn
+    /// pays a Node startup (~300–700ms). The bridge already supports
+    /// multiplexing queries by `threadId`; the natural follow-up is to hold
+    /// a single shared `Arc<SidecarHandle>` in `ChatService` and reuse it
+    /// across messages, with cancellation propagated through the existing
+    /// `SidecarCommand::Cancel`. Tracked separately.
+    pub async fn spawn() -> Result<(Self, ChildStdout), AiError> {
+        let bridge = resolve_bridge_path()?;
+        let node = resolve_node_command();
+        debug!("spawning sidecar: {} {}", node, bridge.display());
+
+        let mut cmd = Command::new(&node);
+        cmd.arg(&bridge)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+        // Don't leak ANTHROPIC_API_KEY into the sidecar — we want subscription auth.
+        cmd.env_remove("ANTHROPIC_API_KEY");
+
+        let mut child = cmd.spawn().map_err(|e| {
+            AiError::Internal(format!(
+                "failed to spawn claude-agent-bridge sidecar (node={}, bridge={}): {}",
+                node,
+                bridge.display(),
+                e
+            ))
+        })?;
+
+        let stdin = child.stdin.take().ok_or_else(|| {
+            AiError::Internal("sidecar stdin unavailable after spawn".to_string())
+        })?;
+        let stdout = child.stdout.take().ok_or_else(|| {
+            AiError::Internal("sidecar stdout unavailable after spawn".to_string())
+        })?;
+
+        Ok((
+            Self {
+                child,
+                stdin: Mutex::new(stdin),
+            },
+            stdout,
+        ))
+    }
+
+    async fn send(&self, cmd: &SidecarCommand<'_>) -> Result<(), AiError> {
+        let mut line = serde_json::to_string(cmd)
+            .map_err(|e| AiError::Internal(format!("sidecar serialize: {}", e)))?;
+        line.push('\n');
+        let mut stdin = self.stdin.lock().await;
+        stdin
+            .write_all(line.as_bytes())
+            .await
+            .map_err(|e| AiError::Internal(format!("sidecar write: {}", e)))?;
+        stdin
+            .flush()
+            .await
+            .map_err(|e| AiError::Internal(format!("sidecar flush: {}", e)))?;
+        Ok(())
+    }
+}
+
+impl Drop for SidecarHandle {
+    fn drop(&mut self) {
+        // Best-effort kill; the bridge also exits when stdin closes.
+        let _ = self.child.start_kill();
+    }
+}
+
+/// Cached bridge.mjs path. Resolution involves env-var lookups, exe-path
+/// queries, and (in dev) a directory walk-up — none of which change at
+/// runtime, so cache the first successful result.
+static CACHED_BRIDGE_PATH: OnceCell<PathBuf> = OnceCell::new();
+
+fn resolve_bridge_path() -> Result<PathBuf, AiError> {
+    if let Some(cached) = CACHED_BRIDGE_PATH.get() {
+        return Ok(cached.clone());
+    }
+    let resolved = resolve_bridge_path_uncached()?;
+    let _ = CACHED_BRIDGE_PATH.set(resolved.clone());
+    Ok(resolved)
+}
+
+fn resolve_bridge_path_uncached() -> Result<PathBuf, AiError> {
+    if let Ok(p) = env::var("WEALTHFOLIO_CLAUDE_BRIDGE_PATH") {
+        let path = PathBuf::from(p);
+        if path.is_file() {
+            return Ok(path);
+        }
+        warn!(
+            "WEALTHFOLIO_CLAUDE_BRIDGE_PATH set but not a file: {}",
+            path.display()
+        );
+    }
+
+    // Production layout: bridge bundled next to the app executable.
+    if let Ok(exe) = env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            let candidate = dir.join("claude-agent-bridge").join("bridge.mjs");
+            if candidate.is_file() {
+                return Ok(candidate);
+            }
+        }
+    }
+
+    // Dev-only fallback: walk up from cwd looking for the workspace sidecar
+    // directory. Excluded from release builds so a misconfigured installer
+    // can't silently load dev assets.
+    #[cfg(debug_assertions)]
+    if let Ok(mut cwd) = env::current_dir() {
+        for _ in 0..6 {
+            let candidate = cwd.join("apps/tauri/sidecars/claude-agent-bridge/bridge.mjs");
+            if candidate.is_file() {
+                return Ok(candidate);
+            }
+            if !cwd.pop() {
+                break;
+            }
+        }
+    }
+
+    Err(AiError::Internal(
+        "could not locate claude-agent-bridge/bridge.mjs — set WEALTHFOLIO_CLAUDE_BRIDGE_PATH"
+            .to_string(),
+    ))
+}
+
+fn resolve_node_command() -> String {
+    env::var("WEALTHFOLIO_NODE_BIN").unwrap_or_else(|_| "node".to_string())
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Tool dispatch helper
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Build the wire-format tool definitions plus a name → dispatch map.
+///
+/// Reuses the same allowlist filter as the rig-core path so any new tool
+/// added to `ToolSet::into_allowed_tools` is picked up automatically.
+async fn build_tool_dispatch<E: AiEnvironment + 'static>(
+    env: Arc<E>,
+    base_currency: String,
+    allowlist: Option<&[String]>,
+) -> (Vec<ToolDefWire>, HashMap<String, Box<dyn ToolDyn>>) {
+    let dyn_tools = ToolSet::new(env, base_currency).into_allowed_tools(allowlist);
+
+    let mut defs: Vec<ToolDefWire> = Vec::with_capacity(dyn_tools.len());
+    let mut by_name: HashMap<String, Box<dyn ToolDyn>> =
+        HashMap::with_capacity(dyn_tools.len());
+
+    for (name, dyn_tool) in dyn_tools {
+        let def = dyn_tool.definition(String::new()).await;
+        defs.push(ToolDefWire {
+            name: def.name.clone(),
+            description: def.description,
+            input_schema: def.parameters,
+        });
+        by_name.insert(name.to_string(), dyn_tool);
+    }
+
+    (defs, by_name)
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Public entry point
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Stream a chat conversation through the Claude Code subscription sidecar.
+///
+/// This bypasses rig-core entirely. It builds the tool registry, spawns the
+/// sidecar, sends `start_query`, and translates sidecar events into
+/// `AiStreamEvent`s on the same `tx` channel that the rig-core path uses.
+#[allow(clippy::too_many_arguments)]
+pub async fn subscription_chat_stream<E: AiEnvironment + 'static>(
+    env: Arc<E>,
+    tx: mpsc::Sender<AiStreamEvent>,
+    user_message: String,
+    history: Vec<SimpleChatMessage>,
+    preamble: String,
+    tools_allowlist: Option<Vec<String>>,
+    thread_id: String,
+    run_id: String,
+    message_id: String,
+) -> Result<(), AiError> {
+    // Always emit a terminal `Done` event so the frontend stream closes —
+    // returning `Err` from this function only emits an `error` event upstream
+    // and the chat UI hangs waiting for `Done`.
+    async fn fail(
+        tx: &mpsc::Sender<AiStreamEvent>,
+        thread_id: &str,
+        run_id: &str,
+        message_id: &str,
+        err: AiError,
+    ) -> Result<(), AiError> {
+        let message = err.to_string();
+        error!("subscription chat failed: {}: {}", err.code(), message);
+        let _ = tx
+            .send(AiStreamEvent::error(
+                thread_id,
+                run_id,
+                Some(message_id),
+                err.code(),
+                &message,
+            ))
+            .await;
+        let final_message = ChatMessage {
+            id: message_id.to_string(),
+            role: ChatMessageRole::Assistant,
+            content: ChatMessageContent::new(vec![ChatMessagePart::Text {
+                content: format!("[error] {}", message),
+            }]),
+            thread_id: thread_id.to_string(),
+            created_at: chrono::Utc::now(),
+        };
+        let _ = tx
+            .send(AiStreamEvent::done(thread_id, run_id, final_message, None))
+            .await;
+        Ok(())
+    }
+
+    let base_currency = env.base_currency();
+    let (tool_defs, tool_dispatch) =
+        build_tool_dispatch(env.clone(), base_currency, tools_allowlist.as_deref()).await;
+
+    debug!(
+        "claude subscription: starting with {} tools",
+        tool_defs.len()
+    );
+
+    let (sidecar, stdout) = match SidecarHandle::spawn().await {
+        Ok(pair) => pair,
+        Err(e) => return fail(&tx, &thread_id, &run_id, &message_id, e).await,
+    };
+    let mut lines = BufReader::new(stdout).lines();
+
+    // The Agent SDK takes a single prompt string, so prior turns are flattened
+    // into the prompt instead of being passed as a message array.
+    let prompt = render_prompt_with_history(&history, &user_message);
+
+    if let Err(e) = sidecar
+        .send(&SidecarCommand::StartQuery {
+            thread_id: &thread_id,
+            prompt,
+            system_prompt: Some(preamble),
+            tool_defs,
+            max_turns: Some(25),
+        })
+        .await
+    {
+        return fail(&tx, &thread_id, &run_id, &message_id, e).await;
+    }
+
+    // Drain events.
+    let mut accumulated_text = String::new();
+    let mut last_usage: Option<UsageStats> = None;
+    let mut stream_ok = false;
+
+    loop {
+        let line = match lines.next_line().await {
+            Ok(Some(l)) => l,
+            Ok(None) => {
+                warn!("sidecar stdout closed unexpectedly");
+                break;
+            }
+            Err(e) => {
+                error!("sidecar read error: {}", e);
+                let _ = tx
+                    .send(AiStreamEvent::error(
+                        &thread_id,
+                        &run_id,
+                        Some(&message_id),
+                        "sidecar_io",
+                        &format!("sidecar read error: {}", e),
+                    ))
+                    .await;
+                break;
+            }
+        };
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let event: SidecarEvent = match serde_json::from_str(trimmed) {
+            Ok(e) => e,
+            Err(e) => {
+                warn!("unparsable sidecar line: {} ({})", trimmed, e);
+                continue;
+            }
+        };
+
+        match event {
+            // ChatService already emitted the upstream `system` event.
+            SidecarEvent::System {} | SidecarEvent::ToolResultAck {} => {}
+
+            SidecarEvent::TextDelta { text } => {
+                accumulated_text.push_str(&text);
+                let _ = tx
+                    .send(AiStreamEvent::text_delta(
+                        &thread_id,
+                        &run_id,
+                        &message_id,
+                        &text,
+                    ))
+                    .await;
+            }
+
+            SidecarEvent::ReasoningDelta { text } => {
+                let _ = tx
+                    .send(AiStreamEvent::reasoning_delta(
+                        &thread_id,
+                        &run_id,
+                        &message_id,
+                        &text,
+                    ))
+                    .await;
+            }
+
+            SidecarEvent::ToolCall {
+                tool_call_id,
+                name,
+                args,
+            } => {
+                let domain_call = DomainToolCall {
+                    id: tool_call_id.clone(),
+                    name: name.clone(),
+                    arguments: args.clone(),
+                };
+                let _ = tx
+                    .send(AiStreamEvent::tool_call(
+                        &thread_id,
+                        &run_id,
+                        &message_id,
+                        domain_call,
+                    ))
+                    .await;
+
+                let (ok, content_value, error_msg) =
+                    match dispatch_tool(&tool_dispatch, &name, args.clone()).await {
+                        Ok(value) => (true, Some(value), None),
+                        Err(err) => (false, None, Some(err.to_string())),
+                    };
+
+                let result_data = ToolResultData {
+                    tool_call_id: tool_call_id.clone(),
+                    success: ok,
+                    data: content_value.clone().unwrap_or(Value::Null),
+                    meta: HashMap::new(),
+                    error: error_msg.clone(),
+                };
+                let _ = tx
+                    .send(AiStreamEvent::tool_result(
+                        &thread_id,
+                        &run_id,
+                        &message_id,
+                        result_data,
+                    ))
+                    .await;
+
+                if let Err(e) = sidecar
+                    .send(&SidecarCommand::ToolResult {
+                        thread_id: &thread_id,
+                        tool_call_id: &tool_call_id,
+                        ok,
+                        content: content_value,
+                        error: error_msg,
+                    })
+                    .await
+                {
+                    error!("failed to send tool_result to sidecar: {}", e);
+                    break;
+                }
+            }
+
+            SidecarEvent::RateLimit { status, resets_at } => {
+                debug!(
+                    "claude subscription rate limit: status={} resetsAt={:?}",
+                    status, resets_at
+                );
+            }
+
+            SidecarEvent::Usage {
+                input_tokens,
+                output_tokens,
+            } => {
+                let total = input_tokens + output_tokens;
+                last_usage = Some(UsageStats {
+                    prompt_tokens: input_tokens,
+                    completion_tokens: output_tokens,
+                    total_tokens: total,
+                });
+
+                if (total as u64) > DEFAULT_MAX_TOKENS_PER_QUERY {
+                    warn!(
+                        "subscription chat exceeded token cap: {} > {}",
+                        total, DEFAULT_MAX_TOKENS_PER_QUERY
+                    );
+                    let _ = sidecar
+                        .send(&SidecarCommand::Cancel {
+                            thread_id: &thread_id,
+                        })
+                        .await;
+                    let _ = tx
+                        .send(AiStreamEvent::error(
+                            &thread_id,
+                            &run_id,
+                            Some(&message_id),
+                            "token_cap_exceeded",
+                            &format!(
+                                "Conversation exceeded the {}-token safety cap",
+                                DEFAULT_MAX_TOKENS_PER_QUERY
+                            ),
+                        ))
+                        .await;
+                    break;
+                }
+            }
+
+            SidecarEvent::Error { message } => {
+                let _ = tx
+                    .send(AiStreamEvent::error(
+                        &thread_id,
+                        &run_id,
+                        Some(&message_id),
+                        AiError::provider(&message).code(),
+                        &message,
+                    ))
+                    .await;
+            }
+
+            SidecarEvent::Done {
+                ok,
+                total_tokens,
+                total_cost_usd,
+            } => {
+                stream_ok = ok;
+                debug!(
+                    "subscription chat done: ok={}, totalTokens={}, totalCostUsd={}",
+                    ok, total_tokens, total_cost_usd
+                );
+                if let Some(u) = last_usage.as_mut() {
+                    if u.total_tokens < total_tokens {
+                        u.total_tokens = total_tokens;
+                    }
+                }
+                break;
+            }
+        }
+    }
+
+    // Build the final ChatMessage and emit Done.
+    let final_message = ChatMessage {
+        id: message_id.clone(),
+        role: ChatMessageRole::Assistant,
+        content: ChatMessageContent::new(vec![ChatMessagePart::Text {
+            content: accumulated_text,
+        }]),
+        thread_id: thread_id.clone(),
+        created_at: chrono::Utc::now(),
+    };
+
+    if !stream_ok {
+        // We still send Done so the frontend can close the stream.
+        debug!("subscription chat finished with stream_ok=false");
+    }
+
+    let _ = tx
+        .send(AiStreamEvent::done(
+            &thread_id, &run_id, final_message, last_usage,
+        ))
+        .await;
+
+    Ok(())
+}
+
+async fn dispatch_tool(
+    dispatch: &HashMap<String, Box<dyn ToolDyn>>,
+    name: &str,
+    args: Value,
+) -> Result<Value, AiError> {
+    let tool = dispatch
+        .get(name)
+        .ok_or_else(|| AiError::ToolNotAllowed(name.to_string()))?;
+
+    let args_str = serde_json::to_string(&args)
+        .map_err(|e| AiError::Internal(format!("serialize tool args: {}", e)))?;
+
+    let raw = tool
+        .call(args_str)
+        .await
+        .map_err(|e| AiError::ToolExecutionFailed(format!("{}: {}", name, e)))?;
+
+    // ToolDyn outputs are JSON strings; deserialize back to structured JSON
+    // when possible so the UI can render results richly.
+    Ok(serde_json::from_str::<Value>(&raw).unwrap_or_else(|_| json!(raw)))
+}
+
+fn render_prompt_with_history(history: &[SimpleChatMessage], user_message: &str) -> String {
+    if history.is_empty() {
+        return user_message.to_string();
+    }
+    let mut out = String::with_capacity(user_message.len() + history.len() * 64);
+    out.push_str("# Prior conversation\n\n");
+    for msg in history {
+        let role = if msg.role.eq_ignore_ascii_case("user") {
+            "User"
+        } else {
+            "Assistant"
+        };
+        out.push_str(&format!("**{}**: {}\n\n", role, msg.content));
+    }
+    out.push_str("# Current request\n\n");
+    out.push_str(user_message);
+    out
+}
+

--- a/crates/ai/src/claude_subscription.rs
+++ b/crates/ai/src/claude_subscription.rs
@@ -69,6 +69,8 @@ enum SidecarCommand<'a> {
         tool_defs: Vec<ToolDefWire>,
         #[serde(rename = "maxTurns", skip_serializing_if = "Option::is_none")]
         max_turns: Option<u32>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        model: Option<String>,
     },
     #[serde(rename = "tool_result")]
     ToolResult {
@@ -341,6 +343,7 @@ pub async fn subscription_chat_stream<E: AiEnvironment + 'static>(
     thread_id: String,
     run_id: String,
     message_id: String,
+    model_id: Option<String>,
 ) -> Result<(), AiError> {
     // Always emit a terminal `Done` event so the frontend stream closes —
     // returning `Err` from this function only emits an `error` event upstream
@@ -397,6 +400,10 @@ pub async fn subscription_chat_stream<E: AiEnvironment + 'static>(
     // into the prompt instead of being passed as a message array.
     let prompt = render_prompt_with_history(&history, &user_message);
 
+    // Map well-known Wealthfolio model IDs to Claude model identifiers.
+    // "claude-code-default" (or None) → let the SDK pick; otherwise pass through.
+    let sidecar_model = model_id.filter(|m| m != "claude-code-default" && !m.is_empty());
+
     if let Err(e) = sidecar
         .send(&SidecarCommand::StartQuery {
             thread_id: &thread_id,
@@ -404,6 +411,7 @@ pub async fn subscription_chat_stream<E: AiEnvironment + 'static>(
             system_prompt: Some(preamble),
             tool_defs,
             max_turns: Some(25),
+            model: sidecar_model,
         })
         .await
     {
@@ -622,6 +630,16 @@ pub async fn subscription_chat_stream<E: AiEnvironment + 'static>(
     if !stream_ok {
         // We still send Done so the frontend can close the stream.
         debug!("subscription chat finished with stream_ok=false");
+    }
+
+    // Persist the assistant message so chat history survives app restarts.
+    // This mirrors the rig-core path in chat.rs (line ~1675).
+    if let Err(e) = env
+        .chat_repository()
+        .create_message(final_message.clone())
+        .await
+    {
+        error!("Failed to save subscription assistant message: {}", e);
     }
 
     let _ = tx

--- a/crates/ai/src/lib.rs
+++ b/crates/ai/src/lib.rs
@@ -48,6 +48,7 @@
 //! ```
 
 pub mod chat;
+pub mod claude_subscription;
 pub mod env;
 pub mod error;
 #[cfg(test)]

--- a/crates/ai/src/provider_service.rs
+++ b/crates/ai/src/provider_service.rs
@@ -460,6 +460,19 @@ impl AiProviderServiceTrait for AiProviderService {
         &self,
         provider_id: &str,
     ) -> std::result::Result<ListModelsResponse, ProviderApiError> {
+        // The Claude Subscription provider doesn't have a remote model listing
+        // endpoint — the model is whatever the user's local Claude Code is
+        // configured with. Return the single static catalog entry instead.
+        if provider_id == crate::claude_subscription::SUBSCRIPTION_PROVIDER_ID {
+            return Ok(ListModelsResponse {
+                models: vec![crate::provider_model::FetchedModel {
+                    id: "claude-code-default".to_string(),
+                    name: Some("Claude (Subscription default)".to_string()),
+                }],
+                supports_listing: false,
+            });
+        }
+
         // Get provider config (validates provider exists and has API key if needed)
         let config = self.get_provider_config(provider_id)?;
 

--- a/crates/ai/src/provider_service.rs
+++ b/crates/ai/src/provider_service.rs
@@ -287,6 +287,7 @@ impl AiProviderServiceTrait for AiProviderService {
                 // Sort models alphabetically for consistent ordering
                 models.sort_by(|a, b| a.id.cmp(&b.id));
 
+
                 // Check if provider supports dynamic model listing
                 let supports_model_listing = Self::provider_supports_model_listing(id);
 
@@ -461,14 +462,28 @@ impl AiProviderServiceTrait for AiProviderService {
         provider_id: &str,
     ) -> std::result::Result<ListModelsResponse, ProviderApiError> {
         // The Claude Subscription provider doesn't have a remote model listing
-        // endpoint — the model is whatever the user's local Claude Code is
-        // configured with. Return the single static catalog entry instead.
+        // endpoint. Return a static list of known Claude models. The user can
+        // pick one; "claude-code-default" lets the SDK choose automatically.
         if provider_id == crate::claude_subscription::SUBSCRIPTION_PROVIDER_ID {
             return Ok(ListModelsResponse {
-                models: vec![crate::provider_model::FetchedModel {
-                    id: "claude-code-default".to_string(),
-                    name: Some("Claude (Subscription default)".to_string()),
-                }],
+                models: vec![
+                    crate::provider_model::FetchedModel {
+                        id: "claude-code-default".to_string(),
+                        name: Some("Default (auto)".to_string()),
+                    },
+                    crate::provider_model::FetchedModel {
+                        id: "claude-sonnet-4-6".to_string(),
+                        name: Some("Claude Sonnet 4.6".to_string()),
+                    },
+                    crate::provider_model::FetchedModel {
+                        id: "claude-opus-4-6".to_string(),
+                        name: Some("Claude Opus 4.6".to_string()),
+                    },
+                    crate::provider_model::FetchedModel {
+                        id: "claude-haiku-4-5-20251001".to_string(),
+                        name: Some("Claude Haiku 4.5".to_string()),
+                    },
+                ],
                 supports_listing: false,
             });
         }

--- a/crates/ai/src/tools/mod.rs
+++ b/crates/ai/src/tools/mod.rs
@@ -45,6 +45,8 @@ pub use valuation::GetValuationHistoryTool;
 
 use std::sync::Arc;
 
+use rig::tool::ToolDyn;
+
 use crate::env::AiEnvironment;
 
 /// Container for all AI tools, simplifying tool registration across providers.
@@ -78,6 +80,64 @@ impl<E: AiEnvironment> ToolSet<E> {
             record_activities: RecordActivitiesTool::new(env.clone()),
             import_csv: ImportCsvTool::new(env, base_currency),
         }
+    }
+
+    /// Consume the tool set and return `(name, dyn handle)` pairs filtered
+    /// against an optional allowlist (`None` keeps all). The order is the
+    /// canonical registration order shared by every chat code path.
+    ///
+    /// Used by both the rig-core dispatch and the Claude Subscription bridge —
+    /// they iterate the same registry so any new tool only needs to be added
+    /// here.
+    pub fn into_allowed_tools(
+        self,
+        allowlist: Option<&[String]>,
+    ) -> Vec<(&'static str, Box<dyn ToolDyn>)>
+    where
+        E: 'static,
+    {
+        let is_allowed = |name: &str| -> bool {
+            match allowlist {
+                None => true,
+                Some(list) => list.iter().any(|t| t == name),
+            }
+        };
+
+        let mut out: Vec<(&'static str, Box<dyn ToolDyn>)> = Vec::new();
+        if is_allowed("get_holdings") {
+            out.push(("get_holdings", Box::new(self.holdings)));
+        }
+        if is_allowed("get_accounts") {
+            out.push(("get_accounts", Box::new(self.accounts)));
+        }
+        if is_allowed("search_activities") {
+            out.push(("search_activities", Box::new(self.activities)));
+        }
+        if is_allowed("get_goals") {
+            out.push(("get_goals", Box::new(self.goals)));
+        }
+        if is_allowed("get_valuation_history") {
+            out.push(("get_valuation_history", Box::new(self.valuation)));
+        }
+        if is_allowed("get_income") {
+            out.push(("get_income", Box::new(self.income)));
+        }
+        if is_allowed("get_asset_allocation") {
+            out.push(("get_asset_allocation", Box::new(self.allocation)));
+        }
+        if is_allowed("get_performance") {
+            out.push(("get_performance", Box::new(self.performance)));
+        }
+        if is_allowed("record_activity") {
+            out.push(("record_activity", Box::new(self.record_activity)));
+        }
+        if is_allowed("record_activities") {
+            out.push(("record_activities", Box::new(self.record_activities)));
+        }
+        if is_allowed("import_csv") {
+            out.push(("import_csv", Box::new(self.import_csv)));
+        }
+        out
     }
 }
 


### PR DESCRIPTION
## Description

Add a new AI provider — **Claude (Subscription)** — that lets users access
Claude through their local Claude Code (Pro/Max) subscription instead of an
Anthropic API key. The existing API-key path is unchanged; this is purely
additive.

In the UI, the new provider is presented as an embedded sub-mode of the
existing Anthropic provider card (one Anthropic entry, two connection
methods), so the settings page stays clean.

### Why

Users on a Claude Pro / Max plan already pay a flat monthly fee. Today the
only way to use Claude in Wealthfolio is to also create an Anthropic API key
and pay per token on top of that subscription. This change lets those users
re-use the Claude they already pay for.

### How it works

```
ChatService ─► subscription_chat_stream() ─► Node sidecar (bridge.mjs)
                                                    │
                                                    ▼
                                          @anthropic-ai/claude-agent-sdk
                                                    │
                                                    ▼
                                          local Claude Code (authed)
```

- The Rust backend spawns a small Node sidecar at
  `apps/tauri/sidecars/claude-agent-bridge` that wraps
  `@anthropic-ai/claude-agent-sdk`. The SDK transparently uses the local
  Claude Code login as the auth source.
- The Rust ↔ Node bridge speaks NDJSON over stdio:
  `start_query` / `tool_call` / `tool_result` / `done`.
- Wealthfolio's existing portfolio tools (`get_holdings`, `get_performance`,
  …) are exposed to Claude via an in-process MCP server in the bridge.
  When Claude calls a tool, the bridge emits a `tool_call` event; the Rust
  side dispatches it through the same `rig::tool::ToolDyn` registry the
  rig-core path already uses, then sends the result back through stdin.
  **No tool logic is duplicated** — both code paths go through a new shared
  helper `ToolSet::into_allowed_tools()`.
- `spawn_chat_stream()` short-circuits to the new path when the provider id
  is `claude-subscription`. The rig-core path is otherwise untouched.

### Security model

- `ANTHROPIC_API_KEY` is stripped from the sidecar's environment so the SDK
  can never accidentally fall back to API-key billing.
- All default Claude Code tools that touch the filesystem or shell
  (`Bash`, `Read`, `Write`, `Edit`, `Glob`, `Grep`, `Agent`,
  `AskUserQuestion`) are dropped via `tools: []`.
- Only **`WebSearch`** and **`WebFetch`** are whitelisted as built-in tools
  (read-only network access for stock prices, news, ticker info).
- Wealthfolio's per-provider tools allowlist is honored end-to-end: any tool
  not in the allowlist is rejected with `AiError::ToolNotAllowed` before
  reaching the SDK.
- Per-thread token cap (100 k default) cancels runaway loops.
- Settings are loaded from neither `~/.claude` nor `CLAUDE.md` files
  (`settingSources: []`), so the sidecar can't be influenced by external
  user instructions.

### Code-quality notes

- The 11-arm tool-builder ladder previously inlined inside a macro in
  `chat.rs` is now a single `ToolSet::into_allowed_tools()` helper used by
  both code paths. Adding a new tool only needs one site.
- `dispatch_tool` returns `Result<Value, AiError>`, so tool failures
  surface with their proper error code (`TOOL_NOT_ALLOWED`,
  `TOOL_EXECUTION_FAILED`) in stream events.
- `subscription_chat_stream` always emits a terminal `Done` event even on
  failure, so the chat UI never hangs.
- The dev-only workspace walk-up in `resolve_bridge_path` is gated behind
  `#[cfg(debug_assertions)]`.
- The cached bridge path uses a `OnceCell<PathBuf>` so we don't re-stat
  on every spawn.

### Known follow-up (not in this PR)

The sidecar is currently spawned **per chat message** (~300–700 ms of Node
startup per turn). The bridge already supports multiplexing queries by
`threadId`, so the natural next step is to hold a single shared
`Arc<SidecarHandle>` in `ChatService` and reuse it across messages, with
cancellation propagated through the existing `SidecarCommand::Cancel`.
Documented inline at `SidecarHandle::spawn` with a `NOTE(perf)` comment.
Happy to land that as a follow-up PR if the maintainers prefer a smaller
first change.

### Testing

- **Sidecar smoke test** (`apps/tauri/sidecars/claude-agent-bridge/smoke-test.mjs`):
  spawns the bridge as a child process and exercises a full
  ping → start_query → tool_call → tool_result → done round-trip with a
  fake bridged tool. No Tauri or Wealthfolio app required:
  ```bash
  cd apps/tauri/sidecars/claude-agent-bridge
  npm install
  node smoke-test.mjs
  ```
  Expected output: `[smoke] PASS — bridge protocol works end-to-end with
  tool round-trip.`

- **Manual end-to-end** in the desktop app:
  1. Install Claude Code and `claude login` with a Pro/Max account.
  2. `pnpm tauri dev`
  3. Settings → AI Providers → Anthropic → expand the card → enable
     **Claude Code Subscription**
  4. Open the AI chat, pick **Claude (Subscription)** in the provider
     picker, send "Show me my current portfolio holdings"
  5. Expected: streamed text → `get_holdings` tool call → real numbers
     from the local DB → final assistant message using those numbers.
     No `ANTHROPIC_API_KEY` required.

### Files changed

**Rust (backend)**
- `crates/ai/src/claude_subscription.rs` — new module: sidecar process
  management, NDJSON protocol, streaming loop, tool dispatch, prompt
  rendering (~660 LOC).
- `crates/ai/src/chat.rs` — early branch in `spawn_chat_stream` routes
  the new provider to the sidecar path. Existing rig-core paths refactored
  to use the new shared `ToolSet::into_allowed_tools()` helper instead of
  the inline 11-arm ladder.
- `crates/ai/src/tools/mod.rs` — new `ToolSet::into_allowed_tools()`
  helper, used by both chat code paths.
- `crates/ai/src/lib.rs` — `pub mod claude_subscription;`
- `crates/ai/src/provider_service.rs` — `list_models` short-circuit for
  the subscription provider (returns the catalog entry directly instead
  of calling Anthropic's API, which would 401 without a key).
- `crates/ai/src/ai_providers.json` — new `claude-subscription` provider
  entry with `type: "subscription"`.
- `crates/ai/Cargo.toml` — enable `tokio` features `process` and
  `io-util`.

**Node sidecar** (`apps/tauri/sidecars/claude-agent-bridge/`)
- `bridge.mjs` — long-running NDJSON server. Wraps the Agent SDK's
  `query()`, exposes Wealthfolio tools through an in-process MCP server,
  forwards `tool_call`s to the Rust parent.
- `smoke-test.mjs` — standalone integration test for the bridge protocol.
- `package.json` / `package-lock.json` — pins
  `@anthropic-ai/claude-agent-sdk`.

**Frontend**
- `apps/frontend/src/features/ai-assistant/components/provider-settings-card.tsx`
  — embedded "Claude Code Subscription" sub-mode UI inside the Anthropic
  card; new optional `subscriptionProvider` / `onToggleSubscription` props.
- `apps/frontend/src/pages/settings/ai-providers/ai-providers-page.tsx`
  — filters `claude-subscription` out of the standalone list, surfaces it
  to the Anthropic card via props. Hoisted memos above early returns to
  comply with the Rules of Hooks.
- `apps/frontend/src/features/ai-assistant/hooks/use-chat-model.ts` and
  `use-provider-picker.ts` — allow `type: "subscription"` providers
  through the enabled-provider filter.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).
