### PR TITLE
fix symbol mapping validation

### DIFF
--- a/apps/frontend/src/adapters/shared/market-data.ts
+++ b/apps/frontend/src/adapters/shared/market-data.ts
@@ -188,6 +188,7 @@ export const resolveSymbolQuote = async (
   exchangeMic?: string,
   instrumentType?: string,
   providerId?: string,
+  quoteCcy?: string,
 ): Promise<ResolvedQuote | null> => {
   try {
     return await invoke<ResolvedQuote>("resolve_symbol_quote", {
@@ -195,6 +196,7 @@ export const resolveSymbolQuote = async (
       exchangeMic,
       instrumentType,
       providerId,
+      quoteCcy,
     });
   } catch (_error) {
     logger.error("Error resolving symbol quote.");

--- a/apps/frontend/src/adapters/web/core.ts
+++ b/apps/frontend/src/adapters/web/core.ts
@@ -711,17 +711,19 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
       break;
     }
     case "resolve_symbol_quote": {
-      const { symbol, exchangeMic, instrumentType, providerId } = payload as {
+      const { symbol, exchangeMic, instrumentType, providerId, quoteCcy } = payload as {
         symbol: string;
         exchangeMic?: string;
         instrumentType?: string;
         providerId?: string;
+        quoteCcy?: string;
       };
       const params = new URLSearchParams();
       params.set("symbol", symbol);
       if (exchangeMic) params.set("exchangeMic", exchangeMic);
       if (instrumentType) params.set("instrumentType", instrumentType);
       if (providerId) params.set("providerId", providerId);
+      if (quoteCcy) params.set("quoteCcy", quoteCcy);
       url += `?${params.toString()}`;
       break;
     }

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -430,6 +430,7 @@ export interface SymbolSearchResult {
 export interface ResolvedQuote {
   currency?: string;
   price?: number;
+  resolvedProviderId?: string;
 }
 
 export interface ExchangeInfo {

--- a/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
+++ b/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
@@ -107,6 +107,22 @@ function getSymbolPlaceholder(provider: string): string {
   return PROVIDER_SYMBOL_HINTS[provider] ?? "e.g. AAPL";
 }
 
+function isResolvedByRequestedProvider(
+  resolvedProviderId: string | undefined,
+  requestedProvider: string | undefined,
+): boolean {
+  const requested = requestedProvider?.trim();
+  if (!requested) return true;
+  if (!resolvedProviderId) return false;
+
+  if (requested.startsWith("CUSTOM:")) {
+    const customProviderId = requested.slice("CUSTOM:".length);
+    return resolvedProviderId === `CUSTOM_SCRAPER:${customProviderId}`;
+  }
+
+  return resolvedProviderId === requested;
+}
+
 const EDIT_INSTRUMENT_TYPE_OPTIONS = [
   { value: "EQUITY", label: "Equity (Stock, ETF, Fund)" },
   { value: "CRYPTO", label: "Cryptocurrency" },
@@ -300,6 +316,7 @@ function SymbolMappingRow({
   );
   // Track whether we are on the first render to avoid re-validating pre-loaded values.
   const isFirstRender = useRef(true);
+  const validationRequestSeq = useRef(0);
 
   const symbol = useWatch({
     control,
@@ -309,8 +326,22 @@ function SymbolMappingRow({
     control,
     name: `providerConfig.${index}.provider` as Path<AssetFormValues>,
   }) as string | undefined;
+  const instrumentType = useWatch({
+    control,
+    name: "instrumentType" as Path<AssetFormValues>,
+  }) as string | undefined;
+  const exchangeMic = useWatch({
+    control,
+    name: "instrumentExchangeMic" as Path<AssetFormValues>,
+  }) as string | undefined;
+  const quoteCcy = useWatch({
+    control,
+    name: "quoteCcy" as Path<AssetFormValues>,
+  }) as string | undefined;
 
   useEffect(() => {
+    const requestId = ++validationRequestSeq.current;
+
     // Skip validation on mount when the symbol is already known-good (loaded from DB).
     if (isFirstRender.current) {
       isFirstRender.current = false;
@@ -319,30 +350,51 @@ function SymbolMappingRow({
       }
     }
 
-    if (!symbol?.trim()) {
+    const trimmedSymbol = symbol?.trim();
+    if (!trimmedSymbol) {
       setValidationStatus("idle");
       onValidationChange(fieldId, "idle");
       return;
     }
 
     setValidationStatus("idle");
+    const requestExchangeMic = normalizeMic(exchangeMic) || undefined;
+    const requestInstrumentType = instrumentType?.trim() || undefined;
+    const requestQuoteCcy = quoteCcy?.trim() || undefined;
+    const requestProvider = provider?.trim() || undefined;
 
     const timer = setTimeout(async () => {
+      if (validationRequestSeq.current !== requestId) return;
+
       setValidationStatus("loading");
       onValidationChange(fieldId, "idle");
       try {
-        const result = await resolveSymbolQuote(symbol.trim(), undefined, undefined, provider);
-        const status: SymbolValidationStatus = result?.price != null ? "valid" : "invalid";
+        const result = await resolveSymbolQuote(
+          trimmedSymbol,
+          requestExchangeMic,
+          requestInstrumentType,
+          requestProvider,
+          requestQuoteCcy,
+        );
+        if (validationRequestSeq.current !== requestId) return;
+
+        const status: SymbolValidationStatus =
+          result?.price != null &&
+          isResolvedByRequestedProvider(result.resolvedProviderId, requestProvider)
+            ? "valid"
+            : "invalid";
         setValidationStatus(status);
         onValidationChange(fieldId, status);
       } catch {
+        if (validationRequestSeq.current !== requestId) return;
+
         setValidationStatus("invalid");
         onValidationChange(fieldId, "invalid");
       }
     }, 800);
 
     return () => clearTimeout(timer);
-  }, [symbol, provider, fieldId, onValidationChange]); // eslint-disable-line react-hooks/exhaustive-deps -- initialSymbol is intentionally captured at mount time only
+  }, [symbol, provider, instrumentType, exchangeMic, quoteCcy, fieldId, onValidationChange]); // eslint-disable-line react-hooks/exhaustive-deps -- initialSymbol is intentionally captured at mount time only
 
   return (
     <tr className="border-b last:border-b-0">

--- a/apps/server/src/api/market_data.rs
+++ b/apps/server/src/api/market_data.rs
@@ -243,6 +243,7 @@ struct ResolveSymbolQuoteQuery {
     symbol: String,
     exchange_mic: Option<String>,
     instrument_type: Option<String>,
+    quote_ccy: Option<String>,
     provider_id: Option<String>,
 }
 
@@ -260,6 +261,7 @@ async fn resolve_symbol_quote(
             &q.symbol,
             q.exchange_mic.as_deref(),
             inst_type.as_ref(),
+            q.quote_ccy.as_deref(),
             q.provider_id.as_deref(),
         )
         .await?;

--- a/apps/tauri/src/commands/market_data.rs
+++ b/apps/tauri/src/commands/market_data.rs
@@ -207,6 +207,7 @@ pub async fn resolve_symbol_quote(
     symbol: String,
     exchange_mic: Option<String>,
     instrument_type: Option<String>,
+    quote_ccy: Option<String>,
     provider_id: Option<String>,
     state: State<'_, Arc<ServiceContext>>,
 ) -> Result<wealthfolio_core::quotes::ResolvedQuote, String> {
@@ -219,6 +220,7 @@ pub async fn resolve_symbol_quote(
             &symbol,
             exchange_mic.as_deref(),
             inst_type.as_ref(),
+            quote_ccy.as_deref(),
             provider_id.as_deref(),
         )
         .await

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -247,7 +247,7 @@ impl ActivityService {
             || normalize_quote_ccy_code(existing_asset_quote_ccy).is_some();
         let provider_quote_ccy = if allow_provider_lookup && !has_deterministic_precedence {
             self.quote_service
-                .resolve_symbol_quote(symbol, exchange_mic, instrument_type, None)
+                .resolve_symbol_quote(symbol, exchange_mic, instrument_type, None, None)
                 .await
                 .ok()
                 .and_then(|q| q.currency)
@@ -290,7 +290,7 @@ impl ActivityService {
         }
         let result = self
             .quote_service
-            .resolve_symbol_quote(symbol, exchange_mic, instrument_type, None)
+            .resolve_symbol_quote(symbol, exchange_mic, instrument_type, None, None)
             .await
             .ok()
             .and_then(|q| q.currency);

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -456,6 +456,7 @@ mod tests {
             symbol: &str,
             exchange_mic: Option<&str>,
             _instrument_type: Option<&InstrumentType>,
+            _quote_ccy: Option<&str>,
             _preferred_provider: Option<&str>,
         ) -> Result<ResolvedQuote> {
             let is_uk_vwrp = (exchange_mic == Some("XLON") || exchange_mic == Some("CXE"))
@@ -465,6 +466,7 @@ mod tests {
                 return Ok(ResolvedQuote {
                     currency: Some("GBP".to_string()),
                     price: Some(dec!(131.60)),
+                    resolved_provider_id: Some("YAHOO".to_string()),
                 });
             }
 

--- a/crates/core/src/assets/assets_service.rs
+++ b/crates/core/src/assets/assets_service.rs
@@ -98,7 +98,7 @@ impl AssetService {
         let provider_quote_ccy = if allow_provider_lookup && !has_deterministic_precedence {
             if let Some(sym) = symbol.map(str::trim).filter(|s| !s.is_empty()) {
                 self.quote_service
-                    .resolve_symbol_quote(sym, exchange_mic, instrument_type, None)
+                    .resolve_symbol_quote(sym, exchange_mic, instrument_type, None, None)
                     .await
                     .ok()
                     .and_then(|q| q.currency)

--- a/crates/core/src/quotes/model.rs
+++ b/crates/core/src/quotes/model.rs
@@ -118,7 +118,7 @@ pub struct LatestQuotePair {
     pub previous: Option<Quote>,
 }
 
-/// Result from resolving a symbol's latest quote (currency + price).
+/// Result from resolving a symbol's latest quote (currency, price, and provider).
 ///
 /// Used during symbol selection to confirm inferred currency and pre-fill price.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -126,4 +126,5 @@ pub struct LatestQuotePair {
 pub struct ResolvedQuote {
     pub currency: Option<String>,
     pub price: Option<Decimal>,
+    pub resolved_provider_id: Option<String>,
 }

--- a/crates/core/src/quotes/service.rs
+++ b/crates/core/src/quotes/service.rs
@@ -17,7 +17,7 @@ use tokio::sync::RwLock;
 use crate::utils::time_utils;
 
 use super::client::{MarketDataClient, ProviderConfig};
-use super::constants::DATA_SOURCE_MANUAL;
+use super::constants::{DATA_SOURCE_CUSTOM_SCRAPER, DATA_SOURCE_MANUAL};
 use super::import::{ImportValidationStatus, QuoteConverter, QuoteImport, QuoteValidator};
 use super::model::{LatestQuotePair, Quote, ResolvedQuote, SymbolSearchResult};
 use super::store::{ProviderSettingsStore, QuoteStore};
@@ -135,6 +135,42 @@ fn extract_provider_id_from_sync_error(error: &str) -> Option<&'static str> {
     super::constants::MARKET_DATA_PROVIDER_IDS
         .into_iter()
         .find(|provider_id| error.contains(provider_id))
+}
+
+fn provider_config_for_symbol_resolution(
+    preferred_provider: Option<&str>,
+) -> Option<serde_json::Value> {
+    let provider = preferred_provider
+        .map(str::trim)
+        .filter(|p| !p.is_empty())?;
+
+    if let Some(custom_code) = provider
+        .strip_prefix("CUSTOM:")
+        .map(str::trim)
+        .filter(|code| !code.is_empty())
+    {
+        return Some(serde_json::json!({
+            "preferred_provider": DATA_SOURCE_CUSTOM_SCRAPER,
+            "custom_provider_code": custom_code,
+        }));
+    }
+
+    Some(serde_json::json!({ "preferred_provider": provider }))
+}
+
+fn resolved_provider_matches_requested(
+    resolved_provider: &str,
+    requested_provider: Option<&str>,
+) -> bool {
+    let Some(requested) = requested_provider.map(str::trim).filter(|p| !p.is_empty()) else {
+        return true;
+    };
+
+    if let Some(custom_code) = requested.strip_prefix("CUSTOM:") {
+        return resolved_provider == format!("{}:{}", DATA_SOURCE_CUSTOM_SCRAPER, custom_code);
+    }
+
+    resolved_provider == requested
 }
 
 /// Latest quote payload enriched with backend freshness computation.
@@ -256,7 +292,7 @@ pub trait QuoteServiceTrait: Send + Sync {
         account_currency: Option<&str>,
     ) -> Result<Vec<SymbolSearchResult>>;
 
-    /// Resolve the latest quote for a symbol (currency + price).
+    /// Resolve the latest quote for a symbol (currency, price, and provider).
     ///
     /// Best-effort: returns what the provider can give. Used during symbol selection
     /// to confirm inferred currency and pre-fill the price field.
@@ -265,9 +301,16 @@ pub trait QuoteServiceTrait: Send + Sync {
         symbol: &str,
         exchange_mic: Option<&str>,
         instrument_type: Option<&InstrumentType>,
+        quote_ccy: Option<&str>,
         preferred_provider: Option<&str>,
     ) -> Result<ResolvedQuote> {
-        let _ = (symbol, exchange_mic, instrument_type, preferred_provider);
+        let _ = (
+            symbol,
+            exchange_mic,
+            instrument_type,
+            quote_ccy,
+            preferred_provider,
+        );
         Ok(ResolvedQuote::default())
     }
 
@@ -1041,6 +1084,7 @@ where
         symbol: &str,
         exchange_mic: Option<&str>,
         instrument_type: Option<&InstrumentType>,
+        quote_ccy: Option<&str>,
         preferred_provider: Option<&str>,
     ) -> Result<ResolvedQuote> {
         let trimmed_symbol = symbol.trim();
@@ -1065,8 +1109,11 @@ where
             trimmed_symbol
         };
 
-        let provider_config: Option<serde_json::Value> =
-            preferred_provider.map(|p| serde_json::json!({ "preferred_provider": p }));
+        let clean_quote_ccy = quote_ccy
+            .map(str::trim)
+            .filter(|c| !c.is_empty())
+            .unwrap_or_default();
+        let provider_config = provider_config_for_symbol_resolution(preferred_provider);
 
         for attempt_symbol in symbol_resolution_candidates(clean_symbol) {
             // For bonds, populate metadata with TreasuryDirect details so
@@ -1108,7 +1155,7 @@ where
                 id: format!("_QUOTE_RESOLVE_{}", attempt_symbol),
                 kind: AssetKind::Investment,
                 quote_mode: QuoteMode::Market,
-                quote_ccy: String::new(),
+                quote_ccy: clean_quote_ccy.to_string(),
                 instrument_type: instrument_type.cloned().or(Some(InstrumentType::Equity)),
                 instrument_symbol: Some(resolved_symbol),
                 display_code: Some(attempt_symbol.clone()),
@@ -1139,7 +1186,22 @@ where
                     } else {
                         Some(quote.close)
                     };
-                    return Ok(ResolvedQuote { currency, price });
+                    let resolved_provider_id = quote.data_source.clone();
+                    if !resolved_provider_matches_requested(
+                        &resolved_provider_id,
+                        preferred_provider,
+                    ) {
+                        debug!(
+                            "resolve_symbol_quote: requested provider {:?} but resolved via {} for symbol='{}'",
+                            preferred_provider, resolved_provider_id, attempt_symbol
+                        );
+                        continue;
+                    }
+                    return Ok(ResolvedQuote {
+                        currency,
+                        price,
+                        resolved_provider_id: Some(resolved_provider_id),
+                    });
                 }
                 Err(err) => {
                     debug!(


### PR DESCRIPTION
## Summary

- Return the actual resolved provider from `resolve_symbol_quote` and treat provider-specific validation as invalid when resolution falls through to another provider.
- Pass the asset's current instrument type, exchange MIC, and quote currency into symbol mapping validation.
- Ignore stale async validation responses when users edit the symbol or provider while a previous request is still in flight.

## Validation

- `cargo fmt --all --check`
- `cargo check -p wealthfolio-core -p wealthfolio-server -p wealthfolio-app`
- `pnpm type-check`
- `cargo test -p wealthfolio-core`
- `pnpm --filter frontend test -- --run`