### PR TITLE
Improve AI assistant attachment and activity workflows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8016,6 +8016,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",

--- a/apps/frontend/src/adapters/shared/activities.ts
+++ b/apps/frontend/src/adapters/shared/activities.ts
@@ -155,6 +155,21 @@ export const linkTransferActivities = async (
   }
 };
 
+export const unlinkTransferActivities = async (
+  activityAId: string,
+  activityBId: string,
+): Promise<[Activity, Activity]> => {
+  try {
+    return await invoke<[Activity, Activity]>("unlink_transfer_activities", {
+      activityAId,
+      activityBId,
+    });
+  } catch (err) {
+    logger.error("Error unlinking transfer activities.");
+    throw err;
+  }
+};
+
 // ============================================================================
 // Activity Import Commands
 // ============================================================================

--- a/apps/frontend/src/adapters/web/core.ts
+++ b/apps/frontend/src/adapters/web/core.ts
@@ -100,6 +100,7 @@ export const COMMANDS: CommandMap = {
   save_activities: { method: "POST", path: "/activities/bulk" },
   delete_activity: { method: "DELETE", path: "/activities" },
   link_transfer_activities: { method: "POST", path: "/activities/link" },
+  unlink_transfer_activities: { method: "POST", path: "/activities/unlink" },
   // Activity import
   check_activities_import: { method: "POST", path: "/activities/import/check" },
   preview_import_assets: { method: "POST", path: "/activities/import/assets/preview" },
@@ -663,6 +664,14 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
       break;
     }
     case "link_transfer_activities": {
+      const { activityAId, activityBId } = payload as {
+        activityAId: string;
+        activityBId: string;
+      };
+      body = JSON.stringify({ activityAId, activityBId });
+      break;
+    }
+    case "unlink_transfer_activities": {
       const { activityAId, activityBId } = payload as {
         activityAId: string;
         activityBId: string;

--- a/apps/frontend/src/adapters/web/index.ts
+++ b/apps/frontend/src/adapters/web/index.ts
@@ -83,6 +83,7 @@ export {
   getAccountImportMapping,
   linkAccountTemplate,
   linkTransferActivities,
+  unlinkTransferActivities,
   getActivities,
   importActivities,
   listImportTemplates,

--- a/apps/frontend/src/features/ai-assistant/components/attachment.tsx
+++ b/apps/frontend/src/features/ai-assistant/components/attachment.tsx
@@ -7,7 +7,7 @@ import {
 } from "@assistant-ui/react";
 import { PropsWithChildren, useEffect, useState, type FC } from "react";
 
-import { Icons } from "@wealthfolio/ui/components/ui/icons";
+import { Icons, type Icon } from "@wealthfolio/ui/components/ui/icons";
 import { useShallow } from "zustand/shallow";
 import { cn } from "@/lib/utils";
 import { Avatar, AvatarFallback, AvatarImage } from "@wealthfolio/ui/components/ui/avatar";
@@ -115,6 +115,79 @@ const AttachmentThumb: FC = () => {
   );
 };
 
+const getAttachmentExtension = (name: string) => {
+  const fileName = name.split(/[\\/]/).pop() ?? name;
+  const dotIndex = fileName.lastIndexOf(".");
+  if (dotIndex <= 0 || dotIndex === fileName.length - 1) return "FILE";
+  return fileName
+    .slice(dotIndex + 1)
+    .slice(0, 5)
+    .toUpperCase();
+};
+
+const getAttachmentIcon = (name: string, contentType: string): Icon => {
+  const normalizedName = name.toLowerCase();
+  const normalizedType = contentType.toLowerCase();
+
+  if (normalizedType.includes("csv") || normalizedName.endsWith(".csv")) return Icons.FileCsv;
+  if (
+    normalizedType.includes("spreadsheet") ||
+    normalizedType.includes("excel") ||
+    normalizedName.endsWith(".xls") ||
+    normalizedName.endsWith(".xlsx") ||
+    normalizedName.endsWith(".ods")
+  ) {
+    return Icons.FileSpreadsheet;
+  }
+  if (normalizedType.includes("json") || normalizedName.endsWith(".json")) return Icons.FileJson;
+  if (normalizedType.startsWith("image/")) return Icons.FileImage;
+  if (normalizedType.startsWith("audio/")) return Icons.FileAudio;
+  if (normalizedType.startsWith("video/")) return Icons.FileVideo;
+  if (
+    normalizedType.includes("zip") ||
+    normalizedType.includes("archive") ||
+    normalizedName.endsWith(".zip")
+  ) {
+    return Icons.FileArchive;
+  }
+  if (
+    normalizedType.startsWith("text/") ||
+    normalizedType.includes("pdf") ||
+    normalizedName.endsWith(".txt") ||
+    normalizedName.endsWith(".pdf")
+  ) {
+    return Icons.FileText;
+  }
+
+  return Icons.File;
+};
+
+const ComposerFileAttachment: FC = () => {
+  const name = useAssistantState(({ attachment }) => attachment.name);
+  const contentType = useAssistantState(({ attachment }) => attachment.contentType);
+  const FileIcon = getAttachmentIcon(name, contentType);
+  const extension = getAttachmentExtension(name);
+
+  return (
+    <div
+      className="aui-attachment-file-chip bg-muted/60 border-border/70 hover:bg-muted flex h-11 max-w-[18rem] cursor-pointer items-center gap-2 rounded-xl border py-1.5 pl-2.5 pr-8 text-left transition-colors"
+      role="button"
+      id="attachment-tile"
+      aria-label={`File attachment: ${name}`}
+    >
+      <span className="aui-attachment-file-chip-icon bg-background/80 text-foreground/75 flex size-7 shrink-0 items-center justify-center rounded-lg border">
+        <FileIcon className="size-4" />
+      </span>
+      <span className="aui-attachment-file-chip-name min-w-0 flex-1 truncate text-sm font-medium">
+        {name}
+      </span>
+      <span className="aui-attachment-file-chip-extension text-muted-foreground shrink-0 text-[10px] font-semibold uppercase leading-none">
+        {extension}
+      </span>
+    </div>
+  );
+};
+
 const AttachmentUI: FC = () => {
   const api = useAssistantApi();
   const isComposer = api.attachment.source === "composer";
@@ -145,20 +218,24 @@ const AttachmentUI: FC = () => {
       >
         <AttachmentPreviewDialog>
           <TooltipTrigger asChild>
-            <div
-              className={cn(
-                "aui-attachment-tile bg-muted size-14 cursor-pointer overflow-hidden rounded-[14px] border transition-opacity hover:opacity-75",
-                isComposer && "aui-attachment-tile-composer border-foreground/20",
-              )}
-              role="button"
-              id="attachment-tile"
-              aria-label={`${typeLabel} attachment`}
-            >
-              <AttachmentThumb />
-            </div>
+            {isComposer && !isImage ? (
+              <ComposerFileAttachment />
+            ) : (
+              <div
+                className={cn(
+                  "aui-attachment-tile bg-muted size-14 cursor-pointer overflow-hidden rounded-[14px] border transition-opacity hover:opacity-75",
+                  isComposer && "aui-attachment-tile-composer border-foreground/20",
+                )}
+                role="button"
+                id="attachment-tile"
+                aria-label={`${typeLabel} attachment`}
+              >
+                <AttachmentThumb />
+              </div>
+            )}
           </TooltipTrigger>
         </AttachmentPreviewDialog>
-        {isComposer && <AttachmentRemove />}
+        {isComposer && <AttachmentRemove variant={isImage ? "tile" : "chip"} />}
       </AttachmentPrimitive.Root>
       <TooltipContent side="top">
         <AttachmentPrimitive.Name />
@@ -167,15 +244,29 @@ const AttachmentUI: FC = () => {
   );
 };
 
-const AttachmentRemove: FC = () => {
+interface AttachmentRemoveProps {
+  variant?: "tile" | "chip";
+}
+
+const AttachmentRemove: FC<AttachmentRemoveProps> = ({ variant = "tile" }) => {
   return (
     <AttachmentPrimitive.Remove asChild>
       <TooltipIconButton
         tooltip="Remove file"
-        className="aui-attachment-tile-remove text-muted-foreground hover:[&_svg]:text-destructive hover:bg-white! absolute right-1.5 top-1.5 size-3.5 rounded-full bg-white opacity-100 shadow-sm [&_svg]:text-black"
+        className={cn(
+          "aui-attachment-tile-remove text-muted-foreground hover:[&_svg]:text-destructive hover:bg-white! absolute rounded-full bg-white opacity-100 shadow-sm [&_svg]:text-black",
+          variant === "chip"
+            ? "right-1.5 top-1/2 size-5 -translate-y-1/2"
+            : "right-1.5 top-1.5 size-3.5",
+        )}
         side="top"
       >
-        <Icons.Close className="aui-attachment-remove-icon size-3 dark:stroke-[2.5px]" />
+        <Icons.Close
+          className={cn(
+            "aui-attachment-remove-icon dark:stroke-[2.5px]",
+            variant === "chip" ? "size-3.5" : "size-3",
+          )}
+        />
       </TooltipIconButton>
     </AttachmentPrimitive.Remove>
   );

--- a/apps/frontend/src/features/ai-assistant/components/provider-settings-card.tsx
+++ b/apps/frontend/src/features/ai-assistant/components/provider-settings-card.tsx
@@ -61,28 +61,47 @@ interface ProviderSettingsCardProps {
   onRefreshModels?: () => void;
 }
 
-// Novice-friendly tool mapping for data access settings
+// Novice-friendly tool mapping for data access settings.
+// Each card can represent multiple backend tools that belong to the same user capability.
 const DATA_ACCESS_OPTIONS = [
-  { toolId: "get_accounts", label: "Accounts", description: "Account names, types, and balances" },
-  { toolId: "get_holdings", label: "Holdings", description: "Current positions and their values" },
   {
-    toolId: "search_activities",
-    label: "Transactions",
-    description: "Past transactions and activities",
+    toolIds: ["get_accounts", "get_cash_balances"],
+    label: "Accounts",
+    description: "Account details and cash balances",
   },
   {
-    toolId: "get_performance",
+    toolIds: ["get_holdings"],
+    label: "Holdings",
+    description: "Current positions and their values",
+  },
+  {
+    toolIds: ["search_activities", "record_activity", "record_activities", "import_csv"],
+    label: "Transactions",
+    description: "View, draft, and import activities",
+  },
+  {
+    toolIds: ["get_performance"],
     label: "Performance",
     description: "Returns and performance metrics",
   },
-  { toolId: "get_income", label: "Income", description: "Income summary and breakdown" },
-  { toolId: "get_goals", label: "Goals", description: "Investment goals and progress" },
+  { toolIds: ["get_income"], label: "Income", description: "Income summary and breakdown" },
+  { toolIds: ["get_goals"], label: "Goals", description: "Investment goals and progress" },
   {
-    toolId: "get_asset_allocation",
+    toolIds: ["get_asset_allocation"],
     label: "Allocation",
     description: "Portfolio allocation breakdown",
   },
-  { toolId: "get_valuation_history", label: "History", description: "Portfolio value over time" },
+  {
+    toolIds: ["get_valuation_history"],
+    label: "History",
+    description: "Portfolio value over time",
+  },
+];
+
+const HIDDEN_DEFAULT_TOOL_IDS = ["get_health_status"];
+const ALL_DATA_ACCESS_TOOL_IDS = [
+  ...DATA_ACCESS_OPTIONS.flatMap((option) => option.toolIds),
+  ...HIDDEN_DEFAULT_TOOL_IDS,
 ];
 
 export function ProviderSettingsCard({
@@ -249,41 +268,47 @@ export function ProviderSettingsCard({
     onSetCapabilityOverride(modelId, newOverrides);
   };
 
-  // Handle tool allowlist toggle
-  const handleToolToggle = (toolId: string, enabled: boolean) => {
-    if (!onToolsAllowlistChange) return;
-
-    const currentAllowlist = provider.toolsAllowlist;
-    const allToolIds = DATA_ACCESS_OPTIONS.map((opt) => opt.toolId);
-
-    if (currentAllowlist === null || currentAllowlist === undefined) {
-      // Currently all tools enabled (null = all). If disabling one, create allowlist with all except this one.
-      if (!enabled) {
-        const newAllowlist = allToolIds.filter((id) => id !== toolId);
-        onToolsAllowlistChange(newAllowlist);
-      }
-      // If enabling when already all enabled, no action needed
-    } else {
-      // We have an explicit allowlist
-      if (enabled) {
-        // Add tool to allowlist
-        const newAllowlist = [...currentAllowlist, toolId];
-        // Always send the list - don't use null to avoid serialization issues
-        onToolsAllowlistChange(newAllowlist);
-      } else {
-        // Remove tool from allowlist
-        const newAllowlist = currentAllowlist.filter((id) => id !== toolId);
-        onToolsAllowlistChange(newAllowlist);
-      }
-    }
-  };
-
-  // Check if a tool is enabled
-  const isToolEnabled = (toolId: string): boolean => {
+  // Check if a tool group is enabled. Some legacy settings only contain one
+  // tool from a group, so treat any matching tool as enabled and repair the
+  // full group the next time settings are saved.
+  const isToolGroupEnabled = (toolIds: string[]): boolean => {
     const allowlist = provider.toolsAllowlist;
     // null/undefined means all tools are enabled
     if (allowlist === null || allowlist === undefined) return true;
-    return allowlist.includes(toolId);
+    return toolIds.some((toolId) => allowlist.includes(toolId));
+  };
+
+  // Handle grouped tool allowlist toggle
+  const handleToolToggle = (toolIds: string[], enabled: boolean) => {
+    if (!onToolsAllowlistChange) return;
+
+    const enabledToolIds = new Set<string>();
+    for (const option of DATA_ACCESS_OPTIONS) {
+      const isTarget = option.toolIds.some((toolId) => toolIds.includes(toolId));
+      const nextEnabled = isTarget ? enabled : isToolGroupEnabled(option.toolIds);
+      if (nextEnabled) {
+        for (const toolId of option.toolIds) {
+          enabledToolIds.add(toolId);
+        }
+      }
+    }
+
+    const hasVisibleAccess = DATA_ACCESS_OPTIONS.some((option) =>
+      option.toolIds.some((toolId) => enabledToolIds.has(toolId)),
+    );
+    if (hasVisibleAccess) {
+      for (const toolId of HIDDEN_DEFAULT_TOOL_IDS) {
+        enabledToolIds.add(toolId);
+      }
+    }
+
+    const allEnabled = ALL_DATA_ACCESS_TOOL_IDS.every((toolId) => enabledToolIds.has(toolId));
+    if (allEnabled) {
+      onToolsAllowlistChange(null);
+      return;
+    }
+
+    onToolsAllowlistChange(ALL_DATA_ACCESS_TOOL_IDS.filter((toolId) => enabledToolIds.has(toolId)));
   };
 
   return (
@@ -691,12 +716,12 @@ export function ProviderSettingsCard({
                   </div>
                   <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
                     {DATA_ACCESS_OPTIONS.map((option) => {
-                      const isEnabled = isToolEnabled(option.toolId);
+                      const isEnabled = isToolGroupEnabled(option.toolIds);
                       return (
                         <button
-                          key={option.toolId}
+                          key={option.label}
                           type="button"
-                          onClick={() => handleToolToggle(option.toolId, !isEnabled)}
+                          onClick={() => handleToolToggle(option.toolIds, !isEnabled)}
                           className={cn(
                             "flex items-start gap-2.5 rounded-lg border p-3 text-left transition-all",
                             isEnabled

--- a/apps/frontend/src/features/ai-assistant/components/thread.tsx
+++ b/apps/frontend/src/features/ai-assistant/components/thread.tsx
@@ -221,12 +221,29 @@ const MessageError: FC = () => {
   );
 };
 
-const TypingIndicator: FC = () => {
+interface MessagePartWithResult {
+  type?: string;
+  result?: unknown;
+}
+
+interface TypingIndicatorProps {
+  position: "initial" | "continuation";
+}
+
+const TypingIndicator: FC<TypingIndicatorProps> = ({ position }) => {
   const showIndicator = useAssistantState(({ message }) => {
-    // Show indicator when message is running and has no text/tool content yet
     if (message.status?.type !== "running") return false;
-    // Hide if there are any parts (text started streaming or tools are being called)
-    return message.parts.length === 0;
+
+    if (position === "initial") {
+      return message.parts.length === 0;
+    }
+
+    const lastPart = message.parts[message.parts.length - 1] as MessagePartWithResult | undefined;
+    return (
+      lastPart?.type === "tool-call" &&
+      Object.prototype.hasOwnProperty.call(lastPart, "result") &&
+      lastPart.result !== undefined
+    );
   });
 
   if (!showIndicator) return null;
@@ -247,7 +264,7 @@ const AssistantMessage: FC = () => {
       data-role="assistant"
     >
       <div className="aui-assistant-message-content text-foreground wrap-break-word mx-2 text-sm leading-6">
-        <TypingIndicator />
+        <TypingIndicator position="initial" />
         <MessagePrimitive.Parts
           components={{
             Text: MarkdownText,
@@ -259,6 +276,7 @@ const AssistantMessage: FC = () => {
             },
           }}
         />
+        <TypingIndicator position="continuation" />
         <MessageError />
       </div>
 

--- a/apps/frontend/src/features/ai-assistant/components/tool-uis/import-csv-tool-ui.tsx
+++ b/apps/frontend/src/features/ai-assistant/components/tool-uis/import-csv-tool-ui.tsx
@@ -180,20 +180,26 @@ function ErrorCard({ message }: { message: string }) {
 
 function StaleImportCard({ mapping }: { mapping: ImportCsvMappingOutput }) {
   const fieldCount = Object.keys(mapping.appliedMapping?.fieldMappings ?? {}).length;
+  const account = mapping.availableAccounts.find((item) => item.id === mapping.accountId);
   return (
     <Card className="bg-muted/40 border-muted-foreground/20">
       <CardHeader className="pb-3">
         <div className="flex items-center gap-2">
           <Icons.FileSpreadsheet className="text-muted-foreground h-5 w-5" />
-          <CardTitle className="text-muted-foreground text-base">
-            CSV import · {mapping.totalRows} row{mapping.totalRows === 1 ? "" : "s"}
+          <CardTitle className="text-base">
+            CSV import summary · {mapping.totalRows} row{mapping.totalRows === 1 ? "" : "s"}
           </CardTitle>
         </div>
       </CardHeader>
-      <CardContent>
+      <CardContent className="space-y-2">
         <p className="text-muted-foreground text-sm">
           {fieldCount > 0 ? `Mapped ${fieldCount} columns. ` : ""}
-          This import was not completed. Attach the CSV again to start a new import.
+          {account ? `Target account: ${account.name}. ` : ""}
+          The file contents are no longer available in this chat session, so the review table
+          cannot be reopened.
+        </p>
+        <p className="text-muted-foreground text-xs">
+          Attach the CSV again to review, edit, or import these rows.
         </p>
       </CardContent>
     </Card>
@@ -309,7 +315,8 @@ function ImportCsvToolUIContentImpl({
   const hasCsvContent = !!mapping?.csvContent;
   const isSubmitted = mapping?.submitted ?? false;
   const isLive = !!toolCallId && liveToolCalls.has(toolCallId);
-  const shouldInitSession = (isLive && hasCsvContent) || isSubmitted;
+  const canReviewImport = isLive && hasCsvContent;
+  const shouldInitSession = canReviewImport || isSubmitted;
 
   const session = useChatImportSession({
     mapping: shouldInitSession ? mapping : null,
@@ -333,8 +340,9 @@ function ImportCsvToolUIContentImpl({
   if (isSubmitted || session.submitted) {
     return <SuccessCard count={session.importedCount || mapping.importedCount || 0} />;
   }
-  // Not a live tool call from this page session → stale card
-  if (!isLive) {
+  // Historical imports can keep tool metadata but lose session-only CSV content.
+  // Without the CSV body we cannot rebuild the editable review grid.
+  if (!canReviewImport) {
     return <StaleImportCard mapping={mapping} />;
   }
   if (session.status === "initializing") {

--- a/apps/frontend/src/features/ai-assistant/components/tool-uis/import-csv-tool-ui.tsx
+++ b/apps/frontend/src/features/ai-assistant/components/tool-uis/import-csv-tool-ui.tsx
@@ -195,8 +195,8 @@ function StaleImportCard({ mapping }: { mapping: ImportCsvMappingOutput }) {
         <p className="text-muted-foreground text-sm">
           {fieldCount > 0 ? `Mapped ${fieldCount} columns. ` : ""}
           {account ? `Target account: ${account.name}. ` : ""}
-          The file contents are no longer available in this chat session, so the review table
-          cannot be reopened.
+          The file contents are no longer available in this chat session, so the review table cannot
+          be reopened.
         </p>
         <p className="text-muted-foreground text-xs">
           Attach the CSV again to review, edit, or import these rows.

--- a/apps/frontend/src/features/ai-assistant/components/tool-uis/import-csv-tool-ui.tsx
+++ b/apps/frontend/src/features/ai-assistant/components/tool-uis/import-csv-tool-ui.tsx
@@ -206,8 +206,51 @@ function StaleImportCard({ mapping }: { mapping: ImportCsvMappingOutput }) {
 // "tool call that just completed (initialize)" from "reloaded from DB (stale)".
 // ─────────────────────────────────────────────────────────────────────────────
 
+const MAX_LIVE_IMPORT_CSV_CACHE_ENTRIES = 10;
+const MAX_LIVE_IMPORT_CSV_CACHE_BYTES = 100 * 1024 * 1024;
+
 const liveToolCalls = new Set<string>();
 const liveCsvContentByToolCall = new Map<string, string>();
+
+function getLiveCsvContentBytes(): number {
+  let bytes = 0;
+  for (const content of liveCsvContentByToolCall.values()) {
+    bytes += content.length;
+  }
+  return bytes;
+}
+
+function evictOldestLiveImportSession(): boolean {
+  const oldestToolCallId =
+    liveToolCalls.values().next().value ?? liveCsvContentByToolCall.keys().next().value;
+  if (!oldestToolCallId) return false;
+
+  liveToolCalls.delete(oldestToolCallId);
+  liveCsvContentByToolCall.delete(oldestToolCallId);
+  return true;
+}
+
+function pruneLiveImportSessionCache() {
+  while (
+    liveToolCalls.size > MAX_LIVE_IMPORT_CSV_CACHE_ENTRIES ||
+    liveCsvContentByToolCall.size > MAX_LIVE_IMPORT_CSV_CACHE_ENTRIES ||
+    getLiveCsvContentBytes() > MAX_LIVE_IMPORT_CSV_CACHE_BYTES
+  ) {
+    if (!evictOldestLiveImportSession()) break;
+  }
+}
+
+function rememberLiveToolCall(toolCallId: string) {
+  liveToolCalls.delete(toolCallId);
+  liveToolCalls.add(toolCallId);
+  pruneLiveImportSessionCache();
+}
+
+function rememberSessionCsvContent(toolCallId: string, content: string) {
+  liveCsvContentByToolCall.delete(toolCallId);
+  liveCsvContentByToolCall.set(toolCallId, content);
+  rememberLiveToolCall(toolCallId);
+}
 
 function isRedactedCsvContent(value: unknown): boolean {
   return (
@@ -220,7 +263,7 @@ function isRedactedCsvContent(value: unknown): boolean {
 function getSessionCsvContent(toolCallId: string | undefined, value: unknown): string | undefined {
   if (typeof value === "string" && value.trim() && !isRedactedCsvContent(value)) {
     if (toolCallId) {
-      liveCsvContentByToolCall.set(toolCallId, value);
+      rememberSessionCsvContent(toolCallId, value);
     }
     return value;
   }
@@ -261,7 +304,7 @@ function ImportCsvToolUIContentImpl({
   // so we show the stale card. During a live session, we add the ID when
   // status is "running" and it persists across thread switches.
   if (toolCallId && status?.type === "running") {
-    liveToolCalls.add(toolCallId);
+    rememberLiveToolCall(toolCallId);
   }
   const hasCsvContent = !!mapping?.csvContent;
   const isSubmitted = mapping?.submitted ?? false;

--- a/apps/frontend/src/features/ai-assistant/components/tool-uis/import-csv-tool-ui.tsx
+++ b/apps/frontend/src/features/ai-assistant/components/tool-uis/import-csv-tool-ui.tsx
@@ -207,6 +207,26 @@ function StaleImportCard({ mapping }: { mapping: ImportCsvMappingOutput }) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 const liveToolCalls = new Set<string>();
+const liveCsvContentByToolCall = new Map<string, string>();
+
+function isRedactedCsvContent(value: unknown): boolean {
+  return (
+    typeof value === "string" &&
+    value.toLowerCase().includes("redacted") &&
+    value.toLowerCase().includes("session")
+  );
+}
+
+function getSessionCsvContent(toolCallId: string | undefined, value: unknown): string | undefined {
+  if (typeof value === "string" && value.trim() && !isRedactedCsvContent(value)) {
+    if (toolCallId) {
+      liveCsvContentByToolCall.set(toolCallId, value);
+    }
+    return value;
+  }
+
+  return toolCallId ? liveCsvContentByToolCall.get(toolCallId) : undefined;
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Main
@@ -226,9 +246,10 @@ function ImportCsvToolUIContentImpl({
   const runtime = useRuntimeContext();
   const threadId = runtime.currentThreadId;
 
-  // csvContent lives in the tool ARGS (what the LLM sent), not the result
-  // (the tool no longer echoes it back to avoid double-storing in the DB).
-  const csvContent = (args as Record<string, unknown>)?.csvContent as string | undefined;
+  // csvContent lives in live tool args only. Persisted tool args are redacted,
+  // so keep an in-memory copy for this page session.
+  const rawCsvContent = (args as Record<string, unknown>)?.csvContent;
+  const csvContent = getSessionCsvContent(toolCallId, rawCsvContent);
 
   const { mapping, errorMessage: normalizeError } = useMemo(
     () => normalizeMappingResult(result as RawResult, csvContent ?? ""),

--- a/apps/frontend/src/features/ai-assistant/components/tool-uis/record-activity-tool-ui.tsx
+++ b/apps/frontend/src/features/ai-assistant/components/tool-uis/record-activity-tool-ui.tsx
@@ -149,7 +149,7 @@ function hasSameDisplayValue(a: string | undefined, b: string | undefined): bool
   return Boolean(left && right && left === right);
 }
 
-function joinDisplayParts(parts: Array<string | undefined>): string | undefined {
+function joinDisplayParts(parts: (string | undefined)[]): string | undefined {
   const visibleParts = parts.filter((part): part is string => Boolean(displayPart(part)));
   return visibleParts.length > 0 ? visibleParts.join(" \u00b7 ") : undefined;
 }

--- a/apps/frontend/src/features/ai-assistant/components/tool-uis/record-activity-tool-ui.tsx
+++ b/apps/frontend/src/features/ai-assistant/components/tool-uis/record-activity-tool-ui.tsx
@@ -109,11 +109,94 @@ interface RecordActivityOutput {
 /**
  * Parse an ISO date string preserving the date/time as-is (no timezone conversion).
  */
-function parseActivityDateToLocal(dateString: string): Date {
-  if (dateString.includes("T")) {
-    return dateFnsParse(dateString.substring(0, 19), "yyyy-MM-dd'T'HH:mm:ss", new Date());
+function parseActivityDateToLocal(dateString: string): Date | undefined {
+  const value = dateString.trim();
+  if (!value) return undefined;
+
+  const parsed = value.includes("T")
+    ? dateFnsParse(value.substring(0, 19), "yyyy-MM-dd'T'HH:mm:ss", new Date())
+    : dateFnsParse(value.substring(0, 10), "yyyy-MM-dd", new Date());
+
+  if (Number.isFinite(parsed.getTime())) {
+    return parsed;
   }
-  return dateFnsParse(dateString.substring(0, 10), "yyyy-MM-dd", new Date());
+
+  return undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function finiteNumberValue(value: unknown): number | undefined {
+  if (value == null) return undefined;
+  const numberValue = Number(value);
+  return Number.isFinite(numberValue) ? numberValue : undefined;
+}
+
+function formatActivityDate(dateString: string): string {
+  return parseActivityDateToLocal(dateString)?.toLocaleDateString() ?? "Invalid date";
+}
+
+function displayPart(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
+}
+
+function hasSameDisplayValue(a: string | undefined, b: string | undefined): boolean {
+  const left = displayPart(a)?.toLowerCase();
+  const right = displayPart(b)?.toLowerCase();
+  return Boolean(left && right && left === right);
+}
+
+function joinDisplayParts(parts: Array<string | undefined>): string | undefined {
+  const visibleParts = parts.filter((part): part is string => Boolean(displayPart(part)));
+  return visibleParts.length > 0 ? visibleParts.join(" \u00b7 ") : undefined;
+}
+
+function formatExchange(resolvedAsset: ResolvedAsset | undefined): string | undefined {
+  const exchange = displayPart(resolvedAsset?.exchange);
+  const exchangeMic = displayPart(resolvedAsset?.exchangeMic);
+
+  if (exchange && exchangeMic && !hasSameDisplayValue(exchange, exchangeMic)) {
+    return `${exchange} (${exchangeMic})`;
+  }
+
+  return exchange ?? exchangeMic;
+}
+
+interface AssetSummary {
+  primary: string;
+  secondary?: string;
+}
+
+function getAssetSummary(
+  draft: ActivityDraft,
+  resolvedAsset: ResolvedAsset | undefined,
+): AssetSummary | undefined {
+  const symbol = displayPart(resolvedAsset?.symbol) ?? displayPart(draft.symbol);
+  const name = displayPart(resolvedAsset?.name) ?? displayPart(draft.assetName);
+  const exchange = formatExchange(resolvedAsset);
+  const currency = displayPart(resolvedAsset?.currency) ?? displayPart(draft.currency);
+
+  if (!symbol && !name) {
+    if (
+      draft.activityType === ActivityType.DEPOSIT ||
+      draft.activityType === ActivityType.WITHDRAWAL
+    ) {
+      return { primary: "Cash", secondary: currency };
+    }
+    return undefined;
+  }
+
+  return {
+    primary: symbol ?? name ?? "",
+    secondary: joinDisplayParts([
+      hasSameDisplayValue(symbol, name) ? undefined : name,
+      exchange,
+      currency,
+    ]),
+  };
 }
 
 // ============================================================================
@@ -140,24 +223,20 @@ function normalizeResult(result: unknown, fallbackCurrency: string): RecordActiv
   }
 
   const draftRaw = (candidate.draft ?? candidate) as Record<string, unknown>;
+  const activityDate =
+    stringValue(draftRaw.activityDate) ??
+    stringValue(draftRaw.activity_date) ??
+    new Date().toISOString();
   const draft: ActivityDraft = {
     activityType: (draftRaw.activityType as string) ?? (draftRaw.activity_type as string) ?? "",
-    activityDate:
-      (draftRaw.activityDate as string) ??
-      (draftRaw.activity_date as string) ??
-      new Date().toISOString(),
+    activityDate,
     symbol: (draftRaw.symbol as string) ?? undefined,
     assetId: (draftRaw.assetId as string) ?? (draftRaw.asset_id as string) ?? undefined,
     assetName: (draftRaw.assetName as string) ?? (draftRaw.asset_name as string) ?? undefined,
-    quantity: draftRaw.quantity != null ? Number(draftRaw.quantity) : undefined,
-    unitPrice:
-      draftRaw.unitPrice != null
-        ? Number(draftRaw.unitPrice)
-        : draftRaw.unit_price != null
-          ? Number(draftRaw.unit_price)
-          : undefined,
-    amount: draftRaw.amount != null ? Number(draftRaw.amount) : undefined,
-    fee: draftRaw.fee != null ? Number(draftRaw.fee) : undefined,
+    quantity: finiteNumberValue(draftRaw.quantity),
+    unitPrice: finiteNumberValue(draftRaw.unitPrice ?? draftRaw.unit_price),
+    amount: finiteNumberValue(draftRaw.amount),
+    fee: finiteNumberValue(draftRaw.fee),
     currency: (draftRaw.currency as string) ?? fallbackCurrency,
     accountId: (draftRaw.accountId as string) ?? (draftRaw.account_id as string) ?? undefined,
     accountName: (draftRaw.accountName as string) ?? (draftRaw.account_name as string) ?? undefined,
@@ -324,7 +403,7 @@ function SuccessState({ draft, createdActivityId, currency }: SuccessStateProps)
           </div>
           <div>
             <span className="text-muted-foreground">Date:</span>{" "}
-            <span className="font-medium">{new Date(draft.activityDate).toLocaleDateString()}</span>
+            <span className="font-medium">{formatActivityDate(draft.activityDate)}</span>
           </div>
           {draft.symbol && (
             <div>
@@ -465,6 +544,140 @@ function aiSpecificDefaultOverrides(
   return overrides;
 }
 
+interface ValidationHintsProps {
+  validation: ValidationResult;
+}
+
+function ValidationHints({ validation }: ValidationHintsProps) {
+  if (validation.errors.length === 0 && validation.missingFields.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="bg-warning/10 border-warning/30 rounded-md border p-2 text-xs">
+      <p className="font-medium">The AI flagged some issues — please review:</p>
+      <ul className="mt-1 list-disc pl-4">
+        {validation.errors.map((e, i) => (
+          <li key={`err-${i}`}>
+            <span className="font-medium">{e.field}:</span> {e.message}
+          </li>
+        ))}
+        {validation.missingFields.map((f) => (
+          <li key={`missing-${f}`}>Missing: {f}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+interface DraftReviewProps {
+  draft: ActivityDraft;
+  validation: ValidationResult;
+  resolvedAsset?: ResolvedAsset;
+  activityTypeDisplay: string;
+  isLoading: boolean;
+  canConfirm: boolean;
+  onConfirm: () => void;
+  onEdit: () => void;
+}
+
+interface ReviewFieldProps {
+  label: string;
+  value: string;
+  className?: string;
+}
+
+function ReviewField({ label, value, className }: ReviewFieldProps) {
+  return (
+    <div className={className}>
+      <div className="text-muted-foreground text-xs font-medium">{label}</div>
+      <div className="mt-1 truncate text-sm font-semibold">{value}</div>
+    </div>
+  );
+}
+
+function DraftReview({
+  draft,
+  validation,
+  resolvedAsset,
+  activityTypeDisplay,
+  isLoading,
+  canConfirm,
+  onConfirm,
+  onEdit,
+}: DraftReviewProps) {
+  const { isBalanceHidden } = useBalancePrivacy();
+  const formatAmount = useCallback(
+    (value: number | undefined) => {
+      if (value === undefined) return "-";
+      if (isBalanceHidden) return "\u2022\u2022\u2022\u2022\u2022";
+      return new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: draft.currency,
+      }).format(value);
+    },
+    [draft.currency, isBalanceHidden],
+  );
+
+  const assetSummary = getAssetSummary(draft, resolvedAsset);
+
+  return (
+    <CardContent className="space-y-5">
+      {assetSummary && (
+        <div className="border-border/70 bg-background/60 flex min-w-0 items-start gap-3 rounded-lg border px-3 py-2.5">
+          <div className="bg-muted flex size-9 shrink-0 items-center justify-center rounded-md">
+            <Icons.ReceiptText className="text-muted-foreground size-4" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-base font-semibold">{assetSummary.primary}</div>
+            {assetSummary.secondary && (
+              <div className="text-muted-foreground mt-0.5 truncate text-xs font-medium">
+                {assetSummary.secondary}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-x-6 gap-y-4 sm:grid-cols-4">
+        <ReviewField label="Type" value={activityTypeDisplay} />
+        <ReviewField label="Date" value={formatActivityDate(draft.activityDate)} />
+        <ReviewField label="Account" value={draft.accountName ?? draft.accountId ?? "-"} />
+        {draft.quantity !== undefined && (
+          <ReviewField label="Quantity" value={String(draft.quantity)} />
+        )}
+        {draft.unitPrice !== undefined && (
+          <ReviewField label="Unit price" value={formatAmount(draft.unitPrice)} />
+        )}
+        {draft.amount !== undefined && (
+          <ReviewField label="Amount" value={formatAmount(draft.amount)} />
+        )}
+        {draft.fee !== undefined && <ReviewField label="Fee" value={formatAmount(draft.fee)} />}
+        {draft.subtype && <ReviewField label="Subtype" value={draft.subtype} />}
+      </div>
+
+      {draft.notes && (
+        <div className="border-border/70 rounded-lg border px-3 py-2.5 text-sm">
+          <div className="text-muted-foreground text-xs font-medium">Notes</div>
+          <div className="mt-1 font-medium">{draft.notes}</div>
+        </div>
+      )}
+
+      <ValidationHints validation={validation} />
+
+      <div className="border-border/60 flex justify-end gap-2 border-t pt-4">
+        <Button type="button" variant="ghost" size="sm" onClick={onEdit} disabled={isLoading}>
+          Edit
+        </Button>
+        <Button type="button" size="sm" onClick={onConfirm} disabled={isLoading || !canConfirm}>
+          {isLoading && <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />}
+          Confirm
+        </Button>
+      </div>
+    </CardContent>
+  );
+}
+
 // ============================================================================
 // Draft Form — dispatcher
 // ============================================================================
@@ -488,6 +701,8 @@ function DraftForm({
 }: DraftFormProps) {
   const runtime = useRuntimeContext();
   const threadId = runtime.currentThreadId;
+  const { isBalanceHidden } = useBalancePrivacy();
+  const [isEditing, setIsEditing] = useState(false);
 
   const pickerType = useMemo(() => toPickerActivityType(draft.activityType), [draft.activityType]);
   const config = pickerType ? ACTIVITY_FORM_CONFIG[pickerType] : undefined;
@@ -511,8 +726,14 @@ function DraftForm({
   const defaultValues = useMemo(() => {
     if (!config) return undefined;
     const base = config.getDefaults(pseudoActivity, accountOptions);
-    return { ...base, ...aiSpecificDefaultOverrides(draft, resolvedAsset) };
+    const dateOverride = parseActivityDateToLocal(draft.activityDate)
+      ? {}
+      : { activityDate: undefined };
+    return { ...base, ...aiSpecificDefaultOverrides(draft, resolvedAsset), ...dateOverride };
   }, [config, pseudoActivity, accountOptions, draft, resolvedAsset]);
+  const canConfirm = Boolean(
+    defaultValues && validation.isValid && parseActivityDateToLocal(draft.activityDate),
+  );
 
   // Reuse the existing add-activity mutation — it already handles symbol
   // nesting (id, symbol, exchangeMic, quoteCcy, instrumentType, etc.),
@@ -566,6 +787,11 @@ function DraftForm({
     [config, pickerType, threadId, toolCallId, onSuccess, addActivityMutation],
   );
 
+  const handleConfirm = useCallback(() => {
+    if (!defaultValues || !canConfirm) return;
+    void handleFormSubmit(defaultValues as ActivityFormValues);
+  }, [canConfirm, defaultValues, handleFormSubmit]);
+
   if (!config) {
     return (
       <Card className="border-destructive/30 bg-destructive/5">
@@ -582,50 +808,73 @@ function DraftForm({
   const activityTypeDisplay =
     (ACTIVITY_TYPE_DISPLAY_NAMES as Record<string, string>)[draft.activityType] ??
     draft.activityType;
-
-  // AI-side validation hints (informational only — per-type form runs its own Zod schema).
-  const showValidationHints = validation.errors.length > 0 || validation.missingFields.length > 0;
+  const cardTitle = `${isEditing ? "Edit" : "Review"} ${activityTypeDisplay.toLowerCase()} activity`;
+  const headerAmount =
+    draft.amount ??
+    (draft.quantity != null && draft.unitPrice != null
+      ? draft.quantity * draft.unitPrice
+      : undefined);
+  const headerAmountLabel =
+    headerAmount !== undefined
+      ? isBalanceHidden
+        ? "\u2022\u2022\u2022\u2022\u2022"
+        : new Intl.NumberFormat("en-US", {
+            style: "currency",
+            currency: draft.currency,
+          }).format(headerAmount)
+      : undefined;
 
   return (
     <Card className="bg-muted/40 border-primary/10">
-      <CardHeader className="pb-2">
-        <div className="flex flex-wrap items-center gap-2">
-          <CardTitle className="text-base">{activityTypeDisplay} draft</CardTitle>
-          {draft.isCustomAsset && (
-            <Badge variant="warning" className="text-xs">
-              Custom Asset
-            </Badge>
+      <CardHeader className="pb-3">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              <CardTitle className="text-base">{cardTitle}</CardTitle>
+              {draft.isCustomAsset && (
+                <Badge variant="warning" className="text-xs">
+                  Custom Asset
+                </Badge>
+              )}
+            </div>
+            {draft.isCustomAsset && draft.symbol && (
+              <p className="text-warning mt-1 text-xs">
+                "{draft.symbol}" wasn't found. It will be created as a custom asset on save.
+              </p>
+            )}
+          </div>
+          {headerAmountLabel && (
+            <div className="text-right">
+              <div className="text-muted-foreground text-xs font-medium">Estimated total</div>
+              <div className="text-lg font-semibold tabular-nums">{headerAmountLabel}</div>
+            </div>
           )}
         </div>
-        {draft.isCustomAsset && draft.symbol && (
-          <p className="text-warning mt-1 text-xs">
-            "{draft.symbol}" wasn't found. It will be created as a custom asset on save.
-          </p>
-        )}
-        {showValidationHints && (
-          <div className="bg-warning/10 border-warning/30 mt-2 rounded-md border p-2 text-xs">
-            <p className="font-medium">The AI flagged some issues — please confirm:</p>
-            <ul className="mt-1 list-disc pl-4">
-              {validation.errors.map((e, i) => (
-                <li key={`err-${i}`}>
-                  <span className="font-medium">{e.field}:</span> {e.message}
-                </li>
-              ))}
-              {validation.missingFields.map((f) => (
-                <li key={`missing-${f}`}>Missing: {f}</li>
-              ))}
-            </ul>
-          </div>
-        )}
       </CardHeader>
-      <CardContent>
-        <FormComponent
-          accounts={accountOptions}
-          defaultValues={defaultValues}
-          onSubmit={handleFormSubmit}
+      {!isEditing ? (
+        <DraftReview
+          draft={draft}
+          validation={validation}
+          resolvedAsset={resolvedAsset}
+          activityTypeDisplay={activityTypeDisplay}
           isLoading={addActivityMutation.isPending}
+          canConfirm={canConfirm}
+          onConfirm={handleConfirm}
+          onEdit={() => setIsEditing(true)}
         />
-      </CardContent>
+      ) : (
+        <CardContent>
+          <ValidationHints validation={validation} />
+          <FormComponent
+            accounts={accountOptions}
+            defaultValues={defaultValues}
+            onSubmit={handleFormSubmit}
+            onCancel={() => setIsEditing(false)}
+            isLoading={addActivityMutation.isPending}
+            isEditing
+          />
+        </CardContent>
+      )}
     </Card>
   );
 }

--- a/apps/frontend/src/features/ai-assistant/hooks/use-chat-import-session.test.tsx
+++ b/apps/frontend/src/features/ai-assistant/hooks/use-chat-import-session.test.tsx
@@ -124,4 +124,81 @@ describe("useChatImportSession", () => {
       ],
     });
   });
+
+  it("replaces stale backend errors after the user changes account", async () => {
+    const mappingWithTwoAccounts: ImportCsvMappingOutput = {
+      ...mapping,
+      availableAccounts: [
+        { id: "acct-1", name: "Brokerage", currency: "USD" },
+        { id: "acct-2", name: "Test", currency: "USD" },
+      ],
+    };
+    adapterMocks.checkActivitiesImport
+      .mockResolvedValueOnce([
+        {
+          lineNumber: 1,
+          isValid: false,
+          errors: { general: ["Validation failed: Record not found"] },
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          lineNumber: 1,
+          isValid: true,
+          warnings: {},
+          errors: {},
+        },
+      ]);
+
+    const { result } = renderHook(() => useChatImportSession({ mapping: mappingWithTwoAccounts }));
+
+    await waitFor(() => expect(result.current.stats.errors).toBe(1));
+
+    act(() => {
+      result.current.setAccountId("acct-2");
+    });
+
+    await waitFor(() => expect(result.current.stats.errors).toBe(0));
+    expect(result.current.stats.valid).toBe(1);
+  });
+
+  it("allows confirm when CSV rows carry valid per-row accounts", async () => {
+    adapterMocks.parseCsv.mockResolvedValueOnce({
+      headers: ["Date", "Symbol", "Quantity", "Price", "Type", "Account"],
+      rows: [["2024-01-15", "NEWCO", "2", "10", "Buy", "Test"]],
+      detectedConfig: {
+        defaultCurrency: "USD",
+        dateFormat: "auto",
+        decimalSeparator: ".",
+        thousandsSeparator: ",",
+      },
+      errors: [],
+      rowCount: 1,
+    });
+
+    const mappingWithRowAccount: ImportCsvMappingOutput = {
+      ...mapping,
+      accountId: null,
+      appliedMapping: {
+        ...mapping.appliedMapping,
+        accountId: "",
+        fieldMappings: {
+          ...mapping.appliedMapping.fieldMappings,
+          account: "Account",
+        },
+      },
+      availableAccounts: [
+        { id: "acct-1", name: "Brokerage", currency: "USD" },
+        { id: "acct-2", name: "Test", currency: "USD" },
+      ],
+    };
+
+    const { result } = renderHook(() => useChatImportSession({ mapping: mappingWithRowAccount }));
+
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+
+    expect(result.current.accountId).toBe("");
+    expect(result.current.drafts[0]?.accountId).toBe("acct-2");
+    expect(result.current.canConfirm).toBe(true);
+  });
 });

--- a/apps/frontend/src/features/ai-assistant/hooks/use-chat-import-session.ts
+++ b/apps/frontend/src/features/ai-assistant/hooks/use-chat-import-session.ts
@@ -307,6 +307,45 @@ function normalizeParseConfig(input: ParseConfig): ParseConfig {
   };
 }
 
+function resolveAvailableAccountId(
+  value: string | null | undefined,
+  accounts: ImportCsvMappingOutput["availableAccounts"],
+): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+
+  return (
+    accounts.find((account) => account.id === trimmed)?.id ??
+    accounts.find((account) => account.name.toLowerCase() === trimmed.toLowerCase())?.id
+  );
+}
+
+function normalizeAccountMappings(
+  mappings: Record<string, string>,
+  accounts: ImportCsvMappingOutput["availableAccounts"],
+): Record<string, string> {
+  const normalized: Record<string, string> = {};
+
+  for (const account of accounts) {
+    normalized[account.id] = account.id;
+    normalized[account.name] = account.id;
+    normalized[account.name.toLowerCase()] = account.id;
+  }
+
+  for (const [rawValue, mappedValue] of Object.entries(mappings)) {
+    const key = rawValue.trim();
+    if (!key) continue;
+
+    const accountId =
+      resolveAvailableAccountId(mappedValue, accounts) ?? resolveAvailableAccountId(key, accounts);
+    if (accountId) {
+      normalized[key] = accountId;
+    }
+  }
+
+  return normalized;
+}
+
 /**
  * Merge backend check results (errors, warnings, duplicates, enrichment) into
  * the local drafts. Matches the manual wizard's validate flow, minus the
@@ -333,9 +372,17 @@ function applyBackendValidation(
   validated: ActivityImport[],
 ): DraftActivity[] {
   return drafts.map((draft) => {
+    const localValidation = validateDraft(draft);
     const backendResult = validated.find((v) => v.lineNumber === draft.rowIndex + 1);
     if (!backendResult) {
-      return { ...draft, duplicateOfId: undefined, duplicateOfLineNumber: undefined };
+      return {
+        ...draft,
+        errors: localValidation.errors,
+        warnings: localValidation.warnings,
+        duplicateOfId: undefined,
+        duplicateOfLineNumber: undefined,
+        status: draft.status === "skipped" ? "skipped" : localValidation.status,
+      };
     }
 
     const backendErrors: Record<string, string[]> = {};
@@ -354,10 +401,8 @@ function applyBackendValidation(
       backendErrors.general = ["Validation failed"];
     }
 
-    const mergedErrors = mergeIssueMaps(draft.errors || {}, backendErrors);
-    const retainedWarnings = { ...(draft.warnings || {}) };
-    delete retainedWarnings._duplicate;
-    const mergedWarnings = mergeIssueMaps(retainedWarnings, backendWarnings);
+    const mergedErrors = mergeIssueMaps(localValidation.errors, backendErrors);
+    const mergedWarnings = mergeIssueMaps(localValidation.warnings, backendWarnings);
     const hasErrors = Object.keys(mergedErrors).length > 0;
     const hasWarnings = Object.keys(mergedWarnings).length > 0;
 
@@ -465,6 +510,14 @@ function computeStats(drafts: DraftActivity[]): ChatImportStats {
     }
   }
   return stats;
+}
+
+function isImportableDraft(draft: DraftActivity): boolean {
+  return (
+    draft.status === "valid" ||
+    draft.status === "warning" ||
+    (draft.status === "duplicate" && !!draft.forceImport)
+  );
 }
 
 function filterDrafts(drafts: DraftActivity[], filter: ChatImportFilter): DraftActivity[] {
@@ -584,10 +637,19 @@ export function useChatImportSession({
             ? (aiFieldMappings as Record<string, string | string[]>)
             : autoDetectFieldMappings(parsed.headers);
 
+        const accountMappings = normalizeAccountMappings(
+          applied.accountMappings ?? {},
+          mapping.availableAccounts,
+        );
+        const validAccountIds = new Set(mapping.availableAccounts.map((account) => account.id));
+
         // Prefer AI's inferred account → saved mapping's account → single
-        // available account. Leave empty only when multiple accounts exist
-        // and AI didn't pick one.
-        const inferredAccountId = mapping.accountId ?? applied.accountId ?? "";
+        // available account, but only when the ID/name exists in this app
+        // session. Stale account IDs from older demo DBs must not validate.
+        const inferredAccountId =
+          resolveAvailableAccountId(mapping.accountId, mapping.availableAccounts) ??
+          resolveAvailableAccountId(applied.accountId, mapping.availableAccounts) ??
+          "";
         const accountId =
           inferredAccountId ||
           (mapping.availableAccounts.length === 1 ? mapping.availableAccounts[0].id : "");
@@ -599,7 +661,7 @@ export function useChatImportSession({
             fieldMappings: effectiveFieldMappings,
             activityMappings: applied.activityMappings ?? {},
             symbolMappings: applied.symbolMappings ?? {},
-            accountMappings: applied.accountMappings ?? {},
+            accountMappings,
             symbolMappingMeta: applied.symbolMappingMeta ?? {},
           },
           {
@@ -612,6 +674,7 @@ export function useChatImportSession({
               parsed.detectedConfig.defaultCurrency ?? parseConfig.defaultCurrency ?? "USD",
           },
           accountId,
+          validAccountIds,
         );
 
         if (drafts.length === 0) {
@@ -625,24 +688,25 @@ export function useChatImportSession({
           return;
         }
 
-        // Only run backend validation + asset preview if an account is
-        // selected. Without an account, the backend rejects the batch with
-        // "Record not found". The user picks the account from the dropdown
-        // → triggers revalidation with a real account ID.
-        const hasAccount = !!accountId;
-        const activitiesToValidate = hasAccount
+        // Only run backend validation + asset preview once every imported
+        // row has an account. The user can pick one from the dropdown, which
+        // triggers revalidation with that account ID.
+        const hasAccounts = drafts.every(
+          (draft) => draft.status === "skipped" || !!draft.accountId,
+        );
+        const activitiesToValidate = hasAccounts
           ? buildActivitiesToValidate(drafts, parseConfig.defaultCurrency ?? "USD")
           : [];
-        const candidates = hasAccount
+        const candidates = hasAccounts
           ? drafts
               .map(buildImportAssetCandidateFromDraft)
               .filter((c): c is NonNullable<typeof c> => c !== null)
               .filter((c, i, arr) => arr.findIndex((x) => x.key === c.key) === i)
           : [];
 
-        // Backend validation + asset preview are best-effort. If they fail
-        // (e.g., "Record not found" for a new symbol), proceed with local-only
-        // validation. The user can still review, edit, and import.
+        // Backend validation + asset preview are best-effort. If they fail,
+        // proceed with local-only validation. The user can still review,
+        // edit, and import.
         let validated: ActivityImport[] = [];
         let preview: ImportAssetPreviewItem[] = [];
         try {
@@ -992,8 +1056,11 @@ export function useChatImportSession({
     () => filterDrafts(state.drafts, state.filter),
     [state.drafts, state.filter],
   );
+  const importableDrafts = useMemo(() => state.drafts.filter(isImportableDraft), [state.drafts]);
   const canConfirm =
-    state.status === "ready" && stats.toImport > 0 && state.accountId.trim().length > 0;
+    state.status === "ready" &&
+    importableDrafts.length > 0 &&
+    importableDrafts.every((draft) => Boolean(draft.accountId?.trim()));
   const isSubmitting = state.status === "submitting";
   const submitted = state.status === "submitted";
 

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid-toolbar.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid-toolbar.tsx
@@ -78,6 +78,16 @@ interface ActivityDataGridToolbarProps {
   linkDisabledReason?: string;
   /** Whether a link operation is in progress */
   isLinking?: boolean;
+  /** Handler invoked when user clicks "Unlink internal pair" */
+  onUnlinkSelected?: () => void;
+  /** Whether to show the unlink action for the current selection */
+  showUnlinkSelected?: boolean;
+  /** Whether the current selection is a linked TRANSFER_IN/TRANSFER_OUT pair */
+  canUnlinkSelected?: boolean;
+  /** Reason the current selection cannot be unlinked (used as button tooltip) */
+  unlinkDisabledReason?: string;
+  /** Whether an unlink operation is in progress */
+  isUnlinking?: boolean;
 }
 
 /**
@@ -100,6 +110,11 @@ export function ActivityDataGridToolbar({
   canLinkSelected,
   linkDisabledReason,
   isLinking,
+  onUnlinkSelected,
+  showUnlinkSelected,
+  canUnlinkSelected,
+  unlinkDisabledReason,
+  isUnlinking,
 }: ActivityDataGridToolbarProps) {
   // Prevent mousedown from bubbling to document, which would clear DataGrid selection
   const handleMouseDown = (e: React.MouseEvent) => {
@@ -214,7 +229,24 @@ export function ActivityDataGridToolbar({
                 <span>Approve {selectedPendingCount}</span>
               </Button>
             )}
-            {selectedRowCount === 2 && onLinkSelected && (
+            {selectedRowCount === 2 && showUnlinkSelected && onUnlinkSelected ? (
+              <Button
+                onClick={onUnlinkSelected}
+                size="xs"
+                variant="outline"
+                className="shrink-0 rounded-md text-xs"
+                title={canUnlinkSelected ? "Unlink internal transfer" : unlinkDisabledReason}
+                aria-label="Unlink internal transfer"
+                disabled={!canUnlinkSelected || isUnlinking || isSaving}
+              >
+                {isUnlinking ? (
+                  <Icons.Spinner className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Icons.Unlink className="h-3.5 w-3.5" />
+                )}
+                <span>Unlink</span>
+              </Button>
+            ) : selectedRowCount === 2 && onLinkSelected ? (
               <Button
                 onClick={onLinkSelected}
                 size="xs"
@@ -231,7 +263,7 @@ export function ActivityDataGridToolbar({
                 )}
                 <span>Link</span>
               </Button>
-            )}
+            ) : null}
             <Button
               onClick={onDeleteSelected}
               size="xs"

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid.tsx
@@ -460,8 +460,10 @@ export function ActivityDataGrid({
   );
 
   // Link state: validate that the 2-row selection is a valid TRANSFER_IN/TRANSFER_OUT pair
-  const { linkTransferActivitiesMutation } = useActivityMutations();
-  const [linkDialogOpen, setLinkDialogOpen] = useState(false);
+  const { linkTransferActivitiesMutation, unlinkTransferActivitiesMutation } =
+    useActivityMutations();
+  const [transferDialogOpen, setTransferDialogOpen] = useState(false);
+  const [transferDialogMode, setTransferDialogMode] = useState<"link" | "unlink">("link");
 
   const linkValidation = useMemo(() => {
     if (selectedRows.length !== 2) {
@@ -508,6 +510,56 @@ export function ActivityDataGrid({
     return { canLink: true, transferIn, transferOut } as const;
   }, [selectedRows, dirtyTransactionIds]);
 
+  const unlinkValidation = useMemo(() => {
+    if (selectedRows.length !== 2) {
+      return { canUnlink: false, reason: "" } as const;
+    }
+    const [first, second] = selectedRows.map((row) => row.original);
+    if (first.isNew || second.isNew) {
+      return {
+        canUnlink: false,
+        reason: "Save new activities before unlinking",
+      } as const;
+    }
+    if (dirtyTransactionIds.has(first.id) || dirtyTransactionIds.has(second.id)) {
+      return {
+        canUnlink: false,
+        reason: "Save or discard pending edits on the selected rows before unlinking",
+      } as const;
+    }
+    const types = new Set([first.activityType, second.activityType]);
+    if (
+      !types.has(ActivityType.TRANSFER_IN) ||
+      !types.has(ActivityType.TRANSFER_OUT) ||
+      types.size !== 2
+    ) {
+      return {
+        canUnlink: false,
+        reason: "Select one TRANSFER_IN and one TRANSFER_OUT activity",
+      } as const;
+    }
+    if (!first.sourceGroupId || !second.sourceGroupId) {
+      return {
+        canUnlink: false,
+        reason: "Both selected activities must already be linked",
+      } as const;
+    }
+    if (first.sourceGroupId !== second.sourceGroupId) {
+      return {
+        canUnlink: false,
+        reason: "Selected activities belong to different linked transfers",
+      } as const;
+    }
+    const transferIn = first.activityType === ActivityType.TRANSFER_IN ? first : second;
+    const transferOut = first.activityType === ActivityType.TRANSFER_OUT ? first : second;
+    return { canUnlink: true, transferIn, transferOut } as const;
+  }, [selectedRows, dirtyTransactionIds]);
+
+  const showUnlinkSelected = useMemo(
+    () => selectedRows.length === 2 && selectedRows.every((row) => !!row.original.sourceGroupId),
+    [selectedRows],
+  );
+
   const linkWarnings = useMemo(() => {
     if (!linkValidation.canLink) return [] as string[];
     const { transferIn, transferOut } = linkValidation;
@@ -542,10 +594,21 @@ export function ActivityDataGrid({
       activityAId: linkValidation.transferIn.id,
       activityBId: linkValidation.transferOut.id,
     });
-    setLinkDialogOpen(false);
+    setTransferDialogOpen(false);
     dataGrid.table.resetRowSelection();
     onRefetch();
   }, [linkValidation, linkTransferActivitiesMutation, dataGrid.table, onRefetch]);
+
+  const handleUnlinkConfirm = useCallback(async () => {
+    if (!unlinkValidation.canUnlink) return;
+    await unlinkTransferActivitiesMutation.mutateAsync({
+      activityAId: unlinkValidation.transferIn.id,
+      activityBId: unlinkValidation.transferOut.id,
+    });
+    setTransferDialogOpen(false);
+    dataGrid.table.resetRowSelection();
+    onRefetch();
+  }, [unlinkValidation, unlinkTransferActivitiesMutation, dataGrid.table, onRefetch]);
 
   // Delete selected rows handler
   const deleteSelectedRows = useCallback(() => {
@@ -621,6 +684,15 @@ export function ActivityDataGrid({
     customAssetDialog.rowIndex >= 0 && localTransactions[customAssetDialog.rowIndex]
       ? (localTransactions[customAssetDialog.rowIndex].accountCurrency ?? fallbackCurrency)
       : fallbackCurrency;
+  let dialogActivityIn: LocalTransaction | undefined;
+  let dialogActivityOut: LocalTransaction | undefined;
+  if (transferDialogMode === "link" && linkValidation.canLink) {
+    dialogActivityIn = linkValidation.transferIn;
+    dialogActivityOut = linkValidation.transferOut;
+  } else if (transferDialogMode === "unlink" && unlinkValidation.canUnlink) {
+    dialogActivityIn = unlinkValidation.transferIn;
+    dialogActivityOut = unlinkValidation.transferOut;
+  }
 
   return (
     <div className="flex min-h-0 flex-1 flex-col space-y-3">
@@ -636,10 +708,21 @@ export function ActivityDataGrid({
         onApproveSelected={approveSelectedRows}
         onSave={handleSaveChanges}
         onCancel={handleCancelChanges}
-        onLinkSelected={() => setLinkDialogOpen(true)}
+        onLinkSelected={() => {
+          setTransferDialogMode("link");
+          setTransferDialogOpen(true);
+        }}
         canLinkSelected={linkValidation.canLink}
         linkDisabledReason={linkValidation.canLink ? undefined : linkValidation.reason}
         isLinking={linkTransferActivitiesMutation.isPending}
+        onUnlinkSelected={() => {
+          setTransferDialogMode("unlink");
+          setTransferDialogOpen(true);
+        }}
+        showUnlinkSelected={showUnlinkSelected}
+        canUnlinkSelected={unlinkValidation.canUnlink}
+        unlinkDisabledReason={unlinkValidation.canUnlink ? undefined : unlinkValidation.reason}
+        isUnlinking={unlinkTransferActivitiesMutation.isPending}
       />
 
       <div className="min-h-0 flex-1 overflow-hidden">
@@ -669,13 +752,18 @@ export function ActivityDataGrid({
       />
 
       <LinkTransferModal
-        isOpen={linkDialogOpen}
-        isLinking={linkTransferActivitiesMutation.isPending}
-        activityIn={linkValidation.canLink ? linkValidation.transferIn : undefined}
-        activityOut={linkValidation.canLink ? linkValidation.transferOut : undefined}
-        warnings={linkWarnings}
-        onConfirm={handleLinkConfirm}
-        onCancel={() => setLinkDialogOpen(false)}
+        isOpen={transferDialogOpen}
+        mode={transferDialogMode}
+        isProcessing={
+          transferDialogMode === "link"
+            ? linkTransferActivitiesMutation.isPending
+            : unlinkTransferActivitiesMutation.isPending
+        }
+        activityIn={dialogActivityIn}
+        activityOut={dialogActivityOut}
+        warnings={transferDialogMode === "link" ? linkWarnings : []}
+        onConfirm={transferDialogMode === "link" ? handleLinkConfirm : handleUnlinkConfirm}
+        onCancel={() => setTransferDialogOpen(false)}
       />
     </div>
   );

--- a/apps/frontend/src/pages/activity/components/link-transfer-modal.tsx
+++ b/apps/frontend/src/pages/activity/components/link-transfer-modal.tsx
@@ -14,7 +14,8 @@ import { formatDateTime } from "@/lib/utils";
 
 interface LinkTransferModalProps {
   isOpen: boolean;
-  isLinking: boolean;
+  mode: "link" | "unlink";
+  isProcessing: boolean;
   activityIn?: ActivityDetails;
   activityOut?: ActivityDetails;
   warnings: string[];
@@ -49,21 +50,27 @@ function ActivityRow({ activity, label }: { activity: ActivityDetails; label: st
 
 export function LinkTransferModal({
   isOpen,
-  isLinking,
+  mode,
+  isProcessing,
   activityIn,
   activityOut,
   warnings,
   onConfirm,
   onCancel,
 }: LinkTransferModalProps) {
+  const isUnlinkMode = mode === "unlink";
+
   return (
     <AlertDialog open={isOpen} onOpenChange={(open) => (!open ? onCancel() : undefined)}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Link as internal transfer</AlertDialogTitle>
+          <AlertDialogTitle>
+            {isUnlinkMode ? "Unlink internal transfer" : "Link as internal transfer"}
+          </AlertDialogTitle>
           <AlertDialogDescription>
-            These two activities will be paired and treated as a single internal transfer between
-            your accounts.
+            {isUnlinkMode
+              ? "These two activities will become external transfers again."
+              : "These two activities will be paired and treated as a single internal transfer between your accounts."}
           </AlertDialogDescription>
         </AlertDialogHeader>
 
@@ -77,8 +84,8 @@ export function LinkTransferModal({
           </div>
         ) : null}
 
-        {warnings.length > 0 ? (
-          <div className="border-warning/40 bg-warning/10 text-warning-foreground flex gap-2 rounded-md border px-3 py-2 text-xs">
+        {!isUnlinkMode && warnings.length > 0 ? (
+          <div className="border-warning/40 bg-warning/10 text-warning flex gap-2 rounded-md border px-3 py-2 text-xs">
             <Icons.AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
             <ul className="space-y-0.5">
               {warnings.map((warning) => (
@@ -89,14 +96,16 @@ export function LinkTransferModal({
         ) : null}
 
         <AlertDialogFooter>
-          <AlertDialogCancel disabled={isLinking}>Cancel</AlertDialogCancel>
-          <Button onClick={onConfirm} disabled={isLinking}>
-            {isLinking ? (
+          <AlertDialogCancel disabled={isProcessing}>Cancel</AlertDialogCancel>
+          <Button onClick={onConfirm} disabled={isProcessing}>
+            {isProcessing ? (
               <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />
+            ) : isUnlinkMode ? (
+              <Icons.Unlink className="mr-2 h-4 w-4" />
             ) : (
               <Icons.Link className="mr-2 h-4 w-4" />
             )}
-            <span>Link transfers</span>
+            <span>{isUnlinkMode ? "Unlink transfers" : "Link transfers"}</span>
           </Button>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/apps/frontend/src/pages/activity/hooks/use-activity-mutations.ts
+++ b/apps/frontend/src/pages/activity/hooks/use-activity-mutations.ts
@@ -4,6 +4,7 @@ import {
   linkTransferActivities,
   logger,
   saveActivities,
+  unlinkTransferActivities,
   updateActivity,
 } from "@/adapters";
 import { generateId } from "@/lib/id";
@@ -255,6 +256,23 @@ export function useActivityMutations(
     },
   });
 
+  const unlinkTransferActivitiesMutation = useMutation({
+    mutationFn: ({ activityAId, activityBId }: { activityAId: string; activityBId: string }) =>
+      unlinkTransferActivities(activityAId, activityBId),
+    onSuccess: () => {
+      queryClient.invalidateQueries();
+      toast.success("Transfers unlinked", {
+        description: "The two activities are external transfers again.",
+      });
+    },
+    onError: (error: string) => {
+      logger.error(`Error unlinking transfers: ${String(error)}`);
+      toast.error("Failed to unlink transfers", {
+        description: String(error),
+      });
+    },
+  });
+
   const duplicateActivity = async (activityToDuplicate: ActivityDetails) => {
     const {
       id: _id,
@@ -355,5 +373,6 @@ export function useActivityMutations(
     duplicateActivityMutation,
     saveActivitiesMutation,
     linkTransferActivitiesMutation,
+    unlinkTransferActivitiesMutation,
   };
 }

--- a/apps/frontend/src/pages/activity/import/utils/draft-utils.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/draft-utils.test.ts
@@ -47,6 +47,44 @@ function createSingleDraftWithMapping(row: string[], activityMappings: Record<st
 }
 
 describe("createDraftActivities explicit activity mapping", () => {
+  it("falls back to the selected account when a CSV account value is not valid", () => {
+    const [draft] = createDraftActivities(
+      [["2024-03-15", "DEPOSIT", "1000.00", "USD", "stale-account"]],
+      [...headers, ImportFormat.ACCOUNT],
+      {
+        ...baseMapping,
+        fieldMappings: {
+          ...baseMapping.fieldMappings,
+          [ImportFormat.ACCOUNT]: ImportFormat.ACCOUNT,
+        },
+      },
+      parseConfig,
+      "account-1",
+      new Set(["account-1"]),
+    );
+
+    expect(draft.accountId).toBe("account-1");
+  });
+
+  it("keeps a CSV account value when it is a valid account id", () => {
+    const [draft] = createDraftActivities(
+      [["2024-03-15", "DEPOSIT", "1000.00", "USD", "account-2"]],
+      [...headers, ImportFormat.ACCOUNT],
+      {
+        ...baseMapping,
+        fieldMappings: {
+          ...baseMapping.fieldMappings,
+          [ImportFormat.ACCOUNT]: ImportFormat.ACCOUNT,
+        },
+      },
+      parseConfig,
+      "account-1",
+      new Set(["account-1", "account-2"]),
+    );
+
+    expect(draft.accountId).toBe("account-2");
+  });
+
   it("keeps explicitly mapped withdrawal labels when amount is positive", () => {
     const draft = createSingleDraftWithMapping(["2024-03-15", "WITHDRAWAL", "1000.00", "USD"], {
       [ActivityType.WITHDRAWAL]: ["WITHDRAWAL"],

--- a/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
@@ -364,6 +364,7 @@ export function createDraftActivities(
     defaultCurrency: string;
   },
   defaultAccountId: string,
+  validAccountIds?: Set<string>,
 ): DraftActivity[] {
   const { fieldMappings, activityMappings, symbolMappings, accountMappings, symbolMappingMeta } =
     mapping;
@@ -450,12 +451,13 @@ export function createDraftActivities(
     // Resolve account ID: use CSV account mapping, or fall back to default
     let accountId = accountMappings[""] || defaultAccountId;
     if (rawAccount?.trim()) {
-      const mappedAccount = accountMappings[rawAccount.trim()];
+      const rawAccountId = rawAccount.trim();
+      const mappedAccount =
+        accountMappings[rawAccountId] ?? accountMappings[rawAccountId.toLowerCase()];
       if (mappedAccount) {
         accountId = mappedAccount;
-      } else if (rawAccount.trim()) {
-        // Use raw account value if no mapping exists (might be an account ID already)
-        accountId = rawAccount.trim();
+      } else if (!validAccountIds || validAccountIds.has(rawAccountId)) {
+        accountId = rawAccountId;
       }
     }
 

--- a/apps/frontend/src/pages/asset/asset-utils.test.ts
+++ b/apps/frontend/src/pages/asset/asset-utils.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AssetKind } from "@/lib/constants";
+import type { Asset } from "@/lib/types";
+import { isExpiredOptionAsset } from "./asset-utils";
+
+const makeAsset = (overrides: Partial<Asset> = {}): Asset => ({
+  id: "asset-1",
+  kind: AssetKind.INVESTMENT,
+  name: "Option",
+  displayCode: "TSLA260426C00397500",
+  quoteMode: "MARKET",
+  quoteCcy: "USD",
+  instrumentType: "OPTION",
+  instrumentSymbol: "TSLA260426C00397500",
+  createdAt: "2026-04-01T00:00:00Z",
+  updatedAt: "2026-04-01T00:00:00Z",
+  ...overrides,
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("isExpiredOptionAsset", () => {
+  it("uses the configured timezone for the current date", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T01:00:00Z"));
+
+    const asset = makeAsset({
+      metadata: {
+        option: {
+          expiration: "2026-04-26",
+        },
+      },
+    });
+
+    expect(isExpiredOptionAsset(asset, "America/Los_Angeles")).toBe(false);
+    expect(isExpiredOptionAsset(asset, "UTC")).toBe(true);
+  });
+
+  it("falls back to the OCC symbol when metadata is missing", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T12:00:00Z"));
+
+    expect(isExpiredOptionAsset(makeAsset(), "UTC")).toBe(true);
+  });
+
+  it("ignores non-option assets", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-27T12:00:00Z"));
+
+    expect(
+      isExpiredOptionAsset(
+        makeAsset({
+          instrumentType: "EQUITY",
+          metadata: {
+            option: {
+              expiration: "2026-04-26",
+            },
+          },
+        }),
+        "UTC",
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/frontend/src/pages/asset/asset-utils.ts
+++ b/apps/frontend/src/pages/asset/asset-utils.ts
@@ -1,5 +1,6 @@
 import { Asset, LatestQuoteSnapshot } from "@/lib/types";
 import { parseOccSymbol } from "@/lib/occ-symbol";
+import { resolveDisplayTimezone } from "@/lib/utils";
 
 export interface WeightedBreakdown {
   name: string;
@@ -11,17 +12,26 @@ export interface ParsedAsset extends Asset {
   countriesList: WeightedBreakdown[];
 }
 
-const getLocalDateString = (): string => {
-  const today = new Date();
-  return `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+const getDateStringInTimezone = (timezone?: string | null): string => {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone: resolveDisplayTimezone(timezone),
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const parts = formatter.formatToParts(new Date());
+  const year = parts.find((part) => part.type === "year")?.value ?? "";
+  const month = parts.find((part) => part.type === "month")?.value ?? "";
+  const day = parts.find((part) => part.type === "day")?.value ?? "";
+  return `${year}-${month}-${day}`;
 };
 
-export const isExpiredOptionAsset = (asset: Asset): boolean => {
+export const isExpiredOptionAsset = (asset: Asset, timezone?: string | null): boolean => {
   if (asset.instrumentType !== "OPTION") {
     return false;
   }
 
-  const today = getLocalDateString();
+  const today = getDateStringInTimezone(timezone);
   const option = asset.metadata?.option as { expiration?: unknown } | undefined;
   const metadataExpiration =
     typeof option?.expiration === "string" && /^\d{4}-\d{2}-\d{2}$/.test(option.expiration)

--- a/apps/frontend/src/pages/asset/asset-utils.ts
+++ b/apps/frontend/src/pages/asset/asset-utils.ts
@@ -1,4 +1,5 @@
 import { Asset, LatestQuoteSnapshot } from "@/lib/types";
+import { parseOccSymbol } from "@/lib/occ-symbol";
 
 export interface WeightedBreakdown {
   name: string;
@@ -9,6 +10,30 @@ export interface ParsedAsset extends Asset {
   sectorsList: WeightedBreakdown[];
   countriesList: WeightedBreakdown[];
 }
+
+const getLocalDateString = (): string => {
+  const today = new Date();
+  return `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+};
+
+export const isExpiredOptionAsset = (asset: Asset): boolean => {
+  if (asset.instrumentType !== "OPTION") {
+    return false;
+  }
+
+  const today = getLocalDateString();
+  const option = asset.metadata?.option as { expiration?: unknown } | undefined;
+  const metadataExpiration =
+    typeof option?.expiration === "string" && /^\d{4}-\d{2}-\d{2}$/.test(option.expiration)
+      ? option.expiration
+      : null;
+  const parsedExpiration =
+    parseOccSymbol(asset.instrumentSymbol ?? "")?.expiration ??
+    parseOccSymbol(asset.displayCode ?? "")?.expiration;
+  const expiration = metadataExpiration ?? parsedExpiration;
+
+  return !!expiration && expiration < today;
+};
 
 export const isStaleQuote = (snapshot?: LatestQuoteSnapshot, asset?: ParsedAsset): boolean => {
   if (!snapshot || asset?.isActive === false) {

--- a/apps/frontend/src/pages/asset/assets-page.tsx
+++ b/apps/frontend/src/pages/asset/assets-page.tsx
@@ -21,7 +21,7 @@ import { useSyncMarketDataMutation } from "@/hooks/use-sync-market-data";
 import { PORTFOLIO_ACCOUNT_ID } from "@/lib/constants";
 import { SettingsHeader } from "../settings/settings-header";
 import { AssetEditSheet } from "./asset-edit-sheet";
-import { ParsedAsset, toParsedAsset } from "./asset-utils";
+import { isExpiredOptionAsset, ParsedAsset, toParsedAsset } from "./asset-utils";
 import { AssetsTable } from "./assets-table";
 import { AssetsTableMobile } from "./assets-table-mobile";
 import { CreateSecurityDialog } from "./create-security-dialog";
@@ -48,7 +48,11 @@ export default function AssetsPage() {
   }, [holdings]);
 
   const parsedAssets = useMemo(() => assets.map(toParsedAsset), [assets]);
-  const assetIds = useMemo(() => parsedAssets.map((asset) => asset.id), [parsedAssets]);
+  const visibleAssets = useMemo(
+    () => parsedAssets.filter((asset) => !isExpiredOptionAsset(asset)),
+    [parsedAssets],
+  );
+  const assetIds = useMemo(() => visibleAssets.map((asset) => asset.id), [visibleAssets]);
   const { data: latestQuotes = {}, isLoading: isQuotesLoading } = useLatestQuotes(assetIds);
 
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
@@ -77,7 +81,7 @@ export default function AssetsPage() {
       <div className="w-full">
         {isMobileViewport ? (
           <AssetsTableMobile
-            assets={parsedAssets}
+            assets={visibleAssets}
             latestQuotes={latestQuotes}
             heldAssetIds={heldAssetIds}
             isLoading={isLoading || isQuotesLoading}
@@ -90,7 +94,7 @@ export default function AssetsPage() {
           />
         ) : (
           <AssetsTable
-            assets={parsedAssets}
+            assets={visibleAssets}
             latestQuotes={latestQuotes}
             heldAssetIds={heldAssetIds}
             isLoading={isLoading || isQuotesLoading}

--- a/apps/frontend/src/pages/asset/assets-page.tsx
+++ b/apps/frontend/src/pages/asset/assets-page.tsx
@@ -19,6 +19,7 @@ import { useHoldings } from "@/hooks/use-holdings";
 import { useIsMobileViewport } from "@/hooks/use-platform";
 import { useSyncMarketDataMutation } from "@/hooks/use-sync-market-data";
 import { PORTFOLIO_ACCOUNT_ID } from "@/lib/constants";
+import { useSettingsContext } from "@/lib/settings-provider";
 import { SettingsHeader } from "../settings/settings-header";
 import { AssetEditSheet } from "./asset-edit-sheet";
 import { isExpiredOptionAsset, ParsedAsset, toParsedAsset } from "./asset-utils";
@@ -36,6 +37,8 @@ export default function AssetsPage() {
   const updateQuotesMutation = useSyncMarketDataMutation(false);
   const isMobileViewport = useIsMobileViewport();
   const { holdings } = useHoldings(PORTFOLIO_ACCOUNT_ID);
+  const { settings } = useSettingsContext();
+  const appTimezone = settings?.timezone?.trim() || undefined;
 
   const heldAssetIds = useMemo(() => {
     const ids = new Set<string>();
@@ -49,8 +52,8 @@ export default function AssetsPage() {
 
   const parsedAssets = useMemo(() => assets.map(toParsedAsset), [assets]);
   const visibleAssets = useMemo(
-    () => parsedAssets.filter((asset) => !isExpiredOptionAsset(asset)),
-    [parsedAssets],
+    () => parsedAssets.filter((asset) => !isExpiredOptionAsset(asset, appTimezone)),
+    [parsedAssets, appTimezone],
   );
   const assetIds = useMemo(() => visibleAssets.map((asset) => asset.id), [visibleAssets]);
   const { data: latestQuotes = {}, isLoading: isQuotesLoading } = useLatestQuotes(assetIds);

--- a/apps/frontend/src/pages/holdings/components/holdings-mobile-filter-sheet.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-mobile-filter-sheet.tsx
@@ -96,7 +96,6 @@ export const HoldingsMobileFilterSheet = ({
                   className="inline-flex w-auto"
                 />
               </div>
-
             </div>
 
             <Separator />

--- a/apps/frontend/src/pages/holdings/components/holdings-mobile-filter-sheet.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-mobile-filter-sheet.tsx
@@ -30,9 +30,6 @@ interface HoldingsMobileFilterSheetProps {
   categoryFilter?: HoldingCategoryFilterId;
   setCategoryFilter?: (value: HoldingCategoryFilterId) => void;
   typeOptions?: { value: string; label: string }[];
-  hideExpired?: boolean;
-  setHideExpired?: (value: boolean) => void;
-  showExpiredToggle?: boolean;
 }
 
 export const HoldingsMobileFilterSheet = ({
@@ -51,9 +48,6 @@ export const HoldingsMobileFilterSheet = ({
   categoryFilter = "investments",
   setCategoryFilter,
   typeOptions,
-  hideExpired,
-  setHideExpired,
-  showExpiredToggle = false,
 }: HoldingsMobileFilterSheetProps) => {
   const { settings } = useSettingsContext();
   const baseCurrency = settings?.baseCurrency ?? "USD";
@@ -103,23 +97,6 @@ export const HoldingsMobileFilterSheet = ({
                 />
               </div>
 
-              {showExpiredToggle && setHideExpired && (
-                <div className="space-y-3">
-                  <h4 className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
-                    Expired Options
-                  </h4>
-                  <AnimatedToggleGroup<"hide" | "show">
-                    value={hideExpired ? "hide" : "show"}
-                    onValueChange={(value) => setHideExpired(value === "hide")}
-                    items={[
-                      { value: "hide", label: "Hide" },
-                      { value: "show", label: "Show" },
-                    ]}
-                    size="sm"
-                    className="inline-flex w-auto"
-                  />
-                </div>
-              )}
             </div>
 
             <Separator />

--- a/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
@@ -1,12 +1,10 @@
 import { TickerAvatar } from "@/components/ticker-avatar";
 import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
-import { usePersistentState } from "@/hooks/use-persistent-state";
 import { PORTFOLIO_ACCOUNT_ID } from "@/lib/constants";
-import { isExpiredOptionSymbol, parseOccSymbol } from "@/lib/occ-symbol";
+import { parseOccSymbol } from "@/lib/occ-symbol";
 import { Account, Holding } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { AmountDisplay, GainPercent, Input, Separator } from "@wealthfolio/ui";
-import { Badge } from "@wealthfolio/ui/components/ui/badge";
 import { Button } from "@wealthfolio/ui/components/ui/button";
 import { Card } from "@wealthfolio/ui/components/ui/card";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
@@ -64,13 +62,6 @@ export const HoldingsTableMobile = ({
   const showTotalReturn = controlledShowTotalReturn ?? internalShowTotalReturn;
   const setShowTotalReturn = controlledSetShowTotalReturn ?? setInternalShowTotalReturn;
 
-  const [hideExpired, setHideExpired] = usePersistentState<boolean>("holdings-hide-expired", true);
-
-  const hasAnyExpired = useMemo(
-    () => holdings.some((h) => isExpiredOptionSymbol(h.instrument?.symbol ?? h.id)),
-    [holdings],
-  );
-
   const hasActiveFilters = useMemo(() => {
     const hasAccountFilter = showAccountFilter && selectedAccount?.id !== PORTFOLIO_ACCOUNT_ID;
     const hasTypeFilter = selectedTypes.length > 0;
@@ -79,12 +70,6 @@ export const HoldingsTableMobile = ({
 
   const filteredHoldings = useMemo(() => {
     let result = [...holdings];
-
-    if (hideExpired && hasAnyExpired) {
-      result = result.filter(
-        (holding) => !isExpiredOptionSymbol(holding.instrument?.symbol ?? holding.id),
-      );
-    }
 
     if (selectedTypes.length > 0) {
       result = result.filter((holding) => {
@@ -123,7 +108,7 @@ export const HoldingsTableMobile = ({
       }
       return 0;
     });
-  }, [holdings, selectedTypes, searchQuery, sortBy, hideExpired, hasAnyExpired]);
+  }, [holdings, selectedTypes, searchQuery, sortBy]);
 
   const handleNavigate = (holding: Holding) => {
     // Use instrument.id (asset ID) for navigation, not symbol (which may be stripped)
@@ -177,7 +162,6 @@ export const HoldingsTableMobile = ({
             const symbol = holding.instrument?.symbol ?? holding.id;
             const isCash = symbol.startsWith("$CASH");
             const parsedOption = isCash ? null : parseOccSymbol(symbol);
-            const isExpiredOption = !isCash && isExpiredOptionSymbol(symbol);
             const avatarSymbol = isCash ? "$CASH" : parsedOption ? parsedOption.underlying : symbol;
             const displaySymbol = isCash
               ? symbol.split("-")[0]
@@ -204,11 +188,6 @@ export const HoldingsTableMobile = ({
                     <div className="flex-1 overflow-hidden">
                       <div className="flex items-center gap-1.5">
                         <p className="truncate font-semibold">{displaySymbol}</p>
-                        {isExpiredOption && (
-                          <Badge variant="destructive" className="h-4 px-1 py-0 text-[10px]">
-                            Expired
-                          </Badge>
-                        )}
                       </div>
                       {subtitle && (
                         <p className="text-muted-foreground truncate text-sm">{subtitle}</p>
@@ -276,9 +255,6 @@ export const HoldingsTableMobile = ({
         showTotalReturn={showTotalReturn}
         setShowTotalReturn={setShowTotalReturn}
         typeOptions={typeOptions}
-        hideExpired={hideExpired}
-        setHideExpired={setHideExpired}
-        showExpiredToggle={hasAnyExpired}
       />
     </div>
   );

--- a/apps/frontend/src/pages/holdings/components/holdings-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table.tsx
@@ -8,9 +8,8 @@ import {
   DropdownMenuTrigger,
 } from "@wealthfolio/ui/components/ui/dropdown-menu";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
-import { isExpiredOptionSymbol, parseOccSymbol } from "@/lib/occ-symbol";
+import { parseOccSymbol } from "@/lib/occ-symbol";
 import { safeDivide } from "@/lib/utils";
-import { usePersistentState } from "@/hooks/use-persistent-state";
 import type { ColumnDef } from "@tanstack/react-table";
 import { GainPercent, Badge } from "@wealthfolio/ui";
 
@@ -66,13 +65,6 @@ export const HoldingsTable = ({
   const { isBalanceHidden } = useBalancePrivacy();
   const { settings } = useSettingsContext();
   const [showConvertedValues, setShowConvertedValues] = useState(false);
-  const [hideExpired, setHideExpired] = usePersistentState<boolean>("holdings-hide-expired", true);
-
-  const hasAnyExpired = holdings.some((h) => isExpiredOptionSymbol(h.instrument?.symbol ?? h.id));
-  const visibleHoldings =
-    hideExpired && hasAnyExpired
-      ? holdings.filter((h) => !isExpiredOptionSymbol(h.instrument?.symbol ?? h.id))
-      : holdings;
 
   const baseCurrency = settings?.baseCurrency ?? holdings[0]?.baseCurrency;
   const hasMultipleCurrencies = holdings.some((holding) => {
@@ -119,7 +111,7 @@ export const HoldingsTable = ({
   return (
     <div className="flex h-full flex-col">
       <DataTable
-        data={visibleHoldings}
+        data={holdings}
         columns={getColumns(isBalanceHidden, showConvertedValues, showTotalReturn, onClassify)}
         searchBy="symbol"
         filters={filters}
@@ -168,27 +160,6 @@ export const HoldingsTable = ({
                 </TooltipContent>
               </Tooltip>
             )}
-            {hasAnyExpired && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    variant="outline"
-                    size="icon"
-                    onClick={() => setHideExpired(!hideExpired)}
-                    className="h-8 w-8 rounded-lg"
-                  >
-                    {hideExpired ? (
-                      <Icons.EyeOff className="h-4 w-4" />
-                    ) : (
-                      <Icons.Eye className="h-4 w-4" />
-                    )}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  <p>{hideExpired ? "Show expired options" : "Hide expired options"}</p>
-                </TooltipContent>
-              </Tooltip>
-            )}
           </div>
         }
       />
@@ -219,7 +190,6 @@ const getColumns = (
       // Parse OCC symbol for options
       const parsedOption = parseOccSymbol(symbol);
       const displaySymbol = parsedOption ? parsedOption.underlying : symbol;
-      const isExpiredOption = isExpiredOptionSymbol(symbol);
 
       // Option subtitle: "Mar 29 $150 CALL"
       const optionSubtitle = parsedOption
@@ -242,11 +212,6 @@ const getColumns = (
           <div className="flex flex-col">
             <div className="flex items-center gap-1.5">
               <span className="font-medium">{displaySymbol}</span>
-              {isExpiredOption && (
-                <Badge variant="destructive" className="h-4 px-1 py-0 text-[10px]">
-                  Expired
-                </Badge>
-              )}
               {isManual && (
                 <Badge variant="secondary" className="h-4 px-1 py-0 text-[10px]">
                   Manual

--- a/apps/frontend/src/pages/holdings/holdings-page.tsx
+++ b/apps/frontend/src/pages/holdings/holdings-page.tsx
@@ -22,7 +22,6 @@ import {
   apiKindToAlternativeAssetKind,
 } from "@/lib/constants";
 import { Account, HoldingType, AlternativeAssetHolding, AlternativeAssetKind } from "@/lib/types";
-import { isExpiredOptionSymbol } from "@/lib/occ-symbol";
 import { canAddHoldings } from "@/lib/activity-restrictions";
 import { useIsMobileViewport } from "@/hooks/use-platform";
 import { HoldingsMobileFilterSheet } from "./components/holdings-mobile-filter-sheet";
@@ -84,7 +83,6 @@ export const HoldingsPage = () => {
     "holdings-show-total-return",
     true,
   );
-  const [hideExpired, setHideExpired] = usePersistentState<boolean>("holdings-hide-expired", true);
 
   // Alternative asset action state
   const [editAsset, setEditAsset] = useState<AssetDetailsSheetAsset | null>(null);
@@ -335,11 +333,6 @@ export const HoldingsPage = () => {
 
   // Combined loading state
   const isDataLoading = isLoading || isAccountsLoading || isAlternativeHoldingsLoading;
-
-  const hasAnyExpiredHolding = useMemo(
-    () => (nonCashHoldings ?? []).some((h) => isExpiredOptionSymbol(h.instrument?.symbol ?? h.id)),
-    [nonCashHoldings],
-  );
 
   // Empty state checks
   const hasNoInvestments = !isDataLoading && (!nonCashHoldings || nonCashHoldings.length === 0);
@@ -669,9 +662,6 @@ export const HoldingsPage = () => {
         showTotalReturn={showTotalReturn}
         setShowTotalReturn={setShowTotalReturn}
         typeOptions={availableTypeOptions}
-        hideExpired={hideExpired}
-        setHideExpired={setHideExpired}
-        showExpiredToggle={hasAnyExpiredHolding}
       />
 
       {/* Alternative Asset Quick Add Modal */}

--- a/apps/server/src/api/activities.rs
+++ b/apps/server/src/api/activities.rs
@@ -156,6 +156,18 @@ async fn link_transfer_activities(
     Ok(Json(pair))
 }
 
+async fn unlink_transfer_activities(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<LinkTransferActivitiesBody>,
+) -> ApiResult<Json<(Activity, Activity)>> {
+    let pair = state
+        .activity_service
+        .unlink_transfer_activities(body.activity_a_id, body.activity_b_id)
+        .await?;
+    // Domain events handle portfolio recalculation
+    Ok(Json(pair))
+}
+
 #[derive(serde::Deserialize)]
 struct ImportCheckBody {
     activities: Vec<ActivityImport>,
@@ -380,6 +392,7 @@ pub fn router() -> Router<Arc<AppState>> {
         .route("/activities/bulk", post(save_activities))
         .route("/activities/{id}", delete(delete_activity))
         .route("/activities/link", post(link_transfer_activities))
+        .route("/activities/unlink", post(unlink_transfer_activities))
         .route("/activities/import/check", post(check_activities_import))
         .route(
             "/activities/import/assets/preview",

--- a/apps/tauri/src/commands/activity.rs
+++ b/apps/tauri/src/commands/activity.rs
@@ -110,6 +110,21 @@ pub async fn link_transfer_activities(
 }
 
 #[tauri::command]
+pub async fn unlink_transfer_activities(
+    activity_a_id: String,
+    activity_b_id: String,
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<(Activity, Activity), String> {
+    debug!("Unlinking transfer activities...");
+    // Domain events handle recalculation automatically
+    state
+        .activity_service()
+        .unlink_transfer_activities(activity_a_id, activity_b_id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
 pub async fn save_activities(
     request: ActivityBulkMutationRequest,
     state: State<'_, Arc<ServiceContext>>,

--- a/apps/tauri/src/lib.rs
+++ b/apps/tauri/src/lib.rs
@@ -286,6 +286,7 @@ pub fn run() {
             commands::activity::save_activities,
             commands::activity::delete_activity,
             commands::activity::link_transfer_activities,
+            commands::activity::unlink_transfer_activities,
             commands::activity::check_activities_import,
             commands::activity::preview_import_assets,
             commands::activity::import_activities,

--- a/crates/ai/Cargo.toml
+++ b/crates/ai/Cargo.toml
@@ -23,6 +23,7 @@ async-trait = { workspace = true }
 futures = { workspace = true }
 log = { workspace = true }
 reqwest = { workspace = true }
+sha2 = { workspace = true }
 
 # LLM orchestration (rig-core crate exports as "rig")
 rig = { package = "rig-core", version = "0.30" }

--- a/crates/ai/src/chat.rs
+++ b/crates/ai/src/chat.rs
@@ -315,13 +315,14 @@ fn validate_attachments_with_limits(
     Ok(total_size)
 }
 
+fn text_has_attachment_marker(text: &str) -> bool {
+    text.lines().any(|line| line.starts_with(ATTACHMENT_MARKER))
+}
+
 fn messages_have_attachment_markers(messages: &[ChatMessage]) -> bool {
     messages.iter().any(|message| {
         message.role == ChatMessageRole::User
-            && message
-                .content
-                .get_text_content()
-                .contains(ATTACHMENT_MARKER)
+            && text_has_attachment_marker(&message.content.get_text_content())
     })
 }
 
@@ -2382,6 +2383,18 @@ mod tests {
             max_total_attachments_bytes: 20,
             max_session_cache_bytes: 100,
         }
+    }
+
+    #[test]
+    fn test_text_has_attachment_marker_matches_stored_marker_lines_only() {
+        assert!(text_has_attachment_marker("import this\n📎 statement.csv"));
+        assert!(text_has_attachment_marker("📎 statement.csv"));
+        assert!(!text_has_attachment_marker(
+            "please explain 📎 statement.csv"
+        ));
+        assert!(!text_has_attachment_marker(
+            "not an attachment: 📎 statement.csv"
+        ));
     }
 
     #[tokio::test]

--- a/crates/ai/src/chat.rs
+++ b/crates/ai/src/chat.rs
@@ -29,10 +29,13 @@ use rig::{
     tool::ToolDyn,
     OneOrMany,
 };
-use std::sync::Arc;
+use sha2::{Digest, Sha256};
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::mpsc;
 use uuid::Uuid;
+use wealthfolio_core::utils::time_utils::{parse_user_timezone, DEFAULT_VALUATION_TZ};
 
 use crate::env::AiEnvironment;
 use crate::error::AiError;
@@ -56,6 +59,536 @@ fn derive_initial_thread_title(first_user_message: &str) -> Option<String> {
         return None;
     }
     Some(truncate_to_title(trimmed, 50))
+}
+
+const ATTACHMENT_MARKER: &str = "\u{1F4CE} ";
+const REDACTED_CSV_CONTENT_PLACEHOLDER: &str =
+    "[redacted: CSV content kept only in session memory]";
+const MAX_SESSION_ATTACHMENT_CACHE_BYTES: usize = 100 * 1024 * 1024;
+const MAX_WORKING_CONTEXT_ACCOUNTS: usize = 20;
+const MAX_WORKING_CONTEXT_ATTACHMENTS: usize = 10;
+
+#[derive(Debug, Clone)]
+struct UserTimeContext {
+    timezone: String,
+    date: String,
+    weekday: String,
+    datetime: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct AttachmentLimits {
+    max_count: usize,
+    max_attachment_size_bytes: usize,
+    max_total_attachments_bytes: usize,
+    max_session_cache_bytes: usize,
+}
+
+impl Default for AttachmentLimits {
+    fn default() -> Self {
+        Self {
+            max_count: MAX_ATTACHMENTS_COUNT,
+            max_attachment_size_bytes: MAX_ATTACHMENT_SIZE_BYTES,
+            max_total_attachments_bytes: MAX_TOTAL_ATTACHMENTS_BYTES,
+            max_session_cache_bytes: MAX_SESSION_ATTACHMENT_CACHE_BYTES,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct AttachmentCacheKey {
+    name: String,
+    content_type: String,
+    data_sha256: [u8; 32],
+}
+
+#[derive(Debug, Clone)]
+struct CachedAttachment {
+    key: AttachmentCacheKey,
+    effective_size: usize,
+    attachment: MessageAttachment,
+}
+
+#[derive(Debug, Clone, Default)]
+struct ThreadAttachmentCache {
+    attachments: Vec<CachedAttachment>,
+    total_size: usize,
+    last_access: u64,
+}
+
+#[derive(Debug, Default)]
+struct SessionAttachmentCacheState {
+    threads: HashMap<String, ThreadAttachmentCache>,
+    total_size: usize,
+    access_counter: u64,
+}
+
+/// Process-local attachment cache for the current app/server session.
+#[derive(Debug)]
+struct SessionAttachmentCache {
+    inner: Mutex<SessionAttachmentCacheState>,
+    limits: AttachmentLimits,
+}
+
+impl SessionAttachmentCache {
+    fn new() -> Self {
+        Self::with_limits(AttachmentLimits::default())
+    }
+
+    fn with_limits(limits: AttachmentLimits) -> Self {
+        Self {
+            inner: Mutex::new(SessionAttachmentCacheState::default()),
+            limits,
+        }
+    }
+
+    fn resolve_for_thread(
+        &self,
+        thread_id: &str,
+        incoming: &[MessageAttachment],
+    ) -> Result<Vec<MessageAttachment>, AiError> {
+        validate_attachments_with_limits(incoming, self.limits)?;
+
+        let mut state = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        state.access_counter = state.access_counter.saturating_add(1);
+        let last_access = state.access_counter;
+
+        if incoming.is_empty() {
+            return Ok(state
+                .threads
+                .get_mut(thread_id)
+                .map(|entry| {
+                    entry.last_access = last_access;
+                    entry
+                        .attachments
+                        .iter()
+                        .map(|cached| cached.attachment.clone())
+                        .collect()
+                })
+                .unwrap_or_default());
+        }
+
+        let mut next_cached = state
+            .threads
+            .get(thread_id)
+            .map(|entry| entry.attachments.clone())
+            .unwrap_or_default();
+        let mut keys: HashSet<AttachmentCacheKey> = next_cached
+            .iter()
+            .map(|cached| cached.key.clone())
+            .collect();
+
+        for attachment in incoming {
+            let key = attachment_cache_key(attachment);
+            if keys.insert(key.clone()) {
+                next_cached.push(CachedAttachment {
+                    key,
+                    effective_size: attachment_effective_size(attachment),
+                    attachment: attachment.clone(),
+                });
+            }
+        }
+
+        let next_attachments: Vec<MessageAttachment> = next_cached
+            .iter()
+            .map(|cached| cached.attachment.clone())
+            .collect();
+        let next_total = validate_attachments_with_limits(&next_attachments, self.limits)?;
+        let cached_total: usize = next_cached.iter().map(|cached| cached.effective_size).sum();
+        debug_assert_eq!(next_total, cached_total);
+
+        let old_total = state
+            .threads
+            .get(thread_id)
+            .map(|entry| entry.total_size)
+            .unwrap_or_default();
+        let entry = state.threads.entry(thread_id.to_string()).or_default();
+        entry.attachments = next_cached;
+        entry.total_size = cached_total;
+        entry.last_access = last_access;
+
+        state.total_size = state
+            .total_size
+            .saturating_sub(old_total)
+            .saturating_add(cached_total);
+        self.evict_if_needed(&mut state, thread_id);
+
+        Ok(state
+            .threads
+            .get(thread_id)
+            .map(|entry| {
+                entry
+                    .attachments
+                    .iter()
+                    .map(|cached| cached.attachment.clone())
+                    .collect()
+            })
+            .unwrap_or_default())
+    }
+
+    fn clear_thread(&self, thread_id: &str) {
+        let mut state = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(entry) = state.threads.remove(thread_id) {
+            state.total_size = state.total_size.saturating_sub(entry.total_size);
+        }
+    }
+
+    fn evict_if_needed(&self, state: &mut SessionAttachmentCacheState, active_thread_id: &str) {
+        while state.total_size > self.limits.max_session_cache_bytes {
+            let Some(evict_thread_id) = state
+                .threads
+                .iter()
+                .filter(|(thread_id, _)| thread_id.as_str() != active_thread_id)
+                .min_by_key(|(_, entry)| entry.last_access)
+                .map(|(thread_id, _)| thread_id.clone())
+            else {
+                break;
+            };
+
+            if let Some(entry) = state.threads.remove(&evict_thread_id) {
+                state.total_size = state.total_size.saturating_sub(entry.total_size);
+            }
+        }
+    }
+}
+
+fn attachment_cache_key(attachment: &MessageAttachment) -> AttachmentCacheKey {
+    let mut hasher = Sha256::new();
+    hasher.update(attachment.data.as_bytes());
+    let digest = hasher.finalize();
+    let mut data_sha256 = [0_u8; 32];
+    data_sha256.copy_from_slice(&digest);
+
+    AttachmentCacheKey {
+        name: attachment.name.clone(),
+        content_type: attachment.content_type.clone(),
+        data_sha256,
+    }
+}
+
+fn attachment_effective_size(attachment: &MessageAttachment) -> usize {
+    let is_binary = attachment.content_type.starts_with("image/")
+        || attachment.content_type == "application/pdf";
+    if is_binary {
+        attachment.data.len() * 3 / 4
+    } else {
+        attachment.data.len()
+    }
+}
+
+fn validate_attachments(attachments: &[MessageAttachment]) -> Result<usize, AiError> {
+    validate_attachments_with_limits(attachments, AttachmentLimits::default())
+}
+
+fn validate_attachments_with_limits(
+    attachments: &[MessageAttachment],
+    limits: AttachmentLimits,
+) -> Result<usize, AiError> {
+    if attachments.len() > limits.max_count {
+        return Err(AiError::InvalidInput(format!(
+            "Too many attachments: {} (max {})",
+            attachments.len(),
+            limits.max_count
+        )));
+    }
+
+    let mut total_size: usize = 0;
+    for attachment in attachments {
+        let effective_size = attachment_effective_size(attachment);
+        if effective_size > limits.max_attachment_size_bytes {
+            return Err(AiError::InvalidInput(format!(
+                "Attachment '{}' too large (max {} MB)",
+                attachment.name,
+                limits.max_attachment_size_bytes / (1024 * 1024)
+            )));
+        }
+        total_size += effective_size;
+    }
+
+    if total_size > limits.max_total_attachments_bytes {
+        return Err(AiError::InvalidInput(format!(
+            "Total attachment size too large (max {} MB)",
+            limits.max_total_attachments_bytes / (1024 * 1024)
+        )));
+    }
+
+    Ok(total_size)
+}
+
+fn messages_have_attachment_markers(messages: &[ChatMessage]) -> bool {
+    messages.iter().any(|message| {
+        message.role == ChatMessageRole::User
+            && message
+                .content
+                .get_text_content()
+                .contains(ATTACHMENT_MARKER)
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WorkingContextAccount {
+    id: String,
+    name: String,
+    currency: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WorkingContextAttachment {
+    name: String,
+    content_type: String,
+    size_bytes: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WorkingContextImport {
+    rows: Option<usize>,
+    account_id: Option<String>,
+    confidence: Option<String>,
+    submitted: bool,
+    imported_count: Option<usize>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+struct ChatWorkingContext {
+    accounts: Vec<WorkingContextAccount>,
+    attachments: Vec<WorkingContextAttachment>,
+    current_import: Option<WorkingContextImport>,
+}
+
+impl ChatWorkingContext {
+    fn from_messages_and_attachments(
+        messages: &[ChatMessage],
+        attachments: &[MessageAttachment],
+    ) -> Self {
+        let mut context = Self {
+            accounts: Vec::new(),
+            attachments: attachments
+                .iter()
+                .take(MAX_WORKING_CONTEXT_ATTACHMENTS)
+                .map(|attachment| WorkingContextAttachment {
+                    name: attachment.name.clone(),
+                    content_type: attachment.content_type.clone(),
+                    size_bytes: attachment_effective_size(attachment),
+                })
+                .collect(),
+            current_import: None,
+        };
+
+        for message in messages {
+            if message.role != ChatMessageRole::Assistant {
+                continue;
+            }
+
+            let mut tool_names_by_id: HashMap<&str, &str> = HashMap::new();
+            for part in &message.content.parts {
+                match part {
+                    ChatMessagePart::ToolCall {
+                        tool_call_id, name, ..
+                    } => {
+                        tool_names_by_id.insert(tool_call_id.as_str(), name.as_str());
+                    }
+                    ChatMessagePart::ToolResult {
+                        tool_call_id,
+                        success,
+                        data,
+                        ..
+                    } if *success => {
+                        if let Some(tool_name) = tool_names_by_id.get(tool_call_id.as_str()) {
+                            context.ingest_tool_result(tool_name, data);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        context
+    }
+
+    fn ingest_tool_result(&mut self, tool_name: &str, data: &serde_json::Value) {
+        match tool_name {
+            "get_accounts" => {
+                if let Some(accounts) = extract_accounts(data.get("accounts")) {
+                    self.accounts = accounts;
+                }
+            }
+            "import_csv" => {
+                if let Some(accounts) = extract_accounts(data.get("availableAccounts")) {
+                    self.accounts = accounts;
+                }
+                self.current_import = Some(WorkingContextImport {
+                    rows: json_usize(data, "totalRows"),
+                    account_id: json_string(data, "accountId"),
+                    confidence: json_string(data, "mappingConfidence"),
+                    submitted: json_bool(data, "submitted").unwrap_or(false),
+                    imported_count: json_usize(data, "importedCount"),
+                });
+            }
+            "record_activity" | "record_activities" => {}
+            _ => {}
+        }
+    }
+
+    fn render(&self) -> Option<String> {
+        if self.accounts.is_empty() && self.attachments.is_empty() && self.current_import.is_none()
+        {
+            return None;
+        }
+
+        let mut lines = vec![
+            "## Known App Context".to_string(),
+            "Use these compact facts for references. Do not call tools only to re-fetch information already listed here; call tools when fresh data is needed.".to_string(),
+        ];
+
+        if !self.accounts.is_empty() {
+            lines.push("Accounts:".to_string());
+            for account in self.accounts.iter().take(MAX_WORKING_CONTEXT_ACCOUNTS) {
+                lines.push(format!(
+                    "- {}: id={}, currency={}",
+                    account.name, account.id, account.currency
+                ));
+            }
+            if self.accounts.len() > MAX_WORKING_CONTEXT_ACCOUNTS {
+                lines.push(format!(
+                    "- ... {} more account(s) omitted",
+                    self.accounts.len() - MAX_WORKING_CONTEXT_ACCOUNTS
+                ));
+            }
+        }
+
+        if !self.attachments.is_empty() {
+            lines.push("Attachments available this session:".to_string());
+            for attachment in &self.attachments {
+                lines.push(format!(
+                    "- {} ({}, {})",
+                    attachment.name,
+                    attachment.content_type,
+                    format_bytes(attachment.size_bytes)
+                ));
+            }
+        }
+
+        if let Some(import) = &self.current_import {
+            lines.push("Current CSV import:".to_string());
+            if let Some(rows) = import.rows {
+                lines.push(format!("- rows prepared: {}", rows));
+            }
+            if let Some(account_id) = &import.account_id {
+                lines.push(format!("- target account id: {}", account_id));
+            }
+            if let Some(confidence) = &import.confidence {
+                lines.push(format!("- mapping confidence: {}", confidence));
+            }
+            if import.submitted {
+                lines.push(format!(
+                    "- status: imported {} activit{}",
+                    import.imported_count.unwrap_or(0),
+                    if import.imported_count == Some(1) {
+                        "y"
+                    } else {
+                        "ies"
+                    }
+                ));
+            } else {
+                lines.push("- status: prepared, not imported yet".to_string());
+            }
+        }
+
+        Some(lines.join("\n"))
+    }
+}
+
+fn extract_accounts(value: Option<&serde_json::Value>) -> Option<Vec<WorkingContextAccount>> {
+    let accounts = value?.as_array()?;
+    let extracted: Vec<WorkingContextAccount> = accounts
+        .iter()
+        .filter_map(|account| {
+            Some(WorkingContextAccount {
+                id: json_string(account, "id")?,
+                name: json_string(account, "name")?,
+                currency: json_string(account, "currency").unwrap_or_default(),
+            })
+        })
+        .collect();
+
+    if extracted.is_empty() {
+        None
+    } else {
+        Some(extracted)
+    }
+}
+
+fn json_string(value: &serde_json::Value, key: &str) -> Option<String> {
+    value.get(key)?.as_str().map(ToString::to_string)
+}
+
+fn json_usize(value: &serde_json::Value, key: &str) -> Option<usize> {
+    value
+        .get(key)?
+        .as_u64()
+        .and_then(|n| usize::try_from(n).ok())
+}
+
+fn json_bool(value: &serde_json::Value, key: &str) -> Option<bool> {
+    value.get(key)?.as_bool()
+}
+
+fn format_bytes(bytes: usize) -> String {
+    const KB: usize = 1024;
+    const MB: usize = 1024 * KB;
+
+    if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.1} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{} B", bytes)
+    }
+}
+
+fn user_time_context<E: AiEnvironment + ?Sized>(env: &E) -> UserTimeContext {
+    let configured_timezone = env
+        .settings_service()
+        .get_settings()
+        .map(|settings| settings.timezone)
+        .unwrap_or_default();
+    let configured_timezone = configured_timezone.trim();
+    let timezone = parse_user_timezone(configured_timezone).unwrap_or(DEFAULT_VALUATION_TZ);
+    let now = chrono::Utc::now().with_timezone(&timezone);
+
+    UserTimeContext {
+        timezone: timezone.name().to_string(),
+        date: now.format("%Y-%m-%d").to_string(),
+        weekday: now.format("%A").to_string(),
+        datetime: now.format("%Y-%m-%dT%H:%M:%S%:z").to_string(),
+    }
+}
+
+fn redact_tool_arguments_for_persistence(
+    tool_name: &str,
+    args: &serde_json::Value,
+) -> serde_json::Value {
+    if tool_name != "import_csv" {
+        return args.clone();
+    }
+
+    let mut redacted = args.clone();
+    if let Some(arguments) = redacted.as_object_mut() {
+        if arguments.contains_key("csvContent") {
+            arguments.insert(
+                "csvContent".to_string(),
+                serde_json::Value::String(REDACTED_CSV_CONTENT_PLACEHOLDER.to_string()),
+            );
+        }
+        if arguments.contains_key("csv_content") {
+            arguments.insert(
+                "csv_content".to_string(),
+                serde_json::Value::String(REDACTED_CSV_CONTENT_PLACEHOLDER.to_string()),
+            );
+        }
+    }
+
+    redacted
 }
 
 // ============================================================================
@@ -89,6 +622,7 @@ impl Default for ChatConfig {
 /// Chat service for managing threads and streaming responses.
 pub struct ChatService<E: AiEnvironment + 'static> {
     env: Arc<E>,
+    session_attachments: Arc<SessionAttachmentCache>,
     #[allow(dead_code)]
     config: ChatConfig,
 }
@@ -96,7 +630,11 @@ pub struct ChatService<E: AiEnvironment + 'static> {
 impl<E: AiEnvironment + 'static> ChatService<E> {
     /// Create a new chat service.
     pub fn new(env: Arc<E>, config: ChatConfig) -> Self {
-        Self { env, config }
+        Self {
+            env,
+            session_attachments: Arc::new(SessionAttachmentCache::new()),
+            config,
+        }
     }
 
     /// Create a new chat thread and persist it to the repository.
@@ -168,7 +706,9 @@ impl<E: AiEnvironment + 'static> ChatService<E> {
 
     /// Delete a thread and its messages from the repository.
     pub async fn delete_thread(&self, thread_id: &str) -> Result<(), AiError> {
-        self.env.chat_repository().delete_thread(thread_id).await
+        self.env.chat_repository().delete_thread(thread_id).await?;
+        self.session_attachments.clear_thread(thread_id);
+        Ok(())
     }
 
     /// Send a message and get a streaming response.
@@ -178,44 +718,9 @@ impl<E: AiEnvironment + 'static> ChatService<E> {
     ) -> Result<BoxStream<'static, AiStreamEvent>, AiError> {
         let repo = self.env.chat_repository();
 
-        // Validate attachments
-        let attachments = request.attachments.clone().unwrap_or_default();
-        if !attachments.is_empty() {
-            if attachments.len() > MAX_ATTACHMENTS_COUNT {
-                return Err(AiError::InvalidInput(format!(
-                    "Too many attachments: {} (max {})",
-                    attachments.len(),
-                    MAX_ATTACHMENTS_COUNT
-                )));
-            }
-            let mut total_size: usize = 0;
-            for att in &attachments {
-                // For base64-encoded payloads (images/PDFs), estimate the
-                // decoded byte size (~75% of encoded length) so limits stay
-                // consistent with the frontend's raw file.size check.
-                let is_binary =
-                    att.content_type.starts_with("image/") || att.content_type == "application/pdf";
-                let effective_size = if is_binary {
-                    att.data.len() * 3 / 4
-                } else {
-                    att.data.len()
-                };
-                if effective_size > MAX_ATTACHMENT_SIZE_BYTES {
-                    return Err(AiError::InvalidInput(format!(
-                        "Attachment '{}' too large (max {} MB)",
-                        att.name,
-                        MAX_ATTACHMENT_SIZE_BYTES / (1024 * 1024)
-                    )));
-                }
-                total_size += effective_size;
-            }
-            if total_size > MAX_TOTAL_ATTACHMENTS_BYTES {
-                return Err(AiError::InvalidInput(format!(
-                    "Total attachment size too large (max {} MB)",
-                    MAX_TOTAL_ATTACHMENTS_BYTES / (1024 * 1024)
-                )));
-            }
-        }
+        // Validate attachments sent with this request before creating/persisting anything.
+        let incoming_attachments = request.attachments.clone().unwrap_or_default();
+        validate_attachments(&incoming_attachments)?;
 
         // Get or create thread
         let (thread, is_new_thread, initial_title) = match &request.thread_id {
@@ -278,9 +783,20 @@ impl<E: AiEnvironment + 'static> ChatService<E> {
             skipped_empty,
         );
 
+        let effective_attachments = self
+            .session_attachments
+            .resolve_for_thread(&thread_id, &incoming_attachments)?;
+        let prior_attachment_content_unavailable = incoming_attachments.is_empty()
+            && effective_attachments.is_empty()
+            && messages_have_attachment_markers(&previous_messages);
+        let working_context = ChatWorkingContext::from_messages_and_attachments(
+            &previous_messages,
+            &effective_attachments,
+        );
+
         // Save user message with attachment placeholders (no binary data stored)
         let mut persist_text = request.content.clone();
-        for att in &attachments {
+        for att in &incoming_attachments {
             persist_text.push_str(&format!("\n\u{1F4CE} {}", att.name));
         }
         let user_message = ChatMessage::user(&thread_id, &persist_text);
@@ -326,7 +842,7 @@ impl<E: AiEnvironment + 'static> ChatService<E> {
                 tx.clone(),
                 content,
                 history_messages,
-                attachments,
+                effective_attachments,
                 provider_id,
                 model_id,
                 thread_id_clone.clone(),
@@ -336,6 +852,8 @@ impl<E: AiEnvironment + 'static> ChatService<E> {
                 initial_title_clone,
                 is_new_thread_clone,
                 thinking_override,
+                prior_attachment_content_unavailable,
+                working_context,
             )
             .await
             {
@@ -569,6 +1087,8 @@ async fn spawn_chat_stream<E: AiEnvironment + 'static>(
     initial_title: Option<String>,
     is_new_thread: bool,
     thinking_override: Option<bool>,
+    prior_attachment_content_unavailable: bool,
+    working_context: ChatWorkingContext,
 ) -> Result<(), AiError> {
     // Send system event first
     tx.send(AiStreamEvent::system(&thread_id, &run_id, &message_id))
@@ -602,19 +1122,36 @@ async fn spawn_chat_stream<E: AiEnvironment + 'static>(
 
     // Build dynamic context
     let base_currency = env.base_currency();
-    let current_date = chrono::Local::now().format("%Y-%m-%d").to_string();
-    let current_datetime = chrono::Local::now().format("%Y-%m-%d %H:%M").to_string();
+    let user_time = user_time_context(env.as_ref());
 
     let dynamic_context = format!(
         "\n\n## Current Context\n\
-        - Current date: {}\n\
-        - Current datetime: {}\n\
-        - Base currency: {}",
-        current_date, current_datetime, base_currency
+        - User timezone: {}\n\
+        - Current date in user timezone: {}\n\
+        - Current weekday in user timezone: {}\n\
+        - Current datetime in user timezone: {}\n\
+        - Base currency: {}\n\
+        - When a tool requires a date, resolve relative phrases such as yesterday, today, \
+        tomorrow, last Friday, or next Monday against this current date before calling the tool.",
+        user_time.timezone, user_time.date, user_time.weekday, user_time.datetime, base_currency
     );
 
     // Build preamble with capability-specific instructions
     let mut preamble = format!("{}{}", base_preamble, dynamic_context);
+
+    if let Some(context) = working_context.render() {
+        preamble.push_str("\n\n");
+        preamble.push_str(&context);
+    }
+
+    if prior_attachment_content_unavailable {
+        preamble.push_str(
+            "\n\n## Attachment Availability\n\
+            Previous messages may show attachment filename markers, but those file contents are \
+            not available in the current app session. If the user refers to those files, ask them \
+            to reattach the file instead of inferring from the filename or prior chat history.",
+        );
+    }
 
     // Add tool limitation notice if model doesn't support tools
     if !capabilities.tools {
@@ -1568,11 +2105,12 @@ async fn stream_agent_response<M: CompletionModel + 'static, E: AiEnvironment + 
 
                 let args: serde_json::Value =
                     serde_json::from_str(&function.arguments.to_string()).unwrap_or_default();
+                let persisted_args = redact_tool_arguments_for_persistence(&function.name, &args);
 
                 content_parts.push(ChatMessagePart::ToolCall {
                     tool_call_id: id.clone(),
                     name: function.name.clone(),
-                    arguments: args.clone(),
+                    arguments: persisted_args,
                 });
 
                 tx.send(AiStreamEvent::tool_call(
@@ -1829,6 +2367,23 @@ mod tests {
     use super::*;
     use crate::env::test_env::MockEnvironment;
 
+    fn test_attachment(name: &str, data: &str) -> MessageAttachment {
+        MessageAttachment {
+            name: name.to_string(),
+            content_type: "text/csv".to_string(),
+            data: data.to_string(),
+        }
+    }
+
+    fn test_limits() -> AttachmentLimits {
+        AttachmentLimits {
+            max_count: 3,
+            max_attachment_size_bytes: 10,
+            max_total_attachments_bytes: 20,
+            max_session_cache_bytes: 100,
+        }
+    }
+
     #[tokio::test]
     async fn test_chat_service_create_thread() {
         let env = Arc::new(MockEnvironment::new());
@@ -1859,6 +2414,236 @@ mod tests {
         let tools = service.list_tools();
         assert!(tools.contains(&"get_accounts".to_string()));
         assert!(tools.contains(&"get_holdings".to_string()));
+    }
+
+    #[test]
+    fn test_chat_working_context_extracts_accounts_from_tool_result() {
+        let mut assistant = ChatMessage::assistant("thread-1");
+        assistant.content = ChatMessageContent::new(vec![
+            ChatMessagePart::ToolCall {
+                tool_call_id: "call-1".to_string(),
+                name: "get_accounts".to_string(),
+                arguments: serde_json::json!({ "displayMode": "compact" }),
+            },
+            ChatMessagePart::ToolResult {
+                tool_call_id: "call-1".to_string(),
+                success: true,
+                data: serde_json::json!({
+                    "accounts": [
+                        { "id": "acct-test", "name": "Test", "currency": "USD" },
+                        { "id": "acct-default", "name": "Default", "currency": "CAD" }
+                    ],
+                    "count": 2
+                }),
+                meta: HashMap::new(),
+                error: None,
+            },
+        ]);
+
+        let context = ChatWorkingContext::from_messages_and_attachments(&[assistant], &[]);
+
+        assert_eq!(context.accounts.len(), 2);
+        assert_eq!(context.accounts[0].name, "Test");
+        let rendered = context.render().unwrap();
+        assert!(rendered.contains("Test: id=acct-test, currency=USD"));
+        assert!(rendered.contains("Do not call tools only to re-fetch"));
+    }
+
+    #[test]
+    fn test_chat_working_context_summarizes_import_and_attachment_metadata() {
+        let mut assistant = ChatMessage::assistant("thread-1");
+        assistant.content = ChatMessageContent::new(vec![
+            ChatMessagePart::ToolCall {
+                tool_call_id: "call-1".to_string(),
+                name: "import_csv".to_string(),
+                arguments: serde_json::json!({ "accountId": "acct-test" }),
+            },
+            ChatMessagePart::ToolResult {
+                tool_call_id: "call-1".to_string(),
+                success: true,
+                data: serde_json::json!({
+                    "totalRows": 52,
+                    "accountId": "acct-test",
+                    "mappingConfidence": "HIGH",
+                    "availableAccounts": [
+                        { "id": "acct-test", "name": "Test", "currency": "USD" }
+                    ]
+                }),
+                meta: HashMap::new(),
+                error: None,
+            },
+        ]);
+        let attachment = test_attachment("activities.csv", "Date,Symbol\n2025-01-01,AAPL");
+
+        let context =
+            ChatWorkingContext::from_messages_and_attachments(&[assistant], &[attachment]);
+        let rendered = context.render().unwrap();
+
+        assert!(rendered.contains("Attachments available this session:"));
+        assert!(rendered.contains("activities.csv (text/csv"));
+        assert!(rendered.contains("Current CSV import:"));
+        assert!(rendered.contains("rows prepared: 52"));
+        assert!(rendered.contains("status: prepared, not imported yet"));
+        assert!(!rendered.contains("2025-01-01,AAPL"));
+    }
+
+    #[test]
+    fn test_redact_import_csv_tool_arguments_for_persistence() {
+        let args = serde_json::json!({
+            "csvContent": "Date,Symbol\n2025-01-01,AAPL",
+            "accountId": "acct-test"
+        });
+
+        let redacted = redact_tool_arguments_for_persistence("import_csv", &args);
+        let serialized = serde_json::to_string(&redacted).unwrap();
+
+        assert_eq!(redacted["accountId"], "acct-test");
+        assert_eq!(redacted["csvContent"], REDACTED_CSV_CONTENT_PLACEHOLDER);
+        assert!(!serialized.contains("2025-01-01,AAPL"));
+    }
+
+    #[test]
+    fn test_session_attachment_cache_stores_and_reuses_attachments() {
+        let cache = SessionAttachmentCache::with_limits(test_limits());
+        let incoming = vec![test_attachment("trades.csv", "a,b\n1,2")];
+
+        let stored = cache.resolve_for_thread("thread-1", &incoming).unwrap();
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].name, "trades.csv");
+
+        let reused = cache.resolve_for_thread("thread-1", &[]).unwrap();
+        assert_eq!(reused.len(), stored.len());
+        assert_eq!(reused[0].name, stored[0].name);
+        assert_eq!(reused[0].data, stored[0].data);
+    }
+
+    #[test]
+    fn test_session_attachment_cache_appends_unique_and_skips_duplicates() {
+        let cache = SessionAttachmentCache::with_limits(test_limits());
+        let first = test_attachment("trades.csv", "a,b\n1,2");
+        let second = test_attachment("statement.csv", "c,d\n3,4");
+
+        cache
+            .resolve_for_thread("thread-1", std::slice::from_ref(&first))
+            .unwrap();
+        let with_duplicate = cache
+            .resolve_for_thread("thread-1", &[first.clone(), second.clone()])
+            .unwrap();
+
+        assert_eq!(with_duplicate.len(), 2);
+        assert_eq!(with_duplicate[0].name, first.name);
+        assert_eq!(with_duplicate[0].data, first.data);
+        assert_eq!(with_duplicate[1].name, second.name);
+        assert_eq!(with_duplicate[1].data, second.data);
+    }
+
+    #[test]
+    fn test_session_attachment_cache_enforces_limits() {
+        let cache = SessionAttachmentCache::with_limits(test_limits());
+
+        let too_large = vec![test_attachment("large.csv", "01234567890")];
+        assert!(matches!(
+            cache.resolve_for_thread("thread-1", &too_large),
+            Err(AiError::InvalidInput(_))
+        ));
+
+        let too_many = vec![
+            test_attachment("a.csv", "1"),
+            test_attachment("b.csv", "2"),
+            test_attachment("c.csv", "3"),
+            test_attachment("d.csv", "4"),
+        ];
+        assert!(matches!(
+            cache.resolve_for_thread("thread-1", &too_many),
+            Err(AiError::InvalidInput(_))
+        ));
+
+        cache
+            .resolve_for_thread("thread-1", &[test_attachment("a.csv", "1234567890")])
+            .unwrap();
+        assert!(matches!(
+            cache.resolve_for_thread("thread-1", &[test_attachment("b.csv", "12345678901")]),
+            Err(AiError::InvalidInput(_))
+        ));
+        assert!(matches!(
+            cache.resolve_for_thread(
+                "thread-1",
+                &[
+                    test_attachment("b.csv", "1234567890"),
+                    test_attachment("c.csv", "x"),
+                ],
+            ),
+            Err(AiError::InvalidInput(_))
+        ));
+    }
+
+    #[test]
+    fn test_session_attachment_cache_evicts_least_recently_used_thread() {
+        let cache = SessionAttachmentCache::with_limits(AttachmentLimits {
+            max_session_cache_bytes: 15,
+            ..test_limits()
+        });
+
+        cache
+            .resolve_for_thread("thread-a", &[test_attachment("a.csv", "123456")])
+            .unwrap();
+        cache
+            .resolve_for_thread("thread-b", &[test_attachment("b.csv", "123456")])
+            .unwrap();
+        cache.resolve_for_thread("thread-a", &[]).unwrap();
+        cache
+            .resolve_for_thread("thread-c", &[test_attachment("c.csv", "123456")])
+            .unwrap();
+
+        assert_eq!(cache.resolve_for_thread("thread-b", &[]).unwrap().len(), 0);
+        assert_eq!(cache.resolve_for_thread("thread-a", &[]).unwrap().len(), 1);
+        assert_eq!(cache.resolve_for_thread("thread-c", &[]).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_session_attachment_cache_clears_thread() {
+        let cache = SessionAttachmentCache::with_limits(test_limits());
+
+        cache
+            .resolve_for_thread("thread-1", &[test_attachment("a.csv", "1")])
+            .unwrap();
+        cache.clear_thread("thread-1");
+
+        assert!(cache
+            .resolve_for_thread("thread-1", &[])
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_chat_service_clears_cached_attachments_when_thread_is_deleted() {
+        let env = Arc::new(MockEnvironment::new());
+        let service = ChatService::new(env, ChatConfig::default());
+
+        let thread = service.create_thread().await.unwrap();
+        let thread_id = thread.id.clone();
+        let attachment = test_attachment("trades.csv", "a,b\n1,2");
+
+        service
+            .session_attachments
+            .resolve_for_thread(&thread_id, &[attachment])
+            .unwrap();
+        assert_eq!(
+            service
+                .session_attachments
+                .resolve_for_thread(&thread_id, &[])
+                .unwrap()
+                .len(),
+            1
+        );
+
+        service.delete_thread(&thread_id).await.unwrap();
+
+        assert!(service
+            .session_attachments
+            .resolve_for_thread(&thread_id, &[])
+            .unwrap()
+            .is_empty());
     }
 
     #[tokio::test]

--- a/crates/ai/src/env.rs
+++ b/crates/ai/src/env.rs
@@ -339,6 +339,14 @@ pub mod test_env {
             unimplemented!("MockActivityService::link_transfer_activities")
         }
 
+        async fn unlink_transfer_activities(
+            &self,
+            _activity_a_id: String,
+            _activity_b_id: String,
+        ) -> CoreResult<(Activity, Activity)> {
+            unimplemented!("MockActivityService::unlink_transfer_activities")
+        }
+
         async fn bulk_mutate_activities(
             &self,
             _request: ActivityBulkMutationRequest,

--- a/crates/ai/src/provider_service.rs
+++ b/crates/ai/src/provider_service.rs
@@ -15,6 +15,7 @@ use crate::provider_model::{
     SetDefaultProviderRequest, UpdateProviderSettingsRequest, AI_PROVIDER_SETTINGS_KEY,
     AI_PROVIDER_SETTINGS_SCHEMA_VERSION,
 };
+use crate::types::normalize_tools_allowlist;
 
 /// Service trait for AI provider operations.
 #[async_trait]
@@ -330,7 +331,7 @@ impl AiProviderServiceTrait for AiProviderService {
                     },
                     favorite_models: user.favorite_models.clone(),
                     model_capability_overrides: user.model_capability_overrides.clone(),
-                    tools_allowlist: user.tools_allowlist.clone(),
+                    tools_allowlist: normalize_tools_allowlist(user.tools_allowlist.clone()),
                     has_api_key: self.has_api_key(id),
                     is_default: user_settings.default_provider.as_ref() == Some(id),
                     supports_model_listing,
@@ -411,7 +412,7 @@ impl AiProviderServiceTrait for AiProviderService {
         // Handle tools allowlist update
         // Some(Some([...])) = set specific tools, Some(None) = all tools enabled
         if let Some(tools_allowlist) = request.tools_allowlist {
-            provider_settings.tools_allowlist = tools_allowlist;
+            provider_settings.tools_allowlist = normalize_tools_allowlist(tools_allowlist);
         }
 
         // Handle tuning overrides update

--- a/crates/ai/src/providers.rs
+++ b/crates/ai/src/providers.rs
@@ -16,6 +16,7 @@ use crate::provider_model::{
     AiProviderSettings, CapabilityInfo, ConnectionField, ModelCapabilities, ProviderDefaultConfig,
     ProviderTuning, AI_PROVIDER_SETTINGS_KEY,
 };
+use crate::types::normalize_tools_allowlist;
 
 // ============================================================================
 // Provider Catalog (Static JSON)
@@ -373,7 +374,7 @@ impl<E: AiEnvironment> ProviderService<E> {
         stored
             .providers
             .get(provider_id)
-            .and_then(|p| p.tools_allowlist.clone())
+            .and_then(|p| normalize_tools_allowlist(p.tools_allowlist.clone()))
     }
 
     /// Resolve effective provider tuning: catalog defaults merged with any

--- a/crates/ai/src/system_prompt.txt
+++ b/crates/ai/src/system_prompt.txt
@@ -77,44 +77,50 @@ You have access to these tools:
 
 10. record_activity - Record investment transactions from natural language
    - Parameters:
-     - activity_type (required): BUY, SELL, DIVIDEND, DEPOSIT, WITHDRAWAL, TRANSFER_IN, TRANSFER_OUT, INTEREST, FEE, SPLIT, TAX
-     - activity_date (required): ISO 8601 date (YYYY-MM-DD). Convert relative dates like "yesterday" to actual dates.
+     - activityType (required): BUY, SELL, DIVIDEND, DEPOSIT, WITHDRAWAL, TRANSFER_IN, TRANSFER_OUT, INTEREST, FEE, SPLIT, TAX
+     - activityDate (required): ISO 8601 date (YYYY-MM-DD). Convert relative dates like "yesterday" to actual dates.
      - symbol (required for trading): Pass the user's exact text — the backend resolves names to tickers automatically. See RECORD_ACTIVITY RULES below for full guidance.
      - quantity: number of shares/units
-     - unit_price: price per unit
+     - unitPrice: price per unit
      - amount: total amount (for DEPOSIT/WITHDRAWAL/DIVIDEND)
      - fee: transaction fee
      - account: account name from the accounts list in context
      - subtype: activity subtype (DRIP, DIVIDEND_IN_KIND, STAKING_REWARD, BONUS)
      - notes: optional notes
    - Returns: draft preview for user confirmation in UI
-   - Examples (always include activity_type + activity_date; resolve relative date phrases against the current date from context):
+   - Do not call this tool with a missing account when the user has multiple accounts. Ask which account first.
+   - Examples (always include activityType + activityDate; resolve relative date phrases against the current date from context):
 
 <examples>
   <example>
-    <user_says>Buy 20 AAPL at 240 today</user_says>
-    <tool_call>{activity_type: "BUY", activity_date: "<today>", symbol: "AAPL", quantity: 20, unit_price: 240}</tool_call>
+    <user_says>Buy 20 AAPL at 240 today in my Taxable account</user_says>
+    <tool_call>{activityType: "BUY", activityDate: "<today>", symbol: "AAPL", quantity: 20, unitPrice: 240, account: "Taxable"}</tool_call>
   </example>
   <example>
     <user_says>Purchase 5 Tesla last Monday</user_says>
-    <tool_call>{activity_type: "BUY", activity_date: "<last Monday>", symbol: "Tesla", quantity: 5}</tool_call>
+    <assistant_should_ask>Which account should I record this in?</assistant_should_ask>
+    <why>The account is missing. If the user has multiple accounts, ask before calling record_activity.</why>
+  </example>
+  <example>
+    <user_says>Purchase 5 Tesla last Monday in RRSP</user_says>
+    <tool_call>{activityType: "BUY", activityDate: "<last Monday>", symbol: "Tesla", quantity: 5, account: "RRSP"}</tool_call>
     <why>Pass "Tesla" verbatim — the backend resolves it to TSLA. Same for any company name ("nvidia", "Apple", "cloudflare", etc.).</why>
   </example>
   <example>
-    <user_says>Sold 10 nvidia yesterday</user_says>
-    <tool_call>{activity_type: "SELL", activity_date: "<yesterday>", symbol: "nvidia", quantity: 10}</tool_call>
+    <user_says>Sold 10 nvidia yesterday in Default</user_says>
+    <tool_call>{activityType: "SELL", activityDate: "<yesterday>", symbol: "nvidia", quantity: 10, account: "Default"}</tool_call>
   </example>
   <example>
     <user_says>Deposit $5000 to my Roth IRA</user_says>
-    <tool_call>{activity_type: "DEPOSIT", activity_date: "<today>", amount: 5000, account: "Roth IRA"}</tool_call>
+    <tool_call>{activityType: "DEPOSIT", activityDate: "<today>", amount: 5000, account: "Roth IRA"}</tool_call>
   </example>
   <example>
     <user_says>Got $150 dividend from MSFT yesterday</user_says>
-    <tool_call>{activity_type: "DIVIDEND", activity_date: "<yesterday>", symbol: "MSFT", amount: 150}</tool_call>
+    <tool_call>{activityType: "DIVIDEND", activityDate: "<yesterday>", symbol: "MSFT", amount: 150}</tool_call>
   </example>
   <example>
     <user_says>Reinvested dividend of 2 shares AAPL</user_says>
-    <tool_call>{activity_type: "DIVIDEND", activity_date: "<today>", symbol: "AAPL", quantity: 2, subtype: "DRIP"}</tool_call>
+    <tool_call>{activityType: "DIVIDEND", activityDate: "<today>", symbol: "AAPL", quantity: 2, subtype: "DRIP"}</tool_call>
     <why>"Reinvested dividend" maps to the DRIP subtype.</why>
   </example>
 </examples>
@@ -153,11 +159,14 @@ When calling a data-fetching tool (get_accounts, get_holdings, get_performance, 
 - User says "how is my portfolio?" → get_performance({accountId: "TOTAL"}) — NO displayMode (user wants the chart)
 
 RECORD_ACTIVITY RULES:
-- The user sees an editable form after this tool runs — every field can be adjusted before save. Prefer a COMPLETE best-effort draft over asking clarifying questions for missing details; let the form handle corrections.
+- The user sees an editable form after this tool runs — every field can be adjusted before save. Prefer a COMPLETE best-effort draft for non-account details, but account selection is a precondition when the user has multiple accounts.
 - Always convert relative dates ("yesterday", "last Monday", "2 days ago") to ISO 8601 format using the current date from context.
 - Account handling:
   - If there is only ONE account, pass that account name in the tool call.
-  - If there are MULTIPLE accounts and the user didn't specify, leave `account` empty — the form renders an account picker.
+  - If accounts are listed in Known App Context, use those account names as the available choices.
+  - If accounts are not listed yet, call get_accounts with displayMode="compact" only when get_accounts is available in this thread's tool access scope. If get_accounts is not available, ask the user which account to use.
+  - If there are MULTIPLE accounts and the user didn't specify one, ask which account to use before calling record_activity or record_activities.
+  - Do not create a confirmation draft with an empty `account` just to show the account picker.
   - Same rule per row for record_activities.
 - Symbol handling:
   - Pass whatever the user wrote (ticker OR company name OR freeform like "my rental property") verbatim. The backend resolves names to tickers automatically and marks unresolvable symbols as custom assets (shown with a "Custom Asset" badge; the form creates them on save).

--- a/crates/ai/src/tools/import_csv.rs
+++ b/crates/ai/src/tools/import_csv.rs
@@ -61,6 +61,7 @@ fn has_usable_llm_mappings(args: &ImportCsvArgs) -> bool {
         || has_usable_string_map(&args.account_mappings)
 }
 
+use wealthfolio_core::accounts::Account;
 use wealthfolio_core::activities::{
     import_type, into_field_mapping_values, ImportMappingData, ParseConfig,
 };
@@ -482,6 +483,39 @@ fn estimate_confidence(mapping: &ImportMappingData) -> MappingConfidence {
 
 const MAX_SAMPLE_ROWS: usize = 10;
 
+fn valid_account_id(value: &str, accounts: &[Account]) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    accounts
+        .iter()
+        .find(|account| account.id == trimmed)
+        .map(|account| account.id.clone())
+}
+
+fn clean_account_mappings(
+    map: Option<HashMap<String, String>>,
+    accounts: &[Account],
+) -> HashMap<String, String> {
+    clean_string_map(map)
+        .into_iter()
+        .filter_map(|(key, value)| {
+            valid_account_id(&value, accounts).map(|account_id| (key, account_id))
+        })
+        .collect()
+}
+
+fn sanitize_mapping_accounts(
+    mut mapping: ImportMappingData,
+    accounts: &[Account],
+) -> ImportMappingData {
+    mapping.account_id = valid_account_id(&mapping.account_id, accounts).unwrap_or_default();
+    mapping.account_mappings = clean_account_mappings(Some(mapping.account_mappings), accounts);
+    mapping
+}
+
 // ============================================================================
 // Tool Implementation
 // ============================================================================
@@ -636,6 +670,10 @@ impl<E: AiEnvironment + 'static> Tool for ImportCsvTool<E> {
                 currency: a.currency.clone(),
             })
             .collect();
+        let account_id = args
+            .account_id
+            .as_deref()
+            .and_then(|id| valid_account_id(id, &accounts));
 
         // Build the parse config from LLM input (unset fields fall back to auto-detect).
         let llm_parse_config = ParseConfig {
@@ -655,7 +693,7 @@ impl<E: AiEnvironment + 'static> Tool for ImportCsvTool<E> {
         // Fast path: saved template exists for this account.
         let mut used_saved_profile = false;
         let mut mapping: Option<ImportMappingData> = None;
-        if let Some(ref account_id) = args.account_id {
+        if let Some(ref account_id) = account_id {
             if !has_usable_llm_mappings(&args) {
                 if let Ok(saved) = self
                     .env
@@ -707,16 +745,17 @@ impl<E: AiEnvironment + 'static> Tool for ImportCsvTool<E> {
             };
 
             ImportMappingData {
-                account_id: args.account_id.clone().unwrap_or_default(),
+                account_id: account_id.clone().unwrap_or_default(),
                 context_kind: import_type::ACTIVITY.to_string(),
                 field_mappings: into_field_mapping_values(field_mappings),
                 activity_mappings: merge_activity_mappings(args.activity_mappings.clone()),
                 symbol_mappings: clean_string_map(args.symbol_mappings.clone()),
-                account_mappings: clean_string_map(args.account_mappings.clone()),
+                account_mappings: clean_account_mappings(args.account_mappings.clone(), &accounts),
                 parse_config: Some(effective_parse_config.clone()),
                 ..Default::default()
             }
         };
+        let applied_mapping = sanitize_mapping_accounts(applied_mapping, &accounts);
 
         let mapping_confidence = if used_saved_profile {
             MappingConfidence::High
@@ -727,7 +766,7 @@ impl<E: AiEnvironment + 'static> Tool for ImportCsvTool<E> {
         Ok(ImportCsvMappingOutput {
             applied_mapping,
             parse_config: effective_parse_config,
-            account_id: args.account_id,
+            account_id,
             detected_headers: headers,
             sample_rows,
             total_rows,
@@ -741,7 +780,20 @@ impl<E: AiEnvironment + 'static> Tool for ImportCsvTool<E> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::env::test_env::MockEnvironment;
+    use crate::env::test_env::{MockAccountService, MockEnvironment};
+    use chrono::Utc;
+
+    fn account(id: &str, name: &str, currency: &str) -> Account {
+        Account {
+            id: id.to_string(),
+            name: name.to_string(),
+            currency: currency.to_string(),
+            is_active: true,
+            created_at: Utc::now().naive_utc(),
+            updated_at: Utc::now().naive_utc(),
+            ..Account::default()
+        }
+    }
 
     #[test]
     fn test_auto_detect_field_mappings() {
@@ -931,6 +983,81 @@ mod tests {
         assert!(buy.iter().any(|v| v == "Kopen"));
         // Defaults are merged in alongside the LLM-provided CSV value.
         assert!(buy.iter().any(|v| v.to_uppercase() == "PURCHASE"));
+    }
+
+    #[tokio::test]
+    async fn test_import_csv_drops_unknown_account_id() {
+        let mut env = MockEnvironment::new();
+        env.account_service = Arc::new(MockAccountService {
+            accounts: vec![account("acct-1", "Default", "USD")],
+        });
+        let tool = ImportCsvTool::new(Arc::new(env), "USD".to_string());
+
+        let args = ImportCsvArgs {
+            csv_content: "Date,Symbol,Quantity,Price,Type\n2024-01-15,AAPL,10,150.00,Buy"
+                .to_string(),
+            account_id: Some("stale-account".to_string()),
+            field_mappings: None,
+            activity_mappings: None,
+            symbol_mappings: None,
+            account_mappings: None,
+            delimiter: None,
+            skip_top_rows: None,
+            skip_bottom_rows: None,
+            date_format: None,
+            decimal_separator: None,
+            thousands_separator: None,
+            default_currency: None,
+        };
+
+        let result = tool.call(args).await.unwrap();
+        assert_eq!(result.account_id, None);
+        assert_eq!(result.applied_mapping.account_id, "");
+    }
+
+    #[tokio::test]
+    async fn test_import_csv_keeps_valid_account_ids_and_drops_invalid_mappings() {
+        let mut env = MockEnvironment::new();
+        env.account_service = Arc::new(MockAccountService {
+            accounts: vec![account("acct-1", "Default", "USD")],
+        });
+        let tool = ImportCsvTool::new(Arc::new(env), "USD".to_string());
+
+        let mut account_mappings = HashMap::new();
+        account_mappings.insert("Broker Account".to_string(), "acct-1".to_string());
+        account_mappings.insert("Old Account".to_string(), "stale-account".to_string());
+
+        let args = ImportCsvArgs {
+            csv_content: "Date,Symbol,Quantity,Price,Type\n2024-01-15,AAPL,10,150.00,Buy"
+                .to_string(),
+            account_id: Some("acct-1".to_string()),
+            field_mappings: None,
+            activity_mappings: None,
+            symbol_mappings: None,
+            account_mappings: Some(account_mappings),
+            delimiter: None,
+            skip_top_rows: None,
+            skip_bottom_rows: None,
+            date_format: None,
+            decimal_separator: None,
+            thousands_separator: None,
+            default_currency: None,
+        };
+
+        let result = tool.call(args).await.unwrap();
+        assert_eq!(result.account_id, Some("acct-1".to_string()));
+        assert_eq!(result.applied_mapping.account_id, "acct-1");
+        assert_eq!(
+            result
+                .applied_mapping
+                .account_mappings
+                .get("Broker Account"),
+            Some(&"acct-1".to_string())
+        );
+        assert!(!result
+            .applied_mapping
+            .account_mappings
+            .contains_key("Old Account"));
     }
 
     #[tokio::test]

--- a/crates/ai/src/tools/record_activities.rs
+++ b/crates/ai/src/tools/record_activities.rs
@@ -84,7 +84,7 @@ impl<E: AiEnvironment + 'static> Tool for RecordActivitiesTool<E> {
     async fn definition(&self, _prompt: String) -> ToolDefinition {
         ToolDefinition {
             name: Self::NAME.to_string(),
-            description: "Record multiple investment transactions from natural language. Returns a read-only batch draft preview for single confirmation.".to_string(),
+            description: "Record multiple investment transactions from natural language. Returns a read-only batch draft preview for single confirmation. If the user has multiple accounts and did not specify which account to use, ask which account before calling this tool.".to_string(),
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -125,7 +125,7 @@ impl<E: AiEnvironment + 'static> Tool for RecordActivitiesTool<E> {
                                 },
                                 "account": {
                                     "type": "string",
-                                    "description": "Account name or ID"
+                                    "description": "Account name or ID. Required before calling this tool when the user has multiple accounts. If the user did not specify an account for a row, ask which account first instead of calling this tool with an empty account."
                                 },
                                 "subtype": {
                                     "type": "string",

--- a/crates/ai/src/tools/record_activity.rs
+++ b/crates/ai/src/tools/record_activity.rs
@@ -7,6 +7,7 @@ use log::debug;
 use rig::{completion::ToolDefinition, tool::Tool};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use wealthfolio_core::utils::time_utils::{parse_user_timezone, DEFAULT_VALUATION_TZ};
 
 use crate::env::AiEnvironment;
 use crate::error::AiError;
@@ -584,9 +585,30 @@ impl<E: AiEnvironment + 'static> Tool for RecordActivityTool<E> {
     type Output = RecordActivityOutput;
 
     async fn definition(&self, _prompt: String) -> ToolDefinition {
+        let configured_timezone = self
+            .env
+            .settings_service()
+            .get_settings()
+            .map(|settings| settings.timezone)
+            .unwrap_or_default();
+        let timezone =
+            parse_user_timezone(configured_timezone.trim()).unwrap_or(DEFAULT_VALUATION_TZ);
+        let now = chrono::Utc::now().with_timezone(&timezone);
+        let current_date = now.format("%Y-%m-%d").to_string();
+        let current_weekday = now.format("%A").to_string();
+        let timezone_name = timezone.name();
+
         ToolDefinition {
             name: Self::NAME.to_string(),
-            description: "Record investment transactions from natural language. Creates a draft preview for user confirmation. Supports all activity types: BUY, SELL, DIVIDEND, DEPOSIT, WITHDRAWAL, TRANSFER_IN, TRANSFER_OUT, INTEREST, FEE, SPLIT, TAX, CREDIT, ADJUSTMENT.".to_string(),
+            description: format!(
+                "Record investment transactions from natural language. Creates a draft preview \
+                for user confirmation. Supports all activity types: BUY, SELL, DIVIDEND, \
+                DEPOSIT, WITHDRAWAL, TRANSFER_IN, TRANSFER_OUT, INTEREST, FEE, SPLIT, TAX, \
+                CREDIT, ADJUSTMENT. User timezone is {timezone_name}; current date there is \
+                {current_date} ({current_weekday}). Resolve all relative date phrases yourself \
+                before calling this tool. If the user has multiple accounts and did not specify \
+                which account to use, ask which account before calling this tool."
+            ),
             parameters: serde_json::json!({
                 "type": "object",
                 "properties": {
@@ -601,7 +623,13 @@ impl<E: AiEnvironment + 'static> Tool for RecordActivityTool<E> {
                     },
                     "activityDate": {
                         "type": "string",
-                        "description": "ISO 8601 date (e.g., '2026-01-17'). Parse relative dates like 'yesterday' or 'last Monday' to ISO format"
+                        "description": format!(
+                            "Concrete ISO 8601 date only, e.g. '2026-01-17'. Do not pass \
+                            relative phrases like 'yesterday', 'today', 'last Friday', or \
+                            'next Monday'. Resolve them relative to current local date \
+                            {current_date} ({current_weekday}) in timezone {timezone_name} \
+                            before calling this tool."
+                        )
                     },
                     "quantity": {
                         "type": "number",
@@ -621,7 +649,7 @@ impl<E: AiEnvironment + 'static> Tool for RecordActivityTool<E> {
                     },
                     "account": {
                         "type": "string",
-                        "description": "Account name or ID. If user has multiple accounts and doesn't specify, ask which account"
+                        "description": "Account name or ID. Required before calling this tool when the user has multiple accounts. If the user did not specify an account, ask which account first instead of calling this tool with an empty account."
                     },
                     "subtype": {
                         "type": "string",

--- a/crates/ai/src/types.rs
+++ b/crates/ai/src/types.rs
@@ -28,6 +28,7 @@ pub const CHAT_CONFIG_SCHEMA_VERSION: u32 = 1;
 pub const DEFAULT_TOOLS_ALLOWLIST: &[&str] = &[
     "get_holdings",
     "get_accounts",
+    "get_cash_balances",
     "get_performance",
     "search_activities",
     "get_valuation_history",
@@ -39,6 +40,57 @@ pub const DEFAULT_TOOLS_ALLOWLIST: &[&str] = &[
     "import_csv",
     "get_health_status",
 ];
+
+const LEGACY_VISIBLE_DATA_TOOLS: &[&str] = &[
+    "get_accounts",
+    "get_holdings",
+    "search_activities",
+    "get_performance",
+    "get_income",
+    "get_asset_allocation",
+    "get_valuation_history",
+    "get_goals",
+];
+
+/// Normalize persisted provider tool allowlists to match grouped UI access controls.
+///
+/// Older settings stored only the visible card tool IDs. For example, the
+/// Transactions card saved `search_activities` but omitted transaction draft
+/// and import tools. Keep those legacy settings working by expanding each
+/// group to the backend tools it represents.
+pub fn normalize_tools_allowlist(tools_allowlist: Option<Vec<String>>) -> Option<Vec<String>> {
+    let mut tools = tools_allowlist?;
+    if tools.is_empty() {
+        return Some(tools);
+    }
+
+    let has = |tools: &[String], tool: &str| tools.iter().any(|item| item == tool);
+
+    if has(&tools, "get_accounts") {
+        push_tool_once(&mut tools, "get_cash_balances");
+    }
+
+    if has(&tools, "search_activities") {
+        push_tool_once(&mut tools, "record_activity");
+        push_tool_once(&mut tools, "record_activities");
+        push_tool_once(&mut tools, "import_csv");
+    }
+
+    if LEGACY_VISIBLE_DATA_TOOLS
+        .iter()
+        .all(|tool| has(&tools, tool))
+    {
+        push_tool_once(&mut tools, "get_health_status");
+    }
+
+    Some(tools)
+}
+
+fn push_tool_once(tools: &mut Vec<String>, tool: &str) {
+    if !tools.iter().any(|item| item == tool) {
+        tools.push(tool.to_string());
+    }
+}
 
 /// Maximum size in bytes for persisted message content (256KB).
 pub const CHAT_MAX_CONTENT_SIZE_BYTES: usize = 256 * 1024;
@@ -1032,6 +1084,37 @@ mod tests {
         let tools = config.get_tools_allowlist();
         assert!(tools.contains(&"get_holdings".to_string()));
         assert!(tools.contains(&"get_accounts".to_string()));
+        assert!(tools.contains(&"get_cash_balances".to_string()));
+    }
+
+    #[test]
+    fn test_normalize_tools_allowlist_expands_grouped_tools() {
+        let tools = normalize_tools_allowlist(Some(vec![
+            "get_accounts".to_string(),
+            "get_holdings".to_string(),
+            "search_activities".to_string(),
+            "get_performance".to_string(),
+            "get_income".to_string(),
+            "get_asset_allocation".to_string(),
+            "get_valuation_history".to_string(),
+            "get_goals".to_string(),
+        ]))
+        .unwrap();
+
+        assert!(tools.contains(&"get_cash_balances".to_string()));
+        assert!(tools.contains(&"record_activity".to_string()));
+        assert!(tools.contains(&"record_activities".to_string()));
+        assert!(tools.contains(&"import_csv".to_string()));
+        assert!(tools.contains(&"get_health_status".to_string()));
+    }
+
+    #[test]
+    fn test_normalize_tools_allowlist_preserves_empty_and_none() {
+        assert!(normalize_tools_allowlist(None).is_none());
+        assert_eq!(
+            normalize_tools_allowlist(Some(Vec::new())),
+            Some(Vec::new())
+        );
     }
 
     #[test]

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -2792,6 +2792,37 @@ impl ActivityServiceTrait for ActivityService {
         Ok((transfer_in, transfer_out))
     }
 
+    async fn unlink_transfer_activities(
+        &self,
+        activity_a_id: String,
+        activity_b_id: String,
+    ) -> Result<(Activity, Activity)> {
+        let (transfer_in, transfer_out) = self
+            .activity_repository
+            .unlink_transfer_activities(activity_a_id, activity_b_id)
+            .await?;
+
+        let mut account_ids: HashSet<String> = HashSet::new();
+        let mut asset_ids: HashSet<String> = HashSet::new();
+        let mut currencies: HashSet<String> = HashSet::new();
+        for activity in [&transfer_in, &transfer_out] {
+            account_ids.insert(activity.account_id.clone());
+            if let Some(ref asset_id) = activity.asset_id {
+                asset_ids.insert(asset_id.clone());
+            }
+            currencies.insert(activity.currency.clone());
+        }
+        let earliest_at = transfer_in.activity_date.min(transfer_out.activity_date);
+        self.emit_activities_changed(
+            account_ids.into_iter().collect(),
+            asset_ids.into_iter().collect(),
+            currencies.into_iter().collect(),
+            Some(earliest_at),
+        );
+
+        Ok((transfer_in, transfer_out))
+    }
+
     async fn bulk_mutate_activities(
         &self,
         request: ActivityBulkMutationRequest,

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -8,6 +8,7 @@ mod tests {
         UpdateAssetProfile,
     };
     use crate::errors::Result;
+    use crate::events::{DomainEvent, MockDomainEventSink};
     use crate::fx::{ExchangeRate, FxServiceTrait, NewExchangeRate};
     use crate::quotes::service::ProviderInfo;
     use crate::quotes::{
@@ -709,6 +710,61 @@ mod tests {
             _activity_b_id: String,
         ) -> Result<(Activity, Activity)> {
             unimplemented!()
+        }
+
+        async fn unlink_transfer_activities(
+            &self,
+            activity_a_id: String,
+            activity_b_id: String,
+        ) -> Result<(Activity, Activity)> {
+            let mut activities = self.activities.lock().unwrap();
+            let first_index = activities
+                .iter()
+                .position(|activity| activity.id == activity_a_id)
+                .ok_or_else(|| {
+                    crate::errors::Error::Unexpected("first activity not found".to_string())
+                })?;
+            let second_index = activities
+                .iter()
+                .position(|activity| activity.id == activity_b_id)
+                .ok_or_else(|| {
+                    crate::errors::Error::Unexpected("second activity not found".to_string())
+                })?;
+
+            let first = activities[first_index].clone();
+            let second = activities[second_index].clone();
+            let (transfer_in_index, transfer_out_index) =
+                match (first.activity_type.as_str(), second.activity_type.as_str()) {
+                    ("TRANSFER_IN", "TRANSFER_OUT") => (first_index, second_index),
+                    ("TRANSFER_OUT", "TRANSFER_IN") => (second_index, first_index),
+                    _ => {
+                        return Err(crate::errors::Error::Unexpected(
+                            "unlink requires transfer pair".to_string(),
+                        ));
+                    }
+                };
+
+            let transfer_in_group = activities[transfer_in_index].source_group_id.clone();
+            let transfer_out_group = activities[transfer_out_index].source_group_id.clone();
+            if transfer_in_group.is_none() || transfer_in_group != transfer_out_group {
+                return Err(crate::errors::Error::Unexpected(
+                    "transfer pair is not linked".to_string(),
+                ));
+            }
+
+            let mut transfer_in = activities[transfer_in_index].clone();
+            let mut transfer_out = activities[transfer_out_index].clone();
+            transfer_in.source_group_id = None;
+            transfer_in.metadata = Some(json!({ "flow": { "is_external": true } }));
+            transfer_out.source_group_id = None;
+            transfer_out.metadata = Some(json!({ "flow": { "is_external": true } }));
+            transfer_in.updated_at = Utc::now();
+            transfer_out.updated_at = Utc::now();
+
+            activities[transfer_in_index] = transfer_in.clone();
+            activities[transfer_out_index] = transfer_out.clone();
+
+            Ok((transfer_in, transfer_out))
         }
 
         async fn bulk_mutate_activities(
@@ -3788,6 +3844,137 @@ mod tests {
             transfer_out_stored.source_group_id, transfer_in_stored.source_group_id,
             "paired transfers should share the same source_group_id"
         );
+    }
+
+    #[tokio::test]
+    async fn unlink_transfer_activities_emits_activities_changed_event() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+        let event_sink = Arc::new(MockDomainEventSink::new());
+        let quote_service = Arc::new(MockQuoteService);
+        let activity_service = ActivityService::new(
+            activity_repository.clone(),
+            account_service,
+            asset_service,
+            fx_service,
+            quote_service,
+        )
+        .with_event_sink(event_sink.clone());
+
+        let earlier = DateTime::parse_from_rfc3339("2024-01-15T00:00:00Z")
+            .expect("valid date")
+            .with_timezone(&Utc);
+        let later = DateTime::parse_from_rfc3339("2024-01-16T00:00:00Z")
+            .expect("valid date")
+            .with_timezone(&Utc);
+        activity_repository.activities.lock().unwrap().extend([
+            Activity {
+                id: "transfer-in".to_string(),
+                account_id: "acc-in".to_string(),
+                asset_id: Some("asset-in".to_string()),
+                activity_type: "TRANSFER_IN".to_string(),
+                activity_type_override: None,
+                source_type: None,
+                subtype: None,
+                status: ActivityStatus::Posted,
+                activity_date: later,
+                settlement_date: None,
+                quantity: None,
+                unit_price: None,
+                amount: Some(dec!(100)),
+                fee: Some(dec!(0)),
+                currency: "CAD".to_string(),
+                fx_rate: None,
+                notes: None,
+                metadata: Some(json!({ "flow": { "is_external": false } })),
+                source_system: Some("MANUAL".to_string()),
+                source_record_id: None,
+                source_group_id: Some("transfer-group".to_string()),
+                idempotency_key: None,
+                import_run_id: None,
+                is_user_modified: false,
+                needs_review: false,
+                created_at: earlier,
+                updated_at: earlier,
+            },
+            Activity {
+                id: "transfer-out".to_string(),
+                account_id: "acc-out".to_string(),
+                asset_id: Some("asset-out".to_string()),
+                activity_type: "TRANSFER_OUT".to_string(),
+                activity_type_override: None,
+                source_type: None,
+                subtype: None,
+                status: ActivityStatus::Posted,
+                activity_date: earlier,
+                settlement_date: None,
+                quantity: None,
+                unit_price: None,
+                amount: Some(dec!(100)),
+                fee: Some(dec!(0)),
+                currency: "USD".to_string(),
+                fx_rate: None,
+                notes: None,
+                metadata: Some(json!({ "flow": { "is_external": false } })),
+                source_system: Some("MANUAL".to_string()),
+                source_record_id: None,
+                source_group_id: Some("transfer-group".to_string()),
+                idempotency_key: None,
+                import_run_id: None,
+                is_user_modified: false,
+                needs_review: false,
+                created_at: earlier,
+                updated_at: earlier,
+            },
+        ]);
+
+        activity_service
+            .unlink_transfer_activities("transfer-in".to_string(), "transfer-out".to_string())
+            .await
+            .expect("unlink should succeed");
+
+        let stored = activity_repository
+            .get_activities()
+            .expect("stored activities");
+        assert!(stored
+            .iter()
+            .all(|activity| activity.source_group_id.is_none()));
+        assert!(stored.iter().all(|activity| {
+            activity
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("flow"))
+                .and_then(|flow| flow.get("is_external"))
+                .and_then(|value| value.as_bool())
+                == Some(true)
+        }));
+
+        let events = event_sink.events();
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            DomainEvent::ActivitiesChanged {
+                account_ids,
+                asset_ids,
+                currencies,
+                earliest_activity_at_utc,
+            } => {
+                let mut account_ids = account_ids.clone();
+                account_ids.sort();
+                assert_eq!(account_ids, vec!["acc-in", "acc-out"]);
+
+                let mut asset_ids = asset_ids.clone();
+                asset_ids.sort();
+                assert_eq!(asset_ids, vec!["asset-in", "asset-out"]);
+
+                let mut currencies = currencies.clone();
+                currencies.sort();
+                assert_eq!(currencies, vec!["CAD", "USD"]);
+                assert_eq!(*earliest_activity_at_utc, Some(earlier));
+            }
+            event => panic!("expected ActivitiesChanged event, got {event:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/core/src/activities/activities_traits.rs
+++ b/crates/core/src/activities/activities_traits.rs
@@ -48,6 +48,13 @@ pub trait ActivityRepositoryTrait: Send + Sync {
         activity_a_id: String,
         activity_b_id: String,
     ) -> Result<(Activity, Activity)>;
+    /// Unpairs two linked transfer activities by clearing their shared `source_group_id`
+    /// and marking `metadata.flow.is_external` as true on both rows.
+    async fn unlink_transfer_activities(
+        &self,
+        activity_a_id: String,
+        activity_b_id: String,
+    ) -> Result<(Activity, Activity)>;
     async fn bulk_mutate_activities(
         &self,
         creates: Vec<NewActivity>,
@@ -175,6 +182,11 @@ pub trait ActivityServiceTrait: Send + Sync {
     async fn update_activity(&self, activity: ActivityUpdate) -> Result<Activity>;
     async fn delete_activity(&self, activity_id: String) -> Result<Activity>;
     async fn link_transfer_activities(
+        &self,
+        activity_a_id: String,
+        activity_b_id: String,
+    ) -> Result<(Activity, Activity)>;
+    async fn unlink_transfer_activities(
         &self,
         activity_a_id: String,
         activity_b_id: String,

--- a/crates/core/src/limits/limits_service.rs
+++ b/crates/core/src/limits/limits_service.rs
@@ -351,6 +351,13 @@ mod tests {
         ) -> Result<(Activity, Activity)> {
             unimplemented!()
         }
+        async fn unlink_transfer_activities(
+            &self,
+            _: String,
+            _: String,
+        ) -> Result<(Activity, Activity)> {
+            unimplemented!()
+        }
         async fn bulk_mutate_activities(
             &self,
             _: Vec<NewActivity>,

--- a/crates/core/src/portfolio/holdings/holdings_service.rs
+++ b/crates/core/src/portfolio/holdings/holdings_service.rs
@@ -1,4 +1,6 @@
-use crate::assets::{Asset, AssetClassificationService, AssetKind, AssetServiceTrait};
+use crate::assets::{
+    Asset, AssetClassificationService, AssetKind, AssetServiceTrait, InstrumentType,
+};
 use crate::constants::DECIMAL_PRECISION;
 use crate::errors::{CalculatorError, Error as CoreError, Result};
 use crate::fx::currency::{get_normalization_rule, normalize_currency_code};
@@ -6,6 +8,7 @@ use crate::portfolio::holdings::holdings_model::{Holding, HoldingType, Instrumen
 use crate::portfolio::snapshot::{self, SnapshotServiceTrait};
 use crate::utils::time_utils::{parse_user_timezone_or_default, user_today};
 use async_trait::async_trait;
+use chrono::NaiveDate;
 use log::{debug, error, warn};
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
@@ -46,9 +49,36 @@ pub struct HoldingsService {
 
 struct AssetInfo {
     instrument: Instrument,
+    instrument_symbol: Option<String>,
+    is_option: bool,
     kind: AssetKind,
     metadata: Option<Value>,
     purchase_price: Option<Decimal>,
+}
+
+fn is_expired_option(
+    is_option: bool,
+    metadata: Option<&Value>,
+    symbols: &[&str],
+    today: NaiveDate,
+) -> bool {
+    if !is_option {
+        return false;
+    }
+
+    let expiration = metadata
+        .and_then(|m| m.get("option"))
+        .and_then(|o| o.get("expiration"))
+        .and_then(|v| v.as_str())
+        .and_then(|s| NaiveDate::parse_from_str(s, "%Y-%m-%d").ok())
+        .or_else(|| {
+            symbols.iter().find_map(|symbol| {
+                crate::utils::occ_symbol::parse_occ_symbol(symbol)
+                    .ok()
+                    .map(|parsed| parsed.expiration)
+            })
+        });
+    matches!(expiration, Some(exp) if exp < today)
 }
 
 impl HoldingsService {
@@ -94,6 +124,7 @@ impl HoldingsService {
         latest_snapshot: &snapshot::AccountStateSnapshot,
         base_currency: &str,
         lots_asset_id: Option<&str>,
+        skip_expired_options: bool,
     ) -> Vec<Holding> {
         let today = self.today_in_user_timezone();
         let snapshot_positions: Vec<snapshot::Position> = latest_snapshot
@@ -134,6 +165,8 @@ impl HoldingsService {
 
                         let asset_info = AssetInfo {
                             instrument,
+                            instrument_symbol: asset.instrument_symbol.clone(),
+                            is_option: asset.instrument_type == Some(InstrumentType::Option),
                             kind: asset.kind,
                             metadata,
                             purchase_price,
@@ -163,6 +196,24 @@ impl HoldingsService {
                 );
                 continue;
             };
+
+            if skip_expired_options
+                && is_expired_option(
+                    asset_info.is_option,
+                    asset_info.metadata.as_ref(),
+                    &[
+                        asset_info.instrument_symbol.as_deref().unwrap_or_default(),
+                        &asset_info.instrument.symbol,
+                    ],
+                    today,
+                )
+            {
+                debug!(
+                    "Skipping expired option holding {} for account {}.",
+                    snapshot_pos.asset_id, account_id
+                );
+                continue;
+            }
 
             let (holding_type, id_prefix) = if asset_info.kind.is_alternative() {
                 (HoldingType::AlternativeAsset, "ALT")
@@ -384,6 +435,111 @@ fn apply_portfolio_weights(account_id: &str, holdings: &mut [Holding]) {
     }
 }
 
+#[cfg(test)]
+mod expired_option_metadata_tests {
+    use super::is_expired_option;
+    use chrono::NaiveDate;
+    use serde_json::json;
+
+    #[test]
+    fn detects_expired_option_metadata() {
+        let metadata = json!({
+            "option": {
+                "expiration": "2026-03-06"
+            }
+        });
+        let today = NaiveDate::from_ymd_opt(2026, 4, 27).unwrap();
+
+        assert!(is_expired_option(true, Some(&metadata), &[""], today));
+    }
+
+    #[test]
+    fn detects_expired_occ_symbol_without_metadata() {
+        let today = NaiveDate::from_ymd_opt(2026, 4, 27).unwrap();
+
+        assert!(is_expired_option(
+            true,
+            None,
+            &["TSLA260306C00397500"],
+            today
+        ));
+    }
+
+    #[test]
+    fn detects_expired_canonical_symbol_when_display_symbol_is_custom() {
+        let today = NaiveDate::from_ymd_opt(2026, 4, 27).unwrap();
+
+        assert!(is_expired_option(
+            true,
+            None,
+            &["Custom Label", "TSLA260306C00397500"],
+            today
+        ));
+    }
+
+    #[test]
+    fn requires_option_instrument_type() {
+        let metadata = json!({
+            "option": {
+                "expiration": "2026-03-06"
+            }
+        });
+        let today = NaiveDate::from_ymd_opt(2026, 4, 27).unwrap();
+
+        assert!(!is_expired_option(
+            false,
+            Some(&metadata),
+            &["TSLA260306C00397500"],
+            today
+        ));
+    }
+
+    #[test]
+    fn keeps_active_and_same_day_option_metadata() {
+        let same_day = json!({
+            "option": {
+                "expiration": "2026-04-27"
+            }
+        });
+        let future = json!({
+            "option": {
+                "expiration": "2026-05-15"
+            }
+        });
+        let today = NaiveDate::from_ymd_opt(2026, 4, 27).unwrap();
+
+        assert!(!is_expired_option(true, Some(&same_day), &[""], today));
+        assert!(!is_expired_option(true, Some(&future), &[""], today));
+        assert!(!is_expired_option(
+            true,
+            None,
+            &["TSLA260427C00397500"],
+            today
+        ));
+    }
+
+    #[test]
+    fn ignores_non_option_or_invalid_metadata() {
+        let non_option = json!({ "bond": { "maturityDate": "2026-03-06" } });
+        let invalid_option = json!({ "option": { "expiration": "not-a-date" } });
+        let today = NaiveDate::from_ymd_opt(2026, 4, 27).unwrap();
+
+        assert!(!is_expired_option(
+            true,
+            Some(&non_option),
+            &["AAPL"],
+            today
+        ));
+        assert!(!is_expired_option(
+            true,
+            Some(&invalid_option),
+            &["AAPL"],
+            today
+        ));
+        assert!(!is_expired_option(true, None, &["AAPL"], today));
+    }
+}
+
 #[async_trait]
 impl HoldingsServiceTrait for HoldingsService {
     async fn get_holdings(&self, account_id: &str, base_currency: &str) -> Result<Vec<Holding>> {
@@ -414,7 +570,13 @@ impl HoldingsServiceTrait for HoldingsService {
         };
 
         let mut holdings = self
-            .build_live_holdings_from_snapshot(account_id, &latest_snapshot, base_currency, None)
+            .build_live_holdings_from_snapshot(
+                account_id,
+                &latest_snapshot,
+                base_currency,
+                None,
+                true,
+            )
             .await;
         self.value_holdings_best_effort(account_id, &mut holdings)
             .await;
@@ -499,6 +661,7 @@ impl HoldingsServiceTrait for HoldingsService {
                 &latest_snapshot,
                 base_currency,
                 Some(asset_id),
+                false,
             )
             .await;
         self.value_holdings_best_effort(account_id, &mut holdings)

--- a/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
+++ b/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
@@ -395,6 +395,13 @@ mod tests {
         ) -> AppResult<(Activity, Activity)> {
             unimplemented!()
         }
+        async fn unlink_transfer_activities(
+            &self,
+            _activity_a_id: String,
+            _activity_b_id: String,
+        ) -> AppResult<(Activity, Activity)> {
+            unimplemented!()
+        }
         async fn bulk_mutate_activities(
             &self,
             _creates: Vec<NewActivity>,
@@ -599,6 +606,13 @@ mod tests {
             unimplemented!()
         }
         async fn link_transfer_activities(
+            &self,
+            _a: String,
+            _b: String,
+        ) -> AppResult<(Activity, Activity)> {
+            unimplemented!()
+        }
+        async fn unlink_transfer_activities(
             &self,
             _a: String,
             _b: String,

--- a/crates/core/src/quotes/service.rs
+++ b/crates/core/src/quotes/service.rs
@@ -2462,6 +2462,14 @@ mod tests {
             unimplemented!("unused in this test")
         }
 
+        async fn unlink_transfer_activities(
+            &self,
+            _activity_a_id: String,
+            _activity_b_id: String,
+        ) -> Result<(Activity, Activity)> {
+            unimplemented!("unused in this test")
+        }
+
         async fn bulk_mutate_activities(
             &self,
             _creates: Vec<NewActivity>,

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -45,12 +45,15 @@ fn apply_decimal_patch(existing: Option<String>, patch: Option<Option<Decimal>>)
 fn set_transfer_flow_external(metadata: Option<String>, is_external: bool) -> Option<String> {
     let mut value = metadata
         .and_then(|metadata| serde_json::from_str::<serde_json::Value>(&metadata).ok())
-        .filter(|value| value.is_object())
         .unwrap_or_else(|| serde_json::json!({}));
 
-    let Some(object) = value.as_object_mut() else {
-        return Some(serde_json::json!({ "flow": { "is_external": is_external } }).to_string());
-    };
+    if !value.is_object() {
+        value = serde_json::json!({});
+    }
+
+    let object = value
+        .as_object_mut()
+        .expect("transfer metadata value should be an object");
     let flow = object
         .entry("flow")
         .or_insert_with(|| serde_json::json!({}));
@@ -492,16 +495,26 @@ impl ActivityRepositoryTrait for ActivityRepository {
                 transfer_out.updated_at = now;
 
                 let updated_in = diesel::update(activities::table.find(&transfer_in.id))
-                    .set(&transfer_in)
+                    .set((
+                        activities::source_group_id.eq(transfer_in.source_group_id.clone()),
+                        activities::metadata.eq(transfer_in.metadata.clone()),
+                        activities::is_user_modified.eq(transfer_in.is_user_modified),
+                        activities::updated_at.eq(&transfer_in.updated_at),
+                    ))
                     .get_result::<ActivityDB>(tx.conn())
                     .map_err(StorageError::from)?;
                 let updated_out = diesel::update(activities::table.find(&transfer_out.id))
-                    .set(&transfer_out)
+                    .set((
+                        activities::source_group_id.eq(transfer_out.source_group_id.clone()),
+                        activities::metadata.eq(transfer_out.metadata.clone()),
+                        activities::is_user_modified.eq(transfer_out.is_user_modified),
+                        activities::updated_at.eq(&transfer_out.updated_at),
+                    ))
                     .get_result::<ActivityDB>(tx.conn())
                     .map_err(StorageError::from)?;
 
-                tx.update(&transfer_in)?;
-                tx.update(&transfer_out)?;
+                tx.update(&updated_in)?;
+                tx.update(&updated_out)?;
 
                 Ok((Activity::from(updated_in), Activity::from(updated_out)))
             })

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -42,6 +42,28 @@ fn apply_decimal_patch(existing: Option<String>, patch: Option<Option<Decimal>>)
     }
 }
 
+fn set_transfer_flow_external(metadata: Option<String>, is_external: bool) -> Option<String> {
+    let mut value = metadata
+        .and_then(|metadata| serde_json::from_str::<serde_json::Value>(&metadata).ok())
+        .filter(|value| value.is_object())
+        .unwrap_or_else(|| serde_json::json!({}));
+
+    let Some(object) = value.as_object_mut() else {
+        return Some(serde_json::json!({ "flow": { "is_external": is_external } }).to_string());
+    };
+    let flow = object
+        .entry("flow")
+        .or_insert_with(|| serde_json::json!({}));
+    if !flow.is_object() {
+        *flow = serde_json::json!({});
+    }
+    if let Some(flow_object) = flow.as_object_mut() {
+        flow_object.insert("is_external".to_string(), serde_json::json!(is_external));
+    }
+
+    Some(value.to_string())
+}
+
 // Inherent methods for ActivityRepository
 impl ActivityRepository {
     /// Creates a new ActivityRepository instance
@@ -451,16 +473,22 @@ impl ActivityRepositoryTrait for ActivityRepository {
                         "One or both activities are already linked to another transfer".to_string(),
                     )));
                 }
+                if transfer_in.account_id == transfer_out.account_id {
+                    return Err(Error::from(ActivityError::InvalidData(
+                        "Both transfer legs share the same account".to_string(),
+                    )));
+                }
 
                 let group_id = Uuid::new_v4().to_string();
                 let now = chrono::Utc::now().to_rfc3339();
-                let internal_metadata = Some(r#"{"flow":{"is_external":false}}"#.to_string());
 
                 transfer_in.source_group_id = Some(group_id.clone());
-                transfer_in.metadata = internal_metadata.clone();
+                transfer_in.metadata = set_transfer_flow_external(transfer_in.metadata, false);
+                transfer_in.is_user_modified = 1;
                 transfer_in.updated_at = now.clone();
                 transfer_out.source_group_id = Some(group_id);
-                transfer_out.metadata = internal_metadata;
+                transfer_out.metadata = set_transfer_flow_external(transfer_out.metadata, false);
+                transfer_out.is_user_modified = 1;
                 transfer_out.updated_at = now;
 
                 let updated_in = diesel::update(activities::table.find(&transfer_in.id))
@@ -474,6 +502,97 @@ impl ActivityRepositoryTrait for ActivityRepository {
 
                 tx.update(&transfer_in)?;
                 tx.update(&transfer_out)?;
+
+                Ok((Activity::from(updated_in), Activity::from(updated_out)))
+            })
+            .await
+    }
+
+    async fn unlink_transfer_activities(
+        &self,
+        activity_a_id: String,
+        activity_b_id: String,
+    ) -> Result<(Activity, Activity)> {
+        use wealthfolio_core::activities::{ACTIVITY_TYPE_TRANSFER_IN, ACTIVITY_TYPE_TRANSFER_OUT};
+
+        if activity_a_id == activity_b_id {
+            return Err(Error::from(ActivityError::InvalidData(
+                "Cannot unlink an activity from itself".to_string(),
+            )));
+        }
+
+        self.writer
+            .exec_tx(move |tx| -> Result<(Activity, Activity)> {
+                let a = activities::table
+                    .select(ActivityDB::as_select())
+                    .find(&activity_a_id)
+                    .first::<ActivityDB>(tx.conn())
+                    .map_err(|e| Error::from(ActivityError::NotFound(e.to_string())))?;
+                let b = activities::table
+                    .select(ActivityDB::as_select())
+                    .find(&activity_b_id)
+                    .first::<ActivityDB>(tx.conn())
+                    .map_err(|e| Error::from(ActivityError::NotFound(e.to_string())))?;
+
+                let (mut transfer_in, mut transfer_out) =
+                    match (a.activity_type.as_str(), b.activity_type.as_str()) {
+                        (ACTIVITY_TYPE_TRANSFER_IN, ACTIVITY_TYPE_TRANSFER_OUT) => (a, b),
+                        (ACTIVITY_TYPE_TRANSFER_OUT, ACTIVITY_TYPE_TRANSFER_IN) => (b, a),
+                        _ => {
+                            return Err(Error::from(ActivityError::InvalidData(
+                                "Unlinking requires one TRANSFER_IN and one TRANSFER_OUT activity"
+                                    .to_string(),
+                            )));
+                        }
+                    };
+
+                let Some(in_group_id) = transfer_in.source_group_id.clone() else {
+                    return Err(Error::from(ActivityError::InvalidData(
+                        "Both activities must already be linked".to_string(),
+                    )));
+                };
+                let Some(out_group_id) = transfer_out.source_group_id.clone() else {
+                    return Err(Error::from(ActivityError::InvalidData(
+                        "Both activities must already be linked".to_string(),
+                    )));
+                };
+                if in_group_id != out_group_id {
+                    return Err(Error::from(ActivityError::InvalidData(
+                        "Selected activities belong to different linked transfers".to_string(),
+                    )));
+                }
+
+                let now = chrono::Utc::now().to_rfc3339();
+                transfer_in.source_group_id = None;
+                transfer_in.metadata = set_transfer_flow_external(transfer_in.metadata, true);
+                transfer_in.is_user_modified = 1;
+                transfer_in.updated_at = now.clone();
+                transfer_out.source_group_id = None;
+                transfer_out.metadata = set_transfer_flow_external(transfer_out.metadata, true);
+                transfer_out.is_user_modified = 1;
+                transfer_out.updated_at = now;
+
+                let updated_in = diesel::update(activities::table.find(&transfer_in.id))
+                    .set((
+                        activities::source_group_id.eq(None::<String>),
+                        activities::metadata.eq(transfer_in.metadata.clone()),
+                        activities::is_user_modified.eq(1),
+                        activities::updated_at.eq(&transfer_in.updated_at),
+                    ))
+                    .get_result::<ActivityDB>(tx.conn())
+                    .map_err(StorageError::from)?;
+                let updated_out = diesel::update(activities::table.find(&transfer_out.id))
+                    .set((
+                        activities::source_group_id.eq(None::<String>),
+                        activities::metadata.eq(transfer_out.metadata.clone()),
+                        activities::is_user_modified.eq(1),
+                        activities::updated_at.eq(&transfer_out.updated_at),
+                    ))
+                    .get_result::<ActivityDB>(tx.conn())
+                    .map_err(StorageError::from)?;
+
+                tx.update(&updated_in)?;
+                tx.update(&updated_out)?;
 
                 Ok((Activity::from(updated_in), Activity::from(updated_out)))
             })
@@ -1832,6 +1951,68 @@ mod tests {
         .expect("insert template");
     }
 
+    fn insert_transfer_activity(
+        conn: &mut SqliteConnection,
+        id: &str,
+        account_id: &str,
+        activity_type: &str,
+        source_group_id: Option<&str>,
+        metadata: Option<&str>,
+    ) {
+        let activity = ActivityDB {
+            id: id.to_string(),
+            account_id: account_id.to_string(),
+            asset_id: None,
+            activity_type: activity_type.to_string(),
+            activity_type_override: None,
+            source_type: None,
+            subtype: None,
+            status: "POSTED".to_string(),
+            activity_date: "2024-01-15T00:00:00+00:00".to_string(),
+            settlement_date: None,
+            quantity: None,
+            unit_price: None,
+            amount: Some("100".to_string()),
+            fee: Some("0".to_string()),
+            currency: "USD".to_string(),
+            fx_rate: None,
+            notes: None,
+            metadata: metadata.map(str::to_string),
+            source_system: Some("MANUAL".to_string()),
+            source_record_id: None,
+            source_group_id: source_group_id.map(str::to_string),
+            idempotency_key: Some(format!("{id}-idempotency")),
+            import_run_id: None,
+            is_user_modified: 0,
+            needs_review: 0,
+            created_at: "2024-01-15T00:00:00+00:00".to_string(),
+            updated_at: "2024-01-15T00:00:00+00:00".to_string(),
+        };
+
+        diesel::insert_into(activities::table)
+            .values(&activity)
+            .execute(conn)
+            .expect("insert transfer activity");
+    }
+
+    fn activity_metadata(conn: &mut SqliteConnection, id: &str) -> serde_json::Value {
+        let metadata: Option<String> = activities::table
+            .filter(activities::id.eq(id))
+            .select(activities::metadata)
+            .first(conn)
+            .expect("activity metadata");
+        serde_json::from_str(metadata.as_deref().expect("metadata should be set"))
+            .expect("valid metadata")
+    }
+
+    fn activity_user_modified(conn: &mut SqliteConnection, id: &str) -> i32 {
+        activities::table
+            .filter(activities::id.eq(id))
+            .select(activities::is_user_modified)
+            .first(conn)
+            .expect("activity is_user_modified")
+    }
+
     /// Regression: re-linking the same (account_id, context_kind, source_system) must preserve the row `id`
     /// so that sync outbox events keep a stable entity_id across updates. Generating a new UUID
     /// on every upsert causes remote devices to receive a different entity_id and fail with a
@@ -1883,6 +2064,230 @@ mod tests {
             .first(&mut conn)
             .expect("template_id after relink");
         assert_eq!(template_id_after, "tmpl-b");
+    }
+
+    #[tokio::test]
+    async fn link_transfer_activities_marks_user_modified_and_rejects_same_account() {
+        let (pool, writer) = setup_db();
+        let repo = ActivityRepository::new(pool.clone(), writer);
+        let mut conn = get_connection(&pool).expect("conn");
+
+        insert_account(&mut conn, "acc-a");
+        insert_account(&mut conn, "acc-b");
+        insert_transfer_activity(
+            &mut conn,
+            "transfer-out",
+            "acc-a",
+            "TRANSFER_OUT",
+            None,
+            Some(r#"{"source":{"id":"manual"}}"#),
+        );
+        insert_transfer_activity(
+            &mut conn,
+            "transfer-in",
+            "acc-b",
+            "TRANSFER_IN",
+            None,
+            Some(r#"{"flow":{"is_external":true}}"#),
+        );
+        insert_transfer_activity(&mut conn, "same-account-in", "acc-a", "TRANSFER_IN", None, None);
+
+        let same_account = repo
+            .link_transfer_activities("same-account-in".to_string(), "transfer-out".to_string())
+            .await;
+        assert!(same_account.is_err());
+        let same_account_group: Option<String> = activities::table
+            .filter(activities::id.eq("same-account-in"))
+            .select(activities::source_group_id)
+            .first(&mut conn)
+            .expect("same-account-in group");
+        assert_eq!(same_account_group, None);
+
+        let (transfer_in, transfer_out) = repo
+            .link_transfer_activities("transfer-in".to_string(), "transfer-out".to_string())
+            .await
+            .expect("link should succeed");
+
+        assert_eq!(transfer_in.is_user_modified, true);
+        assert_eq!(transfer_out.is_user_modified, true);
+        assert!(transfer_in.source_group_id.is_some());
+        assert_eq!(transfer_in.source_group_id, transfer_out.source_group_id);
+        assert_eq!(
+            transfer_in.metadata.as_ref().and_then(|m| {
+                m.get("flow")
+                    .and_then(|flow| flow.get("is_external"))
+                    .and_then(|value| value.as_bool())
+            }),
+            Some(false)
+        );
+        assert_eq!(
+            transfer_out
+                .metadata
+                .as_ref()
+                .and_then(|m| m.get("source"))
+                .and_then(|source| source.get("id"))
+                .and_then(|value| value.as_str()),
+            Some("manual"),
+            "link should preserve unrelated metadata"
+        );
+        assert_eq!(activity_user_modified(&mut conn, "transfer-in"), 1);
+        assert_eq!(activity_user_modified(&mut conn, "transfer-out"), 1);
+    }
+
+    #[tokio::test]
+    async fn unlink_transfer_activities_clears_pair_and_marks_external() {
+        let (pool, writer) = setup_db();
+        let repo = ActivityRepository::new(pool.clone(), writer);
+        let mut conn = get_connection(&pool).expect("conn");
+
+        insert_account(&mut conn, "acc-in");
+        insert_account(&mut conn, "acc-out");
+        insert_transfer_activity(
+            &mut conn,
+            "transfer-in",
+            "acc-in",
+            "TRANSFER_IN",
+            Some("transfer-group"),
+            Some(r#"{"flow":{"is_external":false},"source":{"id":"snaptrade"}}"#),
+        );
+        insert_transfer_activity(
+            &mut conn,
+            "transfer-out",
+            "acc-out",
+            "TRANSFER_OUT",
+            Some("transfer-group"),
+            Some(r#"{"flow":{"is_external":false}}"#),
+        );
+
+        let (transfer_in, transfer_out) = repo
+            .unlink_transfer_activities("transfer-in".to_string(), "transfer-out".to_string())
+            .await
+            .expect("unlink should succeed");
+
+        assert_eq!(transfer_in.id, "transfer-in");
+        assert_eq!(transfer_out.id, "transfer-out");
+        assert_eq!(transfer_in.source_group_id, None);
+        assert_eq!(transfer_out.source_group_id, None);
+        assert_eq!(transfer_in.is_user_modified, true);
+        assert_eq!(transfer_out.is_user_modified, true);
+        assert_eq!(
+            transfer_in.metadata.as_ref().and_then(|m| {
+                m.get("flow")
+                    .and_then(|flow| flow.get("is_external"))
+                    .and_then(|value| value.as_bool())
+            }),
+            Some(true)
+        );
+        assert_eq!(
+            transfer_out.metadata.as_ref().and_then(|m| {
+                m.get("flow")
+                    .and_then(|flow| flow.get("is_external"))
+                    .and_then(|value| value.as_bool())
+            }),
+            Some(true)
+        );
+        assert_eq!(
+            transfer_in
+                .metadata
+                .as_ref()
+                .and_then(|m| m.get("source"))
+                .and_then(|source| source.get("id"))
+                .and_then(|value| value.as_str()),
+            Some("snaptrade"),
+            "unlink should preserve unrelated metadata"
+        );
+
+        let source_group_ids: Vec<Option<String>> = activities::table
+            .filter(activities::id.eq_any(["transfer-in", "transfer-out"]))
+            .select(activities::source_group_id)
+            .load(&mut conn)
+            .expect("source group ids");
+        assert_eq!(source_group_ids, vec![None, None]);
+
+        assert_eq!(
+            activity_metadata(&mut conn, "transfer-in")["flow"]["is_external"],
+            true
+        );
+        assert_eq!(
+            activity_metadata(&mut conn, "transfer-out")["flow"]["is_external"],
+            true
+        );
+        assert_eq!(activity_user_modified(&mut conn, "transfer-in"), 1);
+        assert_eq!(activity_user_modified(&mut conn, "transfer-out"), 1);
+    }
+
+    #[tokio::test]
+    async fn unlink_transfer_activities_rejects_unlinked_or_mismatched_pairs() {
+        let (pool, writer) = setup_db();
+        let repo = ActivityRepository::new(pool.clone(), writer);
+        let mut conn = get_connection(&pool).expect("conn");
+
+        insert_account(&mut conn, "acc-in");
+        insert_account(&mut conn, "acc-out");
+        insert_transfer_activity(
+            &mut conn,
+            "linked-in",
+            "acc-in",
+            "TRANSFER_IN",
+            Some("group-a"),
+            Some(r#"{"flow":{"is_external":false}}"#),
+        );
+        insert_transfer_activity(
+            &mut conn,
+            "linked-out",
+            "acc-out",
+            "TRANSFER_OUT",
+            Some("group-b"),
+            Some(r#"{"flow":{"is_external":false}}"#),
+        );
+        insert_transfer_activity(
+            &mut conn,
+            "unlinked-out",
+            "acc-out",
+            "TRANSFER_OUT",
+            None,
+            Some(r#"{"flow":{"is_external":true}}"#),
+        );
+        insert_transfer_activity(&mut conn, "buy-row", "acc-in", "BUY", Some("group-a"), None);
+
+        let mismatched = repo
+            .unlink_transfer_activities("linked-in".to_string(), "linked-out".to_string())
+            .await;
+        assert!(mismatched.is_err());
+
+        let unlinked = repo
+            .unlink_transfer_activities("linked-in".to_string(), "unlinked-out".to_string())
+            .await;
+        assert!(unlinked.is_err());
+
+        let non_transfer = repo
+            .unlink_transfer_activities("linked-in".to_string(), "buy-row".to_string())
+            .await;
+        assert!(non_transfer.is_err());
+
+        let linked_in_group: Option<String> = activities::table
+            .filter(activities::id.eq("linked-in"))
+            .select(activities::source_group_id)
+            .first(&mut conn)
+            .expect("linked-in group");
+        let linked_out_group: Option<String> = activities::table
+            .filter(activities::id.eq("linked-out"))
+            .select(activities::source_group_id)
+            .first(&mut conn)
+            .expect("linked-out group");
+        let unlinked_out_group: Option<String> = activities::table
+            .filter(activities::id.eq("unlinked-out"))
+            .select(activities::source_group_id)
+            .first(&mut conn)
+            .expect("unlinked-out group");
+
+        assert_eq!(linked_in_group.as_deref(), Some("group-a"));
+        assert_eq!(linked_out_group.as_deref(), Some("group-b"));
+        assert_eq!(unlinked_out_group, None);
+        assert_eq!(
+            activity_metadata(&mut conn, "linked-in")["flow"]["is_external"],
+            false
+        );
     }
 
     #[tokio::test]

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -2090,7 +2090,14 @@ mod tests {
             None,
             Some(r#"{"flow":{"is_external":true}}"#),
         );
-        insert_transfer_activity(&mut conn, "same-account-in", "acc-a", "TRANSFER_IN", None, None);
+        insert_transfer_activity(
+            &mut conn,
+            "same-account-in",
+            "acc-a",
+            "TRANSFER_IN",
+            None,
+            None,
+        );
 
         let same_account = repo
             .link_transfer_activities("same-account-in".to_string(), "transfer-out".to_string())
@@ -2108,8 +2115,8 @@ mod tests {
             .await
             .expect("link should succeed");
 
-        assert_eq!(transfer_in.is_user_modified, true);
-        assert_eq!(transfer_out.is_user_modified, true);
+        assert!(transfer_in.is_user_modified);
+        assert!(transfer_out.is_user_modified);
         assert!(transfer_in.source_group_id.is_some());
         assert_eq!(transfer_in.source_group_id, transfer_out.source_group_id);
         assert_eq!(
@@ -2168,8 +2175,8 @@ mod tests {
         assert_eq!(transfer_out.id, "transfer-out");
         assert_eq!(transfer_in.source_group_id, None);
         assert_eq!(transfer_out.source_group_id, None);
-        assert_eq!(transfer_in.is_user_modified, true);
-        assert_eq!(transfer_out.is_user_modified, true);
+        assert!(transfer_in.is_user_modified);
+        assert!(transfer_out.is_user_modified);
         assert_eq!(
             transfer_in.metadata.as_ref().and_then(|m| {
                 m.get("flow")

--- a/packages/ui/src/components/ui/date-picker-input.tsx
+++ b/packages/ui/src/components/ui/date-picker-input.tsx
@@ -24,6 +24,8 @@ function toDateValue(
   const hasTimeGranularity = granularity !== "day";
 
   if (value instanceof Date) {
+    if (!Number.isFinite(value.getTime())) return null;
+
     if (hasTimeGranularity) {
       return new CalendarDateTime(
         value.getFullYear(),

--- a/packages/ui/src/components/ui/icons.tsx
+++ b/packages/ui/src/components/ui/icons.tsx
@@ -129,6 +129,7 @@ import {
   TrendingUp,
   Type,
   Undo2,
+  Unlink,
   Upload,
   User,
   Users,
@@ -277,6 +278,7 @@ const IconsInternal = {
   TrendingDown: TrendingDown,
   Wand2: Wand2,
   Link: Link,
+  Unlink: Unlink,
   Building: Building2,
   Car: Car,
   Gem: Gem,
@@ -823,6 +825,7 @@ export type IconName =
   | "TrendingDown"
   | "Wand2"
   | "Link"
+  | "Unlink"
   | "Building"
   | "Car"
   | "Gem"


### PR DESCRIPTION
## Summary
- keep AI assistant attachments available in process memory for the active session while avoiding raw file persistence
- expand assistant tool access groups and improve record activity account/date prompting
- harden chat CSV import review, account validation, persisted CSV redaction, and stale import summaries
- bound live import session caches so old CSV tool calls cannot grow memory unbounded
- polish assistant attachment chips, continuation loader, and activity confirmation UI

## Verification
- cargo test -p wealthfolio-ai
- pnpm --filter frontend test -- use-chat-import-session
- pnpm --filter frontend type-check
- pnpm --filter @wealthfolio/ui type-check
- git diff --check