### PR TITLE
fix: propagate asset (de)activate errors and use exact troy ounce constant

### DIFF
--- a/crates/core/src/quotes/service.rs
+++ b/crates/core/src/quotes/service.rs
@@ -9,7 +9,7 @@
 
 use async_trait::async_trait;
 use chrono::{Duration, NaiveDate, TimeZone, Utc};
-use log::{debug, info, warn};
+use log::{debug, info};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -1315,9 +1315,7 @@ where
                         asset_id, current_qty
                     );
                     self.sync_state_store.mark_active(asset_id).await?;
-                    if let Err(e) = self.asset_repo.reactivate(asset_id).await {
-                        warn!("Failed to reactivate asset {}: {}", asset_id, e);
-                    }
+                    self.asset_repo.reactivate(asset_id).await?;
                     marked_active += 1;
                 }
                 // If already active, no change needed
@@ -1327,9 +1325,7 @@ where
                     // Was active, now closed - mark as inactive with today's date
                     debug!("Marking asset {} as inactive (position closed)", asset_id);
                     self.sync_state_store.mark_inactive(asset_id, today).await?;
-                    if let Err(e) = self.asset_repo.deactivate(asset_id).await {
-                        warn!("Failed to deactivate asset {}: {}", asset_id, e);
-                    }
+                    self.asset_repo.deactivate(asset_id).await?;
                     marked_inactive += 1;
                 }
                 // If already inactive, no change needed (preserve existing closed date)

--- a/crates/market-data/src/provider/metal_price_api/mod.rs
+++ b/crates/market-data/src/provider/metal_price_api/mod.rs
@@ -33,8 +33,8 @@ const SUPPORTED_METALS: &[&str] = &["XAU", "XAG", "XPT", "XPD", "XRH", "XRU", "X
 /// Provider ID constant
 const PROVIDER_ID: &str = "METAL_PRICE_API";
 
-/// One troy ounce in grams.
-const TROY_OZ_GRAMS: f64 = 31.1035;
+/// One troy ounce in grams (exact definition).
+const TROY_OZ_GRAMS: Decimal = Decimal::from_parts(311034768, 0, 0, false, 7);
 
 /// API response from Metal Price API (latest and historical endpoints)
 #[derive(Debug, Deserialize)]
@@ -110,17 +110,17 @@ impl MetalPriceApiProvider {
         let multiplier = match suffix {
             None => Decimal::ONE,
             Some(s) => {
-                let grams: f64 = match s {
-                    "1KG" => 1000.0,
-                    "500G" => 500.0,
-                    "250G" => 250.0,
-                    "100G" => 100.0,
-                    "50G" => 50.0,
-                    "10G" => 10.0,
+                let grams: Decimal = match s {
+                    "1KG" => Decimal::from(1000),
+                    "500G" => Decimal::from(500),
+                    "250G" => Decimal::from(250),
+                    "100G" => Decimal::from(100),
+                    "50G" => Decimal::from(50),
+                    "10G" => Decimal::from(10),
                     "1OZ" => TROY_OZ_GRAMS,
                     _ => return None,
                 };
-                Decimal::try_from(grams / TROY_OZ_GRAMS).ok()?
+                grams / TROY_OZ_GRAMS
             }
         };
         Some((base, multiplier))
@@ -387,7 +387,7 @@ mod tests {
     fn test_parse_metal_symbol_1kg() {
         let (base, mult) = MetalPriceApiProvider::parse_metal_symbol("XAU-1KG").unwrap();
         assert_eq!(base, "XAU");
-        // 1 kg = 1000g / 31.1035 g/oz ≈ 32.1507 oz
+        // 1 kg = 1000g / 31.1034768 g/oz ≈ 32.1507 oz
         assert!(mult > dec!(32.15) && mult < dec!(32.16));
     }
 


### PR DESCRIPTION
## Summary

- **quotes/service**: propagate errors from `asset_repo.reactivate()` and `asset_repo.deactivate()` in `update_position_status_from_holdings` instead of swallowing them with `warn!`. A failed asset (de)activation leaves sync state and asset active flag out of sync, so the caller should see the error.
- **metal_price_api**: replace `f64` troy-ounce math with `Decimal`. `TROY_OZ_GRAMS` is now the exact definition (31.1034768 g) as a `Decimal` constant, and the gram-to-ounce conversion stays in Decimal space end-to-end — no more `f64 → Decimal::try_from` that could silently drop precision or fail.

## Test plan
- [ ] `cargo fmt`, `cargo clippy`, `cargo test` pass
- [ ] Verify metal symbol parsing tests (`test_parse_metal_symbol_1kg`, etc.) still pass with tightened constant