### PR TITLE
Fix sell edit holdings warning (#861)

### DIFF
--- a/apps/frontend/src/pages/activity/components/forms/__tests__/sell-form.test.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/__tests__/sell-form.test.tsx
@@ -1,8 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SellForm } from "../sell-form";
 import type { AccountSelectOption } from "../fields";
+import type { Holding } from "@/lib/types";
+
+interface UseHoldingsResult {
+  holdings: Holding[];
+  isLoading: boolean;
+}
+
+const holdingsHook = vi.hoisted(() => ({
+  useHoldings: vi.fn<() => UseHoldingsResult>(() => ({
+    holdings: [],
+    isLoading: false,
+  })),
+}));
 
 // Mock useSettings hook to avoid AuthProvider dependency
 vi.mock("@/hooks/use-settings", () => ({
@@ -15,54 +28,85 @@ vi.mock("@/hooks/use-settings", () => ({
 
 // Mock the useHoldings hook
 vi.mock("@/hooks/use-holdings", () => ({
-  useHoldings: () => ({
-    holdings: [],
-    isLoading: false,
-  }),
+  useHoldings: holdingsHook.useHoldings,
 }));
 
 // Mock the fields components
-vi.mock("../fields", () => ({
-  AccountSelect: ({ name, accounts }: { name: string; accounts: AccountSelectOption[] }) => (
-    <select data-testid={`select-${name}`} name={name}>
-      <option value="">Select account...</option>
-      {accounts.map((acc) => (
-        <option key={acc.value} value={acc.value}>
-          {acc.label}
-        </option>
-      ))}
-    </select>
-  ),
-  SymbolSearch: ({ name }: { name: string }) => (
-    <input data-testid={`symbol-search-${name}`} name={name} />
-  ),
-  DatePicker: ({ name, label }: { name: string; label: string }) => (
-    <div data-testid={`date-picker-${name}`}>{label}</div>
-  ),
-  AmountInput: ({ name, label }: { name: string; label: string }) => (
-    <div>
-      <label htmlFor={name}>{label}</label>
-      <input data-testid={`input-${name}`} name={name} type="number" id={name} />
-    </div>
-  ),
-  QuantityInput: ({ name, label }: { name: string; label: string }) => (
-    <div>
-      <label htmlFor={name}>{label}</label>
-      <input data-testid={`input-${name}`} name={name} type="number" id={name} />
-    </div>
-  ),
-  NotesInput: ({ name, label }: { name: string; label: string }) => (
-    <div>
-      <label htmlFor={name}>{label}</label>
-      <textarea data-testid={`textarea-${name}`} name={name} id={name} />
-    </div>
-  ),
-  AssetTypeSelector: ({ name }: { name: string }) => (
-    <div data-testid={`asset-type-selector-${name}`} />
-  ),
-  AdvancedOptionsSection: () => <div data-testid="advanced-options-section" />,
-  createValidatedSubmit: vi.fn((_form, handler) => handler),
-}));
+vi.mock("../fields", async () => {
+  const { useFormContext } =
+    await vi.importActual<typeof import("react-hook-form")>("react-hook-form");
+
+  return {
+    AccountSelect: ({ name, accounts }: { name: string; accounts: AccountSelectOption[] }) => {
+      const { register } = useFormContext();
+
+      return (
+        <select data-testid={`select-${name}`} {...register(name)}>
+          <option value="">Select account...</option>
+          {accounts.map((acc) => (
+            <option key={acc.value} value={acc.value}>
+              {acc.label}
+            </option>
+          ))}
+        </select>
+      );
+    },
+    SymbolSearch: ({ name }: { name: string }) => {
+      const { register } = useFormContext();
+
+      return <input data-testid={`symbol-search-${name}`} {...register(name)} />;
+    },
+    DatePicker: ({ name, label }: { name: string; label: string }) => (
+      <div data-testid={`date-picker-${name}`}>{label}</div>
+    ),
+    AmountInput: ({ name, label }: { name: string; label: string }) => {
+      const { register } = useFormContext();
+
+      return (
+        <div>
+          <label htmlFor={name}>{label}</label>
+          <input
+            data-testid={`input-${name}`}
+            type="number"
+            id={name}
+            {...register(name, { valueAsNumber: true })}
+          />
+        </div>
+      );
+    },
+    QuantityInput: ({ name, label }: { name: string; label: string }) => {
+      const { register } = useFormContext();
+
+      return (
+        <div>
+          <label htmlFor={name}>{label}</label>
+          <input
+            data-testid={`input-${name}`}
+            type="number"
+            id={name}
+            {...register(name, { valueAsNumber: true })}
+          />
+        </div>
+      );
+    },
+    NotesInput: ({ name, label }: { name: string; label: string }) => {
+      const { register } = useFormContext();
+
+      return (
+        <div>
+          <label htmlFor={name}>{label}</label>
+          <textarea data-testid={`textarea-${name}`} id={name} {...register(name)} />
+        </div>
+      );
+    },
+    OptionContractFields: () => <div data-testid="option-contract-fields" />,
+    AssetTypeSelector: ({ name }: { name: string }) => (
+      <div data-testid={`asset-type-selector-${name}`} />
+    ),
+    AdvancedOptionsSection: () => <div data-testid="advanced-options-section" />,
+    createValidatedSubmit: vi.fn((form, handler) => form.handleSubmit(handler)),
+  };
+});
 
 // Mock UI components
 vi.mock("@wealthfolio/ui/components/ui/button", () => ({
@@ -118,12 +162,38 @@ const mockAccounts: AccountSelectOption[] = [
   { value: "acc-2", label: "Investment Account", currency: "EUR" },
 ];
 
+const baseSellDefaults = {
+  accountId: "acc-1",
+  assetId: "CJR28A",
+  assetType: "bond" as const,
+  activityDate: new Date("2026-04-16T16:00:00"),
+  quantity: 100_000,
+  unitPrice: 1,
+  fee: 0,
+  currency: "USD",
+};
+
+function createHolding(symbol: string, quantity: number, assetId = symbol): Holding {
+  return {
+    id: `SEC-acc-1-${assetId}`,
+    instrument: {
+      id: assetId,
+      symbol,
+    },
+    quantity,
+  } as Holding;
+}
+
 describe("SellForm", () => {
   const mockOnSubmit = vi.fn();
   const mockOnCancel = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
+    holdingsHook.useHoldings.mockReturnValue({
+      holdings: [],
+      isLoading: false,
+    });
   });
 
   describe("Render Tests", () => {
@@ -231,6 +301,126 @@ describe("SellForm", () => {
       render(<SellForm accounts={mockAccounts} onSubmit={mockOnSubmit} isEditing={false} />);
 
       expect(screen.getByTestId("plus-icon")).toBeInTheDocument();
+    });
+  });
+
+  describe("Holdings Warning", () => {
+    it("does not warn when editing a sell that fully closed the holding", () => {
+      render(
+        <SellForm
+          accounts={mockAccounts}
+          defaultValues={baseSellDefaults}
+          onSubmit={mockOnSubmit}
+          isEditing={true}
+        />,
+      );
+
+      expect(screen.queryByTestId("alert")).not.toBeInTheDocument();
+      expect(screen.getByText("Available: 100,000")).toBeInTheDocument();
+    });
+
+    it("adds back the original sell quantity when editing the same holding", async () => {
+      const user = userEvent.setup();
+      holdingsHook.useHoldings.mockReturnValue({
+        holdings: [createHolding("CJR28A", 60)],
+        isLoading: false,
+      });
+
+      render(
+        <SellForm
+          accounts={mockAccounts}
+          defaultValues={{ ...baseSellDefaults, quantity: 40 }}
+          onSubmit={mockOnSubmit}
+          isEditing={true}
+        />,
+      );
+
+      expect(screen.getByText("Available: 100")).toBeInTheDocument();
+
+      const quantityInput = screen.getByTestId("input-quantity");
+      await user.clear(quantityInput);
+      await user.type(quantityInput, "80");
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("alert")).not.toBeInTheDocument();
+      });
+    });
+
+    it("warns when an edited sell exceeds the adjusted available quantity", async () => {
+      const user = userEvent.setup();
+      holdingsHook.useHoldings.mockReturnValue({
+        holdings: [createHolding("CJR28A", 60)],
+        isLoading: false,
+      });
+
+      render(
+        <SellForm
+          accounts={mockAccounts}
+          defaultValues={{ ...baseSellDefaults, quantity: 40 }}
+          onSubmit={mockOnSubmit}
+          isEditing={true}
+        />,
+      );
+
+      const quantityInput = screen.getByTestId("input-quantity");
+      await user.clear(quantityInput);
+      await user.type(quantityInput, "101");
+
+      await waitFor(() => {
+        expect(screen.getByTestId("alert-description")).toHaveTextContent(
+          "than your available holdings (100)",
+        );
+      });
+    });
+
+    it("does not add back the original sell quantity after changing the asset", async () => {
+      const user = userEvent.setup();
+      holdingsHook.useHoldings.mockReturnValue({
+        holdings: [createHolding("CJR28A", 60)],
+        isLoading: false,
+      });
+
+      render(
+        <SellForm
+          accounts={mockAccounts}
+          defaultValues={{ ...baseSellDefaults, quantity: 40 }}
+          onSubmit={mockOnSubmit}
+          isEditing={true}
+        />,
+      );
+
+      const symbolInput = screen.getByTestId("symbol-search-assetId");
+      await user.clear(symbolInput);
+      await user.type(symbolInput, "MSFT");
+
+      await waitFor(() => {
+        expect(screen.getByTestId("alert-description")).toHaveTextContent(
+          "than your available holdings (0)",
+        );
+      });
+    });
+
+    it("matches current holdings by instrument id as well as display symbol", () => {
+      holdingsHook.useHoldings.mockReturnValue({
+        holdings: [createHolding("CJR28A", 10, "SEC:CJR28A:XTSE")],
+        isLoading: false,
+      });
+
+      render(
+        <SellForm
+          accounts={mockAccounts}
+          defaultValues={{
+            ...baseSellDefaults,
+            assetId: "SEC:CJR28A:XTSE",
+            assetType: "stock",
+            quantity: 5,
+          }}
+          onSubmit={mockOnSubmit}
+        />,
+      );
+
+      expect(screen.queryByTestId("alert")).not.toBeInTheDocument();
+      expect(screen.getByText("Available: 10")).toBeInTheDocument();
     });
   });
 });

--- a/apps/frontend/src/pages/activity/components/forms/sell-form.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/sell-form.tsx
@@ -265,19 +265,67 @@ export function SellForm({
     return assetId;
   }, [isOption, assetId, watch]);
 
+  const originalEffectiveAssetId = useMemo(() => {
+    if (!isEditing || !defaultValues) return "";
+    if (defaultValues.assetType !== "option") return defaultValues.assetId ?? "";
+
+    const { underlyingSymbol, strikePrice, expirationDate, optionType } = defaultValues;
+    if (underlyingSymbol && strikePrice && expirationDate && optionType) {
+      return buildOccSymbol(underlyingSymbol, expirationDate, optionType, strikePrice);
+    }
+    return defaultValues.assetId ?? "";
+  }, [
+    isEditing,
+    defaultValues?.assetType,
+    defaultValues?.assetId,
+    defaultValues?.underlyingSymbol,
+    defaultValues?.strikePrice,
+    defaultValues?.expirationDate,
+    defaultValues?.optionType,
+  ]);
+
+  const originalSellQuantity = useMemo(() => {
+    if (!isEditing) return 0;
+    const quantity = Number(defaultValues?.quantity);
+    return Number.isFinite(quantity) ? Math.abs(quantity) : 0;
+  }, [isEditing, defaultValues?.quantity]);
+
   // Find the current holding quantity for the selected symbol
   const currentHoldingQuantity = useMemo(() => {
     const id = effectiveAssetId;
     if (!id || !holdings) return 0;
-    const holding = holdings.find((h) => h.instrument?.symbol === id || h.id === id);
+    const holding = holdings.find(
+      (h) => h.instrument?.symbol === id || h.instrument?.id === id || h.id === id,
+    );
     return holding?.quantity ?? 0;
   }, [effectiveAssetId, holdings]);
 
-  // Check if selling more than current holdings
+  const availableHoldingQuantity = useMemo(() => {
+    const isSameEditedHolding =
+      isEditing &&
+      !!accountId &&
+      accountId === defaultValues?.accountId &&
+      !!effectiveAssetId &&
+      effectiveAssetId === originalEffectiveAssetId;
+
+    return isSameEditedHolding
+      ? currentHoldingQuantity + originalSellQuantity
+      : currentHoldingQuantity;
+  }, [
+    isEditing,
+    accountId,
+    defaultValues?.accountId,
+    effectiveAssetId,
+    originalEffectiveAssetId,
+    currentHoldingQuantity,
+    originalSellQuantity,
+  ]);
+
+  // Check if selling more than the quantity available for this form state
   const isSellingMoreThanHoldings = useMemo(() => {
     if (!optQuantity || optQuantity <= 0 || !effectiveAssetId) return false;
-    return optQuantity > currentHoldingQuantity;
-  }, [optQuantity, currentHoldingQuantity, effectiveAssetId]);
+    return optQuantity > availableHoldingQuantity;
+  }, [optQuantity, availableHoldingQuantity, effectiveAssetId]);
 
   const handleSubmit = createValidatedSubmit(form, async (data) => {
     // Ensure currency is set (required by backend) — fall back to account currency
@@ -391,14 +439,14 @@ export function SellForm({
                     <span>x</span>
                   </div>
                 )}
-                {!isOption && currentHoldingQuantity > 0 && (
+                {!isOption && availableHoldingQuantity > 0 && (
                   <p className="text-muted-foreground mt-1.5 text-xs">
-                    Available: {currentHoldingQuantity.toLocaleString()}
+                    Available: {availableHoldingQuantity.toLocaleString()}
                   </p>
                 )}
-                {isOption && currentHoldingQuantity > 0 && (
+                {isOption && availableHoldingQuantity > 0 && (
                   <p className="text-muted-foreground mt-1.5 text-xs">
-                    Holding: {currentHoldingQuantity.toLocaleString()} contracts
+                    Holding: {availableHoldingQuantity.toLocaleString()} contracts
                   </p>
                 )}
               </div>
@@ -459,8 +507,8 @@ export function SellForm({
                 <Icons.AlertTriangle className="text-warning h-4 w-4" />
                 <AlertDescription className="text-warning text-sm">
                   You are selling more {isOption ? "contracts" : "shares"} (
-                  {optQuantity?.toLocaleString()}) than your current holdings (
-                  {currentHoldingQuantity.toLocaleString()}). This may result in a short position.
+                  {optQuantity?.toLocaleString()}) than your available holdings (
+                  {availableHoldingQuantity.toLocaleString()}). This may result in a short position.
                 </AlertDescription>
               </Alert>
             )}


### PR DESCRIPTION
## Summary

Fixes #861.

This updates the sell activity form so edit mode does not warn that a user is selling more than they hold when the existing sell activity has already reduced the current holdings snapshot.

## Root Cause

The sell form checked the entered quantity against `useHoldings(accountId)`, which returns the latest holdings snapshot after all saved activities have been applied. When editing an existing sell, that sell is already reflected in the snapshot, so a full close can appear as zero available holdings.

## Changes

- Adds an adjusted available quantity for sell edit mode by adding back the original sell quantity only when the edited form still targets the same account and same effective asset/option contract.
- Keeps the normal current-holdings behavior when the user changes account or asset while editing.
- Matches holdings by `instrument.id` as well as display symbol.
- Updates the warning and available/holding labels to use the adjusted available quantity.
- Adds regression tests for full-close edits, partial sell edits, adjusted oversell warnings, changed-asset edits, and `instrument.id` matching.

## Validation

- `pnpm run build:types`
- `pnpm --filter frontend type-check`
- `pnpm --filter frontend lint --quiet`
- `pnpm exec prettier --check apps/frontend/src/pages/activity/components/forms/sell-form.tsx apps/frontend/src/pages/activity/components/forms/__tests__/sell-form.test.tsx`
- `git diff --check`
- `PATH=/Users/aziz/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH pnpm --filter frontend test --run src/pages/activity/components/forms/__tests__/sell-form.test.tsx`

Note: the targeted Vitest command requires a Node runtime supported by the current jsdom dependency stack. The default shell Node was `20.10.0`, while jsdom requires `^20.19.0 || ^22.12.0 || >=24.0.0`; the command above was run with bundled Node `24.14.0`.