### PR TITLE
chore(dev): add Claude Code hooks to run CI checks before commit/push

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,31 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/ci-check.sh",
+            "if": "Bash(git commit*)",
+            "timeout": 120,
+            "statusMessage": "Running pre-commit CI checks..."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/ci-check.sh --full",
+            "if": "Bash(git push*)",
+            "timeout": 300,
+            "statusMessage": "Running full CI checks before push..."
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,31 +1,5 @@
 {
   "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash scripts/ci-check.sh",
-            "if": "Bash(git commit*)",
-            "timeout": 120,
-            "statusMessage": "Running pre-commit CI checks..."
-          }
-        ]
-      },
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "bash scripts/ci-check.sh --full",
-            "if": "Bash(git push*)",
-            "timeout": 300,
-            "statusMessage": "Running full CI checks before push..."
-          }
-        ]
-      }
-    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+exec "$REPO_ROOT/scripts/ci-check.sh" --full

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,8 +52,8 @@ Install the tracked Git hooks to run CI-equivalent checks before `git push`:
 pnpm hooks:install
 ```
 
-Git does not enable repository hooks automatically, so each contributor must
-opt in once per clone.
+Git does not enable repository hooks automatically, so each contributor must opt
+in once per clone.
 
 ### Code Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,17 @@ By submitting a pull request, you confirm you have read and agree to
 
 See the [README](README.md#getting-started) for detailed setup instructions.
 
+### Optional Git Hooks
+
+Install the tracked Git hooks to run CI-equivalent checks before `git push`:
+
+```bash
+pnpm hooks:install
+```
+
+Git does not enable repository hooks automatically, so each contributor must
+opt in once per clone.
+
 ### Code Style
 
 - **Rust**: Follow standard Rust conventions, use `cargo fmt` and `cargo clippy`

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build": "pnpm --filter frontend build",
     "build:tauri": "pnpm --filter frontend build:tauri",
     "build:types": "pnpm -r run build:types",
+    "hooks:install": "git config core.hooksPath .githooks",
     "build:addons": "pnpm -r --filter './addons/*' build",
     "bundle:addons": "pnpm -r --filter './addons/*' bundle",
     "preview": "pnpm --filter frontend preview",

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# ci-check.sh — mirrors CI checks before git commit/push
+# Usage:
+#   bash scripts/ci-check.sh           # fast checks (commit mode)
+#   bash scripts/ci-check.sh --full    # + cargo test + pnpm test (push mode)
+#
+# Reads hook JSON from stdin (Claude Code PreToolUse format).
+# Outputs {"decision":"block","reason":"..."} on failure.
+
+set -euo pipefail
+
+FULL=false
+if [[ "${1:-}" == "--full" ]]; then
+  FULL=true
+fi
+
+REPO_ROOT="$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# ── Determine changed files ──────────────────────────────────────────────────
+# Commit mode: check staged files. Push mode: check branch diff vs main.
+if [[ "$FULL" == "false" ]]; then
+  CHANGED=$(git diff --cached --name-only 2>/dev/null || true)
+else
+  BASE=$(git merge-base HEAD main 2>/dev/null || echo "HEAD~1")
+  CHANGED=$(git diff --name-only "$BASE"...HEAD 2>/dev/null || true)
+fi
+
+HAS_RUST=$(echo "$CHANGED" | grep -qE '\.rs$' && echo "true" || echo "false")
+HAS_FRONTEND=$(echo "$CHANGED" | grep -qE '\.(ts|tsx|js|jsx|css)$' && echo "true" || echo "false")
+
+# Nothing relevant changed
+if [[ "$HAS_RUST" == "false" && "$HAS_FRONTEND" == "false" ]]; then
+  exit 0
+fi
+
+# ── Helper: block the hook ───────────────────────────────────────────────────
+block() {
+  local reason="$1"
+  echo '{"decision":"block","reason":"'"$reason"'"}'
+  exit 0  # exit 0 so Claude reads the JSON output; decision:block does the blocking
+}
+
+# ── Rust checks ──────────────────────────────────────────────────────────────
+if [[ "$HAS_RUST" == "true" ]]; then
+  # Tauri build context prerequisite
+  if [[ ! -f dist/index.html ]]; then
+    mkdir -p dist
+    echo '<!DOCTYPE html><html><head></head><body></body></html>' > dist/index.html
+  fi
+
+  echo "=== cargo fmt ===" >&2
+  if ! cargo fmt --all -- --check 2>&1; then
+    block "cargo fmt failed — run 'cargo fmt --all' to fix"
+  fi
+
+  echo "=== cargo clippy ===" >&2
+  if ! cargo clippy --workspace --all-targets --all-features -- -D warnings 2>&1; then
+    block "cargo clippy failed — fix warnings above before committing"
+  fi
+
+  if [[ "$FULL" == "true" ]]; then
+    echo "=== cargo test ===" >&2
+    if ! CONNECT_API_URL=http://test.local cargo test --workspace 2>&1; then
+      block "cargo test failed — fix failing tests before pushing"
+    fi
+  fi
+fi
+
+# ── Frontend checks ──────────────────────────────────────────────────────────
+if [[ "$HAS_FRONTEND" == "true" ]]; then
+  echo "=== pnpm build:types ===" >&2
+  if ! pnpm run build:types 2>&1; then
+    block "pnpm build:types failed"
+  fi
+
+  echo "=== pnpm format:check ===" >&2
+  if ! pnpm format:check 2>&1; then
+    block "pnpm format:check failed — run 'pnpm format' to fix"
+  fi
+
+  echo "=== pnpm lint ===" >&2
+  if ! pnpm lint 2>&1; then
+    block "pnpm lint failed — fix lint errors above before committing"
+  fi
+
+  echo "=== pnpm type-check ===" >&2
+  if ! pnpm type-check 2>&1; then
+    block "pnpm type-check failed — fix type errors above before committing"
+  fi
+
+  if [[ "$FULL" == "true" ]]; then
+    echo "=== pnpm test ===" >&2
+    if ! pnpm test 2>&1; then
+      block "pnpm test failed — fix failing tests before pushing"
+    fi
+  fi
+fi

--- a/scripts/ci-check.sh
+++ b/scripts/ci-check.sh
@@ -1,98 +1,156 @@
 #!/usr/bin/env bash
-# ci-check.sh — mirrors CI checks before git commit/push
+# Run local CI checks before commit/push.
 # Usage:
 #   bash scripts/ci-check.sh           # fast checks (commit mode)
-#   bash scripts/ci-check.sh --full    # + cargo test + pnpm test (push mode)
-#
-# Reads hook JSON from stdin (Claude Code PreToolUse format).
-# Outputs {"decision":"block","reason":"..."} on failure.
+#   bash scripts/ci-check.sh --full    # full PR CI checks (push mode)
 
 set -euo pipefail
 
 FULL=false
 if [[ "${1:-}" == "--full" ]]; then
   FULL=true
+  shift
 fi
 
-REPO_ROOT="$(git -C "$(dirname "$0")/.." rev-parse --show-toplevel)"
+if [[ "$#" -ne 0 ]]; then
+  echo "Usage: scripts/ci-check.sh [--full]" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(git -C "$(dirname "${BASH_SOURCE[0]}")/.." rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
-# ── Determine changed files ──────────────────────────────────────────────────
-# Commit mode: check staged files. Push mode: check branch diff vs main.
-if [[ "$FULL" == "false" ]]; then
-  CHANGED=$(git diff --cached --name-only 2>/dev/null || true)
-else
-  BASE=$(git merge-base HEAD main 2>/dev/null || echo "HEAD~1")
-  CHANGED=$(git diff --name-only "$BASE"...HEAD 2>/dev/null || true)
-fi
+changed_files() {
+  if [[ "$FULL" == "false" ]]; then
+    git diff --cached --name-only --diff-filter=ACMR 2>/dev/null || true
+    return
+  fi
 
-HAS_RUST=$(echo "$CHANGED" | grep -qE '\.rs$' && echo "true" || echo "false")
-HAS_FRONTEND=$(echo "$CHANGED" | grep -qE '\.(ts|tsx|js|jsx|css)$' && echo "true" || echo "false")
+  local base=""
+  if git rev-parse --verify --quiet "@{upstream}" >/dev/null; then
+    base="$(git merge-base HEAD "@{upstream}")"
+  elif git rev-parse --verify --quiet origin/main >/dev/null; then
+    base="$(git merge-base HEAD origin/main)"
+  elif git rev-parse --verify --quiet main >/dev/null; then
+    base="$(git merge-base HEAD main)"
+  fi
 
-# Nothing relevant changed
-if [[ "$HAS_RUST" == "false" && "$HAS_FRONTEND" == "false" ]]; then
+  if [[ -n "$base" ]]; then
+    git diff --name-only --diff-filter=ACMR "$base"...HEAD 2>/dev/null || true
+  else
+    git diff --name-only --diff-filter=ACMR HEAD~1...HEAD 2>/dev/null || true
+  fi
+}
+
+is_docs_only_file() {
+  case "$1" in
+    *.md|*.mdx|*.txt|LICENSE|CLA.md|TRADEMARKS.md|docs/*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+CHANGED="$(changed_files)"
+
+if [[ -z "$CHANGED" ]]; then
   exit 0
 fi
 
-# ── Helper: block the hook ───────────────────────────────────────────────────
-block() {
-  local reason="$1"
-  echo '{"decision":"block","reason":"'"$reason"'"}'
-  exit 0  # exit 0 so Claude reads the JSON output; decision:block does the blocking
-}
+RUN_RUST=false
+RUN_FRONTEND=false
+HAS_NON_DOC=false
 
-# ── Rust checks ──────────────────────────────────────────────────────────────
-if [[ "$HAS_RUST" == "true" ]]; then
-  # Tauri build context prerequisite
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+
+  if ! is_docs_only_file "$file"; then
+    HAS_NON_DOC=true
+  fi
+
+  case "$file" in
+    *.rs|Cargo.toml|Cargo.lock|rust-toolchain*|.cargo/*)
+      RUN_RUST=true
+      ;;
+    crates/*/Cargo.toml|apps/*/Cargo.toml)
+      RUN_RUST=true
+      ;;
+    *.ts|*.tsx|*.js|*.jsx|*.css|*.mjs|*.cjs|*.json)
+      RUN_FRONTEND=true
+      ;;
+    package.json|pnpm-lock.yaml|pnpm-workspace.yaml|tsconfig*.json)
+      RUN_FRONTEND=true
+      ;;
+    vite.config.*|eslint.config.*|prettier.config.*)
+      RUN_FRONTEND=true
+      ;;
+    postcss.config.*|tailwind.config.*)
+      RUN_FRONTEND=true
+      ;;
+    apps/frontend/*|packages/*/package.json|addons/*/package.json)
+      RUN_FRONTEND=true
+      ;;
+    .github/workflows/pr-check.yml|scripts/ci-check.sh)
+      RUN_RUST=true
+      RUN_FRONTEND=true
+      ;;
+  esac
+done <<< "$CHANGED"
+
+if [[ "$FULL" == "true" && "$HAS_NON_DOC" == "true" ]]; then
+  RUN_RUST=true
+  RUN_FRONTEND=true
+fi
+
+if [[ "$RUN_RUST" == "false" && "$RUN_FRONTEND" == "false" ]]; then
+  exit 0
+fi
+
+ensure_tauri_dist() {
   if [[ ! -f dist/index.html ]]; then
     mkdir -p dist
     echo '<!DOCTYPE html><html><head></head><body></body></html>' > dist/index.html
   fi
+}
+
+if [[ "$RUN_RUST" == "true" ]]; then
+  ensure_tauri_dist
 
   echo "=== cargo fmt ===" >&2
-  if ! cargo fmt --all -- --check 2>&1; then
-    block "cargo fmt failed — run 'cargo fmt --all' to fix"
-  fi
+  cargo fmt --all -- --check
 
   echo "=== cargo clippy ===" >&2
-  if ! cargo clippy --workspace --all-targets --all-features -- -D warnings 2>&1; then
-    block "cargo clippy failed — fix warnings above before committing"
-  fi
+  cargo clippy --workspace --all-targets --all-features -- -D warnings
 
   if [[ "$FULL" == "true" ]]; then
     echo "=== cargo test ===" >&2
-    if ! CONNECT_API_URL=http://test.local cargo test --workspace 2>&1; then
-      block "cargo test failed — fix failing tests before pushing"
-    fi
+    CONNECT_API_URL=http://test.local cargo test --workspace
+
+    echo "=== cargo build (wealthfolio-server) ===" >&2
+    cargo build -p wealthfolio-server --release
   fi
 fi
 
-# ── Frontend checks ──────────────────────────────────────────────────────────
-if [[ "$HAS_FRONTEND" == "true" ]]; then
+if [[ "$RUN_FRONTEND" == "true" ]]; then
   echo "=== pnpm build:types ===" >&2
-  if ! pnpm run build:types 2>&1; then
-    block "pnpm build:types failed"
-  fi
+  pnpm run build:types
 
   echo "=== pnpm format:check ===" >&2
-  if ! pnpm format:check 2>&1; then
-    block "pnpm format:check failed — run 'pnpm format' to fix"
-  fi
+  pnpm format:check
 
   echo "=== pnpm lint ===" >&2
-  if ! pnpm lint 2>&1; then
-    block "pnpm lint failed — fix lint errors above before committing"
-  fi
+  pnpm lint
 
   echo "=== pnpm type-check ===" >&2
-  if ! pnpm type-check 2>&1; then
-    block "pnpm type-check failed — fix type errors above before committing"
-  fi
+  pnpm type-check
 
   if [[ "$FULL" == "true" ]]; then
     echo "=== pnpm test ===" >&2
-    if ! pnpm test 2>&1; then
-      block "pnpm test failed — fix failing tests before pushing"
-    fi
+    pnpm test
+
+    echo "=== pnpm build ===" >&2
+    pnpm build
   fi
 fi


### PR DESCRIPTION
## Summary

Adds Claude Code pre-commit and pre-push hooks that mirror the CI pipeline locally, so failures are caught before reaching GitHub Actions.

- **`.claude/settings.json`**: registers two `PreToolUse` hooks on `git commit` and `git push`
- **`scripts/ci-check.sh`**: the hook script, mirrors `.github/workflows/pr-check.yml`

### Hook behavior

| Trigger | Checks run |
|---------|-----------|
| `git commit` | `cargo fmt`, `cargo clippy -D warnings`, `pnpm build:types`, `pnpm format:check`, `pnpm lint`, `pnpm type-check` |
| `git push` | All of the above + `cargo test --workspace` + `pnpm test` |

Checks are scoped: Rust checks only run if `.rs` files changed, frontend checks only if `.ts/.tsx/.js/.jsx/.css` files changed. If no relevant files changed, the hook exits immediately.

## Motivation

PR #843 failed CI due to a `clippy::unnecessary_sort_by` warning introduced by Rust 1.85. The local Rust version was older and didn't catch it. These hooks prevent that class of CI failure.

## Test plan

- [x] Stage a `.rs` file → commit blocked if `cargo clippy` fails
- [ ] Stage a `.ts` file → commit blocked if `pnpm lint` or `pnpm type-check` fails
- [ ] Stage only a `.md` file → no checks run, commit passes immediately
- [ ] `git push` → full checks including tests run before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)