### PR TITLE
feat: symbol mapping validation with real-time feedback and E2E tests

### DIFF
--- a/.claude/skills/run-e2e-tests/SKILL.md
+++ b/.claude/skills/run-e2e-tests/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: run-e2e-tests
+description: >
+  How to run Wealthfolio E2E tests correctly. Use this skill whenever you are
+  about to run, execute, or trigger Playwright E2E tests — including running a
+  single spec file, the full test suite, or checking whether E2E tests pass.
+  Also use it when setting up the environment for E2E tests or troubleshooting
+  E2E test failures. Do NOT skip this skill just because the task seems simple
+  — the environment setup is mandatory and skipping it leads to silent failures.
+---
+
+# Running Wealthfolio E2E Tests
+
+Read `e2e/README.md` and follow its instructions **exactly and in order** before running any E2E test command. Do not skip any step.

--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ db/
 apps/db/
 apps/tauri/db/
 tasks
+**/*.local.md

--- a/apps/frontend/src/adapters/shared/market-data.ts
+++ b/apps/frontend/src/adapters/shared/market-data.ts
@@ -187,12 +187,14 @@ export const resolveSymbolQuote = async (
   symbol: string,
   exchangeMic?: string,
   instrumentType?: string,
+  providerId?: string,
 ): Promise<ResolvedQuote | null> => {
   try {
     return await invoke<ResolvedQuote>("resolve_symbol_quote", {
       symbol,
       exchangeMic,
       instrumentType,
+      providerId,
     });
   } catch (_error) {
     logger.error("Error resolving symbol quote.");

--- a/apps/frontend/src/adapters/web/core.ts
+++ b/apps/frontend/src/adapters/web/core.ts
@@ -711,15 +711,17 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
       break;
     }
     case "resolve_symbol_quote": {
-      const { symbol, exchangeMic, instrumentType } = payload as {
+      const { symbol, exchangeMic, instrumentType, providerId } = payload as {
         symbol: string;
         exchangeMic?: string;
         instrumentType?: string;
+        providerId?: string;
       };
       const params = new URLSearchParams();
       params.set("symbol", symbol);
       if (exchangeMic) params.set("exchangeMic", exchangeMic);
       if (instrumentType) params.set("instrumentType", instrumentType);
+      if (providerId) params.set("provider_id", providerId);
       url += `?${params.toString()}`;
       break;
     }

--- a/apps/frontend/src/adapters/web/core.ts
+++ b/apps/frontend/src/adapters/web/core.ts
@@ -721,7 +721,7 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
       params.set("symbol", symbol);
       if (exchangeMic) params.set("exchangeMic", exchangeMic);
       if (instrumentType) params.set("instrumentType", instrumentType);
-      if (providerId) params.set("provider_id", providerId);
+      if (providerId) params.set("providerId", providerId);
       url += `?${params.toString()}`;
       break;
     }

--- a/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
+++ b/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
@@ -51,7 +51,7 @@ import {
 import { Skeleton } from "@wealthfolio/ui/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@wealthfolio/ui/components/ui/tabs";
 import { Textarea } from "@wealthfolio/ui/components/ui/textarea";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useFieldArray, useForm, useWatch } from "react-hook-form";
 import * as z from "zod";
 import { toast } from "@wealthfolio/ui/components/ui/use-toast";
@@ -294,6 +294,12 @@ function SymbolMappingRow({
   onValidationChange,
 }: SymbolMappingRowProps) {
   const [validationStatus, setValidationStatus] = useState<SymbolValidationStatus>("idle");
+  const mounted = useRef(true);
+  useEffect(() => {
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
 
   const symbol = useWatch({ control, name: `providerConfig.${index}.symbol` as any });
   const provider = useWatch({ control, name: `providerConfig.${index}.provider` as any });
@@ -305,15 +311,20 @@ function SymbolMappingRow({
       return;
     }
 
-    setValidationStatus("loading");
+    // Reset immediately while user is typing (before the debounce fires)
+    setValidationStatus("idle");
 
     const timer = setTimeout(async () => {
+      setValidationStatus("loading");
+      onValidationChange(fieldId, "idle"); // reset parent while loading
       try {
         const result = await resolveSymbolQuote(symbol.trim(), undefined, undefined, provider);
+        if (!mounted.current) return;
         const status: SymbolValidationStatus = result?.price ? "valid" : "invalid";
         setValidationStatus(status);
         onValidationChange(fieldId, status);
       } catch {
+        if (!mounted.current) return;
         setValidationStatus("invalid");
         onValidationChange(fieldId, "invalid");
       }

--- a/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
+++ b/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
@@ -342,7 +342,7 @@ function SymbolMappingRow({
     }, 800);
 
     return () => clearTimeout(timer);
-  }, [symbol, provider, fieldId, onValidationChange, initialSymbol]);
+  }, [symbol, provider, fieldId, onValidationChange]); // eslint-disable-line react-hooks/exhaustive-deps -- initialSymbol is intentionally captured at mount time only
 
   return (
     <tr className="border-b last:border-b-0">

--- a/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
+++ b/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
@@ -362,13 +362,19 @@ function SymbolMappingRow({
                   />
                   <span className="absolute right-2 flex items-center">
                     {validationStatus === "loading" && (
-                      <Icons.Spinner className="text-muted-foreground h-3.5 w-3.5 animate-spin" />
+                      <span data-testid="symbol-validation-loading">
+                        <Icons.Spinner className="text-muted-foreground h-3.5 w-3.5 animate-spin" />
+                      </span>
                     )}
                     {validationStatus === "valid" && (
-                      <Icons.Check className="h-3.5 w-3.5 text-green-500" />
+                      <span data-testid="symbol-validation-valid">
+                        <Icons.Check className="h-3.5 w-3.5 text-green-500" />
+                      </span>
                     )}
                     {validationStatus === "invalid" && (
-                      <Icons.AlertCircle className="h-3.5 w-3.5 text-red-500" />
+                      <span data-testid="symbol-validation-invalid">
+                        <Icons.AlertCircle className="h-3.5 w-3.5 text-red-500" />
+                      </span>
                     )}
                   </span>
                 </div>

--- a/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
+++ b/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
@@ -527,10 +527,11 @@ export function AssetEditSheet({
     }
   }, [asset, form]);
 
-  // Reset tab when sheet opens
+  // Reset tab and validation state when sheet opens
   useEffect(() => {
     if (open) {
       setActiveTab(defaultTab);
+      setSymbolValidations({});
     }
   }, [open, defaultTab]);
 
@@ -573,7 +574,7 @@ export function AssetEditSheet({
         // Keep sheet open so user can retry
       }
     },
-    [asset, updateAssetProfileMutation, onOpenChange],
+    [asset, updateAssetProfileMutation, onOpenChange, symbolValidations],
   );
 
   const isManualMode = form.watch("quoteMode") === QuoteMode.MANUAL;

--- a/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
+++ b/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
@@ -1,4 +1,4 @@
-import { getExchanges } from "@/adapters";
+import { getExchanges, resolveSymbolQuote } from "@/adapters";
 import { MultiSelectTaxonomy } from "@/components/classification/multi-select-taxonomy";
 import { SingleSelectTaxonomy } from "@/components/classification/single-select-taxonomy";
 import { TickerAvatar } from "@/components/ticker-avatar";
@@ -52,8 +52,9 @@ import { Skeleton } from "@wealthfolio/ui/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@wealthfolio/ui/components/ui/tabs";
 import { Textarea } from "@wealthfolio/ui/components/ui/textarea";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useFieldArray, useForm } from "react-hook-form";
+import { useFieldArray, useForm, useWatch } from "react-hook-form";
 import * as z from "zod";
+import { toast } from "@wealthfolio/ui/components/ui/use-toast";
 import { useAssetProfileMutations } from "./hooks/use-asset-profile-mutations";
 
 // Schema for a single provider override (type is derived from asset kind)
@@ -95,6 +96,16 @@ type AssetFormValues = z.infer<typeof assetFormSchema>;
 type ProviderOverride = z.infer<typeof providerOverrideSchema>;
 
 const normalizeMic = (mic?: string | null): string => mic?.trim().toUpperCase() ?? "";
+
+const PROVIDER_SYMBOL_HINTS: Record<string, string> = {
+  YAHOO: "e.g. AAPL, LYMS.DE",
+  COINGECKO: "e.g. bitcoin, ethereum",
+  TWELVEDATA: "e.g. AAPL, EUR/USD",
+};
+
+function getSymbolPlaceholder(provider: string): string {
+  return PROVIDER_SYMBOL_HINTS[provider] ?? "e.g. AAPL";
+}
 
 const EDIT_INSTRUMENT_TYPE_OPTIONS = [
   { value: "EQUITY", label: "Equity (Stock, ETF, Fund)" },
@@ -263,6 +274,115 @@ interface AssetEditSheetProps {
   defaultTab?: EditTab;
 }
 
+type SymbolValidationStatus = "idle" | "loading" | "valid" | "invalid";
+
+interface SymbolMappingRowProps {
+  index: number;
+  fieldId: string;
+  control: ReturnType<typeof useForm<AssetFormValues>>["control"];
+  mappingProviderOptions: ResponsiveSelectOption[];
+  onRemove: () => void;
+  onValidationChange: (fieldId: string, status: SymbolValidationStatus) => void;
+}
+
+function SymbolMappingRow({
+  index,
+  fieldId,
+  control,
+  mappingProviderOptions,
+  onRemove,
+  onValidationChange,
+}: SymbolMappingRowProps) {
+  const [validationStatus, setValidationStatus] = useState<SymbolValidationStatus>("idle");
+
+  const symbol = useWatch({ control, name: `providerConfig.${index}.symbol` as any });
+  const provider = useWatch({ control, name: `providerConfig.${index}.provider` as any });
+
+  useEffect(() => {
+    if (!symbol?.trim()) {
+      setValidationStatus("idle");
+      onValidationChange(fieldId, "idle");
+      return;
+    }
+
+    setValidationStatus("loading");
+
+    const timer = setTimeout(async () => {
+      try {
+        const result = await resolveSymbolQuote(symbol.trim(), undefined, undefined, provider);
+        const status: SymbolValidationStatus = result?.price ? "valid" : "invalid";
+        setValidationStatus(status);
+        onValidationChange(fieldId, status);
+      } catch {
+        setValidationStatus("invalid");
+        onValidationChange(fieldId, "invalid");
+      }
+    }, 800);
+
+    return () => clearTimeout(timer);
+  }, [symbol, provider, fieldId, onValidationChange]);
+
+  return (
+    <tr className="border-b last:border-b-0">
+      <td className="px-4 py-2">
+        <FormField
+          control={control}
+          name={`providerConfig.${index}.provider` as any}
+          render={({ field: providerField }) => (
+            <FormItem className="space-y-0">
+              <FormControl>
+                <ResponsiveSelect
+                  value={providerField.value}
+                  onValueChange={providerField.onChange}
+                  options={mappingProviderOptions}
+                  placeholder="Select provider"
+                  sheetTitle="Data Provider"
+                  sheetDescription="Select the data provider for this symbol mapping"
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+      </td>
+      <td className="px-4 py-2">
+        <FormField
+          control={control}
+          name={`providerConfig.${index}.symbol` as any}
+          render={({ field: symbolField }) => (
+            <FormItem className="space-y-0">
+              <FormControl>
+                <div className="relative flex items-center">
+                  <Input
+                    placeholder={getSymbolPlaceholder(provider)}
+                    {...symbolField}
+                    className="h-9 pr-8"
+                  />
+                  <span className="absolute right-2 flex items-center">
+                    {validationStatus === "loading" && (
+                      <Icons.Spinner className="text-muted-foreground h-3.5 w-3.5 animate-spin" />
+                    )}
+                    {validationStatus === "valid" && (
+                      <Icons.Check className="h-3.5 w-3.5 text-green-500" />
+                    )}
+                    {validationStatus === "invalid" && (
+                      <Icons.AlertCircle className="h-3.5 w-3.5 text-red-500" />
+                    )}
+                  </span>
+                </div>
+              </FormControl>
+            </FormItem>
+          )}
+        />
+      </td>
+      <td className="px-2 py-2">
+        <Button type="button" variant="ghost" size="icon" className="h-8 w-8" onClick={onRemove}>
+          <Icons.Close className="h-4 w-4" />
+        </Button>
+      </td>
+    </tr>
+  );
+}
+
 export function AssetEditSheet({
   asset,
   latestQuote,
@@ -271,6 +391,16 @@ export function AssetEditSheet({
   defaultTab = "general",
 }: AssetEditSheetProps) {
   const [activeTab, setActiveTab] = useState<EditTab>(defaultTab);
+  const [symbolValidations, setSymbolValidations] = useState<
+    Record<string, SymbolValidationStatus>
+  >({});
+
+  const handleSymbolValidationChange = useCallback(
+    (fieldId: string, status: SymbolValidationStatus) => {
+      setSymbolValidations((prev) => ({ ...prev, [fieldId]: status }));
+    },
+    [],
+  );
   const { data: taxonomies = [], isLoading: isTaxonomiesLoading } = useTaxonomies();
   const { updateAssetProfileMutation } = useAssetProfileMutations();
   const { data: marketDataProviders = [] } = useMarketDataProviders();
@@ -396,6 +526,13 @@ export function AssetEditSheet({
   const handleSave = useCallback(
     async (values: AssetFormValues) => {
       if (!asset) return;
+
+      const hasInvalidMappings = Object.values(symbolValidations).some((s) => s === "invalid");
+      if (hasInvalidMappings) {
+        toast.warning(
+          "Some symbol mappings could not be validated. Prices may not update for those entries.",
+        );
+      }
 
       // Serialize provider config to nested JSON format
       const serializedOverrides = serializeProviderConfig(
@@ -884,56 +1021,22 @@ export function AssetEditSheet({
                               </thead>
                               <tbody>
                                 {overrideFields.map((field, index) => (
-                                  <tr key={field.id} className="border-b last:border-b-0">
-                                    <td className="px-4 py-2">
-                                      <FormField
-                                        control={form.control}
-                                        name={`providerConfig.${index}.provider`}
-                                        render={({ field: providerField }) => (
-                                          <FormItem className="space-y-0">
-                                            <FormControl>
-                                              <ResponsiveSelect
-                                                value={providerField.value}
-                                                onValueChange={providerField.onChange}
-                                                options={mappingProviderOptions}
-                                                placeholder="Select provider"
-                                                sheetTitle="Data Provider"
-                                                sheetDescription="Select the data provider for this symbol mapping"
-                                              />
-                                            </FormControl>
-                                          </FormItem>
-                                        )}
-                                      />
-                                    </td>
-                                    <td className="px-4 py-2">
-                                      <FormField
-                                        control={form.control}
-                                        name={`providerConfig.${index}.symbol`}
-                                        render={({ field: symbolField }) => (
-                                          <FormItem className="space-y-0">
-                                            <FormControl>
-                                              <Input
-                                                placeholder="e.g., SHOP.TO"
-                                                {...symbolField}
-                                                className="h-9"
-                                              />
-                                            </FormControl>
-                                          </FormItem>
-                                        )}
-                                      />
-                                    </td>
-                                    <td className="px-2 py-2">
-                                      <Button
-                                        type="button"
-                                        variant="ghost"
-                                        size="icon"
-                                        className="h-8 w-8"
-                                        onClick={() => removeOverride(index)}
-                                      >
-                                        <Icons.Close className="h-4 w-4" />
-                                      </Button>
-                                    </td>
-                                  </tr>
+                                  <SymbolMappingRow
+                                    key={field.id}
+                                    index={index}
+                                    fieldId={field.id}
+                                    control={form.control}
+                                    mappingProviderOptions={mappingProviderOptions}
+                                    onRemove={() => {
+                                      setSymbolValidations((prev) => {
+                                        const next = { ...prev };
+                                        delete next[field.id];
+                                        return next;
+                                      });
+                                      removeOverride(index);
+                                    }}
+                                    onValidationChange={handleSymbolValidationChange}
+                                  />
                                 ))}
                               </tbody>
                             </table>

--- a/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
+++ b/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
@@ -51,8 +51,8 @@ import {
 import { Skeleton } from "@wealthfolio/ui/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@wealthfolio/ui/components/ui/tabs";
 import { Textarea } from "@wealthfolio/ui/components/ui/textarea";
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { useFieldArray, useForm, useWatch } from "react-hook-form";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type Path, useFieldArray, useForm, useWatch } from "react-hook-form";
 import * as z from "zod";
 import { toast } from "@wealthfolio/ui/components/ui/use-toast";
 import { useAssetProfileMutations } from "./hooks/use-asset-profile-mutations";
@@ -279,6 +279,7 @@ type SymbolValidationStatus = "idle" | "loading" | "valid" | "invalid";
 interface SymbolMappingRowProps {
   index: number;
   fieldId: string;
+  initialSymbol?: string;
   control: ReturnType<typeof useForm<AssetFormValues>>["control"];
   mappingProviderOptions: ResponsiveSelectOption[];
   onRemove: () => void;
@@ -288,32 +289,50 @@ interface SymbolMappingRowProps {
 function SymbolMappingRow({
   index,
   fieldId,
+  initialSymbol,
   control,
   mappingProviderOptions,
   onRemove,
   onValidationChange,
 }: SymbolMappingRowProps) {
-  const [validationStatus, setValidationStatus] = useState<SymbolValidationStatus>("idle");
+  const [validationStatus, setValidationStatus] = useState<SymbolValidationStatus>(
+    initialSymbol?.trim() ? "valid" : "idle",
+  );
+  // Track whether we are on the first render to avoid re-validating pre-loaded values.
+  const isFirstRender = useRef(true);
 
-  const symbol = useWatch({ control, name: `providerConfig.${index}.symbol` as any });
-  const provider = useWatch({ control, name: `providerConfig.${index}.provider` as any });
+  const symbol = useWatch({
+    control,
+    name: `providerConfig.${index}.symbol` as Path<AssetFormValues>,
+  }) as string | undefined;
+  const provider = useWatch({
+    control,
+    name: `providerConfig.${index}.provider` as Path<AssetFormValues>,
+  }) as string | undefined;
 
   useEffect(() => {
+    // Skip validation on mount when the symbol is already known-good (loaded from DB).
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      if (symbol?.trim() === initialSymbol?.trim() && initialSymbol?.trim()) {
+        return;
+      }
+    }
+
     if (!symbol?.trim()) {
       setValidationStatus("idle");
       onValidationChange(fieldId, "idle");
       return;
     }
 
-    // Reset immediately while user is typing (before the debounce fires)
     setValidationStatus("idle");
 
     const timer = setTimeout(async () => {
       setValidationStatus("loading");
-      onValidationChange(fieldId, "idle"); // reset parent while loading
+      onValidationChange(fieldId, "idle");
       try {
         const result = await resolveSymbolQuote(symbol.trim(), undefined, undefined, provider);
-        const status: SymbolValidationStatus = result?.price ? "valid" : "invalid";
+        const status: SymbolValidationStatus = result?.price != null ? "valid" : "invalid";
         setValidationStatus(status);
         onValidationChange(fieldId, status);
       } catch {
@@ -323,19 +342,19 @@ function SymbolMappingRow({
     }, 800);
 
     return () => clearTimeout(timer);
-  }, [symbol, provider, fieldId, onValidationChange]);
+  }, [symbol, provider, fieldId, onValidationChange, initialSymbol]);
 
   return (
     <tr className="border-b last:border-b-0">
       <td className="px-4 py-2">
         <FormField
           control={control}
-          name={`providerConfig.${index}.provider` as any}
+          name={`providerConfig.${index}.provider` as Path<AssetFormValues>}
           render={({ field: providerField }) => (
             <FormItem className="space-y-0">
               <FormControl>
                 <ResponsiveSelect
-                  value={providerField.value}
+                  value={providerField.value as string | undefined}
                   onValueChange={providerField.onChange}
                   options={mappingProviderOptions}
                   placeholder="Select provider"
@@ -350,14 +369,17 @@ function SymbolMappingRow({
       <td className="px-4 py-2">
         <FormField
           control={control}
-          name={`providerConfig.${index}.symbol` as any}
+          name={`providerConfig.${index}.symbol` as Path<AssetFormValues>}
           render={({ field: symbolField }) => (
             <FormItem className="space-y-0">
               <FormControl>
                 <div className="relative flex items-center">
                   <Input
-                    placeholder={getSymbolPlaceholder(provider)}
-                    {...symbolField}
+                    placeholder={getSymbolPlaceholder(provider ?? "")}
+                    {...{
+                      ...symbolField,
+                      value: (symbolField.value as string | undefined) ?? "",
+                    }}
                     className="h-9 pr-8"
                   />
                   <span className="absolute right-2 flex items-center">
@@ -1035,6 +1057,7 @@ export function AssetEditSheet({
                                     key={field.id}
                                     index={index}
                                     fieldId={field.id}
+                                    initialSymbol={field.symbol}
                                     control={form.control}
                                     mappingProviderOptions={mappingProviderOptions}
                                     onRemove={() => {

--- a/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
+++ b/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
@@ -51,7 +51,7 @@ import {
 import { Skeleton } from "@wealthfolio/ui/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@wealthfolio/ui/components/ui/tabs";
 import { Textarea } from "@wealthfolio/ui/components/ui/textarea";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useFieldArray, useForm, useWatch } from "react-hook-form";
 import * as z from "zod";
 import { toast } from "@wealthfolio/ui/components/ui/use-toast";
@@ -294,12 +294,6 @@ function SymbolMappingRow({
   onValidationChange,
 }: SymbolMappingRowProps) {
   const [validationStatus, setValidationStatus] = useState<SymbolValidationStatus>("idle");
-  const mounted = useRef(true);
-  useEffect(() => {
-    return () => {
-      mounted.current = false;
-    };
-  }, []);
 
   const symbol = useWatch({ control, name: `providerConfig.${index}.symbol` as any });
   const provider = useWatch({ control, name: `providerConfig.${index}.provider` as any });
@@ -319,12 +313,10 @@ function SymbolMappingRow({
       onValidationChange(fieldId, "idle"); // reset parent while loading
       try {
         const result = await resolveSymbolQuote(symbol.trim(), undefined, undefined, provider);
-        if (!mounted.current) return;
         const status: SymbolValidationStatus = result?.price ? "valid" : "invalid";
         setValidationStatus(status);
         onValidationChange(fieldId, status);
       } catch {
-        if (!mounted.current) return;
         setValidationStatus("invalid");
         onValidationChange(fieldId, "invalid");
       }

--- a/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
+++ b/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
@@ -553,7 +553,7 @@ export function AssetEditSheet({
       setActiveTab(defaultTab);
       setSymbolValidations({});
     }
-  }, [open, defaultTab]);
+  }, [open, defaultTab, asset?.id]);
 
   const handleSave = useCallback(
     async (values: AssetFormValues) => {

--- a/apps/server/src/api/market_data.rs
+++ b/apps/server/src/api/market_data.rs
@@ -255,7 +255,12 @@ async fn resolve_symbol_quote(
         .and_then(wealthfolio_core::assets::InstrumentType::from_db_str);
     let res = state
         .quote_service
-        .resolve_symbol_quote(&q.symbol, q.exchange_mic.as_deref(), inst_type.as_ref())
+        .resolve_symbol_quote(
+            &q.symbol,
+            q.exchange_mic.as_deref(),
+            inst_type.as_ref(),
+            None,
+        )
         .await?;
     Ok(Json(res))
 }

--- a/apps/server/src/api/market_data.rs
+++ b/apps/server/src/api/market_data.rs
@@ -243,6 +243,7 @@ struct ResolveSymbolQuoteQuery {
     symbol: String,
     exchange_mic: Option<String>,
     instrument_type: Option<String>,
+    provider_id: Option<String>,
 }
 
 async fn resolve_symbol_quote(
@@ -259,7 +260,7 @@ async fn resolve_symbol_quote(
             &q.symbol,
             q.exchange_mic.as_deref(),
             inst_type.as_ref(),
-            None,
+            q.provider_id.as_deref(),
         )
         .await?;
     Ok(Json(res))

--- a/apps/tauri/src/commands/market_data.rs
+++ b/apps/tauri/src/commands/market_data.rs
@@ -214,7 +214,7 @@ pub async fn resolve_symbol_quote(
         .and_then(wealthfolio_core::assets::InstrumentType::from_db_str);
     state
         .quote_service()
-        .resolve_symbol_quote(&symbol, exchange_mic.as_deref(), inst_type.as_ref())
+        .resolve_symbol_quote(&symbol, exchange_mic.as_deref(), inst_type.as_ref(), None)
         .await
         .map_err(|e| format!("Failed to resolve symbol quote: {}", e))
 }

--- a/apps/tauri/src/commands/market_data.rs
+++ b/apps/tauri/src/commands/market_data.rs
@@ -207,6 +207,7 @@ pub async fn resolve_symbol_quote(
     symbol: String,
     exchange_mic: Option<String>,
     instrument_type: Option<String>,
+    provider_id: Option<String>,
     state: State<'_, Arc<ServiceContext>>,
 ) -> Result<wealthfolio_core::quotes::ResolvedQuote, String> {
     let inst_type = instrument_type
@@ -214,7 +215,12 @@ pub async fn resolve_symbol_quote(
         .and_then(wealthfolio_core::assets::InstrumentType::from_db_str);
     state
         .quote_service()
-        .resolve_symbol_quote(&symbol, exchange_mic.as_deref(), inst_type.as_ref(), None)
+        .resolve_symbol_quote(
+            &symbol,
+            exchange_mic.as_deref(),
+            inst_type.as_ref(),
+            provider_id.as_deref(),
+        )
         .await
         .map_err(|e| format!("Failed to resolve symbol quote: {}", e))
 }

--- a/crates/ai/src/provider_service.rs
+++ b/crates/ai/src/provider_service.rs
@@ -285,7 +285,7 @@ impl AiProviderServiceTrait for AiProviderService {
                 }
 
                 // Sort models alphabetically for consistent ordering
-                models.sort_by(|a, b| a.id.cmp(&b.id));
+                models.sort_by_key(|a| a.id.clone());
 
                 // Check if provider supports dynamic model listing
                 let supports_model_listing = Self::provider_supports_model_listing(id);

--- a/crates/ai/src/tools/valuation.rs
+++ b/crates/ai/src/tools/valuation.rs
@@ -175,7 +175,7 @@ impl<E: AiEnvironment + 'static> Tool for GetValuationHistoryTool<E> {
                     },
                 )
                 .collect();
-            result.sort_by(|a, b| a.date.cmp(&b.date));
+            result.sort_by_key(|a| a.date.clone());
             result
         } else {
             // Single account valuations

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -247,7 +247,7 @@ impl ActivityService {
             || normalize_quote_ccy_code(existing_asset_quote_ccy).is_some();
         let provider_quote_ccy = if allow_provider_lookup && !has_deterministic_precedence {
             self.quote_service
-                .resolve_symbol_quote(symbol, exchange_mic, instrument_type)
+                .resolve_symbol_quote(symbol, exchange_mic, instrument_type, None)
                 .await
                 .ok()
                 .and_then(|q| q.currency)
@@ -290,7 +290,7 @@ impl ActivityService {
         }
         let result = self
             .quote_service
-            .resolve_symbol_quote(symbol, exchange_mic, instrument_type)
+            .resolve_symbol_quote(symbol, exchange_mic, instrument_type, None)
             .await
             .ok()
             .and_then(|q| q.currency);

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -456,6 +456,7 @@ mod tests {
             symbol: &str,
             exchange_mic: Option<&str>,
             _instrument_type: Option<&InstrumentType>,
+            _preferred_provider: Option<&str>,
         ) -> Result<ResolvedQuote> {
             let is_uk_vwrp = (exchange_mic == Some("XLON") || exchange_mic == Some("CXE"))
                 && (symbol.eq_ignore_ascii_case("VWRPL")

--- a/crates/core/src/assets/assets_service.rs
+++ b/crates/core/src/assets/assets_service.rs
@@ -98,7 +98,7 @@ impl AssetService {
         let provider_quote_ccy = if allow_provider_lookup && !has_deterministic_precedence {
             if let Some(sym) = symbol.map(str::trim).filter(|s| !s.is_empty()) {
                 self.quote_service
-                    .resolve_symbol_quote(sym, exchange_mic, instrument_type)
+                    .resolve_symbol_quote(sym, exchange_mic, instrument_type, None)
                     .await
                     .ok()
                     .and_then(|q| q.currency)

--- a/crates/core/src/quotes/service.rs
+++ b/crates/core/src/quotes/service.rs
@@ -1466,7 +1466,7 @@ where
             });
         }
 
-        infos.sort_by(|a, b| a.priority.cmp(&b.priority));
+        infos.sort_by_key(|a| a.priority);
         Ok(infos)
     }
 

--- a/crates/core/src/quotes/service.rs
+++ b/crates/core/src/quotes/service.rs
@@ -265,8 +265,9 @@ pub trait QuoteServiceTrait: Send + Sync {
         symbol: &str,
         exchange_mic: Option<&str>,
         instrument_type: Option<&InstrumentType>,
+        preferred_provider: Option<&str>,
     ) -> Result<ResolvedQuote> {
-        let _ = (symbol, exchange_mic, instrument_type);
+        let _ = (symbol, exchange_mic, instrument_type, preferred_provider);
         Ok(ResolvedQuote::default())
     }
 
@@ -1040,6 +1041,7 @@ where
         symbol: &str,
         exchange_mic: Option<&str>,
         instrument_type: Option<&InstrumentType>,
+        preferred_provider: Option<&str>,
     ) -> Result<ResolvedQuote> {
         let trimmed_symbol = symbol.trim();
         if trimmed_symbol.is_empty() {
@@ -1062,6 +1064,9 @@ where
         } else {
             trimmed_symbol
         };
+
+        let provider_config: Option<serde_json::Value> =
+            preferred_provider.map(|p| serde_json::json!({ "preferred_provider": p }));
 
         for attempt_symbol in symbol_resolution_candidates(clean_symbol) {
             // For bonds, populate metadata with TreasuryDirect details so
@@ -1108,6 +1113,7 @@ where
                 instrument_symbol: Some(resolved_symbol),
                 display_code: Some(attempt_symbol.clone()),
                 instrument_exchange_mic: exchange_mic.map(str::to_string),
+                provider_config: provider_config.clone(),
                 metadata,
                 ..Default::default()
             };

--- a/crates/market-data/src/provider/alpha_vantage/mod.rs
+++ b/crates/market-data/src/provider/alpha_vantage/mod.rs
@@ -667,7 +667,7 @@ impl AlphaVantageProvider {
             .collect();
 
         // Sort by timestamp ascending
-        quotes.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        quotes.sort_by_key(|a| a.timestamp);
 
         debug!(
             "Alpha Vantage: fetched {} equity quotes for {}",
@@ -808,7 +808,7 @@ impl AlphaVantageProvider {
             .collect();
 
         // Sort by timestamp ascending
-        quotes.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        quotes.sort_by_key(|a| a.timestamp);
 
         debug!(
             "Alpha Vantage: fetched {} FX quotes for {}/{}",
@@ -869,7 +869,7 @@ impl AlphaVantageProvider {
             .collect();
 
         // Sort by timestamp ascending
-        quotes.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        quotes.sort_by_key(|a| a.timestamp);
 
         debug!(
             "Alpha Vantage: fetched {} crypto quotes for {}/{}",

--- a/crates/market-data/src/provider/finnhub/mod.rs
+++ b/crates/market-data/src/provider/finnhub/mod.rs
@@ -435,7 +435,7 @@ impl FinnhubProvider {
         }
 
         // Sort by timestamp ascending
-        quotes.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
+        quotes.sort_by_key(|a| a.timestamp);
 
         debug!(
             "Finnhub: fetched {} historical quotes for {} ({} to {})",

--- a/e2e/10-symbol-mapping-validation.spec.ts
+++ b/e2e/10-symbol-mapping-validation.spec.ts
@@ -90,14 +90,14 @@ test.describe("Symbol Mapping Validation", () => {
   }
 
   async function addMappingRow(provider: string, symbol: string) {
-    // Click Add to create a new mapping row
-    await page.getByRole("button", { name: "Add" }).click();
-    await page.waitForTimeout(300);
-
     // Scope to the mapping table (contains "Provider" column header)
     const mappingTable = page.locator("table").filter({
       has: page.getByRole("columnheader", { name: "Provider" }),
     });
+
+    // Click Add to create a new mapping row
+    await page.getByRole("button", { name: "Add" }).click();
+    await page.waitForTimeout(300);
 
     // The row's provider combobox defaults to YAHOO; change if needed
     if (provider !== "Yahoo Finance") {
@@ -109,16 +109,21 @@ test.describe("Symbol Mapping Validation", () => {
       await page.waitForTimeout(300);
     }
 
-    // Fill the symbol input in the last row
     const lastRow = mappingTable.locator("tbody tr").last();
     const symbolInput = lastRow.getByRole("textbox");
     await symbolInput.fill(symbol);
     await page.waitForTimeout(1000);
+
+    return mappingTable.locator("tbody tr").last();
   }
 
-  async function waitForValidation(expected: "valid" | "invalid", timeoutMs = 30000) {
-    // Poll directly for the final icon — skip racing on the spinner
-    await expect(page.getByTestId(`symbol-validation-${expected}`)).toBeVisible({
+  async function waitForValidation(
+    row: ReturnType<typeof page.locator>,
+    expected: "valid" | "invalid",
+    timeoutMs = 30000,
+  ) {
+    // Poll directly for the final icon scoped to the specific row
+    await expect(row.getByTestId(`symbol-validation-${expected}`)).toBeVisible({
       timeout: timeoutMs,
     });
   }
@@ -150,16 +155,16 @@ test.describe("Symbol Mapping Validation", () => {
   test("1. Yahoo Finance — valid symbol shows green check", async () => {
     test.setTimeout(60000);
     await openAssetMarketDataTab();
-    await addMappingRow("Yahoo Finance", "AAPL");
-    await waitForValidation("valid", 30000);
+    const row = await addMappingRow("Yahoo Finance", "AAPL");
+    await waitForValidation(row, "valid", 30000);
     await closeSheet();
   });
 
   test("2. Yahoo Finance — invalid symbol shows red error", async () => {
     test.setTimeout(60000);
     await openAssetMarketDataTab();
-    await addMappingRow("Yahoo Finance", "INVALID_TICKER_XYZ_E2E");
-    await waitForValidation("invalid", 30000);
+    const row = await addMappingRow("Yahoo Finance", "INVALID_TICKER_XYZ_E2E");
+    await waitForValidation(row, "invalid", 30000);
     await closeSheet();
   });
 
@@ -168,16 +173,16 @@ test.describe("Symbol Mapping Validation", () => {
   test("3. Börse Frankfurt — valid ISIN shows green check", async () => {
     test.setTimeout(60000);
     await openAssetMarketDataTab();
-    await addMappingRow("Börse Frankfurt", "DE0007164600");
-    await waitForValidation("valid", 30000);
+    const row = await addMappingRow("Börse Frankfurt", "DE0007164600");
+    await waitForValidation(row, "valid", 30000);
     await closeSheet();
   });
 
   test("4. Börse Frankfurt — invalid symbol shows red error", async () => {
     test.setTimeout(60000);
     await openAssetMarketDataTab();
-    await addMappingRow("Börse Frankfurt", "INVALID_TICKER_XYZ_E2E");
-    await waitForValidation("invalid", 30000);
+    const row = await addMappingRow("Börse Frankfurt", "INVALID_TICKER_XYZ_E2E");
+    await waitForValidation(row, "invalid", 30000);
     await closeSheet();
   });
 });

--- a/e2e/10-symbol-mapping-validation.spec.ts
+++ b/e2e/10-symbol-mapping-validation.spec.ts
@@ -148,18 +148,40 @@ test.describe("Symbol Mapping Validation", () => {
     });
   }
 
-  async function closeSheet() {
-    // Try close button first (Escape may close a Radix dropdown instead of the sheet)
-    const closeBtn = page
-      .getByRole("button", { name: /close/i })
-      .or(page.locator('[aria-label="Close"]'))
-      .first();
-    if (await closeBtn.isVisible({ timeout: 1000 }).catch(() => false)) {
-      await closeBtn.click();
-    } else {
-      await page.keyboard.press("Escape");
-    }
+  async function saveChanges() {
+    await page.getByRole("button", { name: "Save changes" }).click();
+    await expect(page.getByText("Asset profile updated successfully")).toBeVisible({
+      timeout: 10000,
+    });
     await expect(page.getByRole("dialog").first()).not.toBeVisible({ timeout: 5000 });
+  }
+
+  async function removeMapping(symbol: string) {
+    // Re-open the sheet and go to Market Data tab
+    await openAssetMarketDataTab();
+
+    const mappingTable = page.locator("table").filter({
+      has: page.getByRole("columnheader", { name: "Provider" }),
+    });
+
+    // hasText doesn't match React controlled input values — iterate rows and compare inputValue()
+    const rows = mappingTable.locator("tbody tr");
+    const count = await rows.count();
+    let found = false;
+    for (let i = 0; i < count; i++) {
+      const row = rows.nth(i);
+      const value = await row.getByRole("textbox").inputValue();
+      if (value === symbol) {
+        await row.locator("button").last().click();
+        await page.waitForTimeout(300);
+        found = true;
+        break;
+      }
+    }
+    if (!found) throw new Error(`Mapping row for symbol "${symbol}" not found`);
+
+    // Save the removal
+    await saveChanges();
   }
 
   // ── setup ─────────────────────────────────────────────────────────────────
@@ -172,37 +194,55 @@ test.describe("Symbol Mapping Validation", () => {
 
   // ── Yahoo Finance ─────────────────────────────────────────────────────────
 
-  test("1. Yahoo Finance — valid symbol shows green check", async () => {
-    test.setTimeout(60000);
+  test("1. Yahoo Finance — valid symbol shows green check and price after save", async () => {
+    test.setTimeout(120000);
     await openAssetMarketDataTab();
     const row = await addMappingRow("Yahoo Finance", "AAPL");
     await waitForValidation(row, "valid", 30000);
-    await closeSheet();
+    await saveChanges();
+
+    // Re-open and verify the latest price card is shown
+    await openAssetMarketDataTab();
+    await expect(page.getByText("Latest price")).toBeVisible({ timeout: 30000 });
+
+    await removeMapping("AAPL");
   });
 
-  test("2. Yahoo Finance — invalid symbol shows red error", async () => {
-    test.setTimeout(60000);
+  test("2. Yahoo Finance — invalid symbol shows red error and mapping is persisted after save", async () => {
+    test.setTimeout(120000);
     await openAssetMarketDataTab();
     const row = await addMappingRow("Yahoo Finance", "INVALID_TICKER_XYZ_E2E");
     await waitForValidation(row, "invalid", 30000);
-    await closeSheet();
+    await saveChanges();
+
+    // Re-open and verify the invalid mapping was persisted (removeMapping throws if not found)
+    await removeMapping("INVALID_TICKER_XYZ_E2E");
   });
 
   // ── Börse Frankfurt ───────────────────────────────────────────────────────
 
-  test("3. Börse Frankfurt — valid ISIN shows green check", async () => {
-    test.setTimeout(60000);
+  test("3. Börse Frankfurt — valid ISIN shows green check and price after save", async () => {
+    test.setTimeout(120000);
     await openAssetMarketDataTab();
     const row = await addMappingRow("Börse Frankfurt", "DE0007164600");
     await waitForValidation(row, "valid", 30000);
-    await closeSheet();
+    await saveChanges();
+
+    // Re-open and verify the latest price card is shown
+    await openAssetMarketDataTab();
+    await expect(page.getByText("Latest price")).toBeVisible({ timeout: 30000 });
+
+    await removeMapping("DE0007164600");
   });
 
-  test("4. Börse Frankfurt — invalid symbol shows red error", async () => {
-    test.setTimeout(60000);
+  test("4. Börse Frankfurt — invalid symbol shows red error and mapping is persisted after save", async () => {
+    test.setTimeout(120000);
     await openAssetMarketDataTab();
     const row = await addMappingRow("Börse Frankfurt", "INVALID_TICKER_XYZ_E2E");
     await waitForValidation(row, "invalid", 30000);
-    await closeSheet();
+    await saveChanges();
+
+    // Re-open and verify the invalid mapping was persisted (removeMapping throws if not found)
+    await removeMapping("INVALID_TICKER_XYZ_E2E");
   });
 });

--- a/e2e/10-symbol-mapping-validation.spec.ts
+++ b/e2e/10-symbol-mapping-validation.spec.ts
@@ -8,6 +8,8 @@ const ASSET_SYMBOL = "SYMVAL_TEST";
 test.describe("Symbol Mapping Validation", () => {
   let page: Page;
 
+  test.use({ timeout: 120000 });
+
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage();
   });
@@ -23,13 +25,14 @@ test.describe("Symbol Mapping Validation", () => {
       waitUntil: "domcontentloaded",
     });
     await expect(page.getByRole("heading", { name: "Securities" })).toBeVisible({ timeout: 10000 });
-    await page.waitForTimeout(500);
 
     // Reset portfolio filter so all assets are visible
     const resetBtn = page.getByRole("button", { name: "Reset" });
     if (await resetBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
       await resetBtn.click();
-      await page.waitForTimeout(500);
+      await expect(resetBtn)
+        .not.toBeVisible({ timeout: 3000 })
+        .catch(() => {});
     }
 
     // Skip creation if asset already exists
@@ -45,13 +48,14 @@ test.describe("Symbol Mapping Validation", () => {
     await expect(page.getByRole("dialog")).not.toBeVisible({
       timeout: 10000,
     });
-    await page.waitForTimeout(1000);
 
     // Reset filter again after creation
     const resetBtn2 = page.getByRole("button", { name: "Reset" });
     if (await resetBtn2.isVisible({ timeout: 2000 }).catch(() => false)) {
       await resetBtn2.click();
-      await page.waitForTimeout(500);
+      await expect(resetBtn2)
+        .not.toBeVisible({ timeout: 3000 })
+        .catch(() => {});
     }
 
     await expect(page.getByRole("row").filter({ hasText: ASSET_SYMBOL }).first()).toBeVisible({
@@ -64,13 +68,14 @@ test.describe("Symbol Mapping Validation", () => {
       waitUntil: "domcontentloaded",
     });
     await expect(page.getByRole("heading", { name: "Securities" })).toBeVisible({ timeout: 10000 });
-    await page.waitForTimeout(500);
 
     // Reset filter
     const resetBtn = page.getByRole("button", { name: "Reset" });
     if (await resetBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
       await resetBtn.click();
-      await page.waitForTimeout(500);
+      await expect(resetBtn)
+        .not.toBeVisible({ timeout: 3000 })
+        .catch(() => {});
     }
 
     const assetRow = page.getByRole("row").filter({ hasText: ASSET_SYMBOL }).first();
@@ -78,7 +83,7 @@ test.describe("Symbol Mapping Validation", () => {
 
     const actionsBtn = assetRow.getByRole("button", { name: "Open actions" });
     await actionsBtn.click();
-    await page.waitForTimeout(300);
+    await expect(page.getByRole("menuitem", { name: "Edit" })).toBeVisible({ timeout: 3000 });
     await page.getByRole("menuitem", { name: "Edit" }).click();
 
     const editSheet = page.getByRole("dialog").first();
@@ -86,21 +91,25 @@ test.describe("Symbol Mapping Validation", () => {
 
     // Click the Market Data tab
     await page.getByRole("tab", { name: "Market Data" }).click();
-    await page.waitForTimeout(300);
+    await expect(page.getByRole("switch"))
+      .toBeVisible({ timeout: 3000 })
+      .catch(() => {});
 
     // Symbol Mapping section is only visible when pricing is Automatic.
     // If the asset is in Manual mode, enable Automatic pricing first.
-    const pricingSwitch = page.getByRole("switch").first();
+    const pricingSwitch = editSheet.getByRole("switch").first();
     if (await pricingSwitch.isVisible({ timeout: 2000 }).catch(() => false)) {
       const isChecked = await pricingSwitch.getAttribute("aria-checked");
       if (isChecked === "false") {
         await pricingSwitch.click();
-        await page.waitForTimeout(500);
         // Confirm if a confirmation dialog appears
-        const confirmBtn = page.getByRole("button", { name: /confirm|enable|yes/i }).first();
+        // Using broad regex because the exact button label varies by app state
+        const confirmBtn = page
+          .getByRole("button")
+          .filter({ hasText: /confirm|enable|yes/i })
+          .first();
         if (await confirmBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
           await confirmBtn.click();
-          await page.waitForTimeout(300);
         }
       }
     }
@@ -115,26 +124,28 @@ test.describe("Symbol Mapping Validation", () => {
       has: page.getByRole("columnheader", { name: "Provider" }),
     });
 
+    // Capture row count before clicking Add to get a stable nth() index
+    const rowIndex = await mappingTable.locator("tbody tr").count();
+
     // Click Add to create a new mapping row
     await page.getByRole("button", { name: "Add" }).click();
-    await page.waitForTimeout(300);
+    await page.waitForTimeout(300); // wait for row to appear — no observable state to poll here
 
     // The row's provider combobox defaults to YAHOO; change if needed
     if (provider !== "Yahoo Finance") {
-      const lastRow = mappingTable.locator("tbody tr").last();
-      const providerTrigger = lastRow.getByRole("combobox").first();
+      const newRow = mappingTable.locator("tbody tr").nth(rowIndex);
+      const providerTrigger = newRow.getByRole("combobox").first();
       await providerTrigger.click();
-      await page.waitForTimeout(300);
+      await expect(page.getByRole("listbox")).toBeVisible({ timeout: 3000 });
       await page.getByRole("option", { name: provider }).click();
-      await page.waitForTimeout(300);
+      await expect(page.getByRole("listbox")).not.toBeVisible({ timeout: 3000 });
     }
 
-    const lastRow = mappingTable.locator("tbody tr").last();
-    const symbolInput = lastRow.getByRole("textbox");
+    const newRow = mappingTable.locator("tbody tr").nth(rowIndex);
+    const symbolInput = newRow.getByRole("textbox");
     await symbolInput.fill(symbol);
-    await page.waitForTimeout(1000);
 
-    return mappingTable.locator("tbody tr").last();
+    return mappingTable.locator("tbody tr").nth(rowIndex);
   }
 
   async function waitForValidation(
@@ -153,7 +164,7 @@ test.describe("Symbol Mapping Validation", () => {
     await expect(page.getByText("Asset profile updated successfully")).toBeVisible({
       timeout: 10000,
     });
-    await expect(page.getByRole("dialog").first()).not.toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole("dialog").first()).not.toBeVisible({ timeout: 10000 });
   }
 
   async function removeMapping(symbol: string) {
@@ -173,7 +184,6 @@ test.describe("Symbol Mapping Validation", () => {
       const value = await row.getByRole("textbox").inputValue();
       if (value === symbol) {
         await row.locator("button").last().click();
-        await page.waitForTimeout(300);
         found = true;
         break;
       }
@@ -195,7 +205,6 @@ test.describe("Symbol Mapping Validation", () => {
   // ── Yahoo Finance ─────────────────────────────────────────────────────────
 
   test("1. Yahoo Finance — valid symbol shows green check and price after save", async () => {
-    test.setTimeout(120000);
     await openAssetMarketDataTab();
     const row = await addMappingRow("Yahoo Finance", "AAPL");
     await waitForValidation(row, "valid", 30000);
@@ -203,13 +212,12 @@ test.describe("Symbol Mapping Validation", () => {
 
     // Re-open and verify the latest price card is shown
     await openAssetMarketDataTab();
-    await expect(page.getByText("Latest price")).toBeVisible({ timeout: 30000 });
+    await expect(page.getByText("Latest price", { exact: true })).toBeVisible({ timeout: 30000 });
 
     await removeMapping("AAPL");
   });
 
   test("2. Yahoo Finance — invalid symbol shows red error and mapping is persisted after save", async () => {
-    test.setTimeout(120000);
     await openAssetMarketDataTab();
     const row = await addMappingRow("Yahoo Finance", "INVALID_TICKER_XYZ_E2E");
     await waitForValidation(row, "invalid", 30000);
@@ -222,7 +230,6 @@ test.describe("Symbol Mapping Validation", () => {
   // ── Börse Frankfurt ───────────────────────────────────────────────────────
 
   test("3. Börse Frankfurt — valid ISIN shows green check and price after save", async () => {
-    test.setTimeout(120000);
     await openAssetMarketDataTab();
     const row = await addMappingRow("Börse Frankfurt", "DE0007164600");
     await waitForValidation(row, "valid", 30000);
@@ -230,19 +237,18 @@ test.describe("Symbol Mapping Validation", () => {
 
     // Re-open and verify the latest price card is shown
     await openAssetMarketDataTab();
-    await expect(page.getByText("Latest price")).toBeVisible({ timeout: 30000 });
+    await expect(page.getByText("Latest price", { exact: true })).toBeVisible({ timeout: 30000 });
 
     await removeMapping("DE0007164600");
   });
 
   test("4. Börse Frankfurt — invalid symbol shows red error and mapping is persisted after save", async () => {
-    test.setTimeout(120000);
     await openAssetMarketDataTab();
-    const row = await addMappingRow("Börse Frankfurt", "INVALID_TICKER_XYZ_E2E");
+    const row = await addMappingRow("Börse Frankfurt", "INVALID_BF_XYZ_E2E");
     await waitForValidation(row, "invalid", 30000);
     await saveChanges();
 
     // Re-open and verify the invalid mapping was persisted (removeMapping throws if not found)
-    await removeMapping("INVALID_TICKER_XYZ_E2E");
+    await removeMapping("INVALID_BF_XYZ_E2E");
   });
 });

--- a/e2e/10-symbol-mapping-validation.spec.ts
+++ b/e2e/10-symbol-mapping-validation.spec.ts
@@ -89,14 +89,14 @@ test.describe("Symbol Mapping Validation", () => {
     for (let attempt = 0; attempt < 5 && !editClicked; attempt++) {
       try {
         await actionsBtn.click({ timeout: 5000 });
-        await page.waitForTimeout(300);
         const editItem = page.getByRole("menuitem", { name: "Edit" });
         await expect(editItem).toBeVisible({ timeout: 3000 });
         await editItem.click({ force: true });
         editClicked = true;
       } catch {
         // button detached or menu closed before click landed — retry
-        await page.waitForTimeout(200);
+        // Brief pause before retry is unavoidable here (no observable DOM state).
+        await page.waitForTimeout(100);
       }
     }
     if (!editClicked) throw new Error("Could not click Edit menu item after 5 attempts");
@@ -147,9 +147,12 @@ test.describe("Symbol Mapping Validation", () => {
     while (true) {
       const rows = mappingTable.locator("tbody tr");
       if ((await rows.count()) === 0) break;
+      const rowCountBefore = await rows.count();
       const deleteBtn = rows.first().locator("button").last();
       await deleteBtn.click();
-      await page.waitForTimeout(100);
+      await expect(mappingTable.locator("tbody tr")).not.toHaveCount(rowCountBefore, {
+        timeout: 3000,
+      });
     }
   }
 
@@ -163,8 +166,11 @@ test.describe("Symbol Mapping Validation", () => {
     const rowIndex = await mappingTable.locator("tbody tr").count();
 
     // Click Add to create a new mapping row
+    const rowCountBefore = await mappingTable.locator("tbody tr").count();
     await page.getByRole("button", { name: "Add" }).click();
-    await page.waitForTimeout(300); // wait for row to appear — no observable state to poll here
+    await expect(mappingTable.locator("tbody tr")).toHaveCount(rowCountBefore + 1, {
+      timeout: 3000,
+    });
 
     // The row's provider combobox defaults to YAHOO; change if needed
     if (provider !== "Yahoo Finance") {

--- a/e2e/10-symbol-mapping-validation.spec.ts
+++ b/e2e/10-symbol-mapping-validation.spec.ts
@@ -166,9 +166,8 @@ test.describe("Symbol Mapping Validation", () => {
     const rowIndex = await mappingTable.locator("tbody tr").count();
 
     // Click Add to create a new mapping row
-    const rowCountBefore = await mappingTable.locator("tbody tr").count();
     await page.getByRole("button", { name: "Add" }).click();
-    await expect(mappingTable.locator("tbody tr")).toHaveCount(rowCountBefore + 1, {
+    await expect(mappingTable.locator("tbody tr")).toHaveCount(rowIndex + 1, {
       timeout: 3000,
     });
 

--- a/e2e/10-symbol-mapping-validation.spec.ts
+++ b/e2e/10-symbol-mapping-validation.spec.ts
@@ -63,7 +63,7 @@ test.describe("Symbol Mapping Validation", () => {
     });
   }
 
-  async function openAssetMarketDataTab() {
+  async function openMarketDataTab() {
     await page.goto(`${BASE_URL}/settings/securities`, {
       waitUntil: "domcontentloaded",
     });
@@ -82,9 +82,24 @@ test.describe("Symbol Mapping Validation", () => {
     await expect(assetRow).toBeVisible({ timeout: 10000 });
 
     const actionsBtn = assetRow.getByRole("button", { name: "Open actions" });
-    await actionsBtn.click();
-    await expect(page.getByRole("menuitem", { name: "Edit" })).toBeVisible({ timeout: 3000 });
-    await page.getByRole("menuitem", { name: "Edit" }).click();
+
+    // Retry loop: Radix UI dropdown may close during animation before the click lands.
+    // The table can re-render (quote updates) causing the button to detach — we retry.
+    let editClicked = false;
+    for (let attempt = 0; attempt < 5 && !editClicked; attempt++) {
+      try {
+        await actionsBtn.click({ timeout: 5000 });
+        await page.waitForTimeout(300);
+        const editItem = page.getByRole("menuitem", { name: "Edit" });
+        await expect(editItem).toBeVisible({ timeout: 3000 });
+        await editItem.click({ force: true });
+        editClicked = true;
+      } catch {
+        // button detached or menu closed before click landed — retry
+        await page.waitForTimeout(200);
+      }
+    }
+    if (!editClicked) throw new Error("Could not click Edit menu item after 5 attempts");
 
     const editSheet = page.getByRole("dialog").first();
     await expect(editSheet).toBeVisible({ timeout: 5000 });
@@ -116,6 +131,26 @@ test.describe("Symbol Mapping Validation", () => {
 
     // Wait for the Symbol Mapping "Add" button to be visible
     await expect(page.getByRole("button", { name: "Add" })).toBeVisible({ timeout: 5000 });
+  }
+
+  async function openAssetMarketDataTab() {
+    await openMarketDataTab();
+    // Remove any leftover mapping rows from a previous partial run
+    await clearAllMappings();
+  }
+
+  async function clearAllMappings() {
+    const mappingTable = page.locator("table").filter({
+      has: page.getByRole("columnheader", { name: "Provider" }),
+    });
+    // Remove rows one at a time until none remain
+    while (true) {
+      const rows = mappingTable.locator("tbody tr");
+      if ((await rows.count()) === 0) break;
+      const deleteBtn = rows.first().locator("button").last();
+      await deleteBtn.click();
+      await page.waitForTimeout(100);
+    }
   }
 
   async function addMappingRow(provider: string, symbol: string) {
@@ -168,8 +203,8 @@ test.describe("Symbol Mapping Validation", () => {
   }
 
   async function removeMapping(symbol: string) {
-    // Re-open the sheet and go to Market Data tab
-    await openAssetMarketDataTab();
+    // Re-open the sheet and go to Market Data tab (without clearing mappings)
+    await openMarketDataTab();
 
     const mappingTable = page.locator("table").filter({
       has: page.getByRole("columnheader", { name: "Provider" }),

--- a/e2e/10-symbol-mapping-validation.spec.ts
+++ b/e2e/10-symbol-mapping-validation.spec.ts
@@ -87,6 +87,26 @@ test.describe("Symbol Mapping Validation", () => {
     // Click the Market Data tab
     await page.getByRole("tab", { name: "Market Data" }).click();
     await page.waitForTimeout(300);
+
+    // Symbol Mapping section is only visible when pricing is Automatic.
+    // If the asset is in Manual mode, enable Automatic pricing first.
+    const pricingSwitch = page.getByRole("switch").first();
+    if (await pricingSwitch.isVisible({ timeout: 2000 }).catch(() => false)) {
+      const isChecked = await pricingSwitch.getAttribute("aria-checked");
+      if (isChecked === "false") {
+        await pricingSwitch.click();
+        await page.waitForTimeout(500);
+        // Confirm if a confirmation dialog appears
+        const confirmBtn = page.getByRole("button", { name: /confirm|enable|yes/i }).first();
+        if (await confirmBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
+          await confirmBtn.click();
+          await page.waitForTimeout(300);
+        }
+      }
+    }
+
+    // Wait for the Symbol Mapping "Add" button to be visible
+    await expect(page.getByRole("button", { name: "Add" })).toBeVisible({ timeout: 5000 });
   }
 
   async function addMappingRow(provider: string, symbol: string) {

--- a/e2e/10-symbol-mapping-validation.spec.ts
+++ b/e2e/10-symbol-mapping-validation.spec.ts
@@ -94,10 +94,14 @@ test.describe("Symbol Mapping Validation", () => {
     await page.getByRole("button", { name: "Add" }).click();
     await page.waitForTimeout(300);
 
+    // Scope to the mapping table (contains "Provider" column header)
+    const mappingTable = page.locator("table").filter({
+      has: page.getByRole("columnheader", { name: "Provider" }),
+    });
+
     // The row's provider combobox defaults to YAHOO; change if needed
     if (provider !== "Yahoo Finance") {
-      // Find the combobox in the last table row
-      const lastRow = page.locator("tbody tr").last();
+      const lastRow = mappingTable.locator("tbody tr").last();
       const providerTrigger = lastRow.getByRole("combobox").first();
       await providerTrigger.click();
       await page.waitForTimeout(300);
@@ -106,27 +110,31 @@ test.describe("Symbol Mapping Validation", () => {
     }
 
     // Fill the symbol input in the last row
-    const lastRow = page.locator("tbody tr").last();
+    const lastRow = mappingTable.locator("tbody tr").last();
     const symbolInput = lastRow.getByRole("textbox");
     await symbolInput.fill(symbol);
+    await page.waitForTimeout(1000);
   }
 
   async function waitForValidation(expected: "valid" | "invalid", timeoutMs = 30000) {
-    // Wait for loading spinner to appear (debounce fires after 800ms)
-    await expect(page.getByTestId("symbol-validation-loading")).toBeVisible({
-      timeout: 5000,
-    });
-    // Wait for loading spinner to disappear (network call completes)
-    await expect(page.getByTestId("symbol-validation-loading")).not.toBeVisible({
+    // Poll directly for the final icon — skip racing on the spinner
+    await expect(page.getByTestId(`symbol-validation-${expected}`)).toBeVisible({
       timeout: timeoutMs,
     });
-    // Check final icon
-    await expect(page.getByTestId(`symbol-validation-${expected}`)).toBeVisible({ timeout: 3000 });
   }
 
   async function closeSheet() {
-    await page.keyboard.press("Escape");
-    await expect(page.getByRole("dialog")).not.toBeVisible({ timeout: 5000 });
+    // Try close button first (Escape may close a Radix dropdown instead of the sheet)
+    const closeBtn = page
+      .getByRole("button", { name: /close/i })
+      .or(page.locator('[aria-label="Close"]'))
+      .first();
+    if (await closeBtn.isVisible({ timeout: 1000 }).catch(() => false)) {
+      await closeBtn.click();
+    } else {
+      await page.keyboard.press("Escape");
+    }
+    await expect(page.getByRole("dialog").first()).not.toBeVisible({ timeout: 5000 });
   }
 
   // ── setup ─────────────────────────────────────────────────────────────────

--- a/e2e/10-symbol-mapping-validation.spec.ts
+++ b/e2e/10-symbol-mapping-validation.spec.ts
@@ -1,0 +1,175 @@
+import { expect, Page, test } from "@playwright/test";
+import { BASE_URL, loginIfNeeded } from "./helpers";
+
+test.describe.configure({ mode: "serial" });
+
+const ASSET_SYMBOL = "SYMVAL_TEST";
+
+test.describe("Symbol Mapping Validation", () => {
+  let page: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  // ── helpers ──────────────────────────────────────────────────────────────
+
+  async function ensureAssetExists() {
+    await page.goto(`${BASE_URL}/settings/securities`, {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(page.getByRole("heading", { name: "Securities" })).toBeVisible({ timeout: 10000 });
+    await page.waitForTimeout(500);
+
+    // Reset portfolio filter so all assets are visible
+    const resetBtn = page.getByRole("button", { name: "Reset" });
+    if (await resetBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await resetBtn.click();
+      await page.waitForTimeout(500);
+    }
+
+    // Skip creation if asset already exists
+    const existingRow = page.getByRole("row").filter({ hasText: ASSET_SYMBOL });
+    if (await existingRow.isVisible({ timeout: 2000 }).catch(() => false)) return;
+
+    await page.getByRole("button", { name: "Add Security" }).click();
+    await expect(page.getByRole("dialog")).toBeVisible({ timeout: 5000 });
+
+    await page.getByPlaceholder("e.g., AAPL").fill(ASSET_SYMBOL);
+    await page.getByPlaceholder("e.g., Apple Inc.").fill("Symbol Validation Test Asset");
+    await page.getByRole("button", { name: "Create Security" }).click();
+    await expect(page.getByRole("dialog")).not.toBeVisible({
+      timeout: 10000,
+    });
+    await page.waitForTimeout(1000);
+
+    // Reset filter again after creation
+    const resetBtn2 = page.getByRole("button", { name: "Reset" });
+    if (await resetBtn2.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await resetBtn2.click();
+      await page.waitForTimeout(500);
+    }
+
+    await expect(page.getByRole("row").filter({ hasText: ASSET_SYMBOL }).first()).toBeVisible({
+      timeout: 5000,
+    });
+  }
+
+  async function openAssetMarketDataTab() {
+    await page.goto(`${BASE_URL}/settings/securities`, {
+      waitUntil: "domcontentloaded",
+    });
+    await expect(page.getByRole("heading", { name: "Securities" })).toBeVisible({ timeout: 10000 });
+    await page.waitForTimeout(500);
+
+    // Reset filter
+    const resetBtn = page.getByRole("button", { name: "Reset" });
+    if (await resetBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await resetBtn.click();
+      await page.waitForTimeout(500);
+    }
+
+    const assetRow = page.getByRole("row").filter({ hasText: ASSET_SYMBOL }).first();
+    await expect(assetRow).toBeVisible({ timeout: 10000 });
+
+    const actionsBtn = assetRow.getByRole("button", { name: "Open actions" });
+    await actionsBtn.click();
+    await page.waitForTimeout(300);
+    await page.getByRole("menuitem", { name: "Edit" }).click();
+
+    const editSheet = page.getByRole("dialog").first();
+    await expect(editSheet).toBeVisible({ timeout: 5000 });
+
+    // Click the Market Data tab
+    await page.getByRole("tab", { name: "Market Data" }).click();
+    await page.waitForTimeout(300);
+  }
+
+  async function addMappingRow(provider: string, symbol: string) {
+    // Click Add to create a new mapping row
+    await page.getByRole("button", { name: "Add" }).click();
+    await page.waitForTimeout(300);
+
+    // The row's provider combobox defaults to YAHOO; change if needed
+    if (provider !== "Yahoo Finance") {
+      // Find the combobox in the last table row
+      const lastRow = page.locator("tbody tr").last();
+      const providerTrigger = lastRow.getByRole("combobox").first();
+      await providerTrigger.click();
+      await page.waitForTimeout(300);
+      await page.getByRole("option", { name: provider }).click();
+      await page.waitForTimeout(300);
+    }
+
+    // Fill the symbol input in the last row
+    const lastRow = page.locator("tbody tr").last();
+    const symbolInput = lastRow.getByRole("textbox");
+    await symbolInput.fill(symbol);
+  }
+
+  async function waitForValidation(expected: "valid" | "invalid", timeoutMs = 30000) {
+    // Wait for loading spinner to appear (debounce fires after 800ms)
+    await expect(page.getByTestId("symbol-validation-loading")).toBeVisible({
+      timeout: 5000,
+    });
+    // Wait for loading spinner to disappear (network call completes)
+    await expect(page.getByTestId("symbol-validation-loading")).not.toBeVisible({
+      timeout: timeoutMs,
+    });
+    // Check final icon
+    await expect(page.getByTestId(`symbol-validation-${expected}`)).toBeVisible({ timeout: 3000 });
+  }
+
+  async function closeSheet() {
+    await page.keyboard.press("Escape");
+    await expect(page.getByRole("dialog")).not.toBeVisible({ timeout: 5000 });
+  }
+
+  // ── setup ─────────────────────────────────────────────────────────────────
+
+  test("0. Setup: login and create test asset", async () => {
+    test.setTimeout(180000);
+    await loginIfNeeded(page);
+    await ensureAssetExists();
+  });
+
+  // ── Yahoo Finance ─────────────────────────────────────────────────────────
+
+  test("1. Yahoo Finance — valid symbol shows green check", async () => {
+    test.setTimeout(60000);
+    await openAssetMarketDataTab();
+    await addMappingRow("Yahoo Finance", "AAPL");
+    await waitForValidation("valid", 30000);
+    await closeSheet();
+  });
+
+  test("2. Yahoo Finance — invalid symbol shows red error", async () => {
+    test.setTimeout(60000);
+    await openAssetMarketDataTab();
+    await addMappingRow("Yahoo Finance", "INVALID_TICKER_XYZ_E2E");
+    await waitForValidation("invalid", 30000);
+    await closeSheet();
+  });
+
+  // ── Börse Frankfurt ───────────────────────────────────────────────────────
+
+  test("3. Börse Frankfurt — valid ISIN shows green check", async () => {
+    test.setTimeout(60000);
+    await openAssetMarketDataTab();
+    await addMappingRow("Börse Frankfurt", "DE0007164600");
+    await waitForValidation("valid", 30000);
+    await closeSheet();
+  });
+
+  test("4. Börse Frankfurt — invalid symbol shows red error", async () => {
+    test.setTimeout(60000);
+    await openAssetMarketDataTab();
+    await addMappingRow("Börse Frankfurt", "INVALID_TICKER_XYZ_E2E");
+    await waitForValidation("invalid", 30000);
+    await closeSheet();
+  });
+});

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -40,6 +40,11 @@ This starts two processes in parallel:
 Wait until both are ready (you'll see Vite's "ready in Xms" and the Rust server
 binding messages in the output).
 
+> **If the web app is already running:** Stop it first (Ctrl+C), then re-run
+> `prep-e2e.mjs` and restart. The running instance is using a stale database —
+> tests assume an empty DB and will silently skip asset creation if data already
+> exists, causing failures for unrelated reasons.
+
 ### Step 3 — Run the tests
 
 In a separate terminal:

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -94,6 +94,16 @@ npx playwright test && npx playwright show-report
 | `09-bulk-holdings.spec.ts`             | Bulk holdings CSV import                                             |
 | `10-symbol-mapping-validation.spec.ts` | Symbol mapping real-time validation (Yahoo Finance, Börse Frankfurt) |
 
+> **Dependency:** `10-symbol-mapping-validation.spec.ts` requires
+> `01-happy-path.spec.ts` to have run first on the same database. Test 0 (setup)
+> calls `loginIfNeeded`, which expects either a login page or a dashboard —
+> neither exists on a fresh DB until onboarding is complete. Always run spec 01
+> before spec 10 on a fresh database:
+>
+> ```bash
+> npx playwright test e2e/01-happy-path.spec.ts e2e/10-symbol-mapping-validation.spec.ts
+> ```
+
 ---
 
 ## Debugging a failing test

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -16,7 +16,30 @@ frontend and backend must be running against a fresh database.
 
 ## Running E2E Tests
 
-### Step 1 — Prepare a fresh database
+### Automated — full suite
+
+The easiest way to run the entire suite. Handles everything automatically:
+prepares a fresh database, starts the web app, waits for both servers, runs
+Playwright, and shuts everything down.
+
+```bash
+pnpm test:e2e
+```
+
+To open the Playwright UI instead:
+
+```bash
+pnpm test:e2e:ui
+```
+
+---
+
+### Manual — specific tests or debugging
+
+Use this when you want to run a subset of tests or iterate quickly without
+restarting the server on every run.
+
+#### Step 1 — Prepare a fresh database
 
 ```bash
 node scripts/prep-e2e.mjs
@@ -26,38 +49,45 @@ This creates a new timestamped SQLite database (e.g.
 `db/app-testing-20260411T120000Z.db`) and writes its path to `.env.web`. **Run
 this every time** before starting the server — it ensures test isolation.
 
-### Step 2 — Start the web app
+#### Step 2 — Start the web app
+
+**Option A — watch the terminal output directly:**
 
 ```bash
 pnpm run dev:web
 ```
 
-This starts two processes in parallel:
+Wait until you see Vite's "ready in Xms" and the Rust server binding messages,
+then move on to Step 3 in a separate terminal.
 
-- **Frontend** — Vite dev server on `http://localhost:1420`
-- **Backend** — Rust Axum server on `http://localhost:8088`
+**Option B — redirect output to a log file and use the wait script:**
 
-Wait until both are ready (you'll see Vite's "ready in Xms" and the Rust server
-binding messages in the output).
+```bash
+pnpm run dev:web > /tmp/wealthfolio-dev2.log 2>&1 &
+./scripts/wait-for-both-servers-to-be-ready.sh
+```
+
+`wait-for-both-servers-to-be-ready.sh` polls the log file until it detects both
+"ready in" (Vite) and the Axum server binding on port 8088, then prints the last
+few lines and exits. The output redirect is required — the script reads from a
+file, not from a live terminal.
 
 > **If the web app is already running:** Stop it first (Ctrl+C), then re-run
 > `prep-e2e.mjs` and restart. The running instance is using a stale database —
 > tests assume an empty DB and will silently skip asset creation if data already
 > exists, causing failures for unrelated reasons.
 
-### Step 3 — Run the tests
-
-In a separate terminal:
+#### Step 3 — Run specific tests
 
 ```bash
-# Run all E2E tests
-npx playwright test
-
 # Run a specific spec file
 npx playwright test e2e/10-symbol-mapping-validation.spec.ts
 
 # Run with browser visible (useful for debugging)
-npx playwright test --headed
+npx playwright test e2e/10-symbol-mapping-validation.spec.ts --headed
+
+# Run all tests
+npx playwright test
 
 # Run and open the HTML report afterwards
 npx playwright test && npx playwright show-report

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,105 @@
+# E2E Tests
+
+Wealthfolio E2E tests use [Playwright](https://playwright.dev/) and run against
+the **web app** (not the Tauri desktop app). There are **no mocks** — both
+frontend and backend must be running against a fresh database.
+
+---
+
+## Prerequisites
+
+- `pnpm` installed
+- Rust toolchain installed (for the backend server)
+- Chrome installed (Playwright uses the system Chrome)
+
+---
+
+## Running E2E Tests
+
+### Step 1 — Prepare a fresh database
+
+```bash
+node scripts/prep-e2e.mjs
+```
+
+This creates a new timestamped SQLite database (e.g.
+`db/app-testing-20260411T120000Z.db`) and writes its path to `.env.web`. **Run
+this every time** before starting the server — it ensures test isolation.
+
+### Step 2 — Start the web app
+
+```bash
+pnpm run dev:web
+```
+
+This starts two processes in parallel:
+
+- **Frontend** — Vite dev server on `http://localhost:1420`
+- **Backend** — Rust Axum server on `http://localhost:8088`
+
+Wait until both are ready (you'll see Vite's "ready in Xms" and the Rust server
+binding messages in the output).
+
+### Step 3 — Run the tests
+
+In a separate terminal:
+
+```bash
+# Run all E2E tests
+npx playwright test
+
+# Run a specific spec file
+npx playwright test e2e/10-symbol-mapping-validation.spec.ts
+
+# Run with browser visible (useful for debugging)
+npx playwright test --headed
+
+# Run and open the HTML report afterwards
+npx playwright test && npx playwright show-report
+```
+
+---
+
+## Important rules
+
+- **Always run `prep-e2e.mjs` before starting the server.** Tests assume an
+  empty database. If you run against an existing database, setup steps may
+  silently skip asset creation and tests may fail for unrelated reasons.
+- **Do not run E2E tests against the Tauri desktop app.** The tests are
+  hardcoded to `http://localhost:1420`.
+- **Do not run E2E tests while the Tauri dev server (`pnpm tauri dev`) is
+  running** on the same ports — they conflict.
+- Tests run **serially** (1 worker, serial mode). Do not try to parallelize
+  them.
+
+---
+
+## Test files
+
+| File                                   | What it tests                                                        |
+| -------------------------------------- | -------------------------------------------------------------------- |
+| `01-happy-path.spec.ts`                | Onboarding, accounts, deposits, trades                               |
+| `02-activities.spec.ts`                | All activity types                                                   |
+| `03-fx-cash-balance.spec.ts`           | FX cash balances                                                     |
+| `04-csv-import.spec.ts`                | CSV activity import                                                  |
+| `05-form-validation.spec.ts`           | Form field validation errors                                         |
+| `06-activity-data-grid.spec.ts`        | Activity data grid interactions                                      |
+| `07-asset-creation.spec.ts`            | Manual asset creation and editing                                    |
+| `08-holdings-and-performance.spec.ts`  | Holdings and performance views                                       |
+| `09-bulk-holdings.spec.ts`             | Bulk holdings CSV import                                             |
+| `10-symbol-mapping-validation.spec.ts` | Symbol mapping real-time validation (Yahoo Finance, Börse Frankfurt) |
+
+---
+
+## Debugging a failing test
+
+```bash
+# Run with Playwright inspector (step through actions)
+npx playwright test e2e/<spec>.spec.ts --debug
+
+# Show the last HTML report
+npx playwright show-report
+
+# Record a trace for a failing test (trace is saved on retry)
+# Already configured in playwright.config.ts: trace: "on-first-retry"
+```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,58 +54,6 @@ importers:
         specifier: ^8.55.0
         version: 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
 
-  addons/fire-planner:
-    dependencies:
-      '@tanstack/react-query':
-        specifier: ^5.90.20
-        version: 5.90.21(react@19.2.4)
-      '@wealthfolio/addon-sdk':
-        specifier: workspace:*
-        version: link:../../packages/addon-sdk
-      '@wealthfolio/ui':
-        specifier: workspace:*
-        version: link:../../packages/ui
-      react:
-        specifier: ^19.2.4
-        version: 19.2.4
-      react-dom:
-        specifier: ^19.2.4
-        version: 19.2.4(react@19.2.4)
-      recharts:
-        specifier: ^3.7.0
-        version: 3.7.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react-is@17.0.2)(react@19.2.4)(redux@5.0.1)
-    devDependencies:
-      '@tailwindcss/vite':
-        specifier: ^4.1.18
-        version: 4.2.1(vite@7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1))
-      '@types/node':
-        specifier: ^20.19.33
-        version: 20.19.35
-      '@types/react':
-        specifier: ^19.2.13
-        version: 19.2.14
-      '@types/react-dom':
-        specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.14)
-      '@vitejs/plugin-react':
-        specifier: ^5.1.4
-        version: 5.1.4(vite@7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1))
-      '@wealthfolio/addon-dev-tools':
-        specifier: workspace:*
-        version: link:../../packages/addon-dev-tools
-      rollup-plugin-external-globals:
-        specifier: ^0.13.0
-        version: 0.13.0(rollup@4.57.1)
-      tailwindcss:
-        specifier: ^4.1.18
-        version: 4.2.1
-      typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
-      vite:
-        specifier: ^7.3.1
-        version: 7.3.1(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)
-
   addons/goal-progress-tracker:
     dependencies:
       '@tanstack/react-query':

--- a/scripts/wait-for-both-servers-to-be-ready.sh
+++ b/scripts/wait-for-both-servers-to-be-ready.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+# Default values
+LOG_FILE="/tmp/wealthfolio-dev2.log"
+MAX_ATTEMPTS=60
+INTERVAL=2
+TAIL_LINES=25
+PORT=8088
+
+# Function to show usage
+show_help() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Wait for both servers to be ready by checking the log file."
+    echo ""
+    echo "Options:"
+    echo "  -l, --log-file LOG_FILE    Path to the log file (default: /tmp/wealthfolio-dev2.log)"
+    echo "  -m, --max-attempts NUM     Maximum number of attempts (default: 60)"
+    echo "  -i, --interval SEC         Interval between checks in seconds (default: 2)"
+    echo "  -t, --tail-lines NUM       Number of lines to show at the end (default: 25)"
+    echo "  -p, --port PORT            Port number to check for (default: 8088)"
+    echo "  -h, --help                 Show this help message"
+    echo ""
+    echo "The script checks for 'ready in' and 'listening|:$PORT|Axum' in the log file."
+}
+
+# Parse options
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -l|--log-file)
+            LOG_FILE="$2"
+            shift 2
+            ;;
+        -m|--max-attempts)
+            MAX_ATTEMPTS="$2"
+            shift 2
+            ;;
+        -i|--interval)
+            INTERVAL="$2"
+            shift 2
+            ;;
+        -t|--tail-lines)
+            TAIL_LINES="$2"
+            shift 2
+            ;;
+        -p|--port)
+            PORT="$2"
+            shift 2
+            ;;
+        -h|--help)
+            show_help
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            show_help
+            exit 1
+            ;;
+    esac
+done
+
+# Validate inputs
+if ! [[ "$MAX_ATTEMPTS" =~ ^[0-9]+$ ]] || [ "$MAX_ATTEMPTS" -le 0 ]; then
+    echo "Error: max-attempts must be a positive integer"
+    exit 1
+fi
+
+if ! [[ "$INTERVAL" =~ ^[0-9]+$ ]] || [ "$INTERVAL" -le 0 ]; then
+    echo "Error: interval must be a positive integer"
+    exit 1
+fi
+
+if ! [[ "$TAIL_LINES" =~ ^[0-9]+$ ]] || [ "$TAIL_LINES" -lt 0 ]; then
+    echo "Error: tail-lines must be a non-negative integer"
+    exit 1
+fi
+
+if ! [[ "$PORT" =~ ^[0-9]+$ ]] || [ "$PORT" -le 0 ] || [ "$PORT" -gt 65535 ]; then
+    echo "Error: port must be an integer between 1 and 65535"
+    exit 1
+fi
+
+# Wait loop
+for ((i=1; i<=MAX_ATTEMPTS; i++)); do
+    if grep -q "ready in" "$LOG_FILE" 2>/dev/null && grep -qE "listening|:$PORT|Axum" "$LOG_FILE" 2>/dev/null; then
+        echo "Both servers ready after $((i*INTERVAL))s"
+        break
+    fi
+    sleep "$INTERVAL"
+done
+
+# Show tail of log
+if [ -f "$LOG_FILE" ]; then
+    tail -"$TAIL_LINES" "$LOG_FILE"
+else
+    echo "Log file $LOG_FILE does not exist or is not accessible."
+fi


### PR DESCRIPTION
## Summary

- **Real-time symbol validation** in the Market Data tab: each provider override row now validates the typed symbol against the selected provider (Yahoo Finance, Börse Frankfurt, etc.) with an 800ms debounce, showing a spinner → green check or red error icon
- **Provider-specific validation**: threaded `preferred_provider` through the full stack (Rust `resolve_symbol_quote` trait → Tauri command → Axum route → TypeScript adapter) so validation uses the exact provider selected in each row, not the default
- **Save warning**: a non-blocking toast warns when saving with invalid symbol mappings
- **E2E tests**: 4 Playwright tests covering Yahoo Finance (AAPL valid, invalid ticker) and Börse Frankfurt (DE0007164600 ISIN valid, invalid ticker), with `data-testid` attributes on validation icons for reliable selection

## Test Plan

- [x] Open an asset's Market Data tab → enable Automatic pricing → click Add → type `AAPL` with Yahoo Finance selected → green check appears within ~2s
- [x] Same flow with `INVALID_TICKER_XYZ_E2E` → red error icon appears
- [x] Change provider to Börse Frankfurt → type `DE0007164600` → green check
- [x] Change provider to Börse Frankfurt → type `INVALID_TICKER_XYZ_E2E` → red error icon appears
- [x] E2E suite passes: `npx playwright test e2e/01-happy-path.spec.ts e2e/10-symbol-mapping-validation.spec.ts` (01 must run first to complete onboarding; requires fresh DB from `node scripts/prep-e2e.mjs`)

Closes #833

🤖 Generated with [Claude Code](https://claude.ai/claude-code)