### PR TITLE
feat(custom-provider): allow self-hosted / private-network URLs

### DIFF
--- a/crates/core/src/custom_provider/model.rs
+++ b/crates/core/src/custom_provider/model.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use std::net::IpAddr;
 
 /// Valid source kinds.
 pub const VALID_SOURCE_KINDS: &[&str] = &["latest", "historical"];
@@ -53,43 +52,11 @@ pub fn expand_template(template: &str, ctx: &TemplateContext<'_>) -> String {
     out
 }
 
-/// Returns true if the IP address is private, loopback, or otherwise reserved.
-fn is_private_or_reserved(addr: IpAddr) -> bool {
-    match addr {
-        IpAddr::V4(ip) => {
-            let octets = ip.octets();
-            let is_shared = octets[0] == 100 && (octets[1] & 0xC0) == 64; // 100.64.0.0/10 (CGNAT)
-            let is_benchmarking = octets[0] == 198 && (octets[1] & 0xFE) == 18; // 198.18.0.0/15
-            let is_multicast = octets[0] >= 224 && octets[0] <= 239; // 224.0.0.0/4
-            let is_reserved = octets[0] >= 240; // 240.0.0.0/4
-            ip.is_loopback()
-                || ip.is_private()
-                || ip.is_link_local()
-                || ip.is_broadcast()
-                || ip.is_unspecified()
-                || is_shared
-                || is_benchmarking
-                || is_multicast
-                || is_reserved
-        }
-        IpAddr::V6(ip) => {
-            let segs = ip.segments();
-            let is_unique_local = (segs[0] & 0xfe00) == 0xfc00; // fc00::/7
-            let is_link_local = (segs[0] & 0xffc0) == 0xfe80; // fe80::/10
-            let is_multicast = (segs[0] & 0xff00) == 0xff00; // ff00::/8
-            ip.is_loopback()
-                || ip.is_unspecified()
-                || is_unique_local
-                || is_link_local
-                || is_multicast
-        }
-    }
-}
-
-/// Validate that a URL is safe to fetch (no SSRF).
+/// Validate that a URL parses and uses an http(s) scheme.
 ///
-/// Rejects non-HTTP(S) schemes and URLs with literal private/loopback addresses.
-/// Does NOT resolve DNS — call [`validate_url_resolved`] after this for full protection.
+/// The user is the author of their provider URLs, so we don't restrict which
+/// hosts they can target (self-hosted providers on private networks are
+/// supported). Only rejects malformed URLs and non-HTTP(S) schemes.
 pub fn validate_url(raw: &str) -> Result<(), anyhow::Error> {
     let parsed =
         url::Url::parse(raw).map_err(|e| anyhow::anyhow!("Invalid URL '{}': {}", raw, e))?;
@@ -104,67 +71,8 @@ pub fn validate_url(raw: &str) -> Result<(), anyhow::Error> {
         }
     }
 
