### PR TITLE
[codex] Fix mobile activity table asset link guard

### DIFF
--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
@@ -65,6 +65,7 @@ export const ActivityTableMobile = ({
         const isCash = isTransferActivity
           ? isCashTransfer(activityType, symbol, activity.assetId)
           : isCashActivity(activityType) && !isAssetBackedIncome;
+        const hasAsset = Boolean(activity.assetId?.trim());
         const isOptionActivity = activity.instrumentType === "OPTION";
         const parsedOption = isOptionActivity ? parseOccSymbol(symbol) : null;
         const displaySymbol = isCash ? "Cash" : parsedOption ? parsedOption.underlying : symbol;

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
@@ -216,7 +216,11 @@ export const ActivityTableMobile = ({
                       ? "Ratio"
                       : (isCashActivity(activity.activityType) &&
                             !isAssetBackedIncome &&
-                            !isSecuritiesTransfer(activity.activityType, symbol, activity.assetId)) ||
+                            !isSecuritiesTransfer(
+                              activity.activityType,
+                              symbol,
+                              activity.assetId,
+                            )) ||
                           isCashTransfer(activity.activityType, symbol, activity.assetId) ||
                           (isIncomeActivity(activity.activityType) && !isAssetBackedIncome)
                         ? "Amount"
@@ -231,7 +235,11 @@ export const ActivityTableMobile = ({
                         ? formatSplitRatio(Number(activity.amount))
                         : (isCashActivity(activity.activityType) &&
                               !isAssetBackedIncome &&
-                              !isSecuritiesTransfer(activity.activityType, symbol, activity.assetId)) ||
+                              !isSecuritiesTransfer(
+                                activity.activityType,
+                                symbol,
+                                activity.assetId,
+                              )) ||
                             isCashTransfer(activity.activityType, symbol, activity.assetId) ||
                             (isIncomeActivity(activity.activityType) && !isAssetBackedIncome)
                           ? formatAmount(Number(activity.amount), activity.currency)


### PR DESCRIPTION
## Summary

- Restore the `hasAsset` local in the mobile activity table after PR #864 removed it while later render branches still referenced it.
- Keep the new cash-transfer classification logic intact while preserving the existing no-link behavior for cash or assetless rows.

## Root Cause

PR #864 updated transfer cash/security classification and removed the `hasAsset` declaration from the mobile activity map. The compact and detailed mobile card wrappers still used `hasAsset` to decide whether to render a holdings link, causing `pnpm --filter frontend type-check` to fail with `TS2304: Cannot find name 'hasAsset'`.

## Validation

- `pnpm run build:types`
- `pnpm --filter frontend type-check`
- `pnpm --filter frontend test --run src/lib/activity-utils.test.ts`
- `pnpm --filter frontend exec eslint src/pages/activity/components/activity-table/activity-table-mobile.tsx`
- `cargo test -p wealthfolio-core securities_transfer_tests`