### PR TITLE
feat(ai): add get_health_status tool to AI assistant

### DIFF
--- a/apps/server/src/ai_environment.rs
+++ b/apps/server/src/ai_environment.rs
@@ -8,9 +8,10 @@ use std::sync::{Arc, RwLock};
 use wealthfolio_ai::{AiEnvironment, ChatRepositoryTrait};
 use wealthfolio_core::{
     accounts::AccountServiceTrait, activities::ActivityServiceTrait,
-    allocation::AllocationServiceTrait, goals::GoalServiceTrait, holdings::HoldingsServiceTrait,
-    income::IncomeServiceTrait, performance::PerformanceServiceTrait, quotes::QuoteServiceTrait,
-    secrets::SecretStore, settings::SettingsServiceTrait, valuation::ValuationServiceTrait,
+    allocation::AllocationServiceTrait, goals::GoalServiceTrait, health::HealthServiceTrait,
+    holdings::HoldingsServiceTrait, income::IncomeServiceTrait,
+    performance::PerformanceServiceTrait, quotes::QuoteServiceTrait, secrets::SecretStore,
+    settings::SettingsServiceTrait, valuation::ValuationServiceTrait,
 };
 
 /// Server-side implementation of AiEnvironment.
@@ -31,6 +32,7 @@ pub struct ServerAiEnvironment {
     allocation_service: Arc<dyn AllocationServiceTrait + Send + Sync>,
     performance_service: Arc<dyn PerformanceServiceTrait + Send + Sync>,
     income_service: Arc<dyn IncomeServiceTrait + Send + Sync>,
+    health_service: Arc<dyn HealthServiceTrait + Send + Sync>,
 }
 
 impl ServerAiEnvironment {
@@ -50,6 +52,7 @@ impl ServerAiEnvironment {
         allocation_service: Arc<dyn AllocationServiceTrait + Send + Sync>,
         performance_service: Arc<dyn PerformanceServiceTrait + Send + Sync>,
         income_service: Arc<dyn IncomeServiceTrait + Send + Sync>,
+        health_service: Arc<dyn HealthServiceTrait + Send + Sync>,
     ) -> Self {
         Self {
             base_currency,
@@ -65,6 +68,7 @@ impl ServerAiEnvironment {
             allocation_service,
             performance_service,
             income_service,
+            health_service,
         }
     }
 }
@@ -120,5 +124,9 @@ impl AiEnvironment for ServerAiEnvironment {
 
     fn income_service(&self) -> Arc<dyn IncomeServiceTrait> {
         self.income_service.clone()
+    }
+
+    fn health_service(&self) -> Arc<dyn HealthServiceTrait> {
+        self.health_service.clone()
     }
 }

--- a/apps/server/src/main_lib.rs
+++ b/apps/server/src/main_lib.rs
@@ -378,6 +378,12 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
             ai_catalog_json,
         )?);
 
+    // Health service for portfolio health diagnostics
+    let health_dismissal_repository =
+        Arc::new(HealthDismissalRepository::new(pool.clone(), writer.clone()));
+    let health_service: Arc<dyn HealthServiceTrait + Send + Sync> =
+        Arc::new(HealthService::new(health_dismissal_repository));
+
     // AI chat repository for thread/message persistence
     let ai_chat_repository = Arc::new(AiChatRepository::new(pool.clone(), writer.clone()));
 
@@ -396,6 +402,7 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
         allocation_service.clone(),
         performance_service.clone(),
         income_service.clone(),
+        health_service.clone(),
     ));
     let ai_chat_service = Arc::new(ChatService::new(ai_environment, ChatConfig::default()));
 
@@ -409,12 +416,6 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
         device_display_name,
         app_version,
     ));
-
-    // Health service for portfolio health diagnostics
-    let health_dismissal_repository =
-        Arc::new(HealthDismissalRepository::new(pool.clone(), writer.clone()));
-    let health_service: Arc<dyn HealthServiceTrait + Send + Sync> =
-        Arc::new(HealthService::new(health_dismissal_repository));
 
     let event_bus = EventBus::new(256);
     let device_sync_runtime = Arc::new(DeviceSyncRuntimeState::new());

