### PR TITLE
Prevent mobile chart drags from triggering page swipes

### DIFF
--- a/apps/frontend/src/components/history-chart-symbol.tsx
+++ b/apps/frontend/src/components/history-chart-symbol.tsx
@@ -38,7 +38,7 @@ export default function HistoryChart({
   height?: number;
 }) {
   return (
-    <div className="relative flex h-full flex-col">
+    <div className="relative flex h-full flex-col" data-no-swipe-drag>
       <div className="grow">
         <ResponsiveContainer width="100%" height="100%" minHeight={height}>
           <AreaChart

--- a/apps/frontend/src/components/performance-chart-mobile.tsx
+++ b/apps/frontend/src/components/performance-chart-mobile.tsx
@@ -97,7 +97,7 @@ export function PerformanceChartMobile({ data }: PerformanceChartMobileProps) {
 
   return (
     <div className="h-full w-full">
-      <ChartContainer config={chartConfig} className="h-full w-full">
+      <ChartContainer config={chartConfig} className="h-full w-full" data-no-swipe-drag>
         <ResponsiveContainer width="100%" height="100%" aspect={undefined}>
           <LineChart data={formattedData} margin={{ top: 5, right: 5, left: 0, bottom: 5 }}>
             <CartesianGrid vertical={false} strokeDasharray="3 3" opacity={0.3} />

--- a/apps/frontend/src/pages/income/income-history-chart.tsx
+++ b/apps/frontend/src/pages/income/income-history-chart.tsx
@@ -215,6 +215,7 @@ export const IncomeHistoryChart: React.FC<IncomeHistoryChartProps> = ({
           <ChartContainer
             config={accountChartConfig}
             className={cn("h-[280px] w-full md:h-[380px]")}
+            data-no-swipe-drag
           >
             <BarChart
               key={selectedPeriod}
@@ -295,6 +296,7 @@ export const IncomeHistoryChart: React.FC<IncomeHistoryChartProps> = ({
               },
             }}
             className={cn("h-[280px] w-full md:h-[380px]")}
+            data-no-swipe-drag
           >
             <ComposedChart
               data={chartData}


### PR DESCRIPTION
## Summary

- Add the existing `data-no-swipe-drag` opt-out marker to asset profile price/value history charts.
- Add the same marker to the mobile performance chart.
- Add the marker to both income history chart modes.

## Why

Mobile chart scrubbing can start from inside a swipeable page. These chart regions should keep their drag gestures for chart interaction instead of triggering the page carousel swipe.

## Validation

- `pnpm check`