### PR TITLE
Fix CSV import asset review timeout for large Options imports

### DIFF
--- a/apps/frontend/src/adapters/tauri/core.ts
+++ b/apps/frontend/src/adapters/tauri/core.ts
@@ -26,17 +26,26 @@ export const logger: Logger = {
   },
 };
 
-const INVOKE_TIMEOUT_MS = 120_000;
+const DEFAULT_INVOKE_TIMEOUT_MS = 120_000;
+
+// Commands that legitimately do batched network I/O over many symbols (Yahoo
+// Finance lookups during CSV import). Larger imports — especially Options —
+// can exceed the default 2-minute safety net. See issue #884.
+const INVOKE_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
+  preview_import_assets: 600_000,
+  check_activities_import: 600_000,
+};
 
 /**
  * Invoke a Tauri command (internal - use typed adapter functions instead)
  */
 export const invoke = async <T>(command: string, payload?: Record<string, unknown>): Promise<T> => {
+  const timeoutMs = INVOKE_TIMEOUT_OVERRIDES_MS[command] ?? DEFAULT_INVOKE_TIMEOUT_MS;
   try {
     const result = await Promise.race([
       tauriInvoke<T>(command, payload),
       new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error(`Command "${command}" timed out`)), INVOKE_TIMEOUT_MS),
+        setTimeout(() => reject(new Error(`Command "${command}" timed out`)), timeoutMs),
       ),
     ]);
     return result;

--- a/apps/frontend/src/adapters/web/core.ts
+++ b/apps/frontend/src/adapters/web/core.ts
@@ -14,6 +14,16 @@ export const API_PREFIX = "/api/v1";
 export const EVENTS_ENDPOINT = `${API_PREFIX}/events/stream`;
 export const AI_CHAT_STREAM_ENDPOINT = `${API_PREFIX}/ai/chat/stream`;
 
+const DEFAULT_INVOKE_TIMEOUT_MS = 300_000;
+
+// Commands that legitimately do batched network I/O over many symbols (Yahoo
+// Finance lookups during CSV import). Larger imports — especially Options —
+// can exceed the default 5-minute safety net. See issue #884.
+const INVOKE_TIMEOUT_OVERRIDES_MS: Record<string, number> = {
+  preview_import_assets: 600_000,
+  check_activities_import: 600_000,
+};
+
 type CommandMap = Record<string, { method: string; path: string }>;
 
 export const COMMANDS: CommandMap = {
@@ -1352,7 +1362,7 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
     headers,
     body,
     credentials: "same-origin",
-    signal: AbortSignal.timeout(300_000),
+    signal: AbortSignal.timeout(INVOKE_TIMEOUT_OVERRIDES_MS[command] ?? DEFAULT_INVOKE_TIMEOUT_MS),
   });
 
   // 401 = app auth failure (JWT expired/invalid). Cloud auth failures return 403.


### PR DESCRIPTION
## Description

Fixes #884.

The "Review Assets" step in the CSV import wizard calls `preview_import_assets`, which resolves unique symbols against the market-data provider. For Options, each symbol generates 3–4 candidate variants (bare, currency-suffixed, exchange-suffixed) and backend symbol-resolution concurrency caps at 10. Large Options imports legitimately exceed the **global 2-minute Tauri invoke timeout** (`apps/frontend/src/adapters/tauri/core.ts`) and the 5-minute web `AbortSignal` timeout (`apps/frontend/src/adapters/web/core.ts`), causing the wizard to fail with "Asset preview failed".

### Root cause

- Tauri adapter wrapped every IPC call in `Promise.race(..., setTimeout(reject, 120_000))`.
- Web adapter used a single `AbortSignal.timeout(300_000)` for every HTTP call.
- Both safety nets fired on perfectly valid long-running batch operations, not just hung commands.

### Fix

Per-command timeout override map in both adapters. The 2 min / 5 min defaults remain in place as a safety net for unrelated commands; the two commands that legitimately do batched provider lookups get 10 minutes:

- `preview_import_assets`
- `check_activities_import` (runs the same `resolve_symbols_batch` per account)

`import_activities` itself does not call `resolve_symbols_batch` (assets are already resolved upstream by the preview step) and is left on the default. The AI-assistant import path uses the same shared adapter and inherits the override automatically.

### Why not "configurable in settings"?

The issue suggested making the timeout configurable. Rejected as over-engineering — a correctly-sized timeout shouldn't be a user preference, it just shouldn't trip on legitimate work.

### Backend left unchanged

`SYMBOL_RESOLVE_CONCURRENCY: usize = 10` in `crates/core/src/activities/activities_service.rs:707` is left as-is. Bumping it would help large imports finish faster but risks Yahoo Finance rate-limiting (HTTP 429) and warrants its own validation; tracking as a follow-up.

## Files changed

- `apps/frontend/src/adapters/tauri/core.ts` — default + override map applied to `Promise.race` setTimeout.
- `apps/frontend/src/adapters/web/core.ts` — same override map applied to `AbortSignal.timeout`.

## Test plan

- [x] `pnpm type-check` passes.
- [x] `pnpm lint` — no new warnings on edited files (the two warnings reported are pre-existing in unchanged code).
- [ ] Manual: import a CSV containing ~150+ unique Options transactions on desktop (`pnpm tauri dev`). The "Review Assets" step should finish within 10 minutes instead of failing at 2.
- [ ] Manual (web mode): same scenario via `pnpm run dev:web`. Browser should not abort the request.
- [ ] Smoke: an unrelated command that hangs should still reject at the 2 min (Tauri) / 5 min (web) default — the safety net is preserved.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).