### PR TITLE
fix(quotes): deactivate assets when positions close

### DIFF
--- a/crates/core/src/quotes/service.rs
+++ b/crates/core/src/quotes/service.rs
@@ -9,7 +9,7 @@
 
 use async_trait::async_trait;
 use chrono::{Duration, NaiveDate, TimeZone, Utc};
-use log::{debug, info};
+use log::{debug, info, warn};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -1315,6 +1315,9 @@ where
                         asset_id, current_qty
                     );
                     self.sync_state_store.mark_active(asset_id).await?;
+                    if let Err(e) = self.asset_repo.reactivate(asset_id).await {
+                        warn!("Failed to reactivate asset {}: {}", asset_id, e);
+                    }
                     marked_active += 1;
                 }
                 // If already active, no change needed
@@ -1324,6 +1327,9 @@ where
                     // Was active, now closed - mark as inactive with today's date
                     debug!("Marking asset {} as inactive (position closed)", asset_id);
                     self.sync_state_store.mark_inactive(asset_id, today).await?;
+                    if let Err(e) = self.asset_repo.deactivate(asset_id).await {
+                        warn!("Failed to deactivate asset {}: {}", asset_id, e);
+                    }
                     marked_inactive += 1;
                 }
                 // If already inactive, no change needed (preserve existing closed date)


### PR DESCRIPTION
## Summary

- When `update_position_status_from_holdings` detects a fully sold
  position (quantity = 0), set `assets.is_active = false` alongside
  the existing `quote_sync_state.position_closed_date` update.
- When a position reopens (quantity > 0 after being closed), reactivate
  the asset via `reactivate()`.
- This stops the sync from attempting to fetch quotes for closed positions
  and prevents the health check from flagging them as stale. Previously,
  `should_sync_asset()` checked `Asset.is_active` (always true) while
  sync planning checked `QuoteSyncState.position_closed_date`, causing
  closed positions to pass the pre-filter and accumulate errors during
  the 30-day grace period.
- Reactivation is also handled by `resolve_or_create_asset` on new
  activity creation, so same-day sell+rebuy is covered by both paths.

## Test plan
- [x] `cargo fmt`, `cargo clippy`, `cargo test` all pass
- [x] Frontend: `pnpm format:check`, `lint`, `type-check`, `test`, `build` all pass
- [x] Verified no UI endpoints filter by `assets.is_active` — change only
  affects sync planning and health checks