### PR TITLE
fix(activity): securities transfers show qty × price, never a stored amount

### DIFF
--- a/apps/frontend/src/lib/activity-utils.test.ts
+++ b/apps/frontend/src/lib/activity-utils.test.ts
@@ -211,6 +211,50 @@ describe("Activity Utilities", () => {
       expect(calculateActivityValue(transferOut)).toBe(1010);
     });
 
+    it("treats blank-asset transfers as cash and uses amount", () => {
+      const transferIn = createActivity({
+        activityType: ActivityType.TRANSFER_IN,
+        assetSymbol: "",
+        assetId: "",
+        quantity: "0",
+        unitPrice: "0",
+        amount: "500",
+        fee: "0",
+      });
+
+      expect(calculateActivityValue(transferIn)).toBe(500);
+    });
+
+    it("treats broker cash placeholders ($CASH-EUR, CASH-GBP, CASH_GBP) as cash and uses amount", () => {
+      const placeholders = ["$CASH-EUR", "CASH-GBP", "CASH_GBP", "$CASH_CAD"];
+      for (const symbol of placeholders) {
+        const transferIn = createActivity({
+          activityType: ActivityType.TRANSFER_IN,
+          assetSymbol: symbol,
+          assetId: symbol,
+          quantity: "0",
+          unitPrice: "0",
+          amount: "750",
+          fee: "0",
+        });
+        expect(calculateActivityValue(transferIn)).toBe(750);
+      }
+    });
+
+    it("preserves amount for securities transfers missing unitPrice (legacy imports)", () => {
+      const transferIn = createActivity({
+        activityType: ActivityType.TRANSFER_IN,
+        assetSymbol: "AAPL",
+        assetId: "AAPL",
+        quantity: "10",
+        unitPrice: "0",
+        amount: "1500",
+        fee: "0",
+      });
+
+      expect(calculateActivityValue(transferIn)).toBe(1500);
+    });
+
     it("should calculate securities transfer value from qty × unitPrice, not amount", () => {
       // Simulates a real DB row where `amount` is stale/corrupted but
       // quantity and unitPrice are correct. For securities transfers the

--- a/apps/frontend/src/lib/activity-utils.test.ts
+++ b/apps/frontend/src/lib/activity-utils.test.ts
@@ -210,6 +210,34 @@ describe("Activity Utilities", () => {
 
       expect(calculateActivityValue(transferOut)).toBe(1010);
     });
+
+    it("should calculate securities transfer value from qty × unitPrice, not amount", () => {
+      // Simulates a real DB row where `amount` is stale/corrupted but
+      // quantity and unitPrice are correct. For securities transfers the
+      // activity value must derive from qty × unitPrice, NOT the amount field.
+      const transferIn = createActivity({
+        activityType: ActivityType.TRANSFER_IN,
+        assetSymbol: "FWIA",
+        quantity: "2078",
+        unitPrice: "7.29",
+        amount: "31478832.36", // bogus value that must be ignored
+        fee: "0",
+      });
+
+      expect(calculateActivityValue(transferIn)).toBeCloseTo(15148.62, 2);
+
+      const transferOut = createActivity({
+        activityType: ActivityType.TRANSFER_OUT,
+        assetSymbol: "AAPL",
+        quantity: "10",
+        unitPrice: "150",
+        amount: "999999", // bogus
+        fee: "5",
+      });
+
+      // Transfer out of securities: qty × price + fee (mirrors SELL-like handling for value display)
+      expect(calculateActivityValue(transferOut)).toBe(1500);
+    });
   });
 
   describe("formatSplitRatio", () => {

--- a/apps/frontend/src/lib/activity-utils.ts
+++ b/apps/frontend/src/lib/activity-utils.ts
@@ -91,6 +91,18 @@ export const isCashTransfer = (activityType: string, assetSymbol: string): boole
   return false;
 };
 
+/**
+ * Securities transfer: TRANSFER_IN/OUT whose symbol is NOT a cash symbol.
+ * These move assets (shares/units), so their value derives from quantity × unitPrice,
+ * unlike cash transfers which carry a plain amount.
+ */
+export const isSecuritiesTransfer = (activityType: string, assetSymbol: string): boolean => {
+  if (activityType !== ActivityType.TRANSFER_IN && activityType !== ActivityType.TRANSFER_OUT) {
+    return false;
+  }
+  return !isCashTransfer(activityType, assetSymbol);
+};
+
 const isCanonicalCashIdentifier = (identifier: string): boolean => {
   const upper = identifier.toUpperCase();
   if (upper === "CASH") {
@@ -235,9 +247,9 @@ export const calculateActivityValue = (activity: ActivityDetails): number => {
     return roundCurrency(getFee(activity));
   }
 
-  // Handle cash activities
+  // Handle cash activities (but NOT securities transfers, which need qty × price)
   if (
-    isCashActivity(activityType) ||
+    (isCashActivity(activityType) && !isSecuritiesTransfer(activityType, assetSymbol)) ||
     isCashTransfer(activityType, assetSymbol) ||
     isIncomeActivity(activityType)
   ) {

--- a/apps/frontend/src/lib/activity-utils.ts
+++ b/apps/frontend/src/lib/activity-utils.ts
@@ -65,42 +65,65 @@ export const needsImportAssetResolution = (
 };
 
 /**
- * Determines if an activity is a cash transfer based on its type and symbol
- * @param activityType The activity type to check
- * @param assetSymbol The asset symbol to check
- * @returns True if the activity is a cash transfer
+ * Determines if an activity is a cash transfer based on its type and identifiers.
+ * A transfer is cash when:
+ * - it has no asset identifier at all (blank symbol AND blank assetId), OR
+ * - its symbol/assetId matches any supported cash placeholder:
+ *   `CASH`, `CASH:USD`, `$CASH-EUR`, `CASH-GBP`, `CASH_GBP`, etc.
  */
-export const isCashTransfer = (activityType: string, assetSymbol: string): boolean => {
+export const isCashTransfer = (
+  activityType: string,
+  assetSymbol?: string,
+  assetId?: string,
+): boolean => {
   if (activityType !== ActivityType.TRANSFER_IN && activityType !== ActivityType.TRANSFER_OUT) {
     return false;
   }
-  // Recognize cash transfers by symbol:
-  // - CASH:{currency} (e.g., CASH:USD)
-  // - Display value: "CASH" (set by applyCashDefaults)
-  const upperSymbol = assetSymbol.toUpperCase();
 
-  if (upperSymbol === "CASH") {
+  const symbol = assetSymbol?.trim() ?? "";
+  const id = assetId?.trim() ?? "";
+
+  // No asset at all → cash transfer
+  if (!symbol && !id) {
     return true;
   }
 
-  if (upperSymbol.startsWith("CASH:")) {
-    const currency = upperSymbol.slice("CASH:".length);
+  const upper = (symbol || id).toUpperCase();
+
+  // Display placeholder used by applyCashDefaults
+  if (upper === "CASH") {
+    return true;
+  }
+
+  // Canonical backend form: CASH:{ccy}
+  if (upper.startsWith("CASH:")) {
+    const currency = upper.slice("CASH:".length);
     return /^[A-Z]{3}$/.test(currency);
   }
 
-  return false;
+  // Broker-export placeholders: $CASH-XXX, $CASH_XXX, CASH-XXX, CASH_XXX
+  return isCashSymbol(symbol) || isCashSymbol(id);
 };
 
 /**
- * Securities transfer: TRANSFER_IN/OUT whose symbol is NOT a cash symbol.
- * These move assets (shares/units), so their value derives from quantity × unitPrice,
- * unlike cash transfers which carry a plain amount.
+ * Securities transfer: TRANSFER_IN/OUT whose asset identifiers clearly refer
+ * to a real security (not cash, not blank). These move shares/units, so their
+ * value derives from quantity × unitPrice (or a stored amount when unitPrice
+ * is absent on legacy/imported rows).
  */
-export const isSecuritiesTransfer = (activityType: string, assetSymbol: string): boolean => {
+export const isSecuritiesTransfer = (
+  activityType: string,
+  assetSymbol?: string,
+  assetId?: string,
+): boolean => {
   if (activityType !== ActivityType.TRANSFER_IN && activityType !== ActivityType.TRANSFER_OUT) {
     return false;
   }
-  return !isCashTransfer(activityType, assetSymbol);
+  const hasConcreteAsset = Boolean((assetSymbol?.trim() || assetId?.trim())?.length);
+  if (!hasConcreteAsset) {
+    return false;
+  }
+  return !isCashTransfer(activityType, assetSymbol, assetId);
 };
 
 const isCanonicalCashIdentifier = (identifier: string): boolean => {
@@ -232,7 +255,7 @@ export const getUnitPrice = (activity: ActivityDetails): number => {
  * @returns The calculated value
  */
 export const calculateActivityValue = (activity: ActivityDetails): number => {
-  const { activityType, assetSymbol } = activity;
+  const { activityType, assetSymbol, assetId } = activity;
 
   // Handle special cases first
   if (activityType === ActivityType.SPLIT) {
@@ -247,10 +270,12 @@ export const calculateActivityValue = (activity: ActivityDetails): number => {
     return roundCurrency(getFee(activity));
   }
 
+  const isSecTransfer = isSecuritiesTransfer(activityType, assetSymbol, assetId);
+
   // Handle cash activities (but NOT securities transfers, which need qty × price)
   if (
-    (isCashActivity(activityType) && !isSecuritiesTransfer(activityType, assetSymbol)) ||
-    isCashTransfer(activityType, assetSymbol) ||
+    (isCashActivity(activityType) && !isSecTransfer) ||
+    isCashTransfer(activityType, assetSymbol, assetId) ||
     isIncomeActivity(activityType)
   ) {
     const amount = getAmount(activity);
@@ -265,11 +290,21 @@ export const calculateActivityValue = (activity: ActivityDetails): number => {
     return roundCurrency(Number(amount) - Number(fee));
   }
 
-  // Handle trading activities
+  // Handle trading activities (and securities transfers)
   const quantity = getQuantity(activity);
   const unitPrice = getUnitPrice(activity);
   const fee = getFee(activity);
-  const activityAmount = roundCurrency(Number(quantity) * Number(unitPrice));
+  let activityAmount = roundCurrency(Number(quantity) * Number(unitPrice));
+
+  // Securities transfers imported without a unit price (legacy / some broker
+  // exports) carry their monetary value on `amount`. Fall back to it so those
+  // rows don't render as 0 just because we no longer trust `amount` by default.
+  if (isSecTransfer && activityAmount === 0) {
+    const storedAmount = getAmount(activity);
+    if (storedAmount !== 0) {
+      activityAmount = roundCurrency(storedAmount);
+    }
+  }
 
   if (activityType === ActivityType.BUY) {
     return roundCurrency(Number(activityAmount) + Number(fee)); // Total cost including fees

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
@@ -62,9 +62,8 @@ export const ActivityTableMobile = ({
           symbol,
           activity.assetId,
         );
-        const hasAsset = Boolean(activity.assetId?.trim());
         const isCash = isTransferActivity
-          ? !hasAsset || isCashTransfer(activityType, symbol)
+          ? isCashTransfer(activityType, symbol, activity.assetId)
           : isCashActivity(activityType) && !isAssetBackedIncome;
         const isOptionActivity = activity.instrumentType === "OPTION";
         const parsedOption = isOptionActivity ? parseOccSymbol(symbol) : null;
@@ -216,8 +215,8 @@ export const ActivityTableMobile = ({
                       ? "Ratio"
                       : (isCashActivity(activity.activityType) &&
                             !isAssetBackedIncome &&
-                            !isSecuritiesTransfer(activity.activityType, symbol)) ||
-                          isCashTransfer(activity.activityType, symbol) ||
+                            !isSecuritiesTransfer(activity.activityType, symbol, activity.assetId)) ||
+                          isCashTransfer(activity.activityType, symbol, activity.assetId) ||
                           (isIncomeActivity(activity.activityType) && !isAssetBackedIncome)
                         ? "Amount"
                         : isOptionActivity
@@ -231,8 +230,8 @@ export const ActivityTableMobile = ({
                         ? formatSplitRatio(Number(activity.amount))
                         : (isCashActivity(activity.activityType) &&
                               !isAssetBackedIncome &&
-                              !isSecuritiesTransfer(activity.activityType, symbol)) ||
-                            isCashTransfer(activity.activityType, symbol) ||
+                              !isSecuritiesTransfer(activity.activityType, symbol, activity.assetId)) ||
+                            isCashTransfer(activity.activityType, symbol, activity.assetId) ||
                             (isIncomeActivity(activity.activityType) && !isAssetBackedIncome)
                           ? formatAmount(Number(activity.amount), activity.currency)
                           : formatAmount(Number(activity.unitPrice), activity.currency)}

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
@@ -8,6 +8,7 @@ import {
   isCashTransfer,
   isFeeActivity,
   isIncomeActivity,
+  isSecuritiesTransfer,
   isSplitActivity,
 } from "@/lib/activity-utils";
 import { ActivityType, ActivityTypeNames } from "@/lib/constants";
@@ -213,7 +214,9 @@ export const ActivityTableMobile = ({
                   <span className="text-muted-foreground">
                     {activity.activityType === "SPLIT"
                       ? "Ratio"
-                      : (isCashActivity(activity.activityType) && !isAssetBackedIncome) ||
+                      : (isCashActivity(activity.activityType) &&
+                            !isAssetBackedIncome &&
+                            !isSecuritiesTransfer(activity.activityType, symbol)) ||
                           isCashTransfer(activity.activityType, symbol) ||
                           (isIncomeActivity(activity.activityType) && !isAssetBackedIncome)
                         ? "Amount"
@@ -226,7 +229,9 @@ export const ActivityTableMobile = ({
                       ? "-"
                       : activity.activityType === "SPLIT"
                         ? formatSplitRatio(Number(activity.amount))
-                        : (isCashActivity(activity.activityType) && !isAssetBackedIncome) ||
+                        : (isCashActivity(activity.activityType) &&
+                              !isAssetBackedIncome &&
+                              !isSecuritiesTransfer(activity.activityType, symbol)) ||
                             isCashTransfer(activity.activityType, symbol) ||
                             (isIncomeActivity(activity.activityType) && !isAssetBackedIncome)
                           ? formatAmount(Number(activity.amount), activity.currency)

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
@@ -23,6 +23,7 @@ import {
   isAssetBackedIncomeActivity,
   isCashActivity,
   isCashTransfer,
+  isSecuritiesTransfer,
   isFeeActivity,
   isIncomeActivity,
   isSplitActivity,
@@ -308,7 +309,9 @@ export const ActivityTable = ({
             return <div className="text-right">{formatSplitRatio(Number(amount))}</div>;
           }
           if (
-            (isCashActivity(activityType) && !isAssetBackedIncome) ||
+            (isCashActivity(activityType) &&
+              !isAssetBackedIncome &&
+              !isSecuritiesTransfer(activityType, assetSymbol)) ||
             isCashTransfer(activityType, assetSymbol) ||
             (isIncomeActivity(activityType) && !isAssetBackedIncome)
           ) {

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
@@ -162,7 +162,7 @@ export const ActivityTable = ({
           const isAssetBackedIncome = isAssetBackedIncomeActivity(activityType, symbol, assetId);
           const hasAsset = Boolean(assetId?.trim());
           const isCash = isTransferActivity
-            ? !hasAsset || isCashTransfer(activityType, symbol)
+            ? isCashTransfer(activityType, symbol, assetId)
             : isCashActivity(activityType) && !isAssetBackedIncome;
 
           // Parse OCC symbol for options
@@ -242,9 +242,8 @@ export const ActivityTable = ({
           );
           const isTransfer =
             activityType === ActivityType.TRANSFER_IN || activityType === ActivityType.TRANSFER_OUT;
-          const hasAsset = Boolean(row.original.assetId?.trim());
           const isCash = isTransfer
-            ? !hasAsset || isCashTransfer(activityType, assetSymbol)
+            ? isCashTransfer(activityType, assetSymbol, row.original.assetId)
             : isCashActivity(activityType) && !isAssetBackedIncome;
 
           if (
@@ -311,8 +310,8 @@ export const ActivityTable = ({
           if (
             (isCashActivity(activityType) &&
               !isAssetBackedIncome &&
-              !isSecuritiesTransfer(activityType, assetSymbol)) ||
-            isCashTransfer(activityType, assetSymbol) ||
+              !isSecuritiesTransfer(activityType, assetSymbol, row.original.assetId)) ||
+            isCashTransfer(activityType, assetSymbol, row.original.assetId) ||
             (isIncomeActivity(activityType) && !isAssetBackedIncome)
           ) {
             return <div className="text-right">{formatAmount(Number(amount), currency)}</div>;

--- a/apps/frontend/src/pages/activity/components/forms/bulk-holdings-modal.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/bulk-holdings-modal.tsx
@@ -145,7 +145,11 @@ export const BulkHoldingsModal = ({
         },
         quantity: Number(holding.sharesOwned),
         unitPrice: Number(holding.averageCost),
-        amount: Number(holding.sharesOwned) * Number(holding.averageCost),
+        // Securities transfers derive value from qty × unitPrice at display time.
+        // Sending a precomputed amount here is redundant and has produced corrupted
+        // rows in the wild (e.g. amount = qty² × unitPrice); leave it null so the
+        // backend stores NULL and readers fall back to qty × unitPrice.
+        amount: null,
         currency,
         fee: 0,
         comment: data.comment?.trim() || undefined,

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -1488,8 +1488,11 @@ impl ActivityService {
         // Securities transfers derive monetary value from quantity × unit_price at
         // read time. Any inbound `amount` is redundant and has historically been
         // a source of corruption (e.g. amount = qty² × unit_price stored on the
-        // row). Force it to None so the DB holds a single source of truth.
-        if is_securities_transfer(&activity.activity_type, resolved_asset_id.as_deref()) {
+        // row). Clear it only when unit_price is present so legacy imports that
+        // carry qty + amount (no unit_price) keep their monetary value.
+        if is_securities_transfer(&activity.activity_type, resolved_asset_id.as_deref())
+            && activity.unit_price.is_some()
+        {
             activity.amount = None;
         }
 
@@ -1874,9 +1877,14 @@ impl ActivityService {
         activity.amount = activity.amount.map(|v| v.map(|d| d.abs()));
         activity.fee = activity.fee.map(|v| v.map(|d| d.abs()));
 
-        // Securities transfers derive value from quantity × unit_price; always
-        // clear `amount` on update so a caller cannot re-introduce a stale value.
-        if is_securities_transfer(&activity.activity_type, resolved_asset_id.as_deref()) {
+        // Securities transfers derive value from quantity × unit_price; clear
+        // `amount` on update only when the patch carries a unit_price so callers
+        // cannot re-introduce a stale value. Legacy rows that lack unit_price
+        // rely on amount as their monetary source of truth, so leave amount
+        // alone when unit_price isn't being set.
+        if is_securities_transfer(&activity.activity_type, resolved_asset_id.as_deref())
+            && matches!(activity.unit_price, Some(Some(_)))
+        {
             activity.amount = Some(None);
         }
 
@@ -4141,8 +4149,12 @@ impl ActivityService {
             activity.fee = activity.fee.map(|v| v.abs());
 
             // Securities transfers derive monetary value from quantity × unit_price;
-            // never persist an inbound `amount` for them (see prepare_new_activity).
-            if is_securities_transfer(&activity.activity_type, resolved_asset_id.as_deref()) {
+            // never persist an inbound `amount` for them when unit_price is present
+            // (see prepare_new_activity). Legacy imports with qty + amount and no
+            // unit_price keep their monetary value.
+            if is_securities_transfer(&activity.activity_type, resolved_asset_id.as_deref())
+                && activity.unit_price.is_some()
+            {
                 activity.amount = None;
             }
 

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -7,10 +7,10 @@ use std::sync::Arc;
 
 use crate::accounts::{Account, AccountServiceTrait};
 use crate::activities::activities_constants::{
-    classify_import_activity, is_garbage_symbol, requires_symbol, ImportSymbolDisposition,
-    ACTIVITY_SUBTYPE_DIVIDEND_IN_KIND, ACTIVITY_SUBTYPE_DRIP, ACTIVITY_SUBTYPE_STAKING_REWARD,
-    ACTIVITY_TYPE_SPLIT, ACTIVITY_TYPE_TRANSFER_IN, ACTIVITY_TYPE_TRANSFER_OUT,
-    PRICE_BEARING_ACTIVITY_TYPES,
+    classify_import_activity, is_cash_symbol, is_garbage_symbol, requires_symbol,
+    ImportSymbolDisposition, ACTIVITY_SUBTYPE_DIVIDEND_IN_KIND, ACTIVITY_SUBTYPE_DRIP,
+    ACTIVITY_SUBTYPE_STAKING_REWARD, ACTIVITY_TYPE_SPLIT, ACTIVITY_TYPE_TRANSFER_IN,
+    ACTIVITY_TYPE_TRANSFER_OUT, PRICE_BEARING_ACTIVITY_TYPES,
 };
 use crate::activities::activities_errors::ActivityError;
 use crate::activities::activities_model::*;
@@ -58,6 +58,20 @@ fn yahoo_suffix_for_mic(mic: &str) -> Option<&'static str> {
         }
     }
     None
+}
+
+/// A TRANSFER_IN/TRANSFER_OUT that moves a security (not cash). The monetary
+/// value of such an activity is always `quantity × unit_price`; the DB column
+/// `amount` must remain NULL so there is a single source of truth and we cannot
+/// drift into storing e.g. `qty² × unit_price`.
+fn is_securities_transfer(activity_type: &str, resolved_asset_id: Option<&str>) -> bool {
+    if activity_type != ACTIVITY_TYPE_TRANSFER_IN && activity_type != ACTIVITY_TYPE_TRANSFER_OUT {
+        return false;
+    }
+    match resolved_asset_id {
+        None => false,
+        Some(id) => !is_cash_symbol(id),
+    }
 }
 
 fn normalize_isin_key(isin: Option<&str>) -> Option<String> {
@@ -1471,6 +1485,14 @@ impl ActivityService {
         activity.amount = activity.amount.map(|v| v.abs());
         activity.fee = activity.fee.map(|v| v.abs());
 
+        // Securities transfers derive monetary value from quantity × unit_price at
+        // read time. Any inbound `amount` is redundant and has historically been
+        // a source of corruption (e.g. amount = qty² × unit_price stored on the
+        // row). Force it to None so the DB holds a single source of truth.
+        if is_securities_transfer(&activity.activity_type, resolved_asset_id.as_deref()) {
+            activity.amount = None;
+        }
+
         // Normalize minor currency units (e.g., GBp -> GBP) and convert amounts
         if get_normalization_rule(&activity.currency).is_some() {
             if let Some(unit_price) = activity.unit_price {
@@ -1851,6 +1873,12 @@ impl ActivityService {
         activity.unit_price = activity.unit_price.map(|v| v.map(|d| d.abs()));
         activity.amount = activity.amount.map(|v| v.map(|d| d.abs()));
         activity.fee = activity.fee.map(|v| v.map(|d| d.abs()));
+
+        // Securities transfers derive value from quantity × unit_price; always
+        // clear `amount` on update so a caller cannot re-introduce a stale value.
+        if is_securities_transfer(&activity.activity_type, resolved_asset_id.as_deref()) {
+            activity.amount = Some(None);
+        }
 
         // Normalize minor currency units
         if get_normalization_rule(&activity.currency).is_some() {
@@ -4112,6 +4140,12 @@ impl ActivityService {
             activity.amount = activity.amount.map(|v| v.abs());
             activity.fee = activity.fee.map(|v| v.abs());
 
+            // Securities transfers derive monetary value from quantity × unit_price;
+            // never persist an inbound `amount` for them (see prepare_new_activity).
+            if is_securities_transfer(&activity.activity_type, resolved_asset_id.as_deref()) {
+                activity.amount = None;
+            }
+
             // Normalize minor currency units (e.g., GBp -> GBP) and convert amounts
             if get_normalization_rule(&activity.currency).is_some() {
                 if let Some(unit_price) = activity.unit_price {
@@ -4251,5 +4285,34 @@ impl ActivityService {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod securities_transfer_tests {
+    use super::is_securities_transfer;
+
+    #[test]
+    fn transfer_with_security_asset_is_securities() {
+        assert!(is_securities_transfer("TRANSFER_IN", Some("AAPL")));
+        assert!(is_securities_transfer("TRANSFER_OUT", Some("FWIA")));
+    }
+
+    #[test]
+    fn transfer_with_cash_asset_is_not_securities() {
+        assert!(!is_securities_transfer("TRANSFER_IN", Some("CASH:USD")));
+        assert!(!is_securities_transfer("TRANSFER_OUT", Some("$CASH-EUR")));
+        assert!(!is_securities_transfer("TRANSFER_IN", Some("CASH-GBP")));
+    }
+
+    #[test]
+    fn transfer_without_resolved_asset_is_not_securities() {
+        assert!(!is_securities_transfer("TRANSFER_IN", None));
+    }
+
+    #[test]
+    fn non_transfer_types_are_not_securities_transfers() {
+        assert!(!is_securities_transfer("BUY", Some("AAPL")));
+        assert!(!is_securities_transfer("DEPOSIT", Some("CASH:USD")));
     }
 }


### PR DESCRIPTION
First of all, a huge thank you for Wealthfolio - it's a joy to use and the local-first, privacy-respecting philosophy is exactly what this space needed. I've been running it self-hosted on a spare phone over local network / Tailscale and it is becoming my daily portfolio tracker.

Disclosure: I had Claude assist me in investigating the bug and drafting this change. Every line has been reviewed and tested by me before submitting.

## Summary
Securities `TRANSFER_IN` / `TRANSFER_OUT` were being rendered in the activity view from the stored `amount` column, which is redundant with `quantity × unit_price` and in the wild can hold corrupted values (I had two rows where `amount = qty² × unit_price`, producing absurd totals like €31M for 2,078 shares at €7.29). The account page was correct because it already derived value from `qty × price` — only the activity table was affected.

The fix is in two layers:

- **Display** — new `isSecuritiesTransfer` helper; `calculateActivityValue`, the activity table, and the mobile activity card all now derive securities-transfer value from `qty × unit_price` and ignore `amount`. Cash transfers are unchanged (still use `amount`).
- **Write path (defensive)** — so a bad `amount` can't be persisted in the first place:
  - `bulk-holdings-modal` no longer sends a precomputed `amount` for the `TRANSFER_IN` it creates.
  - `ActivityService::prepare_new_activity`, `prepare_update_activity`, and `prepare_activities_internal` force `amount = None` whenever a transfer's resolved asset is non-cash. This mirrors how the dividend-in-kind compiler already leaves `transfer_in_leg.amount = None`, making `qty × unit_price` the single source of truth for securities transfers.

## Test plan
- [x] `pnpm test` — all 505 frontend tests pass, including a new regression in `activity-utils.test.ts` that feeds a deliberately bogus `amount` and asserts the value still comes from `qty × unit_price`.
- [x] Backend unit tests for the new `is_securities_transfer` classifier (cash vs. security vs. non-transfer).
- [x] Verified on my instance: after nulling the corrupted `amount` column, the two rows now show correct totals.
- [ ] Reviewer: confirm cash transfers (`CASH:USD`, `$CASH-EUR`, …) still show `amount` unchanged in the activity view.
- [ ] Reviewer: confirm a new *Add Existing Holdings* entry persists with `amount IS NULL` in SQLite.