### PR TITLE
Link existing transfer activities as an internal pair + fix Transfer In cost basis edit

### DIFF
--- a/apps/frontend/src/adapters/shared/activities.ts
+++ b/apps/frontend/src/adapters/shared/activities.ts
@@ -140,6 +140,21 @@ export const deleteActivity = async (activityId: string): Promise<Activity> => {
   }
 };
 
+export const linkTransferActivities = async (
+  activityAId: string,
+  activityBId: string,
+): Promise<[Activity, Activity]> => {
+  try {
+    return await invoke<[Activity, Activity]>("link_transfer_activities", {
+      activityAId,
+      activityBId,
+    });
+  } catch (err) {
+    logger.error("Error linking transfer activities.");
+    throw err;
+  }
+};
+
 // ============================================================================
 // Activity Import Commands
 // ============================================================================

--- a/apps/frontend/src/adapters/web/core.ts
+++ b/apps/frontend/src/adapters/web/core.ts
@@ -67,6 +67,7 @@ export const COMMANDS: CommandMap = {
   update_activity: { method: "PUT", path: "/activities" },
   save_activities: { method: "POST", path: "/activities/bulk" },
   delete_activity: { method: "DELETE", path: "/activities" },
+  link_transfer_activities: { method: "POST", path: "/activities/link" },
   // Activity import
   check_activities_import: { method: "POST", path: "/activities/import/check" },
   preview_import_assets: { method: "POST", path: "/activities/import/assets/preview" },
@@ -579,6 +580,14 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
     case "delete_activity": {
       const { activityId } = payload as { activityId: string };
       url += `/${encodeURIComponent(activityId)}`;
+      break;
+    }
+    case "link_transfer_activities": {
+      const { activityAId, activityBId } = payload as {
+        activityAId: string;
+        activityBId: string;
+      };
+      body = JSON.stringify({ activityAId, activityBId });
       break;
     }
     case "check_activities_import":

--- a/apps/frontend/src/adapters/web/index.ts
+++ b/apps/frontend/src/adapters/web/index.ts
@@ -82,6 +82,7 @@ export {
   getImportTemplate,
   getAccountImportMapping,
   linkAccountTemplate,
+  linkTransferActivities,
   getActivities,
   importActivities,
   listImportTemplates,

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -188,6 +188,7 @@ export interface ActivityDetails {
   // Sync/source metadata
   sourceSystem?: string;
   sourceRecordId?: string;
+  sourceGroupId?: string;
   idempotencyKey?: string;
   importRunId?: string;
   isUserModified?: boolean;

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid-toolbar.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid-toolbar.tsx
@@ -70,6 +70,14 @@ interface ActivityDataGridToolbarProps {
   onSave: () => void;
   /** Handler for canceling/discarding changes */
   onCancel: () => void;
+  /** Handler invoked when user clicks "Link as internal pair" */
+  onLinkSelected?: () => void;
+  /** Whether the current selection is a valid TRANSFER_IN/TRANSFER_OUT pair */
+  canLinkSelected?: boolean;
+  /** Reason the current selection cannot be linked (used as button tooltip) */
+  linkDisabledReason?: string;
+  /** Whether a link operation is in progress */
+  isLinking?: boolean;
 }
 
 /**
@@ -88,6 +96,10 @@ export function ActivityDataGridToolbar({
   onApproveSelected,
   onSave,
   onCancel,
+  onLinkSelected,
+  canLinkSelected,
+  linkDisabledReason,
+  isLinking,
 }: ActivityDataGridToolbarProps) {
   // Prevent mousedown from bubbling to document, which would clear DataGrid selection
   const handleMouseDown = (e: React.MouseEvent) => {
@@ -200,6 +212,24 @@ export function ActivityDataGridToolbar({
               >
                 <Icons.CheckCircle className="h-3.5 w-3.5" />
                 <span>Approve {selectedPendingCount}</span>
+              </Button>
+            )}
+            {selectedRowCount === 2 && onLinkSelected && (
+              <Button
+                onClick={onLinkSelected}
+                size="xs"
+                variant="outline"
+                className="shrink-0 rounded-md text-xs"
+                title={canLinkSelected ? "Link as internal transfer" : linkDisabledReason}
+                aria-label="Link as internal transfer"
+                disabled={!canLinkSelected || isLinking || isSaving}
+              >
+                {isLinking ? (
+                  <Icons.Spinner className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Icons.Link className="h-3.5 w-3.5" />
+                )}
+                <span>Link</span>
               </Button>
             )}
             <Button

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid.tsx
@@ -8,6 +8,9 @@ import { DataGrid, useDataGrid, type SymbolSearchResult } from "@wealthfolio/ui"
 import { useCallback, useMemo, useRef, useState } from "react";
 import { resolveSymbolQuote } from "@/adapters";
 import { CreateCustomAssetDialog } from "@/components/create-custom-asset-dialog";
+import { ActivityType } from "@/lib/constants";
+import { LinkTransferModal } from "../link-transfer-modal";
+import { useActivityMutations } from "../../hooks/use-activity-mutations";
 import { ActivityDataGridPagination } from "./activity-data-grid-pagination";
 import { ActivityDataGridToolbar } from "./activity-data-grid-toolbar";
 import {
@@ -456,6 +459,88 @@ export function ActivityDataGrid({
     [selectedRows],
   );
 
+  // Link state: validate that the 2-row selection is a valid TRANSFER_IN/TRANSFER_OUT pair
+  const { linkTransferActivitiesMutation } = useActivityMutations();
+  const [linkDialogOpen, setLinkDialogOpen] = useState(false);
+
+  const linkValidation = useMemo(() => {
+    if (selectedRows.length !== 2) {
+      return { canLink: false, reason: "" } as const;
+    }
+    const [first, second] = selectedRows.map((row) => row.original);
+    if (first.isNew || second.isNew) {
+      return {
+        canLink: false,
+        reason: "Save new activities before linking",
+      } as const;
+    }
+    const types = new Set([first.activityType, second.activityType]);
+    if (
+      !types.has(ActivityType.TRANSFER_IN) ||
+      !types.has(ActivityType.TRANSFER_OUT) ||
+      types.size !== 2
+    ) {
+      return {
+        canLink: false,
+        reason: "Select one TRANSFER_IN and one TRANSFER_OUT activity",
+      } as const;
+    }
+    if (first.sourceGroupId || second.sourceGroupId) {
+      return {
+        canLink: false,
+        reason: "One of the selected activities is already linked",
+      } as const;
+    }
+    const transferIn = first.activityType === ActivityType.TRANSFER_IN ? first : second;
+    const transferOut = first.activityType === ActivityType.TRANSFER_OUT ? first : second;
+    if (transferIn.accountId === transferOut.accountId) {
+      return {
+        canLink: false,
+        reason: "Both legs share the same account",
+      } as const;
+    }
+    return { canLink: true, transferIn, transferOut } as const;
+  }, [selectedRows]);
+
+  const linkWarnings = useMemo(() => {
+    if (!linkValidation.canLink) return [] as string[];
+    const { transferIn, transferOut } = linkValidation;
+    const warnings: string[] = [];
+    if (transferIn.currency !== transferOut.currency) {
+      warnings.push(
+        `Currencies differ (${transferOut.currency} → ${transferIn.currency}). The pair will still be linked.`,
+      );
+    }
+    const inAmount = Number(transferIn.amount ?? transferIn.unitPrice ?? 0);
+    const outAmount = Number(transferOut.amount ?? transferOut.unitPrice ?? 0);
+    if (Number.isFinite(inAmount) && Number.isFinite(outAmount) && inAmount && outAmount) {
+      const diff = Math.abs(inAmount - outAmount) / Math.max(inAmount, outAmount);
+      if (diff > 0.01) {
+        warnings.push("Amounts differ by more than 1%.");
+      }
+    }
+    const inDate = new Date(transferIn.date).getTime();
+    const outDate = new Date(transferOut.date).getTime();
+    if (Number.isFinite(inDate) && Number.isFinite(outDate)) {
+      const dayDiff = Math.abs(inDate - outDate) / (1000 * 60 * 60 * 24);
+      if (dayDiff > 7) {
+        warnings.push(`Dates differ by ${Math.round(dayDiff)} days.`);
+      }
+    }
+    return warnings;
+  }, [linkValidation]);
+
+  const handleLinkConfirm = useCallback(async () => {
+    if (!linkValidation.canLink) return;
+    await linkTransferActivitiesMutation.mutateAsync({
+      activityAId: linkValidation.transferIn.id,
+      activityBId: linkValidation.transferOut.id,
+    });
+    setLinkDialogOpen(false);
+    dataGrid.table.resetRowSelection();
+    onRefetch();
+  }, [linkValidation, linkTransferActivitiesMutation, dataGrid.table, onRefetch]);
+
   // Delete selected rows handler
   const deleteSelectedRows = useCallback(() => {
     const selected = dataGrid.table.getSelectedRowModel().rows;
@@ -545,6 +630,10 @@ export function ActivityDataGrid({
         onApproveSelected={approveSelectedRows}
         onSave={handleSaveChanges}
         onCancel={handleCancelChanges}
+        onLinkSelected={() => setLinkDialogOpen(true)}
+        canLinkSelected={linkValidation.canLink}
+        linkDisabledReason={linkValidation.canLink ? undefined : linkValidation.reason}
+        isLinking={linkTransferActivitiesMutation.isPending}
       />
 
       <div className="min-h-0 flex-1 overflow-hidden">
@@ -571,6 +660,16 @@ export function ActivityDataGrid({
         onAssetCreated={handleCustomAssetCreated}
         defaultSymbol={customAssetDialog.symbol}
         defaultCurrency={dialogDefaultCurrency}
+      />
+
+      <LinkTransferModal
+        isOpen={linkDialogOpen}
+        isLinking={linkTransferActivitiesMutation.isPending}
+        activityIn={linkValidation.canLink ? linkValidation.transferIn : undefined}
+        activityOut={linkValidation.canLink ? linkValidation.transferOut : undefined}
+        warnings={linkWarnings}
+        onConfirm={handleLinkConfirm}
+        onCancel={() => setLinkDialogOpen(false)}
       />
     </div>
   );

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid.tsx
@@ -474,6 +474,12 @@ export function ActivityDataGrid({
         reason: "Save new activities before linking",
       } as const;
     }
+    if (dirtyTransactionIds.has(first.id) || dirtyTransactionIds.has(second.id)) {
+      return {
+        canLink: false,
+        reason: "Save or discard pending edits on the selected rows before linking",
+      } as const;
+    }
     const types = new Set([first.activityType, second.activityType]);
     if (
       !types.has(ActivityType.TRANSFER_IN) ||
@@ -500,7 +506,7 @@ export function ActivityDataGrid({
       } as const;
     }
     return { canLink: true, transferIn, transferOut } as const;
-  }, [selectedRows]);
+  }, [selectedRows, dirtyTransactionIds]);
 
   const linkWarnings = useMemo(() => {
     if (!linkValidation.canLink) return [] as string[];

--- a/apps/frontend/src/pages/activity/components/link-transfer-modal.tsx
+++ b/apps/frontend/src/pages/activity/components/link-transfer-modal.tsx
@@ -1,0 +1,105 @@
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@wealthfolio/ui/components/ui/alert-dialog";
+import { Button, formatAmount, Icons } from "@wealthfolio/ui";
+import { ActivityType } from "@/lib/constants";
+import type { ActivityDetails } from "@/lib/types";
+import { formatDateTime } from "@/lib/utils";
+
+interface LinkTransferModalProps {
+  isOpen: boolean;
+  isLinking: boolean;
+  activityIn?: ActivityDetails;
+  activityOut?: ActivityDetails;
+  warnings: string[];
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+function ActivityRow({ activity, label }: { activity: ActivityDetails; label: string }) {
+  const date = formatDateTime(activity.date).date;
+  const value = activity.amount ?? activity.unitPrice;
+  return (
+    <div className="bg-muted/30 flex flex-col gap-1 rounded-md border px-3 py-2 text-sm">
+      <div className="text-muted-foreground flex items-center justify-between text-xs uppercase">
+        <span>{label}</span>
+        <span>
+          {activity.activityType === ActivityType.TRANSFER_IN ? "Transfer In" : "Transfer Out"}
+        </span>
+      </div>
+      <div className="flex items-center justify-between">
+        <span className="font-medium">{activity.accountName}</span>
+        <span>{date}</span>
+      </div>
+      <div className="text-muted-foreground flex items-center justify-between text-xs">
+        <span>{activity.assetSymbol || "Cash"}</span>
+        <span>
+          {value != null ? formatAmount(Number(value), activity.currency) : activity.currency}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export function LinkTransferModal({
+  isOpen,
+  isLinking,
+  activityIn,
+  activityOut,
+  warnings,
+  onConfirm,
+  onCancel,
+}: LinkTransferModalProps) {
+  return (
+    <AlertDialog open={isOpen} onOpenChange={(open) => (!open ? onCancel() : undefined)}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Link as internal transfer</AlertDialogTitle>
+          <AlertDialogDescription>
+            These two activities will be paired and treated as a single internal transfer between
+            your accounts.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        {activityIn && activityOut ? (
+          <div className="flex flex-col gap-2">
+            <ActivityRow activity={activityOut} label="Source" />
+            <div className="flex justify-center">
+              <Icons.ArrowDown className="text-muted-foreground h-4 w-4" />
+            </div>
+            <ActivityRow activity={activityIn} label="Destination" />
+          </div>
+        ) : null}
+
+        {warnings.length > 0 ? (
+          <div className="border-warning/40 bg-warning/10 text-warning-foreground flex gap-2 rounded-md border px-3 py-2 text-xs">
+            <Icons.AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <ul className="space-y-0.5">
+              {warnings.map((warning) => (
+                <li key={warning}>{warning}</li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isLinking}>Cancel</AlertDialogCancel>
+          <Button onClick={onConfirm} disabled={isLinking}>
+            {isLinking ? (
+              <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Icons.Link className="mr-2 h-4 w-4" />
+            )}
+            <span>Link transfers</span>
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/frontend/src/pages/activity/config/activity-form-config.ts
+++ b/apps/frontend/src/pages/activity/config/activity-form-config.ts
@@ -357,6 +357,7 @@ export const ACTIVITY_FORM_CONFIG: Record<
         amount: absNum(activity?.amount),
         assetId: activity?.assetSymbol ?? activity?.assetId ?? null,
         quantity: absNum(activity?.quantity) ?? null,
+        unitPrice: absNum(activity?.unitPrice) ?? null,
         comment: activity?.comment ?? null,
         // Advanced options
         currency: activity?.currency,

--- a/apps/frontend/src/pages/activity/hooks/use-activity-mutations.ts
+++ b/apps/frontend/src/pages/activity/hooks/use-activity-mutations.ts
@@ -1,4 +1,11 @@
-import { createActivity, deleteActivity, logger, saveActivities, updateActivity } from "@/adapters";
+import {
+  createActivity,
+  deleteActivity,
+  linkTransferActivities,
+  logger,
+  saveActivities,
+  updateActivity,
+} from "@/adapters";
 import { generateId } from "@/lib/id";
 import {
   ActivityBulkMutationRequest,
@@ -231,6 +238,23 @@ export function useActivityMutations(
     ...createMutationOptions("deleting"),
   });
 
+  const linkTransferActivitiesMutation = useMutation({
+    mutationFn: ({ activityAId, activityBId }: { activityAId: string; activityBId: string }) =>
+      linkTransferActivities(activityAId, activityBId),
+    onSuccess: () => {
+      queryClient.invalidateQueries();
+      toast.success("Transfers linked", {
+        description: "The two activities are now paired as an internal transfer.",
+      });
+    },
+    onError: (error: string) => {
+      logger.error(`Error linking transfers: ${String(error)}`);
+      toast.error("Failed to link transfers", {
+        description: String(error),
+      });
+    },
+  });
+
   const duplicateActivity = async (activityToDuplicate: ActivityDetails) => {
     const {
       id: _id,
@@ -330,5 +354,6 @@ export function useActivityMutations(
     deleteActivityMutation,
     duplicateActivityMutation,
     saveActivitiesMutation,
+    linkTransferActivitiesMutation,
   };
 }

--- a/apps/server/src/api/activities.rs
+++ b/apps/server/src/api/activities.rs
@@ -138,6 +138,25 @@ async fn delete_activity(
 }
 
 #[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LinkTransferActivitiesBody {
+    activity_a_id: String,
+    activity_b_id: String,
+}
+
+async fn link_transfer_activities(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<LinkTransferActivitiesBody>,
+) -> ApiResult<Json<(Activity, Activity)>> {
+    let pair = state
+        .activity_service
+        .link_transfer_activities(body.activity_a_id, body.activity_b_id)
+        .await?;
+    // Domain events handle portfolio recalculation
+    Ok(Json(pair))
+}
+
+#[derive(serde::Deserialize)]
 struct ImportCheckBody {
     activities: Vec<ActivityImport>,
 }
@@ -360,6 +379,7 @@ pub fn router() -> Router<Arc<AppState>> {
         .route("/activities", post(create_activity).put(update_activity))
         .route("/activities/bulk", post(save_activities))
         .route("/activities/{id}", delete(delete_activity))
+        .route("/activities/link", post(link_transfer_activities))
         .route("/activities/import/check", post(check_activities_import))
         .route(
             "/activities/import/assets/preview",

--- a/apps/tauri/src/commands/activity.rs
+++ b/apps/tauri/src/commands/activity.rs
@@ -95,6 +95,21 @@ pub async fn delete_activity(
 }
 
 #[tauri::command]
+pub async fn link_transfer_activities(
+    activity_a_id: String,
+    activity_b_id: String,
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<(Activity, Activity), String> {
+    debug!("Linking transfer activities...");
+    // Domain events handle recalculation automatically
+    state
+        .activity_service()
+        .link_transfer_activities(activity_a_id, activity_b_id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 pub async fn save_activities(
     request: ActivityBulkMutationRequest,
     state: State<'_, Arc<ServiceContext>>,

--- a/apps/tauri/src/lib.rs
+++ b/apps/tauri/src/lib.rs
@@ -285,6 +285,7 @@ pub fn run() {
             commands::activity::update_activity,
             commands::activity::save_activities,
             commands::activity::delete_activity,
+            commands::activity::link_transfer_activities,
             commands::activity::check_activities_import,
             commands::activity::preview_import_assets,
             commands::activity::import_activities,

--- a/crates/ai/src/env.rs
+++ b/crates/ai/src/env.rs
@@ -326,6 +326,14 @@ pub mod test_env {
             unimplemented!("MockActivityService::delete_activity")
         }
 
+        async fn link_transfer_activities(
+            &self,
+            _activity_a_id: String,
+            _activity_b_id: String,
+        ) -> CoreResult<(Activity, Activity)> {
+            unimplemented!("MockActivityService::link_transfer_activities")
+        }
+
         async fn bulk_mutate_activities(
             &self,
             _request: ActivityBulkMutationRequest,

--- a/crates/core/src/activities/activities_model.rs
+++ b/crates/core/src/activities/activities_model.rs
@@ -532,6 +532,7 @@ pub struct ActivityDetails {
     // Sync/source metadata
     pub source_system: Option<String>,
     pub source_record_id: Option<String>,
+    pub source_group_id: Option<String>,
     pub idempotency_key: Option<String>,
     pub import_run_id: Option<String>,
     pub is_user_modified: bool,

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -2761,6 +2761,37 @@ impl ActivityServiceTrait for ActivityService {
         Ok(deleted)
     }
 
+    async fn link_transfer_activities(
+        &self,
+        activity_a_id: String,
+        activity_b_id: String,
+    ) -> Result<(Activity, Activity)> {
+        let (transfer_in, transfer_out) = self
+            .activity_repository
+            .link_transfer_activities(activity_a_id, activity_b_id)
+            .await?;
+
+        let mut account_ids: HashSet<String> = HashSet::new();
+        let mut asset_ids: HashSet<String> = HashSet::new();
+        let mut currencies: HashSet<String> = HashSet::new();
+        for activity in [&transfer_in, &transfer_out] {
+            account_ids.insert(activity.account_id.clone());
+            if let Some(ref asset_id) = activity.asset_id {
+                asset_ids.insert(asset_id.clone());
+            }
+            currencies.insert(activity.currency.clone());
+        }
+        let earliest_at = transfer_in.activity_date.min(transfer_out.activity_date);
+        self.emit_activities_changed(
+            account_ids.into_iter().collect(),
+            asset_ids.into_iter().collect(),
+            currencies.into_iter().collect(),
+            Some(earliest_at),
+        );
+
+        Ok((transfer_in, transfer_out))
+    }
+
     async fn bulk_mutate_activities(
         &self,
         request: ActivityBulkMutationRequest,

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -703,6 +703,14 @@ mod tests {
             unimplemented!()
         }
 
+        async fn link_transfer_activities(
+            &self,
+            _activity_a_id: String,
+            _activity_b_id: String,
+        ) -> Result<(Activity, Activity)> {
+            unimplemented!()
+        }
+
         async fn bulk_mutate_activities(
             &self,
             creates: Vec<NewActivity>,

--- a/crates/core/src/activities/activities_traits.rs
+++ b/crates/core/src/activities/activities_traits.rs
@@ -40,6 +40,14 @@ pub trait ActivityRepositoryTrait: Send + Sync {
     async fn create_activity(&self, new_activity: NewActivity) -> Result<Activity>;
     async fn update_activity(&self, activity_update: ActivityUpdate) -> Result<Activity>;
     async fn delete_activity(&self, activity_id: String) -> Result<Activity>;
+    /// Pairs two existing transfer activities by writing a shared `source_group_id`
+    /// and clearing `metadata.flow.is_external` on both. Order of `activity_a_id` /
+    /// `activity_b_id` is irrelevant; the impl resolves which is IN vs OUT.
+    async fn link_transfer_activities(
+        &self,
+        activity_a_id: String,
+        activity_b_id: String,
+    ) -> Result<(Activity, Activity)>;
     async fn bulk_mutate_activities(
         &self,
         creates: Vec<NewActivity>,
@@ -166,6 +174,11 @@ pub trait ActivityServiceTrait: Send + Sync {
     async fn create_activity(&self, activity: NewActivity) -> Result<Activity>;
     async fn update_activity(&self, activity: ActivityUpdate) -> Result<Activity>;
     async fn delete_activity(&self, activity_id: String) -> Result<Activity>;
+    async fn link_transfer_activities(
+        &self,
+        activity_a_id: String,
+        activity_b_id: String,
+    ) -> Result<(Activity, Activity)>;
     async fn bulk_mutate_activities(
         &self,
         request: ActivityBulkMutationRequest,

--- a/crates/core/src/limits/limits_service.rs
+++ b/crates/core/src/limits/limits_service.rs
@@ -344,6 +344,13 @@ mod tests {
         async fn delete_activity(&self, _: String) -> Result<Activity> {
             unimplemented!()
         }
+        async fn link_transfer_activities(
+            &self,
+            _: String,
+            _: String,
+        ) -> Result<(Activity, Activity)> {
+            unimplemented!()
+        }
         async fn bulk_mutate_activities(
             &self,
             _: Vec<NewActivity>,

--- a/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
+++ b/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
@@ -388,6 +388,13 @@ mod tests {
         async fn delete_activity(&self, _activity_id: String) -> AppResult<Activity> {
             unimplemented!()
         }
+        async fn link_transfer_activities(
+            &self,
+            _activity_a_id: String,
+            _activity_b_id: String,
+        ) -> AppResult<(Activity, Activity)> {
+            unimplemented!()
+        }
         async fn bulk_mutate_activities(
             &self,
             _creates: Vec<NewActivity>,
@@ -589,6 +596,13 @@ mod tests {
             unimplemented!()
         }
         async fn delete_activity(&self, _id: String) -> AppResult<Activity> {
+            unimplemented!()
+        }
+        async fn link_transfer_activities(
+            &self,
+            _a: String,
+            _b: String,
+        ) -> AppResult<(Activity, Activity)> {
             unimplemented!()
         }
         async fn bulk_mutate_activities(

--- a/crates/core/src/quotes/service.rs
+++ b/crates/core/src/quotes/service.rs
@@ -2454,6 +2454,14 @@ mod tests {
             unimplemented!("unused in this test")
         }
 
+        async fn link_transfer_activities(
+            &self,
+            _activity_a_id: String,
+            _activity_b_id: String,
+        ) -> Result<(Activity, Activity)> {
+            unimplemented!("unused in this test")
+        }
+
         async fn bulk_mutate_activities(
             &self,
             _creates: Vec<NewActivity>,

--- a/crates/storage-sqlite/src/activities/model.rs
+++ b/crates/storage-sqlite/src/activities/model.rs
@@ -141,6 +141,8 @@ pub struct ActivityDetailsDB {
     #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
     pub source_record_id: Option<String>,
     #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+    pub source_group_id: Option<String>,
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
     pub idempotency_key: Option<String>,
     #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
     pub import_run_id: Option<String>,
@@ -306,6 +308,7 @@ impl From<ActivityDetailsDB> for wealthfolio_core::activities::ActivityDetails {
             instrument_type: db.instrument_type,
             source_system: db.source_system,
             source_record_id: db.source_record_id,
+            source_group_id: db.source_group_id,
             idempotency_key: db.idempotency_key,
             import_run_id: db.import_run_id,
             is_user_modified: db.is_user_modified != 0,

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -252,6 +252,7 @@ impl ActivityRepositoryTrait for ActivityRepository {
                 activities::is_user_modified,
                 activities::source_system,
                 activities::source_record_id,
+                activities::source_group_id,
                 activities::idempotency_key,
                 activities::import_run_id,
                 activities::created_at,
@@ -403,6 +404,78 @@ impl ActivityRepositoryTrait for ActivityRepository {
                     .map_err(StorageError::from)?;
                 tx.delete::<ActivityDB>(activity_id.clone());
                 Ok(activity.into())
+            })
+            .await
+    }
+
+    async fn link_transfer_activities(
+        &self,
+        activity_a_id: String,
+        activity_b_id: String,
+    ) -> Result<(Activity, Activity)> {
+        use wealthfolio_core::activities::{ACTIVITY_TYPE_TRANSFER_IN, ACTIVITY_TYPE_TRANSFER_OUT};
+
+        if activity_a_id == activity_b_id {
+            return Err(Error::from(ActivityError::InvalidData(
+                "Cannot link an activity to itself".to_string(),
+            )));
+        }
+
+        self.writer
+            .exec_tx(move |tx| -> Result<(Activity, Activity)> {
+                let a = activities::table
+                    .select(ActivityDB::as_select())
+                    .find(&activity_a_id)
+                    .first::<ActivityDB>(tx.conn())
+                    .map_err(|e| Error::from(ActivityError::NotFound(e.to_string())))?;
+                let b = activities::table
+                    .select(ActivityDB::as_select())
+                    .find(&activity_b_id)
+                    .first::<ActivityDB>(tx.conn())
+                    .map_err(|e| Error::from(ActivityError::NotFound(e.to_string())))?;
+
+                let (mut transfer_in, mut transfer_out) =
+                    match (a.activity_type.as_str(), b.activity_type.as_str()) {
+                        (ACTIVITY_TYPE_TRANSFER_IN, ACTIVITY_TYPE_TRANSFER_OUT) => (a, b),
+                        (ACTIVITY_TYPE_TRANSFER_OUT, ACTIVITY_TYPE_TRANSFER_IN) => (b, a),
+                        _ => {
+                            return Err(Error::from(ActivityError::InvalidData(
+                                "Linking requires one TRANSFER_IN and one TRANSFER_OUT activity"
+                                    .to_string(),
+                            )));
+                        }
+                    };
+
+                if transfer_in.source_group_id.is_some() || transfer_out.source_group_id.is_some() {
+                    return Err(Error::from(ActivityError::InvalidData(
+                        "One or both activities are already linked to another transfer".to_string(),
+                    )));
+                }
+
+                let group_id = Uuid::new_v4().to_string();
+                let now = chrono::Utc::now().to_rfc3339();
+                let internal_metadata = Some(r#"{"flow":{"is_external":false}}"#.to_string());
+
+                transfer_in.source_group_id = Some(group_id.clone());
+                transfer_in.metadata = internal_metadata.clone();
+                transfer_in.updated_at = now.clone();
+                transfer_out.source_group_id = Some(group_id);
+                transfer_out.metadata = internal_metadata;
+                transfer_out.updated_at = now;
+
+                let updated_in = diesel::update(activities::table.find(&transfer_in.id))
+                    .set(&transfer_in)
+                    .get_result::<ActivityDB>(tx.conn())
+                    .map_err(StorageError::from)?;
+                let updated_out = diesel::update(activities::table.find(&transfer_out.id))
+                    .set(&transfer_out)
+                    .get_result::<ActivityDB>(tx.conn())
+                    .map_err(StorageError::from)?;
+
+                tx.update(&transfer_in)?;
+                tx.update(&transfer_out)?;
+
+                Ok((Activity::from(updated_in), Activity::from(updated_out)))
             })
             .await
     }


### PR DESCRIPTION
## Description

Two related improvements to manual transfer handling.

### 1. Link two existing transfers as an internal pair (new feature)

Users who created two separate external transfer activities (one `TRANSFER_IN`, one `TRANSFER_OUT`) had no way to retroactively pair them — the form path can create internal pairs from scratch but there was no reconciliation flow.

**UX:** in the activity datagrid, select exactly two rows and click **Link** in the toolbar. The button only appears when 2 rows are selected and is disabled with an explanatory tooltip when the selection isn't a valid pair (not one IN + one OUT, already linked, same account, or unsaved drafts). A confirmation dialog shows the source/destination summary and warns on currency mismatch, amount drift > 1%, or date drift > 7 days. Confirming writes a shared `source_group_id` UUID on both rows and flips `metadata.flow.is_external=false`.

**Backend:**
- New `link_transfer_activities` repo trait + impl: atomic transactional update, validates the pair, writes the shared UUID + metadata, returns both updated activities.
- Service method emits the existing `ActivitiesChanged` domain event so portfolio recalculation runs.
- New Tauri command `link_transfer_activities` (registered in `lib.rs`) and Axum route `POST /activities/link` for web mode.
- `source_group_id` is now exposed on `ActivityDetails` (DTO + DB select + TS type) so the client can detect already-linked rows during validation.

### 2. Fix cost basis not loaded when editing Transfer In (#883)

`TRANSFER.getDefaults` in `activity-form-config.ts` omitted `unitPrice`, so editing an external Transfer In with securities showed an empty cost basis field and failed validation on save. Now pre-populates from the stored activity, matching what BUY/SELL/DIVIDEND already do. One-line fix verified safe across all transfer permutations (the cost basis input is only rendered for external IN, validation is scoped identically, and `toPayload` already sent `unitPrice`).

Closes [#883](https://github.com/afadil/wealthfolio/issues/883).

## Test plan

- [ ] `cargo check --workspace --tests` clean
- [ ] `pnpm type-check` clean
- [ ] Frontend tests pass (`pnpm test`)
- [ ] Activity tests pass (`cargo test -p wealthfolio-core --lib activities::`)
- [ ] Manually create two external transfer activities (one IN, one OUT) in different accounts, select both in datagrid, click Link, confirm dialog shows correct summary, confirm pair has matching `source_group_id` after save
- [ ] Verify Link button stays disabled (with tooltip) for invalid selections: same account, already-linked rows, two INs, unsaved rows
- [ ] Edit an existing external Transfer In with securities → cost basis field is pre-populated, save without changes succeeds

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).