### PR TITLE
fix(activity): clarify FX rate direction in activity form

### DIFF
--- a/apps/frontend/src/pages/activity/components/forms/fields/advanced-options-section.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/fields/advanced-options-section.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo } from "react";
-import { useFormContext, type FieldPath, type FieldValues } from "react-hook-form";
+import { useFormContext, useWatch, type FieldPath, type FieldValues } from "react-hook-form";
 import {
   Collapsible,
   CollapsibleContent,
@@ -17,6 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@wealthfolio/ui";
+import { FormDescription } from "@wealthfolio/ui/components/ui/form";
 import { CurrencyInput, MoneyInput } from "@wealthfolio/ui/components/financial";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
 import { Button } from "@wealthfolio/ui/components/ui/button";
@@ -74,6 +75,23 @@ export function AdvancedOptionsSection<TFieldValues extends FieldValues = FieldV
   const isMobile = variant === "mobile";
   const [isOpen, setIsOpen] = useState(defaultOpen);
   const { control } = useFormContext<TFieldValues>();
+
+  const watchedCurrency = useWatch({
+    control,
+    name: currencyName as FieldPath<TFieldValues>,
+    disabled: !currencyName,
+  }) as string | undefined;
+  const fromCurrency = watchedCurrency || assetCurrency;
+
+  const watchedFxRate = useWatch({
+    control,
+    name: fxRateName as FieldPath<TFieldValues>,
+    disabled: !fxRateName,
+  }) as number | undefined;
+  const fxRateDisplay =
+    typeof watchedFxRate === "number" && Number.isFinite(watchedFxRate) && watchedFxRate > 0
+      ? watchedFxRate.toString()
+      : "?";
 
   // Get available subtypes for the current activity type
   const availableSubtypes = useMemo(() => {
@@ -198,6 +216,11 @@ export function AdvancedOptionsSection<TFieldValues extends FieldValues = FieldV
                       data-testid="fx-rate-input"
                     />
                   </FormControl>
+                  {fromCurrency && accountCurrency && fromCurrency !== accountCurrency && (
+                    <FormDescription className="text-xs">
+                      1 {fromCurrency} = {fxRateDisplay} {accountCurrency}
+                    </FormDescription>
+                  )}
                   <FormMessage />
                 </FormItem>
               )}


### PR DESCRIPTION
## Summary
- Adds a live hint below the FX Rate input reading `1 {activityCurrency} = {rate|?} {accountCurrency}`, so users know which direction to enter and can verify the value they typed.
- The hint only renders when the activity and account currencies differ (otherwise the FX rate field is unused).
- Direction matches the existing backend convention (`crates/core/src/portfolio/snapshot/holdings_calculator.rs` — `amount * fx_rate` converts activity → account currency).

Fixes #832

## Test plan
- [ ] Open Buy form with an account in CAD and a symbol in USD → expand Advanced Options → FX Rate shows `1 USD = ? CAD`
- [ ] Type `1.3` → hint updates to `1 USD = 1.3 CAD`
- [ ] Clear the field / enter `0` → hint falls back to `?`
- [ ] Change the Currency field via the pill buttons → hint updates accordingly
- [ ] When account currency equals activity currency → hint is hidden
- [ ] Sell form, mobile variant, dividend form (anywhere `AdvancedOptionsSection` is used with an FX rate field) behave the same