### PR TITLE
feat(health): improve health center issue details for negative balance and FX integrity

### DIFF
--- a/apps/frontend/src/pages/health/components/issue-detail-sheet.tsx
+++ b/apps/frontend/src/pages/health/components/issue-detail-sheet.tsx
@@ -210,7 +210,7 @@ export function IssueDetailSheet({
               <h4 className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
                 Details
               </h4>
-              <p className="text-muted-foreground text-sm">{issue.details}</p>
+              <p className="text-muted-foreground whitespace-pre-line text-sm">{issue.details}</p>
             </div>
           )}
         </div>

--- a/crates/ai/src/env.rs
+++ b/crates/ai/src/env.rs
@@ -11,11 +11,9 @@ use wealthfolio_core::{
     activities::ActivityServiceTrait,
     goals::GoalServiceTrait,
     portfolio::{
-        allocation::AllocationServiceTrait,
-        holdings::HoldingsServiceTrait,
-        income::IncomeServiceTrait,
-        performance::PerformanceServiceTrait,
-        valuation::{NegativeBalanceInfo, ValuationServiceTrait},
+        allocation::AllocationServiceTrait, holdings::HoldingsServiceTrait,
+        income::IncomeServiceTrait, performance::PerformanceServiceTrait,
+        valuation::ValuationServiceTrait,
     },
     quotes::QuoteServiceTrait,
     secrets::SecretStore,
@@ -104,7 +102,9 @@ pub mod test_env {
         },
         secrets::SecretStore,
         settings::{Settings, SettingsServiceTrait, SettingsUpdate},
-        valuation::{DailyAccountValuation, ValuationRecalcMode, ValuationServiceTrait},
+        valuation::{
+            DailyAccountValuation, NegativeBalanceInfo, ValuationRecalcMode, ValuationServiceTrait,
+        },
         Error as CoreError, Result as CoreResult,
     };
 

