### PR TITLE
Fix #814 symbol quote currency resolution

### DIFF
--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid.tsx
@@ -40,6 +40,24 @@ interface ActivityDataGridProps {
   onPageSizeChange: (pageSize: number) => void;
 }
 
+function shouldApplyResolvedQuoteCurrency(result: SymbolSearchResult): boolean {
+  if (result.isExisting || result.dataSource === "MANUAL") {
+    return false;
+  }
+  return (
+    !result.currency?.trim() ||
+    result.currencySource === "exchange_inferred" ||
+    !result.currencySource
+  );
+}
+
+function shouldApplyResolvedActivityCurrency(result: SymbolSearchResult): boolean {
+  if (result.isExisting || result.dataSource === "MANUAL") {
+    return false;
+  }
+  return !result.currency?.trim() || result.currencySource === "exchange_inferred";
+}
+
 /**
  * Activity data grid component with inline editing, bulk operations, and optimistic updates
  */
@@ -202,7 +220,15 @@ export function ActivityDataGrid({
 
       // Resolve quote to confirm currency and get latest price
       if (result.dataSource !== "MANUAL") {
-        resolveSymbolQuote(result.symbol, result.exchangeMic, result.quoteType).then((resolved) => {
+        const shouldUseResolvedQuoteCurrency = shouldApplyResolvedQuoteCurrency(result);
+        const shouldUseResolvedActivityCurrency = shouldApplyResolvedActivityCurrency(result);
+        resolveSymbolQuote(
+          result.symbol,
+          result.exchangeMic,
+          result.quoteType,
+          undefined,
+          result.currency,
+        ).then((resolved) => {
           if (requestId !== latestResolveRequestId.current) return;
           if (!resolved) return;
 
@@ -219,9 +245,10 @@ export function ActivityDataGrid({
             // Update currency from resolved quote to correct exchange-inferred values
             // (e.g., search returns "GBp" inferred, resolve confirms "GBP")
             // Only overwrite if user hasn't manually changed it since selection
-            if (resolved.currency) {
+            if (resolved.currency && shouldUseResolvedQuoteCurrency) {
               const confirmedCurrency = resolved.currency.trim();
               if (
+                shouldUseResolvedActivityCurrency &&
                 confirmedCurrency &&
                 row.currency !== confirmedCurrency &&
                 row.currency === (provisionalCurrency ?? row.accountCurrency ?? fallbackCurrency)

--- a/apps/frontend/src/pages/activity/components/forms/fields/__tests__/symbol-search.test.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/fields/__tests__/symbol-search.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FormProvider, useForm } from "react-hook-form";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { SymbolSearch } from "../symbol-search";
 
 const resolveSymbolQuoteMock = vi.fn();
@@ -17,26 +17,47 @@ vi.mock("@/components/ticker-search", () => ({
   }: {
     onSelectResult: (symbol: string, result?: Record<string, unknown>) => void;
   }) => (
-    <button
-      type="button"
-      data-testid="select-symbol"
-      onClick={() =>
-        onSelectResult("VWRPL.XC", {
-          symbol: "VWRPL.XC",
-          longName: "Vanguard FTSE All-World UCITS ETF",
-          shortName: "VWRP",
-          exchange: "CXE",
-          exchangeMic: "CXE",
-          quoteType: "EQUITY",
-          currency: "GBp",
-          // Intentionally omitted to reproduce the regression path.
-          currencySource: undefined,
-          dataSource: "YAHOO",
-        })
-      }
-    >
-      Select Symbol
-    </button>
+    <>
+      <button
+        type="button"
+        data-testid="select-symbol"
+        onClick={() =>
+          onSelectResult("VWRPL.XC", {
+            symbol: "VWRPL.XC",
+            longName: "Vanguard FTSE All-World UCITS ETF",
+            shortName: "VWRP",
+            exchange: "CXE",
+            exchangeMic: "CXE",
+            quoteType: "EQUITY",
+            currency: "GBp",
+            // Intentionally omitted to reproduce the regression path.
+            currencySource: undefined,
+            dataSource: "YAHOO",
+          })
+        }
+      >
+        Select Symbol
+      </button>
+      <button
+        type="button"
+        data-testid="select-existing-crypto"
+        onClick={() =>
+          onSelectResult("BTC", {
+            symbol: "BTC",
+            longName: "Bitcoin EUR",
+            shortName: "Bitcoin EUR",
+            exchange: "",
+            quoteType: "CRYPTOCURRENCY",
+            currency: "EUR",
+            dataSource: "YAHOO",
+            isExisting: true,
+            existingAssetId: "asset-btc-eur",
+          })
+        }
+      >
+        Select Existing Crypto
+      </button>
+    </>
   ),
 }));
 
@@ -81,6 +102,10 @@ function TestForm() {
 }
 
 describe("SymbolSearch", () => {
+  beforeEach(() => {
+    resolveSymbolQuoteMock.mockReset();
+  });
+
   it("persists provider-resolved quote currency hint even without currencySource", async () => {
     resolveSymbolQuoteMock.mockResolvedValue({
       currency: "GBP",
@@ -99,5 +124,37 @@ describe("SymbolSearch", () => {
     expect(screen.getByTestId("asset-id")).toHaveTextContent("VWRPL");
     expect(screen.getByTestId("exchange-mic")).toHaveTextContent("CXE");
     expect(screen.getByTestId("asset-name")).toHaveTextContent("Vanguard FTSE All-World UCITS ETF");
+    expect(resolveSymbolQuoteMock).toHaveBeenCalledWith(
+      "VWRPL.XC",
+      "CXE",
+      "EQUITY",
+      undefined,
+      "GBp",
+    );
+  });
+
+  it("does not overwrite an existing asset quote currency with resolver output", async () => {
+    resolveSymbolQuoteMock.mockResolvedValue({
+      currency: "CAD",
+      price: 103121.59,
+    });
+
+    const user = userEvent.setup();
+    render(<TestForm />);
+
+    await user.click(screen.getByTestId("select-existing-crypto"));
+
+    await waitFor(() => {
+      expect(resolveSymbolQuoteMock).toHaveBeenCalledWith(
+        "BTC",
+        undefined,
+        "CRYPTOCURRENCY",
+        undefined,
+        "EUR",
+      );
+    });
+
+    expect(screen.getByTestId("asset-id")).toHaveTextContent("BTC");
+    expect(screen.getByTestId("quote-ccy")).toHaveTextContent("EUR");
   });
 });

--- a/apps/frontend/src/pages/activity/components/forms/fields/symbol-search.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/fields/symbol-search.tsx
@@ -38,6 +38,26 @@ function stripCryptoQuoteSuffix(symbol: string, currencyHint?: string): string {
   return base || trimmed;
 }
 
+function shouldApplyResolvedQuoteCurrency(searchResult: SymbolSearchResult | undefined): boolean {
+  if (!searchResult || searchResult.isExisting || searchResult.dataSource === DataSource.MANUAL) {
+    return false;
+  }
+  return (
+    !searchResult.currency?.trim() ||
+    searchResult.currencySource === "exchange_inferred" ||
+    !searchResult.currencySource
+  );
+}
+
+function shouldApplyResolvedActivityCurrency(
+  searchResult: SymbolSearchResult | undefined,
+): boolean {
+  if (!searchResult || searchResult.isExisting || searchResult.dataSource === DataSource.MANUAL) {
+    return false;
+  }
+  return !searchResult.currency?.trim() || searchResult.currencySource === "exchange_inferred";
+}
+
 interface SymbolSearchProps<TFieldValues extends FieldValues = FieldValues> {
   /** Field name for the symbol value */
   name: FieldPath<TFieldValues>;
@@ -144,23 +164,28 @@ export function SymbolSearch<TFieldValues extends FieldValues = FieldValues>({
     // Update activity currency when:
     // - currency was exchange-inferred (needs provider confirmation)
     // - search result had no currency at all (e.g., OpenFIGI bonds)
+    const shouldUseResolvedQuoteCurrency = shouldApplyResolvedQuoteCurrency(searchResult);
     const needsCurrencyConfirmation =
-      currencyName &&
-      !searchResult?.isExisting &&
-      (searchResult?.currencySource === "exchange_inferred" || !searchResult?.currency);
+      currencyName && shouldApplyResolvedActivityCurrency(searchResult);
 
     if (searchResult) {
       setQuoteDisplay({ price: null, isLoading: true });
       const provisionalCurrency = searchResult.currency?.trim();
-      resolveSymbolQuote(searchResult.symbol, searchResult.exchangeMic, searchResult.quoteType)
+      resolveSymbolQuote(
+        searchResult.symbol,
+        searchResult.exchangeMic,
+        searchResult.quoteType,
+        undefined,
+        searchResult.currency,
+      )
         .then((resolved) => {
           if (requestId !== latestResolveRequestId.current) return;
           setQuoteDisplay({ price: resolved?.price ?? null, isLoading: false });
 
           const confirmedCurrency = resolved?.currency?.trim();
-          if (confirmedCurrency && quoteCcyName) {
-            // Always persist provider-resolved quote currency as a symbol hint.
-            // Activity currency may still be user-controlled below.
+          if (confirmedCurrency && quoteCcyName && shouldUseResolvedQuoteCurrency) {
+            // Only replace provisional hints; existing assets and selected pairs already
+            // carry stronger quote-currency identity.
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             setValue(quoteCcyName, confirmedCurrency as any);
           }

--- a/apps/server/src/api/market_data.rs
+++ b/apps/server/src/api/market_data.rs
@@ -254,7 +254,7 @@ async fn resolve_symbol_quote(
     let inst_type = q
         .instrument_type
         .as_deref()
-        .and_then(wealthfolio_core::assets::InstrumentType::from_db_str);
+        .and_then(wealthfolio_core::assets::InstrumentType::from_external_str);
     let res = state
         .quote_service
         .resolve_symbol_quote(

--- a/apps/tauri/src/commands/market_data.rs
+++ b/apps/tauri/src/commands/market_data.rs
@@ -213,7 +213,7 @@ pub async fn resolve_symbol_quote(
 ) -> Result<wealthfolio_core::quotes::ResolvedQuote, String> {
     let inst_type = instrument_type
         .as_deref()
-        .and_then(wealthfolio_core::assets::InstrumentType::from_db_str);
+        .and_then(wealthfolio_core::assets::InstrumentType::from_external_str);
     state
         .quote_service()
         .resolve_symbol_quote(

--- a/crates/core/src/assets/assets_model.rs
+++ b/crates/core/src/assets/assets_model.rs
@@ -97,6 +97,22 @@ impl InstrumentType {
             _ => None,
         }
     }
+
+    /// Parses provider/UI instrument labels into the canonical instrument type.
+    pub fn from_external_str(s: &str) -> Option<Self> {
+        match s.trim().to_uppercase().as_str() {
+            "EQUITY" | "STOCK" | "ETF" | "MUTUALFUND" | "MUTUAL_FUND" | "MUTUAL FUND" | "INDEX"
+            | "FUTURE" | "FUTURES" => Some(InstrumentType::Equity),
+            "CRYPTO" | "CRYPTOCURRENCY" => Some(InstrumentType::Crypto),
+            "FX" | "FOREX" | "CURRENCY" => Some(InstrumentType::Fx),
+            "OPTION" => Some(InstrumentType::Option),
+            "METAL" | "COMMODITY" => Some(InstrumentType::Metal),
+            "BOND" | "FIXEDINCOME" | "FIXED_INCOME" | "DEBT" | "MONEYMARKET" => {
+                Some(InstrumentType::Bond)
+            }
+            _ => None,
+        }
+    }
 }
 
 /// Option contract specification stored in Asset.metadata

--- a/crates/core/src/assets/assets_model_tests.rs
+++ b/crates/core/src/assets/assets_model_tests.rs
@@ -233,6 +233,22 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_instrument_type_external_aliases() {
+        assert_eq!(
+            InstrumentType::from_external_str("CRYPTOCURRENCY"),
+            Some(InstrumentType::Crypto)
+        );
+        assert_eq!(
+            InstrumentType::from_external_str("ETF"),
+            Some(InstrumentType::Equity)
+        );
+        assert_eq!(
+            InstrumentType::from_external_str("FOREX"),
+            Some(InstrumentType::Fx)
+        );
+    }
+
     // Test AssetKind db roundtrip
     #[test]
     fn test_asset_kind_db_roundtrip() {

--- a/crates/core/src/quotes/service.rs
+++ b/crates/core/src/quotes/service.rs
@@ -26,8 +26,9 @@ use super::sync_state::{QuoteSyncState, SymbolSyncPlan, SyncMode, SyncStateStore
 use super::types::{quote_id, AssetId, Day, QuoteSource};
 use crate::activities::ActivityRepositoryTrait;
 use crate::assets::{
-    canonicalize_market_identity, symbol_resolution_candidates, Asset, AssetKind,
-    AssetRepositoryTrait, AssetSpec, InstrumentType, ProviderProfile, QuoteMode,
+    canonicalize_market_identity, normalize_quote_ccy_code, parse_crypto_pair_symbol,
+    symbol_resolution_candidates, Asset, AssetKind, AssetRepositoryTrait, AssetSpec,
+    InstrumentType, ProviderProfile, QuoteMode,
 };
 use crate::errors::Result;
 use crate::fx::currency::{get_normalization_rule, normalize_currency_code};
@@ -1109,10 +1110,7 @@ where
             trimmed_symbol
         };
 
-        let clean_quote_ccy = quote_ccy
-            .map(str::trim)
-            .filter(|c| !c.is_empty())
-            .unwrap_or_default();
+        let requested_quote_ccy = normalize_quote_ccy_code(quote_ccy);
         let provider_config = provider_config_for_symbol_resolution(preferred_provider);
 
         for attempt_symbol in symbol_resolution_candidates(clean_symbol) {
@@ -1151,15 +1149,47 @@ where
                 None => (attempt_symbol.clone(), None),
             };
 
+            let pair_quote_ccy = if matches!(instrument_type, Some(InstrumentType::Crypto)) {
+                parse_crypto_pair_symbol(&resolved_symbol).map(|(_, quote)| quote)
+            } else {
+                None
+            };
+            let quote_ccy_for_identity =
+                pair_quote_ccy.as_deref().or(requested_quote_ccy.as_deref());
+            let inferred_instrument_type =
+                instrument_type.cloned().unwrap_or(InstrumentType::Equity);
+            let canonical_identity = canonicalize_market_identity(
+                Some(inferred_instrument_type.clone()),
+                Some(resolved_symbol.as_str()),
+                exchange_mic,
+                quote_ccy_for_identity,
+            );
+            if matches!(
+                inferred_instrument_type,
+                InstrumentType::Crypto | InstrumentType::Fx
+            ) && canonical_identity.quote_ccy.is_none()
+            {
+                debug!(
+                    "resolve_symbol_quote: missing quote currency for {} symbol='{}'",
+                    inferred_instrument_type.as_db_str(),
+                    resolved_symbol
+                );
+                continue;
+            }
+
             let temp_asset = Asset {
                 id: format!("_QUOTE_RESOLVE_{}", attempt_symbol),
                 kind: AssetKind::Investment,
                 quote_mode: QuoteMode::Market,
-                quote_ccy: clean_quote_ccy.to_string(),
-                instrument_type: instrument_type.cloned().or(Some(InstrumentType::Equity)),
-                instrument_symbol: Some(resolved_symbol),
-                display_code: Some(attempt_symbol.clone()),
-                instrument_exchange_mic: exchange_mic.map(str::to_string),
+                quote_ccy: canonical_identity.quote_ccy.unwrap_or_default(),
+                instrument_type: Some(inferred_instrument_type),
+                instrument_symbol: canonical_identity
+                    .instrument_symbol
+                    .or_else(|| Some(resolved_symbol.clone())),
+                display_code: canonical_identity
+                    .display_code
+                    .or_else(|| Some(attempt_symbol.clone())),
+                instrument_exchange_mic: canonical_identity.instrument_exchange_mic,
                 provider_config: provider_config.clone(),
                 metadata,
                 ..Default::default()

--- a/packages/ui/src/components/data-grid/data-grid-types.ts
+++ b/packages/ui/src/components/data-grid/data-grid-types.ts
@@ -28,6 +28,10 @@ export interface SymbolSearchResult {
   dataSource?: string;
   /** Asset kind for custom assets (e.g., "SECURITY", "CRYPTO", "OTHER") */
   assetKind?: string;
+  /** True when this result maps to an existing persisted asset. */
+  isExisting?: boolean;
+  /** Persisted asset id when this result maps to an existing asset. */
+  existingAssetId?: string;
 }
 
 export type CellOpts =


### PR DESCRIPTION
## Summary

Fixes the symbol quote-currency resolution path for existing crypto assets such as BTC quoted in EUR.

## Root Cause

Existing asset search results can return the canonical display symbol, for example `BTC`, while carrying the selected asset quote currency separately as `currency: "EUR"`. The frontend resolver call was dropping that quote-currency context, and the backend command parsing did not recognize provider/UI labels like `CRYPTOCURRENCY`, so `resolve_symbol_quote` could query an ambiguous bare crypto symbol and return the provider default currency.

## Changes

- Add optional `quoteCcy` context to `resolve_symbol_quote` across frontend, Tauri, web, and core service boundaries.
- Parse provider/UI instrument labels such as `CRYPTOCURRENCY` into the canonical backend `InstrumentType`.
- Canonicalize crypto/FX resolver identity with explicit quote currency or explicit pair symbols, without guessing quote currency for bare crypto/FX symbols.
- Preserve existing/manual asset quote currencies in activity symbol selection and the activity data grid.
- Add regression coverage for an existing `BTC` asset quoted in `EUR` when the resolver returns a different currency.

## Validation

- `pnpm --filter frontend test -- src/pages/activity/components/forms/fields/__tests__/symbol-search.test.tsx`
- `pnpm type-check`
- `cargo test -p wealthfolio-core`
- `cargo check --workspace`
- `git diff --check`