### PR TITLE
Add toggle to hide expired options from holdings views

### DIFF
--- a/apps/frontend/src/lib/occ-symbol.ts
+++ b/apps/frontend/src/lib/occ-symbol.ts
@@ -115,6 +115,16 @@ export function normalizeOptionSymbol(symbol: string): string | null {
 }
 
 /**
+ * Returns true if the symbol parses as an OCC option whose expiration date is in the past.
+ */
+export function isExpiredOptionSymbol(symbol: string): boolean {
+  const parsed = parseOccSymbol(symbol);
+  if (!parsed) return false;
+  const today = new Date().toISOString().split("T")[0];
+  return parsed.expiration < today;
+}
+
+/**
  * Heuristic check if a symbol looks like an OCC option symbol.
  * Does not fully validate — use parseOccSymbol for that.
  */

--- a/apps/frontend/src/pages/holdings/components/holdings-mobile-filter-sheet.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-mobile-filter-sheet.tsx
@@ -30,6 +30,9 @@ interface HoldingsMobileFilterSheetProps {
   categoryFilter?: HoldingCategoryFilterId;
   setCategoryFilter?: (value: HoldingCategoryFilterId) => void;
   typeOptions?: { value: string; label: string }[];
+  hideExpired?: boolean;
+  setHideExpired?: (value: boolean) => void;
+  showExpiredToggle?: boolean;
 }
 
 export const HoldingsMobileFilterSheet = ({
@@ -48,6 +51,9 @@ export const HoldingsMobileFilterSheet = ({
   categoryFilter = "investments",
   setCategoryFilter,
   typeOptions,
+  hideExpired,
+  setHideExpired,
+  showExpiredToggle = false,
 }: HoldingsMobileFilterSheetProps) => {
   const { settings } = useSettingsContext();
   const baseCurrency = settings?.baseCurrency ?? "USD";
@@ -96,6 +102,24 @@ export const HoldingsMobileFilterSheet = ({
                   className="inline-flex w-auto"
                 />
               </div>
+
+              {showExpiredToggle && setHideExpired && (
+                <div className="space-y-3">
+                  <h4 className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
+                    Expired Options
+                  </h4>
+                  <AnimatedToggleGroup<"hide" | "show">
+                    value={hideExpired ? "hide" : "show"}
+                    onValueChange={(value) => setHideExpired(value === "hide")}
+                    items={[
+                      { value: "hide", label: "Hide" },
+                      { value: "show", label: "Show" },
+                    ]}
+                    size="sm"
+                    className="inline-flex w-auto"
+                  />
+                </div>
+              )}
             </div>
 
             <Separator />

--- a/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
@@ -1,7 +1,8 @@
 import { TickerAvatar } from "@/components/ticker-avatar";
 import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
+import { usePersistentState } from "@/hooks/use-persistent-state";
 import { PORTFOLIO_ACCOUNT_ID } from "@/lib/constants";
-import { parseOccSymbol } from "@/lib/occ-symbol";
+import { isExpiredOptionSymbol, parseOccSymbol } from "@/lib/occ-symbol";
 import { Account, Holding } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { AmountDisplay, GainPercent, Input, Separator } from "@wealthfolio/ui";
@@ -63,6 +64,13 @@ export const HoldingsTableMobile = ({
   const showTotalReturn = controlledShowTotalReturn ?? internalShowTotalReturn;
   const setShowTotalReturn = controlledSetShowTotalReturn ?? setInternalShowTotalReturn;
 
+  const [hideExpired, setHideExpired] = usePersistentState<boolean>("holdings-hide-expired", true);
+
+  const hasAnyExpired = useMemo(
+    () => holdings.some((h) => isExpiredOptionSymbol(h.instrument?.symbol ?? h.id)),
+    [holdings],
+  );
+
   const hasActiveFilters = useMemo(() => {
     const hasAccountFilter = showAccountFilter && selectedAccount?.id !== PORTFOLIO_ACCOUNT_ID;
     const hasTypeFilter = selectedTypes.length > 0;
@@ -71,6 +79,12 @@ export const HoldingsTableMobile = ({
 
   const filteredHoldings = useMemo(() => {
     let result = [...holdings];
+
+    if (hideExpired && hasAnyExpired) {
+      result = result.filter(
+        (holding) => !isExpiredOptionSymbol(holding.instrument?.symbol ?? holding.id),
+      );
+    }
 
     if (selectedTypes.length > 0) {
       result = result.filter((holding) => {
@@ -109,7 +123,7 @@ export const HoldingsTableMobile = ({
       }
       return 0;
     });
-  }, [holdings, selectedTypes, searchQuery, sortBy]);
+  }, [holdings, selectedTypes, searchQuery, sortBy, hideExpired, hasAnyExpired]);
 
   const handleNavigate = (holding: Holding) => {
     // Use instrument.id (asset ID) for navigation, not symbol (which may be stripped)
@@ -163,8 +177,7 @@ export const HoldingsTableMobile = ({
             const symbol = holding.instrument?.symbol ?? holding.id;
             const isCash = symbol.startsWith("$CASH");
             const parsedOption = isCash ? null : parseOccSymbol(symbol);
-            const today = new Date().toISOString().split("T")[0];
-            const isExpiredOption = parsedOption ? parsedOption.expiration < today : false;
+            const isExpiredOption = !isCash && isExpiredOptionSymbol(symbol);
             const avatarSymbol = isCash ? "$CASH" : parsedOption ? parsedOption.underlying : symbol;
             const displaySymbol = isCash
               ? symbol.split("-")[0]
@@ -263,6 +276,9 @@ export const HoldingsTableMobile = ({
         showTotalReturn={showTotalReturn}
         setShowTotalReturn={setShowTotalReturn}
         typeOptions={typeOptions}
+        hideExpired={hideExpired}
+        setHideExpired={setHideExpired}
+        showExpiredToggle={hasAnyExpired}
       />
     </div>
   );

--- a/apps/frontend/src/pages/holdings/components/holdings-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table.tsx
@@ -8,8 +8,9 @@ import {
   DropdownMenuTrigger,
 } from "@wealthfolio/ui/components/ui/dropdown-menu";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
-import { parseOccSymbol } from "@/lib/occ-symbol";
+import { isExpiredOptionSymbol, parseOccSymbol } from "@/lib/occ-symbol";
 import { safeDivide } from "@/lib/utils";
+import { usePersistentState } from "@/hooks/use-persistent-state";
 import type { ColumnDef } from "@tanstack/react-table";
 import { GainPercent, Badge } from "@wealthfolio/ui";
 
@@ -65,6 +66,13 @@ export const HoldingsTable = ({
   const { isBalanceHidden } = useBalancePrivacy();
   const { settings } = useSettingsContext();
   const [showConvertedValues, setShowConvertedValues] = useState(false);
+  const [hideExpired, setHideExpired] = usePersistentState<boolean>("holdings-hide-expired", true);
+
+  const hasAnyExpired = holdings.some((h) => isExpiredOptionSymbol(h.instrument?.symbol ?? h.id));
+  const visibleHoldings =
+    hideExpired && hasAnyExpired
+      ? holdings.filter((h) => !isExpiredOptionSymbol(h.instrument?.symbol ?? h.id))
+      : holdings;
 
   const baseCurrency = settings?.baseCurrency ?? holdings[0]?.baseCurrency;
   const hasMultipleCurrencies = holdings.some((holding) => {
@@ -111,7 +119,7 @@ export const HoldingsTable = ({
   return (
     <div className="flex h-full flex-col">
       <DataTable
-        data={holdings}
+        data={visibleHoldings}
         columns={getColumns(isBalanceHidden, showConvertedValues, showTotalReturn, onClassify)}
         searchBy="symbol"
         filters={filters}
@@ -160,6 +168,27 @@ export const HoldingsTable = ({
                 </TooltipContent>
               </Tooltip>
             )}
+            {hasAnyExpired && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    onClick={() => setHideExpired(!hideExpired)}
+                    className="h-8 w-8 rounded-lg"
+                  >
+                    {hideExpired ? (
+                      <Icons.EyeOff className="h-4 w-4" />
+                    ) : (
+                      <Icons.Eye className="h-4 w-4" />
+                    )}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>{hideExpired ? "Show expired options" : "Hide expired options"}</p>
+                </TooltipContent>
+              </Tooltip>
+            )}
           </div>
         }
       />
@@ -190,10 +219,7 @@ const getColumns = (
       // Parse OCC symbol for options
       const parsedOption = parseOccSymbol(symbol);
       const displaySymbol = parsedOption ? parsedOption.underlying : symbol;
-
-      // Check if option is expired (date-only: expired once the day after expiration)
-      const today = new Date().toISOString().split("T")[0];
-      const isExpiredOption = parsedOption ? parsedOption.expiration < today : false;
+      const isExpiredOption = isExpiredOptionSymbol(symbol);
 
       // Option subtitle: "Mar 29 $150 CALL"
       const optionSubtitle = parsedOption

--- a/apps/frontend/src/pages/holdings/holdings-page.tsx
+++ b/apps/frontend/src/pages/holdings/holdings-page.tsx
@@ -22,6 +22,7 @@ import {
   apiKindToAlternativeAssetKind,
 } from "@/lib/constants";
 import { Account, HoldingType, AlternativeAssetHolding, AlternativeAssetKind } from "@/lib/types";
+import { isExpiredOptionSymbol } from "@/lib/occ-symbol";
 import { canAddHoldings } from "@/lib/activity-restrictions";
 import { useIsMobileViewport } from "@/hooks/use-platform";
 import { HoldingsMobileFilterSheet } from "./components/holdings-mobile-filter-sheet";
@@ -83,6 +84,7 @@ export const HoldingsPage = () => {
     "holdings-show-total-return",
     true,
   );
+  const [hideExpired, setHideExpired] = usePersistentState<boolean>("holdings-hide-expired", true);
 
   // Alternative asset action state
   const [editAsset, setEditAsset] = useState<AssetDetailsSheetAsset | null>(null);
@@ -333,6 +335,11 @@ export const HoldingsPage = () => {
 
   // Combined loading state
   const isDataLoading = isLoading || isAccountsLoading || isAlternativeHoldingsLoading;
+
+  const hasAnyExpiredHolding = useMemo(
+    () => (nonCashHoldings ?? []).some((h) => isExpiredOptionSymbol(h.instrument?.symbol ?? h.id)),
+    [nonCashHoldings],
+  );
 
   // Empty state checks
   const hasNoInvestments = !isDataLoading && (!nonCashHoldings || nonCashHoldings.length === 0);
@@ -662,6 +669,9 @@ export const HoldingsPage = () => {
         showTotalReturn={showTotalReturn}
         setShowTotalReturn={setShowTotalReturn}
         typeOptions={availableTypeOptions}
+        hideExpired={hideExpired}
+        setHideExpired={setHideExpired}
+        showExpiredToggle={hasAnyExpiredHolding}
       />
 
       {/* Alternative Asset Quick Add Modal */}


### PR DESCRIPTION
## Description

Expired options were valued at $0 in core (and skipped from quote sync) but still rendered as rows in the holdings table — cluttering both the per-account Portfolio view and the global Holdings page. This PR adds a persisted toggle to hide them, defaulting to **hide** since at $0 they carry no useful display signal.

### What changed

- New `isExpiredOptionSymbol(symbol)` helper in `apps/frontend/src/lib/occ-symbol.ts` (deduplicates the inline expired check that previously lived in two cell renderers).
- Desktop `HoldingsTable`: filters expired rows when toggle is on; eye/eye-off icon button in the toolbar (next to the existing currency toggle), only rendered when the holdings list contains ≥1 expired option.
- Mobile `HoldingsTableMobile`: same filter, same persistence key.
- Mobile `HoldingsMobileFilterSheet`: new "Expired Options" Hide/Show row, surfaced only when the parent reports expired holdings exist.
- Global `holdings-page.tsx`: lifts `hideExpired` state up so the standalone `HoldingsMobileFilterSheet` (used when `HoldingsTableMobile` runs with `showFilterButton={false}`) gets the toggle wired through. `usePersistentState` broadcasts a same-page custom event so the embedded table picks up changes.
- Shared `usePersistentState` key `holdings-hide-expired` (default `true`) keeps desktop ↔ mobile and per-account ↔ global views in sync.

### What didn't change

- No backend / Rust changes. Core already zero-values expired options and skips quote sync — the issue was purely presentational.
- The `Expired` badge on individual rows is unchanged; it shows when the user opts in to revealing them.
- The Holdings Insights page is intentionally out of scope: at $0 value, expired options already contribute zero area to allocation/treemap/donut visualizations.

### Reviewer notes

- Default flips from "show all" to "hide expired" — first load after this lands will hide expired option rows for users that have any. One click from the toolbar (or the mobile filter sheet) brings them back; the choice is persisted in localStorage.
- Toggle is auto-hidden when no holdings expire, so accounts without options are unaffected.
- Codex P1 follow-up addressed in 996dec06: the global `/holdings` mobile flow uses a standalone filter sheet at the page level (its embedded one is suppressed via `showFilterButton={false}`); without lifting state, the toggle row would not have rendered there even though the filter still hid rows by default. State now lives on the page and is shared with the standalone sheet.
- Verified with `pnpm type-check` and `pnpm lint` (0 errors; existing warnings unchanged).

### Manual test plan

- [ ] Account with active + expired options on `/accounts/:id` and `/holdings` → expired hidden by default; clicking eye toggle (desktop) or filter sheet row (mobile) reveals them with the red `Expired` badge.
- [ ] On `/holdings` mobile, open the filter sheet and confirm the "Expired Options" row appears and toggling it updates the visible list.
- [ ] Refresh page → toggle state persists.
- [ ] Toggle on desktop, switch to mobile (filter sheet) — value is in sync.
- [ ] Switch between per-account view and global Holdings page — value is in sync.
- [ ] Account with no options at all → toggle button absent (desktop) and row absent (mobile filter sheet).
- [ ] Cash and non-option holdings unaffected.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).