### PR TITLE
[codex] fix Docker Compose auth hash escaping

### DIFF
--- a/.env.web.example
+++ b/.env.web.example
@@ -54,7 +54,8 @@ WF_SECRET_KEY=
 # Authentication for web mode (required to enable login)
 # Provide an Argon2id PHC string. Generate with argon2.online or:
 #   printf 'your-password' | argon2 yoursalt16chars! -id -e
-# For Docker Compose, double every $ in the hash ($$argon2id$$...)
+# If reusing this value with Docker Compose .env/--env-file, single-quote it
+# or double every $ in the hash ($$argon2id$$...)
 WF_AUTH_PASSWORD_HASH=
 
 # Optional JWT access token lifetime in minutes (default: 60)

--- a/README.md
+++ b/README.md
@@ -280,19 +280,22 @@ All configuration is done via environment variables in `.env.web`.
   > - The first argument is the **salt** (use 16+ characters); the password is
   >   read from stdin.
   > - Use `printf` instead of `echo -n` to avoid hidden newline issues.
-  > - For Docker Compose, double every `$` in the hash (`$$argon2id$$...`).
+  > - For Docker Compose `.env` / `--env-file`, single-quote the hash or double
+  >   every `$` (`$$argon2id$$...`).
 
   Copy the full output (starting with `$argon2id$...`) into `.env.web`.
 
   **Dollar-sign (`$`) escaping cheat-sheet** — Argon2 hashes contain `$`
   characters that shells and Compose interpret as variable references:
 
-  | Context                      | Syntax                                | Notes                                            |
-  | ---------------------------- | ------------------------------------- | ------------------------------------------------ |
-  | `.env` file                  | `WF_AUTH_PASSWORD_HASH=$argon2id$...` | No quotes, no escaping needed                    |
-  | Docker Compose YAML inline   | `HASH: '$$argon2id$$v=19$$...'`       | Double every `$` to escape Compose interpolation |
-  | `docker run` (single quotes) | `-e HASH='$argon2id$...'`             | Single quotes prevent shell expansion            |
-  | `docker run` (double quotes) | `-e HASH="\$argon2id\$..."`           | Backslash-escape each `$`                        |
+  | Context                            | Syntax                                  | Notes                                            |
+  | ---------------------------------- | --------------------------------------- | ------------------------------------------------ |
+  | `.env.web` / app-loaded dotenv     | `WF_AUTH_PASSWORD_HASH=$argon2id$...`   | Loaded by the app; no Compose interpolation      |
+  | Docker Compose `.env`/`--env-file` | `WF_AUTH_PASSWORD_HASH='$argon2id$...'` | Single quotes prevent Compose interpolation      |
+  | Docker Compose `.env`/`--env-file` | `WF_AUTH_PASSWORD_HASH=$$argon2id$$...` | Alternative: double every `$`                    |
+  | Docker Compose YAML inline         | `HASH: '$$argon2id$$v=19$$...'`         | Double every `$` to escape Compose interpolation |
+  | `docker run` (single quotes)       | `-e HASH='$argon2id$...'`               | Single quotes prevent shell expansion            |
+  | `docker run` (double quotes)       | `-e HASH="\$argon2id\$..."`             | Backslash-escape each `$`                        |
 
 - Sessions are cookie-based (`HttpOnly`, `SameSite=Lax`, `Path=/api`). The login
   endpoint sets the session cookie automatically — no token is exposed to

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -30,7 +30,8 @@ Key environment variables
   ```
   The first argument is the **salt** (use 16+ characters); the password is read from stdin.
   Use `printf` instead of `echo -n` to avoid hidden newline issues.
-  For Docker Compose, double every `$` in the hash (`$$argon2id$$...`).
+  For Docker Compose `.env`/`--env-file`, single-quote the value or double every `$`;
+  for YAML inline values, double every `$` in the hash (`$$argon2id$$...`).
   When unset, authentication is disabled.
 - `WF_AUTH_TOKEN_TTL_MINUTES`: Optional JWT access token lifetime (minutes). Defaults to `60`.
 - `WF_SECRET_FILE`: Optional override for where encrypted secrets are stored. Defaults to `<data-root>/secrets.json`.

--- a/apps/server/src/auth.rs
+++ b/apps/server/src/auth.rs
@@ -106,8 +106,8 @@ impl AuthManager {
             anyhow::anyhow!(
                 "Failed to parse WF_AUTH_PASSWORD_HASH: {e}. \
                  The hash must be a valid Argon2id PHC string starting with '$argon2id$'. \
-                 If using Docker Compose YAML, double every '$' (e.g. '$$argon2id$$v=19$$...'). \
-                 If using a .env file, no escaping is needed."
+                 If using Docker Compose .env/--env-file, single-quote it or double every '$'. \
+                 If using Docker Compose YAML, double every '$' (e.g. '$$argon2id$$v=19$$...')."
             )
         })?;
         let encoding_key = EncodingKey::from_secret(&config.jwt_secret);

--- a/apps/server/src/config.rs
+++ b/apps/server/src/config.rs
@@ -105,7 +105,8 @@ impl Config {
                      \n\
                      1. Set WF_AUTH_PASSWORD_HASH to an Argon2id hash of your password.\n\
                         Generate one with: printf 'your-password' | argon2 yoursalt16chars! -id -e\n\
-                        In a .env file, no escaping is needed.\n\
+                        In app-loaded dotenv files, use the hash as-is.\n\
+                        In Docker Compose .env/--env-file, single-quote it or double every $ sign.\n\
                         In Docker Compose YAML, double every $ sign: '$$argon2id$$v=19$$...'\n\
                      \n\
                      2. Set WF_AUTH_REQUIRED=false if a reverse proxy handles authentication."

--- a/compose.yml
+++ b/compose.yml
@@ -25,8 +25,9 @@ services:
       # Required when listening on 0.0.0.0 (the default for Docker).
       # Provide an Argon2id PHC hash of your password.
       #
-      # IMPORTANT — the hash contains "$" signs that need escaping:
-      #   .env file  → WF_AUTH_PASSWORD_HASH=$argon2id$v=19$...  (no quotes, no escaping)
+      # IMPORTANT — Docker Compose interpolates "$" in .env files and YAML:
+      #   .env file  → WF_AUTH_PASSWORD_HASH='$argon2id$v=19$...'  (single quotes)
+      #   .env file  → WF_AUTH_PASSWORD_HASH=$$argon2id$$v=19$$...  (double every $)
       #   YAML inline → WF_AUTH_PASSWORD_HASH: '$$argon2id$$v=19$$...'  (double every $)
       #
       # Generate a hash:


### PR DESCRIPTION
## Summary

- Clarify that Docker Compose `.env` / `--env-file` values interpolate `$` and must not use a raw Argon2 PHC hash.
- Document both supported Compose forms: single-quoted values and doubled-dollar escaping.
- Update `compose.yml`, web/server docs, and auth/config error messages so users get consistent remediation guidance.

Fixes #865

## Validation

- `pnpm exec prettier --check README.md apps/server/README.md compose.yml`
- `cargo fmt --check --all`
- `cargo check -p wealthfolio-server`
- `cargo test -p wealthfolio-server auth`
- Manual Docker Compose v2.40.3 repro: raw `.env` hash is mangled; single-quoted and `$$`-escaped forms reach the container correctly.