### PR TITLE
Fix expired options and add transfer unlink

### DIFF
--- a/apps/frontend/src/adapters/shared/activities.ts
+++ b/apps/frontend/src/adapters/shared/activities.ts
@@ -155,6 +155,21 @@ export const linkTransferActivities = async (
   }
 };
 
+export const unlinkTransferActivities = async (
+  activityAId: string,
+  activityBId: string,
+): Promise<[Activity, Activity]> => {
+  try {
+    return await invoke<[Activity, Activity]>("unlink_transfer_activities", {
+      activityAId,
+      activityBId,
+    });
+  } catch (err) {
+    logger.error("Error unlinking transfer activities.");
+    throw err;
+  }
+};
+
 // ============================================================================
 // Activity Import Commands
 // ============================================================================

--- a/apps/frontend/src/adapters/web/core.ts
+++ b/apps/frontend/src/adapters/web/core.ts
@@ -100,6 +100,7 @@ export const COMMANDS: CommandMap = {
   save_activities: { method: "POST", path: "/activities/bulk" },
   delete_activity: { method: "DELETE", path: "/activities" },
   link_transfer_activities: { method: "POST", path: "/activities/link" },
+  unlink_transfer_activities: { method: "POST", path: "/activities/unlink" },
   // Activity import
   check_activities_import: { method: "POST", path: "/activities/import/check" },
   preview_import_assets: { method: "POST", path: "/activities/import/assets/preview" },
@@ -663,6 +664,14 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
       break;
     }
     case "link_transfer_activities": {
+      const { activityAId, activityBId } = payload as {
+        activityAId: string;
+        activityBId: string;
+      };
+      body = JSON.stringify({ activityAId, activityBId });
+      break;
+    }
+    case "unlink_transfer_activities": {
       const { activityAId, activityBId } = payload as {
         activityAId: string;
         activityBId: string;

--- a/apps/frontend/src/adapters/web/index.ts
+++ b/apps/frontend/src/adapters/web/index.ts
@@ -83,6 +83,7 @@ export {
   getAccountImportMapping,
   linkAccountTemplate,
   linkTransferActivities,
+  unlinkTransferActivities,
   getActivities,
   importActivities,
   listImportTemplates,

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid-toolbar.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid-toolbar.tsx
@@ -78,6 +78,16 @@ interface ActivityDataGridToolbarProps {
   linkDisabledReason?: string;
   /** Whether a link operation is in progress */
   isLinking?: boolean;
+  /** Handler invoked when user clicks "Unlink internal pair" */
+  onUnlinkSelected?: () => void;
+  /** Whether to show the unlink action for the current selection */
+  showUnlinkSelected?: boolean;
+  /** Whether the current selection is a linked TRANSFER_IN/TRANSFER_OUT pair */
+  canUnlinkSelected?: boolean;
+  /** Reason the current selection cannot be unlinked (used as button tooltip) */
+  unlinkDisabledReason?: string;
+  /** Whether an unlink operation is in progress */
+  isUnlinking?: boolean;
 }
 
 /**
@@ -100,6 +110,11 @@ export function ActivityDataGridToolbar({
   canLinkSelected,
   linkDisabledReason,
   isLinking,
+  onUnlinkSelected,
+  showUnlinkSelected,
+  canUnlinkSelected,
+  unlinkDisabledReason,
+  isUnlinking,
 }: ActivityDataGridToolbarProps) {
   // Prevent mousedown from bubbling to document, which would clear DataGrid selection
   const handleMouseDown = (e: React.MouseEvent) => {
@@ -214,7 +229,24 @@ export function ActivityDataGridToolbar({
                 <span>Approve {selectedPendingCount}</span>
               </Button>
             )}
-            {selectedRowCount === 2 && onLinkSelected && (
+            {selectedRowCount === 2 && showUnlinkSelected && onUnlinkSelected ? (
+              <Button
+                onClick={onUnlinkSelected}
+                size="xs"
+                variant="outline"
+                className="shrink-0 rounded-md text-xs"
+                title={canUnlinkSelected ? "Unlink internal transfer" : unlinkDisabledReason}
+                aria-label="Unlink internal transfer"
+                disabled={!canUnlinkSelected || isUnlinking || isSaving}
+              >
+                {isUnlinking ? (
+                  <Icons.Spinner className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Icons.Unlink className="h-3.5 w-3.5" />
+                )}
+                <span>Unlink</span>
+              </Button>
+            ) : selectedRowCount === 2 && onLinkSelected ? (
               <Button
                 onClick={onLinkSelected}
                 size="xs"
@@ -231,7 +263,7 @@ export function ActivityDataGridToolbar({
                 )}
                 <span>Link</span>
               </Button>
-            )}
+            ) : null}
             <Button
               onClick={onDeleteSelected}
               size="xs"

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid.tsx
@@ -460,8 +460,10 @@ export function ActivityDataGrid({
   );
 
   // Link state: validate that the 2-row selection is a valid TRANSFER_IN/TRANSFER_OUT pair
-  const { linkTransferActivitiesMutation } = useActivityMutations();
-  const [linkDialogOpen, setLinkDialogOpen] = useState(false);
+  const { linkTransferActivitiesMutation, unlinkTransferActivitiesMutation } =
+    useActivityMutations();
+  const [transferDialogOpen, setTransferDialogOpen] = useState(false);
+  const [transferDialogMode, setTransferDialogMode] = useState<"link" | "unlink">("link");
 
   const linkValidation = useMemo(() => {
     if (selectedRows.length !== 2) {
@@ -508,6 +510,56 @@ export function ActivityDataGrid({
     return { canLink: true, transferIn, transferOut } as const;
   }, [selectedRows, dirtyTransactionIds]);
 
+  const unlinkValidation = useMemo(() => {
+    if (selectedRows.length !== 2) {
+      return { canUnlink: false, reason: "" } as const;
+    }
+    const [first, second] = selectedRows.map((row) => row.original);
+    if (first.isNew || second.isNew) {
+      return {
+        canUnlink: false,
+        reason: "Save new activities before unlinking",
+      } as const;
+    }
+    if (dirtyTransactionIds.has(first.id) || dirtyTransactionIds.has(second.id)) {
+      return {
+        canUnlink: false,
+        reason: "Save or discard pending edits on the selected rows before unlinking",
+      } as const;
+    }
+    const types = new Set([first.activityType, second.activityType]);
+    if (
+      !types.has(ActivityType.TRANSFER_IN) ||
+      !types.has(ActivityType.TRANSFER_OUT) ||
+      types.size !== 2
+    ) {
+      return {
+        canUnlink: false,
+        reason: "Select one TRANSFER_IN and one TRANSFER_OUT activity",
+      } as const;
+    }
+    if (!first.sourceGroupId || !second.sourceGroupId) {
+      return {
+        canUnlink: false,
+        reason: "Both selected activities must already be linked",
+      } as const;
+    }
+    if (first.sourceGroupId !== second.sourceGroupId) {
+      return {
+        canUnlink: false,
+        reason: "Selected activities belong to different linked transfers",
+      } as const;
+    }
+    const transferIn = first.activityType === ActivityType.TRANSFER_IN ? first : second;
+    const transferOut = first.activityType === ActivityType.TRANSFER_OUT ? first : second;
+    return { canUnlink: true, transferIn, transferOut } as const;
+  }, [selectedRows, dirtyTransactionIds]);
+
+  const showUnlinkSelected = useMemo(
+    () => selectedRows.length === 2 && selectedRows.every((row) => !!row.original.sourceGroupId),
+    [selectedRows],
+  );
+
   const linkWarnings = useMemo(() => {
     if (!linkValidation.canLink) return [] as string[];
     const { transferIn, transferOut } = linkValidation;
@@ -542,10 +594,21 @@ export function ActivityDataGrid({
       activityAId: linkValidation.transferIn.id,
       activityBId: linkValidation.transferOut.id,
     });
-    setLinkDialogOpen(false);
+    setTransferDialogOpen(false);
     dataGrid.table.resetRowSelection();
     onRefetch();
   }, [linkValidation, linkTransferActivitiesMutation, dataGrid.table, onRefetch]);
+
+  const handleUnlinkConfirm = useCallback(async () => {
+    if (!unlinkValidation.canUnlink) return;
+    await unlinkTransferActivitiesMutation.mutateAsync({
+      activityAId: unlinkValidation.transferIn.id,
+      activityBId: unlinkValidation.transferOut.id,
+    });
+    setTransferDialogOpen(false);
+    dataGrid.table.resetRowSelection();
+    onRefetch();
+  }, [unlinkValidation, unlinkTransferActivitiesMutation, dataGrid.table, onRefetch]);
 
   // Delete selected rows handler
   const deleteSelectedRows = useCallback(() => {
@@ -621,6 +684,15 @@ export function ActivityDataGrid({
     customAssetDialog.rowIndex >= 0 && localTransactions[customAssetDialog.rowIndex]
       ? (localTransactions[customAssetDialog.rowIndex].accountCurrency ?? fallbackCurrency)
       : fallbackCurrency;
+  let dialogActivityIn: LocalTransaction | undefined;
+  let dialogActivityOut: LocalTransaction | undefined;
+  if (transferDialogMode === "link" && linkValidation.canLink) {
+    dialogActivityIn = linkValidation.transferIn;
+    dialogActivityOut = linkValidation.transferOut;
+  } else if (transferDialogMode === "unlink" && unlinkValidation.canUnlink) {
+    dialogActivityIn = unlinkValidation.transferIn;
+    dialogActivityOut = unlinkValidation.transferOut;
+  }
 
   return (
     <div className="flex min-h-0 flex-1 flex-col space-y-3">
@@ -636,10 +708,21 @@ export function ActivityDataGrid({
         onApproveSelected={approveSelectedRows}
         onSave={handleSaveChanges}
         onCancel={handleCancelChanges}
-        onLinkSelected={() => setLinkDialogOpen(true)}
+        onLinkSelected={() => {
+          setTransferDialogMode("link");
+          setTransferDialogOpen(true);
+        }}
         canLinkSelected={linkValidation.canLink}
         linkDisabledReason={linkValidation.canLink ? undefined : linkValidation.reason}
         isLinking={linkTransferActivitiesMutation.isPending}
+        onUnlinkSelected={() => {
+          setTransferDialogMode("unlink");
+          setTransferDialogOpen(true);
+        }}
+        showUnlinkSelected={showUnlinkSelected}
+        canUnlinkSelected={unlinkValidation.canUnlink}
+        unlinkDisabledReason={unlinkValidation.canUnlink ? undefined : unlinkValidation.reason}
+        isUnlinking={unlinkTransferActivitiesMutation.isPending}
       />
 
       <div className="min-h-0 flex-1 overflow-hidden">
@@ -669,13 +752,18 @@ export function ActivityDataGrid({
       />
 
       <LinkTransferModal
-        isOpen={linkDialogOpen}
-        isLinking={linkTransferActivitiesMutation.isPending}
-        activityIn={linkValidation.canLink ? linkValidation.transferIn : undefined}
-        activityOut={linkValidation.canLink ? linkValidation.transferOut : undefined}
-        warnings={linkWarnings}
-        onConfirm={handleLinkConfirm}
-        onCancel={() => setLinkDialogOpen(false)}
+        isOpen={transferDialogOpen}
+        mode={transferDialogMode}
+        isProcessing={
+          transferDialogMode === "link"
+            ? linkTransferActivitiesMutation.isPending
+            : unlinkTransferActivitiesMutation.isPending
+        }
+        activityIn={dialogActivityIn}
+        activityOut={dialogActivityOut}
+        warnings={transferDialogMode === "link" ? linkWarnings : []}
+        onConfirm={transferDialogMode === "link" ? handleLinkConfirm : handleUnlinkConfirm}
+        onCancel={() => setTransferDialogOpen(false)}
       />
     </div>
   );

--- a/apps/frontend/src/pages/activity/components/link-transfer-modal.tsx
+++ b/apps/frontend/src/pages/activity/components/link-transfer-modal.tsx
@@ -14,7 +14,8 @@ import { formatDateTime } from "@/lib/utils";
 
 interface LinkTransferModalProps {
   isOpen: boolean;
-  isLinking: boolean;
+  mode: "link" | "unlink";
+  isProcessing: boolean;
   activityIn?: ActivityDetails;
   activityOut?: ActivityDetails;
   warnings: string[];
@@ -49,21 +50,27 @@ function ActivityRow({ activity, label }: { activity: ActivityDetails; label: st
 
 export function LinkTransferModal({
   isOpen,
-  isLinking,
+  mode,
+  isProcessing,
   activityIn,
   activityOut,
   warnings,
   onConfirm,
   onCancel,
 }: LinkTransferModalProps) {
+  const isUnlinkMode = mode === "unlink";
+
   return (
     <AlertDialog open={isOpen} onOpenChange={(open) => (!open ? onCancel() : undefined)}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Link as internal transfer</AlertDialogTitle>
+          <AlertDialogTitle>
+            {isUnlinkMode ? "Unlink internal transfer" : "Link as internal transfer"}
+          </AlertDialogTitle>
           <AlertDialogDescription>
-            These two activities will be paired and treated as a single internal transfer between
-            your accounts.
+            {isUnlinkMode
+              ? "These two activities will become external transfers again."
+              : "These two activities will be paired and treated as a single internal transfer between your accounts."}
           </AlertDialogDescription>
         </AlertDialogHeader>
 
@@ -77,8 +84,8 @@ export function LinkTransferModal({
           </div>
         ) : null}
 
-        {warnings.length > 0 ? (
-          <div className="border-warning/40 bg-warning/10 text-warning-foreground flex gap-2 rounded-md border px-3 py-2 text-xs">
+        {!isUnlinkMode && warnings.length > 0 ? (
+          <div className="border-warning/40 bg-warning/10 text-warning flex gap-2 rounded-md border px-3 py-2 text-xs">
             <Icons.AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
             <ul className="space-y-0.5">
               {warnings.map((warning) => (
@@ -89,14 +96,16 @@ export function LinkTransferModal({
         ) : null}
 
         <AlertDialogFooter>
-          <AlertDialogCancel disabled={isLinking}>Cancel</AlertDialogCancel>
-          <Button onClick={onConfirm} disabled={isLinking}>
-            {isLinking ? (
+          <AlertDialogCancel disabled={isProcessing}>Cancel</AlertDialogCancel>
+          <Button onClick={onConfirm} disabled={isProcessing}>
+            {isProcessing ? (
               <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />
+            ) : isUnlinkMode ? (
+              <Icons.Unlink className="mr-2 h-4 w-4" />
             ) : (
               <Icons.Link className="mr-2 h-4 w-4" />
             )}
-            <span>Link transfers</span>
+            <span>{isUnlinkMode ? "Unlink transfers" : "Link transfers"}</span>
           </Button>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/apps/frontend/src/pages/activity/hooks/use-activity-mutations.ts
+++ b/apps/frontend/src/pages/activity/hooks/use-activity-mutations.ts
@@ -4,6 +4,7 @@ import {
   linkTransferActivities,
   logger,
   saveActivities,
+  unlinkTransferActivities,
   updateActivity,
 } from "@/adapters";
 import { generateId } from "@/lib/id";
@@ -255,6 +256,23 @@ export function useActivityMutations(
     },
   });
 
+  const unlinkTransferActivitiesMutation = useMutation({
+    mutationFn: ({ activityAId, activityBId }: { activityAId: string; activityBId: string }) =>
+      unlinkTransferActivities(activityAId, activityBId),
+    onSuccess: () => {
+      queryClient.invalidateQueries();
+      toast.success("Transfers unlinked", {
+        description: "The two activities are external transfers again.",
+      });
+    },
+    onError: (error: string) => {
+      logger.error(`Error unlinking transfers: ${String(error)}`);
+      toast.error("Failed to unlink transfers", {
+        description: String(error),
+      });
+    },
+  });
+
   const duplicateActivity = async (activityToDuplicate: ActivityDetails) => {
     const {
       id: _id,
@@ -355,5 +373,6 @@ export function useActivityMutations(
     duplicateActivityMutation,
     saveActivitiesMutation,
     linkTransferActivitiesMutation,
+    unlinkTransferActivitiesMutation,
   };
 }

--- a/apps/frontend/src/pages/asset/asset-utils.test.ts
+++ b/apps/frontend/src/pages/asset/asset-utils.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AssetKind } from "@/lib/constants";
+import type { Asset } from "@/lib/types";
+import { isExpiredOptionAsset } from "./asset-utils";
+
+const makeAsset = (overrides: Partial<Asset> = {}): Asset => ({
+  id: "asset-1",
+  kind: AssetKind.INVESTMENT,
+  name: "Option",
+  displayCode: "TSLA260426C00397500",
+  quoteMode: "MARKET",
+  quoteCcy: "USD",
+  instrumentType: "OPTION",
+  instrumentSymbol: "TSLA260426C00397500",
+  createdAt: "2026-04-01T00:00:00Z",
+  updatedAt: "2026-04-01T00:00:00Z",
+  ...overrides,
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("isExpiredOptionAsset", () => {
+  it("uses the configured timezone for the current date", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T01:00:00Z"));
+
+    const asset = makeAsset({
+      metadata: {
+        option: {
+          expiration: "2026-04-26",
+        },
+      },
+    });
+
+    expect(isExpiredOptionAsset(asset, "America/Los_Angeles")).toBe(false);
+    expect(isExpiredOptionAsset(asset, "UTC")).toBe(true);
+  });
+
+  it("falls back to the OCC symbol when metadata is missing", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T12:00:00Z"));
+
+    expect(isExpiredOptionAsset(makeAsset(), "UTC")).toBe(true);
+  });
+
+  it("ignores non-option assets", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T12:00:00Z"));
+
+    expect(
+      isExpiredOptionAsset(
+        makeAsset({
+          instrumentType: "EQUITY",
+          metadata: {
+            option: {
+              expiration: "2026-04-26",
+            },
+          },
+        }),
+        "UTC",
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/frontend/src/pages/asset/asset-utils.ts
+++ b/apps/frontend/src/pages/asset/asset-utils.ts
@@ -1,5 +1,6 @@
 import { Asset, LatestQuoteSnapshot } from "@/lib/types";
 import { parseOccSymbol } from "@/lib/occ-symbol";
+import { resolveDisplayTimezone } from "@/lib/utils";
 
 export interface WeightedBreakdown {
   name: string;
@@ -11,17 +12,26 @@ export interface ParsedAsset extends Asset {
   countriesList: WeightedBreakdown[];
 }
 
-const getLocalDateString = (): string => {
-  const today = new Date();
-  return `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+const getDateStringInTimezone = (timezone?: string | null): string => {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: resolveDisplayTimezone(timezone),
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const parts = formatter.formatToParts(new Date());
+  const year = parts.find((part) => part.type === "year")?.value ?? "";
+  const month = parts.find((part) => part.type === "month")?.value ?? "";
+  const day = parts.find((part) => part.type === "day")?.value ?? "";
+  return `${year}-${month}-${day}`;
 };
 
-export const isExpiredOptionAsset = (asset: Asset): boolean => {
+export const isExpiredOptionAsset = (asset: Asset, timezone?: string | null): boolean => {
   if (asset.instrumentType !== "OPTION") {
     return false;
   }
 
-  const today = getLocalDateString();
+  const today = getDateStringInTimezone(timezone);
   const option = asset.metadata?.option as { expiration?: unknown } | undefined;
   const metadataExpiration =
     typeof option?.expiration === "string" && /^\d{4}-\d{2}-\d{2}$/.test(option.expiration)

--- a/apps/frontend/src/pages/asset/asset-utils.ts
+++ b/apps/frontend/src/pages/asset/asset-utils.ts
@@ -1,4 +1,5 @@
 import { Asset, LatestQuoteSnapshot } from "@/lib/types";
+import { parseOccSymbol } from "@/lib/occ-symbol";
 
 export interface WeightedBreakdown {
   name: string;
@@ -9,6 +10,30 @@ export interface ParsedAsset extends Asset {
   sectorsList: WeightedBreakdown[];
   countriesList: WeightedBreakdown[];
 }
+
+const getLocalDateString = (): string => {
+  const today = new Date();
+  return `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+};
+
+export const isExpiredOptionAsset = (asset: Asset): boolean => {
+  if (asset.instrumentType !== "OPTION") {
+    return false;
+  }
+
+  const today = getLocalDateString();
+  const option = asset.metadata?.option as { expiration?: unknown } | undefined;
+  const metadataExpiration =
+    typeof option?.expiration === "string" && /^\d{4}-\d{2}-\d{2}$/.test(option.expiration)
+      ? option.expiration
+      : null;
+  const parsedExpiration =
+    parseOccSymbol(asset.instrumentSymbol ?? "")?.expiration ??
+    parseOccSymbol(asset.displayCode ?? "")?.expiration;
+  const expiration = metadataExpiration ?? parsedExpiration;
+
+  return !!expiration && expiration < today;
+};
 
 export const isStaleQuote = (snapshot?: LatestQuoteSnapshot, asset?: ParsedAsset): boolean => {
   if (!snapshot || asset?.isActive === false) {

--- a/apps/frontend/src/pages/asset/assets-page.tsx
+++ b/apps/frontend/src/pages/asset/assets-page.tsx
@@ -21,7 +21,7 @@ import { useSyncMarketDataMutation } from "@/hooks/use-sync-market-data";
 import { PORTFOLIO_ACCOUNT_ID } from "@/lib/constants";
 import { SettingsHeader } from "../settings/settings-header";
 import { AssetEditSheet } from "./asset-edit-sheet";
-import { ParsedAsset, toParsedAsset } from "./asset-utils";
+import { isExpiredOptionAsset, ParsedAsset, toParsedAsset } from "./asset-utils";
 import { AssetsTable } from "./assets-table";
 import { AssetsTableMobile } from "./assets-table-mobile";
 import { CreateSecurityDialog } from "./create-security-dialog";
@@ -48,7 +48,11 @@ export default function AssetsPage() {
   }, [holdings]);
 
   const parsedAssets = useMemo(() => assets.map(toParsedAsset), [assets]);
-  const assetIds = useMemo(() => parsedAssets.map((asset) => asset.id), [parsedAssets]);
+  const visibleAssets = useMemo(
+    () => parsedAssets.filter((asset) => !isExpiredOptionAsset(asset)),
+    [parsedAssets],
+  );
+  const assetIds = useMemo(() => visibleAssets.map((asset) => asset.id), [visibleAssets]);
   const { data: latestQuotes = {}, isLoading: isQuotesLoading } = useLatestQuotes(assetIds);
 
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
@@ -77,7 +81,7 @@ export default function AssetsPage() {
       <div className="w-full">
         {isMobileViewport ? (
           <AssetsTableMobile
-            assets={parsedAssets}
+            assets={visibleAssets}
             latestQuotes={latestQuotes}
             heldAssetIds={heldAssetIds}
             isLoading={isLoading || isQuotesLoading}
@@ -90,7 +94,7 @@ export default function AssetsPage() {
           />
         ) : (
           <AssetsTable
-            assets={parsedAssets}
+            assets={visibleAssets}
             latestQuotes={latestQuotes}
             heldAssetIds={heldAssetIds}
             isLoading={isLoading || isQuotesLoading}

--- a/apps/frontend/src/pages/asset/assets-page.tsx
+++ b/apps/frontend/src/pages/asset/assets-page.tsx
@@ -19,6 +19,7 @@ import { useHoldings } from "@/hooks/use-holdings";
 import { useIsMobileViewport } from "@/hooks/use-platform";
 import { useSyncMarketDataMutation } from "@/hooks/use-sync-market-data";
 import { PORTFOLIO_ACCOUNT_ID } from "@/lib/constants";
+import { useSettingsContext } from "@/lib/settings-provider";
 import { SettingsHeader } from "../settings/settings-header";
 import { AssetEditSheet } from "./asset-edit-sheet";
 import { isExpiredOptionAsset, ParsedAsset, toParsedAsset } from "./asset-utils";
@@ -36,6 +37,8 @@ export default function AssetsPage() {
   const updateQuotesMutation = useSyncMarketDataMutation(false);
   const isMobileViewport = useIsMobileViewport();
   const { holdings } = useHoldings(PORTFOLIO_ACCOUNT_ID);
+  const { settings } = useSettingsContext();
+  const appTimezone = settings?.timezone?.trim() || undefined;
 
   const heldAssetIds = useMemo(() => {
     const ids = new Set<string>();
@@ -49,8 +52,8 @@ export default function AssetsPage() {
 
   const parsedAssets = useMemo(() => assets.map(toParsedAsset), [assets]);
   const visibleAssets = useMemo(
-    () => parsedAssets.filter((asset) => !isExpiredOptionAsset(asset)),
-    [parsedAssets],
+    () => parsedAssets.filter((asset) => !isExpiredOptionAsset(asset, appTimezone)),
+    [parsedAssets, appTimezone],
   );
   const assetIds = useMemo(() => visibleAssets.map((asset) => asset.id), [visibleAssets]);
   const { data: latestQuotes = {}, isLoading: isQuotesLoading } = useLatestQuotes(assetIds);

--- a/apps/frontend/src/pages/holdings/components/holdings-mobile-filter-sheet.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-mobile-filter-sheet.tsx
@@ -96,7 +96,6 @@ export const HoldingsMobileFilterSheet = ({
                   className="inline-flex w-auto"
                 />
               </div>
-
             </div>
 
             <Separator />

--- a/apps/frontend/src/pages/holdings/components/holdings-mobile-filter-sheet.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-mobile-filter-sheet.tsx
@@ -30,9 +30,6 @@ interface HoldingsMobileFilterSheetProps {
   categoryFilter?: HoldingCategoryFilterId;
   setCategoryFilter?: (value: HoldingCategoryFilterId) => void;
   typeOptions?: { value: string; label: string }[];
-  hideExpired?: boolean;
-  setHideExpired?: (value: boolean) => void;
-  showExpiredToggle?: boolean;
 }
 
 export const HoldingsMobileFilterSheet = ({
@@ -51,9 +48,6 @@ export const HoldingsMobileFilterSheet = ({
   categoryFilter = "investments",
   setCategoryFilter,
   typeOptions,
-  hideExpired,
-  setHideExpired,
-  showExpiredToggle = false,
 }: HoldingsMobileFilterSheetProps) => {
   const { settings } = useSettingsContext();
   const baseCurrency = settings?.baseCurrency ?? "USD";
@@ -103,23 +97,6 @@ export const HoldingsMobileFilterSheet = ({
                 />
               </div>
 
-              {showExpiredToggle && setHideExpired && (
-                <div className="space-y-3">
-                  <h4 className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
-                    Expired Options
-                  </h4>
-                  <AnimatedToggleGroup<"hide" | "show">
-                    value={hideExpired ? "hide" : "show"}
-                    onValueChange={(value) => setHideExpired(value === "hide")}
-                    items={[
-                      { value: "hide", label: "Hide" },
-                      { value: "show", label: "Show" },
-                    ]}
-                    size="sm"
-                    className="inline-flex w-auto"
-                  />
-                </div>
-              )}
             </div>
 
             <Separator />

--- a/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
@@ -1,12 +1,10 @@
 import { TickerAvatar } from "@/components/ticker-avatar";
 import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
-import { usePersistentState } from "@/hooks/use-persistent-state";
 import { PORTFOLIO_ACCOUNT_ID } from "@/lib/constants";
-import { isExpiredOptionSymbol, parseOccSymbol } from "@/lib/occ-symbol";
+import { parseOccSymbol } from "@/lib/occ-symbol";
 import { Account, Holding } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { AmountDisplay, GainPercent, Input, Separator } from "@wealthfolio/ui";
-import { Badge } from "@wealthfolio/ui/components/ui/badge";
 import { Button } from "@wealthfolio/ui/components/ui/button";
 import { Card } from "@wealthfolio/ui/components/ui/card";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
@@ -64,13 +62,6 @@ export const HoldingsTableMobile = ({
   const showTotalReturn = controlledShowTotalReturn ?? internalShowTotalReturn;
   const setShowTotalReturn = controlledSetShowTotalReturn ?? setInternalShowTotalReturn;
 
-  const [hideExpired, setHideExpired] = usePersistentState<boolean>("holdings-hide-expired", true);
-
-  const hasAnyExpired = useMemo(
-    () => holdings.some((h) => isExpiredOptionSymbol(h.instrument?.symbol ?? h.id)),
-    [holdings],
-  );
-
   const hasActiveFilters = useMemo(() => {
     const hasAccountFilter = showAccountFilter && selectedAccount?.id !== PORTFOLIO_ACCOUNT_ID;
     const hasTypeFilter = selectedTypes.length > 0;
@@ -79,12 +70,6 @@ export const HoldingsTableMobile = ({
 
   const filteredHoldings = useMemo(() => {
     let result = [...holdings];
-
-    if (hideExpired && hasAnyExpired) {
-      result = result.filter(
-        (holding) => !isExpiredOptionSymbol(holding.instrument?.symbol ?? holding.id),
-      );
-    }
 
     if (selectedTypes.length > 0) {
       result = result.filter((holding) => {
@@ -123,7 +108,7 @@ export const HoldingsTableMobile = ({
       }
       return 0;
     });
-  }, [holdings, selectedTypes, searchQuery, sortBy, hideExpired, hasAnyExpired]);
+  }, [holdings, selectedTypes, searchQuery, sortBy]);
 
   const handleNavigate = (holding: Holding) => {
     // Use instrument.id (asset ID) for navigation, not symbol (which may be stripped)
@@ -177,7 +162,6 @@ export const HoldingsTableMobile = ({
             const symbol = holding.instrument?.symbol ?? holding.id;
             const isCash = symbol.startsWith("$CASH");
             const parsedOption = isCash ? null : parseOccSymbol(symbol);
-            const isExpiredOption = !isCash && isExpiredOptionSymbol(symbol);
             const avatarSymbol = isCash ? "$CASH" : parsedOption ? parsedOption.underlying : symbol;
             const displaySymbol = isCash
               ? symbol.split("-")[0]
@@ -204,11 +188,6 @@ export const HoldingsTableMobile = ({
                     <div className="flex-1 overflow-hidden">
                       <div className="flex items-center gap-1.5">
                         <p className="truncate font-semibold">{displaySymbol}</p>
-                        {isExpiredOption && (
-                          <Badge variant="destructive" className="h-4 px-1 py-0 text-[10px]">
-                            Expired
-                          </Badge>
-                        )}
                       </div>
                       {subtitle && (
                         <p className="text-muted-foreground truncate text-sm">{subtitle}</p>
@@ -276,9 +255,6 @@ export const HoldingsTableMobile = ({
         showTotalReturn={showTotalReturn}
         setShowTotalReturn={setShowTotalReturn}
         typeOptions={typeOptions}
-        hideExpired={hideExpired}
-        setHideExpired={setHideExpired}
-        showExpiredToggle={hasAnyExpired}
       />
     </div>
   );

--- a/apps/frontend/src/pages/holdings/components/holdings-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table.tsx
@@ -8,9 +8,8 @@ import {
   DropdownMenuTrigger,
 } from "@wealthfolio/ui/components/ui/dropdown-menu";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
-import { isExpiredOptionSymbol, parseOccSymbol } from "@/lib/occ-symbol";
+import { parseOccSymbol } from "@/lib/occ-symbol";
 import { safeDivide } from "@/lib/utils";
-import { usePersistentState } from "@/hooks/use-persistent-state";
 import type { ColumnDef } from "@tanstack/react-table";
 import { GainPercent, Badge } from "@wealthfolio/ui";
 
@@ -66,13 +65,6 @@ export const HoldingsTable = ({
   const { isBalanceHidden } = useBalancePrivacy();
   const { settings } = useSettingsContext();
   const [showConvertedValues, setShowConvertedValues] = useState(false);
-  const [hideExpired, setHideExpired] = usePersistentState<boolean>("holdings-hide-expired", true);
-
-  const hasAnyExpired = holdings.some((h) => isExpiredOptionSymbol(h.instrument?.symbol ?? h.id));
-  const visibleHoldings =
-    hideExpired && hasAnyExpired
-      ? holdings.filter((h) => !isExpiredOptionSymbol(h.instrument?.symbol ?? h.id))
-      : holdings;
 
   const baseCurrency = settings?.baseCurrency ?? holdings[0]?.baseCurrency;
   const hasMultipleCurrencies = holdings.some((holding) => {
@@ -119,7 +111,7 @@ export const HoldingsTable = ({
   return (
     <div className="flex h-full flex-col">
       <DataTable
-        data={visibleHoldings}
+        data={holdings}
         columns={getColumns(isBalanceHidden, showConvertedValues, showTotalReturn, onClassify)}
         searchBy="symbol"
         filters={filters}
@@ -168,27 +160,6 @@ export const HoldingsTable = ({
                 </TooltipContent>
               </Tooltip>
             )}
-            {hasAnyExpired && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="outline"
-                    size="icon"
-                    onClick={() => setHideExpired(!hideExpired)}
-                    className="h-8 w-8 rounded-lg"
-                  >
-                    {hideExpired ? (
-                      <Icons.EyeOff className="h-4 w-4" />
-                    ) : (
-                      <Icons.Eye className="h-4 w-4" />
-                    )}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>{hideExpired ? "Show expired options" : "Hide expired options"}</p>
-                </TooltipContent>
-              </Tooltip>
-            )}
           </div>
         }
       />
@@ -219,7 +190,6 @@ const getColumns = (
       // Parse OCC symbol for options
       const parsedOption = parseOccSymbol(symbol);
       const displaySymbol = parsedOption ? parsedOption.underlying : symbol;
-      const isExpiredOption = isExpiredOptionSymbol(symbol);
 
       // Option subtitle: "Mar 29 $150 CALL"
       const optionSubtitle = parsedOption
@@ -242,11 +212,6 @@ const getColumns = (
           <div className="flex flex-col">
             <div className="flex items-center gap-1.5">
               <span className="font-medium">{displaySymbol}</span>
-              {isExpiredOption && (
-                <Badge variant="destructive" className="h-4 px-1 py-0 text-[10px]">
-                  Expired
-                </Badge>
-              )}
               {isManual && (
                 <Badge variant="secondary" className="h-4 px-1 py-0 text-[10px]">
                   Manual

--- a/apps/frontend/src/pages/holdings/holdings-page.tsx
+++ b/apps/frontend/src/pages/holdings/holdings-page.tsx
@@ -22,7 +22,6 @@ import {
   apiKindToAlternativeAssetKind,
 } from "@/lib/constants";
 import { Account, HoldingType, AlternativeAssetHolding, AlternativeAssetKind } from "@/lib/types";
-import { isExpiredOptionSymbol } from "@/lib/occ-symbol";
 import { canAddHoldings } from "@/lib/activity-restrictions";
 import { useIsMobileViewport } from "@/hooks/use-platform";
 import { HoldingsMobileFilterSheet } from "./components/holdings-mobile-filter-sheet";
@@ -84,7 +83,6 @@ export const HoldingsPage = () => {
     "holdings-show-total-return",
     true,
   );
-  const [hideExpired, setHideExpired] = usePersistentState<boolean>("holdings-hide-expired", true);
 
   // Alternative asset action state
   const [editAsset, setEditAsset] = useState<AssetDetailsSheetAsset | null>(null);
@@ -335,11 +333,6 @@ export const HoldingsPage = () => {
 
   // Combined loading state
   const isDataLoading = isLoading || isAccountsLoading || isAlternativeHoldingsLoading;
-
-  const hasAnyExpiredHolding = useMemo(
-    () => (nonCashHoldings ?? []).some((h) => isExpiredOptionSymbol(h.instrument?.symbol ?? h.id)),
-    [nonCashHoldings],
-  );
 
   // Empty state checks
   const hasNoInvestments = !isDataLoading && (!nonCashHoldings || nonCashHoldings.length === 0);
@@ -669,9 +662,6 @@ export const HoldingsPage = () => {
         showTotalReturn={showTotalReturn}
         setShowTotalReturn={setShowTotalReturn}
         typeOptions={availableTypeOptions}
-        hideExpired={hideExpired}
-        setHideExpired={setHideExpired}
-        showExpiredToggle={hasAnyExpiredHolding}
       />
 
       {/* Alternative Asset Quick Add Modal */}

--- a/apps/server/src/api/activities.rs
+++ b/apps/server/src/api/activities.rs
@@ -156,6 +156,18 @@ async fn link_transfer_activities(
     Ok(Json(pair))
 }
 
+async fn unlink_transfer_activities(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<LinkTransferActivitiesBody>,
+) -> ApiResult<Json<(Activity, Activity)>> {
+    let pair = state
+        .activity_service
+        .unlink_transfer_activities(body.activity_a_id, body.activity_b_id)
+        .await?;
+    // Domain events handle portfolio recalculation
+    Ok(Json(pair))
+}
+
 #[derive(serde::Deserialize)]
 struct ImportCheckBody {
     activities: Vec<ActivityImport>,
@@ -380,6 +392,7 @@ pub fn router() -> Router<Arc<AppState>> {
         .route("/activities/bulk", post(save_activities))
         .route("/activities/{id}", delete(delete_activity))
         .route("/activities/link", post(link_transfer_activities))
+        .route("/activities/unlink", post(unlink_transfer_activities))
         .route("/activities/import/check", post(check_activities_import))
         .route(
             "/activities/import/assets/preview",

--- a/apps/tauri/src/commands/activity.rs
+++ b/apps/tauri/src/commands/activity.rs
@@ -110,6 +110,21 @@ pub async fn link_transfer_activities(
 }
 
 #[tauri::command]
+pub async fn unlink_transfer_activities(
+    activity_a_id: String,
+    activity_b_id: String,
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<(Activity, Activity), String> {
+    debug!("Unlinking transfer activities...");
+    // Domain events handle recalculation automatically
+    state
+        .activity_service()
+        .unlink_transfer_activities(activity_a_id, activity_b_id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 pub async fn save_activities(
     request: ActivityBulkMutationRequest,
     state: State<'_, Arc<ServiceContext>>,

--- a/apps/tauri/src/lib.rs
+++ b/apps/tauri/src/lib.rs
@@ -286,6 +286,7 @@ pub fn run() {
             commands::activity::save_activities,
             commands::activity::delete_activity,
             commands::activity::link_transfer_activities,
+            commands::activity::unlink_transfer_activities,
             commands::activity::check_activities_import,
             commands::activity::preview_import_assets,
             commands::activity::import_activities,

--- a/crates/ai/src/env.rs
+++ b/crates/ai/src/env.rs
@@ -339,6 +339,14 @@ pub mod test_env {
             unimplemented!("MockActivityService::link_transfer_activities")
         }
 
+        async fn unlink_transfer_activities(
+            &self,
+            _activity_a_id: String,
+            _activity_b_id: String,
+        ) -> CoreResult<(Activity, Activity)> {
+            unimplemented!("MockActivityService::unlink_transfer_activities")
+        }
+
         async fn bulk_mutate_activities(
             &self,
             _request: ActivityBulkMutationRequest,

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -2792,6 +2792,37 @@ impl ActivityServiceTrait for ActivityService {
         Ok((transfer_in, transfer_out))
     }
 
+    async fn unlink_transfer_activities(
+        &self,
+        activity_a_id: String,
+        activity_b_id: String,
+    ) -> Result<(Activity, Activity)> {
+        let (transfer_in, transfer_out) = self
+            .activity_repository
+            .unlink_transfer_activities(activity_a_id, activity_b_id)
+            .await?;
+
+        let mut account_ids: HashSet<String> = HashSet::new();
+        let mut asset_ids: HashSet<String> = HashSet::new();
+        let mut currencies: HashSet<String> = HashSet::new();
+        for activity in [&transfer_in, &transfer_out] {
+            account_ids.insert(activity.account_id.clone());
+            if let Some(ref asset_id) = activity.asset_id {
+                asset_ids.insert(asset_id.clone());
+            }
+            currencies.insert(activity.currency.clone());
+        }
+        let earliest_at = transfer_in.activity_date.min(transfer_out.activity_date);
+        self.emit_activities_changed(
+            account_ids.into_iter().collect(),
+            asset_ids.into_iter().collect(),
+            currencies.into_iter().collect(),
+            Some(earliest_at),
+        );
+
+        Ok((transfer_in, transfer_out))
+    }
+
     async fn bulk_mutate_activities(
         &self,
         request: ActivityBulkMutationRequest,

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -8,6 +8,7 @@ mod tests {
         UpdateAssetProfile,
     };
     use crate::errors::Result;
+    use crate::events::{DomainEvent, MockDomainEventSink};
     use crate::fx::{ExchangeRate, FxServiceTrait, NewExchangeRate};
     use crate::quotes::service::ProviderInfo;
     use crate::quotes::{
@@ -709,6 +710,61 @@ mod tests {
             _activity_b_id: String,
         ) -> Result<(Activity, Activity)> {
             unimplemented!()
+        }
+
+        async fn unlink_transfer_activities(
+            &self,
+            activity_a_id: String,
+            activity_b_id: String,
+        ) -> Result<(Activity, Activity)> {
+            let mut activities = self.activities.lock().unwrap();
+            let first_index = activities
+                .iter()
+                .position(|activity| activity.id == activity_a_id)
+                .ok_or_else(|| {
+                    crate::errors::Error::Unexpected("first activity not found".to_string())
+                })?;
+            let second_index = activities
+                .iter()
+                .position(|activity| activity.id == activity_b_id)
+                .ok_or_else(|| {
+                    crate::errors::Error::Unexpected("second activity not found".to_string())
+                })?;
+
+            let first = activities[first_index].clone();
+            let second = activities[second_index].clone();
+            let (transfer_in_index, transfer_out_index) =
+                match (first.activity_type.as_str(), second.activity_type.as_str()) {
+                    ("TRANSFER_IN", "TRANSFER_OUT") => (first_index, second_index),
+                    ("TRANSFER_OUT", "TRANSFER_IN") => (second_index, first_index),
+                    _ => {
+                        return Err(crate::errors::Error::Unexpected(
+                            "unlink requires transfer pair".to_string(),
+                        ));
+                    }
+                };
+
+            let transfer_in_group = activities[transfer_in_index].source_group_id.clone();
+            let transfer_out_group = activities[transfer_out_index].source_group_id.clone();
+            if transfer_in_group.is_none() || transfer_in_group != transfer_out_group {
+                return Err(crate::errors::Error::Unexpected(
+                    "transfer pair is not linked".to_string(),
+                ));
+            }
+
+            let mut transfer_in = activities[transfer_in_index].clone();
+            let mut transfer_out = activities[transfer_out_index].clone();
+            transfer_in.source_group_id = None;
+            transfer_in.metadata = Some(json!({ "flow": { "is_external": true } }));
+            transfer_out.source_group_id = None;
+            transfer_out.metadata = Some(json!({ "flow": { "is_external": true } }));
+            transfer_in.updated_at = Utc::now();
+            transfer_out.updated_at = Utc::now();
+
+            activities[transfer_in_index] = transfer_in.clone();
+            activities[transfer_out_index] = transfer_out.clone();
+
+            Ok((transfer_in, transfer_out))
         }
 
         async fn bulk_mutate_activities(
@@ -3788,6 +3844,137 @@ mod tests {
             transfer_out_stored.source_group_id, transfer_in_stored.source_group_id,
             "paired transfers should share the same source_group_id"
         );
+    }
+
+    #[tokio::test]
+    async fn unlink_transfer_activities_emits_activities_changed_event() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+        let event_sink = Arc::new(MockDomainEventSink::new());
+        let quote_service = Arc::new(MockQuoteService);
+        let activity_service = ActivityService::new(
+            activity_repository.clone(),
+            account_service,
+            asset_service,
+            fx_service,
+            quote_service,
+        )
+        .with_event_sink(event_sink.clone());
+
+        let earlier = DateTime::parse_from_rfc3339("2024-01-15T00:00:00Z")
+            .expect("valid date")
+            .with_timezone(&Utc);
+        let later = DateTime::parse_from_rfc3339("2024-01-16T00:00:00Z")
+            .expect("valid date")
+            .with_timezone(&Utc);
+        activity_repository.activities.lock().unwrap().extend([
+            Activity {
+                id: "transfer-in".to_string(),
+                account_id: "acc-in".to_string(),
+                asset_id: Some("asset-in".to_string()),
+                activity_type: "TRANSFER_IN".to_string(),
+                activity_type_override: None,
+                source_type: None,
+                subtype: None,
+                status: ActivityStatus::Posted,
+                activity_date: later,
+                settlement_date: None,
+                quantity: None,
+                unit_price: None,
+                amount: Some(dec!(100)),
+                fee: Some(dec!(0)),
+                currency: "CAD".to_string(),
+                fx_rate: None,
+                notes: None,
+                metadata: Some(json!({ "flow": { "is_external": false } })),
+                source_system: Some("MANUAL".to_string()),
+                source_record_id: None,
+                source_group_id: Some("transfer-group".to_string()),
+                idempotency_key: None,
+                import_run_id: None,
+                is_user_modified: false,
+                needs_review: false,
+                created_at: earlier,
+                updated_at: earlier,
+            },
+            Activity {
+                id: "transfer-out".to_string(),
+                account_id: "acc-out".to_string(),
+                asset_id: Some("asset-out".to_string()),
+                activity_type: "TRANSFER_OUT".to_string(),
+                activity_type_override: None,
+                source_type: None,
+                subtype: None,
+                status: ActivityStatus::Posted,
+                activity_date: earlier,
+                settlement_date: None,
+                quantity: None,
+                unit_price: None,
+                amount: Some(dec!(100)),
+                fee: Some(dec!(0)),
+                currency: "USD".to_string(),
+                fx_rate: None,
+                notes: None,
+                metadata: Some(json!({ "flow": { "is_external": false } })),
+                source_system: Some("MANUAL".to_string()),
+                source_record_id: None,
+                source_group_id: Some("transfer-group".to_string()),
+                idempotency_key: None,
+                import_run_id: None,
+                is_user_modified: false,
+                needs_review: false,
+                created_at: earlier,
+                updated_at: earlier,
+            },
+        ]);
+
+        activity_service
+            .unlink_transfer_activities("transfer-in".to_string(), "transfer-out".to_string())
+            .await
+            .expect("unlink should succeed");
+
+        let stored = activity_repository
+            .get_activities()
+            .expect("stored activities");
+        assert!(stored
+            .iter()
+            .all(|activity| activity.source_group_id.is_none()));
+        assert!(stored.iter().all(|activity| {
+            activity
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("flow"))
+                .and_then(|flow| flow.get("is_external"))
+                .and_then(|value| value.as_bool())
+                == Some(true)
+        }));
+
+        let events = event_sink.events();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            DomainEvent::ActivitiesChanged {
+                account_ids,
+                asset_ids,
+                currencies,
+                earliest_activity_at_utc,
+            } => {
+                let mut account_ids = account_ids.clone();
+                account_ids.sort();
+                assert_eq!(account_ids, vec!["acc-in", "acc-out"]);
+
+                let mut asset_ids = asset_ids.clone();
+                asset_ids.sort();
+                assert_eq!(asset_ids, vec!["asset-in", "asset-out"]);
+
+                let mut currencies = currencies.clone();
+                currencies.sort();
+                assert_eq!(currencies, vec!["CAD", "USD"]);
+                assert_eq!(*earliest_activity_at_utc, Some(earlier));
+            }
+            event => panic!("expected ActivitiesChanged event, got {event:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/core/src/activities/activities_traits.rs
+++ b/crates/core/src/activities/activities_traits.rs
@@ -48,6 +48,13 @@ pub trait ActivityRepositoryTrait: Send + Sync {
         activity_a_id: String,
         activity_b_id: String,
     ) -> Result<(Activity, Activity)>;
+    /// Unpairs two linked transfer activities by clearing their shared `source_group_id`
+    /// and marking `metadata.flow.is_external` as true on both rows.
+    async fn unlink_transfer_activities(
+        &self,
+        activity_a_id: String,
+        activity_b_id: String,
+    ) -> Result<(Activity, Activity)>;
     async fn bulk_mutate_activities(
         &self,
         creates: Vec<NewActivity>,
@@ -175,6 +182,11 @@ pub trait ActivityServiceTrait: Send + Sync {
     async fn update_activity(&self, activity: ActivityUpdate) -> Result<Activity>;
     async fn delete_activity(&self, activity_id: String) -> Result<Activity>;
     async fn link_transfer_activities(
+        &self,
+        activity_a_id: String,
+        activity_b_id: String,
+    ) -> Result<(Activity, Activity)>;
+    async fn unlink_transfer_activities(
         &self,
         activity_a_id: String,
         activity_b_id: String,

--- a/crates/core/src/limits/limits_service.rs
+++ b/crates/core/src/limits/limits_service.rs
@@ -351,6 +351,13 @@ mod tests {
         ) -> Result<(Activity, Activity)> {
             unimplemented!()
         }
+        async fn unlink_transfer_activities(
+            &self,
+            _: String,
+            _: String,
+        ) -> Result<(Activity, Activity)> {
+            unimplemented!()
+        }
         async fn bulk_mutate_activities(
             &self,
             _: Vec<NewActivity>,

--- a/crates/core/src/portfolio/holdings/holdings_service.rs
+++ b/crates/core/src/portfolio/holdings/holdings_service.rs
@@ -1,4 +1,6 @@
-use crate::assets::{Asset, AssetClassificationService, AssetKind, AssetServiceTrait};
+use crate::assets::{
+    Asset, AssetClassificationService, AssetKind, AssetServiceTrait, InstrumentType,
+};
 use crate::constants::DECIMAL_PRECISION;
 use crate::errors::{CalculatorError, Error as CoreError, Result};
 use crate::fx::currency::{get_normalization_rule, normalize_currency_code};
@@ -6,6 +8,7 @@ use crate::portfolio::holdings::holdings_model::{Holding, HoldingType, Instrumen
 use crate::portfolio::snapshot::{self, SnapshotServiceTrait};
 use crate::utils::time_utils::{parse_user_timezone_or_default, user_today};
 use async_trait::async_trait;
+use chrono::NaiveDate;
 use log::{debug, error, warn};
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
@@ -46,9 +49,36 @@ pub struct HoldingsService {
 
 struct AssetInfo {
     instrument: Instrument,
+    instrument_symbol: Option<String>,
+    is_option: bool,
     kind: AssetKind,
     metadata: Option<Value>,
     purchase_price: Option<Decimal>,
+}
+
+fn is_expired_option(
+    is_option: bool,
+    metadata: Option<&Value>,
+    symbols: &[&str],
+    today: NaiveDate,
+) -> bool {
+    if !is_option {
+        return false;
+    }
+
+    let expiration = metadata
+        .and_then(|m| m.get("option"))
+        .and_then(|o| o.get("expiration"))
+        .and_then(|v| v.as_str())
+        .and_then(|s| NaiveDate::parse_from_str(s, "%Y-%m-%d").ok())
+        .or_else(|| {
+            symbols.iter().find_map(|symbol| {
+                crate::utils::occ_symbol::parse_occ_symbol(symbol)
+                    .ok()
+                    .map(|parsed| parsed.expiration)
+            })
+        });
+    matches!(expiration, Some(exp) if exp < today)
 }
 
 impl HoldingsService {
@@ -94,6 +124,7 @@ impl HoldingsService {
         latest_snapshot: &snapshot::AccountStateSnapshot,
         base_currency: &str,
         lots_asset_id: Option<&str>,
+        skip_expired_options: bool,
     ) -> Vec<Holding> {
         let today = self.today_in_user_timezone();
         let snapshot_positions: Vec<snapshot::Position> = latest_snapshot
@@ -134,6 +165,8 @@ impl HoldingsService {
 
                         let asset_info = AssetInfo {
                             instrument,
+                            instrument_symbol: asset.instrument_symbol.clone(),
+                            is_option: asset.instrument_type == Some(InstrumentType::Option),
                             kind: asset.kind,
                             metadata,
                             purchase_price,
@@ -163,6 +196,24 @@ impl HoldingsService {
                 );
                 continue;
             };
+
+            if skip_expired_options
+                && is_expired_option(
+                    asset_info.is_option,
+                    asset_info.metadata.as_ref(),
+                    &[
+                        asset_info.instrument_symbol.as_deref().unwrap_or_default(),
+                        &asset_info.instrument.symbol,
+                    ],
+                    today,
+                )
+            {
+                debug!(
+                    "Skipping expired option holding {} for account {}.",
+                    snapshot_pos.asset_id, account_id
+                );
+                continue;
+            }
 
             let (holding_type, id_prefix) = if asset_info.kind.is_alternative() {
                 (HoldingType::AlternativeAsset, "ALT")
@@ -384,6 +435,111 @@ fn apply_portfolio_weights(account_id: &str, holdings: &mut [Holding]) {
     }
 }
 
+#[cfg(test)]
+mod expired_option_metadata_tests {
+    use super::is_expired_option;
+    use chrono::NaiveDate;
+    use serde_json::json;
+
+    #[test]
+    fn detects_expired_option_metadata() {
+        let metadata = json!({
+            "option": {
+                "expiration": "2026-03-06"
+            }
+        });
+        let today = NaiveDate::from_ymd_opt(2026, 4, 27).unwrap();
+
+        assert!(is_expired_option(true, Some(&metadata), &[""], today));
+    }
+
+    #[test]
+    fn detects_expired_occ_symbol_without_metadata() {
+        let today = NaiveDate::from_ymd_opt(2026, 4, 27).unwrap();
+
+        assert!(is_expired_option(
+            true,
+            None,
+            &["TSLA260306C00397500"],
+            today
+        ));
+    }
+
+    #[test]
+    fn detects_expired_canonical_symbol_when_display_symbol_is_custom() {
+        let today = NaiveDate::from_ymd_opt(2026, 4, 27).unwrap();
+
+        assert!(is_expired_option(
+            true,
+            None,
+            &["Custom Label", "TSLA260306C00397500"],
+            today
+        ));
+    }
+
+    #[test]
+    fn requires_option_instrument_type() {
+        let metadata = json!({
+            "option": {
+                "expiration": "2026-03-06"
+            }
+        });
+        let today = NaiveDate::from_ymd_opt(2026, 4, 27).unwrap();
+
+        assert!(!is_expired_option(
+            false,
+            Some(&metadata),
+            &["TSLA260306C00397500"],
+            today
+        ));
+    }
+
+    #[test]
+    fn keeps_active_and_same_day_option_metadata() {
+        let same_day = json!({
+            "option": {
+                "expiration": "2026-04-27"
+            }
+        });
+        let future = json!({
+            "option": {
+                "expiration": "2026-05-15"
+            }
+        });
+        let today = NaiveDate::from_ymd_opt(2026, 4, 27).unwrap();
+
+        assert!(!is_expired_option(true, Some(&same_day), &[""], today));
+        assert!(!is_expired_option(true, Some(&future), &[""], today));
+        assert!(!is_expired_option(
+            true,
+            None,
+            &["TSLA260427C00397500"],
+            today
+        ));
+    }
+
+    #[test]
+    fn ignores_non_option_or_invalid_metadata() {
+        let non_option = json!({ "bond": { "maturityDate": "2026-03-06" } });
+        let invalid_option = json!({ "option": { "expiration": "not-a-date" } });
+        let today = NaiveDate::from_ymd_opt(2026, 4, 27).unwrap();
+
+        assert!(!is_expired_option(
+            true,
+            Some(&non_option),
+            &["AAPL"],
+            today
+        ));
+        assert!(!is_expired_option(
+            true,
+            Some(&invalid_option),
+            &["AAPL"],
+            today
+        ));
+        assert!(!is_expired_option(true, None, &["AAPL"], today));
+    }
+}
+
 #[async_trait]
 impl HoldingsServiceTrait for HoldingsService {
     async fn get_holdings(&self, account_id: &str, base_currency: &str) -> Result<Vec<Holding>> {
@@ -414,7 +570,13 @@ impl HoldingsServiceTrait for HoldingsService {
         };
 
         let mut holdings = self
-            .build_live_holdings_from_snapshot(account_id, &latest_snapshot, base_currency, None)
+            .build_live_holdings_from_snapshot(
+                account_id,
+                &latest_snapshot,
+                base_currency,
+                None,
+                true,
+            )
             .await;
         self.value_holdings_best_effort(account_id, &mut holdings)
             .await;
@@ -499,6 +661,7 @@ impl HoldingsServiceTrait for HoldingsService {
                 &latest_snapshot,
                 base_currency,
                 Some(asset_id),
+                false,
             )
             .await;
         self.value_holdings_best_effort(account_id, &mut holdings)

--- a/crates/core/src/portfolio/holdings/holdings_service.rs
+++ b/crates/core/src/portfolio/holdings/holdings_service.rs
@@ -81,6 +81,18 @@ fn is_expired_option(
     matches!(expiration, Some(exp) if exp < today)
 }
 
+fn is_expired_option_asset(asset: &Asset, today: NaiveDate) -> bool {
+    is_expired_option(
+        asset.instrument_type.as_ref() == Some(&InstrumentType::Option),
+        asset.metadata.as_ref(),
+        &[
+            asset.instrument_symbol.as_deref().unwrap_or_default(),
+            asset.display_code.as_deref().unwrap_or_default(),
+        ],
+        today,
+    )
+}
+
 impl HoldingsService {
     pub fn new(
         asset_service: Arc<dyn AssetServiceTrait>,
@@ -661,7 +673,7 @@ impl HoldingsServiceTrait for HoldingsService {
                 &latest_snapshot,
                 base_currency,
                 Some(asset_id),
-                false,
+                true,
             )
             .await;
         self.value_holdings_best_effort(account_id, &mut holdings)
@@ -679,6 +691,16 @@ impl HoldingsServiceTrait for HoldingsService {
         });
 
         let Some(index) = holding_index else {
+            if let Ok(asset) = self.asset_service.get_asset_by_id(asset_id) {
+                if is_expired_option_asset(&asset, self.today_in_user_timezone()) {
+                    debug!(
+                        "Asset {} exists in snapshot for account {} but is an expired option hidden from live holdings.",
+                        asset_id, account_id
+                    );
+                    return Ok(None);
+                }
+            }
+
             error!(
                 "Asset {} exists in snapshot for account {} but holding view could not be built.",
                 asset_id, account_id
@@ -854,14 +876,429 @@ impl HoldingsServiceTrait for HoldingsService {
 
 #[cfg(test)]
 mod tests {
+    use crate::assets::{
+        AssetMetadata, AssetSpec, EnsureAssetsResult, NewAsset, QuoteMode, UpdateAssetProfile,
+    };
+    use crate::errors::Error;
+    use crate::portfolio::snapshot::{AccountStateSnapshot, Position, SnapshotRecalcMode};
     use crate::snapshot::Lot;
+    use crate::taxonomies::{
+        AssetTaxonomyAssignment, Category, NewAssetTaxonomyAssignment, NewCategory, NewTaxonomy,
+        Taxonomy, TaxonomyServiceTrait, TaxonomyWithCategories,
+    };
     use crate::utils::time_utils::valuation_date_today;
 
     use super::*;
-    use chrono::Utc;
+    use chrono::{NaiveDate, Utc};
     use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
-    use std::collections::VecDeque;
+    use serde_json::json;
+    use std::collections::{HashMap, VecDeque};
+    use std::sync::Arc;
+
+    struct MockAssetService {
+        assets: HashMap<String, Asset>,
+    }
+
+    impl MockAssetService {
+        fn new(assets: Vec<Asset>) -> Self {
+            Self {
+                assets: assets
+                    .into_iter()
+                    .map(|asset| (asset.id.clone(), asset))
+                    .collect(),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl AssetServiceTrait for MockAssetService {
+        fn get_assets(&self) -> Result<Vec<Asset>> {
+            Ok(self.assets.values().cloned().collect())
+        }
+
+        fn get_asset_by_id(&self, asset_id: &str) -> Result<Asset> {
+            self.assets
+                .get(asset_id)
+                .cloned()
+                .ok_or_else(|| Error::Asset(format!("Asset not found: {asset_id}")))
+        }
+
+        async fn delete_asset(&self, _asset_id: &str) -> Result<()> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        async fn update_asset_profile(
+            &self,
+            _asset_id: &str,
+            _payload: UpdateAssetProfile,
+        ) -> Result<Asset> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        async fn create_asset(&self, _new_asset: NewAsset) -> Result<Asset> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        async fn get_or_create_minimal_asset(
+            &self,
+            _asset_id: &str,
+            _context_currency: Option<String>,
+            _metadata: Option<AssetMetadata>,
+            _quote_mode: Option<String>,
+        ) -> Result<Asset> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        async fn update_quote_mode(&self, _asset_id: &str, _quote_mode: &str) -> Result<Asset> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        async fn get_assets_by_asset_ids(&self, asset_ids: &[String]) -> Result<Vec<Asset>> {
+            Ok(asset_ids
+                .iter()
+                .filter_map(|asset_id| self.assets.get(asset_id).cloned())
+                .collect())
+        }
+
+        async fn enrich_asset_profile(&self, _asset_id: &str) -> Result<Asset> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        async fn enrich_assets(&self, _asset_ids: Vec<String>) -> Result<(usize, usize, usize)> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        async fn cleanup_legacy_metadata(&self, _asset_id: &str) -> Result<()> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        async fn merge_unknown_asset(
+            &self,
+            _resolved_asset_id: &str,
+            _unknown_asset_id: &str,
+            _activity_repository: &dyn crate::activities::ActivityRepositoryTrait,
+        ) -> Result<u32> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        async fn ensure_assets(
+            &self,
+            _specs: Vec<AssetSpec>,
+            _activity_repository: &dyn crate::activities::ActivityRepositoryTrait,
+        ) -> Result<EnsureAssetsResult> {
+            unimplemented!("unused in holdings service tests")
+        }
+    }
+
+    struct MockSnapshotService {
+        snapshot: AccountStateSnapshot,
+    }
+
+    #[async_trait::async_trait]
+    impl SnapshotServiceTrait for MockSnapshotService {
+        async fn recalculate_holdings_snapshots(
+            &self,
+            _account_ids: Option<&[String]>,
+            _mode: SnapshotRecalcMode,
+        ) -> Result<usize> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        fn get_holdings_keyframes(
+            &self,
+            _account_id: &str,
+            _start_date: Option<NaiveDate>,
+            _end_date: Option<NaiveDate>,
+        ) -> Result<Vec<AccountStateSnapshot>> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        fn get_daily_holdings_snapshots(
+            &self,
+            _account_id: &str,
+            _start_date: Option<NaiveDate>,
+            _end_date: Option<NaiveDate>,
+        ) -> Result<Vec<AccountStateSnapshot>> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        fn get_latest_holdings_snapshot(
+            &self,
+            _account_id: &str,
+        ) -> Result<Option<AccountStateSnapshot>> {
+            Ok(Some(self.snapshot.clone()))
+        }
+
+        async fn recalculate_total_portfolio_snapshots(
+            &self,
+            _mode: SnapshotRecalcMode,
+        ) -> Result<usize> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        async fn save_manual_snapshot(
+            &self,
+            _account_id: &str,
+            _snapshot: AccountStateSnapshot,
+        ) -> Result<()> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        async fn update_snapshots_source(
+            &self,
+            _account_id: &str,
+            _new_source: &str,
+        ) -> Result<usize> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        async fn ensure_holdings_history(&self, _account_id: &str) -> Result<()> {
+            unimplemented!("unused in holdings service tests")
+        }
+    }
+
+    struct MockValuationService {
+        values: HashMap<String, Decimal>,
+    }
+
+    #[async_trait::async_trait]
+    impl HoldingsValuationServiceTrait for MockValuationService {
+        async fn calculate_holdings_live_valuation(&self, holdings: &mut [Holding]) -> Result<()> {
+            for holding in holdings {
+                if let Some(asset_id) = holding.instrument.as_ref().map(|instrument| &instrument.id)
+                {
+                    if let Some(value) = self.values.get(asset_id) {
+                        holding.market_value = MonetaryValue {
+                            local: *value,
+                            base: *value,
+                        };
+                    }
+                }
+            }
+            Ok(())
+        }
+    }
+
+    struct EmptyTaxonomyService;
+
+    #[async_trait::async_trait]
+    impl TaxonomyServiceTrait for EmptyTaxonomyService {
+        fn get_taxonomies(&self) -> Result<Vec<Taxonomy>> {
+            Ok(Vec::new())
+        }
+
+        fn get_taxonomy(&self, _id: &str) -> Result<Option<TaxonomyWithCategories>> {
+            Ok(None)
+        }
+
+        fn get_taxonomies_with_categories(&self) -> Result<Vec<TaxonomyWithCategories>> {
+            Ok(Vec::new())
+        }
+
+        async fn create_taxonomy(&self, _taxonomy: NewTaxonomy) -> Result<Taxonomy> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        async fn update_taxonomy(&self, _taxonomy: Taxonomy) -> Result<Taxonomy> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        async fn delete_taxonomy(&self, _id: &str) -> Result<usize> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        async fn create_category(&self, _category: NewCategory) -> Result<Category> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        async fn update_category(&self, _category: Category) -> Result<Category> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        async fn delete_category(&self, _taxonomy_id: &str, _category_id: &str) -> Result<usize> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        async fn move_category(
+            &self,
+            _taxonomy_id: &str,
+            _category_id: &str,
+            _new_parent_id: Option<String>,
+            _position: i32,
+        ) -> Result<Category> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        async fn import_taxonomy_json(&self, _json_str: &str) -> Result<Taxonomy> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        fn export_taxonomy_json(&self, _id: &str) -> Result<String> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        fn get_asset_assignments(&self, _asset_id: &str) -> Result<Vec<AssetTaxonomyAssignment>> {
+            Ok(Vec::new())
+        }
+
+        fn get_category_assignments(
+            &self,
+            _taxonomy_id: &str,
+            _category_id: &str,
+        ) -> Result<Vec<AssetTaxonomyAssignment>> {
+            Ok(Vec::new())
+        }
+
+        async fn assign_asset_to_category(
+            &self,
+            _assignment: NewAssetTaxonomyAssignment,
+        ) -> Result<AssetTaxonomyAssignment> {
+            unimplemented!("unused in holdings service tests")
+        }
+
+        async fn remove_asset_assignment(&self, _id: &str) -> Result<usize> {
+            unimplemented!("unused in holdings service tests")
+        }
+    }
+
+    fn test_asset(id: &str, symbol: &str, instrument_type: InstrumentType) -> Asset {
+        let now = Utc::now().naive_utc();
+        Asset {
+            id: id.to_string(),
+            kind: AssetKind::Investment,
+            name: Some(symbol.to_string()),
+            display_code: Some(symbol.to_string()),
+            quote_mode: QuoteMode::Market,
+            quote_ccy: "USD".to_string(),
+            instrument_type: Some(instrument_type),
+            instrument_symbol: Some(symbol.to_string()),
+            created_at: now,
+            updated_at: now,
+            ..Default::default()
+        }
+    }
+
+    fn test_position(account_id: &str, asset_id: &str) -> Position {
+        let now = Utc::now();
+        Position {
+            id: format!("POS-{asset_id}-{account_id}"),
+            account_id: account_id.to_string(),
+            asset_id: asset_id.to_string(),
+            quantity: dec!(1),
+            average_cost: dec!(100),
+            total_cost_basis: dec!(100),
+            currency: "USD".to_string(),
+            inception_date: now,
+            lots: VecDeque::new(),
+            created_at: now,
+            last_updated: now,
+            is_alternative: false,
+            contract_multiplier: Decimal::ONE,
+        }
+    }
+
+    fn test_service(
+        snapshot: AccountStateSnapshot,
+        assets: Vec<Asset>,
+        values: HashMap<String, Decimal>,
+    ) -> HoldingsService {
+        HoldingsService::new(
+            Arc::new(MockAssetService::new(assets)),
+            Arc::new(MockSnapshotService { snapshot }),
+            Arc::new(MockValuationService { values }),
+            Arc::new(AssetClassificationService::new(Arc::new(
+                EmptyTaxonomyService,
+            ))),
+        )
+    }
+
+    #[tokio::test]
+    async fn get_holding_uses_filtered_universe_for_weight() {
+        let account_id = "acc-1";
+        let active_asset_id = "AAPL";
+        let expired_asset_id = "TSLA200117C00397500";
+
+        let active_asset = test_asset(active_asset_id, "AAPL", InstrumentType::Equity);
+        let mut expired_asset =
+            test_asset(expired_asset_id, expired_asset_id, InstrumentType::Option);
+        expired_asset.metadata = Some(json!({
+            "option": {
+                "expiration": "2020-01-17"
+            }
+        }));
+
+        let mut positions = HashMap::new();
+        positions.insert(
+            active_asset_id.to_string(),
+            test_position(account_id, active_asset_id),
+        );
+        positions.insert(
+            expired_asset_id.to_string(),
+            test_position(account_id, expired_asset_id),
+        );
+
+        let snapshot = AccountStateSnapshot {
+            account_id: account_id.to_string(),
+            currency: "USD".to_string(),
+            positions,
+            ..Default::default()
+        };
+        let service = test_service(
+            snapshot,
+            vec![active_asset, expired_asset],
+            HashMap::from([
+                (active_asset_id.to_string(), dec!(100)),
+                (expired_asset_id.to_string(), dec!(100)),
+            ]),
+        );
+
+        let holdings = service.get_holdings(account_id, "USD").await.unwrap();
+        assert_eq!(holdings.len(), 1);
+        assert_eq!(holdings[0].weight, dec!(1));
+
+        let holding = service
+            .get_holding(account_id, active_asset_id, "USD")
+            .await
+            .unwrap()
+            .expect("active holding should exist");
+        assert_eq!(holding.weight, dec!(1));
+    }
+
+    #[tokio::test]
+    async fn get_holding_returns_none_for_expired_option_position() {
+        let account_id = "acc-1";
+        let expired_asset_id = "TSLA200117C00397500";
+
+        let mut expired_asset =
+            test_asset(expired_asset_id, expired_asset_id, InstrumentType::Option);
+        expired_asset.metadata = Some(json!({
+            "option": {
+                "expiration": "2020-01-17"
+            }
+        }));
+
+        let snapshot = AccountStateSnapshot {
+            account_id: account_id.to_string(),
+            currency: "USD".to_string(),
+            positions: HashMap::from([(
+                expired_asset_id.to_string(),
+                test_position(account_id, expired_asset_id),
+            )]),
+            ..Default::default()
+        };
+        let service = test_service(
+            snapshot,
+            vec![expired_asset],
+            HashMap::from([(expired_asset_id.to_string(), dec!(100))]),
+        );
+
+        let holding = service
+            .get_holding(account_id, expired_asset_id, "USD")
+            .await
+            .unwrap();
+        assert!(holding.is_none());
+    }
 
     #[test]
     fn normalize_holding_currency_converts_minor_security_units() {

--- a/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
+++ b/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
@@ -395,6 +395,13 @@ mod tests {
         ) -> AppResult<(Activity, Activity)> {
             unimplemented!()
         }
+        async fn unlink_transfer_activities(
+            &self,
+            _activity_a_id: String,
+            _activity_b_id: String,
+        ) -> AppResult<(Activity, Activity)> {
+            unimplemented!()
+        }
         async fn bulk_mutate_activities(
             &self,
             _creates: Vec<NewActivity>,
@@ -599,6 +606,13 @@ mod tests {
             unimplemented!()
         }
         async fn link_transfer_activities(
+            &self,
+            _a: String,
+            _b: String,
+        ) -> AppResult<(Activity, Activity)> {
+            unimplemented!()
+        }
+        async fn unlink_transfer_activities(
             &self,
             _a: String,
             _b: String,

--- a/crates/core/src/quotes/service.rs
+++ b/crates/core/src/quotes/service.rs
@@ -2462,6 +2462,14 @@ mod tests {
             unimplemented!("unused in this test")
         }
 
+        async fn unlink_transfer_activities(
+            &self,
+            _activity_a_id: String,
+            _activity_b_id: String,
+        ) -> Result<(Activity, Activity)> {
+            unimplemented!("unused in this test")
+        }
+
         async fn bulk_mutate_activities(
             &self,
             _creates: Vec<NewActivity>,

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -45,12 +45,15 @@ fn apply_decimal_patch(existing: Option<String>, patch: Option<Option<Decimal>>)
 fn set_transfer_flow_external(metadata: Option<String>, is_external: bool) -> Option<String> {
     let mut value = metadata
         .and_then(|metadata| serde_json::from_str::<serde_json::Value>(&metadata).ok())
-        .filter(|value| value.is_object())
         .unwrap_or_else(|| serde_json::json!({}));
 
-    let Some(object) = value.as_object_mut() else {
-        return Some(serde_json::json!({ "flow": { "is_external": is_external } }).to_string());
-    };
+    if !value.is_object() {
+        value = serde_json::json!({});
+    }
+
+    let object = value
+        .as_object_mut()
+        .expect("transfer metadata value should be an object");
     let flow = object
         .entry("flow")
         .or_insert_with(|| serde_json::json!({}));
@@ -492,16 +495,26 @@ impl ActivityRepositoryTrait for ActivityRepository {
                 transfer_out.updated_at = now;
 
                 let updated_in = diesel::update(activities::table.find(&transfer_in.id))
-                    .set(&transfer_in)
+                    .set((
+                        activities::source_group_id.eq(transfer_in.source_group_id.clone()),
+                        activities::metadata.eq(transfer_in.metadata.clone()),
+                        activities::is_user_modified.eq(transfer_in.is_user_modified),
+                        activities::updated_at.eq(&transfer_in.updated_at),
+                    ))
                     .get_result::<ActivityDB>(tx.conn())
                     .map_err(StorageError::from)?;
                 let updated_out = diesel::update(activities::table.find(&transfer_out.id))
-                    .set(&transfer_out)
+                    .set((
+                        activities::source_group_id.eq(transfer_out.source_group_id.clone()),
+                        activities::metadata.eq(transfer_out.metadata.clone()),
+                        activities::is_user_modified.eq(transfer_out.is_user_modified),
+                        activities::updated_at.eq(&transfer_out.updated_at),
+                    ))
                     .get_result::<ActivityDB>(tx.conn())
                     .map_err(StorageError::from)?;
 
-                tx.update(&transfer_in)?;
-                tx.update(&transfer_out)?;
+                tx.update(&updated_in)?;
+                tx.update(&updated_out)?;
 
                 Ok((Activity::from(updated_in), Activity::from(updated_out)))
             })

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -42,6 +42,28 @@ fn apply_decimal_patch(existing: Option<String>, patch: Option<Option<Decimal>>)
     }
 }
 
+fn set_transfer_flow_external(metadata: Option<String>, is_external: bool) -> Option<String> {
+    let mut value = metadata
+        .and_then(|metadata| serde_json::from_str::<serde_json::Value>(&metadata).ok())
+        .filter(|value| value.is_object())
+        .unwrap_or_else(|| serde_json::json!({}));
+
+    let Some(object) = value.as_object_mut() else {
+        return Some(serde_json::json!({ "flow": { "is_external": is_external } }).to_string());
+    };
+    let flow = object
+        .entry("flow")
+        .or_insert_with(|| serde_json::json!({}));
+    if !flow.is_object() {
+        *flow = serde_json::json!({});
+    }
+    if let Some(flow_object) = flow.as_object_mut() {
+        flow_object.insert("is_external".to_string(), serde_json::json!(is_external));
+    }
+
+    Some(value.to_string())
+}
+
 // Inherent methods for ActivityRepository
 impl ActivityRepository {
     /// Creates a new ActivityRepository instance
@@ -451,16 +473,22 @@ impl ActivityRepositoryTrait for ActivityRepository {
                         "One or both activities are already linked to another transfer".to_string(),
                     )));
                 }
+                if transfer_in.account_id == transfer_out.account_id {
+                    return Err(Error::from(ActivityError::InvalidData(
+                        "Both transfer legs share the same account".to_string(),
+                    )));
+                }
 
                 let group_id = Uuid::new_v4().to_string();
                 let now = chrono::Utc::now().to_rfc3339();
-                let internal_metadata = Some(r#"{"flow":{"is_external":false}}"#.to_string());
 
                 transfer_in.source_group_id = Some(group_id.clone());
-                transfer_in.metadata = internal_metadata.clone();
+                transfer_in.metadata = set_transfer_flow_external(transfer_in.metadata, false);
+                transfer_in.is_user_modified = 1;
                 transfer_in.updated_at = now.clone();
                 transfer_out.source_group_id = Some(group_id);
-                transfer_out.metadata = internal_metadata;
+                transfer_out.metadata = set_transfer_flow_external(transfer_out.metadata, false);
+                transfer_out.is_user_modified = 1;
                 transfer_out.updated_at = now;
 
                 let updated_in = diesel::update(activities::table.find(&transfer_in.id))
@@ -474,6 +502,97 @@ impl ActivityRepositoryTrait for ActivityRepository {
 
                 tx.update(&transfer_in)?;
                 tx.update(&transfer_out)?;
+
+                Ok((Activity::from(updated_in), Activity::from(updated_out)))
+            })
+            .await
+    }
+
+    async fn unlink_transfer_activities(
+        &self,
+        activity_a_id: String,
+        activity_b_id: String,
+    ) -> Result<(Activity, Activity)> {
+        use wealthfolio_core::activities::{ACTIVITY_TYPE_TRANSFER_IN, ACTIVITY_TYPE_TRANSFER_OUT};
+
+        if activity_a_id == activity_b_id {
+            return Err(Error::from(ActivityError::InvalidData(
+                "Cannot unlink an activity from itself".to_string(),
+            )));
+        }
+
+        self.writer
+            .exec_tx(move |tx| -> Result<(Activity, Activity)> {
+                let a = activities::table
+                    .select(ActivityDB::as_select())
+                    .find(&activity_a_id)
+                    .first::<ActivityDB>(tx.conn())
+                    .map_err(|e| Error::from(ActivityError::NotFound(e.to_string())))?;
+                let b = activities::table
+                    .select(ActivityDB::as_select())
+                    .find(&activity_b_id)
+                    .first::<ActivityDB>(tx.conn())
+                    .map_err(|e| Error::from(ActivityError::NotFound(e.to_string())))?;
+
+                let (mut transfer_in, mut transfer_out) =
+                    match (a.activity_type.as_str(), b.activity_type.as_str()) {
+                        (ACTIVITY_TYPE_TRANSFER_IN, ACTIVITY_TYPE_TRANSFER_OUT) => (a, b),
+                        (ACTIVITY_TYPE_TRANSFER_OUT, ACTIVITY_TYPE_TRANSFER_IN) => (b, a),
+                        _ => {
+                            return Err(Error::from(ActivityError::InvalidData(
+                                "Unlinking requires one TRANSFER_IN and one TRANSFER_OUT activity"
+                                    .to_string(),
+                            )));
+                        }
+                    };
+
+                let Some(in_group_id) = transfer_in.source_group_id.clone() else {
+                    return Err(Error::from(ActivityError::InvalidData(
+                        "Both activities must already be linked".to_string(),
+                    )));
+                };
+                let Some(out_group_id) = transfer_out.source_group_id.clone() else {
+                    return Err(Error::from(ActivityError::InvalidData(
+                        "Both activities must already be linked".to_string(),
+                    )));
+                };
+                if in_group_id != out_group_id {
+                    return Err(Error::from(ActivityError::InvalidData(
+                        "Selected activities belong to different linked transfers".to_string(),
+                    )));
+                }
+
+                let now = chrono::Utc::now().to_rfc3339();
+                transfer_in.source_group_id = None;
+                transfer_in.metadata = set_transfer_flow_external(transfer_in.metadata, true);
+                transfer_in.is_user_modified = 1;
+                transfer_in.updated_at = now.clone();
+                transfer_out.source_group_id = None;
+                transfer_out.metadata = set_transfer_flow_external(transfer_out.metadata, true);
+                transfer_out.is_user_modified = 1;
+                transfer_out.updated_at = now;
+
+                let updated_in = diesel::update(activities::table.find(&transfer_in.id))
+                    .set((
+                        activities::source_group_id.eq(None::<String>),
+                        activities::metadata.eq(transfer_in.metadata.clone()),
+                        activities::is_user_modified.eq(1),
+                        activities::updated_at.eq(&transfer_in.updated_at),
+                    ))
+                    .get_result::<ActivityDB>(tx.conn())
+                    .map_err(StorageError::from)?;
+                let updated_out = diesel::update(activities::table.find(&transfer_out.id))
+                    .set((
+                        activities::source_group_id.eq(None::<String>),
+                        activities::metadata.eq(transfer_out.metadata.clone()),
+                        activities::is_user_modified.eq(1),
+                        activities::updated_at.eq(&transfer_out.updated_at),
+                    ))
+                    .get_result::<ActivityDB>(tx.conn())
+                    .map_err(StorageError::from)?;
+
+                tx.update(&updated_in)?;
+                tx.update(&updated_out)?;
 
                 Ok((Activity::from(updated_in), Activity::from(updated_out)))
             })
@@ -1832,6 +1951,68 @@ mod tests {
         .expect("insert template");
     }
 
+    fn insert_transfer_activity(
+        conn: &mut SqliteConnection,
+        id: &str,
+        account_id: &str,
+        activity_type: &str,
+        source_group_id: Option<&str>,
+        metadata: Option<&str>,
+    ) {
+        let activity = ActivityDB {
+            id: id.to_string(),
+            account_id: account_id.to_string(),
+            asset_id: None,
+            activity_type: activity_type.to_string(),
+            activity_type_override: None,
+            source_type: None,
+            subtype: None,
+            status: "POSTED".to_string(),
+            activity_date: "2024-01-15T00:00:00+00:00".to_string(),
+            settlement_date: None,
+            quantity: None,
+            unit_price: None,
+            amount: Some("100".to_string()),
+            fee: Some("0".to_string()),
+            currency: "USD".to_string(),
+            fx_rate: None,
+            notes: None,
+            metadata: metadata.map(str::to_string),
+            source_system: Some("MANUAL".to_string()),
+            source_record_id: None,
+            source_group_id: source_group_id.map(str::to_string),
+            idempotency_key: Some(format!("{id}-idempotency")),
+            import_run_id: None,
+            is_user_modified: 0,
+            needs_review: 0,
+            created_at: "2024-01-15T00:00:00+00:00".to_string(),
+            updated_at: "2024-01-15T00:00:00+00:00".to_string(),
+        };
+
+        diesel::insert_into(activities::table)
+            .values(&activity)
+            .execute(conn)
+            .expect("insert transfer activity");
+    }
+
+    fn activity_metadata(conn: &mut SqliteConnection, id: &str) -> serde_json::Value {
+        let metadata: Option<String> = activities::table
+            .filter(activities::id.eq(id))
+            .select(activities::metadata)
+            .first(conn)
+            .expect("activity metadata");
+        serde_json::from_str(metadata.as_deref().expect("metadata should be set"))
+            .expect("valid metadata")
+    }
+
+    fn activity_user_modified(conn: &mut SqliteConnection, id: &str) -> i32 {
+        activities::table
+            .filter(activities::id.eq(id))
+            .select(activities::is_user_modified)
+            .first(conn)
+            .expect("activity is_user_modified")
+    }
+
     /// Regression: re-linking the same (account_id, context_kind, source_system) must preserve the row `id`
     /// so that sync outbox events keep a stable entity_id across updates. Generating a new UUID
     /// on every upsert causes remote devices to receive a different entity_id and fail with a
@@ -1883,6 +2064,230 @@ mod tests {
             .first(&mut conn)
             .expect("template_id after relink");
         assert_eq!(template_id_after, "tmpl-b");
+    }
+
+    #[tokio::test]
+    async fn link_transfer_activities_marks_user_modified_and_rejects_same_account() {
+        let (pool, writer) = setup_db();
+        let repo = ActivityRepository::new(pool.clone(), writer);
+        let mut conn = get_connection(&pool).expect("conn");
+
+        insert_account(&mut conn, "acc-a");
+        insert_account(&mut conn, "acc-b");
+        insert_transfer_activity(
+            &mut conn,
+            "transfer-out",
+            "acc-a",
+            "TRANSFER_OUT",
+            None,
+            Some(r#"{"source":{"id":"manual"}}"#),
+        );
+        insert_transfer_activity(
+            &mut conn,
+            "transfer-in",
+            "acc-b",
+            "TRANSFER_IN",
+            None,
+            Some(r#"{"flow":{"is_external":true}}"#),
+        );
+        insert_transfer_activity(&mut conn, "same-account-in", "acc-a", "TRANSFER_IN", None, None);
+
+        let same_account = repo
+            .link_transfer_activities("same-account-in".to_string(), "transfer-out".to_string())
+            .await;
+        assert!(same_account.is_err());
+        let same_account_group: Option<String> = activities::table
+            .filter(activities::id.eq("same-account-in"))
+            .select(activities::source_group_id)
+            .first(&mut conn)
+            .expect("same-account-in group");
+        assert_eq!(same_account_group, None);
+
+        let (transfer_in, transfer_out) = repo
+            .link_transfer_activities("transfer-in".to_string(), "transfer-out".to_string())
+            .await
+            .expect("link should succeed");
+
+        assert_eq!(transfer_in.is_user_modified, true);
+        assert_eq!(transfer_out.is_user_modified, true);
+        assert!(transfer_in.source_group_id.is_some());
+        assert_eq!(transfer_in.source_group_id, transfer_out.source_group_id);
+        assert_eq!(
+            transfer_in.metadata.as_ref().and_then(|m| {
+                m.get("flow")
+                    .and_then(|flow| flow.get("is_external"))
+                    .and_then(|value| value.as_bool())
+            }),
+            Some(false)
+        );
+        assert_eq!(
+            transfer_out
+                .metadata
+                .as_ref()
+                .and_then(|m| m.get("source"))
+                .and_then(|source| source.get("id"))
+                .and_then(|value| value.as_str()),
+            Some("manual"),
+            "link should preserve unrelated metadata"
+        );
+        assert_eq!(activity_user_modified(&mut conn, "transfer-in"), 1);
+        assert_eq!(activity_user_modified(&mut conn, "transfer-out"), 1);
+    }
+
+    #[tokio::test]
+    async fn unlink_transfer_activities_clears_pair_and_marks_external() {
+        let (pool, writer) = setup_db();
+        let repo = ActivityRepository::new(pool.clone(), writer);
+        let mut conn = get_connection(&pool).expect("conn");
+
+        insert_account(&mut conn, "acc-in");
+        insert_account(&mut conn, "acc-out");
+        insert_transfer_activity(
+            &mut conn,
+            "transfer-in",
+            "acc-in",
+            "TRANSFER_IN",
+            Some("transfer-group"),
+            Some(r#"{"flow":{"is_external":false},"source":{"id":"snaptrade"}}"#),
+        );
+        insert_transfer_activity(
+            &mut conn,
+            "transfer-out",
+            "acc-out",
+            "TRANSFER_OUT",
+            Some("transfer-group"),
+            Some(r#"{"flow":{"is_external":false}}"#),
+        );
+
+        let (transfer_in, transfer_out) = repo
+            .unlink_transfer_activities("transfer-in".to_string(), "transfer-out".to_string())
+            .await
+            .expect("unlink should succeed");
+
+        assert_eq!(transfer_in.id, "transfer-in");
+        assert_eq!(transfer_out.id, "transfer-out");
+        assert_eq!(transfer_in.source_group_id, None);
+        assert_eq!(transfer_out.source_group_id, None);
+        assert_eq!(transfer_in.is_user_modified, true);
+        assert_eq!(transfer_out.is_user_modified, true);
+        assert_eq!(
+            transfer_in.metadata.as_ref().and_then(|m| {
+                m.get("flow")
+                    .and_then(|flow| flow.get("is_external"))
+                    .and_then(|value| value.as_bool())
+            }),
+            Some(true)
+        );
+        assert_eq!(
+            transfer_out.metadata.as_ref().and_then(|m| {
+                m.get("flow")
+                    .and_then(|flow| flow.get("is_external"))
+                    .and_then(|value| value.as_bool())
+            }),
+            Some(true)
+        );
+        assert_eq!(
+            transfer_in
+                .metadata
+                .as_ref()
+                .and_then(|m| m.get("source"))
+                .and_then(|source| source.get("id"))
+                .and_then(|value| value.as_str()),
+            Some("snaptrade"),
+            "unlink should preserve unrelated metadata"
+        );
+
+        let source_group_ids: Vec<Option<String>> = activities::table
+            .filter(activities::id.eq_any(["transfer-in", "transfer-out"]))
+            .select(activities::source_group_id)
+            .load(&mut conn)
+            .expect("source group ids");
+        assert_eq!(source_group_ids, vec![None, None]);
+
+        assert_eq!(
+            activity_metadata(&mut conn, "transfer-in")["flow"]["is_external"],
+            true
+        );
+        assert_eq!(
+            activity_metadata(&mut conn, "transfer-out")["flow"]["is_external"],
+            true
+        );
+        assert_eq!(activity_user_modified(&mut conn, "transfer-in"), 1);
+        assert_eq!(activity_user_modified(&mut conn, "transfer-out"), 1);
+    }
+
+    #[tokio::test]
+    async fn unlink_transfer_activities_rejects_unlinked_or_mismatched_pairs() {
+        let (pool, writer) = setup_db();
+        let repo = ActivityRepository::new(pool.clone(), writer);
+        let mut conn = get_connection(&pool).expect("conn");
+
+        insert_account(&mut conn, "acc-in");
+        insert_account(&mut conn, "acc-out");
+        insert_transfer_activity(
+            &mut conn,
+            "linked-in",
+            "acc-in",
+            "TRANSFER_IN",
+            Some("group-a"),
+            Some(r#"{"flow":{"is_external":false}}"#),
+        );
+        insert_transfer_activity(
+            &mut conn,
+            "linked-out",
+            "acc-out",
+            "TRANSFER_OUT",
+            Some("group-b"),
+            Some(r#"{"flow":{"is_external":false}}"#),
+        );
+        insert_transfer_activity(
+            &mut conn,
+            "unlinked-out",
+            "acc-out",
+            "TRANSFER_OUT",
+            None,
+            Some(r#"{"flow":{"is_external":true}}"#),
+        );
+        insert_transfer_activity(&mut conn, "buy-row", "acc-in", "BUY", Some("group-a"), None);
+
+        let mismatched = repo
+            .unlink_transfer_activities("linked-in".to_string(), "linked-out".to_string())
+            .await;
+        assert!(mismatched.is_err());
+
+        let unlinked = repo
+            .unlink_transfer_activities("linked-in".to_string(), "unlinked-out".to_string())
+            .await;
+        assert!(unlinked.is_err());
+
+        let non_transfer = repo
+            .unlink_transfer_activities("linked-in".to_string(), "buy-row".to_string())
+            .await;
+        assert!(non_transfer.is_err());
+
+        let linked_in_group: Option<String> = activities::table
+            .filter(activities::id.eq("linked-in"))
+            .select(activities::source_group_id)
+            .first(&mut conn)
+            .expect("linked-in group");
+        let linked_out_group: Option<String> = activities::table
+            .filter(activities::id.eq("linked-out"))
+            .select(activities::source_group_id)
+            .first(&mut conn)
+            .expect("linked-out group");
+        let unlinked_out_group: Option<String> = activities::table
+            .filter(activities::id.eq("unlinked-out"))
+            .select(activities::source_group_id)
+            .first(&mut conn)
+            .expect("unlinked-out group");
+
+        assert_eq!(linked_in_group.as_deref(), Some("group-a"));
+        assert_eq!(linked_out_group.as_deref(), Some("group-b"));
+        assert_eq!(unlinked_out_group, None);
+        assert_eq!(
+            activity_metadata(&mut conn, "linked-in")["flow"]["is_external"],
+            false
+        );
     }
 
     #[tokio::test]

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -2090,7 +2090,14 @@ mod tests {
             None,
             Some(r#"{"flow":{"is_external":true}}"#),
         );
-        insert_transfer_activity(&mut conn, "same-account-in", "acc-a", "TRANSFER_IN", None, None);
+        insert_transfer_activity(
+            &mut conn,
+            "same-account-in",
+            "acc-a",
+            "TRANSFER_IN",
+            None,
+            None,
+        );
 
         let same_account = repo
             .link_transfer_activities("same-account-in".to_string(), "transfer-out".to_string())
@@ -2108,8 +2115,8 @@ mod tests {
             .await
             .expect("link should succeed");
 
-        assert_eq!(transfer_in.is_user_modified, true);
-        assert_eq!(transfer_out.is_user_modified, true);
+        assert!(transfer_in.is_user_modified);
+        assert!(transfer_out.is_user_modified);
         assert!(transfer_in.source_group_id.is_some());
         assert_eq!(transfer_in.source_group_id, transfer_out.source_group_id);
         assert_eq!(
@@ -2168,8 +2175,8 @@ mod tests {
         assert_eq!(transfer_out.id, "transfer-out");
         assert_eq!(transfer_in.source_group_id, None);
         assert_eq!(transfer_out.source_group_id, None);
-        assert_eq!(transfer_in.is_user_modified, true);
-        assert_eq!(transfer_out.is_user_modified, true);
+        assert!(transfer_in.is_user_modified);
+        assert!(transfer_out.is_user_modified);
         assert_eq!(
             transfer_in.metadata.as_ref().and_then(|m| {
                 m.get("flow")

--- a/packages/ui/src/components/ui/icons.tsx
+++ b/packages/ui/src/components/ui/icons.tsx
@@ -129,6 +129,7 @@ import {
   TrendingUp,
   Type,
   Undo2,
+  Unlink,
   Upload,
   User,
   Users,
@@ -277,6 +278,7 @@ const IconsInternal = {
   TrendingDown: TrendingDown,
   Wand2: Wand2,
   Link: Link,
+  Unlink: Unlink,
   Building: Building2,
   Car: Car,
   Gem: Gem,
@@ -823,6 +825,7 @@ export type IconName =
   | "TrendingDown"
   | "Wand2"
   | "Link"
+  | "Unlink"
   | "Building"
   | "Car"
   | "Gem"


### PR DESCRIPTION
## Summary

- Hide expired option holdings at the holdings service layer and filter expired option assets from the assets settings view.
- Add an Activity grid unlink flow for linked transfer pairs, including frontend validation, confirmation UI, Tauri/web commands, service/repository updates, and regression coverage.
- Preserve transfer metadata, mark link/unlink edits as user-modified, and enforce different-account linking in the backend.

## Commits

- 82af4248 Fix expired option visibility
- 3348ffd5 Add transfer unlink flow

## Validation

- `pnpm type-check`
- `cargo check -p wealthfolio-core -p wealthfolio-storage-sqlite -p wealthfolio-ai -p wealthfolio-server -p wealthfolio-app`
- `cargo test -p wealthfolio-storage-sqlite transfer_activities -- --nocapture`
- `cargo test -p wealthfolio-core expired_option_metadata_tests -- --nocapture`