--- a/crates/ai/src/env.rs
+++ b/crates/ai/src/env.rs
@@ -11,9 +11,11 @@ use wealthfolio_core::{
     activities::ActivityServiceTrait,
     goals::GoalServiceTrait,
     portfolio::{
-        allocation::AllocationServiceTrait, holdings::HoldingsServiceTrait,
-        income::IncomeServiceTrait, performance::PerformanceServiceTrait,
-        valuation::ValuationServiceTrait,
+        allocation::AllocationServiceTrait,
+        holdings::HoldingsServiceTrait,
+        income::IncomeServiceTrait,
+        performance::PerformanceServiceTrait,
+        valuation::{NegativeBalanceInfo, ValuationServiceTrait},
     },
     quotes::QuoteServiceTrait,
     secrets::SecretStore,
@@ -523,7 +525,7 @@ pub mod test_env {
         fn get_accounts_with_negative_balance(
             &self,
             _account_ids: &[String],
-        ) -> CoreResult<Vec<String>> {
+        ) -> CoreResult<Vec<NegativeBalanceInfo>> {
             Ok(Vec::new())
         }
 

--- a/crates/core/src/health/checks/data_consistency.rs
+++ b/crates/core/src/health/checks/data_consistency.rs
@@ -5,7 +5,9 @@
 use async_trait::async_trait;
 
 use crate::errors::Result;
-use crate::health::model::{FixAction, HealthCategory, HealthIssue, NavigateAction, Severity};
+use crate::health::model::{
+    AffectedItem, FixAction, HealthCategory, HealthIssue, NavigateAction, Severity,
+};
 use crate::health::traits::{HealthCheck, HealthContext};
 
 /// Types of data consistency issues.
@@ -200,6 +202,10 @@ impl DataConsistencyCheck {
                 .map(|i| i.record_id.clone())
                 .collect();
             let data_hash = compute_data_hash(&account_ids);
+            let affected_items: Vec<AffectedItem> = negative_balance_issues
+                .iter()
+                .map(|i| AffectedItem::account(i.record_id.clone(), i.description.clone()))
+                .collect();
 
             health_issues.push(
                 HealthIssue::builder()
@@ -215,6 +221,7 @@ impl DataConsistencyCheck {
                         "One or more accounts show a negative total value in their history. This is usually caused by missing buy transactions. Review your activities to fix this.",
                     )
                     .affected_count(count as u32)
+                    .affected_items(affected_items)
                     .navigate_action(NavigateAction::to_activities(None))
                     .data_hash(data_hash)
                     .build(),

--- a/crates/core/src/health/checks/data_consistency.rs
+++ b/crates/core/src/health/checks/data_consistency.rs
@@ -25,6 +25,8 @@ pub enum ConsistencyIssueType {
     LegacyClassification,
     /// Account has negative total portfolio value in its history
     NegativeAccountBalance,
+    /// Cash account had a negative balance at some point (may be a bank overdraft)
+    NegativeCashBalance,
 }
 
 /// Data about a consistency issue.
@@ -262,6 +264,57 @@ impl DataConsistencyCheck {
                 })
                 .message(
                     "One or more accounts show a negative total value in their history. This is usually caused by missing buy transactions. Review your activities to fix this.",
+                )
+                .affected_count(count as u32)
+                .affected_items(affected_items)
+                .navigate_action(NavigateAction::to_activities(None))
+                .data_hash(data_hash);
+            if !details.is_empty() {
+                builder = builder.details(details);
+            }
+            health_issues.push(builder.build());
+        }
+
+        // Emit info issue for cash accounts with negative balance (may be a normal overdraft)
+        if let Some(cash_balance_issues) = by_type.get(&ConsistencyIssueType::NegativeCashBalance) {
+            let count = cash_balance_issues.len();
+            let account_ids: Vec<String> = cash_balance_issues
+                .iter()
+                .map(|i| i.record_id.clone())
+                .collect();
+            let data_hash = compute_data_hash(&account_ids);
+            let affected_items: Vec<AffectedItem> = cash_balance_issues
+                .iter()
+                .map(|i| AffectedItem::account(i.record_id.clone(), i.description.clone()))
+                .collect();
+            let details: String = cash_balance_issues
+                .iter()
+                .filter_map(|i| {
+                    let ccy = i.account_currency.as_deref()?;
+                    let cash = i.cash_balance?;
+                    let date_line = i
+                        .first_negative_date
+                        .map(|d| format!("First went negative on {}.", d.format("%Y-%m-%d")))
+                        .unwrap_or_default();
+                    Some(format!(
+                        "{}\n{}\nCash: {} {}\n→ This may be a bank overdraft or a missing deposit entry.",
+                        i.description, date_line, cash.round_dp(2), ccy,
+                    ))
+                })
+                .collect::<Vec<_>>()
+                .join("\n\n");
+
+            let mut builder = HealthIssue::builder()
+                .id(format!("negative_cash_balance:{}", data_hash))
+                .severity(Severity::Info)
+                .category(HealthCategory::DataConsistency)
+                .title(if count == 1 {
+                    "Cash account had a negative balance".to_string()
+                } else {
+                    format!("{} cash accounts had a negative balance", count)
+                })
+                .message(
+                    "One or more cash accounts show a negative balance in their history. This may be a normal bank overdraft or a missing deposit entry.",
                 )
                 .affected_count(count as u32)
                 .affected_items(affected_items)

--- a/crates/core/src/health/checks/data_consistency.rs
+++ b/crates/core/src/health/checks/data_consistency.rs
@@ -212,18 +212,9 @@ impl DataConsistencyCheck {
                 .map(|i| i.record_id.clone())
                 .collect();
             let data_hash = compute_data_hash(&account_ids);
-            // AffectedItem: name = account name, symbol = date badge
             let affected_items: Vec<AffectedItem> = negative_balance_issues
                 .iter()
-                .map(|i| {
-                    let date_str = i
-                        .first_negative_date
-                        .map(|d| d.format("%Y-%m-%d").to_string());
-                    let mut item =
-                        AffectedItem::account(i.record_id.clone(), i.description.clone());
-                    item.symbol = date_str;
-                    item
-                })
+                .map(|i| AffectedItem::account(i.record_id.clone(), i.description.clone()))
                 .collect();
 
             // Details: one entry per account with date, breakdown, and likely cause
@@ -236,7 +227,7 @@ impl DataConsistencyCheck {
                     let investments = total - cash;
                     let date_line = i
                         .first_negative_date
-                        .map(|d| format!("First went negative on {}", d.format("%Y-%m-%d")))
+                        .map(|d| format!("First went negative on {}.", d.format("%Y-%m-%d")))
                         .unwrap_or_default();
                     let breakdown = format!(
                         "Cash: {} {} | Investments: {} {}",
@@ -246,11 +237,11 @@ impl DataConsistencyCheck {
                         ccy,
                     );
                     let likely_cause = if cash < Decimal::ZERO && investments >= Decimal::ZERO {
-                        "→ Likely missing Transfer In or deposit before a buy transaction"
+                        "→ Likely missing Transfer In or deposit before a buy transaction."
                     } else if cash >= Decimal::ZERO && investments < Decimal::ZERO {
-                        "→ Likely missing Buy transaction before a Sell"
+                        "→ Likely missing Buy transaction before a Sell."
                     } else {
-                        "→ Multiple data issues — check activities around this date"
+                        "→ Multiple data issues — check activities around this date."
                     };
                     Some(format!(
                         "{}\n{}\n{}\n{}",

--- a/crates/core/src/health/checks/data_consistency.rs
+++ b/crates/core/src/health/checks/data_consistency.rs
@@ -3,6 +3,8 @@
 //! Detects orphan references, negative positions, and legacy data needing migration.
 
 use async_trait::async_trait;
+use chrono::NaiveDate;
+use rust_decimal::Decimal;
 
 use crate::errors::Result;
 use crate::health::model::{
@@ -32,12 +34,18 @@ pub struct ConsistencyIssueInfo {
     pub issue_type: ConsistencyIssueType,
     /// ID of the affected record (activity_id, asset_id, etc.)
     pub record_id: String,
-    /// Human-readable description
+    /// Human-readable description (used as display name for affected items)
     pub description: String,
     /// Related account ID (if applicable)
     pub account_id: Option<String>,
     /// Related asset ID (if applicable)
     pub asset_id: Option<String>,
+    /// First date the balance went negative (NegativeAccountBalance only)
+    pub first_negative_date: Option<NaiveDate>,
+    /// Cash balance on first_negative_date, in account currency (NegativeAccountBalance only)
+    pub cash_balance: Option<Decimal>,
+    /// Account currency (NegativeAccountBalance only)
+    pub account_currency: Option<String>,
 }
 
 /// Health check that detects data consistency problems.
@@ -204,7 +212,17 @@ impl DataConsistencyCheck {
             let data_hash = compute_data_hash(&account_ids);
             let affected_items: Vec<AffectedItem> = negative_balance_issues
                 .iter()
-                .map(|i| AffectedItem::account(i.record_id.clone(), i.description.clone()))
+                .map(|i| {
+                    let mut name = i.description.clone();
+                    if let Some(date) = i.first_negative_date {
+                        name.push_str(&format!(" — since {}", date.format("%Y-%m-%d")));
+                    }
+                    if let (Some(cash), Some(ccy)) = (i.cash_balance, i.account_currency.as_deref())
+                    {
+                        name.push_str(&format!(" (cash: {} {})", cash.round_dp(2), ccy));
+                    }
+                    AffectedItem::account(i.record_id.clone(), name)
+                })
                 .collect();
 
             health_issues.push(
@@ -285,6 +303,9 @@ mod tests {
             description: "Activity references deleted account".to_string(),
             account_id: Some("acc_deleted".to_string()),
             asset_id: None,
+            first_negative_date: None,
+            cash_balance: None,
+            account_currency: None,
         }];
 
         let issues = check.analyze(&issues_data, &ctx);
@@ -304,6 +325,9 @@ mod tests {
             description: "Position has negative quantity".to_string(),
             account_id: Some("acc_1".to_string()),
             asset_id: Some("SEC:AAPL:XNAS".to_string()),
+            first_negative_date: None,
+            cash_balance: None,
+            account_currency: None,
         }];
 
         let issues = check.analyze(&issues_data, &ctx);
@@ -322,6 +346,9 @@ mod tests {
             description: "Asset has legacy sector data".to_string(),
             account_id: None,
             asset_id: Some("SEC:AAPL:XNAS".to_string()),
+            first_negative_date: None,
+            cash_balance: None,
+            account_currency: None,
         }];
 
         let issues = check.analyze(&issues_data, &ctx);
@@ -342,6 +369,9 @@ mod tests {
                 description: "Orphan 1".to_string(),
                 account_id: None,
                 asset_id: None,
+                first_negative_date: None,
+                cash_balance: None,
+                account_currency: None,
             },
             ConsistencyIssueInfo {
                 issue_type: ConsistencyIssueType::OrphanActivityAccount,
@@ -349,6 +379,9 @@ mod tests {
                 description: "Orphan 2".to_string(),
                 account_id: None,
                 asset_id: None,
+                first_negative_date: None,
+                cash_balance: None,
+                account_currency: None,
             },
             ConsistencyIssueInfo {
                 issue_type: ConsistencyIssueType::NegativePosition,
@@ -356,6 +389,9 @@ mod tests {
                 description: "Negative".to_string(),
                 account_id: None,
                 asset_id: None,
+                first_negative_date: None,
+                cash_balance: None,
+                account_currency: None,
             },
         ];
 
@@ -372,9 +408,12 @@ mod tests {
         let issues_data = vec![ConsistencyIssueInfo {
             issue_type: ConsistencyIssueType::NegativeAccountBalance,
             record_id: "acc_123".to_string(),
-            description: "Account has negative total value".to_string(),
+            description: "My Account".to_string(),
             account_id: Some("acc_123".to_string()),
             asset_id: None,
+            first_negative_date: Some(chrono::NaiveDate::from_ymd_opt(2025, 1, 10).unwrap()),
+            cash_balance: Some(rust_decimal_macros::dec!(-50.20)),
+            account_currency: Some("EUR".to_string()),
         }];
 
         let issues = check.analyze(&issues_data, &ctx);

--- a/crates/core/src/health/checks/data_consistency.rs
+++ b/crates/core/src/health/checks/data_consistency.rs
@@ -44,6 +44,8 @@ pub struct ConsistencyIssueInfo {
     pub first_negative_date: Option<NaiveDate>,
     /// Cash balance on first_negative_date, in account currency (NegativeAccountBalance only)
     pub cash_balance: Option<Decimal>,
+    /// Total portfolio value on first_negative_date, in account currency (NegativeAccountBalance only)
+    pub total_value_at_date: Option<Decimal>,
     /// Account currency (NegativeAccountBalance only)
     pub account_currency: Option<String>,
 }
@@ -210,40 +212,60 @@ impl DataConsistencyCheck {
                 .map(|i| i.record_id.clone())
                 .collect();
             let data_hash = compute_data_hash(&account_ids);
+            // AffectedItem: name = account name, symbol = date badge
             let affected_items: Vec<AffectedItem> = negative_balance_issues
                 .iter()
                 .map(|i| {
-                    let mut name = i.description.clone();
-                    if let Some(date) = i.first_negative_date {
-                        name.push_str(&format!(" — since {}", date.format("%Y-%m-%d")));
-                    }
-                    if let (Some(cash), Some(ccy)) = (i.cash_balance, i.account_currency.as_deref())
-                    {
-                        name.push_str(&format!(" (cash: {} {})", cash.round_dp(2), ccy));
-                    }
-                    AffectedItem::account(i.record_id.clone(), name)
+                    let date_str = i
+                        .first_negative_date
+                        .map(|d| d.format("%Y-%m-%d").to_string());
+                    let mut item =
+                        AffectedItem::account(i.record_id.clone(), i.description.clone());
+                    item.symbol = date_str;
+                    item
                 })
                 .collect();
 
-            health_issues.push(
-                HealthIssue::builder()
-                    .id(format!("negative_account_balance:{}", data_hash))
-                    .severity(Severity::Warning)
-                    .category(HealthCategory::DataConsistency)
-                    .title(if count == 1 {
-                        "Account has negative portfolio balance".to_string()
-                    } else {
-                        format!("{} accounts have negative portfolio balance", count)
-                    })
-                    .message(
-                        "One or more accounts show a negative total value in their history. This is usually caused by missing buy transactions. Review your activities to fix this.",
-                    )
-                    .affected_count(count as u32)
-                    .affected_items(affected_items)
-                    .navigate_action(NavigateAction::to_activities(None))
-                    .data_hash(data_hash)
-                    .build(),
-            );
+            // Details: one line per account with cash / investments breakdown
+            let details: String = negative_balance_issues
+                .iter()
+                .filter_map(|i| {
+                    let ccy = i.account_currency.as_deref()?;
+                    let cash = i.cash_balance?;
+                    let total = i.total_value_at_date?;
+                    let investments = total - cash;
+                    Some(format!(
+                        "{}: cash {} {}, investments {} {}",
+                        i.description,
+                        cash.round_dp(2),
+                        ccy,
+                        investments.round_dp(2),
+                        ccy,
+                    ))
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            let mut builder = HealthIssue::builder()
+                .id(format!("negative_account_balance:{}", data_hash))
+                .severity(Severity::Warning)
+                .category(HealthCategory::DataConsistency)
+                .title(if count == 1 {
+                    "Account has negative portfolio balance".to_string()
+                } else {
+                    format!("{} accounts have negative portfolio balance", count)
+                })
+                .message(
+                    "One or more accounts show a negative total value in their history. This is usually caused by missing buy transactions. Review your activities to fix this.",
+                )
+                .affected_count(count as u32)
+                .affected_items(affected_items)
+                .navigate_action(NavigateAction::to_activities(None))
+                .data_hash(data_hash);
+            if !details.is_empty() {
+                builder = builder.details(details);
+            }
+            health_issues.push(builder.build());
         }
 
         health_issues
@@ -305,6 +327,7 @@ mod tests {
             asset_id: None,
             first_negative_date: None,
             cash_balance: None,
+            total_value_at_date: None,
             account_currency: None,
         }];
 
@@ -327,6 +350,7 @@ mod tests {
             asset_id: Some("SEC:AAPL:XNAS".to_string()),
             first_negative_date: None,
             cash_balance: None,
+            total_value_at_date: None,
             account_currency: None,
         }];
 
@@ -348,6 +372,7 @@ mod tests {
             asset_id: Some("SEC:AAPL:XNAS".to_string()),
             first_negative_date: None,
             cash_balance: None,
+            total_value_at_date: None,
             account_currency: None,
         }];
 
@@ -371,6 +396,7 @@ mod tests {
                 asset_id: None,
                 first_negative_date: None,
                 cash_balance: None,
+                total_value_at_date: None,
                 account_currency: None,
             },
             ConsistencyIssueInfo {
@@ -381,6 +407,7 @@ mod tests {
                 asset_id: None,
                 first_negative_date: None,
                 cash_balance: None,
+                total_value_at_date: None,
                 account_currency: None,
             },
             ConsistencyIssueInfo {
@@ -391,6 +418,7 @@ mod tests {
                 asset_id: None,
                 first_negative_date: None,
                 cash_balance: None,
+                total_value_at_date: None,
                 account_currency: None,
             },
         ];
@@ -413,6 +441,7 @@ mod tests {
             asset_id: None,
             first_negative_date: Some(chrono::NaiveDate::from_ymd_opt(2025, 1, 10).unwrap()),
             cash_balance: Some(rust_decimal_macros::dec!(-50.20)),
+            total_value_at_date: Some(rust_decimal_macros::dec!(-50.20)),
             account_currency: Some("EUR".to_string()),
         }];
 

--- a/crates/core/src/health/checks/data_consistency.rs
+++ b/crates/core/src/health/checks/data_consistency.rs
@@ -226,7 +226,7 @@ impl DataConsistencyCheck {
                 })
                 .collect();
 
-            // Details: one line per account with cash / investments breakdown
+            // Details: one entry per account with date, breakdown, and likely cause
             let details: String = negative_balance_issues
                 .iter()
                 .filter_map(|i| {
@@ -234,17 +234,31 @@ impl DataConsistencyCheck {
                     let cash = i.cash_balance?;
                     let total = i.total_value_at_date?;
                     let investments = total - cash;
-                    Some(format!(
-                        "{}: cash {} {}, investments {} {}",
-                        i.description,
+                    let date_line = i
+                        .first_negative_date
+                        .map(|d| format!("First went negative on {}", d.format("%Y-%m-%d")))
+                        .unwrap_or_default();
+                    let breakdown = format!(
+                        "Cash: {} {} | Investments: {} {}",
                         cash.round_dp(2),
                         ccy,
                         investments.round_dp(2),
                         ccy,
+                    );
+                    let likely_cause = if cash < Decimal::ZERO && investments >= Decimal::ZERO {
+                        "→ Likely missing Transfer In or deposit before a buy transaction"
+                    } else if cash >= Decimal::ZERO && investments < Decimal::ZERO {
+                        "→ Likely missing Buy transaction before a Sell"
+                    } else {
+                        "→ Multiple data issues — check activities around this date"
+                    };
+                    Some(format!(
+                        "{}\n{}\n{}\n{}",
+                        i.description, date_line, breakdown, likely_cause
                     ))
                 })
                 .collect::<Vec<_>>()
-                .join("\n");
+                .join("\n\n");
 
             let mut builder = HealthIssue::builder()
                 .id(format!("negative_account_balance:{}", data_hash))

--- a/crates/core/src/health/checks/fx_integrity.rs
+++ b/crates/core/src/health/checks/fx_integrity.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 
 use crate::errors::Result;
-use crate::health::model::{FixAction, HealthCategory, HealthIssue, Severity};
+use crate::health::model::{AffectedItem, FixAction, HealthCategory, HealthIssue, Severity};
 use crate::health::traits::{HealthCheck, HealthContext};
 
 /// Data about a currency pair needed for FX checks.
@@ -47,27 +47,27 @@ impl FxIntegrityCheck {
             ctx.now - Duration::hours(ctx.config.fx_stale_critical_hours as i64);
 
         // Track issues by type
-        let mut missing_pairs: Vec<String> = Vec::new();
+        let mut missing_pairs: Vec<&FxPairInfo> = Vec::new();
         let mut missing_mv = 0.0;
-        let mut stale_warning_pairs: Vec<String> = Vec::new();
+        let mut stale_warning_pairs: Vec<&FxPairInfo> = Vec::new();
         let mut stale_warning_mv = 0.0;
-        let mut stale_error_pairs: Vec<String> = Vec::new();
+        let mut stale_error_pairs: Vec<&FxPairInfo> = Vec::new();
         let mut stale_error_mv = 0.0;
 
         for pair in fx_pairs {
             match pair.latest_quote_time {
                 Some(quote_time) => {
                     if quote_time < critical_threshold {
-                        stale_error_pairs.push(pair.pair_id.clone());
+                        stale_error_pairs.push(pair);
                         stale_error_mv += pair.affected_mv;
                     } else if quote_time < warning_threshold {
-                        stale_warning_pairs.push(pair.pair_id.clone());
+                        stale_warning_pairs.push(pair);
                         stale_warning_mv += pair.affected_mv;
                     }
                 }
                 None => {
                     // No rate exists at all
-                    missing_pairs.push(pair.pair_id.clone());
+                    missing_pairs.push(pair);
                     missing_mv += pair.affected_mv;
                 }
             }
@@ -91,13 +91,23 @@ impl FxIntegrityCheck {
             let title = if count == 1 {
                 format!(
                     "Missing exchange rate for {}",
-                    missing_pairs[0].split(':').next().unwrap_or("currency")
+                    missing_pairs[0].from_currency
                 )
             } else {
                 format!("Missing exchange rates for {} currencies", count)
             };
 
-            let data_hash = compute_data_hash(&missing_pairs, severity, mv_pct);
+            let pair_ids: Vec<String> = missing_pairs.iter().map(|p| p.pair_id.clone()).collect();
+            let affected_items: Vec<AffectedItem> = missing_pairs
+                .iter()
+                .map(|p| {
+                    AffectedItem::simple(
+                        &p.pair_id,
+                        format!("{} → {}", p.from_currency, p.to_currency),
+                    )
+                })
+                .collect();
+            let data_hash = compute_data_hash(&pair_ids, severity, mv_pct);
 
             issues.push(
                 HealthIssue::builder()
@@ -110,7 +120,8 @@ impl FxIntegrityCheck {
                     )
                     .affected_count(count as u32)
                     .affected_mv_pct(mv_pct)
-                    .fix_action(FixAction::fetch_fx(missing_pairs))
+                    .fix_action(FixAction::fetch_fx(pair_ids))
+                    .affected_items(affected_items)
                     .data_hash(data_hash)
                     .build(),
             );
@@ -137,7 +148,20 @@ impl FxIntegrityCheck {
                 format!("Outdated exchange rates for {} currencies", count)
             };
 
-            let data_hash = compute_data_hash(&stale_error_pairs, severity, mv_pct);
+            let pair_ids: Vec<String> = stale_error_pairs
+                .iter()
+                .map(|p| p.pair_id.clone())
+                .collect();
+            let affected_items: Vec<AffectedItem> = stale_error_pairs
+                .iter()
+                .map(|p| {
+                    AffectedItem::simple(
+                        &p.pair_id,
+                        format!("{} → {}", p.from_currency, p.to_currency),
+                    )
+                })
+                .collect();
+            let data_hash = compute_data_hash(&pair_ids, severity, mv_pct);
 
             issues.push(
                 HealthIssue::builder()
@@ -150,7 +174,8 @@ impl FxIntegrityCheck {
                     )
                     .affected_count(count as u32)
                     .affected_mv_pct(mv_pct)
-                    .fix_action(FixAction::fetch_fx(stale_error_pairs))
+                    .fix_action(FixAction::fetch_fx(pair_ids))
+                    .affected_items(affected_items)
                     .data_hash(data_hash)
                     .build(),
             );
@@ -177,7 +202,20 @@ impl FxIntegrityCheck {
                 format!("Exchange rate updates needed for {} currencies", count)
             };
 
-            let data_hash = compute_data_hash(&stale_warning_pairs, severity, mv_pct);
+            let pair_ids: Vec<String> = stale_warning_pairs
+                .iter()
+                .map(|p| p.pair_id.clone())
+                .collect();
+            let affected_items: Vec<AffectedItem> = stale_warning_pairs
+                .iter()
+                .map(|p| {
+                    AffectedItem::simple(
+                        &p.pair_id,
+                        format!("{} → {}", p.from_currency, p.to_currency),
+                    )
+                })
+                .collect();
+            let data_hash = compute_data_hash(&pair_ids, severity, mv_pct);
 
             issues.push(
                 HealthIssue::builder()
@@ -190,7 +228,8 @@ impl FxIntegrityCheck {
                     )
                     .affected_count(count as u32)
                     .affected_mv_pct(mv_pct)
-                    .fix_action(FixAction::fetch_fx(stale_warning_pairs))
+                    .fix_action(FixAction::fetch_fx(pair_ids))
+                    .affected_items(affected_items)
                     .data_hash(data_hash)
                     .build(),
             );

--- a/crates/core/src/health/service.rs
+++ b/crates/core/src/health/service.rs
@@ -366,8 +366,13 @@ impl HealthService {
         };
         let unclassified_assets: Vec<UnclassifiedAssetInfo> = Vec::new();
 
-        // Detect accounts with negative portfolio balance in their history
-        let account_ids: Vec<String> = accounts.iter().map(|a| a.id.clone()).collect();
+        // Detect accounts with negative portfolio balance in their history.
+        // Exclude CASH accounts — a negative cash balance is a normal bank overdraft.
+        let account_ids: Vec<String> = accounts
+            .iter()
+            .filter(|a| a.account_type != crate::accounts::account_types::CASH)
+            .map(|a| a.id.clone())
+            .collect();
         let account_name_map: std::collections::HashMap<String, String> = accounts
             .iter()
             .map(|a| (a.id.clone(), a.name.clone()))

--- a/crates/core/src/health/service.rs
+++ b/crates/core/src/health/service.rs
@@ -393,6 +393,7 @@ impl HealthService {
                     asset_id: None,
                     first_negative_date: Some(info.first_negative_date),
                     cash_balance: Some(info.cash_balance),
+                    total_value_at_date: Some(info.total_value),
                     account_currency: Some(info.account_currency),
                 }
             })

--- a/crates/core/src/health/service.rs
+++ b/crates/core/src/health/service.rs
@@ -380,17 +380,20 @@ impl HealthService {
             });
         let consistency_issues: Vec<ConsistencyIssueInfo> = negative_balance_accounts
             .into_iter()
-            .map(|acc_id| {
+            .map(|info| {
                 let name = account_name_map
-                    .get(&acc_id)
+                    .get(&info.account_id)
                     .cloned()
-                    .unwrap_or_else(|| acc_id.clone());
+                    .unwrap_or_else(|| info.account_id.clone());
                 ConsistencyIssueInfo {
                     issue_type: super::checks::ConsistencyIssueType::NegativeAccountBalance,
-                    record_id: acc_id.clone(),
+                    record_id: info.account_id.clone(),
                     description: name,
-                    account_id: Some(acc_id),
+                    account_id: Some(info.account_id),
                     asset_id: None,
+                    first_negative_date: Some(info.first_negative_date),
+                    cash_balance: Some(info.cash_balance),
+                    account_currency: Some(info.account_currency),
                 }
             })
             .collect();

--- a/crates/core/src/health/service.rs
+++ b/crates/core/src/health/service.rs
@@ -383,7 +383,7 @@ impl HealthService {
                 warn!("Failed to check for negative account balances: {}", e);
                 Vec::new()
             });
-        let consistency_issues: Vec<ConsistencyIssueInfo> = negative_balance_accounts
+        let mut consistency_issues: Vec<ConsistencyIssueInfo> = negative_balance_accounts
             .into_iter()
             .map(|info| {
                 let name = account_name_map
@@ -403,6 +403,38 @@ impl HealthService {
                 }
             })
             .collect();
+
+        // Check CASH accounts separately — negative balance may be a normal overdraft (INFO only)
+        let cash_account_ids: Vec<String> = accounts
+            .iter()
+            .filter(|a| a.account_type == crate::accounts::account_types::CASH)
+            .map(|a| a.id.clone())
+            .collect();
+        if !cash_account_ids.is_empty() {
+            let negative_cash_accounts = valuation_service
+                .get_accounts_with_negative_balance(&cash_account_ids)
+                .unwrap_or_else(|e| {
+                    warn!("Failed to check for negative cash balances: {}", e);
+                    Vec::new()
+                });
+            for info in negative_cash_accounts {
+                let name = account_name_map
+                    .get(&info.account_id)
+                    .cloned()
+                    .unwrap_or_else(|| info.account_id.clone());
+                consistency_issues.push(ConsistencyIssueInfo {
+                    issue_type: super::checks::ConsistencyIssueType::NegativeCashBalance,
+                    record_id: info.account_id.clone(),
+                    description: name,
+                    account_id: Some(info.account_id),
+                    asset_id: None,
+                    first_negative_date: Some(info.first_negative_date),
+                    cash_balance: Some(info.cash_balance),
+                    total_value_at_date: Some(info.total_value),
+                    account_currency: Some(info.account_currency),
+                });
+            }
+        }
 
         // Gather accounts without tracking mode set
         let unconfigured_accounts: Vec<UnconfiguredAccountInfo> = accounts

--- a/crates/core/src/health/service.rs
+++ b/crates/core/src/health/service.rs
@@ -368,6 +368,10 @@ impl HealthService {
 
         // Detect accounts with negative portfolio balance in their history
         let account_ids: Vec<String> = accounts.iter().map(|a| a.id.clone()).collect();
+        let account_name_map: std::collections::HashMap<String, String> = accounts
+            .iter()
+            .map(|a| (a.id.clone(), a.name.clone()))
+            .collect();
         let negative_balance_accounts = valuation_service
             .get_accounts_with_negative_balance(&account_ids)
             .unwrap_or_else(|e| {
@@ -376,12 +380,18 @@ impl HealthService {
             });
         let consistency_issues: Vec<ConsistencyIssueInfo> = negative_balance_accounts
             .into_iter()
-            .map(|acc_id| ConsistencyIssueInfo {
-                issue_type: super::checks::ConsistencyIssueType::NegativeAccountBalance,
-                record_id: acc_id.clone(),
-                description: format!("Account {} has negative total value in history", acc_id),
-                account_id: Some(acc_id),
-                asset_id: None,
+            .map(|acc_id| {
+                let name = account_name_map
+                    .get(&acc_id)
+                    .cloned()
+                    .unwrap_or_else(|| acc_id.clone());
+                ConsistencyIssueInfo {
+                    issue_type: super::checks::ConsistencyIssueType::NegativeAccountBalance,
+                    record_id: acc_id.clone(),
+                    description: name,
+                    account_id: Some(acc_id),
+                    asset_id: None,
+                }
             })
             .collect();
 

--- a/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
+++ b/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
@@ -11,7 +11,9 @@ use crate::fx::{ExchangeRate, FxServiceTrait, NewExchangeRate};
 use crate::portfolio::snapshot::{
     AccountStateSnapshot, Position, SnapshotRepositoryTrait, SnapshotSource,
 };
-use crate::portfolio::valuation::{DailyAccountValuation, ValuationRepositoryTrait};
+use crate::portfolio::valuation::{
+    DailyAccountValuation, NegativeBalanceInfo, ValuationRepositoryTrait,
+};
 use crate::quotes::{
     LatestQuotePair, LatestQuoteSnapshot, ProviderInfo, Quote, QuoteImport, QuoteServiceTrait,
     QuoteSyncState, SymbolSearchResult, SymbolSyncPlan, SyncResult,
@@ -792,7 +794,10 @@ impl ValuationRepositoryTrait for MockValuationRepository {
         Ok(filtered)
     }
 
-    fn get_accounts_with_negative_balance(&self, _account_ids: &[String]) -> Result<Vec<String>> {
+    fn get_accounts_with_negative_balance(
+        &self,
+        _account_ids: &[String],
+    ) -> Result<Vec<NegativeBalanceInfo>> {
         Ok(Vec::new())
     }
 }

--- a/crates/core/src/portfolio/valuation/valuation_model.rs
+++ b/crates/core/src/portfolio/valuation/valuation_model.rs
@@ -4,6 +4,20 @@ use chrono::{DateTime, NaiveDate, Utc};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
+/// Details about an account that has a negative total_value in its history.
+#[derive(Debug, Clone)]
+pub struct NegativeBalanceInfo {
+    pub account_id: String,
+    /// First date the total_value went negative.
+    pub first_negative_date: NaiveDate,
+    /// Cash balance on that date (account currency).
+    pub cash_balance: Decimal,
+    /// Total value on that date (account currency).
+    pub total_value: Decimal,
+    /// Account currency (e.g. "EUR").
+    pub account_currency: String,
+}
+
 /// Domain model for daily account valuation
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]

--- a/crates/core/src/portfolio/valuation/valuation_service.rs
+++ b/crates/core/src/portfolio/valuation/valuation_service.rs
@@ -3,7 +3,7 @@ use crate::fx::currency::normalize_currency_code;
 use crate::fx::FxServiceTrait;
 use crate::portfolio::snapshot::SnapshotServiceTrait;
 use crate::portfolio::valuation::valuation_calculator::calculate_valuation;
-use crate::portfolio::valuation::valuation_model::DailyAccountValuation;
+use crate::portfolio::valuation::valuation_model::{DailyAccountValuation, NegativeBalanceInfo};
 use crate::portfolio::valuation::ValuationRepositoryTrait;
 use crate::quotes::QuoteServiceTrait;
 use crate::utils::time_utils;
@@ -81,9 +81,11 @@ pub trait ValuationServiceTrait: Send + Sync {
         date: NaiveDate,
     ) -> CoreResult<Vec<DailyAccountValuation>>;
 
-    /// Returns account IDs that have at least one negative total_value in their history.
-    fn get_accounts_with_negative_balance(&self, account_ids: &[String])
-        -> CoreResult<Vec<String>>;
+    /// Returns info about accounts that have at least one negative total_value in their history.
+    fn get_accounts_with_negative_balance(
+        &self,
+        account_ids: &[String],
+    ) -> CoreResult<Vec<NegativeBalanceInfo>>;
 }
 
 #[derive(Clone)]
@@ -419,7 +421,7 @@ impl ValuationServiceTrait for ValuationService {
     fn get_accounts_with_negative_balance(
         &self,
         account_ids: &[String],
-    ) -> CoreResult<Vec<String>> {
+    ) -> CoreResult<Vec<NegativeBalanceInfo>> {
         self.valuation_repository
             .get_accounts_with_negative_balance(account_ids)
     }

--- a/crates/core/src/portfolio/valuation/valuation_traits.rs
+++ b/crates/core/src/portfolio/valuation/valuation_traits.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use chrono::NaiveDate;
 
-use super::DailyAccountValuation;
+use super::{DailyAccountValuation, NegativeBalanceInfo};
 use crate::errors::Result;
 
 /// Repository trait for managing daily account valuations.
@@ -42,6 +42,9 @@ pub trait ValuationRepositoryTrait: Send + Sync {
         date: NaiveDate,
     ) -> Result<Vec<DailyAccountValuation>>;
 
-    /// Returns account IDs that have at least one negative total_value in their history.
-    fn get_accounts_with_negative_balance(&self, account_ids: &[String]) -> Result<Vec<String>>;
+    /// Returns info about accounts that have at least one negative total_value in their history.
+    fn get_accounts_with_negative_balance(
+        &self,
+        account_ids: &[String],
+    ) -> Result<Vec<NegativeBalanceInfo>>;
 }

--- a/crates/storage-sqlite/src/portfolio/valuation/repository.rs
+++ b/crates/storage-sqlite/src/portfolio/valuation/repository.rs
@@ -15,7 +15,9 @@ use crate::errors::StorageError;
 use crate::schema::daily_account_valuation;
 use crate::schema::daily_account_valuation::dsl::*;
 use wealthfolio_core::errors::Result;
-use wealthfolio_core::portfolio::valuation::{DailyAccountValuation, ValuationRepositoryTrait};
+use wealthfolio_core::portfolio::valuation::{
+    DailyAccountValuation, NegativeBalanceInfo, ValuationRepositoryTrait,
+};
 
 pub struct ValuationRepository {
     pool: Arc<Pool<ConnectionManager<SqliteConnection>>>,
@@ -215,7 +217,7 @@ impl ValuationRepositoryTrait for ValuationRepository {
     fn get_accounts_with_negative_balance(
         &self,
         input_account_ids: &[String],
-    ) -> Result<Vec<String>> {
+    ) -> Result<Vec<NegativeBalanceInfo>> {
         if input_account_ids.is_empty() {
             return Ok(Vec::new());
         }
@@ -225,9 +227,13 @@ impl ValuationRepositoryTrait for ValuationRepository {
             .map(|_| "?")
             .collect::<Vec<&str>>()
             .join(", ");
+        // SQLite returns non-aggregated columns from the row that determines MIN().
         let sql = format!(
-            "SELECT DISTINCT account_id FROM daily_account_valuation \
-             WHERE CAST(total_value AS REAL) < 0 AND account_id IN ({})",
+            "SELECT account_id, MIN(valuation_date) AS first_negative_date, \
+             cash_balance, total_value, account_currency \
+             FROM daily_account_valuation \
+             WHERE CAST(total_value AS REAL) < 0 AND account_id IN ({}) \
+             GROUP BY account_id",
             placeholders
         );
         let mut query_builder = sql_query(sql).into_boxed::<Sqlite>();
@@ -235,14 +241,37 @@ impl ValuationRepositoryTrait for ValuationRepository {
             query_builder = query_builder.bind::<Text, _>(acc_id);
         }
         #[derive(QueryableByName)]
-        struct AccountIdRow {
+        struct NegativeBalanceRow {
             #[diesel(sql_type = diesel::sql_types::Text, column_name = "account_id")]
             acc_id: String,
+            #[diesel(sql_type = diesel::sql_types::Text, column_name = "first_negative_date")]
+            neg_date: String,
+            #[diesel(sql_type = diesel::sql_types::Text, column_name = "cash_balance")]
+            cash_bal: String,
+            #[diesel(sql_type = diesel::sql_types::Text, column_name = "total_value")]
+            total_val: String,
+            #[diesel(sql_type = diesel::sql_types::Text, column_name = "account_currency")]
+            acc_currency: String,
         }
-        let rows: Vec<AccountIdRow> = query_builder
-            .load::<AccountIdRow>(&mut conn)
+        let rows: Vec<NegativeBalanceRow> = query_builder
+            .load::<NegativeBalanceRow>(&mut conn)
             .map_err(StorageError::from)?;
-        Ok(rows.into_iter().map(|r| r.acc_id).collect())
+        let result = rows
+            .into_iter()
+            .filter_map(|r| {
+                let date = NaiveDate::parse_from_str(&r.neg_date, "%Y-%m-%d").ok()?;
+                let cash = r.cash_bal.parse::<rust_decimal::Decimal>().ok()?;
+                let total = r.total_val.parse::<rust_decimal::Decimal>().ok()?;
+                Some(NegativeBalanceInfo {
+                    account_id: r.acc_id,
+                    first_negative_date: date,
+                    cash_balance: cash,
+                    total_value: total,
+                    account_currency: r.acc_currency,
+                })
+            })
+            .collect();
+        Ok(result)
     }
 
     fn get_valuations_on_date(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,58 +54,6 @@ importers:
         specifier: ^8.55.0
         version: 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
 
-  addons/fire-planner:
-    dependencies:
-      '@tanstack/react-query':
-        specifier: ^5.90.20
-        version: 5.90.21(react@19.2.4)
-      '@wealthfolio/addon-sdk':
-        specifier: workspace:*
-        version: link:../../packages/addon-sdk
-      '@wealthfolio/ui':
-        specifier: workspace:*
-        version: link:../../packages/ui
-      react:
-        specifier: ^19.2.4
-        version: 19.2.4
-      react-dom:
-        specifier: ^19.2.4
-        version: 19.2.4(react@19.2.4)
-      recharts:
-        specifier: ^3.7.0
-        version: 3.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1)
-    devDependencies:
-      '@tailwindcss/vite':
-        specifier: ^4.1.18
-        version: 4.2.1(vite@7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1))
-      '@types/node':
-        specifier: ^20.19.33
-        version: 20.19.35
-      '@types/react':
-        specifier: ^19.2.13
-        version: 19.2.14
-      '@types/react-dom':
-        specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.14)
-      '@vitejs/plugin-react':
-        specifier: ^5.1.4
-        version: 5.1.4(vite@7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1))
-      '@wealthfolio/addon-dev-tools':
-        specifier: workspace:*
-        version: link:../../packages/addon-dev-tools
-      rollup-plugin-external-globals:
-        specifier: ^0.13.0
-        version: 0.13.0(rollup@4.57.1)
-      tailwindcss:
-        specifier: ^4.1.18
-        version: 4.2.1
-      typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)
-
   addons/goal-progress-tracker:
     dependencies:
       '@tanstack/react-query':
@@ -2606,79 +2554,66 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -2792,28 +2727,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
     resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
     resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.1':
     resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.1':
     resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
@@ -2916,35 +2847,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.10.0':
     resolution: {integrity: sha512-GUoPdVJmrJRIXFfW3Rkt+eGK9ygOdyISACZfC/bCSfOnGt8kNdQIQr5WRH9QUaTVFIwxMlQyV3m+yXYP+xhSVA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.10.0':
     resolution: {integrity: sha512-JO7s3TlSxshwsoKNCDkyvsx5gw2QAs/Y2GbR5UE2d5kkU138ATKoPOtxn8G1fFT1aDW4LH0rYAAfBpGkDyJJnw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.10.0':
     resolution: {integrity: sha512-Uvh4SUUp4A6DVRSMWjelww0GnZI3PlVy7VS+DRF5napKuIehVjGl9XD0uKoCoxwAQBLctvipyEK+pDXpJeoHng==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.10.0':
     resolution: {integrity: sha512-AP0KRK6bJuTpQ8kMNWvhIpKUkQJfcPFeba7QshOQZjJ8wOS6emwTN4K5g/d3AbCMo0RRdnZWwu67MlmtJyxC1Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.10.0':
     resolution: {integrity: sha512-97DXVU3dJystrq7W41IX+82JEorLNY+3+ECYxvXWqkq7DBN6FsA08x/EFGE8N/b0LTOui9X2dvpGGoeZKKV08g==}
@@ -4806,28 +4732,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}


### PR DESCRIPTION
Hello @afadil, 

I hope you are doing great. 
I did some changes for the health center, to help the user got more informations to solve the issues. 
Specially regarding negative balance and Fx integrity. 

## Summary

Improves the Health Center issue drawer with more actionable details for two issue types.

### Negative Balance (Data Consistency)
- **Before**: only showed the account name and affected count
- **After**: shows per-account details — first negative date, cash balance, investment value, and a likely cause (missing transfer, missing buy transaction, etc.)
- CASH accounts that go negative now show an INFO warning instead of ERROR, since it's common and expected behavior (e.g. fees debited before cash is deposited)

### FX Integrity
- **Before**: only showed a count of affected currency pairs
- **After**: lists each affected pair (e.g. EUR → USD) in the drawer so the user knows exactly which conversions are broken

### Other
- Fix unused import warning for `NegativeBalanceInfo` in `crates/ai/src/env.rs`

## Key files changed
- `crates/core/src/health/checks/data_consistency.rs` — negative balance logic and details
- `crates/core/src/health/checks/fx_integrity.rs` — FX affected items
- `crates/core/src/portfolio/valuation/` — `NegativeBalanceInfo` model and query

## Test plan

- [ ] Account with negative balance shows date, cash/investment breakdown and likely cause in detail drawer
- [ ] CASH account with negative balance shows INFO (not ERROR)
- [ ] FX integrity issue lists affected currency pairs in detail drawer


## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).