-    match parsed.host() {
-        Some(url::Host::Domain(domain)) => {
-            if domain == "localhost" {
-                return Err(anyhow::anyhow!("URLs targeting localhost are not allowed"));
-            }
-        }
-        Some(url::Host::Ipv4(ip)) => {
-            if is_private_or_reserved(IpAddr::V4(ip)) {
-                return Err(anyhow::anyhow!(
-                    "URLs targeting private/reserved IP address {} are not allowed",
-                    ip
-                ));
-            }
-        }
-        Some(url::Host::Ipv6(ip)) => {
-            if is_private_or_reserved(IpAddr::V6(ip)) {
-                return Err(anyhow::anyhow!(
-                    "URLs targeting private/reserved IP address {} are not allowed",
-                    ip
-                ));
-            }
-        }
-        None => return Err(anyhow::anyhow!("URL '{}' has no host", raw)),
-    }
-
-    Ok(())
-}
-
-/// Validate a URL by resolving its hostname and checking the resolved IPs.
-///
-/// Catches DNS-based SSRF where a public-looking hostname resolves to a
-/// private/loopback address.
-pub async fn validate_url_resolved(raw: &str) -> Result<(), anyhow::Error> {
-    // First run the fast syntactic check
-    validate_url(raw)?;
-
-    let parsed = url::Url::parse(raw)?;
-
-    // Only domain hostnames need DNS resolution; literal IPs were already checked.
-    if let Some(url::Host::Domain(domain)) = parsed.host() {
-        let port = parsed.port_or_known_default().unwrap_or(443);
-        let host_port = format!("{}:{}", domain, port);
-
-        let addrs: Vec<std::net::SocketAddr> = tokio::net::lookup_host(&host_port).await?.collect();
-
-        if addrs.is_empty() {
-            return Err(anyhow::anyhow!(
-                "DNS resolution for '{}' returned no addresses",
-                domain
-            ));
-        }
-
-        for addr in &addrs {
-            if is_private_or_reserved(addr.ip()) {
-                return Err(anyhow::anyhow!(
-                    "DNS for '{}' resolves to private/reserved address {} — not allowed",
-                    domain,
-                    addr.ip()
-                ));
-            }
-        }
+    if parsed.host().is_none() {
+        return Err(anyhow::anyhow!("URL '{}' has no host", raw));
     }
 
     Ok(())

--- a/crates/core/src/custom_provider/service.rs
+++ b/crates/core/src/custom_provider/service.rs
@@ -136,9 +136,7 @@ impl CustomProviderService {
         };
         let url = expand_template(&payload.url, &tctx);
 
-        validate_url_resolved(&url)
-            .await
-            .map_err(|e| crate::Error::Unexpected(e.to_string()))?;
+        validate_url(&url).map_err(|e| crate::Error::Unexpected(e.to_string()))?;
 
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(15))

--- a/crates/core/src/quotes/custom_scraper_provider.rs
+++ b/crates/core/src/quotes/custom_scraper_provider.rs
@@ -9,7 +9,7 @@ use log::debug;
 use rust_decimal::Decimal;
 
 use crate::custom_provider::model::{
-    expand_template, extract_html_value, validate_url_resolved, TemplateContext, MAX_RESPONSE_BYTES,
+    expand_template, extract_html_value, validate_url, TemplateContext, MAX_RESPONSE_BYTES,
 };
 use crate::custom_provider::service::{
     detect_html_locale, parse_csv_records, parse_number_string, resolve_csv_column,
@@ -218,13 +218,10 @@ impl CustomScraperProvider {
 
         let url = self.expand_url(&source.url, symbol, context, from, to);
 
-        // SSRF check (includes DNS resolution to catch rebinding attacks)
-        validate_url_resolved(&url)
-            .await
-            .map_err(|e| MarketDataError::ProviderError {
-                provider: DATA_SOURCE_CUSTOM_SCRAPER.to_string(),
-                message: e.to_string(),
-            })?;
+        validate_url(&url).map_err(|e| MarketDataError::ProviderError {
+            provider: DATA_SOURCE_CUSTOM_SCRAPER.to_string(),
+            message: e.to_string(),
+        })?;
 
         let headers = self.build_headers(source)?;
 


### PR DESCRIPTION
## Summary

- Drops the SSRF-style URL gate on custom provider URLs (localhost, private/loopback/CGNAT/link-local IP rejection, DNS-resolution check).
- `validate_url` now only verifies parse correctness + http(s) scheme. `validate_url_resolved` is removed.
- Unblocks users who want to point custom providers at self-hosted endpoints on their own network (e.g. `http://myserver.lan:8080/...`, `http://192.168.x.x/...`, `http://localhost:...`).

## Why

Wealthfolio is a single-user, local-first app. Custom provider URLs are always author-entered by the trusted user. SSRF protection against URLs you type yourself is paternalistic — there's no untrusted party whose input we're mediating. The check's only practical effect was blocking legitimate self-hosted setups.

Every "edge case" for keeping the check unwinds the same way:
- IMDS exfiltration on cloud hosts — you chose to deploy there with that IAM role, and you type the URL.
- Device-sync propagating a malicious config — requires a compromised device, which can already write anything to the DB. URL validation isn't a meaningful mitigation at that point.
- Template-expansion into host position — you wrote the template and control symbol sources.

The right trust boundary is authentication, not URL validation.

## Scope

- `crates/core/src/custom_provider/model.rs` — remove `is_private_or_reserved`, delete `validate_url_resolved`, simplify `validate_url`.
- `crates/core/src/custom_provider/service.rs` — `test_source` uses sync `validate_url`.
- `crates/core/src/quotes/custom_scraper_provider.rs` — runtime fetch uses sync `validate_url`.

Net: **+12 / -109**.

No schema change, no UI change, no config flag, no env var.

## Test plan

- [x] `cargo check --workspace` — clean
- [x] `cargo test -p wealthfolio-core custom_provider` — passes
- [ ] Manual: create custom provider pointing at a self-hosted URL on a private IP → saves + fetches quote successfully
- [ ] Manual: malformed URL (e.g. `not-a-url`) still rejected with a clear error
- [ ] Manual: non-http(s) URL (e.g. `file:///etc/passwd`, `ftp://...`) still rejected

## Notes

Related to user feedback requesting the ability to use self-hosted custom providers whose domains resolve to local IPs.