### PR TITLE
Improve custom provider preview and runtime sync

### DIFF
--- a/apps/frontend/src/lib/types/custom-provider.ts
+++ b/apps/frontend/src/lib/types/custom-provider.ts
@@ -113,7 +113,12 @@ export interface TestSourceResult {
   success: boolean;
   // Rust `Option<T>::None` serializes to JSON `null` (no `skip_serializing_if`
   // attribute). Typing these as `T | null` makes TS flag unsafe direct access.
+  statusCode?: number | null;
   price?: number | null;
+  open?: number | null;
+  high?: number | null;
+  low?: number | null;
+  volume?: number | null;
   currency?: string | null;
   date?: string | null;
   error?: string | null;

--- a/apps/frontend/src/lib/types/custom-provider.ts
+++ b/apps/frontend/src/lib/types/custom-provider.ts
@@ -12,6 +12,7 @@ export interface CustomProviderSource {
   invert?: boolean;
   locale?: string;
   headers?: string;
+  openPath?: string;
   highPath?: string;
   lowPath?: string;
   volumePath?: string;
@@ -56,6 +57,7 @@ export interface NewCustomProviderSource {
   invert?: boolean;
   locale?: string;
   headers?: string;
+  openPath?: string;
   highPath?: string;
   lowPath?: string;
   volumePath?: string;
@@ -76,6 +78,9 @@ export interface TestSourceRequest {
   headers?: string;
   symbol: string;
   currency?: string;
+  from?: string;
+  to?: string;
+  openPath?: string;
   highPath?: string;
   lowPath?: string;
   volumePath?: string;
@@ -106,11 +111,13 @@ export interface DetectedHtmlTable {
 
 export interface TestSourceResult {
   success: boolean;
-  price?: number;
-  currency?: string;
-  date?: string;
-  error?: string;
-  rawResponse?: string;
-  detectedElements?: DetectedHtmlElement[];
-  detectedTables?: DetectedHtmlTable[];
+  // Rust `Option<T>::None` serializes to JSON `null` (no `skip_serializing_if`
+  // attribute). Typing these as `T | null` makes TS flag unsafe direct access.
+  price?: number | null;
+  currency?: string | null;
+  date?: string | null;
+  error?: string | null;
+  rawResponse?: string | null;
+  detectedElements?: DetectedHtmlElement[] | null;
+  detectedTables?: DetectedHtmlTable[] | null;
 }

--- a/apps/frontend/src/pages/settings/market-data/custom-provider-form.tsx
+++ b/apps/frontend/src/pages/settings/market-data/custom-provider-form.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
@@ -15,58 +15,41 @@ import {
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
 import { Input } from "@wealthfolio/ui/components/ui/input";
 import { Textarea } from "@wealthfolio/ui/components/ui/textarea";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@wealthfolio/ui";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@wealthfolio/ui/components/ui/tabs";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@wealthfolio/ui/components/ui/collapsible";
+import { toast } from "@wealthfolio/ui/components/ui/use-toast";
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@wealthfolio/ui";
 
+import { ExternalLink } from "@/components/external-link";
 import { useCreateCustomProvider, useUpdateCustomProvider } from "@/hooks/use-custom-providers";
+import { useSettingsContext } from "@/lib/settings-provider";
 import type {
   CustomProviderWithSources,
   NewCustomProviderSource,
 } from "@/lib/types/custom-provider";
+import { cn } from "@/lib/utils";
 
 import { SourceConfigPanel } from "./source-config-panel";
+import { LivePreviewPane } from "./live-preview-pane";
+import { useSourceRuntime, type SourceRuntime } from "./use-source-runtime";
 
+const DOCS_URL = "https://wealthfolio.app/docs/guide/custom-providers/";
+
+// Base fields use `.default(...)` so zod substitutes sane defaults when the
+// inactive source's inputs aren't mounted (e.g. Dated-series mode only renders
+// the historical panel, so `latestSource` fields may come through undefined).
+// Real required-field checking is done in the `superRefine` below, gated by
+// `latestEnabled` / `historicalEnabled`.
 const sourceSchema = z.object({
-  format: z.enum(["json", "html", "html_table", "csv"]),
-  url: z
-    .string()
-    .min(1, "URL is required")
-    .refine((val) => /^https?:\/\//i.test(val), {
-      message: "URL must start with http:// or https://",
-    }),
-  pricePath: z.string().min(1, "Price path is required"),
+  format: z.enum(["json", "html", "html_table", "csv"]).default("json"),
+  url: z.string().default(""),
+  pricePath: z.string().default(""),
   datePath: z.string().optional(),
   dateFormat: z.string().optional(),
   currencyPath: z.string().optional(),
   factor: z.coerce.number().optional(),
   invert: z.boolean().optional(),
   locale: z.string().optional(),
-  headers: z
-    .string()
-    .optional()
-    .refine(
-      (val) => {
-        if (!val || val.trim() === "") return true;
-        try {
-          JSON.parse(val);
-          return true;
-        } catch {
-          return false;
-        }
-      },
-      { message: "Headers must be valid JSON" },
-    ),
+  headers: z.string().optional(),
+  openPath: z.string().optional(),
   highPath: z.string().optional(),
   lowPath: z.string().optional(),
   volumePath: z.string().optional(),
@@ -74,20 +57,112 @@ const sourceSchema = z.object({
   dateTimezone: z.string().optional(),
 });
 
-const formSchema = z.object({
-  name: z.string().min(1, "Name is required"),
-  code: z
-    .string()
-    .min(1, "Code is required")
-    .regex(/^[a-z0-9-]+$/, "Lowercase alphanumeric and hyphens only"),
-  description: z.string().optional(),
-  priority: z.coerce.number().int().min(1).default(50),
-  latestSource: sourceSchema,
-  historicalEnabled: z.boolean(),
-  historicalSource: sourceSchema.optional(),
-});
+const formSchema = z
+  .object({
+    name: z.string().min(1, "Name is required"),
+    code: z
+      .string()
+      .min(1, "Code is required")
+      .regex(/^[a-z0-9-]+$/, "Lowercase alphanumeric and hyphens only"),
+    description: z.string().optional(),
+    priority: z.coerce.number().int().min(1).default(50),
+    latestEnabled: z.boolean(),
+    latestSource: sourceSchema,
+    historicalEnabled: z.boolean(),
+    historicalSource: sourceSchema,
+  })
+  .superRefine((values, ctx) => {
+    if (!values.latestEnabled && !values.historicalEnabled) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["latestEnabled"],
+        message: "Enable at least one price source",
+      });
+    }
+    if (values.latestEnabled) validateSource(ctx, "latestSource", values.latestSource);
+    if (values.historicalEnabled) validateSource(ctx, "historicalSource", values.historicalSource);
+  });
 
 export type FormValues = z.infer<typeof formSchema>;
+type SourceFormValues = z.infer<typeof sourceSchema>;
+export type SourceKey = "latestSource" | "historicalSource";
+type SourceMode = "historical" | "latest" | "both";
+type SubTab = "latest" | "historical";
+
+const URL_RE = /^https?:\/\//i;
+
+function emptySource(dateTimezoneDefault = ""): SourceFormValues {
+  return {
+    format: "json",
+    url: "",
+    pricePath: "",
+    datePath: "",
+    dateFormat: "",
+    currencyPath: "",
+    locale: "",
+    headers: "",
+    openPath: "",
+    highPath: "",
+    lowPath: "",
+    volumePath: "",
+    dateTimezone: dateTimezoneDefault,
+  };
+}
+
+function sourceDefaults(
+  source?: CustomProviderWithSources["sources"][number],
+  dateTimezoneDefault = "",
+): SourceFormValues {
+  return source
+    ? {
+        format: source.format ?? "json",
+        url: source.url,
+        pricePath: source.pricePath,
+        datePath: source.datePath ?? "",
+        dateFormat: source.dateFormat ?? "",
+        currencyPath: source.currencyPath ?? "",
+        factor: source.factor ?? undefined,
+        invert: source.invert ?? false,
+        locale: source.locale ?? "",
+        headers: source.headers ?? "",
+        openPath: source.openPath ?? "",
+        highPath: source.highPath ?? "",
+        lowPath: source.lowPath ?? "",
+        volumePath: source.volumePath ?? "",
+        defaultPrice: source.defaultPrice ?? undefined,
+        dateTimezone: source.dateTimezone ?? "",
+      }
+    : emptySource(dateTimezoneDefault);
+}
+
+function addSourceIssue(
+  ctx: z.RefinementCtx,
+  sourceKey: SourceKey,
+  field: keyof SourceFormValues,
+  message: string,
+) {
+  ctx.addIssue({ code: z.ZodIssueCode.custom, path: [sourceKey, field], message });
+}
+
+function validateSource(ctx: z.RefinementCtx, sourceKey: SourceKey, source: SourceFormValues) {
+  const url = source.url.trim();
+  if (!url) {
+    addSourceIssue(ctx, sourceKey, "url", "URL is required");
+  } else if (!URL_RE.test(url)) {
+    addSourceIssue(ctx, sourceKey, "url", "URL must start with http:// or https://");
+  }
+  if (!source.pricePath.trim()) {
+    addSourceIssue(ctx, sourceKey, "pricePath", "Price path is required");
+  }
+  const headers = source.headers?.trim();
+  if (headers) {
+    try {
+      JSON.parse(headers);
+    } catch {
+      addSourceIssue(ctx, sourceKey, "headers", "Headers must be valid JSON");
+    }
+  }
+}
 
 function generateCode(name: string): string {
   return name
@@ -96,13 +171,10 @@ function generateCode(name: string): string {
     .replace(/^-|-$/g, "");
 }
 
-/** Extract a human-friendly name from a URL domain (e.g. "CoinGecko" from "https://api.coingecko.com/...") */
 function nameFromUrl(url: string): string | null {
   try {
     const hostname = new URL(url).hostname;
-    // Extract the main domain name (e.g., "euronext" from "live.euronext.com")
     const parts = hostname.split(".");
-    // For "euronext.com" → "euronext", "live.euronext.com" → "euronext"
     const domain = parts.length >= 2 ? parts[parts.length - 2] : parts[0];
     if (!domain) return null;
     return domain.charAt(0).toUpperCase() + domain.slice(1);
@@ -111,16 +183,14 @@ function nameFromUrl(url: string): string | null {
   }
 }
 
+// ---------------------------------------------------------------------------
+
 interface CustomProviderFormProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   provider?: CustomProviderWithSources;
 }
 
-/**
- * Thin shell: renders the Dialog and keys the inner content so it
- * remounts (= full reset) whenever the dialog opens or the provider changes.
- */
 export function CustomProviderForm({ open, onOpenChange, provider }: CustomProviderFormProps) {
   const [saving, setSaving] = useState(false);
   return (
@@ -131,7 +201,10 @@ export function CustomProviderForm({ open, onOpenChange, provider }: CustomProvi
         onOpenChange(nextOpen);
       }}
     >
-      <DialogContent className="flex h-[90vh] max-h-[800px] w-[95vw] max-w-5xl flex-col overflow-hidden sm:h-[85vh]">
+      <DialogContent
+        className="flex h-[92vh] w-[98vw] max-w-[1400px] flex-col overflow-hidden p-0 [--input-height:2.25rem]"
+        showCloseButton={false}
+      >
         {open && (
           <CustomProviderFormContent
             key={provider?.id ?? "__new__"}
@@ -145,6 +218,8 @@ export function CustomProviderForm({ open, onOpenChange, provider }: CustomProvi
   );
 }
 
+// ---------------------------------------------------------------------------
+
 function CustomProviderFormContent({
   provider,
   onOpenChange,
@@ -157,11 +232,19 @@ function CustomProviderFormContent({
   const isEditing = !!provider;
   const { mutate: createProvider, isPending: isCreating } = useCreateCustomProvider();
   const { mutate: updateProvider, isPending: isUpdating } = useUpdateCustomProvider();
+  const { settings } = useSettingsContext();
   const isSaving = isCreating || isUpdating;
-  onSavingChange(isSaving);
 
-  const latestSource = provider?.sources.find((s) => s.kind === "latest");
-  const historicalSource = provider?.sources.find((s) => s.kind === "historical");
+  useEffect(() => {
+    onSavingChange(isSaving);
+  }, [isSaving, onSavingChange]);
+
+  const latestSourceInitial = provider?.sources.find((s) => s.kind === "latest");
+  const historicalSourceInitial = provider?.sources.find((s) => s.kind === "historical");
+
+  // For brand-new providers, seed dateTimezone with the user's global timezone
+  // from app settings. Editing an existing provider keeps whatever was saved.
+  const defaultTimezone = settings?.timezone ?? "";
 
   const form = useForm<FormValues>({
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -171,51 +254,19 @@ function CustomProviderFormContent({
       code: provider?.id ?? "",
       description: provider?.description ?? "",
       priority: provider?.priority ?? 50,
-      latestSource: {
-        format: latestSource?.format ?? "json",
-        url: latestSource?.url ?? "",
-        pricePath: latestSource?.pricePath ?? "",
-        datePath: latestSource?.datePath ?? "",
-        dateFormat: latestSource?.dateFormat ?? "",
-        currencyPath: latestSource?.currencyPath ?? "",
-        factor: latestSource?.factor ?? undefined,
-        invert: latestSource?.invert ?? false,
-        locale: latestSource?.locale ?? "",
-        headers: latestSource?.headers ?? "",
-        highPath: latestSource?.highPath ?? "",
-        lowPath: latestSource?.lowPath ?? "",
-        volumePath: latestSource?.volumePath ?? "",
-        defaultPrice: latestSource?.defaultPrice ?? undefined,
-        dateTimezone: latestSource?.dateTimezone ?? "",
-      },
-      historicalEnabled: !!historicalSource,
-      historicalSource: historicalSource
-        ? {
-            format: historicalSource.format ?? "json",
-            url: historicalSource.url,
-            pricePath: historicalSource.pricePath,
-            datePath: historicalSource.datePath ?? "",
-            dateFormat: historicalSource.dateFormat ?? "",
-            currencyPath: historicalSource.currencyPath ?? "",
-            factor: historicalSource.factor ?? undefined,
-            invert: historicalSource.invert ?? false,
-            locale: historicalSource.locale ?? "",
-            headers: historicalSource.headers ?? "",
-            highPath: historicalSource.highPath ?? "",
-            lowPath: historicalSource.lowPath ?? "",
-            volumePath: historicalSource.volumePath ?? "",
-            defaultPrice: historicalSource.defaultPrice ?? undefined,
-            dateTimezone: historicalSource.dateTimezone ?? "",
-          }
-        : undefined,
+      latestEnabled: !!latestSourceInitial || !historicalSourceInitial,
+      latestSource: sourceDefaults(latestSourceInitial, defaultTimezone),
+      historicalEnabled: !!historicalSourceInitial,
+      historicalSource: sourceDefaults(historicalSourceInitial, defaultTimezone),
     },
   });
 
   const [nameManuallyEdited, setNameManuallyEdited] = useState(isEditing);
   const [codeManuallyEdited, setCodeManuallyEdited] = useState(isEditing);
-  const [descriptionOpen, setDescriptionOpen] = useState(!!provider?.description);
+  const [subTab, setSubTab] = useState<SubTab>(
+    historicalSourceInitial && !latestSourceInitial ? "historical" : "latest",
+  );
 
-  // Called by SourceConfigPanel when the URL input changes
   const handleUrlChange = useCallback(
     (url: string) => {
       if (isEditing) return;
@@ -239,10 +290,87 @@ function CustomProviderFormContent({
     }
   };
 
+  const latestRuntime = useSourceRuntime({
+    form,
+    prefix: "latestSource",
+    isHistorical: false,
+    onUrlChange: handleUrlChange,
+  });
+  const historicalRuntime = useSourceRuntime({
+    form,
+    prefix: "historicalSource",
+    isHistorical: true,
+    onUrlChange: handleUrlChange,
+  });
+
+  const latestEnabled = form.watch("latestEnabled");
+  const historicalEnabled = form.watch("historicalEnabled");
+  const name = form.watch("name");
+
+  const sourceMode: SourceMode =
+    latestEnabled && historicalEnabled ? "both" : historicalEnabled ? "historical" : "latest";
+
+  const setSourceMode = (mode: SourceMode) => {
+    form.clearErrors(["latestEnabled", "latestSource", "historicalSource"]);
+    form.setValue("latestEnabled", mode === "latest" || mode === "both", { shouldValidate: true });
+    form.setValue("historicalEnabled", mode === "historical" || mode === "both", {
+      shouldValidate: true,
+    });
+    setSubTab(mode === "historical" ? "historical" : "latest");
+  };
+
+  const activeSource: SubTab =
+    sourceMode === "both" ? subTab : sourceMode === "historical" ? "historical" : "latest";
+
+  const activePrefix: SourceKey = activeSource === "latest" ? "latestSource" : "historicalSource";
+  const activeRuntime: SourceRuntime =
+    activeSource === "latest" ? latestRuntime : historicalRuntime;
+
+  // Watched values feed the footer checklist — using `watch` (not `getValues`)
+  // so the memo recomputes whenever the user edits the URL or Price path.
+  const latestUrlValue = form.watch("latestSource.url");
+  const latestPriceValue = form.watch("latestSource.pricePath");
+  const historicalUrlValue = form.watch("historicalSource.url");
+  const historicalPriceValue = form.watch("historicalSource.pricePath");
+
+  const checklist = useMemo(() => {
+    const check = (enabled: boolean, url: string | undefined, price: string | undefined) => {
+      if (!enabled) return { url: true, mapped: true };
+      return { url: !!url && URL_RE.test(url), mapped: !!price };
+    };
+    const latestCheck = check(latestEnabled, latestUrlValue, latestPriceValue);
+    const historicalCheck = check(historicalEnabled, historicalUrlValue, historicalPriceValue);
+    return {
+      urlTemplate: latestCheck.url && historicalCheck.url && (latestEnabled || historicalEnabled),
+      fetchSucceeds:
+        (!latestEnabled ||
+          latestRuntime.status?.ok === true ||
+          !!latestRuntime.testResult?.success) &&
+        (!historicalEnabled ||
+          historicalRuntime.status?.ok === true ||
+          !!historicalRuntime.testResult?.success) &&
+        (latestEnabled || historicalEnabled),
+      requiredFieldsMapped: latestCheck.mapped && historicalCheck.mapped,
+      providerName: !!name,
+    };
+  }, [
+    latestEnabled,
+    historicalEnabled,
+    latestUrlValue,
+    latestPriceValue,
+    historicalUrlValue,
+    historicalPriceValue,
+    latestRuntime.status,
+    latestRuntime.testResult,
+    historicalRuntime.status,
+    historicalRuntime.testResult,
+    name,
+  ]);
+
   const handleSave = useCallback(
     (values: FormValues) => {
       const mapSource = (
-        src: FormValues["latestSource"],
+        src: SourceFormValues,
         kind: "latest" | "historical",
       ): NewCustomProviderSource => ({
         kind,
@@ -256,6 +384,7 @@ function CustomProviderFormContent({
         invert: src.invert ?? undefined,
         locale: src.locale || undefined,
         headers: src.headers || undefined,
+        openPath: src.openPath || undefined,
         highPath: src.highPath || undefined,
         lowPath: src.lowPath || undefined,
         volumePath: src.volumePath || undefined,
@@ -263,11 +392,9 @@ function CustomProviderFormContent({
         dateTimezone: src.dateTimezone || undefined,
       });
 
-      const sources: NewCustomProviderSource[] = [mapSource(values.latestSource, "latest")];
-
-      if (values.historicalEnabled && values.historicalSource) {
-        sources.push(mapSource(values.historicalSource, "historical"));
-      }
+      const sources: NewCustomProviderSource[] = [];
+      if (values.latestEnabled) sources.push(mapSource(values.latestSource, "latest"));
+      if (values.historicalEnabled) sources.push(mapSource(values.historicalSource, "historical"));
 
       if (isEditing && provider) {
         updateProvider(
@@ -298,220 +425,242 @@ function CustomProviderFormContent({
     [isEditing, provider, createProvider, updateProvider, onOpenChange],
   );
 
-  const historicalEnabled = form.watch("historicalEnabled");
+  // Sub-pill dot colour — green when source looks configured
+  const latestConfigured = isSubConfigured(form, "latestSource", latestRuntime);
+  const historicalConfigured = isSubConfigured(form, "historicalSource", historicalRuntime);
 
   return (
-    <>
-      <DialogHeader className="shrink-0">
-        <DialogTitle>{isEditing ? "Edit Custom Provider" : "Add Custom Provider"}</DialogTitle>
-        <DialogDescription>
-          Configure a custom data source to fetch market prices.
-        </DialogDescription>
-      </DialogHeader>
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(handleSave, (errors) => {
+          console.warn("[CustomProviderForm] validation errors:", errors);
+          const messages = collectErrorMessages(errors);
+          toast({
+            title: "Form has errors",
+            description:
+              messages.length > 0
+                ? messages.slice(0, 4).join(" · ")
+                : "One or more fields are invalid.",
+            variant: "destructive",
+          });
+          if (errors.name || errors.code) {
+            document.getElementById("provider-identity-card")?.scrollIntoView({
+              behavior: "smooth",
+              block: "center",
+            });
+          }
+        })}
+        className="flex min-h-0 flex-1 flex-col"
+      >
+        {/* ── Header ── */}
+        <div className="bg-background flex shrink-0 items-start justify-between gap-4 border-b px-5 py-4">
+          <div>
+            <DialogTitle className="text-lg font-semibold">
+              {isEditing ? "Edit custom provider" : "Add custom provider"}
+            </DialogTitle>
+            <DialogDescription className="text-muted-foreground text-sm">
+              Configure a custom data source to fetch market prices.
+            </DialogDescription>
+          </div>
+          <div className="flex items-center gap-2">
+            <ExternalLink
+              href={DOCS_URL}
+              className="text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs transition-colors"
+            >
+              <Icons.FileText className="h-3.5 w-3.5" />
+              Docs
+            </ExternalLink>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={() => onOpenChange(false)}
+              disabled={isSaving}
+              className="h-8 w-8"
+              aria-label="Close"
+            >
+              <Icons.Close className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
 
-      <Form {...form}>
-        <form
-          onSubmit={form.handleSubmit(handleSave, (errors) => {
-            // Scroll to the first visible error
-            if (errors.latestSource || errors.historicalSource) {
-              // Source errors are at the top — scroll up
-              document.getElementById("source-config-area")?.scrollTo({
-                top: 0,
-                behavior: "smooth",
-              });
-            } else if (errors.name || errors.code) {
-              // Name/Code are at the bottom — scroll to them
-              document.getElementById("provider-identity")?.scrollIntoView({
-                behavior: "smooth",
-                block: "center",
-              });
-            }
-          })}
-          className="flex min-h-0 flex-1 flex-col"
-        >
-          <Tabs defaultValue="latest" className="flex min-h-0 flex-1 flex-col">
-            <TabsList className="w-full shrink-0">
-              <TabsTrigger value="latest" className="flex-1">
-                Latest Price
-              </TabsTrigger>
-              <TabsTrigger value="historical" className="flex-1">
-                Historical
-                <span className="text-muted-foreground ml-1 text-[10px] font-normal">
-                  (optional)
-                </span>
-              </TabsTrigger>
-            </TabsList>
-
-            {/* Scrollable content area */}
-            <div id="source-config-area" className="min-h-0 flex-1 overflow-y-auto">
-              <TabsContent value="latest" className="mt-3">
-                <SourceConfigPanel
-                  form={form}
-                  prefix="latestSource"
-                  onUrlChange={handleUrlChange}
+        {/* ── Body: two-pane ── */}
+        <div className="bg-muted/40 grid min-h-0 flex-1 lg:grid-cols-[minmax(0,1fr)_560px]">
+          {/* LEFT pane */}
+          <div className="min-h-0 space-y-3 overflow-y-auto border-r p-4">
+            {/* Provider Mode */}
+            <div>
+              <div className="text-muted-foreground mb-2 text-[11px] font-medium uppercase tracking-wide">
+                Provider mode
+              </div>
+              <div className="grid gap-2 sm:grid-cols-3">
+                <ModeCard
+                  selected={sourceMode === "historical"}
+                  icon={<Icons.History className="h-4 w-4 shrink-0" />}
+                  title="Dated series"
+                  subtitle="newest row = latest"
+                  onClick={() => setSourceMode("historical")}
                 />
-              </TabsContent>
+                <ModeCard
+                  selected={sourceMode === "latest"}
+                  icon={<Icons.TrendingUp className="h-4 w-4 shrink-0" />}
+                  title="Latest only"
+                  subtitle="one endpoint"
+                  onClick={() => setSourceMode("latest")}
+                />
+                <ModeCard
+                  selected={sourceMode === "both"}
+                  icon={<Icons.BarChart className="h-4 w-4 shrink-0" />}
+                  title="Both"
+                  subtitle="series + override"
+                  onClick={() => setSourceMode("both")}
+                />
+              </div>
 
-              <TabsContent value="historical" className="mt-3">
-                {!historicalEnabled ? (
-                  <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed p-8">
-                    <Icons.Clock className="text-muted-foreground/40 h-8 w-8" />
-                    <div className="text-center">
-                      <p className="text-muted-foreground text-sm">Historical source is optional</p>
-                      <p className="text-muted-foreground mt-1 text-xs">
-                        If not configured, daily prices accumulate from the latest source.
-                      </p>
-                    </div>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      onClick={() => {
-                        form.setValue("historicalEnabled", true);
-                        form.setValue("historicalSource", {
-                          format: "json",
-                          url: "",
-                          pricePath: "",
-                          datePath: "",
-                          dateFormat: "",
-                          currencyPath: "",
-                          locale: "",
-                          headers: "",
-                          highPath: "",
-                          lowPath: "",
-                          volumePath: "",
-                          dateTimezone: "",
-                        });
-                      }}
-                    >
-                      <Icons.Plus className="mr-1 h-3 w-3" />
-                      Enable Historical Source
-                    </Button>
-                  </div>
-                ) : (
-                  <div>
-                    <div className="mb-3 flex items-center justify-between">
-                      <p className="text-muted-foreground text-xs">
-                        Source for fetching historical price data (JSON, HTML table, or CSV).
-                      </p>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="sm"
-                        className="text-muted-foreground h-6 text-xs"
-                        onClick={() => {
-                          form.setValue("historicalEnabled", false);
-                          form.setValue("historicalSource", undefined);
-                        }}
-                      >
-                        Disable
-                      </Button>
-                    </div>
-                    <SourceConfigPanel form={form} prefix="historicalSource" isHistorical />
-                  </div>
-                )}
-              </TabsContent>
-
-              {/* Provider identity — inside scroll area, always visible */}
-              <div id="provider-identity" className="mt-4 border-t pt-4">
-                <div className="grid grid-cols-1 gap-3 sm:grid-cols-[1fr_140px_80px]">
-                  <FormField
-                    control={form.control}
-                    name="name"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>
-                          Provider Name
-                          {!nameManuallyEdited && !isEditing && form.getValues("name") && (
-                            <span className="text-muted-foreground ml-1 font-normal">
-                              (from URL)
-                            </span>
-                          )}
-                        </FormLabel>
-                        <FormControl>
-                          <Input
-                            placeholder="e.g. My Provider"
-                            {...field}
-                            onChange={(e) => handleNameChange(e.target.value, field.onChange)}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
+              {sourceMode === "both" && (
+                <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                  <SubPill
+                    selected={subTab === "latest"}
+                    label="Latest price"
+                    configured={latestConfigured}
+                    onClick={() => setSubTab("latest")}
                   />
-                  <FormField
-                    control={form.control}
-                    name="code"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>
-                          Code <span className="text-muted-foreground font-normal">(auto)</span>
-                        </FormLabel>
-                        <FormControl>
-                          <Input
-                            placeholder="my-provider"
-                            disabled={isEditing}
-                            {...field}
-                            onChange={(e) => {
-                              setCodeManuallyEdited(true);
-                              field.onChange(e.target.value);
-                            }}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name="priority"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Priority</FormLabel>
-                        <FormControl>
-                          <Input type="number" min={1} {...field} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
+                  <SubPill
+                    selected={subTab === "historical"}
+                    label="Historical"
+                    configured={historicalConfigured}
+                    onClick={() => setSubTab("historical")}
                   />
                 </div>
-                <Collapsible open={descriptionOpen} onOpenChange={setDescriptionOpen}>
-                  <CollapsibleTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="sm"
-                      className="text-muted-foreground mt-2 h-8"
-                    >
-                      <Icons.FileText className="mr-1 h-3 w-3" />
-                      Description
-                      <Icons.ChevronDown
-                        className={`ml-1 h-3 w-3 transition-transform ${descriptionOpen ? "rotate-180" : ""}`}
-                      />
-                    </Button>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent>
-                    <FormField
-                      control={form.control}
-                      name="description"
-                      render={({ field }) => (
-                        <FormItem className="mt-2">
-                          <FormControl>
-                            <Textarea rows={2} placeholder="Optional description" {...field} />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                  </CollapsibleContent>
-                </Collapsible>
-              </div>
-            </div>
-          </Tabs>
+              )}
 
-          {/* Footer — fixed at bottom */}
-          <div className="flex shrink-0 justify-end gap-3 border-t pt-3">
+              {form.formState.errors.latestEnabled?.message && (
+                <p className="text-destructive mt-2 text-xs">
+                  {form.formState.errors.latestEnabled.message}
+                </p>
+              )}
+            </div>
+
+            {/* Step 1 + 2 */}
+            <SourceConfigPanel
+              form={form}
+              prefix={activePrefix}
+              runtime={activeRuntime}
+              onUrlChange={handleUrlChange}
+            />
+
+            {/* Step 3 — Provider identity */}
+            <div id="provider-identity-card" className="bg-background rounded-xl border p-4">
+              <div className="mb-3 flex items-center gap-2.5">
+                <div className="bg-muted text-muted-foreground flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-semibold">
+                  3
+                </div>
+                <h3 className="text-sm font-semibold">Provider identity</h3>
+              </div>
+
+              <div className="grid grid-cols-1 gap-3 sm:grid-cols-[1fr_140px_80px]">
+                <FormField
+                  control={form.control}
+                  name="name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="text-muted-foreground text-[11px] font-medium uppercase tracking-wide">
+                        Provider name
+                        {!nameManuallyEdited && !isEditing && form.getValues("name") && (
+                          <span className="text-muted-foreground ml-1 font-normal normal-case tracking-normal">
+                            (from URL)
+                          </span>
+                        )}
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="e.g. My Provider"
+                          {...field}
+                          onChange={(e) => handleNameChange(e.target.value, field.onChange)}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="code"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="text-muted-foreground text-[11px] font-medium uppercase tracking-wide">
+                        Code <span className="font-normal normal-case tracking-normal">(auto)</span>
+                      </FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder="my-provider"
+                          disabled={isEditing}
+                          {...field}
+                          onChange={(e) => {
+                            setCodeManuallyEdited(true);
+                            field.onChange(e.target.value);
+                          }}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="priority"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="text-muted-foreground text-[11px] font-medium uppercase tracking-wide">
+                        Priority
+                      </FormLabel>
+                      <FormControl>
+                        <Input type="number" min={1} {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItem className="mt-3">
+                    <FormLabel className="text-muted-foreground text-[11px] font-medium uppercase tracking-wide">
+                      Description{" "}
+                      <span className="font-normal normal-case tracking-normal">· optional</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Textarea
+                        rows={2}
+                        placeholder="Short note — what this provider covers, caveats, etc."
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          </div>
+
+          {/* RIGHT pane */}
+          <div className="min-h-0 overflow-hidden">
+            <LivePreviewPane form={form} prefix={activePrefix} runtime={activeRuntime} />
+          </div>
+        </div>
+
+        {/* ── Footer ── */}
+        <div className="bg-background flex shrink-0 items-center justify-between gap-3 border-t px-5 py-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <ChecklistItem done={checklist.urlTemplate} label="URL template" />
+            <ChecklistItem done={checklist.fetchSucceeds} label="Fetch succeeds" />
+            <ChecklistItem done={checklist.requiredFieldsMapped} label="Required fields mapped" />
+            <ChecklistItem done={checklist.providerName} label="Provider name" />
+          </div>
+          <div className="flex gap-2">
             <Button
               type="button"
               variant="ghost"
@@ -522,18 +671,143 @@ function CustomProviderFormContent({
             </Button>
             <Button type="submit" disabled={isSaving}>
               {isSaving ? (
-                <span className="flex items-center gap-2">
-                  <Icons.Spinner className="h-4 w-4 animate-spin" /> Saving
-                </span>
-              ) : isEditing ? (
-                "Save Changes"
+                <>
+                  <Icons.Spinner className="mr-1.5 h-4 w-4 animate-spin" />
+                  Saving
+                </>
               ) : (
-                "Create Provider"
+                <>
+                  <Icons.Check className="mr-1.5 h-4 w-4" />
+                  {isEditing ? "Save changes" : "Create provider"}
+                </>
               )}
             </Button>
           </div>
-        </form>
-      </Form>
-    </>
+        </div>
+      </form>
+    </Form>
   );
+}
+
+// ---------------------------------------------------------------------------
+// Small presentational helpers
+// ---------------------------------------------------------------------------
+
+function ModeCard({
+  selected,
+  icon,
+  title,
+  subtitle,
+  onClick,
+}: {
+  selected: boolean;
+  icon: React.ReactNode;
+  title: string;
+  subtitle: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex items-center gap-2 rounded-lg border p-3 text-left transition-all",
+        selected
+          ? "bg-background border-foreground/30 ring-foreground/5 shadow-sm ring-1"
+          : "bg-background/50 border-border hover:bg-background",
+      )}
+    >
+      <div
+        className={cn(
+          "flex h-4 w-4 shrink-0 items-center justify-center rounded-full border",
+          selected ? "border-foreground bg-foreground" : "border-muted-foreground/40",
+        )}
+      >
+        {selected && <div className="bg-background h-1.5 w-1.5 rounded-full" />}
+      </div>
+      {icon}
+      <span className="min-w-0 flex-1">
+        <span className="block text-sm font-medium">{title}</span>
+        <span className="text-muted-foreground block text-xs">{subtitle}</span>
+      </span>
+    </button>
+  );
+}
+
+function SubPill({
+  selected,
+  label,
+  configured,
+  onClick,
+}: {
+  selected: boolean;
+  label: string;
+  configured: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "flex items-center justify-center gap-2 rounded-lg border px-3 py-2 text-xs transition-colors",
+        selected
+          ? "bg-background border-foreground/30 shadow-sm"
+          : "bg-background/30 text-muted-foreground hover:bg-background/60",
+      )}
+    >
+      <span
+        className={cn(
+          "h-1.5 w-1.5 rounded-full",
+          configured ? "bg-success" : "bg-muted-foreground/40",
+        )}
+      />
+      <span className="font-medium">{label}</span>
+    </button>
+  );
+}
+
+function ChecklistItem({ done, label }: { done: boolean; label: string }) {
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center gap-1.5 text-xs",
+        done ? "text-foreground" : "text-muted-foreground",
+      )}
+    >
+      {done ? (
+        <Icons.CheckCircle className="text-success h-4 w-4 shrink-0" />
+      ) : (
+        <Icons.Circle className="text-muted-foreground/40 h-4 w-4 shrink-0" />
+      )}
+      {label}
+    </div>
+  );
+}
+
+/** Walk react-hook-form's nested error object, return human-readable messages with field paths. */
+function collectErrorMessages(errors: unknown, path = ""): string[] {
+  if (!errors || typeof errors !== "object") return [];
+  const out: string[] = [];
+  const record = errors as Record<string, unknown>;
+  // react-hook-form marks leaf errors with a `message` string and a `type`.
+  if (typeof record.message === "string" && record.message.length > 0) {
+    return [path ? `${path}: ${record.message}` : record.message];
+  }
+  for (const [k, v] of Object.entries(record)) {
+    if (k === "ref" || k === "type") continue;
+    const nextPath = path ? `${path}.${k}` : k;
+    out.push(...collectErrorMessages(v, nextPath));
+  }
+  return out;
+}
+
+function isSubConfigured(
+  form: ReturnType<typeof useForm<FormValues>>,
+  prefix: SourceKey,
+  runtime: SourceRuntime,
+): boolean {
+  const url = form.getValues(`${prefix}.url`);
+  const price = form.getValues(`${prefix}.pricePath`);
+  return !!url && !!price && (runtime.status?.ok === true || !!runtime.testResult?.success);
 }

--- a/apps/frontend/src/pages/settings/market-data/json-path-suggestions.tsx
+++ b/apps/frontend/src/pages/settings/market-data/json-path-suggestions.tsx
@@ -7,6 +7,9 @@
 export interface PathEntry {
   path: string;
   value: number;
+  /** Original source-string form if this entry came from a stringified number
+   *  (e.g. "105.90"). Preserves trailing zeros so downstream text lookups match. */
+  raw?: string;
 }
 
 /** Recursively collect all numeric leaf paths from a parsed JSON value.
@@ -18,7 +21,7 @@ export function walkJson(value: unknown, path = "$"): PathEntry[] {
   }
   if (typeof value === "string") {
     const n = parseFloat(value);
-    if (!isNaN(n) && isFinite(n)) return [{ path, value: n }];
+    if (!isNaN(n) && isFinite(n)) return [{ path, value: n, raw: value }];
     return [];
   }
   if (Array.isArray(value)) {

--- a/apps/frontend/src/pages/settings/market-data/live-preview-pane.tsx
+++ b/apps/frontend/src/pages/settings/market-data/live-preview-pane.tsx
@@ -118,7 +118,7 @@ function StatusPill({
     return (
       <span className="text-success border-success/40 bg-success/10 inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border px-3 py-1 text-xs">
         <span className="bg-success h-1.5 w-1.5 rounded-full" />
-        200 OK
+        {status.code} OK
       </span>
     );
   }
@@ -379,41 +379,29 @@ function HtmlElementsResponse({ runtime }: { runtime: SourceRuntime }) {
         {runtime.armedField ? ` to ${labelForField(runtime.armedField)}` : ""}.
       </p>
       <div className="max-h-[420px] space-y-2 overflow-y-auto">
-        {list.map((el) => {
-          const field = runtime.armedField ?? "pricePath";
-          const selected =
-            form_value_equals(runtime, field, el.selector) && runtime.armedField === field;
-          return (
-            <button
-              key={el.selector}
-              type="button"
-              onClick={() =>
-                runtime.handlePathSelect(el.selector, runtime.armedField ?? "pricePath")
-              }
-              className={cn(
-                "group flex w-full items-start gap-3 rounded-lg border p-3 text-left transition-all",
-                selected
-                  ? "bg-background border-foreground/30 ring-foreground/5 shadow-sm ring-1"
-                  : "bg-background hover:bg-muted/30",
+        {list.map((el) => (
+          <button
+            key={el.selector}
+            type="button"
+            onClick={() => runtime.handlePathSelect(el.selector, runtime.armedField ?? "pricePath")}
+            className="bg-background hover:bg-muted/30 group flex w-full items-start gap-3 rounded-lg border p-3 text-left transition-all"
+          >
+            <div className="min-w-0 flex-1 space-y-1">
+              <code className="bg-muted/60 inline-block max-w-full truncate rounded px-1.5 py-0.5 font-mono text-[11px]">
+                {el.selector}
+              </code>
+              {el.label && <p className="text-muted-foreground text-[11px]">{el.label}</p>}
+              {el.htmlContext && (
+                <pre className="bg-muted/40 text-muted-foreground/80 mt-1.5 overflow-x-auto rounded p-2 font-mono text-[10px] leading-relaxed">
+                  {el.htmlContext}
+                </pre>
               )}
-            >
-              <div className="min-w-0 flex-1 space-y-1">
-                <code className="bg-muted/60 inline-block max-w-full truncate rounded px-1.5 py-0.5 font-mono text-[11px]">
-                  {el.selector}
-                </code>
-                {el.label && <p className="text-muted-foreground text-[11px]">{el.label}</p>}
-                {el.htmlContext && (
-                  <pre className="bg-muted/40 text-muted-foreground/80 mt-1.5 overflow-x-auto rounded p-2 font-mono text-[10px] leading-relaxed">
-                    {el.htmlContext}
-                  </pre>
-                )}
-              </div>
-              <span className="shrink-0 pt-0.5 font-mono text-base font-semibold tabular-nums">
-                {formatNumber(el.value)}
-              </span>
-            </button>
-          );
-        })}
+            </div>
+            <span className="shrink-0 pt-0.5 font-mono text-base font-semibold tabular-nums">
+              {formatNumber(el.value)}
+            </span>
+          </button>
+        ))}
       </div>
       {hasMore && !showAll && (
         <button
@@ -426,12 +414,6 @@ function HtmlElementsResponse({ runtime }: { runtime: SourceRuntime }) {
       )}
     </div>
   );
-}
-
-function form_value_equals(_runtime: SourceRuntime, _f: MappingField, _v: string): boolean {
-  // runtime doesn't carry form snapshots; kept as placeholder hook — always false.
-  // Selection highlighting is visually handled by the FieldMapping rows below.
-  return false;
 }
 
 function formatNumber(n: number): string {
@@ -805,6 +787,58 @@ export function LivePreviewPane({ form, prefix, runtime }: LivePreviewPaneProps)
                   display={
                     runtime.testResult.date ? (
                       <span className="font-mono text-xs">{runtime.testResult.date}</span>
+                    ) : null
+                  }
+                />
+              )}
+              {values.openPath && (
+                <ExtractedRow
+                  color="bg-yellow-500"
+                  label="Open"
+                  display={
+                    runtime.testResult.open != null ? (
+                      <span className="tabular-nums">
+                        {runtime.testResult.open.toLocaleString()}
+                      </span>
+                    ) : null
+                  }
+                />
+              )}
+              {values.highPath && (
+                <ExtractedRow
+                  color="bg-orange-500"
+                  label="High"
+                  display={
+                    runtime.testResult.high != null ? (
+                      <span className="tabular-nums">
+                        {runtime.testResult.high.toLocaleString()}
+                      </span>
+                    ) : null
+                  }
+                />
+              )}
+              {values.lowPath && (
+                <ExtractedRow
+                  color="bg-rose-500"
+                  label="Low"
+                  display={
+                    runtime.testResult.low != null ? (
+                      <span className="tabular-nums">
+                        {runtime.testResult.low.toLocaleString()}
+                      </span>
+                    ) : null
+                  }
+                />
+              )}
+              {values.volumePath && (
+                <ExtractedRow
+                  color="bg-violet-500"
+                  label="Volume"
+                  display={
+                    runtime.testResult.volume != null ? (
+                      <span className="tabular-nums">
+                        {runtime.testResult.volume.toLocaleString()}
+                      </span>
                     ) : null
                   }
                 />

--- a/apps/frontend/src/pages/settings/market-data/live-preview-pane.tsx
+++ b/apps/frontend/src/pages/settings/market-data/live-preview-pane.tsx
@@ -1,0 +1,906 @@
+import { useMemo, useState } from "react";
+import { type UseFormReturn } from "react-hook-form";
+
+import { Button } from "@wealthfolio/ui/components/ui/button";
+import { Icons } from "@wealthfolio/ui/components/ui/icons";
+import { Input } from "@wealthfolio/ui/components/ui/input";
+import { Label } from "@wealthfolio/ui/components/ui/label";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@wealthfolio/ui/components/ui/collapsible";
+
+import type { DetectedHtmlTable } from "@/lib/types/custom-provider";
+import { cn } from "@/lib/utils";
+
+import { RawResponseViewer } from "./response-preview";
+import type { FormValues, SourceKey } from "./custom-provider-form";
+import type { MappingField, SourceRuntime } from "./use-source-runtime";
+
+interface LivePreviewPaneProps {
+  form: UseFormReturn<FormValues>;
+  prefix: SourceKey;
+  runtime: SourceRuntime;
+}
+
+const MAPPING_META: {
+  field: MappingField;
+  label: string;
+  color: string;
+  required: boolean;
+}[] = [
+  { field: "pricePath", label: "Price", color: "bg-emerald-500", required: true },
+  { field: "datePath", label: "As of", color: "bg-sky-500", required: false },
+  { field: "currencyPath", label: "Currency", color: "bg-amber-500", required: false },
+  { field: "openPath", label: "Open", color: "bg-yellow-500", required: false },
+  { field: "highPath", label: "High", color: "bg-orange-500", required: false },
+  { field: "lowPath", label: "Low", color: "bg-rose-500", required: false },
+  { field: "volumePath", label: "Volume", color: "bg-violet-500", required: false },
+];
+
+/** Inline chips replacing placeholders in the preview URL. */
+function PreviewUrl({ template, values }: { template: string; values: Record<string, string> }) {
+  const segments = useMemo(() => {
+    if (!template) return [];
+    const re = /\{([A-Za-z:%\-_]+)\}/g;
+    const out: { kind: "text" | "chip"; text: string; value?: string }[] = [];
+    let last = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(template))) {
+      if (m.index > last) out.push({ kind: "text", text: template.slice(last, m.index) });
+      const key = m[1];
+      const value = values[key] || values[key.toUpperCase()];
+      out.push({ kind: "chip", text: key, value });
+      last = m.index + m[0].length;
+    }
+    if (last < template.length) out.push({ kind: "text", text: template.slice(last) });
+    return out;
+  }, [template, values]);
+
+  if (!template) {
+    return (
+      <span className="text-muted-foreground/60 font-mono text-xs italic">
+        Enter a URL template to preview the request…
+      </span>
+    );
+  }
+
+  return (
+    <span className="break-all font-mono text-xs">
+      {segments.map((seg, i) =>
+        seg.kind === "text" ? (
+          <span key={i}>{seg.text}</span>
+        ) : (
+          <span
+            key={i}
+            className={cn(
+              "mx-0.5 inline-flex items-center rounded border px-1 py-0.5 font-mono text-[11px]",
+              seg.value
+                ? "border-primary/30 bg-primary/10 text-primary"
+                : "border-muted-foreground/40 bg-muted text-muted-foreground border-dashed",
+            )}
+          >
+            {seg.value || `{${seg.text}}`}
+          </span>
+        ),
+      )}
+    </span>
+  );
+}
+
+function StatusPill({
+  isFetching,
+  status,
+  error,
+}: {
+  isFetching: boolean;
+  status: { code: number; ok: boolean } | null;
+  error: string | null;
+}) {
+  if (isFetching) {
+    return (
+      <span className="text-muted-foreground inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border px-3 py-1 text-xs">
+        <Icons.Spinner className="h-3 w-3 animate-spin" />
+        Fetching
+      </span>
+    );
+  }
+  if (error || status?.ok === false) {
+    return (
+      <span className="text-destructive border-destructive/40 bg-destructive/10 inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border px-3 py-1 text-xs">
+        <span className="bg-destructive h-1.5 w-1.5 rounded-full" />
+        Error
+      </span>
+    );
+  }
+  if (status?.ok) {
+    return (
+      <span className="text-success border-success/40 bg-success/10 inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border px-3 py-1 text-xs">
+        <span className="bg-success h-1.5 w-1.5 rounded-full" />
+        200 OK
+      </span>
+    );
+  }
+  return (
+    <span className="text-muted-foreground inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full border px-3 py-1 text-xs">
+      <span className="bg-muted-foreground/40 h-1.5 w-1.5 rounded-full" />
+      Idle
+    </span>
+  );
+}
+
+function EmptyResponseState() {
+  return (
+    <div className="flex min-h-[220px] flex-col items-center justify-center gap-3 rounded-xl border border-dashed p-6 text-center">
+      <Icons.Target className="text-muted-foreground/40 h-6 w-6" />
+      <div className="space-y-1">
+        <p className="text-muted-foreground text-sm">
+          Fill in the URL, then press{" "}
+          <span className="bg-muted rounded px-1.5 py-0.5 font-mono text-[11px]">Fetch</span> to
+          test.
+        </p>
+        <p className="text-muted-foreground/70 text-xs">
+          Response previews appear here, and you can click any value to map it.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+const ROLE_COLOR: Record<string, string> = {
+  close: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
+  date: "bg-sky-500/15 text-sky-600 dark:text-sky-400",
+  high: "bg-orange-500/15 text-orange-600 dark:text-orange-400",
+  low: "bg-rose-500/15 text-rose-600 dark:text-rose-400",
+  volume: "bg-violet-500/15 text-violet-600 dark:text-violet-400",
+  open: "bg-amber-500/15 text-amber-600 dark:text-amber-400",
+};
+
+const COLUMN_ROLE_TO_FIELD: Partial<Record<string, MappingField>> = {
+  close: "pricePath",
+  date: "datePath",
+  open: "openPath",
+  high: "highPath",
+  low: "lowPath",
+  volume: "volumePath",
+};
+
+function HtmlTableResponse({
+  tables,
+  runtime,
+}: {
+  tables: DetectedHtmlTable[];
+  runtime: SourceRuntime;
+}) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const table = tables[activeIndex] ?? tables[0];
+  if (!table) return null;
+
+  const handleHeaderClick = (colIndex: number, role?: string) => {
+    const tableIdx = table.index;
+    const cellPath = `${tableIdx}:${colIndex}`;
+    if (runtime.armedField) {
+      runtime.handlePathSelect(cellPath, runtime.armedField);
+      return;
+    }
+    const field = role ? COLUMN_ROLE_TO_FIELD[role] : undefined;
+    runtime.handlePathSelect(cellPath, field ?? "pricePath");
+  };
+
+  // When switching tables, rewrite the table-index prefix of any existing
+  // mappings so they target the new table (keeping the same column).
+  const handleSwitchTable = (newIndex: number) => {
+    const prev = tables[activeIndex];
+    const next = tables[newIndex];
+    if (!prev || !next || prev.index === next.index) {
+      setActiveIndex(newIndex);
+      return;
+    }
+    runtime.remapTableIndex(prev.index, next.index);
+    setActiveIndex(newIndex);
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Table selector — shown always when html_table, as a legend + switcher */}
+      <div className="flex flex-wrap items-center gap-1">
+        <span className="text-muted-foreground mr-1 text-[11px] font-medium uppercase tracking-wide">
+          Table
+        </span>
+        {tables.map((t, i) => (
+          <button
+            key={t.index}
+            type="button"
+            onClick={() => handleSwitchTable(i)}
+            className={cn(
+              "rounded-md border px-2 py-0.5 text-xs transition-colors",
+              i === activeIndex
+                ? "bg-background border-foreground/30 shadow-sm"
+                : "bg-muted/30 text-muted-foreground hover:bg-muted/50 border-transparent",
+            )}
+            title={`${t.columns.length} cols · ${t.rowCount} rows`}
+          >
+            {i + 1}
+          </button>
+        ))}
+        <span className="text-muted-foreground ml-auto text-xs">
+          {table.rowCount} rows · click a column header to map
+          {runtime.armedField ? ` to ${labelForField(runtime.armedField)}` : ""}
+        </span>
+      </div>
+
+      <div className="bg-background max-h-[420px] overflow-auto rounded-lg border">
+        <table className="w-full text-xs">
+          <thead className="bg-muted/40 sticky top-0">
+            <tr>
+              {table.columns.map((col) => (
+                <th key={col.index} className="px-3 py-2 text-left">
+                  <button
+                    type="button"
+                    onClick={() => handleHeaderClick(col.index, col.role)}
+                    className="hover:text-foreground group flex flex-col items-start gap-1 text-left"
+                  >
+                    <span className="text-foreground text-xs font-medium">
+                      {col.header || `Col ${col.index}`}
+                    </span>
+                    {col.role && (
+                      <span
+                        className={cn(
+                          "rounded px-1.5 py-0.5 text-[10px] font-medium",
+                          ROLE_COLOR[col.role] ?? "bg-muted text-muted-foreground",
+                        )}
+                      >
+                        {col.role}
+                      </span>
+                    )}
+                  </button>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {table.sampleRows.slice(0, 8).map((row, ri) => (
+              <tr key={ri} className="border-t">
+                {row.map((cell, ci) => (
+                  <td key={ci} className="text-muted-foreground px-3 py-1.5 font-mono text-[11px]">
+                    {cell}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function CsvResponse({ raw, runtime }: { raw: string; runtime: SourceRuntime }) {
+  const { headers, rows } = useMemo(() => parseCsv(raw), [raw]);
+  if (headers.length === 0) {
+    return (
+      <pre className="bg-background max-h-[420px] overflow-auto whitespace-pre-wrap rounded-lg border p-3 font-mono text-xs">
+        {raw.slice(0, 3000)}
+      </pre>
+    );
+  }
+
+  const handleHeaderClick = (name: string) => {
+    const field = runtime.armedField ?? inferCsvFieldFromHeader(name);
+    runtime.handlePathSelect(name, field);
+  };
+
+  return (
+    <div className="space-y-2">
+      <p className="text-muted-foreground text-xs">
+        {rows.length} rows detected. Click a column header to map it
+        {runtime.armedField ? ` to ${labelForField(runtime.armedField)}` : ""}.
+      </p>
+      <div className="bg-background max-h-[420px] overflow-auto rounded-lg border">
+        <table className="w-full text-xs">
+          <thead className="bg-muted/40 sticky top-0">
+            <tr>
+              {headers.map((h) => (
+                <th key={h} className="px-3 py-2 text-left">
+                  <button
+                    type="button"
+                    onClick={() => handleHeaderClick(h)}
+                    className="text-foreground hover:text-primary text-xs font-medium"
+                  >
+                    {h}
+                  </button>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.slice(0, 8).map((row, ri) => (
+              <tr key={ri} className="border-t">
+                {headers.map((h) => (
+                  <td key={h} className="text-muted-foreground px-3 py-1.5 font-mono text-[11px]">
+                    {row[h]}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+function parseCsv(raw: string): {
+  headers: string[];
+  rows: Record<string, string>[];
+} {
+  const lines = raw.split(/\r?\n/).filter((l) => l.length > 0);
+  if (lines.length === 0) return { headers: [], rows: [] };
+  const delim = lines[0].includes(";") && !lines[0].includes(",") ? ";" : ",";
+  const split = (line: string) => line.split(delim).map((c) => c.trim().replace(/^"|"$/g, ""));
+  const headers = split(lines[0]);
+  const rows = lines.slice(1, 30).map((l) => {
+    const cells = split(l);
+    const obj: Record<string, string> = {};
+    headers.forEach((h, i) => {
+      obj[h] = cells[i] ?? "";
+    });
+    return obj;
+  });
+  return { headers, rows };
+}
+
+function inferCsvFieldFromHeader(h: string): MappingField {
+  const k = h.toLowerCase();
+  if (k.includes("date") || k.includes("time")) return "datePath";
+  if (k.includes("open")) return "openPath";
+  if (k.includes("high")) return "highPath";
+  if (k.includes("low")) return "lowPath";
+  if (k.includes("volume") || k.includes("vol")) return "volumePath";
+  if (k.includes("currency") || k === "ccy") return "currencyPath";
+  return "pricePath";
+}
+
+function labelForField(f: MappingField): string {
+  return MAPPING_META.find((m) => m.field === f)?.label ?? f;
+}
+
+function HtmlElementsResponse({ runtime }: { runtime: SourceRuntime }) {
+  const [showAll, setShowAll] = useState(false);
+  const max = 10;
+  const list = showAll ? runtime.detectedElements : runtime.detectedElements.slice(0, max);
+  const hasMore = runtime.detectedElements.length > max;
+
+  return (
+    <div className="space-y-2">
+      <p className="text-muted-foreground text-xs">
+        {runtime.detectedElements.length} elements detected. Click one to assign its selector
+        {runtime.armedField ? ` to ${labelForField(runtime.armedField)}` : ""}.
+      </p>
+      <div className="max-h-[420px] space-y-2 overflow-y-auto">
+        {list.map((el) => {
+          const field = runtime.armedField ?? "pricePath";
+          const selected =
+            form_value_equals(runtime, field, el.selector) && runtime.armedField === field;
+          return (
+            <button
+              key={el.selector}
+              type="button"
+              onClick={() =>
+                runtime.handlePathSelect(el.selector, runtime.armedField ?? "pricePath")
+              }
+              className={cn(
+                "group flex w-full items-start gap-3 rounded-lg border p-3 text-left transition-all",
+                selected
+                  ? "bg-background border-foreground/30 ring-foreground/5 shadow-sm ring-1"
+                  : "bg-background hover:bg-muted/30",
+              )}
+            >
+              <div className="min-w-0 flex-1 space-y-1">
+                <code className="bg-muted/60 inline-block max-w-full truncate rounded px-1.5 py-0.5 font-mono text-[11px]">
+                  {el.selector}
+                </code>
+                {el.label && <p className="text-muted-foreground text-[11px]">{el.label}</p>}
+                {el.htmlContext && (
+                  <pre className="bg-muted/40 text-muted-foreground/80 mt-1.5 overflow-x-auto rounded p-2 font-mono text-[10px] leading-relaxed">
+                    {el.htmlContext}
+                  </pre>
+                )}
+              </div>
+              <span className="shrink-0 pt-0.5 font-mono text-base font-semibold tabular-nums">
+                {formatNumber(el.value)}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+      {hasMore && !showAll && (
+        <button
+          type="button"
+          onClick={() => setShowAll(true)}
+          className="text-muted-foreground hover:text-foreground text-xs underline underline-offset-2"
+        >
+          Show {runtime.detectedElements.length - max} more elements
+        </button>
+      )}
+    </div>
+  );
+}
+
+function form_value_equals(_runtime: SourceRuntime, _f: MappingField, _v: string): boolean {
+  // runtime doesn't carry form snapshots; kept as placeholder hook — always false.
+  // Selection highlighting is visually handled by the FieldMapping rows below.
+  return false;
+}
+
+function formatNumber(n: number): string {
+  if (Math.abs(n) >= 1000) return n.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  if (n !== Math.floor(n)) return n.toLocaleString(undefined, { maximumFractionDigits: 6 });
+  return String(n);
+}
+
+function CopyButton({ text, disabled }: { text: string; disabled?: boolean }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = async () => {
+    if (disabled || !text) return;
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // clipboard API unavailable — silently ignore
+    }
+  };
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      disabled={disabled}
+      title={copied ? "Copied!" : "Copy URL"}
+      className="text-muted-foreground hover:text-foreground hover:bg-muted/50 absolute right-1.5 top-1.5 flex h-7 w-7 items-center justify-center rounded-md transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+    >
+      {copied ? (
+        <Icons.Check className="text-success h-3.5 w-3.5" />
+      ) : (
+        <Icons.Copy className="h-3.5 w-3.5" />
+      )}
+    </button>
+  );
+}
+
+function ExtractedRow({
+  color,
+  label,
+  display,
+}: {
+  color: string;
+  label: string;
+  display: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-3 px-3 py-2">
+      <span className={cn("h-2 w-2 shrink-0 rounded-sm", color)} />
+      <span className="text-muted-foreground w-16 shrink-0 text-xs font-medium uppercase tracking-wide">
+        {label}
+      </span>
+      <span className="text-foreground min-w-0 flex-1 truncate text-sm font-semibold">
+        {display ?? <span className="text-muted-foreground/60 italic">— not returned</span>}
+      </span>
+      {display && <Icons.CheckCircle className="text-success h-3.5 w-3.5 shrink-0" />}
+    </div>
+  );
+}
+
+function TestField({
+  label,
+  className,
+  children,
+}: {
+  label: string;
+  className?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={cn("space-y-1", className)}>
+      <Label className="text-muted-foreground text-[11px] font-medium uppercase tracking-wide">
+        {label}
+      </Label>
+      {children}
+    </div>
+  );
+}
+
+function FieldMappingRow({
+  field,
+  label,
+  color,
+  required,
+  value,
+  armed,
+  onArm,
+}: {
+  field: MappingField;
+  label: string;
+  color: string;
+  required: boolean;
+  value: string | undefined;
+  armed: boolean;
+  onArm: () => void;
+}) {
+  const assigned = !!value;
+  return (
+    <button
+      type="button"
+      onClick={onArm}
+      className={cn(
+        "flex w-full items-center gap-3 rounded-lg border p-2.5 text-left transition-all",
+        armed
+          ? "bg-background border-foreground/30 ring-foreground/5 shadow-sm ring-1"
+          : "bg-background hover:bg-muted/30",
+      )}
+      data-field={field}
+    >
+      <span className={cn("h-2.5 w-2.5 shrink-0 rounded-sm", color)} />
+      <span className="shrink-0 text-sm font-medium">{label}</span>
+      <span
+        className={cn(
+          "ml-1 h-1.5 w-1.5 shrink-0 rounded-full",
+          assigned ? "bg-success" : armed ? "bg-primary" : "bg-muted-foreground/30",
+        )}
+      />
+      <span
+        className={cn(
+          "min-w-0 flex-1 truncate font-mono text-xs",
+          assigned ? "text-foreground" : "text-muted-foreground/70 italic",
+        )}
+      >
+        {assigned ? value : "unassigned — click to pick"}
+      </span>
+      {required ? (
+        <span
+          className={cn(
+            "shrink-0 text-[10px] font-medium uppercase tracking-wide",
+            assigned ? "text-muted-foreground" : "text-destructive",
+          )}
+        >
+          Required
+        </span>
+      ) : (
+        <span className="text-muted-foreground shrink-0 text-[10px] font-medium uppercase tracking-wide">
+          Optional
+        </span>
+      )}
+    </button>
+  );
+}
+
+export function LivePreviewPane({ form, prefix, runtime }: LivePreviewPaneProps) {
+  const [moreFieldsOpen, setMoreFieldsOpen] = useState(false);
+  const format = form.watch(`${prefix}.format`) ?? "json";
+  const pricePath = form.watch(`${prefix}.pricePath`);
+  const datePath = form.watch(`${prefix}.datePath`);
+  const currencyPath = form.watch(`${prefix}.currencyPath`);
+  const openPath = form.watch(`${prefix}.openPath`);
+  const highPath = form.watch(`${prefix}.highPath`);
+  const lowPath = form.watch(`${prefix}.lowPath`);
+  const volumePath = form.watch(`${prefix}.volumePath`);
+
+  const values: Record<MappingField, string | undefined> = {
+    pricePath,
+    datePath,
+    currencyPath,
+    openPath,
+    highPath,
+    lowPath,
+    volumePath,
+  };
+
+  const { inputs, setInputs, extraPlaceholders, isHistorical } = runtime;
+  const previewCurrency = inputs.currency.trim() || "USD";
+
+  const previewValues: Record<string, string> = {
+    SYMBOL: inputs.symbol,
+    ISIN: inputs.isin,
+    MIC: inputs.mic,
+    CURRENCY: previewCurrency.toUpperCase(),
+    currency: previewCurrency.toLowerCase(),
+    TODAY: new Date().toISOString().slice(0, 10),
+    FROM: inputs.from,
+    TO: inputs.to,
+  };
+
+  const missingRange = isHistorical && (!inputs.from || !inputs.to);
+  const fetchDisabled =
+    runtime.isFetching || !inputs.symbol || missingRange || !runtime.urlTemplate;
+
+  const formatLabel = format.toUpperCase().replace("_", " ");
+
+  return (
+    <div className="flex h-full flex-col gap-4 overflow-y-auto p-5">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-0.5">
+          <h3 className="text-base font-semibold">Live request &amp; response</h3>
+          <p className="text-muted-foreground text-xs">
+            Every change reflects here instantly. Click any value below to map it.
+          </p>
+        </div>
+        <StatusPill
+          isFetching={runtime.isFetching}
+          status={runtime.status}
+          error={runtime.fetchError}
+        />
+      </div>
+
+      {/* Request URL preview */}
+      <section className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label className="text-muted-foreground text-[11px] font-medium uppercase tracking-wide">
+            Request URL (preview)
+          </Label>
+          <span className="text-muted-foreground text-[11px]">
+            GET · {isHistorical ? "historical" : "latest"}
+          </span>
+        </div>
+        <div className="bg-background relative min-h-[40px] rounded-lg border px-3 py-2 pr-10">
+          <PreviewUrl template={runtime.urlTemplate} values={previewValues} />
+          <CopyButton text={runtime.expandedUrl} disabled={!runtime.urlTemplate} />
+        </div>
+      </section>
+
+      {/* Test inputs */}
+      <section className="space-y-2">
+        <div className="flex flex-wrap items-end gap-2">
+          <TestField label="Test symbol" className="min-w-[140px] flex-1">
+            <Input
+              placeholder="e.g. AAPL"
+              value={inputs.symbol}
+              onChange={(e) => setInputs({ symbol: e.target.value })}
+            />
+          </TestField>
+          {extraPlaceholders.isin && (
+            <TestField label="ISIN" className="w-28">
+              <Input
+                placeholder="US0378331005"
+                value={inputs.isin}
+                onChange={(e) => setInputs({ isin: e.target.value })}
+              />
+            </TestField>
+          )}
+          {extraPlaceholders.mic && (
+            <TestField label="MIC" className="w-24">
+              <Input
+                placeholder="XLON"
+                value={inputs.mic}
+                onChange={(e) => setInputs({ mic: e.target.value })}
+              />
+            </TestField>
+          )}
+          {extraPlaceholders.currency && (
+            <TestField label="Currency" className="w-20">
+              <Input
+                placeholder="USD"
+                value={inputs.currency}
+                onChange={(e) => setInputs({ currency: e.target.value })}
+              />
+            </TestField>
+          )}
+          {isHistorical && (
+            <>
+              <TestField label="From" className="w-36">
+                <Input
+                  type="date"
+                  value={inputs.from}
+                  onChange={(e) => setInputs({ from: e.target.value })}
+                />
+              </TestField>
+              <TestField label="To" className="w-36">
+                <Input
+                  type="date"
+                  value={inputs.to}
+                  onChange={(e) => setInputs({ to: e.target.value })}
+                />
+              </TestField>
+            </>
+          )}
+          <Button
+            type="button"
+            onClick={runtime.handleFetch}
+            disabled={fetchDisabled}
+            size="sm"
+            className="h-input-height shrink-0"
+          >
+            {runtime.isFetching ? (
+              <Icons.Spinner className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Icons.PlayCircle className="mr-1.5 h-3.5 w-3.5" />
+            )}
+            Fetch
+          </Button>
+        </div>
+      </section>
+
+      {/* Response */}
+      <section className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label className="text-muted-foreground text-[11px] font-medium uppercase tracking-wide">
+            Response · {formatLabel}
+          </Label>
+          {runtime.detectedTables[0] && (
+            <span className="text-muted-foreground text-[11px]">
+              {runtime.detectedTables[0].rowCount} rows · {runtime.detectedTables[0].columns.length}{" "}
+              cols
+            </span>
+          )}
+        </div>
+
+        {runtime.fetchError && !runtime.isFetching ? (
+          <div className="border-destructive/30 bg-destructive/5 rounded-lg border p-3">
+            <div className="flex items-start gap-2">
+              <Icons.XCircle className="text-destructive mt-0.5 h-4 w-4 shrink-0" />
+              <div>
+                <p className="text-destructive text-sm">{runtime.fetchError}</p>
+                {/403|forbidden|denied/i.test(runtime.fetchError) && (
+                  <p className="text-muted-foreground mt-1 text-xs">
+                    This site may block automated requests. Try adding custom headers.
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+        ) : !runtime.hasFetched && !runtime.testResult ? (
+          <EmptyResponseState />
+        ) : format === "html_table" && runtime.detectedTables.length > 0 ? (
+          <HtmlTableResponse tables={runtime.detectedTables} runtime={runtime} />
+        ) : format === "html" && runtime.detectedElements.length > 0 ? (
+          <HtmlElementsResponse runtime={runtime} />
+        ) : format === "csv" && runtime.rawResponse ? (
+          <CsvResponse raw={runtime.rawResponse} runtime={runtime} />
+        ) : format === "json" && runtime.rawResponse ? (
+          <div className="bg-background max-h-[420px] overflow-auto rounded-lg border">
+            <RawResponseViewer
+              rawResponse={runtime.rawResponse}
+              format="json"
+              onPathClick={(p) => runtime.handlePathSelect(p, runtime.armedField ?? "pricePath")}
+            />
+          </div>
+        ) : runtime.rawResponse ? (
+          <div className="bg-background max-h-[420px] overflow-auto rounded-lg border">
+            <RawResponseViewer rawResponse={runtime.rawResponse} format="html" />
+          </div>
+        ) : (
+          <EmptyResponseState />
+        )}
+      </section>
+
+      {/* Extraction preview — verifies the current mapping against the response */}
+      {runtime.testResult && (
+        <section className="space-y-2">
+          <Label className="text-muted-foreground text-[11px] font-medium uppercase tracking-wide">
+            Extracted
+          </Label>
+          {runtime.testResult.success ? (
+            <div className="border-success/30 bg-success/5 divide-success/20 divide-y rounded-lg border">
+              <ExtractedRow
+                color="bg-emerald-500"
+                label="Price"
+                display={
+                  runtime.testResult.price != null ? (
+                    <span className="tabular-nums">
+                      {runtime.testResult.price.toLocaleString()}
+                      {runtime.testResult.currency && (
+                        <span className="text-muted-foreground ml-1.5 text-xs font-normal">
+                          {runtime.testResult.currency}
+                        </span>
+                      )}
+                    </span>
+                  ) : null
+                }
+              />
+              {values.datePath && (
+                <ExtractedRow
+                  color="bg-sky-500"
+                  label="As of"
+                  display={
+                    runtime.testResult.date ? (
+                      <span className="font-mono text-xs">{runtime.testResult.date}</span>
+                    ) : null
+                  }
+                />
+              )}
+              {values.currencyPath && (
+                <ExtractedRow
+                  color="bg-amber-500"
+                  label="Currency"
+                  display={
+                    runtime.testResult.currency ? (
+                      <span className="font-mono text-xs">{runtime.testResult.currency}</span>
+                    ) : null
+                  }
+                />
+              )}
+            </div>
+          ) : (
+            <div className="border-destructive/30 bg-destructive/5 flex items-start gap-3 rounded-lg border p-3">
+              <Icons.XCircle className="text-destructive mt-0.5 h-4 w-4 shrink-0" />
+              <p className="text-muted-foreground min-w-0 flex-1 text-xs">
+                {runtime.testResult.error ?? "Could not extract a value with the current mapping."}
+              </p>
+            </div>
+          )}
+        </section>
+      )}
+
+      {/* Field mapping */}
+      <section className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label className="text-muted-foreground text-[11px] font-medium uppercase tracking-wide">
+            Field mapping ({isHistorical ? "historical" : "latest"})
+          </Label>
+          <span className="text-muted-foreground text-[11px]">
+            click a row to arm it, then click a value in the response
+          </span>
+        </div>
+
+        <div className="space-y-1.5">
+          {MAPPING_META.slice(0, 2).map((m) => (
+            <FieldMappingRow
+              key={m.field}
+              field={m.field}
+              label={m.label}
+              color={m.color}
+              required={m.required}
+              value={values[m.field]}
+              armed={runtime.armedField === m.field}
+              onArm={() => runtime.setArmedField(runtime.armedField === m.field ? null : m.field)}
+            />
+          ))}
+        </div>
+
+        <Collapsible open={moreFieldsOpen} onOpenChange={setMoreFieldsOpen}>
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className="text-muted-foreground hover:text-foreground mt-1 flex items-center gap-1 text-xs"
+            >
+              <Icons.ChevronRight
+                className={cn("h-3 w-3 transition-transform", moreFieldsOpen && "rotate-90")}
+              />
+              More mapping fields
+            </button>
+          </CollapsibleTrigger>
+          <CollapsibleContent className="mt-2 space-y-1.5">
+            {MAPPING_META.slice(2).map((m) => {
+              if (
+                (m.field === "openPath" ||
+                  m.field === "highPath" ||
+                  m.field === "lowPath" ||
+                  m.field === "volumePath") &&
+                format !== "json" &&
+                format !== "csv" &&
+                format !== "html_table"
+              ) {
+                return null;
+              }
+              return (
+                <FieldMappingRow
+                  key={m.field}
+                  field={m.field}
+                  label={m.label}
+                  color={m.color}
+                  required={m.required}
+                  value={values[m.field]}
+                  armed={runtime.armedField === m.field}
+                  onArm={() =>
+                    runtime.setArmedField(runtime.armedField === m.field ? null : m.field)
+                  }
+                />
+              );
+            })}
+          </CollapsibleContent>
+        </Collapsible>
+      </section>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/settings/market-data/provider-templates.ts
+++ b/apps/frontend/src/pages/settings/market-data/provider-templates.ts
@@ -7,6 +7,8 @@ export interface ProviderTemplate {
   url: string;
   pricePath: string;
   datePath?: string;
+  dateFormat?: string;
+  currencyPath?: string;
   openPath?: string;
   highPath?: string;
   lowPath?: string;
@@ -16,6 +18,17 @@ export interface ProviderTemplate {
 }
 
 export const LATEST_TEMPLATES: ProviderTemplate[] = [
+  {
+    name: "Vanguard",
+    description: "Workplace fund prices (fund code)",
+    format: "json",
+    url: "https://workplace.vanguard.com/investments/product-details/fund/api/price-distribution/fundPrice/{SYMBOL}?startDate={DATE:%Y-01-01}&endDate={TODAY}",
+    pricePath: "$.body.fundPrice.content[-1:].price",
+    datePath: "$.body.fundPrice.content[-1:].effectiveDate",
+    dateFormat: "%Y-%m-%d",
+    currencyPath: "$.body.fundPrice.content[-1:].currencyCode",
+    testSymbol: "M219",
+  },
   {
     name: "CoinGecko",
     description: "Free crypto (use coin ID: bitcoin, ethereum...)",
@@ -68,6 +81,17 @@ export const LATEST_TEMPLATES: ProviderTemplate[] = [
 ];
 
 export const HISTORICAL_TEMPLATES: ProviderTemplate[] = [
+  {
+    name: "Vanguard",
+    description: "Workplace fund price history (fund code)",
+    format: "json",
+    url: "https://workplace.vanguard.com/investments/product-details/fund/api/price-distribution/fundPrice/{SYMBOL}?startDate={FROM}&endDate={TO}",
+    pricePath: "$.body.fundPrice.content[*].price",
+    datePath: "$.body.fundPrice.content[*].effectiveDate",
+    dateFormat: "%Y-%m-%d",
+    currencyPath: "$.body.fundPrice.content[*].currencyCode",
+    testSymbol: "M219",
+  },
   {
     name: "Twelve Data (JSON)",
     description: "Stocks, crypto, FX (set API key in headers)",

--- a/apps/frontend/src/pages/settings/market-data/provider-templates.ts
+++ b/apps/frontend/src/pages/settings/market-data/provider-templates.ts
@@ -7,6 +7,7 @@ export interface ProviderTemplate {
   url: string;
   pricePath: string;
   datePath?: string;
+  openPath?: string;
   highPath?: string;
   lowPath?: string;
   volumePath?: string;
@@ -74,6 +75,7 @@ export const HISTORICAL_TEMPLATES: ProviderTemplate[] = [
     url: "https://api.twelvedata.com/time_series?symbol={SYMBOL}&interval=1day&start_date={FROM}&end_date={TO}&format=JSON",
     pricePath: "$.values[*].close",
     datePath: "$.values[*].datetime",
+    openPath: "$.values[*].open",
     highPath: "$.values[*].high",
     lowPath: "$.values[*].low",
     volumePath: "$.values[*].volume",
@@ -87,6 +89,7 @@ export const HISTORICAL_TEMPLATES: ProviderTemplate[] = [
     url: "https://api.twelvedata.com/time_series?symbol={SYMBOL}&interval=1day&start_date={FROM}&end_date={TO}&format=CSV",
     pricePath: "close",
     datePath: "datetime",
+    openPath: "open",
     highPath: "high",
     lowPath: "low",
     volumePath: "volume",
@@ -100,6 +103,7 @@ export const HISTORICAL_TEMPLATES: ProviderTemplate[] = [
     url: "https://markets.ft.com/data/etfs/tearsheet/historical?s={SYMBOL}:LSE:GBX",
     pricePath: "0:4",
     datePath: "0:0",
+    openPath: "0:1",
     highPath: "0:2",
     lowPath: "0:3",
     volumePath: "0:5",

--- a/apps/frontend/src/pages/settings/market-data/response-preview.tsx
+++ b/apps/frontend/src/pages/settings/market-data/response-preview.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useCallback } from "react";
-import { walkJson } from "./json-path-suggestions";
+import { Fragment, useMemo } from "react";
+
+import { cn } from "@/lib/utils";
 
 interface RawResponseViewerProps {
   rawResponse: string;
@@ -7,10 +8,10 @@ interface RawResponseViewerProps {
   onPathClick?: (path: string) => void;
 }
 
-/** Scrollable raw response viewer. JSON gets clickable numbers; HTML is plain text. */
+/** Scrollable raw response viewer. JSON gets clickable leaves; HTML is plain text. */
 export function RawResponseViewer({ rawResponse, format, onPathClick }: RawResponseViewerProps) {
   if (format === "json") {
-    return <JsonPreview rawResponse={rawResponse} onPathClick={onPathClick} />;
+    return <JsonTreeViewer rawResponse={rawResponse} onPathClick={onPathClick} />;
   }
   return (
     <pre className="text-muted-foreground whitespace-pre-wrap break-all p-3 text-[12px] leading-relaxed">
@@ -19,89 +20,266 @@ export function RawResponseViewer({ rawResponse, format, onPathClick }: RawRespo
   );
 }
 
-function JsonPreview({
+// ---------------------------------------------------------------------------
+// JSON tree
+// ---------------------------------------------------------------------------
+
+const INDENT = "  ";
+
+function JsonTreeViewer({
   rawResponse,
   onPathClick,
 }: {
   rawResponse: string;
   onPathClick?: (path: string) => void;
 }) {
-  const { formatted, pathMap } = useMemo(() => {
+  const parsed = useMemo(() => {
     try {
-      const parsed: unknown = JSON.parse(rawResponse);
-      const entries = walkJson(parsed);
-      const map = new Map<string, string>();
-      for (const entry of entries) {
-        const key = String(entry.value);
-        if (!map.has(key)) {
-          map.set(key, entry.path);
-        }
-      }
-      return { formatted: JSON.stringify(parsed, null, 2), pathMap: map };
+      return { ok: true as const, value: JSON.parse(rawResponse) as unknown };
     } catch {
-      return { formatted: rawResponse, pathMap: new Map<string, string>() };
+      return { ok: false as const };
     }
   }, [rawResponse]);
 
-  const handleClick = useCallback(
-    (e: React.MouseEvent) => {
-      const target = e.target as HTMLElement;
-      const path = target.dataset?.jsonpath;
-      if (path && onPathClick) {
-        onPathClick(path);
-      }
-    },
-    [onPathClick],
-  );
-
-  const htmlContent = useMemo(() => {
-    // IMPORTANT: escape the entire string first to prevent XSS from malicious
-    // JSON string values (e.g. "<img onerror=...>"), then insert clickable spans.
-    const escaped = escapeHtml(formatted);
-
-    if (pathMap.size === 0) return escaped;
-
-    const usedPaths = new Map<string, number>();
-
-    return escaped.replace(
-      /: (-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)/g,
-      (match: string, numStr: string) => {
-        const key = numStr;
-        const count = usedPaths.get(key) ?? 0;
-        usedPaths.set(key, count + 1);
-
-        const entries = Array.from(pathMap.entries()).filter(([k]) => k === key);
-        const entry = entries[0];
-        if (!entry) return match; // already escaped
-
-        const path = entry[1];
-        // numStr is only digits/dots/e — no HTML-special chars — safe to inject as-is
-        return `: <span class="json-number" data-jsonpath="${escapeAttr(path)}">${numStr}</span>`;
-      },
+  if (!parsed.ok) {
+    return (
+      <pre className="text-muted-foreground whitespace-pre-wrap break-all p-3 text-[12px] leading-relaxed">
+        {rawResponse}
+      </pre>
     );
-  }, [formatted, pathMap]);
+  }
 
   return (
-    <pre
-      className="json-preview p-3 text-[12px] leading-relaxed"
-      onClick={handleClick}
-      dangerouslySetInnerHTML={{ __html: htmlContent }}
-    />
+    <pre className="p-3 font-mono text-[12px] leading-relaxed">
+      <JsonValue value={parsed.value} path="$" depth={0} onSelect={onPathClick} />
+    </pre>
   );
 }
 
-function escapeHtml(str: string): string {
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;");
+function JsonValue({
+  value,
+  path,
+  depth,
+  onSelect,
+}: {
+  value: unknown;
+  path: string;
+  depth: number;
+  onSelect?: (path: string) => void;
+}): React.ReactElement {
+  if (value === null || value === undefined)
+    return <PrimitiveSpan kind="null" display="null" path={path} onSelect={onSelect} />;
+  if (typeof value === "boolean")
+    return <PrimitiveSpan kind="bool" display={String(value)} path={path} onSelect={onSelect} />;
+  if (typeof value === "number")
+    return <PrimitiveSpan kind="number" display={String(value)} path={path} onSelect={onSelect} />;
+  if (typeof value === "string")
+    return (
+      <PrimitiveSpan
+        kind="string"
+        display={JSON.stringify(value)}
+        path={path}
+        onSelect={onSelect}
+      />
+    );
+
+  if (Array.isArray(value))
+    return <ArrayBlock items={value} path={path} depth={depth} onSelect={onSelect} />;
+
+  if (typeof value === "object") {
+    return (
+      <ObjectBlock
+        entries={Object.entries(value as Record<string, unknown>)}
+        path={path}
+        depth={depth}
+        onSelect={onSelect}
+      />
+    );
+  }
+
+  // Unreachable under typed JSON input; fallback for exhaustive safety.
+  return <span className="text-muted-foreground">…</span>;
 }
 
-function escapeAttr(str: string): string {
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/"/g, "&quot;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+function ArrayBlock({
+  items,
+  path,
+  depth,
+  onSelect,
+}: {
+  items: unknown[];
+  path: string;
+  depth: number;
+  onSelect?: (path: string) => void;
+}) {
+  if (items.length === 0) return <span>[]</span>;
+  const pad = INDENT.repeat(depth + 1);
+  const padClose = INDENT.repeat(depth);
+  return (
+    <>
+      {"["}
+      {"\n"}
+      {items.map((item, i) => {
+        // Path: use `[*]` for the first element (acts as the "all items" hint),
+        // `[i]` for the rest. Users wanting a specific index can edit manually.
+        const childPath = `${path}[${i === 0 ? "*" : i}]`;
+        const last = i === items.length - 1;
+        return (
+          <Fragment key={i}>
+            {pad}
+            <JsonValue value={item} path={childPath} depth={depth + 1} onSelect={onSelect} />
+            {!last && ","}
+            {"\n"}
+          </Fragment>
+        );
+      })}
+      {padClose}
+      {"]"}
+    </>
+  );
+}
+
+function ObjectBlock({
+  entries,
+  path,
+  depth,
+  onSelect,
+}: {
+  entries: [string, unknown][];
+  path: string;
+  depth: number;
+  onSelect?: (path: string) => void;
+}) {
+  if (entries.length === 0) return <span>{"{}"}</span>;
+  const pad = INDENT.repeat(depth + 1);
+  const padClose = INDENT.repeat(depth);
+  return (
+    <>
+      {"{"}
+      {"\n"}
+      {entries.map(([key, val], i) => {
+        const childPath = `${path}.${key}`;
+        const last = i === entries.length - 1;
+        return (
+          <Fragment key={key}>
+            {pad}
+            <Entry
+              keyName={key}
+              value={val}
+              path={childPath}
+              depth={depth + 1}
+              onSelect={onSelect}
+            />
+            {!last && ","}
+            {"\n"}
+          </Fragment>
+        );
+      })}
+      {padClose}
+      {"}"}
+    </>
+  );
+}
+
+/** One `"key": value` line. Primitive values make the whole line clickable. */
+function Entry({
+  keyName,
+  value,
+  path,
+  depth,
+  onSelect,
+}: {
+  keyName: string;
+  value: unknown;
+  path: string;
+  depth: number;
+  onSelect?: (path: string) => void;
+}) {
+  const isPrimitive =
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean";
+
+  if (isPrimitive && onSelect) {
+    return (
+      <span
+        role="button"
+        tabIndex={0}
+        onClick={() => onSelect(path)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onSelect(path);
+          }
+        }}
+        title={path}
+        className="hover:bg-primary/10 focus:bg-primary/10 -mx-1 cursor-pointer rounded px-1 outline-none focus:outline-none"
+      >
+        <KeyLabel keyName={keyName} />
+        {": "}
+        <JsonValue value={value} path={path} depth={depth} onSelect={undefined} />
+      </span>
+    );
+  }
+
+  // Non-primitive (object/array) — key label is inert; nested content renders its own clickable leaves
+  return (
+    <>
+      <KeyLabel keyName={keyName} />
+      {": "}
+      <JsonValue value={value} path={path} depth={depth} onSelect={onSelect} />
+    </>
+  );
+}
+
+function KeyLabel({ keyName }: { keyName: string }) {
+  return <span className="text-slate-500 dark:text-slate-400">{JSON.stringify(keyName)}</span>;
+}
+
+/** Primitive leaf. When `onSelect` is provided (standalone value, not inside an
+ *  Entry line), the span is itself clickable. When `onSelect` is undefined the
+ *  wrapping Entry handles the click, so this renders as plain text. */
+function PrimitiveSpan({
+  kind,
+  display,
+  path,
+  onSelect,
+}: {
+  kind: "string" | "number" | "bool" | "null";
+  display: string;
+  path: string;
+  onSelect?: (path: string) => void;
+}) {
+  const colorClass = cn(
+    kind === "number" && "text-sky-600 dark:text-sky-400",
+    kind === "string" && "text-emerald-700 dark:text-emerald-400",
+    kind === "bool" && "text-violet-600 dark:text-violet-400",
+    kind === "null" && "text-muted-foreground",
+  );
+
+  if (!onSelect) {
+    return <span className={colorClass}>{display}</span>;
+  }
+
+  return (
+    <span
+      role="button"
+      tabIndex={0}
+      onClick={() => onSelect(path)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect(path);
+        }
+      }}
+      title={path}
+      className={cn(
+        colorClass,
+        "hover:bg-primary/10 focus:bg-primary/10 -mx-0.5 cursor-pointer rounded px-0.5 outline-none focus:outline-none",
+      )}
+    >
+      {display}
+    </span>
+  );
 }

--- a/apps/frontend/src/pages/settings/market-data/source-config-panel.tsx
+++ b/apps/frontend/src/pages/settings/market-data/source-config-panel.tsx
@@ -1,7 +1,6 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { type UseFormReturn } from "react-hook-form";
 
-import { Button } from "@wealthfolio/ui/components/ui/button";
 import {
   FormControl,
   FormField,
@@ -14,373 +13,240 @@ import { Input } from "@wealthfolio/ui/components/ui/input";
 import { Label } from "@wealthfolio/ui/components/ui/label";
 import { Switch } from "@wealthfolio/ui/components/ui/switch";
 import { Textarea } from "@wealthfolio/ui/components/ui/textarea";
-import { Badge } from "@wealthfolio/ui/components/ui/badge";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@wealthfolio/ui/components/ui/collapsible";
 
-import { useTestCustomProviderSource } from "@/hooks/use-custom-providers";
-import type {
-  TestSourceResult,
-  DetectedHtmlElement,
-  DetectedHtmlTable,
-} from "@/lib/types/custom-provider";
 import { cn } from "@/lib/utils";
-
 import { TimezoneInput } from "@/pages/settings/general/timezone-input";
-import { RawResponseViewer } from "./response-preview";
-import { walkJson, friendlyPath, formatNumber, type PathEntry } from "./json-path-suggestions";
-import {
-  LATEST_TEMPLATES,
-  HISTORICAL_TEMPLATES,
-  type ProviderTemplate,
-} from "./provider-templates";
-import type { FormValues } from "./custom-provider-form";
 
-// ---------------------------------------------------------------------------
-// Sub-components
-// ---------------------------------------------------------------------------
-
-function StepIndicator({ number, completed }: { number: number; completed: boolean }) {
-  return (
-    <div
-      className={cn(
-        "flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-bold transition-colors",
-        completed ? "bg-success/15 text-success" : "bg-primary/10 text-primary",
-      )}
-    >
-      {completed ? <Icons.Check className="h-3.5 w-3.5" /> : number}
-    </div>
-  );
-}
-
-function VerificationCard({ result }: { result: TestSourceResult }) {
-  return (
-    <div
-      className={cn(
-        "flex items-center gap-3 rounded-xl border p-4",
-        result.success
-          ? "border-success/30 bg-success/5"
-          : "border-destructive/30 bg-destructive/5",
-      )}
-    >
-      {result.success ? (
-        <>
-          <Icons.CheckCircle className="text-success h-5 w-5 shrink-0" />
-          <div>
-            <p className="text-lg font-semibold tabular-nums">
-              {result.price?.toLocaleString()}
-              {result.currency && (
-                <span className="text-muted-foreground ml-1.5 text-sm font-normal">
-                  {result.currency}
-                </span>
-              )}
-            </p>
-            <p className="text-muted-foreground text-xs">
-              Price verified successfully
-              {result.date ? ` (${result.date})` : ""}
-            </p>
-          </div>
-        </>
-      ) : (
-        <>
-          <Icons.XCircle className="text-destructive h-5 w-5 shrink-0" />
-          <div>
-            <p className="text-destructive text-sm font-medium">Could not extract price</p>
-            <p className="text-muted-foreground text-xs">{result.error}</p>
-          </div>
-        </>
-      )}
-    </div>
-  );
-}
-
-function ValueCardGrid({
-  entries,
-  selectedPath,
-  onSelect,
-  maxVisible = 12,
-}: {
-  entries: PathEntry[];
-  selectedPath?: string;
-  onSelect: (path: string) => void;
-  maxVisible?: number;
-}) {
-  const [showAll, setShowAll] = useState(false);
-  const visible = showAll ? entries : entries.slice(0, maxVisible);
-  const hasMore = entries.length > maxVisible;
-
-  return (
-    <div>
-      <div className="grid grid-cols-2 gap-2 md:grid-cols-3">
-        {visible.map((entry) => (
-          <button
-            key={entry.path}
-            type="button"
-            onClick={() => onSelect(entry.path)}
-            className={cn(
-              "relative flex flex-col rounded-lg border p-3 text-left transition-all",
-              selectedPath === entry.path
-                ? "border-primary bg-primary/5 ring-primary/20 ring-1"
-                : "hover:border-foreground/20 hover:bg-accent/50",
-            )}
-          >
-            <span className="text-muted-foreground truncate font-mono text-[11px]">
-              {friendlyPath(entry.path)}
-            </span>
-            <span className="mt-0.5 font-mono text-base font-semibold tabular-nums">
-              {formatNumber(entry.value)}
-            </span>
-            {selectedPath === entry.path && (
-              <Icons.CheckCircle className="text-primary absolute right-2 top-2 h-4 w-4" />
-            )}
-          </button>
-        ))}
-      </div>
-      {hasMore && !showAll && (
-        <button
-          type="button"
-          onClick={() => setShowAll(true)}
-          className="text-muted-foreground hover:text-foreground mt-2 text-xs underline underline-offset-2"
-        >
-          Show {entries.length - maxVisible} more values
-        </button>
-      )}
-    </div>
-  );
-}
-
-function HtmlElementGrid({
-  elements,
-  selectedSelector,
-  onSelect,
-  maxVisible = 10,
-}: {
-  elements: DetectedHtmlElement[];
-  selectedSelector?: string;
-  onSelect: (selector: string) => void;
-  maxVisible?: number;
-}) {
-  const [showAll, setShowAll] = useState(false);
-  const visible = showAll ? elements : elements.slice(0, maxVisible);
-  const hasMore = elements.length > maxVisible;
-
-  return (
-    <div className="space-y-2">
-      {visible.map((entry) => {
-        const isSelected = selectedSelector === entry.selector;
-        return (
-          <button
-            key={entry.selector}
-            type="button"
-            onClick={() => onSelect(entry.selector)}
-            className={cn(
-              "group flex w-full items-start gap-3 rounded-lg border p-3 text-left transition-all",
-              isSelected
-                ? "border-primary bg-primary/5 ring-primary/20 ring-1"
-                : "hover:border-foreground/20 hover:bg-accent/50",
-            )}
-          >
-            {/* Checkbox */}
-            <div className="mt-0.5 shrink-0">
-              {isSelected ? (
-                <Icons.CheckCircle className="text-primary h-4 w-4" />
-              ) : (
-                <div className="border-muted-foreground/30 group-hover:border-foreground/50 h-4 w-4 rounded border transition-colors" />
-              )}
-            </div>
-
-            {/* Content */}
-            <div className="min-w-0 flex-1 space-y-1">
-              {/* Selector badge */}
-              <code className="bg-muted/60 inline-block max-w-full truncate rounded px-1.5 py-0.5 font-mono text-[11px]">
-                {entry.selector}
-              </code>
-              {/* Label */}
-              {entry.label && <p className="text-muted-foreground text-[11px]">{entry.label}</p>}
-              {/* HTML context preview */}
-              {entry.htmlContext && (
-                <pre className="bg-muted/40 text-muted-foreground/80 mt-1.5 overflow-x-auto rounded p-2 font-mono text-[10px] leading-relaxed">
-                  {entry.htmlContext}
-                </pre>
-              )}
-            </div>
-
-            {/* Value */}
-            <span className="shrink-0 pt-0.5 font-mono text-base font-semibold tabular-nums">
-              {formatNumber(entry.value)}
-            </span>
-          </button>
-        );
-      })}
-      {hasMore && !showAll && (
-        <button
-          type="button"
-          onClick={() => setShowAll(true)}
-          className="text-muted-foreground hover:text-foreground mt-1 text-xs underline underline-offset-2"
-        >
-          Show {elements.length - maxVisible} more elements
-        </button>
-      )}
-    </div>
-  );
-}
-
-function HtmlTablePicker({
-  tables,
-  onSelect,
-}: {
-  tables: DetectedHtmlTable[];
-  onSelect: (
-    pricePath: string,
-    datePath?: string,
-    highPath?: string,
-    lowPath?: string,
-    volumePath?: string,
-  ) => void;
-}) {
-  if (tables.length === 0) return null;
-
-  const roleColor: Record<string, string> = {
-    close: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
-    date: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
-    high: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400",
-    low: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400",
-    volume: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
-    open: "bg-sky-100 text-sky-800 dark:bg-sky-900/30 dark:text-sky-400",
-  };
-
-  return (
-    <div className="space-y-3">
-      <p className="text-muted-foreground text-sm">
-        {tables.length} table{tables.length > 1 ? "s" : ""} found. Click one to auto-configure
-        extraction paths.
-      </p>
-      {tables.map((table) => {
-        const closeCol = table.columns.find((c) => c.role === "close");
-        const dateCol = table.columns.find((c) => c.role === "date");
-        const highCol = table.columns.find((c) => c.role === "high");
-        const lowCol = table.columns.find((c) => c.role === "low");
-        const volCol = table.columns.find((c) => c.role === "volume");
-
-        return (
-          <button
-            key={table.index}
-            type="button"
-            onClick={() => {
-              const ti = table.index;
-              onSelect(
-                closeCol ? `${ti}:${closeCol.index}` : `${ti}:0`,
-                dateCol ? `${ti}:${dateCol.index}` : undefined,
-                highCol ? `${ti}:${highCol.index}` : undefined,
-                lowCol ? `${ti}:${lowCol.index}` : undefined,
-                volCol ? `${ti}:${volCol.index}` : undefined,
-              );
-            }}
-            className="hover:border-foreground/20 hover:bg-accent/50 w-full rounded-lg border p-3 text-left transition-all"
-          >
-            <div className="mb-2 flex items-center gap-2">
-              <span className="text-sm font-medium">Table {table.index + 1}</span>
-              <span className="text-muted-foreground text-xs">
-                {table.rowCount} rows, {table.columns.length} columns
-              </span>
-            </div>
-
-            {/* Column role chips */}
-            <div className="mb-2 flex flex-wrap gap-1">
-              {table.columns.map((col) => (
-                <span
-                  key={col.index}
-                  className={cn(
-                    "rounded px-1.5 py-0.5 text-[10px] font-medium",
-                    col.role
-                      ? (roleColor[col.role] ?? "bg-muted text-muted-foreground")
-                      : "bg-muted text-muted-foreground",
-                  )}
-                >
-                  {col.header || `Col ${col.index}`}
-                  {col.role && ` (${col.role})`}
-                </span>
-              ))}
-            </div>
-
-            {/* Sample rows */}
-            {table.sampleRows.length > 0 && (
-              <div className="overflow-x-auto">
-                <table className="text-muted-foreground w-full text-[11px]">
-                  <thead>
-                    <tr>
-                      {table.columns.map((col) => (
-                        <th key={col.index} className="border-b px-2 py-1 text-left font-medium">
-                          {col.header || `Col ${col.index}`}
-                        </th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {table.sampleRows.slice(0, 3).map((row, ri) => (
-                      <tr key={ri}>
-                        {row.map((cell, ci) => (
-                          <td key={ci} className="border-b px-2 py-1">
-                            {cell}
-                          </td>
-                        ))}
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </button>
-        );
-      })}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Main component
-// ---------------------------------------------------------------------------
+import type { FormValues, SourceKey } from "./custom-provider-form";
+import { LATEST_TEMPLATES, HISTORICAL_TEMPLATES } from "./provider-templates";
+import type { MappingField, SourceRuntime } from "./use-source-runtime";
 
 interface SourceConfigPanelProps {
   form: UseFormReturn<FormValues>;
-  prefix: "latestSource" | "historicalSource";
-  isHistorical?: boolean;
+  prefix: SourceKey;
+  runtime: SourceRuntime;
   onUrlChange?: (url: string) => void;
 }
 
-export function SourceConfigPanel({
+const PLACEHOLDERS = [
+  "{SYMBOL}",
+  "{ISIN}",
+  "{MIC}",
+  "{CURRENCY}",
+  "{currency}",
+  "{TODAY}",
+  "{FROM}",
+  "{TO}",
+  "{DATE:%Y-%m-%d}",
+];
+
+const SOURCE_TYPES: {
+  value: "json" | "html" | "html_table" | "csv";
+  label: string;
+  desc: string;
+  icon: keyof typeof Icons;
+}[] = [
+  { value: "json", label: "JSON API", desc: "REST returning JSON", icon: "FileJson" },
+  { value: "html", label: "Web Page", desc: "CSS selector extraction", icon: "Globe" },
+  { value: "html_table", label: "HTML Table", desc: "Rows & columns", icon: "FileSpreadsheet" },
+  { value: "csv", label: "CSV", desc: "Comma/semi separated", icon: "FileText" },
+];
+
+function StepHeader({
+  number,
+  title,
+  done,
+  badge,
+}: {
+  number: number;
+  title: string;
+  done: boolean;
+  badge?: React.ReactNode;
+}) {
+  return (
+    <div className="mb-3 flex items-center gap-2.5">
+      <div
+        className={cn(
+          "flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-xs font-semibold transition-colors",
+          done ? "bg-foreground text-background" : "bg-muted text-muted-foreground",
+        )}
+      >
+        {done ? <Icons.Check className="h-3.5 w-3.5" /> : number}
+      </div>
+      <h3 className="text-sm font-semibold">{title}</h3>
+      {badge && <div className="ml-auto">{badge}</div>}
+    </div>
+  );
+}
+
+function PlaceholderChip({
+  token,
+  onInsert,
+}: {
+  token: string;
+  onInsert: (token: string) => void;
+}) {
+  return (
+    <button
+      type="button"
+      // Prevent the input from blurring on mousedown so the caret position
+      // inside the URL input is still readable when the click fires.
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={() => onInsert(token)}
+      className="border-border bg-muted/50 hover:border-foreground/30 hover:bg-accent rounded border px-1.5 py-0.5 font-mono text-[11px] transition-colors"
+    >
+      {token}
+    </button>
+  );
+}
+
+function mapChipLabel(field: MappingField): { label: string; color: string; required: boolean } {
+  switch (field) {
+    case "pricePath":
+      return { label: "Price", color: "bg-emerald-500", required: true };
+    case "datePath":
+      return { label: "As of", color: "bg-sky-500", required: false };
+    case "currencyPath":
+      return { label: "Currency", color: "bg-amber-500", required: false };
+    case "openPath":
+      return { label: "Open", color: "bg-yellow-500", required: false };
+    case "highPath":
+      return { label: "High", color: "bg-orange-500", required: false };
+    case "lowPath":
+      return { label: "Low", color: "bg-rose-500", required: false };
+    case "volumePath":
+      return { label: "Volume", color: "bg-violet-500", required: false };
+  }
+}
+
+function MappingChip({
+  field,
+  value,
+  armed,
+  onClick,
+}: {
+  field: MappingField;
+  value?: string;
+  armed: boolean;
+  onClick: () => void;
+}) {
+  const { label, color, required } = mapChipLabel(field);
+  const assigned = !!value;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs transition-all",
+        armed
+          ? "bg-background border-foreground/30 ring-foreground/5 shadow-sm ring-1"
+          : "bg-muted/30 hover:bg-muted/50 border-transparent",
+      )}
+    >
+      <span className={cn("h-2 w-2 rounded-sm", color)} />
+      <span className="font-medium">{label}</span>
+      {required && !assigned && <span className="text-destructive">*</span>}
+      <span className="text-muted-foreground font-mono">
+        {assigned && value ? truncate(value, 18) : "—"}
+      </span>
+    </button>
+  );
+}
+
+function pathPlaceholder(
+  format: "json" | "html" | "html_table" | "csv",
+  kind: "price" | "date",
+): string {
+  if (kind === "price") {
+    if (format === "json") return "$.data.price";
+    if (format === "csv") return "Close";
+    if (format === "html_table") return "0:3";
+    return ".price";
+  }
+  if (format === "json") return "$.data.date";
+  if (format === "csv") return "Date";
+  if (format === "html_table") return "0:0";
+  return ".date";
+}
+
+function MappingInputRow({
   form,
   prefix,
-  isHistorical = false,
-  onUrlChange,
-}: SourceConfigPanelProps) {
-  const [testSymbol, setTestSymbol] = useState("");
-  const [testIsin, setTestIsin] = useState("");
-  const [testMic, setTestMic] = useState("");
-  const [testCurrency, setTestCurrency] = useState("");
-  const [rawResponse, setRawResponse] = useState<string | null>(null);
-  const [detectedElements, setDetectedElements] = useState<DetectedHtmlElement[]>([]);
-  const [detectedTables, setDetectedTables] = useState<DetectedHtmlTable[]>([]);
-  const [fetchError, setFetchError] = useState<string | null>(null);
-  const [testResult, setTestResult] = useState<TestSourceResult | null>(null);
-  const [advancedOpen, setAdvancedOpen] = useState(false);
-  const [rawResponseOpen, setRawResponseOpen] = useState(false);
-  const { mutate: testSource, isPending: isFetching } = useTestCustomProviderSource();
-  const verifyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  field,
+  armed,
+  onArm,
+  placeholder,
+}: {
+  form: UseFormReturn<FormValues>;
+  prefix: SourceKey;
+  field: "pricePath" | "datePath";
+  armed: boolean;
+  onArm: () => void;
+  placeholder: string;
+}) {
+  const { label, color, required } = mapChipLabel(field);
+  return (
+    <FormField
+      control={form.control}
+      name={`${prefix}.${field}`}
+      render={({ field: f }) => (
+        <FormItem
+          className={cn(
+            "flex items-center gap-2.5 rounded-lg border p-2 transition-all",
+            armed
+              ? "bg-background border-foreground/30 ring-foreground/5 shadow-sm ring-1"
+              : "bg-muted/30 border-transparent",
+          )}
+        >
+          <button
+            type="button"
+            onClick={onArm}
+            className="flex shrink-0 items-center gap-1.5"
+            title={armed ? "Click to unarm" : "Click to arm — then click a value in the response"}
+          >
+            <span className={cn("h-2.5 w-2.5 rounded-sm", color)} />
+            <span className="text-sm font-medium">{label}</span>
+            {required && <span className="text-destructive -ml-1 text-xs">*</span>}
+          </button>
+          <FormControl>
+            <Input
+              placeholder={placeholder}
+              className="bg-background flex-1 font-mono text-xs"
+              {...f}
+              onFocus={() => {
+                if (!armed) onArm();
+              }}
+            />
+          </FormControl>
+          <FormMessage className="shrink-0" />
+        </FormItem>
+      )}
+    />
+  );
+}
 
-  // Cleanup pending timer on unmount
-  useEffect(() => {
-    return () => {
-      if (verifyTimer.current) clearTimeout(verifyTimer.current);
-    };
-  }, []);
+function truncate(s: string, n: number): string {
+  return s.length <= n ? s : `${s.slice(0, n - 1)}…`;
+}
+
+export function SourceConfigPanel({ form, prefix, runtime, onUrlChange }: SourceConfigPanelProps) {
+  const [headersOpen, setHeadersOpen] = useState(false);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const urlInputRef = useRef<HTMLInputElement | null>(null);
 
   const format = form.watch(`${prefix}.format`) ?? "json";
-  const pricePath = form.watch(`${prefix}.pricePath`);
   const urlValue = form.watch(`${prefix}.url`) ?? "";
+  const pricePath = form.watch(`${prefix}.pricePath`);
+  const currencyPath = form.watch(`${prefix}.currencyPath`);
+  const openPath = form.watch(`${prefix}.openPath`);
+  const highPath = form.watch(`${prefix}.highPath`);
+  const lowPath = form.watch(`${prefix}.lowPath`);
+  const volumePath = form.watch(`${prefix}.volumePath`);
 
   const timezones = useMemo(() => {
     const supportedValuesOf = (
@@ -391,313 +257,150 @@ export function SourceConfigPanel({
     return Array.from(new Set(merged)).sort((a, b) => a.localeCompare(b));
   }, []);
 
-  // Detect which extra placeholders the URL uses
-  const extraPlaceholders = useMemo(
-    () => ({
-      isin: urlValue.includes("{ISIN}"),
-      mic: urlValue.includes("{MIC}"),
-      currency: urlValue.includes("{CURRENCY}") || urlValue.includes("{currency}"),
-    }),
-    [urlValue],
-  );
-  /** Replace user-provided placeholder values in the URL before sending to test_source. */
-  const expandTestUrl = useCallback(
-    (url: string) => {
-      let expanded = url;
-      if (extraPlaceholders.isin) expanded = expanded.replaceAll("{ISIN}", testIsin);
-      if (extraPlaceholders.mic) expanded = expanded.replaceAll("{MIC}", testMic);
-      if (extraPlaceholders.currency) {
-        expanded = expanded.replaceAll("{currency}", testCurrency.toLowerCase());
-        expanded = expanded.replaceAll("{CURRENCY}", testCurrency);
-      }
-      return expanded;
-    },
-    [extraPlaceholders, testIsin, testMic, testCurrency],
+  const isHistorical = runtime.isHistorical;
+  const templates = (isHistorical ? HISTORICAL_TEMPLATES : LATEST_TEMPLATES).filter(
+    (t) => t.format === format,
   );
 
-  const numericEntries = useMemo(() => {
-    if (!rawResponse || format !== "json") return [];
-    try {
-      const parsed: unknown = JSON.parse(rawResponse);
-      return walkJson(parsed);
-    } catch {
-      return [];
-    }
-  }, [rawResponse, format]);
+  const endpointConfigured = !!urlValue && runtime.hasFetched;
+  const mappingDone = !!pricePath;
 
-  const hasFetched =
-    rawResponse !== null || detectedElements.length > 0 || detectedTables.length > 0;
+  const mapHint =
+    format === "csv" || format === "html"
+      ? "AUTO"
+      : format === "html_table"
+        ? "CLICK A COLUMN"
+        : "CLICK A VALUE";
 
-  const applyTemplate = useCallback(
-    (t: ProviderTemplate) => {
-      // Reset all source fields to defaults before applying template values
-      form.setValue(`${prefix}.format`, t.format);
-      form.setValue(`${prefix}.url`, t.url);
-      form.setValue(`${prefix}.pricePath`, t.pricePath);
-      form.setValue(`${prefix}.datePath`, t.datePath ?? "");
-      form.setValue(`${prefix}.dateFormat`, "");
-      form.setValue(`${prefix}.highPath`, t.highPath ?? "");
-      form.setValue(`${prefix}.lowPath`, t.lowPath ?? "");
-      form.setValue(`${prefix}.volumePath`, t.volumePath ?? "");
-      form.setValue(`${prefix}.headers`, t.headers ?? "");
-      form.setValue(`${prefix}.currencyPath`, "");
-      form.setValue(`${prefix}.locale`, "");
-      form.setValue(`${prefix}.factor`, undefined);
-      form.setValue(`${prefix}.invert`, false);
-      form.setValue(`${prefix}.dateTimezone`, "");
-      if (t.headers) {
-        setAdvancedOpen(true);
-      }
-      setTestSymbol(t.testSymbol);
-      onUrlChange?.(t.url);
-      // Reset previous fetch state
-      setRawResponse(null);
-      setDetectedElements([]);
-      setDetectedTables([]);
-      setTestResult(null);
-      setFetchError(null);
-    },
-    [form, prefix, onUrlChange],
-  );
+  const mapHelper =
+    format === "html"
+      ? "Price comes directly from the selector — no field mapping needed."
+      : format === "csv"
+        ? "We'll auto-map CSV columns by header. Override in the right pane if needed."
+        : format === "html_table"
+          ? "After fetch, click a table column in the right pane to auto-map it."
+          : "Click a numeric value in the right pane to map it to a field below.";
 
-  // Fetch raw response
-  const handleFetch = useCallback(() => {
-    const rawUrl = form.getValues(`${prefix}.url`);
-    if (!rawUrl || !testSymbol) return;
-    const url = expandTestUrl(rawUrl);
+  const insertPlaceholder = (token: string) => {
+    const input = urlInputRef.current;
+    const current = form.getValues(`${prefix}.url`) ?? "";
+    // If the URL input is focused, splice the token at the caret / selection;
+    // otherwise fall back to appending at the end.
+    const start = input?.selectionStart ?? current.length;
+    const end = input?.selectionEnd ?? current.length;
+    const next = current.slice(0, start) + token + current.slice(end);
 
-    setTestResult(null);
-    setFetchError(null);
-    setRawResponseOpen(false);
+    form.setValue(`${prefix}.url`, next, { shouldValidate: true });
+    onUrlChange?.(next);
 
-    const dummyPath = format === "html" ? "body" : format === "html_table" ? "" : "$";
-    const headers = form.getValues(`${prefix}.headers`);
-
-    testSource(
-      {
-        format,
-        url,
-        pricePath: dummyPath,
-        symbol: testSymbol,
-        headers: headers || undefined,
-      },
-      {
-        onSuccess: (result) => {
-          // Store detected HTML elements/tables from backend
-          setDetectedElements(result.detectedElements ?? []);
-          setDetectedTables(result.detectedTables ?? []);
-
-          if (result.detectedTables && result.detectedTables.length > 0) {
-            // HTML table format: show table picker
-            setRawResponse(null);
-          } else if (result.rawResponse) {
-            setRawResponse(result.rawResponse);
-            const trimmed = result.rawResponse.trimStart();
-            const detected = trimmed.startsWith("{") || trimmed.startsWith("[") ? "json" : "html";
-            // Only auto-switch format on the initial connect (when price path is still
-            // at the dummy placeholder), so we don't overwrite a user's explicit choice.
-            if (!isHistorical && format !== "csv" && !pricePath) {
-              form.setValue(`${prefix}.format`, detected);
-            }
-          } else if (result.detectedElements && result.detectedElements.length > 0) {
-            // HTML format: no rawResponse needed, we have structured elements
-            setRawResponse(null);
-          } else if (result.success) {
-            setRawResponse(null);
-            setTestResult(result);
-          } else {
-            setRawResponse(null);
-            setFetchError(result.error ?? "Empty response from server.");
-            if (result.error && /403|forbidden|denied/i.test(result.error)) {
-              setAdvancedOpen(true);
-            }
-          }
-        },
-        onError: (err) => {
-          setRawResponse(null);
-          setDetectedElements([]);
-          setDetectedTables([]);
-          setFetchError(err.message);
-          if (/403|forbidden|denied/i.test(err.message)) {
-            setAdvancedOpen(true);
-          }
-        },
-      },
-    );
-  }, [form, prefix, format, testSymbol, testSource, isHistorical, expandTestUrl]);
-
-  // Debounced verify
-  const scheduleVerify = useCallback(
-    (path: string) => {
-      if (verifyTimer.current) clearTimeout(verifyTimer.current);
-      if (
-        (!rawResponse && detectedElements.length === 0 && detectedTables.length === 0) ||
-        !path ||
-        path === "$" ||
-        path === "body"
-      )
-        return;
-
-      verifyTimer.current = setTimeout(() => {
-        const rawUrl = form.getValues(`${prefix}.url`);
-        if (!rawUrl || !testSymbol) return;
-        const url = expandTestUrl(rawUrl);
-
-        const values = form.getValues(prefix);
-        testSource(
-          {
-            format: values?.format ?? "json",
-            url,
-            pricePath: path,
-            datePath: values?.datePath || undefined,
-            dateFormat: values?.dateFormat || undefined,
-            currencyPath: values?.currencyPath || undefined,
-            factor: values?.factor ?? undefined,
-            invert: values?.invert ?? undefined,
-            locale: values?.locale || undefined,
-            headers: values?.headers || undefined,
-            symbol: testSymbol,
-          },
-          {
-            onSuccess: (result) => setTestResult(result),
-            onError: (err) => setTestResult({ success: false, error: err.message }),
-          },
-        );
-      }, 300);
-    },
-    [
-      rawResponse,
-      detectedElements,
-      detectedTables,
-      form,
-      prefix,
-      testSymbol,
-      testSource,
-      expandTestUrl,
-    ],
-  );
-
-  const handlePathSelect = useCallback(
-    (path: string) => {
-      form.setValue(`${prefix}.pricePath`, path, { shouldValidate: true });
-      scheduleVerify(path);
-    },
-    [form, prefix, scheduleVerify],
-  );
-
-  const handleHtmlTest = useCallback(() => {
-    const values = form.getValues(prefix);
-    const rawUrl = form.getValues(`${prefix}.url`);
-    if (!values?.pricePath || !rawUrl || !testSymbol) return;
-    const url = expandTestUrl(rawUrl);
-    testSource(
-      {
-        format: "html",
-        url,
-        pricePath: values.pricePath,
-        currencyPath: values.currencyPath || undefined,
-        factor: values.factor ?? undefined,
-        invert: values.invert ?? undefined,
-        locale: values.locale || undefined,
-        headers: values.headers || undefined,
-        symbol: testSymbol,
-      },
-      {
-        onSuccess: (result) => setTestResult(result),
-        onError: (err) => setTestResult({ success: false, error: err.message }),
-      },
-    );
-  }, [form, prefix, testSymbol, testSource, expandTestUrl]);
+    // Restore focus + place caret right after the inserted token once React
+    // has re-rendered with the new value.
+    requestAnimationFrame(() => {
+      const el = urlInputRef.current;
+      if (!el) return;
+      el.focus();
+      const caret = start + token.length;
+      el.setSelectionRange(caret, caret);
+    });
+  };
 
   return (
     <div className="space-y-3">
-      {/* ── Step 1: Connect ── */}
-      <div className="rounded-xl border p-4">
-        <div className="mb-3 flex items-center gap-2.5">
-          <StepIndicator number={1} completed={hasFetched} />
-          <h3 className="text-sm font-semibold">Connect to data source</h3>
-        </div>
+      {/* ── Step 1 — Configure endpoint ── */}
+      <div className="bg-background rounded-xl border p-4">
+        <StepHeader
+          number={1}
+          title={`Configure ${isHistorical ? "Historical" : "Latest"} endpoint`}
+          done={endpointConfigured}
+          badge={
+            <span className="text-muted-foreground text-[10px] font-semibold uppercase tracking-wide">
+              Required
+            </span>
+          }
+        />
 
         <div className="space-y-4">
-          {/* Source type toggle */}
+          {/* Source type */}
           <FormField
             control={form.control}
             name={`${prefix}.format`}
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Source type</FormLabel>
+                <FormLabel className="text-muted-foreground text-[11px] font-medium uppercase tracking-wide">
+                  Source type
+                </FormLabel>
                 <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-                  {(
-                    [
-                      { value: "json", label: "JSON API", desc: "REST API returning JSON" },
-                      { value: "html", label: "Web Page", desc: "CSS selector extraction" },
-                      {
-                        value: "html_table",
-                        label: "HTML Table",
-                        desc: "Table with rows & columns",
-                      },
-                      { value: "csv", label: "CSV", desc: "Comma/semicolon-separated" },
-                    ] as const
-                  ).map((opt) => (
-                    <button
-                      key={opt.value}
-                      type="button"
-                      onClick={() => field.onChange(opt.value)}
-                      className={cn(
-                        "flex flex-col items-center gap-1 rounded-lg border p-2.5 text-center transition-all",
-                        field.value === opt.value
-                          ? "border-primary bg-primary/5 ring-primary/20 ring-1"
-                          : "hover:border-foreground/20 hover:bg-accent/50",
-                      )}
-                    >
-                      <span className="text-sm font-medium">{opt.label}</span>
-                      <span className="text-muted-foreground text-[10px]">{opt.desc}</span>
-                    </button>
-                  ))}
+                  {SOURCE_TYPES.map((opt) => {
+                    const Icon = Icons[opt.icon];
+                    const selected = field.value === opt.value;
+                    return (
+                      <button
+                        key={opt.value}
+                        type="button"
+                        onClick={() => {
+                          field.onChange(opt.value);
+                          runtime.resetFetchState();
+                        }}
+                        className={cn(
+                          "flex flex-col items-start gap-1 rounded-lg border p-3 text-left transition-all",
+                          selected
+                            ? "bg-background border-foreground/30 ring-foreground/5 shadow-sm ring-1"
+                            : "bg-muted/30 hover:bg-muted/50 border-transparent",
+                        )}
+                      >
+                        <span className="flex items-center gap-1.5">
+                          {Icon && <Icon className="text-muted-foreground h-3.5 w-3.5" />}
+                          <span className="text-sm font-medium">{opt.label}</span>
+                        </span>
+                        <span className="text-muted-foreground text-[11px]">{opt.desc}</span>
+                      </button>
+                    );
+                  })}
                 </div>
                 <FormMessage />
               </FormItem>
             )}
           />
 
-          {/* Quick-start templates */}
-          {(() => {
-            const templates = (isHistorical ? HISTORICAL_TEMPLATES : LATEST_TEMPLATES).filter(
-              (t) => t.format === format,
-            );
-            if (templates.length === 0) return null;
-            return (
-              <div>
-                <p className="text-muted-foreground mb-2 text-[11px] font-medium uppercase tracking-wide">
-                  Quick start
-                </p>
-                <div className="flex flex-wrap gap-2">
-                  {templates.map((t) => (
-                    <button
-                      key={t.name}
-                      type="button"
-                      onClick={() => applyTemplate(t)}
-                      className="hover:bg-accent hover:border-foreground/20 flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs transition-colors"
-                    >
-                      <Icons.Globe className="text-muted-foreground h-3 w-3" />
+          {/* Quick start templates */}
+          {templates.length > 0 && (
+            <div>
+              <Label className="text-muted-foreground text-[11px] font-medium uppercase tracking-wide">
+                Quick start
+              </Label>
+              <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                {templates.map((t) => (
+                  <button
+                    key={t.name}
+                    type="button"
+                    onClick={() => runtime.applyTemplate(t)}
+                    className="bg-muted/30 hover:bg-muted/50 flex min-w-0 items-center gap-2 rounded-lg border border-transparent px-3 py-2 text-xs transition-colors"
+                  >
+                    <Icons.Globe className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
+                    <span className="min-w-0 truncate">
                       <span className="font-medium">{t.name}</span>
-                      <span className="text-muted-foreground hidden sm:inline">
-                        — {t.description}
-                      </span>
-                    </button>
-                  ))}
-                </div>
+                      <span className="text-muted-foreground"> · {t.description}</span>
+                    </span>
+                  </button>
+                ))}
               </div>
-            );
-          })()}
+            </div>
+          )}
 
-          {/* URL */}
+          {/* URL template + placeholders */}
           <FormField
             control={form.control}
             name={`${prefix}.url`}
             render={({ field }) => (
               <FormItem>
-                <FormLabel>URL template</FormLabel>
+                <div className="flex items-center justify-between">
+                  <FormLabel className="text-muted-foreground text-[11px] font-medium uppercase tracking-wide">
+                    URL template
+                  </FormLabel>
+                  <span className="text-muted-foreground text-[11px]">
+                    · use placeholders for variable parts
+                  </span>
+                </div>
                 <FormControl>
                   <Input
                     placeholder={
@@ -706,565 +409,234 @@ export function SourceConfigPanel({
                         : "https://www.example.com/quote/{SYMBOL}"
                     }
                     {...field}
+                    ref={(el) => {
+                      urlInputRef.current = el;
+                      if (typeof field.ref === "function") field.ref(el);
+                    }}
                     onChange={(e) => {
                       field.onChange(e);
                       onUrlChange?.(e.target.value);
                     }}
                   />
                 </FormControl>
-                <p className="text-muted-foreground text-[11px]">
-                  Placeholders:{" "}
-                  <code className="bg-muted rounded px-1 font-mono">{"{SYMBOL}"}</code>{" "}
-                  <code className="bg-muted rounded px-1 font-mono">{"{ISIN}"}</code>{" "}
-                  <code className="bg-muted rounded px-1 font-mono">{"{MIC}"}</code>{" "}
-                  <code className="bg-muted rounded px-1 font-mono">{"{CURRENCY}"}</code>{" "}
-                  <code className="bg-muted rounded px-1 font-mono">{"{currency}"}</code>{" "}
-                  <code className="bg-muted rounded px-1 font-mono">{"{TODAY}"}</code>{" "}
-                  <code className="bg-muted rounded px-1 font-mono">{"{FROM}"}</code>{" "}
-                  <code className="bg-muted rounded px-1 font-mono">{"{TO}"}</code>{" "}
-                  <code className="bg-muted rounded px-1 font-mono">{"{DATE:%Y-%m-%d}"}</code>
-                </p>
+                <div className="text-muted-foreground mt-1.5 flex flex-wrap items-center gap-1.5 text-[11px]">
+                  <span className="mr-1">Placeholders:</span>
+                  {PLACEHOLDERS.map((p) => (
+                    <PlaceholderChip key={p} token={p} onInsert={insertPlaceholder} />
+                  ))}
+                </div>
                 <FormMessage />
               </FormItem>
             )}
           />
 
-          {/* Symbol + extra placeholders + Fetch */}
-          <div className="flex items-end gap-2">
-            <div className="flex min-w-0 flex-1 gap-2">
-              <div className="min-w-0 flex-1 space-y-1.5">
-                <Label className="text-sm">Test with symbol</Label>
-                <Input
-                  placeholder="e.g. AAPL"
-                  value={testSymbol}
-                  onChange={(e) => setTestSymbol(e.target.value)}
-                />
-              </div>
-              {extraPlaceholders.isin && (
-                <div className="w-28 space-y-1.5">
-                  <Label className="text-sm">ISIN</Label>
-                  <Input
-                    placeholder="e.g. US0378331005"
-                    value={testIsin}
-                    onChange={(e) => setTestIsin(e.target.value)}
-                  />
-                </div>
-              )}
-              {extraPlaceholders.mic && (
-                <div className="w-24 space-y-1.5">
-                  <Label className="text-sm">MIC</Label>
-                  <Input
-                    placeholder="e.g. XLON"
-                    value={testMic}
-                    onChange={(e) => setTestMic(e.target.value)}
-                  />
-                </div>
-              )}
-              {extraPlaceholders.currency && (
-                <div className="w-20 space-y-1.5">
-                  <Label className="text-sm">Currency</Label>
-                  <Input
-                    placeholder="e.g. USD"
-                    value={testCurrency}
-                    onChange={(e) => setTestCurrency(e.target.value)}
-                  />
-                </div>
-              )}
-            </div>
-            <Button
-              type="button"
-              onClick={handleFetch}
-              disabled={isFetching || !testSymbol || !form.getValues(`${prefix}.url`)}
-              className="shrink-0"
-            >
-              {isFetching ? (
-                <Icons.Spinner className="mr-1.5 h-3.5 w-3.5 animate-spin" />
-              ) : (
-                <Icons.PlayCircle className="mr-1.5 h-3.5 w-3.5" />
-              )}
-              Fetch
-            </Button>
-          </div>
-        </div>
-      </div>
-
-      {/* ── Fetch error ── */}
-      {fetchError && !isFetching && (
-        <div className="border-destructive/20 bg-destructive/5 rounded-xl border p-4">
-          <div className="flex items-start gap-2">
-            <Icons.XCircle className="text-destructive mt-0.5 h-4 w-4 shrink-0" />
-            <div>
-              <p className="text-destructive text-sm">{fetchError}</p>
-              {/403|forbidden|denied/i.test(fetchError) && (
-                <p className="text-muted-foreground mt-1 text-xs">
-                  This site may block automated requests. Try adding custom headers in Advanced
-                  Options below.
-                </p>
-              )}
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* ── Loading state ── */}
-      {isFetching && !hasFetched && (
-        <div className="flex items-center justify-center gap-2 rounded-xl border border-dashed p-8">
-          <Icons.Spinner className="text-muted-foreground h-4 w-4 animate-spin" />
-          <span className="text-muted-foreground text-sm">Fetching response...</span>
-        </div>
-      )}
-
-      {/* ── Step 2: Select price ── */}
-      {hasFetched && (
-        <div className="rounded-xl border p-4">
-          <div className="mb-3 flex items-center gap-2.5">
-            <StepIndicator number={2} completed={!!testResult?.success} />
-            <h3 className="text-sm font-semibold">
-              {format === "html_table"
-                ? "Select a table"
-                : format === "csv"
-                  ? "Configure CSV columns"
-                  : format === "json"
-                    ? "Select the price value"
-                    : "Find the price on the page"}
-            </h3>
-            <Badge variant="secondary" className="ml-auto h-5 px-1.5 text-[10px] font-normal">
-              {format.toUpperCase().replace("_", " ")}
-            </Badge>
-          </div>
-
-          {format === "html_table" ? (
-            <div className="space-y-3">
-              <HtmlTablePicker
-                tables={detectedTables}
-                onSelect={(pp, dp, hp, lp, vp) => {
-                  form.setValue(`${prefix}.pricePath`, pp, { shouldValidate: true });
-                  if (dp) form.setValue(`${prefix}.datePath`, dp);
-                  if (hp) form.setValue(`${prefix}.highPath`, hp);
-                  if (lp) form.setValue(`${prefix}.lowPath`, lp);
-                  if (vp) form.setValue(`${prefix}.volumePath`, vp);
-                  scheduleVerify(pp);
-                }}
-              />
-
-              {/* Manual path inputs */}
-              <div className="grid gap-3 sm:grid-cols-2">
-                <FormField
-                  control={form.control}
-                  name={`${prefix}.pricePath`}
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="text-xs">Price column (table:col)</FormLabel>
-                      <FormControl>
-                        <Input placeholder="e.g. 0:3" className="font-mono text-xs" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name={`${prefix}.datePath`}
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="text-xs">Date column (table:col)</FormLabel>
-                      <FormControl>
-                        <Input placeholder="e.g. 0:0" className="font-mono text-xs" {...field} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-
-              {testResult && <VerificationCard result={testResult} />}
-            </div>
-          ) : format === "csv" ? (
-            <div className="space-y-3">
-              <p className="text-muted-foreground text-sm">
-                Enter the column name or 0-based index for each field.
-              </p>
-              <div className="grid gap-3 sm:grid-cols-2">
-                <FormField
-                  control={form.control}
-                  name={`${prefix}.pricePath`}
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="text-xs">Price column</FormLabel>
-                      <FormControl>
-                        <Input
-                          placeholder='e.g. "Close" or "3"'
-                          className="font-mono text-xs"
-                          {...field}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name={`${prefix}.datePath`}
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="text-xs">Date column</FormLabel>
-                      <FormControl>
-                        <Input
-                          placeholder='e.g. "Date" or "0"'
-                          className="font-mono text-xs"
-                          {...field}
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-
-              {testResult && <VerificationCard result={testResult} />}
-
-              {rawResponse && (
-                <Collapsible open={rawResponseOpen} onOpenChange={setRawResponseOpen}>
-                  <CollapsibleTrigger asChild>
-                    <button
-                      type="button"
-                      className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs"
-                    >
-                      <Icons.ChevronRight
-                        className={cn(
-                          "h-3 w-3 transition-transform",
-                          rawResponseOpen && "rotate-90",
-                        )}
-                      />
-                      View raw CSV
-                    </button>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent>
-                    <pre className="bg-muted/30 mt-2 max-h-60 overflow-auto rounded-lg border p-3 font-mono text-xs">
-                      {rawResponse.slice(0, 3000)}
-                    </pre>
-                  </CollapsibleContent>
-                </Collapsible>
-              )}
-            </div>
-          ) : format === "json" ? (
-            <div className="space-y-3">
-              {numericEntries.length > 0 ? (
-                <>
-                  <p className="text-muted-foreground text-sm">
-                    Click the value that represents the price:
+          {/* Format-specific inline field (html → CSS selector) */}
+          {format === "html" && (
+            <FormField
+              control={form.control}
+              name={`${prefix}.pricePath`}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-muted-foreground text-[11px] font-medium uppercase tracking-wide">
+                    CSS Selector
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder=".price-value, [data-field='last']"
+                      className="font-mono text-xs"
+                      {...field}
+                    />
+                  </FormControl>
+                  <p className="text-muted-foreground text-[11px]">
+                    Target the element containing the price. Numbers are auto-parsed.
                   </p>
-                  <ValueCardGrid
-                    entries={numericEntries}
-                    selectedPath={pricePath}
-                    onSelect={handlePathSelect}
-                  />
-                </>
-              ) : (
-                <p className="text-muted-foreground text-sm">
-                  No numeric values found. Enter a path manually below.
-                </p>
+                  <FormMessage />
+                </FormItem>
               )}
+            />
+          )}
 
-              {/* Manual path input */}
+          {/* Headers & auth */}
+          <Collapsible open={headersOpen} onOpenChange={setHeadersOpen}>
+            <CollapsibleTrigger asChild>
+              <button
+                type="button"
+                className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs"
+              >
+                <Icons.ChevronRight
+                  className={cn("h-3 w-3 transition-transform", headersOpen && "rotate-90")}
+                />
+                Headers &amp; auth (optional)
+              </button>
+            </CollapsibleTrigger>
+            <CollapsibleContent className="mt-2">
               <FormField
                 control={form.control}
-                name={`${prefix}.pricePath`}
+                name={`${prefix}.headers`}
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel className="text-muted-foreground text-xs">
-                      Extraction path
-                      {numericEntries.length > 0 && (
-                        <span className="ml-1 font-normal">
-                          (auto-filled when you click a value above)
-                        </span>
-                      )}
-                    </FormLabel>
                     <FormControl>
-                      <Input
-                        placeholder="e.g. $.data.price"
-                        className="font-mono text-xs"
+                      <Textarea
+                        rows={2}
+                        placeholder='{"Authorization": "Bearer token"}'
                         {...field}
-                        onChange={(e) => {
-                          field.onChange(e);
-                          scheduleVerify(e.target.value);
-                        }}
                       />
                     </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-
-              {/* Verification result */}
-              {testResult && <VerificationCard result={testResult} />}
-
-              {/* Raw JSON collapsible */}
-              <Collapsible open={rawResponseOpen} onOpenChange={setRawResponseOpen}>
-                <CollapsibleTrigger asChild>
-                  <button
-                    type="button"
-                    className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs"
-                  >
-                    <Icons.ChevronRight
-                      className={cn("h-3 w-3 transition-transform", rawResponseOpen && "rotate-90")}
-                    />
-                    View raw JSON response
-                  </button>
-                </CollapsibleTrigger>
-                <CollapsibleContent>
-                  {rawResponse && (
-                    <div className="bg-muted/30 mt-2 max-h-60 overflow-auto rounded-lg border">
-                      <RawResponseViewer
-                        rawResponse={rawResponse}
-                        format="json"
-                        onPathClick={handlePathSelect}
-                      />
-                    </div>
-                  )}
-                </CollapsibleContent>
-              </Collapsible>
-            </div>
-          ) : (
-            <div className="space-y-3">
-              <p className="text-muted-foreground text-sm">
-                Page fetched. Enter a CSS selector to extract the price element.
-              </p>
-
-              {/* CSS Selector input + test — primary action */}
-              <FormField
-                control={form.control}
-                name={`${prefix}.pricePath`}
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>CSS Selector</FormLabel>
-                    <div className="flex gap-2">
-                      <FormControl>
-                        <Input
-                          placeholder="e.g. .price-value strong"
-                          className="font-mono text-xs"
-                          {...field}
-                        />
-                      </FormControl>
-                      <Button
-                        type="button"
-                        onClick={handleHtmlTest}
-                        disabled={isFetching || !pricePath}
-                        className="shrink-0"
-                        size="sm"
-                      >
-                        {isFetching ? (
-                          <Icons.Spinner className="mr-1.5 h-3 w-3 animate-spin" />
-                        ) : (
-                          <Icons.PlayCircle className="mr-1.5 h-3 w-3" />
-                        )}
-                        Test
-                      </Button>
-                    </div>
                     <p className="text-muted-foreground text-[11px]">
-                      Tip: Open the page in your browser, right-click the price, choose
-                      &ldquo;Inspect&rdquo;, and copy the selector.
+                      Prefix secret values with __SECRET__ to encrypt them.
                     </p>
                     <FormMessage />
                   </FormItem>
                 )}
               />
+            </CollapsibleContent>
+          </Collapsible>
+        </div>
+      </div>
 
-              {/* Verification result */}
-              {testResult && <VerificationCard result={testResult} />}
+      {/* ── Step 2 — Map response fields ── */}
+      <div className="bg-background rounded-xl border p-4">
+        <StepHeader
+          number={2}
+          title="Map response fields"
+          done={mappingDone}
+          badge={
+            <span className="text-muted-foreground text-[10px] font-semibold uppercase tracking-wide">
+              {mapHint}
+            </span>
+          }
+        />
 
-              {/* Detected elements — shown when available */}
-              {detectedElements.length > 0 && (
-                <div>
-                  <p className="text-muted-foreground mb-2 text-[11px] font-medium uppercase tracking-wide">
-                    Detected elements ({detectedElements.length})
-                  </p>
-                  <p className="text-muted-foreground mb-2 text-xs">
-                    Click one to use its selector, or type a custom one above.
-                  </p>
-                  <div className="max-h-72 overflow-y-auto rounded-lg border p-2">
-                    <HtmlElementGrid
-                      elements={detectedElements}
-                      selectedSelector={pricePath}
-                      onSelect={handlePathSelect}
-                    />
-                  </div>
-                </div>
-              )}
+        <p className="text-muted-foreground mb-3 text-xs">{mapHelper}</p>
 
-              {/* Raw HTML collapsible — only shown when backend returns raw response */}
-              {rawResponse && (
-                <Collapsible open={rawResponseOpen} onOpenChange={setRawResponseOpen}>
-                  <CollapsibleTrigger asChild>
-                    <button
-                      type="button"
-                      className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs"
-                    >
-                      <Icons.ChevronRight
-                        className={cn(
-                          "h-3 w-3 transition-transform",
-                          rawResponseOpen && "rotate-90",
-                        )}
-                      />
-                      View page source
-                    </button>
-                  </CollapsibleTrigger>
-                  <CollapsibleContent>
-                    <div className="bg-muted/30 mt-2 max-h-60 overflow-auto rounded-lg border">
-                      <RawResponseViewer rawResponse={rawResponse} format="html" />
-                    </div>
-                  </CollapsibleContent>
-                </Collapsible>
+        <div className="space-y-2">
+          <MappingInputRow
+            form={form}
+            prefix={prefix}
+            field="pricePath"
+            armed={runtime.armedField === "pricePath"}
+            onArm={() =>
+              runtime.setArmedField(runtime.armedField === "pricePath" ? null : "pricePath")
+            }
+            placeholder={pathPlaceholder(format, "price")}
+          />
+          <MappingInputRow
+            form={form}
+            prefix={prefix}
+            field="datePath"
+            armed={runtime.armedField === "datePath"}
+            onArm={() =>
+              runtime.setArmedField(runtime.armedField === "datePath" ? null : "datePath")
+            }
+            placeholder={pathPlaceholder(format, "date")}
+          />
+        </div>
+
+        {/* More mapping fields (collapsible) */}
+        <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen} className="mt-3">
+          <CollapsibleTrigger asChild>
+            <button
+              type="button"
+              className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs"
+            >
+              <Icons.ChevronRight
+                className={cn("h-3 w-3 transition-transform", advancedOpen && "rotate-90")}
+              />
+              More mappings &amp; options
+            </button>
+          </CollapsibleTrigger>
+          <CollapsibleContent className="mt-3 space-y-3">
+            {/* Additional mapping chips */}
+            <div className="flex flex-wrap gap-2">
+              <MappingChip
+                field="currencyPath"
+                value={currencyPath}
+                armed={runtime.armedField === "currencyPath"}
+                onClick={() =>
+                  runtime.setArmedField(
+                    runtime.armedField === "currencyPath" ? null : "currencyPath",
+                  )
+                }
+              />
+              {(format === "json" || format === "csv" || format === "html_table") && (
+                <>
+                  <MappingChip
+                    field="openPath"
+                    value={openPath}
+                    armed={runtime.armedField === "openPath"}
+                    onClick={() =>
+                      runtime.setArmedField(runtime.armedField === "openPath" ? null : "openPath")
+                    }
+                  />
+                  <MappingChip
+                    field="highPath"
+                    value={highPath}
+                    armed={runtime.armedField === "highPath"}
+                    onClick={() =>
+                      runtime.setArmedField(runtime.armedField === "highPath" ? null : "highPath")
+                    }
+                  />
+                  <MappingChip
+                    field="lowPath"
+                    value={lowPath}
+                    armed={runtime.armedField === "lowPath"}
+                    onClick={() =>
+                      runtime.setArmedField(runtime.armedField === "lowPath" ? null : "lowPath")
+                    }
+                  />
+                  <MappingChip
+                    field="volumePath"
+                    value={volumePath}
+                    armed={runtime.armedField === "volumePath"}
+                    onClick={() =>
+                      runtime.setArmedField(
+                        runtime.armedField === "volumePath" ? null : "volumePath",
+                      )
+                    }
+                  />
+                </>
               )}
             </div>
-          )}
-        </div>
-      )}
 
-      {/* ── Historical fields ── */}
-      {isHistorical && format !== "html_table" && format !== "csv" && (
-        <div className="grid gap-3 sm:grid-cols-2">
-          <FormField
-            control={form.control}
-            name="historicalSource.datePath"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Date Path</FormLabel>
-                <FormControl>
-                  <Input placeholder="e.g. $.data[*].date" {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="historicalSource.dateFormat"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Date Format</FormLabel>
-                <FormControl>
-                  <Input placeholder="e.g. %Y-%m-%d" {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </div>
-      )}
-
-      {/* ── Advanced options ── */}
-      <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
-        <CollapsibleTrigger asChild>
-          <button
-            type="button"
-            className="text-muted-foreground hover:text-foreground flex items-center gap-1 text-xs"
-          >
-            <Icons.ChevronRight
-              className={cn("h-3 w-3 transition-transform", advancedOpen && "rotate-90")}
-            />
-            Advanced options
-          </button>
-        </CollapsibleTrigger>
-        <CollapsibleContent>
-          <div className="mt-2 space-y-3 rounded-xl border p-4">
             <FormField
               control={form.control}
-              name={`${prefix}.currencyPath`}
+              name={`${prefix}.dateFormat`}
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Currency Path</FormLabel>
+                  <FormLabel className="text-xs">Date format</FormLabel>
                   <FormControl>
-                    <Input placeholder="e.g. $.currency" {...field} />
+                    <Input placeholder="e.g. %Y-%m-%d" className="font-mono text-xs" {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
               )}
             />
 
-            <FormField
-              control={form.control}
-              name={`${prefix}.headers`}
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Custom Headers</FormLabel>
-                  <FormControl>
-                    <Textarea rows={2} placeholder='{"Authorization": "Bearer token"}' {...field} />
-                  </FormControl>
-                  <p className="text-muted-foreground text-[11px]">
-                    Prefix secret values with __SECRET__ to encrypt them.
-                  </p>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <div className="grid gap-3 sm:grid-cols-3">
-              <FormField
-                control={form.control}
-                name={`${prefix}.factor`}
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Factor</FormLabel>
-                    <FormControl>
-                      <Input
-                        type="number"
-                        step="any"
-                        placeholder="e.g. 0.01"
-                        {...field}
-                        value={field.value ?? ""}
-                        onChange={(e) =>
-                          field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
-                        }
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name={`${prefix}.locale`}
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Locale</FormLabel>
-                    <FormControl>
-                      <Input placeholder="e.g. de-DE" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name={`${prefix}.invert`}
-                render={({ field }) => (
-                  <FormItem className="flex flex-col justify-end">
-                    <div className="flex items-center gap-2 pb-1">
-                      <Switch
-                        checked={field.value ?? false}
-                        onCheckedChange={field.onChange}
-                        id={`${prefix}-invert`}
-                      />
-                      <Label htmlFor={`${prefix}-invert`} className="text-sm">
-                        Invert
-                      </Label>
-                    </div>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-
-            {/* OHLCV extraction paths */}
             {(format === "json" || format === "csv") && (
-              <div className="grid gap-3 sm:grid-cols-3">
+              <div className="grid gap-3 sm:grid-cols-4">
+                <FormField
+                  control={form.control}
+                  name={`${prefix}.openPath`}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel className="text-xs">Open</FormLabel>
+                      <FormControl>
+                        <Input
+                          placeholder={format === "csv" ? "Open" : "$.open"}
+                          className="font-mono text-xs"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
                 <FormField
                   control={form.control}
                   name={`${prefix}.highPath`}
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>High path</FormLabel>
+                      <FormLabel className="text-xs">High</FormLabel>
                       <FormControl>
                         <Input
                           placeholder={format === "csv" ? "High" : "$.high"}
@@ -1281,7 +653,7 @@ export function SourceConfigPanel({
                   name={`${prefix}.lowPath`}
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Low path</FormLabel>
+                      <FormLabel className="text-xs">Low</FormLabel>
                       <FormControl>
                         <Input
                           placeholder={format === "csv" ? "Low" : "$.low"}
@@ -1298,7 +670,7 @@ export function SourceConfigPanel({
                   name={`${prefix}.volumePath`}
                   render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Volume path</FormLabel>
+                      <FormLabel className="text-xs">Volume</FormLabel>
                       <FormControl>
                         <Input
                           placeholder={format === "csv" ? "Volume" : "$.volume"}
@@ -1313,19 +685,89 @@ export function SourceConfigPanel({
               </div>
             )}
 
-            {/* Default price + date timezone */}
+            <FormField
+              control={form.control}
+              name={`${prefix}.currencyPath`}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel className="text-xs">Currency path</FormLabel>
+                  <FormControl>
+                    <Input placeholder="e.g. $.currency" className="font-mono text-xs" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="grid gap-3 sm:grid-cols-3">
+              <FormField
+                control={form.control}
+                name={`${prefix}.factor`}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="text-xs">Factor</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        step="any"
+                        placeholder="0.01"
+                        {...field}
+                        value={field.value ?? ""}
+                        onChange={(e) =>
+                          field.onChange(e.target.value === "" ? undefined : Number(e.target.value))
+                        }
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name={`${prefix}.locale`}
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel className="text-xs">Locale</FormLabel>
+                    <FormControl>
+                      <Input placeholder="en-US" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name={`${prefix}.invert`}
+                render={({ field }) => (
+                  <FormItem className="flex flex-col justify-end">
+                    <div className="flex items-center gap-2 pb-1">
+                      <Switch
+                        checked={field.value ?? false}
+                        onCheckedChange={field.onChange}
+                        id={`${prefix}-invert`}
+                      />
+                      <Label htmlFor={`${prefix}-invert`} className="text-xs">
+                        Invert
+                      </Label>
+                    </div>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
             <div className="grid gap-3 sm:grid-cols-2">
               <FormField
                 control={form.control}
                 name={`${prefix}.defaultPrice`}
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Default price</FormLabel>
+                    <FormLabel className="text-xs">Default price</FormLabel>
                     <FormControl>
                       <Input
                         type="number"
                         step="any"
-                        placeholder="Static fallback price"
+                        placeholder="Static fallback"
                         {...field}
                         value={field.value ?? ""}
                         onChange={(e) =>
@@ -1345,26 +787,23 @@ export function SourceConfigPanel({
                 name={`${prefix}.dateTimezone`}
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>Date timezone</FormLabel>
+                    <FormLabel className="text-xs">Date timezone</FormLabel>
                     <FormControl>
                       <TimezoneInput
                         value={field.value || ""}
                         onChange={field.onChange}
                         timezones={timezones}
-                        placeholder="e.g. Europe/Berlin"
+                        placeholder="Europe/Berlin"
                       />
                     </FormControl>
-                    <p className="text-muted-foreground text-[11px]">
-                      Timezone for scraped dates (converted to UTC).
-                    </p>
                     <FormMessage />
                   </FormItem>
                 )}
               />
             </div>
-          </div>
-        </CollapsibleContent>
-      </Collapsible>
+          </CollapsibleContent>
+        </Collapsible>
+      </div>
     </div>
   );
 }

--- a/apps/frontend/src/pages/settings/market-data/use-source-runtime.ts
+++ b/apps/frontend/src/pages/settings/market-data/use-source-runtime.ts
@@ -1,0 +1,423 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type UseFormReturn } from "react-hook-form";
+
+import { useTestCustomProviderSource } from "@/hooks/use-custom-providers";
+import type {
+  DetectedHtmlElement,
+  DetectedHtmlTable,
+  TestSourceResult,
+} from "@/lib/types/custom-provider";
+
+import type { FormValues, SourceKey } from "./custom-provider-form";
+import type { ProviderTemplate } from "./provider-templates";
+
+export type MappingField =
+  | "pricePath"
+  | "datePath"
+  | "currencyPath"
+  | "openPath"
+  | "highPath"
+  | "lowPath"
+  | "volumePath";
+
+export interface TestInputs {
+  symbol: string;
+  isin: string;
+  mic: string;
+  currency: string;
+  from: string;
+  to: string;
+}
+
+export interface FetchStatus {
+  code: number;
+  ok: boolean;
+}
+
+function todayDateString() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function yearStartDateString() {
+  return `${new Date().getFullYear()}-01-01`;
+}
+
+const DEFAULT_TEST_CURRENCY = "USD";
+
+function normalizedCurrencyInput(currency: string) {
+  return currency.trim() || DEFAULT_TEST_CURRENCY;
+}
+
+function initialInputs(): TestInputs {
+  return {
+    symbol: "",
+    isin: "",
+    mic: "",
+    currency: DEFAULT_TEST_CURRENCY,
+    from: yearStartDateString(),
+    to: todayDateString(),
+  };
+}
+
+export interface SourceRuntime {
+  isHistorical: boolean;
+  isFetching: boolean;
+  inputs: TestInputs;
+  setInputs: (patch: Partial<TestInputs>) => void;
+  rawResponse: string | null;
+  detectedElements: DetectedHtmlElement[];
+  detectedTables: DetectedHtmlTable[];
+  fetchError: string | null;
+  testResult: TestSourceResult | null;
+  status: FetchStatus | null;
+  armedField: MappingField | null;
+  setArmedField: (f: MappingField | null) => void;
+  handleFetch: () => void;
+  handlePathSelect: (path: string, field?: MappingField) => void;
+  handleColumnSelect: (
+    pricePath: string,
+    datePath?: string,
+    highPath?: string,
+    lowPath?: string,
+    volumePath?: string,
+  ) => void;
+  /** Rewrite the "tableIdx:" prefix of every mapped path from `from` to `to`. */
+  remapTableIndex: (from: number, to: number) => void;
+  applyTemplate: (t: ProviderTemplate) => void;
+  resetFetchState: () => void;
+  extraPlaceholders: { isin: boolean; mic: boolean; currency: boolean };
+  hasFetched: boolean;
+  /** URL with placeholder values substituted (for preview). */
+  expandedUrl: string;
+  urlTemplate: string;
+}
+
+interface UseSourceRuntimeOptions {
+  form: UseFormReturn<FormValues>;
+  prefix: SourceKey;
+  isHistorical: boolean;
+  onUrlChange?: (url: string) => void;
+  onAdvancedOpen?: () => void;
+}
+
+export function useSourceRuntime({
+  form,
+  prefix,
+  isHistorical,
+  onUrlChange,
+  onAdvancedOpen,
+}: UseSourceRuntimeOptions): SourceRuntime {
+  const [inputsState, setInputsState] = useState<TestInputs>(initialInputs);
+  const [rawResponse, setRawResponse] = useState<string | null>(null);
+  const [detectedElements, setDetectedElements] = useState<DetectedHtmlElement[]>([]);
+  const [detectedTables, setDetectedTables] = useState<DetectedHtmlTable[]>([]);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [testResult, setTestResult] = useState<TestSourceResult | null>(null);
+  const [status, setStatus] = useState<FetchStatus | null>(null);
+  const [armedField, setArmedField] = useState<MappingField | null>(null);
+  const { mutate: testSource, isPending: isFetching } = useTestCustomProviderSource();
+  const verifyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (verifyTimer.current) clearTimeout(verifyTimer.current);
+    };
+  }, []);
+
+  const setInputs = useCallback((patch: Partial<TestInputs>) => {
+    setInputsState((prev) => ({ ...prev, ...patch }));
+  }, []);
+
+  const urlTemplate = form.watch(`${prefix}.url`) ?? "";
+
+  const extraPlaceholders = useMemo(
+    () => ({
+      isin: urlTemplate.includes("{ISIN}"),
+      mic: urlTemplate.includes("{MIC}"),
+      currency: urlTemplate.includes("{CURRENCY}") || urlTemplate.includes("{currency}"),
+    }),
+    [urlTemplate],
+  );
+
+  const expandTestUrl = useCallback(
+    (url: string) => {
+      let expanded = url;
+      if (extraPlaceholders.isin) expanded = expanded.replaceAll("{ISIN}", inputsState.isin);
+      if (extraPlaceholders.mic) expanded = expanded.replaceAll("{MIC}", inputsState.mic);
+      if (extraPlaceholders.currency) {
+        const currency = normalizedCurrencyInput(inputsState.currency);
+        expanded = expanded.replaceAll("{currency}", currency.toLowerCase());
+        expanded = expanded.replaceAll("{CURRENCY}", currency.toUpperCase());
+      }
+      return expanded;
+    },
+    [extraPlaceholders, inputsState.isin, inputsState.mic, inputsState.currency],
+  );
+
+  const expandedUrl = useMemo(() => {
+    let u = urlTemplate.replaceAll("{SYMBOL}", inputsState.symbol || "{SYMBOL}");
+    u = expandTestUrl(u);
+    const today = todayDateString();
+    u = u
+      .replaceAll("{TODAY}", today)
+      .replaceAll("{FROM}", inputsState.from)
+      .replaceAll("{TO}", inputsState.to);
+    return u;
+  }, [urlTemplate, expandTestUrl, inputsState.symbol, inputsState.from, inputsState.to]);
+
+  const resetFetchState = useCallback(() => {
+    setRawResponse(null);
+    setDetectedElements([]);
+    setDetectedTables([]);
+    setFetchError(null);
+    setTestResult(null);
+    setStatus(null);
+  }, []);
+
+  const handleFetch = useCallback(() => {
+    const rawUrl = form.getValues(`${prefix}.url`);
+    const symbol = inputsState.symbol;
+    if (!rawUrl || !symbol) return;
+    const format = form.getValues(`${prefix}.format`) ?? "json";
+    const url = expandTestUrl(rawUrl);
+    const headers = form.getValues(`${prefix}.headers`);
+    const pricePathCurrent = form.getValues(`${prefix}.pricePath`);
+
+    setTestResult(null);
+    setFetchError(null);
+
+    const dummyPath = format === "html" ? "body" : format === "html_table" ? "" : "$";
+
+    testSource(
+      {
+        format,
+        url,
+        pricePath: dummyPath,
+        symbol,
+        currency: normalizedCurrencyInput(inputsState.currency),
+        from: isHistorical ? inputsState.from : undefined,
+        to: isHistorical ? inputsState.to : undefined,
+        headers: headers || undefined,
+      },
+      {
+        onSuccess: (result) => {
+          const httpStatusMatch = result.error?.match(/^HTTP\s+(\d{3})/);
+          if (httpStatusMatch) {
+            const code = Number(httpStatusMatch[1]);
+            setRawResponse(null);
+            setDetectedElements([]);
+            setDetectedTables([]);
+            setFetchError(result.error ?? "HTTP request failed.");
+            setStatus({ code, ok: false });
+            if (result.error && /403|forbidden|denied/i.test(result.error)) {
+              onAdvancedOpen?.();
+            }
+            return;
+          }
+
+          setStatus({ code: 200, ok: true });
+          setDetectedElements(result.detectedElements ?? []);
+          setDetectedTables(result.detectedTables ?? []);
+
+          if (result.detectedTables && result.detectedTables.length > 0) {
+            setRawResponse(null);
+          } else if (result.rawResponse) {
+            setRawResponse(result.rawResponse);
+            const trimmed = result.rawResponse.trimStart();
+            const detected = trimmed.startsWith("{") || trimmed.startsWith("[") ? "json" : "html";
+            if (!isHistorical && format !== "csv" && !pricePathCurrent) {
+              form.setValue(`${prefix}.format`, detected);
+            }
+          } else if (result.detectedElements && result.detectedElements.length > 0) {
+            setRawResponse(null);
+          } else if (result.success) {
+            setRawResponse(null);
+            setTestResult(result);
+          } else {
+            setRawResponse(null);
+            setFetchError(result.error ?? "Empty response from server.");
+            setStatus({ code: 0, ok: false });
+            if (result.error && /403|forbidden|denied/i.test(result.error)) {
+              onAdvancedOpen?.();
+            }
+          }
+        },
+        onError: (err) => {
+          setRawResponse(null);
+          setDetectedElements([]);
+          setDetectedTables([]);
+          setFetchError(err.message);
+          setStatus({ code: 0, ok: false });
+          if (/403|forbidden|denied/i.test(err.message)) {
+            onAdvancedOpen?.();
+          }
+        },
+      },
+    );
+  }, [form, prefix, inputsState, expandTestUrl, testSource, isHistorical, onAdvancedOpen]);
+
+  const scheduleVerify = useCallback(
+    (path: string) => {
+      if (verifyTimer.current) clearTimeout(verifyTimer.current);
+      if (
+        (!rawResponse && detectedElements.length === 0 && detectedTables.length === 0) ||
+        !path ||
+        path === "$" ||
+        path === "body"
+      )
+        return;
+
+      verifyTimer.current = setTimeout(() => {
+        const rawUrl = form.getValues(`${prefix}.url`);
+        const symbol = inputsState.symbol;
+        if (!rawUrl || !symbol) return;
+        const url = expandTestUrl(rawUrl);
+        const values = form.getValues(prefix);
+        testSource(
+          {
+            format: values?.format ?? "json",
+            url,
+            pricePath: path,
+            datePath: values?.datePath || undefined,
+            dateFormat: values?.dateFormat || undefined,
+            currencyPath: values?.currencyPath || undefined,
+            factor: values?.factor ?? undefined,
+            invert: values?.invert ?? undefined,
+            locale: values?.locale || undefined,
+            headers: values?.headers || undefined,
+            symbol,
+            currency: normalizedCurrencyInput(inputsState.currency),
+            from: isHistorical ? inputsState.from : undefined,
+            to: isHistorical ? inputsState.to : undefined,
+          },
+          {
+            onSuccess: (result) => setTestResult(result),
+            onError: (err) => setTestResult({ success: false, error: err.message }),
+          },
+        );
+      }, 300);
+    },
+    [
+      form,
+      prefix,
+      rawResponse,
+      detectedElements,
+      detectedTables,
+      inputsState,
+      expandTestUrl,
+      testSource,
+      isHistorical,
+    ],
+  );
+
+  const handlePathSelect = useCallback(
+    (path: string, field?: MappingField) => {
+      const target: MappingField = field ?? armedField ?? "pricePath";
+      form.setValue(`${prefix}.${target}`, path, { shouldValidate: true });
+      // After mapping, if target was optional, keep armed at price (most common next click)
+      if (target === "pricePath") {
+        scheduleVerify(path);
+      } else {
+        // Verify using current pricePath
+        const current = form.getValues(`${prefix}.pricePath`);
+        if (current) scheduleVerify(current);
+      }
+    },
+    [armedField, form, prefix, scheduleVerify],
+  );
+
+  const handleColumnSelect = useCallback(
+    (
+      pricePath: string,
+      datePath?: string,
+      highPath?: string,
+      lowPath?: string,
+      volumePath?: string,
+    ) => {
+      form.setValue(`${prefix}.pricePath`, pricePath, { shouldValidate: true });
+      if (datePath) form.setValue(`${prefix}.datePath`, datePath);
+      if (highPath) form.setValue(`${prefix}.highPath`, highPath);
+      if (lowPath) form.setValue(`${prefix}.lowPath`, lowPath);
+      if (volumePath) form.setValue(`${prefix}.volumePath`, volumePath);
+      scheduleVerify(pricePath);
+    },
+    [form, prefix, scheduleVerify],
+  );
+
+  const remapTableIndex = useCallback(
+    (fromIdx: number, toIdx: number) => {
+      const fields: MappingField[] = [
+        "pricePath",
+        "datePath",
+        "openPath",
+        "highPath",
+        "lowPath",
+        "volumePath",
+      ];
+      const prefixStr = `${fromIdx}:`;
+      for (const f of fields) {
+        const current = form.getValues(`${prefix}.${f}`);
+        if (typeof current === "string" && current.startsWith(prefixStr)) {
+          const next = `${toIdx}:${current.slice(prefixStr.length)}`;
+          form.setValue(`${prefix}.${f}`, next, { shouldValidate: true });
+        }
+      }
+      const newPrice = form.getValues(`${prefix}.pricePath`);
+      if (newPrice) scheduleVerify(newPrice);
+    },
+    [form, prefix, scheduleVerify],
+  );
+
+  const applyTemplate = useCallback(
+    (t: ProviderTemplate) => {
+      form.setValue(`${prefix}.format`, t.format);
+      form.setValue(`${prefix}.url`, t.url);
+      form.setValue(`${prefix}.pricePath`, t.pricePath);
+      form.setValue(`${prefix}.datePath`, t.datePath ?? "");
+      form.setValue(`${prefix}.dateFormat`, "");
+      form.setValue(`${prefix}.openPath`, t.openPath ?? "");
+      form.setValue(`${prefix}.highPath`, t.highPath ?? "");
+      form.setValue(`${prefix}.lowPath`, t.lowPath ?? "");
+      form.setValue(`${prefix}.volumePath`, t.volumePath ?? "");
+      form.setValue(`${prefix}.headers`, t.headers ?? "");
+      form.setValue(`${prefix}.currencyPath`, "");
+      form.setValue(`${prefix}.locale`, "");
+      form.setValue(`${prefix}.factor`, undefined);
+      form.setValue(`${prefix}.invert`, false);
+      form.setValue(`${prefix}.dateTimezone`, "");
+      if (t.headers) onAdvancedOpen?.();
+      setInputsState((prev) => ({ ...prev, symbol: t.testSymbol }));
+      onUrlChange?.(t.url);
+      resetFetchState();
+    },
+    [form, prefix, onAdvancedOpen, onUrlChange, resetFetchState],
+  );
+
+  const hasFetched =
+    rawResponse !== null || detectedElements.length > 0 || detectedTables.length > 0;
+
+  return {
+    isHistorical,
+    isFetching,
+    inputs: inputsState,
+    setInputs,
+    rawResponse,
+    detectedElements,
+    detectedTables,
+    fetchError,
+    testResult,
+    status,
+    armedField,
+    setArmedField,
+    handleFetch,
+    handlePathSelect,
+    handleColumnSelect,
+    remapTableIndex,
+    applyTemplate,
+    resetFetchState,
+    extraPlaceholders,
+    hasFetched,
+    expandedUrl,
+    urlTemplate,
+  };
+}

--- a/apps/frontend/src/pages/settings/market-data/use-source-runtime.ts
+++ b/apps/frontend/src/pages/settings/market-data/use-source-runtime.ts
@@ -201,21 +201,20 @@ export function useSourceRuntime({
       },
       {
         onSuccess: (result) => {
-          const httpStatusMatch = result.error?.match(/^HTTP\s+(\d{3})/);
-          if (httpStatusMatch) {
-            const code = Number(httpStatusMatch[1]);
+          const statusCode = result.statusCode ?? undefined;
+          if (statusCode != null && (statusCode < 200 || statusCode >= 400)) {
             setRawResponse(null);
             setDetectedElements([]);
             setDetectedTables([]);
             setFetchError(result.error ?? "HTTP request failed.");
-            setStatus({ code, ok: false });
+            setStatus({ code: statusCode, ok: false });
             if (result.error && /403|forbidden|denied/i.test(result.error)) {
               onAdvancedOpen?.();
             }
             return;
           }
 
-          setStatus({ code: 200, ok: true });
+          setStatus({ code: statusCode ?? 200, ok: true });
           setDetectedElements(result.detectedElements ?? []);
           setDetectedTables(result.detectedTables ?? []);
 
@@ -285,6 +284,10 @@ export function useSourceRuntime({
             invert: values?.invert ?? undefined,
             locale: values?.locale || undefined,
             headers: values?.headers || undefined,
+            openPath: values?.openPath || undefined,
+            highPath: values?.highPath || undefined,
+            lowPath: values?.lowPath || undefined,
+            volumePath: values?.volumePath || undefined,
             symbol,
             currency: normalizedCurrencyInput(inputsState.currency),
             from: isHistorical ? inputsState.from : undefined,

--- a/apps/frontend/src/pages/settings/market-data/use-source-runtime.ts
+++ b/apps/frontend/src/pages/settings/market-data/use-source-runtime.ts
@@ -377,13 +377,13 @@ export function useSourceRuntime({
       form.setValue(`${prefix}.url`, t.url);
       form.setValue(`${prefix}.pricePath`, t.pricePath);
       form.setValue(`${prefix}.datePath`, t.datePath ?? "");
-      form.setValue(`${prefix}.dateFormat`, "");
+      form.setValue(`${prefix}.dateFormat`, t.dateFormat ?? "");
       form.setValue(`${prefix}.openPath`, t.openPath ?? "");
       form.setValue(`${prefix}.highPath`, t.highPath ?? "");
       form.setValue(`${prefix}.lowPath`, t.lowPath ?? "");
       form.setValue(`${prefix}.volumePath`, t.volumePath ?? "");
       form.setValue(`${prefix}.headers`, t.headers ?? "");
-      form.setValue(`${prefix}.currencyPath`, "");
+      form.setValue(`${prefix}.currencyPath`, t.currencyPath ?? "");
       form.setValue(`${prefix}.locale`, "");
       form.setValue(`${prefix}.factor`, undefined);
       form.setValue(`${prefix}.invert`, false);

--- a/crates/core/src/custom_provider/model.rs
+++ b/crates/core/src/custom_provider/model.rs
@@ -298,11 +298,16 @@ pub struct DetectedHtmlTable {
 }
 
 /// Result of testing a source configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct TestSourceResult {
     pub success: bool,
+    pub status_code: Option<u16>,
     pub price: Option<f64>,
+    pub open: Option<f64>,
+    pub high: Option<f64>,
+    pub low: Option<f64>,
+    pub volume: Option<f64>,
     pub currency: Option<String>,
     pub date: Option<String>,
     pub error: Option<String>,

--- a/crates/core/src/custom_provider/model.rs
+++ b/crates/core/src/custom_provider/model.rs
@@ -12,6 +12,11 @@ pub static DATE_TEMPLATE_RE: std::sync::LazyLock<regex::Regex> =
 /// Maximum HTTP response body size (10 MB).
 pub const MAX_RESPONSE_BYTES: usize = 10 * 1024 * 1024;
 
+/// Browser-like user agent used by custom provider test and runtime requests.
+pub const CUSTOM_PROVIDER_USER_AGENT: &str =
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 \
+     (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+
 /// Context for expanding template variables in URLs and paths.
 pub struct TemplateContext<'a> {
     pub symbol: &'a str,
@@ -78,6 +83,50 @@ pub fn validate_url(raw: &str) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+/// Build default browser-like headers for custom provider HTTP requests.
+pub fn build_browser_like_headers(format: &str, url: &str) -> reqwest::header::HeaderMap {
+    let mut headers = reqwest::header::HeaderMap::new();
+    let default_accept = match format {
+        "json" => "application/json, text/plain, */*",
+        "csv" => "text/csv, text/plain, */*",
+        _ => {
+            "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"
+        }
+    };
+    for (name, value) in [
+        ("accept", default_accept),
+        ("accept-language", "en-US,en;q=0.9"),
+        ("sec-fetch-dest", "empty"),
+        ("sec-fetch-mode", "cors"),
+        ("sec-fetch-site", "same-origin"),
+        (
+            "sec-ch-ua",
+            "\"Chromium\";v=\"131\", \"Not_A Brand\";v=\"24\"",
+        ),
+        ("sec-ch-ua-mobile", "?0"),
+        ("sec-ch-ua-platform", "\"macOS\""),
+        ("upgrade-insecure-requests", "1"),
+    ] {
+        if let (Ok(n), Ok(v)) = (
+            reqwest::header::HeaderName::from_bytes(name.as_bytes()),
+            reqwest::header::HeaderValue::from_str(value),
+        ) {
+            headers.insert(n, v);
+        }
+    }
+
+    if let Ok(parsed) = reqwest::Url::parse(url) {
+        let origin = parsed.origin().ascii_serialization();
+        if origin != "null" {
+            if let Ok(v) = reqwest::header::HeaderValue::from_str(&format!("{origin}/")) {
+                headers.insert(reqwest::header::REFERER, v);
+            }
+        }
+    }
+
+    headers
+}
+
 /// Extract a numeric value from HTML using a CSS selector.
 ///
 /// Shared between `custom_provider::service` (test_source) and
@@ -111,6 +160,8 @@ pub struct CustomProviderSource {
     pub locale: Option<String>,
     /// JSON object string of extra HTTP headers
     pub headers: Option<String>,
+    #[serde(default)]
+    pub open_path: Option<String>,
     pub high_path: Option<String>,
     pub low_path: Option<String>,
     pub volume_path: Option<String>,
@@ -170,6 +221,8 @@ pub struct NewCustomProviderSource {
     pub invert: Option<bool>,
     pub locale: Option<String>,
     pub headers: Option<String>,
+    #[serde(default)]
+    pub open_path: Option<String>,
     pub high_path: Option<String>,
     pub low_path: Option<String>,
     pub volume_path: Option<String>,
@@ -195,6 +248,12 @@ pub struct TestSourceRequest {
     pub symbol: String,
     /// Currency for {currency}/{CURRENCY} placeholders (defaults to "usd")
     pub currency: Option<String>,
+    /// Start date for {FROM} placeholders while testing historical sources.
+    pub from: Option<String>,
+    /// End date for {TO} placeholders while testing historical sources.
+    pub to: Option<String>,
+    #[serde(default)]
+    pub open_path: Option<String>,
     pub high_path: Option<String>,
     pub low_path: Option<String>,
     pub volume_path: Option<String>,

--- a/crates/core/src/custom_provider/service.rs
+++ b/crates/core/src/custom_provider/service.rs
@@ -324,7 +324,6 @@ impl CustomProviderService {
                             raw_response: Some(body),
                             detected_elements: None,
                             detected_tables: None,
-                            ..Default::default()
                         })
                     }
                     None => Ok(TestSourceResult {
@@ -451,7 +450,6 @@ impl CustomProviderService {
                             raw_response: None,
                             detected_elements: None,
                             detected_tables: Some(tables),
-                            ..Default::default()
                         })
                     }
                     None => Ok(TestSourceResult {
@@ -517,7 +515,6 @@ impl CustomProviderService {
                         raw_response: Some(body),
                         detected_elements: None,
                         detected_tables: None,
-                        ..Default::default()
                     })
                 }
                 None => Ok(TestSourceResult {

--- a/crates/core/src/custom_provider/service.rs
+++ b/crates/core/src/custom_provider/service.rs
@@ -190,6 +190,7 @@ impl CustomProviderService {
                     raw_response: None,
                     detected_elements: None,
                     detected_tables: None,
+                    ..Default::default()
                 });
             }
         };
@@ -199,6 +200,7 @@ impl CustomProviderService {
             if len > MAX_RESPONSE_BYTES as u64 {
                 return Ok(TestSourceResult {
                     success: false,
+                    status_code: Some(status.as_u16()),
                     price: None,
                     currency: None,
                     date: None,
@@ -209,6 +211,7 @@ impl CustomProviderService {
                     raw_response: None,
                     detected_elements: None,
                     detected_tables: None,
+                    ..Default::default()
                 });
             }
         }
@@ -217,6 +220,7 @@ impl CustomProviderService {
             Err(e) => {
                 return Ok(TestSourceResult {
                     success: false,
+                    status_code: Some(status.as_u16()),
                     price: None,
                     currency: None,
                     date: None,
@@ -224,12 +228,14 @@ impl CustomProviderService {
                     raw_response: None,
                     detected_elements: None,
                     detected_tables: None,
+                    ..Default::default()
                 });
             }
         };
         if body_bytes.len() > MAX_RESPONSE_BYTES {
             return Ok(TestSourceResult {
                 success: false,
+                status_code: Some(status.as_u16()),
                 price: None,
                 currency: None,
                 date: None,
@@ -241,6 +247,7 @@ impl CustomProviderService {
                 raw_response: None,
                 detected_elements: None,
                 detected_tables: None,
+                ..Default::default()
             });
         }
         let body = String::from_utf8_lossy(&body_bytes).to_string();
@@ -248,6 +255,7 @@ impl CustomProviderService {
         if !status.is_success() {
             return Ok(TestSourceResult {
                 success: false,
+                status_code: Some(status.as_u16()),
                 price: None,
                 currency: None,
                 date: None,
@@ -255,6 +263,7 @@ impl CustomProviderService {
                 raw_response: Some(body),
                 detected_elements: None,
                 detected_tables: None,
+                ..Default::default()
             });
         }
 
@@ -274,28 +283,53 @@ impl CustomProviderService {
                     .as_ref()
                     .map(|dp| expand_path(dp))
                     .and_then(|dp| extract_json_string(&body, &dp));
+                let open = payload
+                    .open_path
+                    .as_ref()
+                    .map(|op| expand_path(op))
+                    .and_then(|op| extract_json_value(&body, &op))
+                    .map(|v| apply_test_factor_invert(v, &payload));
+                let high = payload
+                    .high_path
+                    .as_ref()
+                    .map(|hp| expand_path(hp))
+                    .and_then(|hp| extract_json_value(&body, &hp))
+                    .map(|v| apply_test_factor_invert(v, &payload));
+                let low = payload
+                    .low_path
+                    .as_ref()
+                    .map(|lp| expand_path(lp))
+                    .and_then(|lp| extract_json_value(&body, &lp))
+                    .map(|v| apply_test_factor_invert(v, &payload));
+                let volume = payload
+                    .volume_path
+                    .as_ref()
+                    .map(|vp| expand_path(vp))
+                    .and_then(|vp| extract_json_value(&body, &vp));
 
                 match price {
-                    Some(mut p) => {
-                        if let Some(factor) = payload.factor {
-                            p *= factor;
-                        }
-                        if payload.invert == Some(true) && p != 0.0 {
-                            p = 1.0 / p;
-                        }
+                    Some(p) => {
+                        let p = apply_test_factor_invert(p, &payload);
                         Ok(TestSourceResult {
                             success: true,
+                            status_code: Some(status.as_u16()),
                             price: Some(p),
+                            open,
+                            high,
+                            low,
+                            volume,
                             currency,
                             date,
                             error: None,
                             raw_response: Some(body),
                             detected_elements: None,
                             detected_tables: None,
+                            ..Default::default()
                         })
                     }
                     None => Ok(TestSourceResult {
                         success: false,
+                        status_code: Some(status.as_u16()),
                         price: None,
                         currency: None,
                         date: None,
@@ -306,6 +340,7 @@ impl CustomProviderService {
                         raw_response: Some(body),
                         detected_elements: None,
                         detected_tables: None,
+                        ..Default::default()
                     }),
                 }
             }
@@ -313,27 +348,42 @@ impl CustomProviderService {
                 let detected = detect_html_elements(&body, payload.locale.as_deref());
                 let price =
                     extract_html_value(&body, &payload.price_path, payload.locale.as_deref());
+                let high = payload
+                    .high_path
+                    .as_ref()
+                    .and_then(|p| extract_html_value(&body, p, payload.locale.as_deref()))
+                    .map(|v| apply_test_factor_invert(v, &payload));
+                let low = payload
+                    .low_path
+                    .as_ref()
+                    .and_then(|p| extract_html_value(&body, p, payload.locale.as_deref()))
+                    .map(|v| apply_test_factor_invert(v, &payload));
+                let volume = payload
+                    .volume_path
+                    .as_ref()
+                    .and_then(|p| extract_html_value(&body, p, payload.locale.as_deref()));
                 match price {
-                    Some(mut p) => {
-                        if let Some(factor) = payload.factor {
-                            p *= factor;
-                        }
-                        if payload.invert == Some(true) && p != 0.0 {
-                            p = 1.0 / p;
-                        }
+                    Some(p) => {
+                        let p = apply_test_factor_invert(p, &payload);
                         Ok(TestSourceResult {
                             success: true,
+                            status_code: Some(status.as_u16()),
                             price: Some(p),
+                            high,
+                            low,
+                            volume,
                             currency: None,
                             date: None,
                             error: None,
                             raw_response: None,
                             detected_elements: Some(detected),
                             detected_tables: None,
+                            ..Default::default()
                         })
                     }
                     None => Ok(TestSourceResult {
                         success: false,
+                        status_code: Some(status.as_u16()),
                         price: None,
                         currency: None,
                         date: None,
@@ -344,6 +394,7 @@ impl CustomProviderService {
                         raw_response: None,
                         detected_elements: Some(detected),
                         detected_tables: None,
+                        ..Default::default()
                     }),
                 }
             }
@@ -359,28 +410,53 @@ impl CustomProviderService {
                     .as_ref()
                     .filter(|dp| !dp.is_empty())
                     .and_then(|dp| extract_table_string(&body, dp));
+                let open = payload
+                    .open_path
+                    .as_ref()
+                    .filter(|p| !p.is_empty())
+                    .and_then(|p| extract_table_value(&body, p, payload.locale.as_deref()))
+                    .map(|v| apply_test_factor_invert(v, &payload));
+                let high = payload
+                    .high_path
+                    .as_ref()
+                    .filter(|p| !p.is_empty())
+                    .and_then(|p| extract_table_value(&body, p, payload.locale.as_deref()))
+                    .map(|v| apply_test_factor_invert(v, &payload));
+                let low = payload
+                    .low_path
+                    .as_ref()
+                    .filter(|p| !p.is_empty())
+                    .and_then(|p| extract_table_value(&body, p, payload.locale.as_deref()))
+                    .map(|v| apply_test_factor_invert(v, &payload));
+                let volume = payload
+                    .volume_path
+                    .as_ref()
+                    .filter(|p| !p.is_empty())
+                    .and_then(|p| extract_table_value(&body, p, payload.locale.as_deref()));
 
                 match price {
-                    Some(mut p) => {
-                        if let Some(factor) = payload.factor {
-                            p *= factor;
-                        }
-                        if payload.invert == Some(true) && p != 0.0 {
-                            p = 1.0 / p;
-                        }
+                    Some(p) => {
+                        let p = apply_test_factor_invert(p, &payload);
                         Ok(TestSourceResult {
                             success: true,
+                            status_code: Some(status.as_u16()),
                             price: Some(p),
+                            open,
+                            high,
+                            low,
+                            volume,
                             currency: None,
                             date,
                             error: None,
                             raw_response: None,
                             detected_elements: None,
                             detected_tables: Some(tables),
+                            ..Default::default()
                         })
                     }
                     None => Ok(TestSourceResult {
                         success: !tables.is_empty(),
+                        status_code: Some(status.as_u16()),
                         price: None,
                         currency: None,
                         date: None,
@@ -392,35 +468,61 @@ impl CustomProviderService {
                         raw_response: None,
                         detected_elements: None,
                         detected_tables: Some(tables),
+                        ..Default::default()
                     }),
                 }
             }
             "csv" => match parse_csv_test(&body, &payload.price_path, payload.locale.as_deref()) {
-                Some(mut p) => {
-                    if let Some(factor) = payload.factor {
-                        p *= factor;
-                    }
-                    if payload.invert == Some(true) && p != 0.0 {
-                        p = 1.0 / p;
-                    }
+                Some(p) => {
+                    let p = apply_test_factor_invert(p, &payload);
                     let date = payload
                         .date_path
                         .as_ref()
                         .filter(|dp| !dp.is_empty())
                         .and_then(|dp| extract_csv_string(&body, dp));
+                    let open = payload
+                        .open_path
+                        .as_ref()
+                        .filter(|p| !p.is_empty())
+                        .and_then(|p| parse_csv_test(&body, p, payload.locale.as_deref()))
+                        .map(|v| apply_test_factor_invert(v, &payload));
+                    let high = payload
+                        .high_path
+                        .as_ref()
+                        .filter(|p| !p.is_empty())
+                        .and_then(|p| parse_csv_test(&body, p, payload.locale.as_deref()))
+                        .map(|v| apply_test_factor_invert(v, &payload));
+                    let low = payload
+                        .low_path
+                        .as_ref()
+                        .filter(|p| !p.is_empty())
+                        .and_then(|p| parse_csv_test(&body, p, payload.locale.as_deref()))
+                        .map(|v| apply_test_factor_invert(v, &payload));
+                    let volume = payload
+                        .volume_path
+                        .as_ref()
+                        .filter(|p| !p.is_empty())
+                        .and_then(|p| parse_csv_test(&body, p, payload.locale.as_deref()));
                     Ok(TestSourceResult {
                         success: true,
+                        status_code: Some(status.as_u16()),
                         price: Some(p),
+                        open,
+                        high,
+                        low,
+                        volume,
                         currency: None,
                         date,
                         error: None,
                         raw_response: Some(body),
                         detected_elements: None,
                         detected_tables: None,
+                        ..Default::default()
                     })
                 }
                 None => Ok(TestSourceResult {
                     success: false,
+                    status_code: Some(status.as_u16()),
                     price: None,
                     currency: None,
                     date: None,
@@ -431,10 +533,12 @@ impl CustomProviderService {
                     raw_response: Some(body),
                     detected_elements: None,
                     detected_tables: None,
+                    ..Default::default()
                 }),
             },
             _ => Ok(TestSourceResult {
                 success: false,
+                status_code: Some(status.as_u16()),
                 price: None,
                 currency: None,
                 date: None,
@@ -442,6 +546,7 @@ impl CustomProviderService {
                 raw_response: None,
                 detected_elements: None,
                 detected_tables: None,
+                ..Default::default()
             }),
         }
     }
@@ -466,6 +571,16 @@ fn validate_source_kind_format(kind: &str, format: &str) -> crate::errors::Resul
         .into());
     }
     Ok(())
+}
+
+fn apply_test_factor_invert(mut value: f64, payload: &TestSourceRequest) -> f64 {
+    if let Some(factor) = payload.factor {
+        value *= factor;
+    }
+    if payload.invert == Some(true) && value != 0.0 {
+        value = 1.0 / value;
+    }
+    value
 }
 
 /// Extract a numeric value from JSON using a JSONPath expression.

--- a/crates/core/src/custom_provider/service.rs
+++ b/crates/core/src/custom_provider/service.rs
@@ -131,8 +131,8 @@ impl CustomProviderService {
             currency,
             isin: None,
             mic: None,
-            from: None,
-            to: None,
+            from: payload.from.as_deref(),
+            to: payload.to.as_deref(),
         };
         let url = expand_template(&payload.url, &tctx);
 
@@ -140,14 +140,16 @@ impl CustomProviderService {
 
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(15))
-            .redirect(reqwest::redirect::Policy::none())
-            .user_agent(
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko)",
-            )
+            .redirect(reqwest::redirect::Policy::limited(5))
+            .user_agent(CUSTOM_PROVIDER_USER_AGENT)
             .build()
             .map_err(|e| crate::Error::Unexpected(format!("HTTP client error: {}", e)))?;
 
-        let mut headers = reqwest::header::HeaderMap::new();
+        // Default browser-like headers. Many data APIs sit behind bot-protection
+        // (Akamai/Cloudflare) that serves placebo responses to clients lacking the
+        // typical browser header set. User-supplied headers below override these.
+        let mut headers = build_browser_like_headers(&payload.format, &url);
+
         if let Some(headers_json) = &payload.headers {
             if let Ok(map) =
                 serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(headers_json)
@@ -352,6 +354,11 @@ impl CustomProviderService {
                 } else {
                     None
                 };
+                let date = payload
+                    .date_path
+                    .as_ref()
+                    .filter(|dp| !dp.is_empty())
+                    .and_then(|dp| extract_table_string(&body, dp));
 
                 match price {
                     Some(mut p) => {
@@ -365,7 +372,7 @@ impl CustomProviderService {
                             success: true,
                             price: Some(p),
                             currency: None,
-                            date: None,
+                            date,
                             error: None,
                             raw_response: None,
                             detected_elements: None,
@@ -396,11 +403,16 @@ impl CustomProviderService {
                     if payload.invert == Some(true) && p != 0.0 {
                         p = 1.0 / p;
                     }
+                    let date = payload
+                        .date_path
+                        .as_ref()
+                        .filter(|dp| !dp.is_empty())
+                        .and_then(|dp| extract_csv_string(&body, dp));
                     Ok(TestSourceResult {
                         success: true,
                         price: Some(p),
                         currency: None,
-                        date: None,
+                        date,
                         error: None,
                         raw_response: Some(body),
                         detected_elements: None,
@@ -805,12 +817,27 @@ pub fn parse_number_string(s: &str, locale: Option<&str>) -> Option<f64> {
             // European: 1.234,56 → 1234.56
             stripped.replace('.', "").replace(',', ".")
         }
+        Some(l)
+            if l.starts_with("en")
+                || l.starts_with("ja")
+                || l.starts_with("ko")
+                || l.starts_with("zh")
+                || l == "C" =>
+        {
+            // Locales where comma is thousands separator and dot is decimal.
+            // Drop commas, keep dots. "4,832" → 4832, "1,234.56" → 1234.56.
+            stripped.replace(',', "")
+        }
         _ => {
-            // Auto-detect European format: comma followed by 1-8 digits at end
-            // (e.g. "1.234,56" or "0,12345678" for crypto/FX)
+            // Auto-detect European format: comma followed by 1, 2, or 4-8 digits
+            // at end (e.g. "1.234,56" or "0,12345678" for crypto/FX). Exactly 3
+            // trailing digits is ambiguous with US thousands ("4,832") and is
+            // overwhelmingly the thousands case for English-language financial
+            // sources — handled by the else-if arm below as a thousands strip.
             let has_european_comma = stripped.rfind(',').is_some_and(|pos| {
                 let after = stripped.len() - pos - 1;
-                (1..=8).contains(&after) && stripped[pos + 1..].chars().all(|c| c.is_ascii_digit())
+                stripped[pos + 1..].chars().all(|c| c.is_ascii_digit())
+                    && (after == 1 || after == 2 || (4..=8).contains(&after))
             });
             let has_trailing_dot = stripped.rfind('.').is_some_and(|pos| {
                 let after = stripped.len() - pos - 1;
@@ -882,6 +909,22 @@ fn detect_column_role(header: &str) -> Option<String> {
 }
 
 /// Detect HTML tables on a page, extracting column metadata and sample rows.
+/// Extract text from a cell, tolerant of pages that include multiple viewport
+/// variants of the same content (e.g. desktop + mobile `<span>`s in a single
+/// `<td>`). When the cell has direct child elements with text, returns the
+/// first non-empty one. Falls back to the cell's full text for simple cells.
+fn extract_cell_text(el: scraper::ElementRef<'_>) -> String {
+    for child in el.children() {
+        if let Some(child_el) = scraper::ElementRef::wrap(child) {
+            let text = child_el.text().collect::<String>().trim().to_string();
+            if !text.is_empty() {
+                return text;
+            }
+        }
+    }
+    el.text().collect::<String>().trim().to_string()
+}
+
 fn detect_html_tables(body: &str) -> Vec<DetectedHtmlTable> {
     let document = scraper::Html::parse_document(body);
     let table_sel = match scraper::Selector::parse("table") {
@@ -897,28 +940,19 @@ fn detect_html_tables(body: &str) -> Vec<DetectedHtmlTable> {
         // Extract headers: try <thead><tr><th> first, then first <tr> cells
         let mut headers: Vec<String> = Vec::new();
         if let Ok(thead_sel) = scraper::Selector::parse("thead th") {
-            headers = table_el
-                .select(&thead_sel)
-                .map(|el| el.text().collect::<String>().trim().to_string())
-                .collect();
+            headers = table_el.select(&thead_sel).map(extract_cell_text).collect();
         }
 
         let mut rows: Vec<Vec<String>> = Vec::new();
         let mut body_start = 0;
 
         for (row_idx, tr) in table_el.select(&tr_sel).enumerate() {
-            let cells: Vec<String> = tr
-                .select(&td_sel)
-                .map(|el| el.text().collect::<String>().trim().to_string())
-                .collect();
+            let cells: Vec<String> = tr.select(&td_sel).map(extract_cell_text).collect();
 
             if cells.is_empty() {
                 // This row has no <td>s — might be a header row with <th>s
                 if headers.is_empty() {
-                    headers = tr
-                        .select(&th_sel)
-                        .map(|el| el.text().collect::<String>().trim().to_string())
-                        .collect();
+                    headers = tr.select(&th_sel).map(extract_cell_text).collect();
                 }
                 continue;
             }
@@ -984,14 +1018,41 @@ fn extract_table_value(body: &str, path: &str, locale: Option<&str>) -> Option<f
 
     // Find first row with <td> cells
     for tr in table_el.select(&tr_sel) {
-        let cells: Vec<String> = tr
-            .select(&td_sel)
-            .map(|el| el.text().collect::<String>().trim().to_string())
-            .collect();
+        let cells: Vec<String> = tr.select(&td_sel).map(extract_cell_text).collect();
         if cells.is_empty() || col_idx >= cells.len() {
             continue;
         }
         return parse_number_string(&cells[col_idx], locale);
+    }
+    None
+}
+
+/// Extract a raw cell string (e.g. a date) from an HTML table using "table:col".
+fn extract_table_string(body: &str, path: &str) -> Option<String> {
+    let parts: Vec<&str> = path.split(':').collect();
+    if parts.len() != 2 {
+        return None;
+    }
+    let table_idx: usize = parts[0].parse().ok()?;
+    let col_idx: usize = parts[1].parse().ok()?;
+
+    let document = scraper::Html::parse_document(body);
+    let table_sel = scraper::Selector::parse("table").ok()?;
+    let table_el = document.select(&table_sel).nth(table_idx)?;
+
+    let tr_sel = scraper::Selector::parse("tr").ok()?;
+    let td_sel = scraper::Selector::parse("td").ok()?;
+
+    for tr in table_el.select(&tr_sel) {
+        let cells: Vec<String> = tr.select(&td_sel).map(extract_cell_text).collect();
+        if cells.is_empty() || col_idx >= cells.len() {
+            continue;
+        }
+        let s = cells[col_idx].trim().to_string();
+        if s.is_empty() {
+            return None;
+        }
+        return Some(s);
     }
     None
 }
@@ -1010,6 +1071,23 @@ fn parse_csv_test(body: &str, price_col: &str, locale: Option<&str>) -> Option<f
     let col_idx = resolve_csv_column(headers, price_col)?;
     let val = last_row.get(col_idx)?;
     parse_number_string(val, locale)
+}
+
+/// Extract a raw string cell (e.g. a date) from CSV for test_source. Uses last row.
+fn extract_csv_string(body: &str, col: &str) -> Option<String> {
+    let records = parse_csv_records(body)?;
+    if records.is_empty() {
+        return None;
+    }
+    let (headers, data_rows) = (&records[0], &records[1..]);
+    let last_row = data_rows.last()?;
+    let col_idx = resolve_csv_column(headers, col)?;
+    let val = last_row.get(col_idx)?.trim().to_string();
+    if val.is_empty() {
+        None
+    } else {
+        Some(val)
+    }
 }
 
 /// Parse CSV body into rows, auto-detecting delimiter (; vs ,).

--- a/crates/core/src/quotes/custom_scraper_provider.rs
+++ b/crates/core/src/quotes/custom_scraper_provider.rs
@@ -9,7 +9,8 @@ use log::debug;
 use rust_decimal::Decimal;
 
 use crate::custom_provider::model::{
-    expand_template, extract_html_value, validate_url, TemplateContext, MAX_RESPONSE_BYTES,
+    build_browser_like_headers, expand_template, extract_html_value, validate_url, TemplateContext,
+    CUSTOM_PROVIDER_USER_AGENT, MAX_RESPONSE_BYTES,
 };
 use crate::custom_provider::service::{
     detect_html_locale, parse_csv_records, parse_number_string, resolve_csv_column,
@@ -39,10 +40,8 @@ impl CustomScraperProvider {
     ) -> Self {
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(15))
-            .redirect(reqwest::redirect::Policy::none())
-            .user_agent(
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko)",
-            )
+            .redirect(reqwest::redirect::Policy::limited(5))
+            .user_agent(CUSTOM_PROVIDER_USER_AGENT)
             .build()
             .expect("failed to build reqwest HTTP client");
         Self {
@@ -93,8 +92,9 @@ impl CustomScraperProvider {
     fn build_headers(
         &self,
         source: &CustomProviderSource,
+        url: &str,
     ) -> Result<reqwest::header::HeaderMap, MarketDataError> {
-        let mut headers = reqwest::header::HeaderMap::new();
+        let mut headers = build_browser_like_headers(&source.format, url);
         if let Some(headers_json) = &source.headers {
             if let Ok(map) =
                 serde_json::from_str::<serde_json::Map<String, serde_json::Value>>(headers_json)
@@ -192,6 +192,71 @@ impl CustomScraperProvider {
             })
     }
 
+    async fn fetch_latest_from_historical_sources(
+        &self,
+        context: &QuoteContext,
+        symbol: &str,
+        currency_hint: Option<&str>,
+    ) -> Result<MarketQuote, MarketDataError> {
+        let sources = self.find_sources(context, "historical")?;
+        let to = Utc::now();
+        let from = to - chrono::Duration::days(90);
+        let from_str = from.format("%Y-%m-%d").to_string();
+        let to_str = to.format("%Y-%m-%d").to_string();
+
+        let mut last_err = None;
+        for source in &sources {
+            let sym = Self::resolve_symbol(context, source, symbol);
+            match self
+                .fetch_from_source_with_dates(
+                    source,
+                    &sym,
+                    currency_hint,
+                    Some(context),
+                    Some(&from_str),
+                    Some(&to_str),
+                )
+                .await
+            {
+                Ok(quotes) => {
+                    if let Some(quote) = quotes.into_iter().max_by_key(|q| q.timestamp) {
+                        return Ok(quote);
+                    }
+                    last_err = Some((
+                        source.provider_id.clone(),
+                        MarketDataError::ProviderError {
+                            provider: DATA_SOURCE_CUSTOM_SCRAPER.to_string(),
+                            message: format!("No historical quotes extracted for symbol '{}'", sym),
+                        },
+                    ));
+                }
+                Err(e) => {
+                    log::debug!(
+                        "CustomScraper [{}]: historical latest fallback failed for '{}': {}",
+                        source.provider_id,
+                        sym,
+                        e
+                    );
+                    last_err = Some((source.provider_id.clone(), e));
+                }
+            }
+        }
+
+        let (pid, e) = last_err.unwrap_or_else(|| {
+            (
+                "unknown".to_string(),
+                MarketDataError::ProviderError {
+                    provider: DATA_SOURCE_CUSTOM_SCRAPER.to_string(),
+                    message: "No historical providers found".to_string(),
+                },
+            )
+        });
+        Err(MarketDataError::ProviderError {
+            provider: DATA_SOURCE_CUSTOM_SCRAPER.to_string(),
+            message: format!("[{}] {}", pid, extract_inner_message(&e)),
+        })
+    }
+
     /// Load and execute a source config, returning one or more quotes.
     async fn fetch_from_source_with_dates(
         &self,
@@ -223,7 +288,7 @@ impl CustomScraperProvider {
             message: e.to_string(),
         })?;
 
-        let headers = self.build_headers(source)?;
+        let headers = self.build_headers(source, &url)?;
 
         debug!("CustomScraper: fetching {} for symbol '{}'", url, symbol);
 
@@ -241,7 +306,7 @@ impl CustomScraperProvider {
             }
         };
 
-        let currency = resolve_currency(source, symbol, currency_hint, &body);
+        let currency = resolve_currency(source, symbol, currency_hint, &body, from, to);
 
         // Auto-detect locale from HTML lang if not explicitly set
         let locale = source.locale.as_deref().map(|s| s.to_string()).or_else(|| {
@@ -278,7 +343,8 @@ impl CustomScraperProvider {
                 Ok(rows_to_quotes(rows, source, &currency))
             }
             "json" => {
-                let rows = extract_json_rows(&body, source, symbol, currency_hint, locale_ref);
+                let rows =
+                    extract_json_rows(&body, source, symbol, currency_hint, locale_ref, from, to);
                 if rows.is_empty() {
                     return Err(MarketDataError::ProviderError {
                         provider: DATA_SOURCE_CUSTOM_SCRAPER.to_string(),
@@ -399,42 +465,50 @@ impl MarketDataProvider for CustomScraperProvider {
             }
         };
 
-        let sources = self.find_sources(context, "latest")?;
         let currency_hint = context.currency_hint.as_deref();
 
+        let sources = self.find_sources(context, "latest").ok();
         let mut last_err = None;
-        for source in &sources {
-            let sym = Self::resolve_symbol(context, source, &symbol);
-            match self
-                .fetch_from_source(source, &sym, currency_hint, Some(context))
-                .await
-            {
-                Ok(quote) => return Ok(quote),
-                Err(e) => {
-                    log::debug!(
-                        "CustomScraper [{}]: failed for symbol '{}': {}",
-                        source.provider_id,
-                        sym,
-                        e
-                    );
-                    last_err = Some((source.provider_id.clone(), e));
+        if let Some(sources) = sources {
+            for source in &sources {
+                let sym = Self::resolve_symbol(context, source, &symbol);
+                match self
+                    .fetch_from_source(source, &sym, currency_hint, Some(context))
+                    .await
+                {
+                    Ok(quote) => return Ok(quote),
+                    Err(e) => {
+                        log::debug!(
+                            "CustomScraper [{}]: failed for symbol '{}': {}",
+                            source.provider_id,
+                            sym,
+                            e
+                        );
+                        last_err = Some((source.provider_id.clone(), e));
+                    }
                 }
             }
         }
 
-        let (pid, e) = last_err.unwrap_or_else(|| {
-            (
-                "unknown".to_string(),
-                MarketDataError::ProviderError {
+        match self
+            .fetch_latest_from_historical_sources(context, &symbol, currency_hint)
+            .await
+        {
+            Ok(quote) => Ok(quote),
+            Err(historical_err) => {
+                let Some((pid, e)) = last_err else {
+                    return Err(historical_err);
+                };
+                log::debug!(
+                    "CustomScraper: latest source failed and historical fallback also failed: {}",
+                    historical_err
+                );
+                Err(MarketDataError::ProviderError {
                     provider: DATA_SOURCE_CUSTOM_SCRAPER.to_string(),
-                    message: "No providers found".to_string(),
-                },
-            )
-        });
-        Err(MarketDataError::ProviderError {
-            provider: DATA_SOURCE_CUSTOM_SCRAPER.to_string(),
-            message: format!("[{}] {}", pid, extract_inner_message(&e)),
-        })
+                    message: format!("[{}] {}", pid, extract_inner_message(&e)),
+                })
+            }
+        }
     }
 
     async fn get_historical_quotes(
@@ -608,6 +682,7 @@ impl CustomScraperProvider {
 struct ExtractedRow {
     date: Option<NaiveDate>,
     close: f64,
+    open: Option<f64>,
     high: Option<f64>,
     low: Option<f64>,
     volume: Option<f64>,
@@ -644,6 +719,8 @@ fn resolve_currency(
     symbol: &str,
     currency_hint: Option<&str>,
     body: &str,
+    from: Option<&str>,
+    to: Option<&str>,
 ) -> String {
     if source.format == "json" {
         let currency = currency_hint.unwrap_or("USD");
@@ -652,8 +729,8 @@ fn resolve_currency(
             currency,
             isin: None,
             mic: None,
-            from: None,
-            to: None,
+            from,
+            to,
         };
         source
             .currency_path
@@ -692,6 +769,7 @@ fn rows_to_quotes(
 
             let src = format!("{}:{}", DATA_SOURCE_CUSTOM_SCRAPER, source.provider_id);
             let mut quote = MarketQuote::new(ts, to_decimal(close), currency.to_string(), src);
+            quote.open = row.open.map(|v| to_decimal(apply_factor_invert(v, source)));
             quote.high = row.high.map(|v| to_decimal(apply_factor_invert(v, source)));
             quote.low = row.low.map(|v| to_decimal(apply_factor_invert(v, source)));
             quote.volume = row.volume.map(to_decimal);
@@ -820,6 +898,11 @@ fn extract_table_rows(
         .as_ref()
         .and_then(|p| parse_table_col_path(p))
         .map(|(_, c)| c);
+    let open_col = source
+        .open_path
+        .as_ref()
+        .and_then(|p| parse_table_col_path(p))
+        .map(|(_, c)| c);
     let high_col = source
         .high_path
         .as_ref()
@@ -861,6 +944,9 @@ fn extract_table_rows(
         let date = date_col
             .and_then(|c| cells.get(c))
             .and_then(|s| parse_date(s, date_fmt));
+        let open = open_col
+            .and_then(|c| cells.get(c))
+            .and_then(|s| parse_number_string(s, locale));
         let high = high_col
             .and_then(|c| cells.get(c))
             .and_then(|s| parse_number_string(s, locale));
@@ -874,6 +960,7 @@ fn extract_table_rows(
         rows.push(ExtractedRow {
             date,
             close,
+            open,
             high,
             low,
             volume,
@@ -916,6 +1003,10 @@ fn extract_csv_rows(
         .date_path
         .as_ref()
         .and_then(|p| resolve_csv_column(headers, p));
+    let open_col = source
+        .open_path
+        .as_ref()
+        .and_then(|p| resolve_csv_column(headers, p));
     let high_col = source
         .high_path
         .as_ref()
@@ -940,6 +1031,9 @@ fn extract_csv_rows(
             let date = date_col
                 .and_then(|c| row.get(c))
                 .and_then(|s| parse_date(s, date_fmt));
+            let open = open_col
+                .and_then(|c| row.get(c))
+                .and_then(|s| parse_number_string(s, locale));
             let high = high_col
                 .and_then(|c| row.get(c))
                 .and_then(|s| parse_number_string(s, locale));
@@ -953,6 +1047,7 @@ fn extract_csv_rows(
             Some(ExtractedRow {
                 date,
                 close,
+                open,
                 high,
                 low,
                 volume,
@@ -969,6 +1064,8 @@ fn extract_json_rows(
     symbol: &str,
     currency_hint: Option<&str>,
     locale: Option<&str>,
+    from: Option<&str>,
+    to: Option<&str>,
 ) -> Vec<ExtractedRow> {
     use jsonpath_rust::JsonPathQuery;
 
@@ -983,8 +1080,8 @@ fn extract_json_rows(
         currency,
         isin: None,
         mic: None,
-        from: None,
-        to: None,
+        from,
+        to,
     };
     let expand_path = |p: &str| -> String { expand_template(p, &tctx) };
 
@@ -1011,9 +1108,11 @@ fn extract_json_rows(
         })
         .unwrap_or_default();
 
+    let open_path = source.open_path.as_deref().map(expand_path);
     let high_path = source.high_path.as_deref().map(expand_path);
     let low_path = source.low_path.as_deref().map(expand_path);
     let volume_path = source.volume_path.as_deref().map(expand_path);
+    let opens = extract_json_f64_array(&json, open_path.as_deref(), locale);
     let highs = extract_json_f64_array(&json, high_path.as_deref(), locale);
     let lows = extract_json_f64_array(&json, low_path.as_deref(), locale);
     let volumes = extract_json_f64_array(&json, volume_path.as_deref(), locale);
@@ -1041,6 +1140,7 @@ fn extract_json_rows(
             Some(ExtractedRow {
                 date,
                 close,
+                open: opens.get(i).copied().flatten(),
                 high: highs.get(i).copied().flatten(),
                 low: lows.get(i).copied().flatten(),
                 volume: volumes.get(i).copied().flatten(),
@@ -1109,6 +1209,71 @@ mod tests {
 
     fn ymd(y: i32, m: u32, d: u32) -> NaiveDate {
         NaiveDate::from_ymd_opt(y, m, d).unwrap()
+    }
+
+    fn json_source(price_path: &str) -> CustomProviderSource {
+        CustomProviderSource {
+            id: "test:historical".to_string(),
+            provider_id: "test".to_string(),
+            kind: "historical".to_string(),
+            format: "json".to_string(),
+            url: "https://example.test/prices".to_string(),
+            price_path: price_path.to_string(),
+            date_path: None,
+            date_format: None,
+            currency_path: None,
+            factor: None,
+            invert: None,
+            locale: None,
+            headers: None,
+            open_path: None,
+            high_path: None,
+            low_path: None,
+            volume_path: None,
+            default_price: None,
+            date_timezone: None,
+        }
+    }
+
+    #[test]
+    fn extract_json_rows_expands_historical_date_placeholders() {
+        let body = r#"{
+            "series": {
+                "2026-01-01": [{ "date": "2026-01-01", "close": "10.50", "open": "10.00" }],
+                "2026-02-01": [{ "date": "2026-02-01", "close": "12.50", "open": "12.00" }]
+            },
+            "meta": {
+                "currencyByTo": { "2026-02-01": "CAD" }
+            }
+        }"#;
+        let mut source = json_source("$.series.{TO}[*].close");
+        source.date_path = Some("$.series.{TO}[*].date".to_string());
+        source.open_path = Some("$.series.{TO}[*].open".to_string());
+        source.currency_path = Some("$.meta.currencyByTo.{TO}".to_string());
+
+        let rows = extract_json_rows(
+            body,
+            &source,
+            "ABC",
+            Some("USD"),
+            None,
+            Some("2026-01-01"),
+            Some("2026-02-01"),
+        );
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].date, Some(ymd(2026, 2, 1)));
+        assert_eq!(rows[0].close, 12.5);
+        assert_eq!(rows[0].open, Some(12.0));
+
+        let currency = resolve_currency(
+            &source,
+            "ABC",
+            Some("USD"),
+            body,
+            Some("2026-01-01"),
+            Some("2026-02-01"),
+        );
+        assert_eq!(currency, "CAD");
     }
 
     #[test]

--- a/crates/storage-sqlite/src/custom_provider/repository.rs
+++ b/crates/storage-sqlite/src/custom_provider/repository.rs
@@ -66,6 +66,7 @@ fn parse_sources(config_json: Option<&str>, provider_code: &str) -> Vec<CustomPr
             invert: s.invert,
             locale: s.locale,
             headers: s.headers,
+            open_path: s.open_path,
             high_path: s.high_path,
             low_path: s.low_path,
             volume_path: s.volume_path,


### PR DESCRIPTION
## Summary

- Reworked the custom provider form into a richer live preview flow with dedicated runtime and preview pane modules.
- Aligned preview and runtime HTTP behavior by sharing browser-like headers, redirect handling, response size checks, and template expansion semantics.
- Added support for open/high/low/volume paths across custom provider models, storage mapping, templates, preview mapping, and runtime quote extraction.
- Fixed preview/runtime regressions from review: historical JSON `{FROM}`/`{TO}` path expansion, CSV `open` auto-mapping, render-time saving state updates, HTTP error status handling, and `{currency}` preview payload propagation.

## Root Cause

The refactor introduced richer preview behavior, but some preview-only request and template context values were not mirrored by the runtime quote fetch path. That allowed providers to test successfully in settings while failing during quote sync for redirects, browser-header-sensitive endpoints, date placeholder paths, or currency placeholder paths.

## Validation

- `pnpm type-check`
- `cargo test -p wealthfolio-core custom_scraper_provider`
- `cargo test -p wealthfolio-core custom_provider`
- `cargo fmt --check`
- `git diff --check`
- `pnpm exec eslint --no-ignore apps/frontend/src/pages/settings/market-data/use-source-runtime.ts apps/frontend/src/pages/settings/market-data/live-preview-pane.tsx`