### PR TITLE
fix(activity): activity grid exchange-only asset edits not rebinding transactions

### DIFF
--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.test.ts
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.test.ts
@@ -369,6 +369,8 @@ describe("activity-utils", () => {
           isNew: false,
           assetSymbol: "VWRPL.XC",
           _originalAssetSymbol: "VWRPL.XC",
+          exchangeMic: "XLON",
+          _originalExchangeMic: "XLON",
           _originalAssetId: "asset-1",
           pendingQuoteCcy: "GBP",
           pendingInstrumentType: "EQUITY",
@@ -394,6 +396,44 @@ describe("activity-utils", () => {
           instrumentType: "EQUITY",
         }),
       );
+    });
+
+    it("should re-resolve the asset when only exchange changes", () => {
+      const transactions: LocalTransaction[] = [
+        createMockTransaction({
+          id: "existing-1",
+          isNew: false,
+          assetSymbol: "FBTC",
+          _originalAssetSymbol: "FBTC",
+          exchangeMic: "XTSE",
+          _originalExchangeMic: "XNEO",
+          _originalAssetId: "asset-fbtc-neo",
+          pendingQuoteCcy: "CAD",
+          pendingInstrumentType: "EQUITY",
+        }),
+      ];
+      const dirtyIds = new Set(["existing-1"]);
+
+      const result = buildSavePayload(
+        transactions,
+        dirtyIds,
+        new Set(),
+        mockResolveTransactionCurrency,
+        dirtyCurrencyLookup,
+        assetCurrencyLookup,
+        "USD",
+      );
+
+      expect(result.updates).toHaveLength(1);
+      expect(result.updates[0].symbol).toEqual(
+        expect.objectContaining({
+          symbol: "FBTC",
+          exchangeMic: "XTSE",
+          quoteCcy: "CAD",
+          instrumentType: "EQUITY",
+        }),
+      );
+      expect(result.updates[0].symbol?.id).toBeUndefined();
     });
 
     it("should normalize optional symbol fields and avoid empty string payload values", () => {

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.ts
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.ts
@@ -514,8 +514,9 @@ export function buildSavePayload(
         const currentSymbol = (transaction.assetSymbol || "").trim().toUpperCase();
         const originalSymbol = (transaction._originalAssetSymbol || "").trim().toUpperCase();
         const currentExchangeMic = normalizeOptionalString(transaction.exchangeMic)?.toUpperCase();
-        const originalExchangeMic =
-          normalizeOptionalString(transaction._originalExchangeMic)?.toUpperCase();
+        const originalExchangeMic = normalizeOptionalString(
+          transaction._originalExchangeMic,
+        )?.toUpperCase();
         const symbolChanged = currentSymbol !== originalSymbol;
         const exchangeChanged = currentExchangeMic !== originalExchangeMic;
         const assetIdentityChanged = symbolChanged || exchangeChanged;

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.ts
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.ts
@@ -513,10 +513,15 @@ export function buildSavePayload(
       if (!isCash) {
         const currentSymbol = (transaction.assetSymbol || "").trim().toUpperCase();
         const originalSymbol = (transaction._originalAssetSymbol || "").trim().toUpperCase();
+        const currentExchangeMic = normalizeOptionalString(transaction.exchangeMic)?.toUpperCase();
+        const originalExchangeMic =
+          normalizeOptionalString(transaction._originalExchangeMic)?.toUpperCase();
         const symbolChanged = currentSymbol !== originalSymbol;
+        const exchangeChanged = currentExchangeMic !== originalExchangeMic;
+        const assetIdentityChanged = symbolChanged || exchangeChanged;
 
-        if (symbolChanged && currentSymbol) {
-          // Symbol changed: send symbol + exchangeMic for backend to generate new canonical ID
+        if (assetIdentityChanged && currentSymbol) {
+          // Asset identity changed: send symbol + exchangeMic for backend to re-resolve the asset
           const symbolInput = {
             symbol: currentSymbol,
             exchangeMic: normalizeOptionalString(transaction.exchangeMic),
@@ -530,7 +535,7 @@ export function buildSavePayload(
             ...symbolInput,
           };
         } else if (transaction._originalAssetId) {
-          // Symbol unchanged: send existing asset ID with quoteMode to allow mode updates
+          // Asset identity unchanged: send existing asset ID with quoteMode to allow mode updates
           updatePayload.symbol = {
             id: transaction._originalAssetId,
             quoteMode: normalizeOptionalString(transaction.assetQuoteMode),

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/types.ts
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/types.ts
@@ -18,6 +18,8 @@ export interface LocalTransaction extends ActivityDetails {
   isExternal?: boolean;
   /** Original asset symbol from server - used to detect symbol changes for updates */
   _originalAssetSymbol?: string;
+  /** Original exchange MIC from server - used to detect exchange changes for updates */
+  _originalExchangeMic?: string;
   /** Original asset ID from server - sent for updates when symbol hasn't changed */
   _originalAssetId?: string;
 }
@@ -45,6 +47,7 @@ export function toLocalTransaction(activity: ActivityDetails): LocalTransaction 
     isExternal,
     // Capture original values for change detection during updates
     _originalAssetSymbol: activity.assetSymbol,
+    _originalExchangeMic: activity.exchangeMic,
     _originalAssetId: activity.assetId,
   };
 }

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -21,9 +21,9 @@ use crate::activities::{
     ImportRun, ImportRunMode, ImportRunRepositoryTrait, ImportRunSummary, ImportRunType, ReviewMode,
 };
 use crate::assets::{
-    normalize_quote_ccy_code, parse_crypto_pair_symbol, parse_symbol_with_exchange_suffix,
-    resolve_quote_ccy_precedence, symbol_resolution_candidates, AssetKind, AssetServiceTrait,
-    InstrumentType, QuoteCcyResolutionSource, QuoteMode,
+    canonicalize_market_identity, normalize_quote_ccy_code, parse_crypto_pair_symbol,
+    parse_symbol_with_exchange_suffix, resolve_quote_ccy_precedence, symbol_resolution_candidates,
+    AssetKind, AssetServiceTrait, InstrumentType, QuoteCcyResolutionSource, QuoteMode,
 };
 use crate::events::{DomainEvent, DomainEventSink, NoOpDomainEventSink};
 use crate::fx::currency::{get_normalization_rule, normalize_amount, resolve_currency};
@@ -1044,6 +1044,70 @@ impl ActivityService {
         (AssetKind::Investment, Some(InstrumentType::Equity))
     }
 
+    fn asset_matches_submitted_identity(
+        &self,
+        asset_id: &str,
+        submitted_symbol: Option<&str>,
+        submitted_exchange_mic: Option<&str>,
+        submitted_instrument_type: Option<&InstrumentType>,
+        submitted_quote_ccy: Option<&str>,
+    ) -> bool {
+        let has_explicit_identity = submitted_symbol
+            .map(str::trim)
+            .filter(|symbol| !symbol.is_empty())
+            .is_some()
+            || submitted_exchange_mic
+                .map(str::trim)
+                .filter(|mic| !mic.is_empty())
+                .is_some()
+            || submitted_instrument_type.is_some();
+
+        if !has_explicit_identity {
+            return true;
+        }
+
+        let Ok(existing_asset) = self.asset_service.get_asset_by_id(asset_id) else {
+            return false;
+        };
+
+        let submitted_identity = canonicalize_market_identity(
+            submitted_instrument_type.cloned(),
+            submitted_symbol,
+            submitted_exchange_mic,
+            submitted_quote_ccy,
+        );
+        let existing_identity = canonicalize_market_identity(
+            existing_asset.instrument_type.clone(),
+            existing_asset
+                .instrument_symbol
+                .as_deref()
+                .or(existing_asset.display_code.as_deref()),
+            existing_asset.instrument_exchange_mic.as_deref(),
+            Some(existing_asset.quote_ccy.as_str()),
+        );
+
+        if submitted_instrument_type.is_some()
+            && existing_asset.instrument_type.as_ref() != submitted_instrument_type
+        {
+            return false;
+        }
+
+        if submitted_identity.instrument_symbol != existing_identity.instrument_symbol {
+            return false;
+        }
+
+        match submitted_instrument_type {
+            Some(InstrumentType::Crypto | InstrumentType::Fx) => {
+                submitted_identity.quote_ccy == existing_identity.quote_ccy
+            }
+            Some(InstrumentType::Option) => true,
+            _ => {
+                submitted_identity.instrument_exchange_mic
+                    == existing_identity.instrument_exchange_mic
+            }
+        }
+    }
+
     /// Finds an existing asset by instrument fields, searching all assets.
     fn find_existing_asset_id(
         &self,
@@ -1225,6 +1289,25 @@ impl ActivityService {
         } else {
             Some(base_symbol.to_string())
         };
+
+        if let Some(symbol_id) = activity
+            .get_symbol_id()
+            .filter(|id| !id.trim().is_empty())
+            .map(str::to_string)
+        {
+            let should_keep_symbol_id = self.asset_matches_submitted_identity(
+                &symbol_id,
+                normalized_symbol_for_lookup.as_deref(),
+                exchange_mic.as_deref(),
+                effective_instrument_type.as_ref(),
+                quote_ccy_input.as_deref(),
+            );
+            if !should_keep_symbol_id {
+                if let Some(symbol_input) = activity.symbol.as_mut() {
+                    symbol_input.id = None;
+                }
+            }
+        }
 
         match symbol.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
             Some(raw_symbol) => {

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -609,8 +609,13 @@ mod tests {
 
     #[async_trait]
     impl ActivityRepositoryTrait for MockActivityRepository {
-        fn get_activity(&self, _activity_id: &str) -> Result<Activity> {
-            unimplemented!()
+        fn get_activity(&self, activity_id: &str) -> Result<Activity> {
+            let stored = self.activities.lock().unwrap();
+            stored
+                .iter()
+                .find(|activity| activity.id == activity_id)
+                .cloned()
+                .ok_or_else(|| crate::errors::Error::Unexpected("Activity not found".to_string()))
         }
 
         fn get_activities(&self) -> Result<Vec<Activity>> {
@@ -695,8 +700,31 @@ mod tests {
             Ok(activity)
         }
 
-        async fn update_activity(&self, _activity_update: ActivityUpdate) -> Result<Activity> {
-            unimplemented!()
+        async fn update_activity(&self, activity_update: ActivityUpdate) -> Result<Activity> {
+            let mut stored = self.activities.lock().unwrap();
+            let asset_id = activity_update.get_symbol_id().map(|s| s.to_string());
+            let activity = stored
+                .iter_mut()
+                .find(|activity| activity.id == activity_update.id)
+                .ok_or_else(|| crate::errors::Error::Unexpected("Activity not found".to_string()))?;
+
+            activity.account_id = activity_update.account_id;
+            activity.asset_id = asset_id;
+            activity.activity_type = activity_update.activity_type;
+            activity.subtype = activity_update.subtype;
+            activity.currency = activity_update.currency;
+            activity.quantity = activity_update.quantity.flatten();
+            activity.unit_price = activity_update.unit_price.flatten();
+            activity.amount = activity_update.amount.flatten();
+            activity.fee = activity_update.fee.flatten();
+            activity.fx_rate = activity_update.fx_rate.flatten();
+            activity.notes = activity_update.notes;
+            activity.metadata = activity_update
+                .metadata
+                .and_then(|raw| serde_json::from_str(&raw).ok());
+            activity.updated_at = Utc::now();
+
+            Ok(activity.clone())
         }
 
         async fn delete_activity(&self, _activity_id: String) -> Result<Activity> {
@@ -5151,5 +5179,102 @@ mod tests {
             Some("aapl-opt-uuid".to_string()),
             "OCC symbol should match existing option asset"
         );
+    }
+
+    #[tokio::test]
+    async fn test_update_activity_rebinds_asset_when_symbol_id_conflicts_with_exchange_change() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        account_service.add_account(create_test_account("acc-1", "CAD"));
+
+        let neo_asset = create_test_asset_with_instrument(
+            "asset-fbtc-neo",
+            "FBTC",
+            Some("XNEO"),
+            Some(InstrumentType::Equity),
+            "CAD",
+        );
+        let tsx_asset = create_test_asset_with_instrument(
+            "asset-fbtc-tsx",
+            "FBTC",
+            Some("XTSE"),
+            Some(InstrumentType::Equity),
+            "CAD",
+        );
+        asset_service.add_asset(neo_asset.clone());
+        asset_service.add_asset(tsx_asset.clone());
+
+        activity_repository.activities.lock().unwrap().push(Activity {
+            id: "activity-1".to_string(),
+            account_id: "acc-1".to_string(),
+            asset_id: Some(neo_asset.id.clone()),
+            activity_type: "BUY".to_string(),
+            activity_type_override: None,
+            source_type: None,
+            subtype: None,
+            status: ActivityStatus::Posted,
+            activity_date: Utc::now(),
+            settlement_date: None,
+            quantity: Some(dec!(1)),
+            unit_price: Some(dec!(10)),
+            amount: Some(dec!(10)),
+            fee: Some(dec!(0)),
+            currency: "CAD".to_string(),
+            fx_rate: None,
+            notes: None,
+            metadata: None,
+            source_system: None,
+            source_record_id: None,
+            source_group_id: None,
+            idempotency_key: None,
+            import_run_id: None,
+            is_user_modified: false,
+            needs_review: false,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        });
+
+        let quote_service = Arc::new(MockQuoteService);
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            quote_service,
+        );
+
+        let updated = activity_service
+            .update_activity(ActivityUpdate {
+                id: "activity-1".to_string(),
+                account_id: "acc-1".to_string(),
+                symbol: Some(SymbolInput {
+                    id: Some(neo_asset.id.clone()),
+                    symbol: Some("FBTC".to_string()),
+                    exchange_mic: Some("XTSE".to_string()),
+                    instrument_type: Some("EQUITY".to_string()),
+                    quote_ccy: Some("CAD".to_string()),
+                    quote_mode: Some("MARKET".to_string()),
+                    ..Default::default()
+                }),
+                activity_type: "BUY".to_string(),
+                subtype: None,
+                activity_date: "2026-04-25".to_string(),
+                quantity: Some(Some(dec!(1))),
+                unit_price: Some(Some(dec!(10))),
+                currency: "CAD".to_string(),
+                fee: Some(Some(dec!(0))),
+                amount: Some(Some(dec!(10))),
+                status: Some(ActivityStatus::Posted),
+                notes: None,
+                fx_rate: None,
+                metadata: None,
+            })
+            .await
+            .expect("update should succeed");
+
+        assert_eq!(updated.asset_id.as_deref(), Some(tsx_asset.id.as_str()));
     }
 }

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -706,7 +706,9 @@ mod tests {
             let activity = stored
                 .iter_mut()
                 .find(|activity| activity.id == activity_update.id)
-                .ok_or_else(|| crate::errors::Error::Unexpected("Activity not found".to_string()))?;
+                .ok_or_else(|| {
+                    crate::errors::Error::Unexpected("Activity not found".to_string())
+                })?;
 
             activity.account_id = activity_update.account_id;
             activity.asset_id = asset_id;
@@ -5207,35 +5209,39 @@ mod tests {
         asset_service.add_asset(neo_asset.clone());
         asset_service.add_asset(tsx_asset.clone());
 
-        activity_repository.activities.lock().unwrap().push(Activity {
-            id: "activity-1".to_string(),
-            account_id: "acc-1".to_string(),
-            asset_id: Some(neo_asset.id.clone()),
-            activity_type: "BUY".to_string(),
-            activity_type_override: None,
-            source_type: None,
-            subtype: None,
-            status: ActivityStatus::Posted,
-            activity_date: Utc::now(),
-            settlement_date: None,
-            quantity: Some(dec!(1)),
-            unit_price: Some(dec!(10)),
-            amount: Some(dec!(10)),
-            fee: Some(dec!(0)),
-            currency: "CAD".to_string(),
-            fx_rate: None,
-            notes: None,
-            metadata: None,
-            source_system: None,
-            source_record_id: None,
-            source_group_id: None,
-            idempotency_key: None,
-            import_run_id: None,
-            is_user_modified: false,
-            needs_review: false,
-            created_at: Utc::now(),
-            updated_at: Utc::now(),
-        });
+        activity_repository
+            .activities
+            .lock()
+            .unwrap()
+            .push(Activity {
+                id: "activity-1".to_string(),
+                account_id: "acc-1".to_string(),
+                asset_id: Some(neo_asset.id.clone()),
+                activity_type: "BUY".to_string(),
+                activity_type_override: None,
+                source_type: None,
+                subtype: None,
+                status: ActivityStatus::Posted,
+                activity_date: Utc::now(),
+                settlement_date: None,
+                quantity: Some(dec!(1)),
+                unit_price: Some(dec!(10)),
+                amount: Some(dec!(10)),
+                fee: Some(dec!(0)),
+                currency: "CAD".to_string(),
+                fx_rate: None,
+                notes: None,
+                metadata: None,
+                source_system: None,
+                source_record_id: None,
+                source_group_id: None,
+                idempotency_key: None,
+                import_run_id: None,
+                is_user_modified: false,
+                needs_review: false,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            });
 
         let quote_service = Arc::new(MockQuoteService);
         let activity_service = ActivityService::new(


### PR DESCRIPTION
Close #891 

## Description

This fixes an Activity page grid edit bug where exchange-only symbol updates were treated as unchanged asset identities.

### Example:

`FBTC.NE` -> `FBTC.TO`

### What changed:

- Grid edit state now tracks original exchange MIC alongside original symbol
- Grid save payload logic now treats exchange changes as asset identity changes, not just symbol text changes
- When symbol stays the same but exchange changes, the grid sends `symbol + exchangeMic` instead of reusing the old asset ID
- Added backend hardening so conflicting old asset ID vs submitted market identity is re-resolved safely
- Added regression tests for:
- frontend grid payload generation
- backend activity rebind behavior

### Why:

- The app normalizes provider tickers like `FBTC.NE` and `FBTC.TO` into:
   - symbol: `FBTC`
   - exchange: `XNEO` / `XTSE`
- Grid edit mode previously only compared the normalized symbol field, so exchange-only edits were missed

### Result:

- Activity grid edit mode now correctly persists same-symbol/different-exchange updates
- Transactions are rebound to the intended asset instead of silently staying on the old one

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).
