### PR TITLE
feat(accounts): add tax treatment classification (Taxable / Tax Deferred / Tax Free)

### DIFF
--- a/apps/frontend/src/adapters/shared/accounts.ts
+++ b/apps/frontend/src/adapters/shared/accounts.ts
@@ -27,17 +27,17 @@ export const createAccount = async (account: NewAccount): Promise<Account> => {
 
 export const updateAccount = async (account: NewAccount): Promise<Account> => {
   try {
-    // Platform-aware: desktop strips currency (immutable after creation)
+    // Platform-aware: desktop strips currency (immutable after creation).
+    // `taxTreatment` is Option-typed on the backend; when the caller omits it,
+    // JSON.stringify drops the undefined key and the repository preserves
+    // the existing value.
     const payload = isDesktop
       ? (() => {
           const { currency: _, ...rest } = account;
           return rest;
         })()
       : account;
-    // Remove taxTreatment from payload if not explicitly provided (will be preserved by backend)
-    const { taxTreatment, ...updatePayload } = payload;
-    const finalPayload = taxTreatment ? { ...updatePayload, taxTreatment } : updatePayload;
-    return await invoke<Account>("update_account", { accountUpdate: finalPayload });
+    return await invoke<Account>("update_account", { accountUpdate: payload });
   } catch (error) {
     logger.error("Error updating account.");
     throw error;

--- a/apps/frontend/src/adapters/shared/accounts.ts
+++ b/apps/frontend/src/adapters/shared/accounts.ts
@@ -34,7 +34,10 @@ export const updateAccount = async (account: NewAccount): Promise<Account> => {
           return rest;
         })()
       : account;
-    return await invoke<Account>("update_account", { accountUpdate: payload });
+    // Remove taxTreatment from payload if not explicitly provided (will be preserved by backend)
+    const { taxTreatment, ...updatePayload } = payload;
+    const finalPayload = taxTreatment ? { ...updatePayload, taxTreatment } : updatePayload;
+    return await invoke<Account>("update_account", { accountUpdate: finalPayload });
   } catch (error) {
     logger.error("Error updating account.");
     throw error;

--- a/apps/frontend/src/lib/schemas.ts
+++ b/apps/frontend/src/lib/schemas.ts
@@ -75,6 +75,8 @@ export const importMappingSchema = z.object({
 
 export const trackingModeSchema = z.enum(["TRANSACTIONS", "HOLDINGS", "NOT_SET"]);
 
+export const taxTreatmentSchema = z.enum(["TAXABLE", "TAX_FREE", "TAX_DEFERRED"]);
+
 export const newAccountSchema = z.object({
   id: z.string().uuid().optional(),
   name: z
@@ -92,6 +94,7 @@ export const newAccountSchema = z.object({
   accountType: accountTypeSchema,
   currency: z.string({ required_error: "Please select a currency." }),
   trackingMode: trackingModeSchema.optional().default("NOT_SET"),
+  taxTreatment: taxTreatmentSchema.optional(),
   meta: z.string().nullable().optional(),
 });
 

--- a/apps/frontend/src/lib/settings-provider.tsx
+++ b/apps/frontend/src/lib/settings-provider.tsx
@@ -29,6 +29,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const { data, isLoading, isError, refetch } = useSettings();
   const [settings, setSettings] = useState<Settings | null>(null);
   const [accountsGrouped, setAccountsGrouped] = useState(true);
+  const [groupingMode, setGroupingMode] = useState<"none" | "accountGroup" | "taxTreatment">(
+    "accountGroup",
+  );
 
   const updateMutation = useSettingsMutation(setSettings, applySettingsToDocument);
 
@@ -85,6 +88,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     },
     accountsGrouped,
     setAccountsGrouped,
+    groupingMode,
+    setGroupingMode,
   };
 
   return <SettingsContext.Provider value={contextValue}>{children}</SettingsContext.Provider>;

--- a/apps/frontend/src/lib/settings-provider.tsx
+++ b/apps/frontend/src/lib/settings-provider.tsx
@@ -29,9 +29,6 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const { data, isLoading, isError, refetch } = useSettings();
   const [settings, setSettings] = useState<Settings | null>(null);
   const [accountsGrouped, setAccountsGrouped] = useState(true);
-  const [groupingMode, setGroupingMode] = useState<"none" | "accountGroup" | "taxTreatment">(
-    "accountGroup",
-  );
 
   const updateMutation = useSettingsMutation(setSettings, applySettingsToDocument);
 
@@ -88,8 +85,6 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     },
     accountsGrouped,
     setAccountsGrouped,
-    groupingMode,
-    setGroupingMode,
   };
 
   return <SettingsContext.Provider value={contextValue}>{children}</SettingsContext.Provider>;

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -710,8 +710,6 @@ export interface SettingsContextType {
   updateBaseCurrency: (currency: Settings["baseCurrency"]) => Promise<void>;
   accountsGrouped: boolean;
   setAccountsGrouped: (value: boolean) => void;
-  groupingMode: "none" | "accountGroup" | "taxTreatment";
-  setGroupingMode: (value: "none" | "accountGroup" | "taxTreatment") => void;
 }
 
 export interface Goal {

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -54,6 +54,7 @@ export interface Account {
   isActive: boolean;
   isArchived: boolean;
   trackingMode: TrackingMode;
+  taxTreatment?: TaxTreatment; // Optional - tax classification (TAXABLE, TAX_FREE, TAX_DEFERRED)
   createdAt: Date;
   updatedAt: Date;
   platformId?: string; // Optional - links to platform/broker
@@ -709,6 +710,8 @@ export interface SettingsContextType {
   updateBaseCurrency: (currency: Settings["baseCurrency"]) => Promise<void>;
   accountsGrouped: boolean;
   setAccountsGrouped: (value: boolean) => void;
+  groupingMode: "none" | "accountGroup" | "taxTreatment";
+  setGroupingMode: (value: "none" | "accountGroup" | "taxTreatment") => void;
 }
 
 export interface Goal {
@@ -1539,6 +1542,12 @@ export interface MigrationResult {
  * Matches the backend TrackingMode enum.
  */
 export type TrackingMode = "TRANSACTIONS" | "HOLDINGS" | "NOT_SET";
+
+/**
+ * Tax treatment classification for an account.
+ * Matches the backend TaxTreatment enum.
+ */
+export type TaxTreatment = "TAXABLE" | "TAX_FREE" | "TAX_DEFERRED";
 
 // ============================================================================
 // AI Provider Types

--- a/apps/frontend/src/pages/dashboard/accounts-summary.tsx
+++ b/apps/frontend/src/pages/dashboard/accounts-summary.tsx
@@ -29,6 +29,7 @@ interface AccountSummaryDisplayData {
   accountId?: string;
   accountType?: string;
   accountGroup?: string | null;
+  taxTreatment?: "TAXABLE" | "TAX_FREE" | "TAX_DEFERRED";
   isGroup?: boolean;
   accountCount?: number;
   accounts?: AccountSummaryDisplayData[];
@@ -256,6 +257,60 @@ const AccountSummaryComponent = React.memo(
 );
 AccountSummaryComponent.displayName = "AccountSummaryComponent";
 
+const TAX_TREATMENT_LABELS: Record<"TAXABLE" | "TAX_FREE" | "TAX_DEFERRED", string> = {
+  TAXABLE: "Taxable",
+  TAX_DEFERRED: "Tax Deferred",
+  TAX_FREE: "Tax Free",
+};
+
+const TAX_TREATMENT_ORDER: Array<"TAXABLE" | "TAX_DEFERRED" | "TAX_FREE"> = [
+  "TAXABLE",
+  "TAX_DEFERRED",
+  "TAX_FREE",
+];
+
+const GroupTaxTreatmentSummary = React.memo(
+  ({ accounts, baseCurrency }: { accounts: AccountSummaryDisplayData[]; baseCurrency: string }) => {
+    const totals = useMemo(() => {
+      const map = new Map<"TAXABLE" | "TAX_FREE" | "TAX_DEFERRED", number>();
+      for (const account of accounts) {
+        const treatment = account.taxTreatment ?? "TAXABLE";
+        map.set(treatment, (map.get(treatment) ?? 0) + Number(account.totalValueBaseCurrency ?? 0));
+      }
+      return map;
+    }, [accounts]);
+
+    const entries = TAX_TREATMENT_ORDER.map((treatment) => ({
+      treatment,
+      value: totals.get(treatment) ?? 0,
+    })).filter((entry) => entry.value > 0);
+
+    if (entries.length === 0) {
+      return null;
+    }
+
+    return (
+      <div className="border-border/50 bg-muted/20 border-t px-4 py-3 md:px-5 md:py-3">
+        <p className="text-muted-foreground mb-2 text-xs font-medium uppercase tracking-wider">
+          Tax Treatment Breakdown
+        </p>
+        <div className="flex flex-col gap-1">
+          {entries.map((entry) => (
+            <div
+              key={entry.treatment}
+              className="flex items-center justify-between gap-2 text-xs md:text-sm"
+            >
+              <span className="text-muted-foreground">{TAX_TREATMENT_LABELS[entry.treatment]}</span>
+              <PrivacyAmount value={entry.value} currency={baseCurrency} />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  },
+);
+GroupTaxTreatmentSummary.displayName = "GroupTaxTreatmentSummary";
+
 export const AccountsSummary = React.memo(
   ({ dateRange, isAllTime }: { dateRange?: DateRange; isAllTime?: boolean }) => {
     const { accountsGrouped, setAccountsGrouped, settings } = useSettingsContext();
@@ -329,6 +384,10 @@ export const AccountsSummary = React.memo(
             accountId: acc.id,
             accountType: acc.accountType,
             accountGroup: acc.group ?? null,
+            taxTreatment: (acc.taxTreatment ?? "TAXABLE") as
+              | "TAXABLE"
+              | "TAX_FREE"
+              | "TAX_DEFERRED",
             isGroup: false,
           };
         }
@@ -355,6 +414,7 @@ export const AccountsSummary = React.memo(
           accountId: acc.id,
           accountType: acc.accountType,
           accountGroup: acc.group ?? null,
+          taxTreatment: (acc.taxTreatment ?? "TAXABLE") as "TAXABLE" | "TAX_FREE" | "TAX_DEFERRED",
           isGroup: false,
         };
       });
@@ -543,20 +603,26 @@ export const AccountsSummary = React.memo(
                     />
                   </div>
                   {isExpanded && (
-                    <div className="border-border/50 border-t">
-                      <div className="divide-border/50 divide-y">
-                        {sortedAccounts.map((account) => (
-                          <div key={account.accountId} className="px-4 py-3 md:px-5 md:py-4">
-                            <AccountSummaryComponent
-                              item={account}
-                              isLoadingValuation={isLoadingPerformance}
-                              displayInAccountCurrency
-                              isNested
-                            />
-                          </div>
-                        ))}
+                    <>
+                      <div className="border-border/50 border-t">
+                        <div className="divide-border/50 divide-y">
+                          {sortedAccounts.map((account) => (
+                            <div key={account.accountId} className="px-4 py-3 md:px-5 md:py-4">
+                              <AccountSummaryComponent
+                                item={account}
+                                isLoadingValuation={isLoadingPerformance}
+                                displayInAccountCurrency
+                                isNested
+                              />
+                            </div>
+                          ))}
+                        </div>
                       </div>
-                    </div>
+                      <GroupTaxTreatmentSummary
+                        accounts={sortedAccounts}
+                        baseCurrency={group.baseCurrency}
+                      />
+                    </>
                   )}
                 </div>
               );

--- a/apps/frontend/src/pages/holdings/components/tax-treatment-chart.tsx
+++ b/apps/frontend/src/pages/holdings/components/tax-treatment-chart.tsx
@@ -1,0 +1,180 @@
+import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
+import type { Account, Holding } from "@/lib/types";
+import {
+  AmountDisplay,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  DonutChart,
+  formatPercent,
+  Skeleton,
+} from "@wealthfolio/ui";
+import { useMemo, useState } from "react";
+
+interface TaxTreatmentDonutChartProps {
+  holdings: Holding[];
+  accounts: Account[];
+  baseCurrency: string;
+  isLoading?: boolean;
+}
+
+interface TaxTreatmentDataPoint {
+  key: string;
+  name: string;
+  value: number;
+  percent: number;
+  currency: string;
+}
+
+const TREATMENT_ORDER = ["TAXABLE", "TAX_DEFERRED", "TAX_FREE", "UNCATEGORIZED"];
+
+const TREATMENT_LABELS: Record<string, string> = {
+  TAXABLE: "Taxable",
+  TAX_DEFERRED: "Tax Deferred",
+  TAX_FREE: "Tax Free",
+  UNCATEGORIZED: "Uncategorized",
+};
+
+function normalizeTaxTreatment(taxTreatment?: string): string {
+  const normalized = taxTreatment?.trim().toUpperCase();
+  if (normalized === "TAXABLE" || normalized === "TAX_DEFERRED" || normalized === "TAX_FREE") {
+    return normalized;
+  }
+  return "UNCATEGORIZED";
+}
+
+function buildTaxTreatmentData(
+  holdings: Holding[] = [],
+  accounts: Account[] = [],
+  baseCurrency: string,
+): TaxTreatmentDataPoint[] {
+  if (!holdings.length) {
+    return [];
+  }
+
+  const accountTaxMap = new Map<string, string>();
+  for (const account of accounts) {
+    accountTaxMap.set(account.id, normalizeTaxTreatment(account.taxTreatment));
+  }
+
+  const totalsByTreatment = new Map<string, number>();
+  for (const holding of holdings) {
+    const baseValue = Number(holding.marketValue?.base) || 0;
+    if (!Number.isFinite(baseValue) || baseValue === 0) {
+      continue;
+    }
+
+    const treatment = accountTaxMap.get(holding.accountId) ?? "UNCATEGORIZED";
+    totalsByTreatment.set(treatment, (totalsByTreatment.get(treatment) ?? 0) + baseValue);
+  }
+
+  const total = Array.from(totalsByTreatment.values()).reduce((sum, value) => sum + value, 0);
+  if (total === 0) {
+    return [];
+  }
+
+  return TREATMENT_ORDER.map((treatment) => {
+    const value = totalsByTreatment.get(treatment) ?? 0;
+    if (value <= 0) {
+      return null;
+    }
+
+    return {
+      key: treatment,
+      name: TREATMENT_LABELS[treatment] ?? treatment,
+      value,
+      percent: value / total,
+      currency: baseCurrency,
+    };
+  }).filter((item): item is TaxTreatmentDataPoint => item !== null);
+}
+
+export function TaxTreatmentDonutChart({
+  holdings,
+  accounts,
+  baseCurrency,
+  isLoading = false,
+}: TaxTreatmentDonutChartProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const { isBalanceHidden } = useBalancePrivacy();
+
+  const data = useMemo(
+    () => buildTaxTreatmentData(holdings, accounts, baseCurrency),
+    [holdings, accounts, baseCurrency],
+  );
+
+  if (isLoading) {
+    return (
+      <Card className="overflow-hidden backdrop-blur-sm">
+        <CardHeader>
+          <Skeleton className="h-5 w-[140px]" />
+        </CardHeader>
+        <CardContent className="space-y-4 p-6 pt-0">
+          <div className="flex h-[160px] items-center justify-center">
+            <Skeleton className="h-[120px] w-[120px] rounded-full" />
+          </div>
+          <div className="space-y-2">
+            <Skeleton className="h-6 w-full" />
+            <Skeleton className="h-6 w-full" />
+            <Skeleton className="h-6 w-full" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="overflow-hidden backdrop-blur-sm">
+      <CardHeader>
+        <CardTitle className="text-muted-foreground text-sm font-medium uppercase tracking-wider">
+          Tax Treatment
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4 pt-0">
+        {data.length > 0 ? (
+          <>
+            <DonutChart
+              data={data.map((entry) => ({
+                name: entry.name,
+                value: entry.value,
+                currency: entry.currency,
+              }))}
+              activeIndex={activeIndex}
+              onSectionClick={(_, index) => setActiveIndex(index)}
+              startAngle={180}
+              endAngle={0}
+            />
+
+            <div className="space-y-1">
+              {data.map((entry, index) => (
+                <button
+                  key={entry.key}
+                  type="button"
+                  className="hover:bg-muted/50 flex w-full items-center justify-between rounded-md px-1 py-1 text-left transition-colors"
+                  onClick={() => setActiveIndex(index)}
+                >
+                  <span className="text-sm font-medium">{entry.name}</span>
+                  <div className="flex items-center gap-2 text-sm">
+                    <AmountDisplay
+                      value={entry.value}
+                      currency={baseCurrency}
+                      isHidden={isBalanceHidden}
+                      displayCurrency={false}
+                    />
+                    <span className="text-muted-foreground text-xs">|</span>
+                    <span className="text-muted-foreground">{formatPercent(entry.percent)}</span>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </>
+        ) : (
+          <div className="bg-muted/20 text-muted-foreground rounded-md py-6 text-center text-sm">
+            No tax treatment data available
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/frontend/src/pages/holdings/holdings-insights-page.tsx
+++ b/apps/frontend/src/pages/holdings/holdings-insights-page.tsx
@@ -3,6 +3,7 @@ import { Button } from "@wealthfolio/ui/components/ui/button";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
 import { useCallback, useMemo, useState } from "react";
 
+import { useAccounts } from "@/hooks/use-accounts";
 import { useHoldings } from "@/hooks/use-holdings";
 import { usePortfolioAllocations } from "@/hooks/use-portfolio-allocations";
 import { PORTFOLIO_ACCOUNT_ID, isAlternativeAssetKind, type AssetKind } from "@/lib/constants";
@@ -18,6 +19,7 @@ import { DrillableAccountChart } from "./components/drillable-account-chart";
 import { DrillableDonutChart } from "./components/drillable-donut-chart";
 import { SectorsChart } from "./components/sectors-chart";
 import { SegmentedAllocationBar } from "./components/segmented-allocation-bar";
+import { TaxTreatmentDonutChart } from "./components/tax-treatment-chart";
 
 interface HoldingsInsightsPageProps {
   accountId?: string;
@@ -29,6 +31,10 @@ export const HoldingsInsightsPage = ({ accountId: accountIdProp }: HoldingsInsig
   const baseCurrency = settings?.baseCurrency ?? "USD";
 
   const accountId = accountIdProp ?? PORTFOLIO_ACCOUNT_ID;
+  const { accounts, isLoading: accountsLoading } = useAccounts({
+    filterActive: false,
+    includeArchived: true,
+  });
   const { holdings, isLoading: holdingsLoading } = useHoldings(accountId);
   const { allocations, isLoading: allocationsLoading } = usePortfolioAllocations(accountId);
 
@@ -189,6 +195,16 @@ export const HoldingsInsightsPage = ({ accountId: accountIdProp }: HoldingsInsig
               )
             }
             onCardClick={() => openAllocationSheet(allocations?.regions)}
+          />
+        </div>
+
+        {/* Tax Treatment breakdown */}
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <TaxTreatmentDonutChart
+            holdings={[...cashHoldings, ...nonCashHoldings]}
+            accounts={accounts ?? []}
+            baseCurrency={baseCurrency}
+            isLoading={isLoading || accountsLoading}
           />
         </div>
 

--- a/apps/frontend/src/pages/settings/accounts/accounts-page.tsx
+++ b/apps/frontend/src/pages/settings/accounts/accounts-page.tsx
@@ -59,6 +59,7 @@ const SettingsAccountsPage = () => {
   const handleArchiveAccount = (account: Account, archive: boolean) => {
     updateAccountMutation.mutate({
       ...account,
+      taxTreatment: (account.taxTreatment || "TAXABLE") as "TAXABLE" | "TAX_FREE" | "TAX_DEFERRED",
       isArchived: archive,
     });
   };
@@ -66,6 +67,7 @@ const SettingsAccountsPage = () => {
   const handleHideAccount = (account: Account, hide: boolean) => {
     updateAccountMutation.mutate({
       ...account,
+      taxTreatment: (account.taxTreatment || "TAXABLE") as "TAXABLE" | "TAX_FREE" | "TAX_DEFERRED",
       isActive: !hide,
     });
   };

--- a/apps/frontend/src/pages/settings/accounts/accounts-page.tsx
+++ b/apps/frontend/src/pages/settings/accounts/accounts-page.tsx
@@ -57,17 +57,21 @@ const SettingsAccountsPage = () => {
   };
 
   const handleArchiveAccount = (account: Account, archive: boolean) => {
+    // Only toggle `isArchived`; omit `taxTreatment` so the backend preserves
+    // the existing value rather than risking a fallback to TAXABLE.
+    const { taxTreatment: _taxTreatment, ...rest } = account;
     updateAccountMutation.mutate({
-      ...account,
-      taxTreatment: (account.taxTreatment || "TAXABLE") as "TAXABLE" | "TAX_FREE" | "TAX_DEFERRED",
+      ...rest,
       isArchived: archive,
     });
   };
 
   const handleHideAccount = (account: Account, hide: boolean) => {
+    // Only toggle `isActive`; omit `taxTreatment` so the backend preserves
+    // the existing value rather than risking a fallback to TAXABLE.
+    const { taxTreatment: _taxTreatment, ...rest } = account;
     updateAccountMutation.mutate({
-      ...account,
-      taxTreatment: (account.taxTreatment || "TAXABLE") as "TAXABLE" | "TAX_FREE" | "TAX_DEFERRED",
+      ...rest,
       isActive: !hide,
     });
   };

--- a/apps/frontend/src/pages/settings/accounts/components/account-edit-modal.tsx
+++ b/apps/frontend/src/pages/settings/accounts/components/account-edit-modal.tsx
@@ -24,6 +24,7 @@ export function AccountEditModal({ account, open, onClose }: AccountEditModalPro
     isActive: account?.id ? account?.isActive : true,
     isArchived: account?.isArchived ?? false,
     trackingMode: account?.trackingMode,
+    taxTreatment: account?.taxTreatment as "TAXABLE" | "TAX_FREE" | "TAX_DEFERRED" | undefined,
     meta: account?.meta,
   };
 

--- a/apps/frontend/src/pages/settings/accounts/components/account-form.tsx
+++ b/apps/frontend/src/pages/settings/accounts/components/account-form.tsx
@@ -86,24 +86,35 @@ export function AccountForm({ defaultValues, onSuccess = () => undefined }: Acco
   // Returns a promise when updating so it can be chained with other operations
   const doSubmit = useCallback(
     (data: AccountFormOutput, options?: { async?: boolean }) => {
-      const { id, trackingMode, ...rest } = data;
+      const { id, trackingMode, taxTreatment, ...rest } = data;
 
       if (id) {
         if (options?.async) {
           return updateAccountMutation.mutateAsync({
             id,
             trackingMode,
+            taxTreatment,
             ...rest,
           });
         }
-        return updateAccountMutation.mutate({ id, trackingMode, ...rest });
+        return updateAccountMutation.mutate({ id, trackingMode, taxTreatment, ...rest });
       }
-      return createAccountMutation.mutate({ trackingMode, ...rest });
+      return createAccountMutation.mutate({ trackingMode, taxTreatment, ...rest });
     },
     [createAccountMutation, updateAccountMutation],
   );
 
   function onSubmit(data: AccountFormOutput) {
+    // Validate tax treatment is selected for new accounts
+    const isNewAccount = !data.id;
+    if (isNewAccount && !data.taxTreatment) {
+      form.setError("taxTreatment", {
+        type: "manual",
+        message: "Please select a tax treatment.",
+      });
+      return;
+    }
+
     // Check if this is an existing account (update) and mode is switching from HOLDINGS to TRANSACTIONS
     const isExistingAccount = !!data.id;
     const isSwitchingFromHoldingsToTransactions =
@@ -302,6 +313,32 @@ export function AccountForm({ defaultValues, onSuccess = () => undefined }: Acco
                     </AlertDescription>
                   </Alert>
                 )}
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="taxTreatment"
+            render={({ field }) => (
+              <FormItem className="flex flex-col">
+                <FormLabel>Tax Treatment</FormLabel>
+                <FormControl>
+                  <ResponsiveSelect
+                    value={field.value}
+                    onValueChange={field.onChange}
+                    options={[
+                      { label: "Taxable", value: "TAXABLE" },
+                      { label: "Tax-Free", value: "TAX_FREE" },
+                      { label: "Tax-Deferred", value: "TAX_DEFERRED" },
+                    ]}
+                    placeholder="Select tax treatment"
+                    sheetTitle="Select Tax Treatment"
+                    sheetDescription="Choose how this account is taxed."
+                    triggerClassName="h-11"
+                  />
+                </FormControl>
                 <FormMessage />
               </FormItem>
             )}

--- a/apps/server/src/models.rs
+++ b/apps/server/src/models.rs
@@ -1,5 +1,8 @@
+use std::str::FromStr;
+
 use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 use utoipa::ToSchema;
 use wealthfolio_core::accounts as core_accounts;
 
@@ -98,7 +101,13 @@ fn parse_tracking_mode(s: &str) -> core_accounts::TrackingMode {
 }
 
 fn parse_tax_treatment(s: &str) -> core_accounts::TaxTreatment {
-    core_accounts::TaxTreatment::from_str(s)
+    core_accounts::TaxTreatment::from_str(s).unwrap_or_else(|err| {
+        warn!(
+            "Unrecognized tax_treatment '{}' in HTTP payload ({}); defaulting to TAXABLE",
+            s, err
+        );
+        core_accounts::TaxTreatment::Taxable
+    })
 }
 
 impl From<NewAccount> for core_accounts::NewAccount {

--- a/apps/server/src/models.rs
+++ b/apps/server/src/models.rs
@@ -15,6 +15,8 @@ pub struct Account {
     pub is_active: bool,
     pub is_archived: bool,
     pub tracking_mode: String,
+    #[serde(default = "default_tax_treatment")]
+    pub tax_treatment: String,
     pub created_at: NaiveDateTime,
     pub updated_at: NaiveDateTime,
     pub platform_id: Option<String>,
@@ -32,6 +34,7 @@ impl From<core_accounts::Account> for Account {
             core_accounts::TrackingMode::NotSet => "NOT_SET",
         }
         .to_string();
+        let tax_treatment = a.tax_treatment.as_str().to_string();
         Self {
             id: a.id,
             name: a.name,
@@ -42,6 +45,7 @@ impl From<core_accounts::Account> for Account {
             is_active: a.is_active,
             is_archived: a.is_archived,
             tracking_mode,
+            tax_treatment,
             created_at: a.created_at,
             updated_at: a.updated_at,
             platform_id: a.platform_id,
@@ -68,6 +72,8 @@ pub struct NewAccount {
     pub is_archived: bool,
     #[serde(default = "default_tracking_mode")]
     pub tracking_mode: String,
+    #[serde(default = "default_tax_treatment")]
+    pub tax_treatment: String,
     pub platform_id: Option<String>,
     pub account_number: Option<String>,
     pub meta: Option<String>,
@@ -79,12 +85,20 @@ fn default_tracking_mode() -> String {
     "NOT_SET".to_string()
 }
 
+fn default_tax_treatment() -> String {
+    "TAXABLE".to_string()
+}
+
 fn parse_tracking_mode(s: &str) -> core_accounts::TrackingMode {
     match s {
         "TRANSACTIONS" => core_accounts::TrackingMode::Transactions,
         "HOLDINGS" => core_accounts::TrackingMode::Holdings,
         _ => core_accounts::TrackingMode::NotSet,
     }
+}
+
+fn parse_tax_treatment(s: &str) -> core_accounts::TaxTreatment {
+    core_accounts::TaxTreatment::from_str(s)
 }
 
 impl From<NewAccount> for core_accounts::NewAccount {
@@ -99,6 +113,7 @@ impl From<NewAccount> for core_accounts::NewAccount {
             is_active: a.is_active,
             is_archived: a.is_archived,
             tracking_mode: parse_tracking_mode(&a.tracking_mode),
+            tax_treatment: parse_tax_treatment(&a.tax_treatment),
             platform_id: a.platform_id,
             account_number: a.account_number,
             meta: a.meta,
@@ -119,6 +134,7 @@ pub struct AccountUpdate {
     pub is_active: bool,
     pub is_archived: Option<bool>,
     pub tracking_mode: Option<String>,
+    pub tax_treatment: Option<String>,
     pub platform_id: Option<String>,
     pub account_number: Option<String>,
     pub meta: Option<String>,
@@ -137,6 +153,7 @@ impl From<AccountUpdate> for core_accounts::AccountUpdate {
             is_active: a.is_active,
             is_archived: a.is_archived,
             tracking_mode: a.tracking_mode.map(|s| parse_tracking_mode(&s)),
+            tax_treatment: a.tax_treatment.map(|s| parse_tax_treatment(&s)),
             platform_id: a.platform_id,
             account_number: a.account_number,
             meta: a.meta,

--- a/crates/connect/src/broker/service.rs
+++ b/crates/connect/src/broker/service.rs
@@ -20,7 +20,9 @@ use chrono::{DateTime, Months, NaiveDate, Utc};
 use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::Decimal;
 use std::collections::{HashMap, HashSet};
-use wealthfolio_core::accounts::{Account, AccountServiceTrait, NewAccount, TrackingMode};
+use wealthfolio_core::accounts::{
+    Account, AccountServiceTrait, NewAccount, TaxTreatment, TrackingMode,
+};
 use wealthfolio_core::activities::{
     compute_idempotency_key, ActivityRepositoryTrait, ActivityServiceTrait, ActivityUpsert,
     NewActivity,
@@ -238,6 +240,7 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 provider_account_id: Some(provider_account_id.clone()),
                 is_archived: false,
                 tracking_mode: TrackingMode::Holdings,
+                tax_treatment: TaxTreatment::Taxable,
             };
 
             // Create the account via AccountService (handles FX rate registration)

--- a/crates/core/src/accounts/accounts_model.rs
+++ b/crates/core/src/accounts/accounts_model.rs
@@ -18,6 +18,37 @@ pub enum TrackingMode {
     NotSet,
 }
 
+/// Tax treatment for an account - determines tax categorization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum TaxTreatment {
+    /// Account gains are taxable
+    #[default]
+    Taxable,
+    /// Account gains are not taxed
+    TaxFree,
+    /// Account gains are taxed when withdrawn
+    TaxDeferred,
+}
+
+impl TaxTreatment {
+    pub fn as_str(&self) -> &str {
+        match self {
+            TaxTreatment::Taxable => "TAXABLE",
+            TaxTreatment::TaxFree => "TAX_FREE",
+            TaxTreatment::TaxDeferred => "TAX_DEFERRED",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Self {
+        match s {
+            "TAX_FREE" => TaxTreatment::TaxFree,
+            "TAX_DEFERRED" => TaxTreatment::TaxDeferred,
+            _ => TaxTreatment::Taxable,
+        }
+    }
+}
+
 /// Domain model representing an account in the system.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
@@ -44,6 +75,8 @@ pub struct Account {
     pub is_archived: bool,
     /// Tracking mode for the account
     pub tracking_mode: TrackingMode,
+    /// Tax treatment classification
+    pub tax_treatment: TaxTreatment,
 }
 
 /// Input model for creating a new account.
@@ -67,6 +100,8 @@ pub struct NewAccount {
     pub is_archived: bool,
     #[serde(default)]
     pub tracking_mode: TrackingMode,
+    #[serde(default)]
+    pub tax_treatment: TaxTreatment,
 }
 
 impl NewAccount {
@@ -103,6 +138,7 @@ pub struct AccountUpdate {
     pub provider_account_id: Option<String>,
     pub is_archived: Option<bool>,
     pub tracking_mode: Option<TrackingMode>,
+    pub tax_treatment: Option<TaxTreatment>,
 }
 
 impl AccountUpdate {

--- a/crates/core/src/accounts/accounts_model.rs
+++ b/crates/core/src/accounts/accounts_model.rs
@@ -1,5 +1,7 @@
 //! Account domain models.
 
+use std::str::FromStr;
+
 use chrono::NaiveDateTime;
 use serde::{Deserialize, Serialize};
 
@@ -39,12 +41,20 @@ impl TaxTreatment {
             TaxTreatment::TaxDeferred => "TAX_DEFERRED",
         }
     }
+}
 
-    pub fn from_str(s: &str) -> Self {
+impl FromStr for TaxTreatment {
+    type Err = ValidationError;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         match s {
-            "TAX_FREE" => TaxTreatment::TaxFree,
-            "TAX_DEFERRED" => TaxTreatment::TaxDeferred,
-            _ => TaxTreatment::Taxable,
+            "TAXABLE" => Ok(TaxTreatment::Taxable),
+            "TAX_FREE" => Ok(TaxTreatment::TaxFree),
+            "TAX_DEFERRED" => Ok(TaxTreatment::TaxDeferred),
+            other => Err(ValidationError::InvalidInput(format!(
+                "Unknown tax treatment value: {}",
+                other
+            ))),
         }
     }
 }

--- a/crates/core/src/accounts/accounts_model_tests.rs
+++ b/crates/core/src/accounts/accounts_model_tests.rs
@@ -2,7 +2,7 @@
 
 #[cfg(test)]
 mod tests {
-    use crate::accounts::{Account, TrackingMode};
+    use crate::accounts::{Account, TaxTreatment, TrackingMode};
     use chrono::NaiveDateTime;
 
     // ==================== TrackingMode Serialization Tests ====================
@@ -91,6 +91,7 @@ mod tests {
             provider_account_id: None,
             is_archived: false,
             tracking_mode,
+            tax_treatment: TaxTreatment::Taxable,
         }
     }
 }

--- a/crates/core/src/accounts/mod.rs
+++ b/crates/core/src/accounts/mod.rs
@@ -7,7 +7,7 @@ mod accounts_traits;
 
 // Re-export the public interface
 pub use accounts_constants::*;
-pub use accounts_model::{Account, AccountUpdate, NewAccount, TrackingMode};
+pub use accounts_model::{Account, AccountUpdate, NewAccount, TaxTreatment, TrackingMode};
 pub use accounts_service::AccountService;
 pub use accounts_traits::{AccountRepositoryTrait, AccountServiceTrait};
 

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -905,6 +905,7 @@ mod tests {
             provider_account_id: None,
             is_archived: false,
             tracking_mode: crate::accounts::TrackingMode::NotSet,
+            tax_treatment: crate::accounts::TaxTreatment::Taxable,
         }
     }
 

--- a/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
+++ b/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
@@ -820,6 +820,7 @@ fn create_test_account(id: &str, account_type: &str, currency: &str) -> Account 
         provider_account_id: None,
         is_archived: false,
         tracking_mode: crate::accounts::TrackingMode::NotSet,
+        tax_treatment: crate::accounts::TaxTreatment::Taxable,
     }
 }
 
@@ -1718,6 +1719,7 @@ fn create_test_account_with_archive_state(
         provider_account_id: None,
         is_archived,
         tracking_mode: crate::accounts::TrackingMode::NotSet,
+        tax_treatment: crate::accounts::TaxTreatment::Taxable,
     }
 }
 

--- a/crates/core/src/portfolio/snapshot/snapshot_service.rs
+++ b/crates/core/src/portfolio/snapshot/snapshot_service.rs
@@ -222,6 +222,7 @@ impl SnapshotService {
             provider_account_id: None,
             is_archived: false,
             tracking_mode: crate::accounts::TrackingMode::NotSet,
+            tax_treatment: crate::accounts::TaxTreatment::Taxable,
         }
     }
 

--- a/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
+++ b/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
@@ -1014,6 +1014,7 @@ mod tests {
             provider_account_id: None,
             is_archived: false,
             tracking_mode: crate::accounts::TrackingMode::NotSet,
+            tax_treatment: crate::accounts::TaxTreatment::Taxable,
         }
     }
 
@@ -4594,6 +4595,7 @@ mod tests {
             provider_account_id: None,
             is_archived,
             tracking_mode: crate::accounts::TrackingMode::NotSet,
+            tax_treatment: crate::accounts::TaxTreatment::Taxable,
         }
     }
 

--- a/crates/storage-sqlite/migrations/2026-04-01-000001_add_tax_treatment/down.sql
+++ b/crates/storage-sqlite/migrations/2026-04-01-000001_add_tax_treatment/down.sql
@@ -1,0 +1,2 @@
+-- Remove tax treatment column from accounts
+ALTER TABLE accounts DROP COLUMN tax_treatment;

--- a/crates/storage-sqlite/migrations/2026-04-01-000001_add_tax_treatment/up.sql
+++ b/crates/storage-sqlite/migrations/2026-04-01-000001_add_tax_treatment/up.sql
@@ -1,0 +1,2 @@
+-- Add tax treatment column to accounts
+ALTER TABLE accounts ADD COLUMN tax_treatment TEXT NOT NULL DEFAULT 'TAXABLE';

--- a/crates/storage-sqlite/src/accounts/model.rs
+++ b/crates/storage-sqlite/src/accounts/model.rs
@@ -1,7 +1,10 @@
 //! Database model for accounts.
 
+use std::str::FromStr;
+
 use chrono::NaiveDateTime;
 use diesel::prelude::*;
+use log::warn;
 use serde::{Deserialize, Serialize};
 
 use wealthfolio_core::accounts::{Account, AccountUpdate, NewAccount, TaxTreatment, TrackingMode};
@@ -52,7 +55,13 @@ impl From<AccountDB> for Account {
             "HOLDINGS" => TrackingMode::Holdings,
             _ => TrackingMode::NotSet,
         };
-        let tax_treatment = TaxTreatment::from_str(&db.tax_treatment);
+        let tax_treatment = TaxTreatment::from_str(&db.tax_treatment).unwrap_or_else(|err| {
+            warn!(
+                "Unrecognized tax_treatment '{}' for account '{}' ({}); defaulting to TAXABLE",
+                db.tax_treatment, db.id, err
+            );
+            TaxTreatment::Taxable
+        });
         Self {
             id: db.id,
             name: db.name,
@@ -118,10 +127,13 @@ impl From<AccountUpdate> for AccountDB {
             })
             .unwrap_or("NOT_SET")
             .to_string();
+        // When `tax_treatment` is not provided on the update, leave an empty
+        // placeholder; the repository is responsible for populating it from the
+        // existing record (same pattern as `currency` and `created_at`).
         let tax_treatment = domain
             .tax_treatment
             .map(|tt| tt.as_str().to_string())
-            .unwrap_or_else(|| "TAXABLE".to_string());
+            .unwrap_or_default();
         Self {
             id: domain.id.unwrap_or_default(),
             name: domain.name,

--- a/crates/storage-sqlite/src/accounts/model.rs
+++ b/crates/storage-sqlite/src/accounts/model.rs
@@ -4,7 +4,7 @@ use chrono::NaiveDateTime;
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use wealthfolio_core::accounts::{Account, AccountUpdate, NewAccount, TrackingMode};
+use wealthfolio_core::accounts::{Account, AccountUpdate, NewAccount, TaxTreatment, TrackingMode};
 
 /// Database model for accounts
 #[derive(
@@ -41,6 +41,7 @@ pub struct AccountDB {
     pub provider_account_id: Option<String>,
     pub is_archived: bool,
     pub tracking_mode: String,
+    pub tax_treatment: String,
 }
 
 // Conversion implementations
@@ -51,6 +52,7 @@ impl From<AccountDB> for Account {
             "HOLDINGS" => TrackingMode::Holdings,
             _ => TrackingMode::NotSet,
         };
+        let tax_treatment = TaxTreatment::from_str(&db.tax_treatment);
         Self {
             id: db.id,
             name: db.name,
@@ -68,6 +70,7 @@ impl From<AccountDB> for Account {
             provider_account_id: db.provider_account_id,
             is_archived: db.is_archived,
             tracking_mode,
+            tax_treatment,
         }
     }
 }
@@ -81,6 +84,7 @@ impl From<NewAccount> for AccountDB {
             TrackingMode::NotSet => "NOT_SET",
         }
         .to_string();
+        let tax_treatment = domain.tax_treatment.as_str().to_string();
         Self {
             id: domain.id.unwrap_or_default(),
             name: domain.name,
@@ -98,6 +102,7 @@ impl From<NewAccount> for AccountDB {
             provider_account_id: domain.provider_account_id,
             is_archived: domain.is_archived,
             tracking_mode,
+            tax_treatment,
         }
     }
 }
@@ -113,6 +118,10 @@ impl From<AccountUpdate> for AccountDB {
             })
             .unwrap_or("NOT_SET")
             .to_string();
+        let tax_treatment = domain
+            .tax_treatment
+            .map(|tt| tt.as_str().to_string())
+            .unwrap_or_else(|| "TAXABLE".to_string());
         Self {
             id: domain.id.unwrap_or_default(),
             name: domain.name,
@@ -130,6 +139,7 @@ impl From<AccountUpdate> for AccountDB {
             provider_account_id: domain.provider_account_id,
             is_archived: domain.is_archived.unwrap_or(false),
             tracking_mode,
+            tax_treatment,
         }
     }
 }

--- a/crates/storage-sqlite/src/accounts/repository.rs
+++ b/crates/storage-sqlite/src/accounts/repository.rs
@@ -61,6 +61,7 @@ impl AccountRepositoryTrait for AccountRepository {
         // Capture which optional fields were explicitly set before conversion
         let is_archived_provided = account_update.is_archived.is_some();
         let tracking_mode_provided = account_update.tracking_mode.is_some();
+        let tax_treatment_provided = account_update.tax_treatment.is_some();
 
         self.writer
             .exec_tx(move |tx| {
@@ -90,6 +91,9 @@ impl AccountRepositoryTrait for AccountRepository {
                 }
                 if !tracking_mode_provided {
                     account_db.tracking_mode = existing.tracking_mode;
+                }
+                if !tax_treatment_provided {
+                    account_db.tax_treatment = existing.tax_treatment;
                 }
 
                 diesel::update(accounts.find(&account_db.id))

--- a/crates/storage-sqlite/src/schema.rs
+++ b/crates/storage-sqlite/src/schema.rs
@@ -18,6 +18,7 @@ diesel::table! {
         provider_account_id -> Nullable<Text>,
         is_archived -> Bool,
         tracking_mode -> Text,
+        tax_treatment -> Text,
     }
 }
 


### PR DESCRIPTION
## Summary

Adds a per-account **tax treatment** classification so users can categorize
accounts by how their gains are taxed (Taxable / Tax Deferred / Tax Free)
and view portfolio breakdowns by tax status.

> **Note on authorship:** This feature was implemented end-to-end with
> [Claude Code](https://claude.com/claude-code) (Anthropic's CLI coding
> agent). I'm a hobbyist Wealthfolio user and wanted to contribute it back.
> Happy to iterate on review feedback.

## Features

### Backend (Rust)
- **New migration** `2026-04-01-000001_add_tax_treatment` adds a non-null
  `tax_treatment TEXT` column on `accounts`, defaulting to `TAXABLE` so
  existing rows are preserved on upgrade.
- **`TaxTreatment` enum** in `wealthfolio-core` accounts model with
  `SCREAMING_SNAKE_CASE` serde rename. Variants: `Taxable` (default),
  `TaxDeferred`, `TaxFree`.
- Field is serialized on `Account`, `NewAccount` (with `#[serde(default)]`
  for backwards compat), and `AccountUpdate` (optional for partial updates).
- Wired through `wealthfolio-storage-sqlite` repository, including
  update-path preservation — if the caller omits `tax_treatment` in an
  `AccountUpdate`, the existing value is kept rather than clobbered.
- HTTP models in `wealthfolio-server` and the connect broker service
  both carry the new field.

### Frontend (React / TypeScript)
- **Account form** — new select field with Taxable / Tax Deferred / Tax Free
  options. Preserved across edit, archive, and hide flows.
- **Zod schema + adapter** carry `taxTreatment` through the `update_account`
  IPC call.
- **Holdings Insights** — new `TaxTreatmentDonutChart` widget showing
  portfolio value grouped by the account's tax treatment.
- **Dashboard Accounts card** — expanded account groups now render a
  per-group tax treatment breakdown (Taxable / Tax Deferred / Tax Free
  subtotals) inside the accordion.

## Test plan

- [x] `cargo check -p wealthfolio-core -p wealthfolio-storage-sqlite -p wealthfolio-server -p wealthfolio-connect` passes
- [x] `tsc --noEmit` clean on every modified frontend file
- [x] Migration uses a `NOT NULL DEFAULT 'TAXABLE'` so existing rows upgrade cleanly
- [ ] Maintainer end-to-end smoke test (form → donut → group breakdown)

## Backwards compatibility

- Migration defaults existing rows to `TAXABLE` — no data loss, no manual steps.
- `NewAccount::tax_treatment` uses `#[serde(default)]` so older HTTP clients still work.
- `AccountUpdate::tax_treatment` is `Option<...>`, so partial updates that don't touch the field leave it untouched.

## Notes

- Branched directly off `afadil/wealthfolio@main` at v3.2.1, so no merge conflicts expected.
- All code, tests, and this PR description were written with Claude Code.