--- a/apps/tauri/src/context/ai_environment.rs
+++ b/apps/tauri/src/context/ai_environment.rs
@@ -8,9 +8,10 @@ use std::sync::{Arc, RwLock};
 use wealthfolio_ai::{AiEnvironment, ChatRepositoryTrait};
 use wealthfolio_core::{
     accounts::AccountServiceTrait, activities::ActivityServiceTrait,
-    allocation::AllocationServiceTrait, goals::GoalServiceTrait, holdings::HoldingsServiceTrait,
-    income::IncomeServiceTrait, performance::PerformanceServiceTrait, quotes::QuoteServiceTrait,
-    secrets::SecretStore, settings::SettingsServiceTrait, valuation::ValuationServiceTrait,
+    allocation::AllocationServiceTrait, goals::GoalServiceTrait, health::HealthServiceTrait,
+    holdings::HoldingsServiceTrait, income::IncomeServiceTrait,
+    performance::PerformanceServiceTrait, quotes::QuoteServiceTrait, secrets::SecretStore,
+    settings::SettingsServiceTrait, valuation::ValuationServiceTrait,
 };
 
 /// Tauri-side implementation of AiEnvironment.
@@ -31,6 +32,7 @@ pub struct TauriAiEnvironment {
     allocation_service: Arc<dyn AllocationServiceTrait + Send + Sync>,
     performance_service: Arc<dyn PerformanceServiceTrait + Send + Sync>,
     income_service: Arc<dyn IncomeServiceTrait + Send + Sync>,
+    health_service: Arc<dyn HealthServiceTrait + Send + Sync>,
 }
 
 impl TauriAiEnvironment {
@@ -50,6 +52,7 @@ impl TauriAiEnvironment {
         allocation_service: Arc<dyn AllocationServiceTrait + Send + Sync>,
         performance_service: Arc<dyn PerformanceServiceTrait + Send + Sync>,
         income_service: Arc<dyn IncomeServiceTrait + Send + Sync>,
+        health_service: Arc<dyn HealthServiceTrait + Send + Sync>,
     ) -> Self {
         Self {
             base_currency,
@@ -65,6 +68,7 @@ impl TauriAiEnvironment {
             allocation_service,
             performance_service,
             income_service,
+            health_service,
         }
     }
 }
@@ -120,5 +124,9 @@ impl AiEnvironment for TauriAiEnvironment {
 
     fn income_service(&self) -> Arc<dyn IncomeServiceTrait> {
         self.income_service.clone()
+    }
+
+    fn health_service(&self) -> Arc<dyn HealthServiceTrait> {
+        self.health_service.clone()
     }
 }

--- a/apps/tauri/src/context/providers.rs
+++ b/apps/tauri/src/context/providers.rs
@@ -300,6 +300,11 @@ pub async fn initialize_context(
     // AI chat repository for thread/message persistence
     let ai_chat_repository = Arc::new(AiChatRepository::new(pool.clone(), writer.clone()));
 
+    // Health service for portfolio health diagnostics
+    let health_dismissal_repository =
+        Arc::new(HealthDismissalRepository::new(pool.clone(), writer.clone()));
+    let health_service = Arc::new(HealthService::new(health_dismissal_repository));
+
     // Create AI environment and chat service
     let ai_environment = Arc::new(TauriAiEnvironment::new(
         base_currency.clone(),
@@ -315,6 +320,7 @@ pub async fn initialize_context(
         allocation_service.clone(),
         performance_service.clone(),
         income_service.clone(),
+        health_service.clone(),
     ));
     let ai_chat_service = Arc::new(ChatService::new(ai_environment, ChatConfig::default()));
 
@@ -329,11 +335,6 @@ pub async fn initialize_context(
         app_version,
     ));
     let device_sync_runtime = Arc::new(DeviceSyncRuntimeState::new());
-
-    // Health service for portfolio health diagnostics
-    let health_dismissal_repository =
-        Arc::new(HealthDismissalRepository::new(pool.clone(), writer.clone()));
-    let health_service = Arc::new(HealthService::new(health_dismissal_repository));
 
     Ok(ContextInitResult {
         context: ServiceContext {

--- a/crates/ai/src/chat.rs
+++ b/crates/ai/src/chat.rs
@@ -742,6 +742,9 @@ async fn spawn_chat_stream<E: AiEnvironment + 'static>(
             if is_allowed("import_csv") {
                 allowed_tools.push(Box::new(tool_set.import_csv));
             }
+            if is_allowed("get_health_status") {
+                allowed_tools.push(Box::new(tool_set.health_status));
+            }
 
             let mut builder = $client
                 .agent(&model_id)

--- a/crates/ai/src/env.rs
+++ b/crates/ai/src/env.rs
@@ -114,7 +114,9 @@ pub mod test_env {
         secrets::SecretStore,
         settings::{Settings, SettingsServiceTrait, SettingsUpdate},
         taxonomies::TaxonomyServiceTrait,
-        valuation::{DailyAccountValuation, ValuationRecalcMode, ValuationServiceTrait},
+        valuation::{
+            DailyAccountValuation, NegativeBalanceInfo, ValuationRecalcMode, ValuationServiceTrait,
+        },
         Error as CoreError, Result as CoreResult,
     };
 

--- a/crates/ai/src/env.rs
+++ b/crates/ai/src/env.rs
@@ -1257,16 +1257,9 @@ pub mod test_env {
         }
     }
 
+    #[derive(Default)]
     pub struct MockHealthService {
         pub cached_status: Option<HealthStatus>,
-    }
-
-    impl Default for MockHealthService {
-        fn default() -> Self {
-            Self {
-                cached_status: None,
-            }
-        }
     }
 
     #[async_trait::async_trait]

--- a/crates/ai/src/env.rs
+++ b/crates/ai/src/env.rs
@@ -92,10 +92,16 @@ pub mod test_env {
             ImportAssetPreviewItem, ImportMappingData, ImportTemplateData, ImportTemplateScope,
             NewActivity, SaveBrokerSyncProfileRulesRequest, Sort,
         },
-        assets::{Asset, ProviderProfile},
+        assets::{Asset, AssetServiceTrait, ProviderProfile},
         errors::DatabaseError,
         goals::{Goal, GoalServiceTrait, GoalsAllocation, NewGoal},
-        health::{FixAction, HealthConfig, HealthServiceTrait, HealthStatus},
+        health::{
+            checks::{
+                AssetHoldingInfo, ConsistencyIssueInfo, FxPairInfo, LegacyMigrationInfo,
+                QuoteSyncErrorInfo, UnclassifiedAssetInfo, UnconfiguredAccountInfo,
+            },
+            FixAction, HealthConfig, HealthServiceTrait, HealthStatus,
+        },
         holdings::{Holding, HoldingsServiceTrait},
         portfolio::allocation::{AllocationHoldings, AllocationServiceTrait, PortfolioAllocations},
         portfolio::income::{IncomeServiceTrait, IncomeSummary},
@@ -107,9 +113,8 @@ pub mod test_env {
         },
         secrets::SecretStore,
         settings::{Settings, SettingsServiceTrait, SettingsUpdate},
-        valuation::{
-            DailyAccountValuation, NegativeBalanceInfo, ValuationRecalcMode, ValuationServiceTrait,
-        },
+        taxonomies::TaxonomyServiceTrait,
+        valuation::{DailyAccountValuation, ValuationRecalcMode, ValuationServiceTrait},
         Error as CoreError, Result as CoreResult,
     };
 
@@ -1156,6 +1161,7 @@ pub mod test_env {
         pub allocation_service: Arc<dyn AllocationServiceTrait>,
         pub performance_service: Arc<dyn PerformanceServiceTrait>,
         pub income_service: Arc<dyn IncomeServiceTrait>,
+        pub health_service: Arc<dyn HealthServiceTrait>,
     }
 
     impl Default for MockEnvironment {
@@ -1180,6 +1186,7 @@ pub mod test_env {
                 allocation_service: Arc::new(MockAllocationService),
                 performance_service: Arc::new(MockPerformanceService),
                 income_service: Arc::new(MockIncomeService),
+                health_service: Arc::new(MockHealthService::default()),
             }
         }
 
@@ -1244,11 +1251,21 @@ pub mod test_env {
         }
 
         fn health_service(&self) -> Arc<dyn HealthServiceTrait> {
-            Arc::new(MockHealthService)
+            self.health_service.clone()
         }
     }
 
-    pub struct MockHealthService;
+    pub struct MockHealthService {
+        pub cached_status: Option<HealthStatus>,
+    }
+
+    impl Default for MockHealthService {
+        fn default() -> Self {
+            Self {
+                cached_status: None,
+            }
+        }
+    }
 
     #[async_trait::async_trait]
     impl HealthServiceTrait for MockHealthService {
@@ -1260,21 +1277,37 @@ pub mod test_env {
             &self,
             _base_currency: &str,
             _total_portfolio_value: f64,
-            _holdings: &[wealthfolio_core::portfolio::holdings::Holding],
+            _holdings: &[AssetHoldingInfo],
             _latest_quote_times: &std::collections::HashMap<String, chrono::DateTime<chrono::Utc>>,
-            _quote_sync_errors: &[wealthfolio_core::health::QuoteSyncError],
-            _fx_pairs: &[wealthfolio_core::health::FxPairInfo],
-            _unclassified_assets: &[wealthfolio_core::health::UnclassifiedAssetInfo],
-            _consistency_issues: &[wealthfolio_core::health::DataConsistencyIssue],
-            _legacy_migration_info: Option<&wealthfolio_core::health::LegacyMigrationInfo>,
-            _unconfigured_accounts: &[wealthfolio_core::accounts::Account],
+            _quote_sync_errors: &[QuoteSyncErrorInfo],
+            _fx_pairs: &[FxPairInfo],
+            _unclassified_assets: &[UnclassifiedAssetInfo],
+            _consistency_issues: &[ConsistencyIssueInfo],
+            _legacy_migration_info: &Option<LegacyMigrationInfo>,
+            _unconfigured_accounts: &[UnconfiguredAccountInfo],
             _configured_timezone: Option<&str>,
+            _client_timezone: Option<&str>,
+        ) -> CoreResult<HealthStatus> {
+            Ok(HealthStatus::healthy())
+        }
+
+        async fn run_full_checks(
+            &self,
+            _base_currency: &str,
+            _account_service: Arc<dyn wealthfolio_core::accounts::AccountServiceTrait>,
+            _holdings_service: Arc<dyn HoldingsServiceTrait>,
+            _quote_service: Arc<dyn QuoteServiceTrait>,
+            _asset_service: Arc<dyn AssetServiceTrait>,
+            _taxonomy_service: Arc<dyn TaxonomyServiceTrait>,
+            _valuation_service: Arc<dyn ValuationServiceTrait>,
+            _configured_timezone: Option<&str>,
+            _client_timezone: Option<&str>,
         ) -> CoreResult<HealthStatus> {
             Ok(HealthStatus::healthy())
         }
 
         async fn get_cached_status(&self) -> Option<HealthStatus> {
-            None
+            self.cached_status.clone()
         }
 
         async fn dismiss_issue(&self, _issue_id: &str, _data_hash: &str) -> CoreResult<()> {

--- a/crates/ai/src/env.rs
+++ b/crates/ai/src/env.rs
@@ -10,6 +10,7 @@ use wealthfolio_core::{
     accounts::AccountServiceTrait,
     activities::ActivityServiceTrait,
     goals::GoalServiceTrait,
+    health::HealthServiceTrait,
     portfolio::{
         allocation::AllocationServiceTrait, holdings::HoldingsServiceTrait,
         income::IncomeServiceTrait, performance::PerformanceServiceTrait,
@@ -70,6 +71,9 @@ pub trait AiEnvironment: Send + Sync {
 
     /// Get the income service for income/dividend summaries.
     fn income_service(&self) -> Arc<dyn IncomeServiceTrait>;
+
+    /// Get the health service for portfolio health diagnostics.
+    fn health_service(&self) -> Arc<dyn HealthServiceTrait>;
 }
 
 #[cfg(test)]
@@ -91,6 +95,7 @@ pub mod test_env {
         assets::{Asset, ProviderProfile},
         errors::DatabaseError,
         goals::{Goal, GoalServiceTrait, GoalsAllocation, NewGoal},
+        health::{FixAction, HealthConfig, HealthServiceTrait, HealthStatus},
         holdings::{Holding, HoldingsServiceTrait},
         portfolio::allocation::{AllocationHoldings, AllocationServiceTrait, PortfolioAllocations},
         portfolio::income::{IncomeServiceTrait, IncomeSummary},
@@ -1236,6 +1241,66 @@ pub mod test_env {
 
         fn income_service(&self) -> Arc<dyn IncomeServiceTrait> {
             self.income_service.clone()
+        }
+
+        fn health_service(&self) -> Arc<dyn HealthServiceTrait> {
+            Arc::new(MockHealthService)
+        }
+    }
+
+    pub struct MockHealthService;
+
+    #[async_trait::async_trait]
+    impl HealthServiceTrait for MockHealthService {
+        async fn run_checks(&self, _base_currency: &str) -> CoreResult<HealthStatus> {
+            Ok(HealthStatus::healthy())
+        }
+
+        async fn run_checks_with_data(
+            &self,
+            _base_currency: &str,
+            _total_portfolio_value: f64,
+            _holdings: &[wealthfolio_core::portfolio::holdings::Holding],
+            _latest_quote_times: &std::collections::HashMap<String, chrono::DateTime<chrono::Utc>>,
+            _quote_sync_errors: &[wealthfolio_core::health::QuoteSyncError],
+            _fx_pairs: &[wealthfolio_core::health::FxPairInfo],
+            _unclassified_assets: &[wealthfolio_core::health::UnclassifiedAssetInfo],
+            _consistency_issues: &[wealthfolio_core::health::DataConsistencyIssue],
+            _legacy_migration_info: Option<&wealthfolio_core::health::LegacyMigrationInfo>,
+            _unconfigured_accounts: &[wealthfolio_core::accounts::Account],
+            _configured_timezone: Option<&str>,
+        ) -> CoreResult<HealthStatus> {
+            Ok(HealthStatus::healthy())
+        }
+
+        async fn get_cached_status(&self) -> Option<HealthStatus> {
+            None
+        }
+
+        async fn dismiss_issue(&self, _issue_id: &str, _data_hash: &str) -> CoreResult<()> {
+            Ok(())
+        }
+
+        async fn restore_issue(&self, _issue_id: &str) -> CoreResult<()> {
+            Ok(())
+        }
+
+        async fn get_dismissed_ids(&self) -> CoreResult<Vec<String>> {
+            Ok(Vec::new())
+        }
+
+        async fn execute_fix(&self, _action: &FixAction) -> CoreResult<()> {
+            Ok(())
+        }
+
+        async fn clear_cache(&self) {}
+
+        async fn get_config(&self) -> HealthConfig {
+            HealthConfig::default()
+        }
+
+        async fn update_config(&self, _config: HealthConfig) -> CoreResult<()> {
+            Ok(())
         }
     }
 }

--- a/crates/ai/src/tools/health.rs
+++ b/crates/ai/src/tools/health.rs
@@ -87,7 +87,7 @@ impl<E: AiEnvironment + 'static> Tool for GetHealthStatusTool<E> {
 
         let status = health_service.get_cached_status().await.ok_or_else(|| {
             AiError::ToolExecutionFailed(
-                "Health status not available yet. Please wait a moment and try again.".to_string(),
+                "Health status not available yet. Please open the Health Center to run a check first.".to_string(),
             )
         })?;
 
@@ -119,15 +119,52 @@ impl<E: AiEnvironment + 'static> Tool for GetHealthStatusTool<E> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::env::test_env::MockEnvironment;
+    use crate::env::test_env::{MockEnvironment, MockHealthService};
+    use wealthfolio_core::health::{HealthCategory, HealthIssue, HealthStatus, Severity};
 
     #[tokio::test]
-    async fn test_get_health_status_tool() {
+    async fn test_get_health_status_no_cache() {
         let env = Arc::new(MockEnvironment::new());
         let tool = GetHealthStatusTool::new(env);
 
         let result = tool.call(GetHealthStatusArgs {}).await;
-        // Mock returns None for cached status, so expect an error
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_health_status_with_issues() {
+        let issue = HealthIssue::builder()
+            .id("price_stale:AAPL")
+            .severity(Severity::Warning)
+            .category(HealthCategory::PriceStaleness)
+            .title("Outdated prices")
+            .message("AAPL has stale price data.")
+            .affected_count(1)
+            .affected_mv_pct(0.05)
+            .details("Last updated 10 days ago.")
+            .data_hash("abc123")
+            .build();
+
+        let status = HealthStatus::from_issues(vec![issue]);
+        let health_svc = MockHealthService {
+            cached_status: Some(status),
+        };
+
+        let mut env = MockEnvironment::new();
+        env.health_service = Arc::new(health_svc);
+
+        let tool = GetHealthStatusTool::new(Arc::new(env));
+        let result = tool.call(GetHealthStatusArgs {}).await.unwrap();
+
+        assert_eq!(result.total_count, 1);
+        assert_eq!(result.overall_severity, "WARNING");
+        let dto = &result.issues[0];
+        assert_eq!(dto.id, "price_stale:AAPL");
+        assert_eq!(dto.severity, "WARNING");
+        assert_eq!(dto.category, "Price Updates");
+        assert_eq!(dto.title, "Outdated prices");
+        assert_eq!(dto.affected_count, 1);
+        assert_eq!(dto.affected_mv_pct, Some(0.05));
+        assert_eq!(dto.details.as_deref(), Some("Last updated 10 days ago."));
     }
 }

--- a/crates/ai/src/tools/health.rs
+++ b/crates/ai/src/tools/health.rs
@@ -1,0 +1,133 @@
+//! Health status tool - expose portfolio health issues to the AI assistant.
+
+use rig::{completion::ToolDefinition, tool::Tool};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::env::AiEnvironment;
+use crate::error::AiError;
+
+// ============================================================================
+// Tool Arguments and Output
+// ============================================================================
+
+/// Arguments for the get_health_status tool (no required args).
+#[derive(Debug, Default, Deserialize)]
+pub struct GetHealthStatusArgs {}
+
+/// DTO for a single health issue.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HealthIssueDto {
+    pub id: String,
+    pub severity: String,
+    pub category: String,
+    pub title: String,
+    pub message: String,
+    pub affected_count: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub affected_mv_pct: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<String>,
+}
+
+/// Output envelope for get_health_status tool.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetHealthStatusOutput {
+    pub overall_severity: String,
+    pub issues: Vec<HealthIssueDto>,
+    pub total_count: usize,
+}
+
+// ============================================================================
+// Tool Implementation
+// ============================================================================
+
+/// Tool to get the current portfolio health status.
+pub struct GetHealthStatusTool<E: AiEnvironment> {
+    env: Arc<E>,
+}
+
+impl<E: AiEnvironment> GetHealthStatusTool<E> {
+    pub fn new(env: Arc<E>) -> Self {
+        Self { env }
+    }
+}
+
+impl<E: AiEnvironment> Clone for GetHealthStatusTool<E> {
+    fn clone(&self) -> Self {
+        Self {
+            env: self.env.clone(),
+        }
+    }
+}
+
+impl<E: AiEnvironment + 'static> Tool for GetHealthStatusTool<E> {
+    const NAME: &'static str = "get_health_status";
+
+    type Error = AiError;
+    type Args = GetHealthStatusArgs;
+    type Output = GetHealthStatusOutput;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Get the current health status of the portfolio data. Returns detected issues (missing prices, stale FX rates, negative balances, unclassified assets, etc.) with severity levels and details. Use this to help the user diagnose and fix data problems.".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {},
+                "required": []
+            }),
+        }
+    }
+
+    async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let health_service = self.env.health_service();
+
+        let status = health_service.get_cached_status().await.ok_or_else(|| {
+            AiError::ToolExecutionFailed(
+                "Health status not available yet. Please wait a moment and try again.".to_string(),
+            )
+        })?;
+
+        let issues = status
+            .issues
+            .iter()
+            .map(|issue| HealthIssueDto {
+                id: issue.id.clone(),
+                severity: issue.severity.to_string(),
+                category: issue.category.to_string(),
+                title: issue.title.clone(),
+                message: issue.message.clone(),
+                affected_count: issue.affected_count,
+                affected_mv_pct: issue.affected_mv_pct,
+                details: issue.details.clone(),
+            })
+            .collect::<Vec<_>>();
+
+        let total_count = issues.len();
+
+        Ok(GetHealthStatusOutput {
+            overall_severity: status.overall_severity.to_string(),
+            issues,
+            total_count,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::env::test_env::MockEnvironment;
+
+    #[tokio::test]
+    async fn test_get_health_status_tool() {
+        let env = Arc::new(MockEnvironment::new());
+        let tool = GetHealthStatusTool::new(env);
+
+        let result = tool.call(GetHealthStatusArgs {}).await;
+        // Mock returns None for cached status, so expect an error
+        assert!(result.is_err());
+    }
+}

--- a/crates/ai/src/tools/mod.rs
+++ b/crates/ai/src/tools/mod.rs
@@ -19,6 +19,7 @@ pub mod activities;
 pub mod allocation;
 pub mod constants;
 pub mod goals;
+pub mod health;
 pub mod holdings;
 pub mod import_csv;
 pub mod income;
@@ -35,6 +36,7 @@ pub use accounts::GetAccountsTool;
 pub use activities::SearchActivitiesTool;
 pub use allocation::GetAssetAllocationTool;
 pub use goals::GetGoalsTool;
+pub use health::GetHealthStatusTool;
 pub use holdings::GetHoldingsTool;
 pub use import_csv::ImportCsvTool;
 pub use income::GetIncomeTool;
@@ -60,6 +62,7 @@ pub struct ToolSet<E: AiEnvironment> {
     pub record_activity: RecordActivityTool<E>,
     pub record_activities: RecordActivitiesTool<E>,
     pub import_csv: ImportCsvTool<E>,
+    pub health_status: GetHealthStatusTool<E>,
 }
 
 impl<E: AiEnvironment> ToolSet<E> {
@@ -76,7 +79,8 @@ impl<E: AiEnvironment> ToolSet<E> {
             performance: GetPerformanceTool::new(env.clone(), base_currency.clone()),
             record_activity: RecordActivityTool::new(env.clone()),
             record_activities: RecordActivitiesTool::new(env.clone()),
-            import_csv: ImportCsvTool::new(env, base_currency),
+            import_csv: ImportCsvTool::new(env.clone(), base_currency),
+            health_status: GetHealthStatusTool::new(env),
         }
     }
 }

--- a/crates/ai/src/types.rs
+++ b/crates/ai/src/types.rs
@@ -37,6 +37,7 @@ pub const DEFAULT_TOOLS_ALLOWLIST: &[&str] = &[
     "record_activity",
     "record_activities",
     "import_csv",
+    "get_health_status",
 ];
 
 /// Maximum size in bytes for persisted message content (256KB).


### PR DESCRIPTION
## Summary

While using the AI assistant, I noticed it had no way to help with data problems — it couldn't see the Health Center issues at all. This change adds a `get_health_status` tool so the assistant can detect and explain portfolio health issues and guide the user toward fixing them.

### What the assistant can now do

- Tell the user if they have missing prices, stale FX rates, negative account balances, unclassified assets, etc.
- Explain what each issue means and its impact on the portfolio value
- Guide the user toward the fix (e.g. "you can click Fetch Exchange Rates in the Health Center")

### How it works

- New `get_health_status` tool reads from the cached health status (fast, no re-run of all checks)
- Returns `overall_severity`, list of issues with `severity`, `category`, `title`, `message`, `details`, and `affected_mv_pct`
- Added to the default tools allowlist so it's available by default

### Files changed
- `crates/ai/src/tools/health.rs` — new tool implementation
- `crates/ai/src/tools/mod.rs` — register tool in ToolSet
- `crates/ai/src/chat.rs` — add to allowed tools builder
- `crates/ai/src/types.rs` — add to DEFAULT_TOOLS_ALLOWLIST
- `crates/ai/src/env.rs` — add `health_service()` to AiEnvironment trait + mock
- `apps/tauri/src/context/ai_environment.rs` — wire HealthServiceTrait in TauriAiEnvironment
- `apps/tauri/src/context/providers.rs` — pass health_service to TauriAiEnvironment

## Test plan

- [ ] Ask the AI "Do I have any data issues in my portfolio?" — it should call `get_health_status` and report any issues
- [ ] With no health issues, the assistant should confirm everything looks healthy
- [ ] With a known issue (e.g. stale price), the assistant should describe it and suggest a fix

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).