### PR TITLE
fix(asset): surface and allow editing ISIN on asset profile page

### DIFF
--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -1001,6 +1001,7 @@ export interface UpdateAssetProfile {
   instrumentType?: string | null;
   instrumentExchangeMic?: string | null;
   providerConfig?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
 }
 
 // Rename ComparisonItem to TrackedItem

--- a/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
+++ b/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
@@ -638,8 +638,11 @@ export function AssetEditSheet({
 
       try {
         // Merge ISIN into existing metadata without clobbering other fields
-        const existingMeta = (asset.metadata as Record<string, unknown>) ?? {};
-        const existingIdentifiers = (existingMeta.identifiers as Record<string, unknown>) ?? {};
+        const existingMeta: Record<string, unknown> = asset.metadata ?? {};
+        const existingIdentifiers: Record<string, unknown> =
+          typeof existingMeta.identifiers === "object" && existingMeta.identifiers !== null
+            ? (existingMeta.identifiers as Record<string, unknown>)
+            : {};
         const isinTrimmed = values.isin?.trim() ?? "";
         const newIdentifiers = isinTrimmed
           ? { ...existingIdentifiers, isin: isinTrimmed }

--- a/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
+++ b/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
@@ -84,6 +84,7 @@ type QuoteMode = (typeof QuoteMode)[keyof typeof QuoteMode];
 const assetFormSchema = z.object({
   name: z.string().optional(),
   notes: z.string().optional(),
+  isin: z.string().optional(),
   instrumentType: z.string().optional(),
   quoteCcy: z.string().min(1, "Currency is required"),
   instrumentExchangeMic: z.string().optional(),
@@ -130,6 +131,13 @@ const EDIT_INSTRUMENT_TYPE_OPTIONS = [
   { value: "OPTION", label: "Option" },
   { value: "METAL", label: "Metal (Commodity)" },
 ] as const;
+
+function extractIsin(metadata: unknown): string {
+  if (!metadata || typeof metadata !== "object") return "";
+  const identifiers = (metadata as Record<string, unknown>).identifiers;
+  if (!identifiers || typeof identifiers !== "object") return "";
+  return ((identifiers as Record<string, unknown>).isin as string) ?? "";
+}
 
 // Parse provider overrides from config JSON (supports nested and flat formats)
 function parseProviderOverrides(
@@ -557,6 +565,7 @@ export function AssetEditSheet({
     defaultValues: {
       name: asset?.name ?? "",
       notes: asset?.notes ?? "",
+      isin: extractIsin(asset?.metadata),
       instrumentType: asset?.instrumentType ?? "",
       quoteCcy: asset?.quoteCcy ?? "",
       instrumentExchangeMic: normalizeMic(asset?.instrumentExchangeMic),
@@ -585,6 +594,7 @@ export function AssetEditSheet({
       form.reset({
         name: asset.name ?? "",
         notes: asset.notes ?? "",
+        isin: extractIsin(asset.metadata),
         instrumentType: asset.instrumentType ?? "",
         quoteCcy: asset.quoteCcy ?? "",
         instrumentExchangeMic: normalizeMic(asset.instrumentExchangeMic),
@@ -627,6 +637,20 @@ export function AssetEditSheet({
       const normalizedMic = normalizeMic(values.instrumentExchangeMic);
 
       try {
+        // Merge ISIN into existing metadata without clobbering other fields
+        const existingMeta = (asset.metadata as Record<string, unknown>) ?? {};
+        const existingIdentifiers = (existingMeta.identifiers as Record<string, unknown>) ?? {};
+        const isinTrimmed = values.isin?.trim() ?? "";
+        const newIdentifiers = isinTrimmed
+          ? { ...existingIdentifiers, isin: isinTrimmed }
+          : Object.fromEntries(Object.entries(existingIdentifiers).filter(([k]) => k !== "isin"));
+        const newMetadata = {
+          ...existingMeta,
+          ...(Object.keys(newIdentifiers).length > 0
+            ? { identifiers: newIdentifiers }
+            : { identifiers: undefined }),
+        };
+
         // Update profile with all fields including quote mode
         await updateAssetProfileMutation.mutateAsync({
           id: asset.id,
@@ -638,6 +662,7 @@ export function AssetEditSheet({
           quoteCcy: values.quoteCcy,
           instrumentExchangeMic: normalizedMic || null,
           providerConfig: serializedOverrides,
+          metadata: newMetadata,
         });
 
         onOpenChange(false);
@@ -737,6 +762,25 @@ export function AssetEditSheet({
 
                       <FormField
                         control={form.control}
+                        name="isin"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>ISIN</FormLabel>
+                            <FormControl>
+                              <Input
+                                placeholder="e.g. FR0010959676"
+                                className="font-mono uppercase"
+                                {...field}
+                                onChange={(e) => field.onChange(e.target.value.toUpperCase())}
+                              />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+
+                      <FormField
+                        control={form.control}
                         name="notes"
                         render={({ field }) => (
                           <FormItem>
@@ -800,6 +844,25 @@ export function AssetEditSheet({
                             <FormLabel>Name</FormLabel>
                             <FormControl>
                               <Input placeholder="Asset display name" {...field} />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+
+                      <FormField
+                        control={form.control}
+                        name="isin"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>ISIN</FormLabel>
+                            <FormControl>
+                              <Input
+                                placeholder="e.g. FR0010959676"
+                                className="font-mono uppercase"
+                                {...field}
+                                onChange={(e) => field.onChange(e.target.value.toUpperCase())}
+                              />
                             </FormControl>
                             <FormMessage />
                           </FormItem>

--- a/apps/frontend/src/pages/asset/asset-profile-page.tsx
+++ b/apps/frontend/src/pages/asset/asset-profile-page.tsx
@@ -422,11 +422,13 @@ export const AssetProfilePage = () => {
       | { sectors?: string | null; countries?: string | null }
       | undefined;
 
+    const identifiers = asset?.metadata?.identifiers as { isin?: string } | undefined;
+
     return {
       id: instrument?.id ?? asset?.id ?? "",
       symbol: instrument?.symbol ?? asset?.displayCode ?? assetId,
       name: instrument?.name ?? asset?.name ?? "-",
-      isin: null,
+      isin: identifiers?.isin ?? null,
       assetType: null,
       symbolMapping: null,
       notes: instrument?.notes ?? asset?.notes ?? null,
@@ -1218,6 +1220,13 @@ export const AssetProfilePage = () => {
                         </Button>
                       )}
                     </div>
+
+                    {/* ISIN */}
+                    {profile.isin && (
+                      <p className="text-muted-foreground text-sm">
+                        <span className="font-medium">ISIN:</span> {profile.isin}
+                      </p>
+                    )}
 
                     {/* Notes section */}
                     <p className="text-muted-foreground text-sm">


### PR DESCRIPTION
## Summary

The ISIN identifier stored in `asset.metadata.identifiers.isin` was never surfaced to the user — the profile page hardcoded `isin: null` and the edit sheet had no ISIN field.

This PR fixes both:
- **Display**: ISIN is shown in the About tab of the asset profile page when available
- **Edit**: ISIN input field added to the General tab of AssetEditSheet (monospace, auto-uppercase). Saves by merging into `metadata.identifiers.isin` without clobbering other metadata fields (bond spec, option spec, etc.)

## Files changed

- `apps/frontend/src/pages/asset/asset-profile-page.tsx` — read `isin` from `asset.metadata.identifiers.isin` instead of hardcoding `null`; display in About tab
- `apps/frontend/src/pages/asset/asset-edit-sheet.tsx` — add `isin` to form schema, default values, reset, save logic, and UI
- `apps/frontend/src/lib/types.ts` — add `metadata` field to `UpdateAssetProfile` interface (backend already accepted it)

## Test plan

- [ ] Open any asset profile page → About tab → verify ISIN shown if present
- [ ] Click edit (pencil icon) → General tab → verify ISIN field visible
- [ ] Enter an ISIN (e.g. `FR0010959676`) → Save → reopen → verify persisted
- [ ] Clear the ISIN → Save → verify it is removed from metadata
- [ ] Verify other metadata fields (bond spec, option spec) are not affected by the save

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).