### PR TITLE
fix(health): use exchange MIC for price staleness timezone calculation

### DIFF
--- a/apps/tauri/src/commands/portfolio.rs
+++ b/apps/tauri/src/commands/portfolio.rs
@@ -1017,6 +1017,7 @@ pub async fn get_snapshot_by_date(
             notes: asset.notes.clone(),
             pricing_mode: asset.quote_mode.as_db_str().to_string(),
             preferred_provider: asset.preferred_provider(),
+            exchange_mic: asset.instrument_exchange_mic.clone(),
             classifications: None,
         };
 

--- a/crates/core/src/health/service.rs
+++ b/crates/core/src/health/service.rs
@@ -284,7 +284,7 @@ impl HealthService {
                             asset_id: instrument.id.clone(),
                             symbol: instrument.symbol.clone(),
                             name: instrument.name.clone(),
-                            exchange_mic: None, // TODO: populate from instrument once holdings model is updated
+                            exchange_mic: instrument.exchange_mic.clone(),
                             market_value: market_value_f64,
                             uses_market_pricing,
                         });

--- a/crates/core/src/portfolio/holdings/holdings_model.rs
+++ b/crates/core/src/portfolio/holdings/holdings_model.rs
@@ -29,6 +29,7 @@ pub struct Instrument {
     pub notes: Option<String>,
     pub pricing_mode: String,
     pub preferred_provider: Option<String>,
+    pub exchange_mic: Option<String>,
 
     // Taxonomy-based classifications
     pub classifications: Option<AssetClassifications>,

--- a/crates/core/src/portfolio/holdings/holdings_service.rs
+++ b/crates/core/src/portfolio/holdings/holdings_service.rs
@@ -128,6 +128,7 @@ impl HoldingsService {
                             notes: asset.notes.clone(),
                             pricing_mode: asset.quote_mode.as_db_str().to_string(),
                             preferred_provider: asset.preferred_provider(),
+                            exchange_mic: asset.instrument_exchange_mic.clone(),
                             classifications: None,
                         };
 
@@ -222,6 +223,7 @@ impl HoldingsService {
                 notes: None,
                 pricing_mode: "MANUAL".to_string(),
                 preferred_provider: None,
+                exchange_mic: None,
                 classifications: None,
             };
 
@@ -595,6 +597,7 @@ impl HoldingsServiceTrait for HoldingsService {
                 notes: asset.notes.clone(),
                 pricing_mode: asset.quote_mode.as_db_str().to_string(),
                 preferred_provider: asset.preferred_provider(),
+                exchange_mic: asset.instrument_exchange_mic.clone(),
                 classifications: None,
             };
 
@@ -712,6 +715,7 @@ mod tests {
                 notes: None,
                 pricing_mode: "MARKET".to_string(),
                 preferred_provider: None,
+                exchange_mic: None,
                 classifications: None,
             }),
             asset_kind: None,

--- a/crates/core/src/portfolio/holdings/holdings_valuation_service_tests.rs
+++ b/crates/core/src/portfolio/holdings/holdings_valuation_service_tests.rs
@@ -463,6 +463,7 @@ mod tests {
                 notes: None,
                 pricing_mode: "MARKET".to_string(),
                 preferred_provider: None,
+                exchange_mic: None,
                 classifications: None,
             })
         } else {


### PR DESCRIPTION
## Summary

- The price staleness health check was using UTC for all assets because
  `exchange_mic` was hardcoded to `None` in `AssetHoldingInfo`. This caused
  same-day quotes to be flagged as stale when the server's UTC date was
  ahead of the exchange's local date (e.g., US stocks flagged stale at
  10 PM Pacific because UTC had rolled to the next day).
- Added `exchange_mic: Option<String>` to `Instrument` and populated it
  from `asset.instrument_exchange_mic` at all construction sites (holdings
  service, tauri commands, health service).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo test --workspace`
- Verified that the existing `PriceStalenessCheck` unit tests (weekend
  false positives, trading-day calculation, MIC-based timezone lookup)
  continue to pass. The fix ensures these code paths are now actually
  reached in production.