### PR TITLE
Refactor device sync for 3.3 fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8002,7 +8002,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-ai"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8027,7 +8027,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-app"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8076,7 +8076,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-connect"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8094,7 +8094,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-core"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8139,7 +8139,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-device-sync"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8163,7 +8163,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-market-data"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8185,7 +8185,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-server"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8232,7 +8232,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-storage-sqlite"
-version = "3.2.1"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.2.1"
+version = "3.3.0"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/addons/goal-progress-tracker/manifest.json
+++ b/addons/goal-progress-tracker/manifest.json
@@ -1,11 +1,11 @@
 {
   "id": "goal-progress-tracker-addon",
   "name": "Goal Progress Tracker",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "A simple addon to track your investment progress towards target amounts with a visual representation",
   "author": "Wealthfolio",
   "main": "dist/addon.js",
-  "sdkVersion": "3.2.1",
+  "sdkVersion": "3.3.0",
   "enabled": true,
   "permissions": [
     {

--- a/addons/goal-progress-tracker/package.json
+++ b/addons/goal-progress-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goal-progress-tracker-addon",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "An addon for tracking investment progress towards target amounts with progress visualization",
   "type": "module",
   "main": "dist/addon.js",

--- a/addons/investment-fees-tracker/manifest.json
+++ b/addons/investment-fees-tracker/manifest.json
@@ -1,11 +1,11 @@
 {
   "id": "investment-fees-tracker-addon",
   "name": "Investment Fees Tracker",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "Track and analyze investment fees across your portfolio with detailed analytics and insights",
   "author": "Wealthfolio",
   "main": "dist/addon.js",
-  "sdkVersion": "3.2.1",
+  "sdkVersion": "3.3.0",
   "enabled": true,
   "permissions": [
     {

--- a/addons/investment-fees-tracker/package.json
+++ b/addons/investment-fees-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "investment-fees-tracker-addon",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "An addon for tracking and analyzing investment fees across your portfolio",
   "type": "module",
   "main": "dist/addon.js",

--- a/addons/swingfolio-addon/manifest.json
+++ b/addons/swingfolio-addon/manifest.json
@@ -1,11 +1,11 @@
 {
   "id": "swingfolio-addon",
   "name": "Swingfolio: Simple Stock Trading Tracker",
-  "version": "3.1.0",
+  "version": "3.3.0",
   "description": "A simple swing stock trading tracker with performance analytics and calendar views",
   "author": "Wealthfolio",
   "main": "dist/addon.js",
-  "sdkVersion": "3.0.0",
+  "sdkVersion": "3.3.0",
   "enabled": true,
   "permissions": [
     {

--- a/addons/swingfolio-addon/package.json
+++ b/addons/swingfolio-addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swingfolio-addon",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "A simple swing stock trading tracker with performance analytics and calendar views",
   "type": "module",
   "main": "dist/addon.js",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "3.2.1",
+  "version": "3.3.0",
   "type": "module",
   "scripts": {
     "dev": "cross-env BUILD_TARGET=web vite",

--- a/apps/frontend/src/adapters/types.ts
+++ b/apps/frontend/src/adapters/types.ts
@@ -272,7 +272,7 @@ export interface BackendSyncReconcileReadyResult {
   };
   status: "ok" | "skipped_not_ready" | "error";
   message: string;
-  bootstrapStatus: "applied" | "skipped" | "requested" | "not_attempted";
+  bootstrapStatus: "applied" | "skipped" | "skipped_not_ready" | "requested" | "not_attempted";
   bootstrapMessage: string | null;
   bootstrapSnapshotId: string | null;
   cycleStatus: string | null;

--- a/apps/frontend/src/components/history-chart-scale.test.ts
+++ b/apps/frontend/src/components/history-chart-scale.test.ts
@@ -19,7 +19,7 @@ describe("getAutomaticHistoryChartScale", () => {
     expect(scale.scale).toBe("linear");
     expect(scale.showNetContribution).toBe(true);
     expect(scale.domain[0]).toBe(0);
-    expect(scale.domain[1]).toBeCloseTo(1820);
+    expect(scale.domain[1]).toBeCloseTo(1725);
   });
 
   it("keeps linear scale when total value includes zero or negative values", () => {
@@ -32,20 +32,32 @@ describe("getAutomaticHistoryChartScale", () => {
     expect(scale.scale).toBe("linear");
     expect(scale.showNetContribution).toBe(true);
     expect(scale.domain[0]).toBe(0);
-    expect(scale.domain[1]).toBeCloseTo(1950);
+    expect(scale.domain[1]).toBeCloseTo(1725);
   });
 
   it("keeps linear scale when the visible value range is narrow", () => {
     const scale = getAutomaticHistoryChartScale([
-      { totalValue: 1000, netContribution: 900 },
-      { totalValue: 1500, netContribution: 1200 },
-      { totalValue: 1800, netContribution: 1300 },
+      { totalValue: 1700, netContribution: 1690 },
+      { totalValue: 1750, netContribution: 1720 },
+      { totalValue: 1800, netContribution: 1740 },
     ]);
 
     expect(scale.scale).toBe("linear");
     expect(scale.showNetContribution).toBe(true);
-    expect(scale.domain[0]).toBeCloseTo(880);
-    expect(scale.domain[1]).toBeCloseTo(1920);
+    expect(scale.domain[0]).toBeCloseTo(1685);
+    expect(scale.domain[1]).toBeCloseTo(1815);
+  });
+
+  it("anchors material positive ranges to zero for visual context", () => {
+    const scale = getAutomaticHistoryChartScale([
+      { totalValue: 2000, netContribution: 0 },
+      { totalValue: 1500, netContribution: 0 },
+      { totalValue: 2000, netContribution: 0 },
+    ]);
+
+    expect(scale.scale).toBe("linear");
+    expect(scale.showNetContribution).toBe(true);
+    expect(scale.domain).toEqual([0, 2300]);
   });
 
   it("keeps high-value low-volatility periods readable", () => {
@@ -69,8 +81,21 @@ describe("getAutomaticHistoryChartScale", () => {
 
     expect(scale.scale).toBe("linear");
     expect(scale.showNetContribution).toBe(true);
-    expect(scale.domain[0]).toBeCloseTo(28_000);
-    expect(scale.domain[1]).toBeCloseTo(158_000);
+    expect(scale.domain[0]).toBe(0);
+    expect(scale.domain[1]).toBeCloseTo(164_450);
+  });
+
+  it("anchors material negative ranges to zero for visual context", () => {
+    const scale = getAutomaticHistoryChartScale([
+      { totalValue: -2000, netContribution: -1800 },
+      { totalValue: -1500, netContribution: -1600 },
+      { totalValue: -2000, netContribution: -1700 },
+    ]);
+
+    expect(scale.scale).toBe("linear");
+    expect(scale.showNetContribution).toBe(true);
+    expect(scale.domain[0]).toBeCloseTo(-2300);
+    expect(scale.domain[1]).toBe(0);
   });
 
   it("keeps a valid domain for zero balances", () => {

--- a/apps/frontend/src/components/history-chart-scale.ts
+++ b/apps/frontend/src/components/history-chart-scale.ts
@@ -31,10 +31,7 @@ function getLinearDomain(values: number[]): [number, number] {
     }
 
     if (maxValue <= 0) {
-      return [
-        Math.min(minValue * (1 + LINEAR_DOMAIN_PADDING_RATIO), -LINEAR_MIN_VISIBLE_SPAN),
-        0,
-      ];
+      return [Math.min(minValue * (1 + LINEAR_DOMAIN_PADDING_RATIO), -LINEAR_MIN_VISIBLE_SPAN), 0];
     }
   }
 

--- a/apps/frontend/src/components/history-chart-scale.ts
+++ b/apps/frontend/src/components/history-chart-scale.ts
@@ -1,6 +1,7 @@
 const LOG_SCALE_MIN_POINTS = 3;
 const LOG_SCALE_MIN_RATIO = 10;
 const LINEAR_DOMAIN_PADDING_RATIO = 0.15;
+const LINEAR_ZERO_ANCHOR_RANGE_RATIO = 0.2;
 const LINEAR_MIN_VISIBLE_SPAN_RATIO = 0.0001;
 const LINEAR_MIN_VISIBLE_SPAN = 0.01;
 
@@ -20,8 +21,24 @@ export interface HistoryChartScaleConfig {
 function getLinearDomain(values: number[]): [number, number] {
   const minValue = Math.min(...values);
   const maxValue = Math.max(...values);
-  const center = (minValue + maxValue) / 2;
   const range = maxValue - minValue;
+  const maxMagnitude = Math.max(Math.abs(minValue), Math.abs(maxValue));
+  const relativeRange = maxMagnitude > 0 ? range / maxMagnitude : 0;
+
+  if (relativeRange >= LINEAR_ZERO_ANCHOR_RANGE_RATIO) {
+    if (minValue >= 0) {
+      return [0, Math.max(maxValue * (1 + LINEAR_DOMAIN_PADDING_RATIO), LINEAR_MIN_VISIBLE_SPAN)];
+    }
+
+    if (maxValue <= 0) {
+      return [
+        Math.min(minValue * (1 + LINEAR_DOMAIN_PADDING_RATIO), -LINEAR_MIN_VISIBLE_SPAN),
+        0,
+      ];
+    }
+  }
+
+  const center = (minValue + maxValue) / 2;
   const minVisibleSpan = Math.max(
     Math.abs(center) * LINEAR_MIN_VISIBLE_SPAN_RATIO,
     LINEAR_MIN_VISIBLE_SPAN,

--- a/apps/frontend/src/features/devices-sync/components/device-sync-section.tsx
+++ b/apps/frontend/src/features/devices-sync/components/device-sync-section.tsx
@@ -169,6 +169,9 @@ export function DeviceSyncSection() {
       if (result.status === "error") {
         throw new Error(result.message);
       }
+      if (result.status === "not_ready") {
+        throw new Error(result.message);
+      }
       setOverwriteRisk(null);
       setShowBootstrapOverwriteDialog(false);
     } catch (err) {
@@ -202,6 +205,9 @@ export function DeviceSyncSection() {
         }
 
         if (result.status === "error") {
+          throw new Error(result.message);
+        }
+        if (result.status === "not_ready") {
           throw new Error(result.message);
         }
 

--- a/apps/frontend/src/features/devices-sync/components/pairing-flow/index.test.tsx
+++ b/apps/frontend/src/features/devices-sync/components/pairing-flow/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { PairingFlow } from "./index";
 
@@ -22,6 +22,8 @@ vi.mock("@/adapters", () => ({
     debug: vi.fn(),
     trace: vi.fn(),
   },
+  backupDatabase: vi.fn(),
+  openFileSaveDialog: vi.fn(),
 }));
 
 describe("PairingFlow", () => {
@@ -77,5 +79,33 @@ describe("PairingFlow", () => {
         "Sync needs to be restored from this device before you can connect another device.",
       ),
     ).toBeInTheDocument();
+  });
+
+  it("shows claimer overwrite prompt and approves overwrite once", () => {
+    const approveOverwrite = vi.fn();
+    hookMocks.useSyncStatus.mockReturnValue({
+      device: { trustState: "untrusted" },
+    });
+    hookMocks.usePairingClaimer.mockReturnValue({
+      step: "overwrite_required",
+      error: null,
+      sas: null,
+      overwriteInfo: {
+        localRows: 1,
+        nonEmptyTables: [{ table: "accounts", rows: 1 }],
+      },
+      isApprovingOverwrite: false,
+      submitCode: vi.fn(),
+      approveOverwrite,
+      cancel: vi.fn(),
+      retry: vi.fn(),
+    });
+    hookMocks.usePairingIssuer.mockReturnValue({});
+
+    render(<PairingFlow />);
+
+    expect(screen.getByText("Replace data on this device?")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Replace & Sync" }));
+    expect(approveOverwrite).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/frontend/src/features/devices-sync/components/pairing-flow/index.tsx
+++ b/apps/frontend/src/features/devices-sync/components/pairing-flow/index.tsx
@@ -2,9 +2,11 @@
 // Main component that orchestrates the pairing flow (issuer and claimer)
 // =====================================================================
 
-import { useEffect, useRef, useCallback } from "react";
+import { backupDatabase, logger, openFileSaveDialog } from "@/adapters";
+import { Icons } from "@wealthfolio/ui";
+import { Button } from "@wealthfolio/ui/components/ui/button";
+import { useEffect, useRef, useCallback, useState } from "react";
 import { usePairingIssuer, usePairingClaimer, useSyncStatus } from "../../hooks";
-import { logger } from "@/adapters";
 import { DisplayCode } from "./display-code";
 import { SASVerification } from "./sas-verification";
 import { WaitingState } from "./waiting-state";
@@ -165,7 +167,19 @@ function IssuerFlow({ onComplete, onCancel, title, description }: PairingFlowPro
 
 // Claimer Flow (untrusted device - enters code and receives keys)
 function ClaimerFlow({ onComplete, onCancel, title, description }: PairingFlowProps) {
-  const { step, error, sas, submitCode, cancel, retry } = usePairingClaimer();
+  const {
+    step,
+    error,
+    sas,
+    overwriteInfo,
+    isApprovingOverwrite,
+    submitCode,
+    approveOverwrite,
+    cancel,
+    retry,
+  } = usePairingClaimer();
+  const [isBackingUp, setIsBackingUp] = useState(false);
+  const [backupError, setBackupError] = useState<string | null>(null);
 
   const handleCancel = useCallback(async () => {
     await cancel();
@@ -175,6 +189,21 @@ function ClaimerFlow({ onComplete, onCancel, title, description }: PairingFlowPr
   const handleDone = useCallback(() => {
     onComplete?.();
   }, [onComplete]);
+
+  const handleBackupThenApprove = useCallback(async () => {
+    setIsBackingUp(true);
+    setBackupError(null);
+    try {
+      const { filename, data } = await backupDatabase();
+      const saved = await openFileSaveDialog(data, filename);
+      if (!saved) return;
+      await approveOverwrite();
+    } catch (err) {
+      setBackupError(err instanceof Error ? err.message : "Backup failed");
+    } finally {
+      setIsBackingUp(false);
+    }
+  }, [approveOverwrite]);
 
   switch (step) {
     case "enter_code":
@@ -198,6 +227,19 @@ function ClaimerFlow({ onComplete, onCancel, title, description }: PairingFlowPr
         <WaitingState title="Syncing your data..." description="This may take a few seconds" />
       );
 
+    case "overwrite_required":
+      return (
+        <PairingOverwriteConsent
+          localRows={overwriteInfo?.localRows ?? 0}
+          error={backupError}
+          isBackingUp={isBackingUp}
+          isApproving={isApprovingOverwrite}
+          onCancel={handleCancel}
+          onBackupThenApprove={handleBackupThenApprove}
+          onApprove={approveOverwrite}
+        />
+      );
+
     case "success":
       return <PairingResult success onDone={handleDone} />;
 
@@ -207,6 +249,72 @@ function ClaimerFlow({ onComplete, onCancel, title, description }: PairingFlowPr
     default:
       return null;
   }
+}
+
+function PairingOverwriteConsent({
+  localRows,
+  error,
+  isBackingUp,
+  isApproving,
+  onCancel,
+  onBackupThenApprove,
+  onApprove,
+}: {
+  localRows: number;
+  error: string | null;
+  isBackingUp: boolean;
+  isApproving: boolean;
+  onCancel: () => void;
+  onBackupThenApprove: () => void;
+  onApprove: () => void;
+}) {
+  const isBusy = isBackingUp || isApproving;
+  const rowLabel = localRows === 1 ? "row" : "rows";
+
+  return (
+    <div className="flex flex-col items-center gap-6 px-4 py-2 text-center">
+      <div className="border-warning/30 bg-warning/10 dark:border-warning/20 dark:bg-warning/15 flex h-14 w-14 items-center justify-center rounded-full border">
+        <Icons.AlertTriangle className="h-6 w-6 text-amber-500" />
+      </div>
+      <div className="space-y-2">
+        <h2 className="text-xl font-semibold">Replace data on this device?</h2>
+        <p className="text-muted-foreground text-sm">
+          Your local data will be replaced with data from your other connected device.
+        </p>
+        {localRows > 0 && (
+          <p className="text-muted-foreground text-xs">
+            {localRows} local {rowLabel} will be replaced.
+          </p>
+        )}
+        {error && <p className="text-destructive text-sm">{error}</p>}
+      </div>
+      <div className="flex w-full flex-col gap-2 sm:flex-row sm:justify-center">
+        <Button variant="ghost" onClick={onCancel} disabled={isBusy}>
+          Not now
+        </Button>
+        <Button variant="outline" onClick={onBackupThenApprove} disabled={isBusy}>
+          {isBackingUp ? (
+            <>
+              <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />
+              Backing up...
+            </>
+          ) : (
+            "Back up first"
+          )}
+        </Button>
+        <Button onClick={onApprove} disabled={isBusy}>
+          {isApproving ? (
+            <>
+              <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />
+              Syncing...
+            </>
+          ) : (
+            "Replace & Sync"
+          )}
+        </Button>
+      </div>
+    </div>
+  );
 }
 
 // Re-export sub-components for flexibility

--- a/apps/frontend/src/features/devices-sync/hooks/use-active-app-sync-trigger.test.tsx
+++ b/apps/frontend/src/features/devices-sync/hooks/use-active-app-sync-trigger.test.tsx
@@ -1,0 +1,258 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useActiveAppSyncTrigger } from "./use-active-app-sync-trigger";
+
+const adapterMocks = vi.hoisted(() => ({
+  syncTriggerCycle: vi.fn(),
+}));
+
+const storageMocks = vi.hoisted(() => ({
+  syncStorage: {
+    getDeviceId: vi.fn(),
+    getRootKey: vi.fn(),
+  },
+}));
+
+vi.mock("@/adapters", () => adapterMocks);
+vi.mock("../storage/keyring", () => storageMocks);
+
+function setVisibilityState(value: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    value,
+  });
+}
+
+async function flushLifecycleTrigger() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("useActiveAppSyncTrigger", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-22T12:00:00Z"));
+    vi.clearAllMocks();
+    adapterMocks.syncTriggerCycle.mockResolvedValue(undefined);
+    storageMocks.syncStorage.getDeviceId.mockResolvedValue("device-1");
+    storageMocks.syncStorage.getRootKey.mockResolvedValue("root-key");
+    setVisibilityState("visible");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not trigger sync when disabled", async () => {
+    renderHook(() => useActiveAppSyncTrigger({ enabled: false }));
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+      window.dispatchEvent(new Event("focus"));
+      window.dispatchEvent(new Event("online"));
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    await flushLifecycleTrigger();
+    expect(adapterMocks.syncTriggerCycle).not.toHaveBeenCalled();
+    expect(storageMocks.syncStorage.getDeviceId).not.toHaveBeenCalled();
+    expect(storageMocks.syncStorage.getRootKey).not.toHaveBeenCalled();
+  });
+
+  it("triggers sync on focus, visibility, and online events", async () => {
+    renderHook(() => useActiveAppSyncTrigger({ enabled: true }));
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+      window.dispatchEvent(new Event("focus"));
+    });
+    await flushLifecycleTrigger();
+    expect(adapterMocks.syncTriggerCycle).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    await flushLifecycleTrigger();
+    expect(adapterMocks.syncTriggerCycle).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+      window.dispatchEvent(new Event("online"));
+    });
+    await flushLifecycleTrigger();
+    expect(adapterMocks.syncTriggerCycle).toHaveBeenCalledTimes(3);
+  });
+
+  it("throttles repeated lifecycle events", async () => {
+    renderHook(() => useActiveAppSyncTrigger({ enabled: true }));
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+      window.dispatchEvent(new Event("focus"));
+      window.dispatchEvent(new Event("online"));
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    await flushLifecycleTrigger();
+    expect(adapterMocks.syncTriggerCycle).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(29_999);
+      window.dispatchEvent(new Event("focus"));
+    });
+    expect(adapterMocks.syncTriggerCycle).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+      window.dispatchEvent(new Event("focus"));
+    });
+    await flushLifecycleTrigger();
+    expect(adapterMocks.syncTriggerCycle).toHaveBeenCalledTimes(2);
+  });
+
+  it("triggers sync every minute while visible", async () => {
+    renderHook(() => useActiveAppSyncTrigger({ enabled: true }));
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    await flushLifecycleTrigger();
+    expect(adapterMocks.syncTriggerCycle).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    await flushLifecycleTrigger();
+    expect(adapterMocks.syncTriggerCycle).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not run interval sync while hidden", async () => {
+    renderHook(() => useActiveAppSyncTrigger({ enabled: true }));
+
+    act(() => {
+      setVisibilityState("hidden");
+      vi.advanceTimersByTime(60_000);
+    });
+    await flushLifecycleTrigger();
+    expect(adapterMocks.syncTriggerCycle).not.toHaveBeenCalled();
+
+    act(() => {
+      setVisibilityState("visible");
+      vi.advanceTimersByTime(60_000);
+    });
+    await flushLifecycleTrigger();
+    expect(adapterMocks.syncTriggerCycle).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores hidden visibility changes and swallowed sync failures", async () => {
+    adapterMocks.syncTriggerCycle.mockRejectedValue(new Error("offline"));
+    renderHook(() => useActiveAppSyncTrigger({ enabled: true }));
+
+    act(() => {
+      setVisibilityState("hidden");
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+    expect(adapterMocks.syncTriggerCycle).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+      setVisibilityState("visible");
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    await flushLifecycleTrigger();
+    expect(adapterMocks.syncTriggerCycle).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows online to retry immediately after a failed attempt", async () => {
+    adapterMocks.syncTriggerCycle
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce(undefined);
+    renderHook(() => useActiveAppSyncTrigger({ enabled: true }));
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+      window.dispatchEvent(new Event("focus"));
+    });
+    await flushLifecycleTrigger();
+    expect(adapterMocks.syncTriggerCycle).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+      window.dispatchEvent(new Event("focus"));
+    });
+    await flushLifecycleTrigger();
+    expect(adapterMocks.syncTriggerCycle).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      window.dispatchEvent(new Event("online"));
+    });
+    await flushLifecycleTrigger();
+    expect(adapterMocks.syncTriggerCycle).toHaveBeenCalledTimes(2);
+  });
+
+  it("throttles repeated online recovery retries after failure", async () => {
+    adapterMocks.syncTriggerCycle.mockRejectedValue(new Error("offline"));
+    renderHook(() => useActiveAppSyncTrigger({ enabled: true }));
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+      window.dispatchEvent(new Event("focus"));
+    });
+    await flushLifecycleTrigger();
+    expect(adapterMocks.syncTriggerCycle).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+      window.dispatchEvent(new Event("online"));
+    });
+    await flushLifecycleTrigger();
+    expect(adapterMocks.syncTriggerCycle).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+      window.dispatchEvent(new Event("online"));
+    });
+    await flushLifecycleTrigger();
+    expect(adapterMocks.syncTriggerCycle).toHaveBeenCalledTimes(2);
+
+    act(() => {
+      vi.advanceTimersByTime(29_999);
+      window.dispatchEvent(new Event("online"));
+    });
+    await flushLifecycleTrigger();
+    expect(adapterMocks.syncTriggerCycle).toHaveBeenCalledTimes(3);
+  });
+
+  it("suppresses startup lifecycle events during the initial throttle window", () => {
+    renderHook(() => useActiveAppSyncTrigger({ enabled: true }));
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+      window.dispatchEvent(new Event("online"));
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(adapterMocks.syncTriggerCycle).not.toHaveBeenCalled();
+    expect(storageMocks.syncStorage.getDeviceId).not.toHaveBeenCalled();
+    expect(storageMocks.syncStorage.getRootKey).not.toHaveBeenCalled();
+  });
+
+  it("skips automatic sync when local device sync identity is incomplete", async () => {
+    storageMocks.syncStorage.getRootKey.mockResolvedValue(null);
+    renderHook(() => useActiveAppSyncTrigger({ enabled: true }));
+
+    act(() => {
+      vi.advanceTimersByTime(30_000);
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    await flushLifecycleTrigger();
+    expect(storageMocks.syncStorage.getRootKey).toHaveBeenCalledTimes(1);
+    expect(adapterMocks.syncTriggerCycle).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/features/devices-sync/hooks/use-active-app-sync-trigger.test.tsx
+++ b/apps/frontend/src/features/devices-sync/hooks/use-active-app-sync-trigger.test.tsx
@@ -24,6 +24,13 @@ function setVisibilityState(value: DocumentVisibilityState) {
   });
 }
 
+function setDocumentHasFocus(value: boolean) {
+  Object.defineProperty(document, "hasFocus", {
+    configurable: true,
+    value: () => value,
+  });
+}
+
 async function flushLifecycleTrigger() {
   await Promise.resolve();
   await Promise.resolve();
@@ -40,6 +47,7 @@ describe("useActiveAppSyncTrigger", () => {
     storageMocks.syncStorage.getDeviceId.mockResolvedValue("device-1");
     storageMocks.syncStorage.getRootKey.mockResolvedValue("root-key");
     setVisibilityState("visible");
+    setDocumentHasFocus(true);
   });
 
   afterEach(() => {
@@ -142,6 +150,39 @@ describe("useActiveAppSyncTrigger", () => {
 
     act(() => {
       setVisibilityState("visible");
+      vi.advanceTimersByTime(60_000);
+    });
+    await flushLifecycleTrigger();
+    expect(adapterMocks.syncTriggerCycle).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not run desktop interval sync while visible but unfocused", async () => {
+    setDocumentHasFocus(false);
+    renderHook(() =>
+      useActiveAppSyncTrigger({ enabled: true, requireWindowFocusForInterval: true }),
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    await flushLifecycleTrigger();
+    expect(adapterMocks.syncTriggerCycle).not.toHaveBeenCalled();
+
+    act(() => {
+      setDocumentHasFocus(true);
+      window.dispatchEvent(new Event("focus"));
+    });
+    await flushLifecycleTrigger();
+    expect(adapterMocks.syncTriggerCycle).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps mobile interval sync based on visibility without requiring focus", async () => {
+    setDocumentHasFocus(false);
+    renderHook(() =>
+      useActiveAppSyncTrigger({ enabled: true, requireWindowFocusForInterval: false }),
+    );
+
+    act(() => {
       vi.advanceTimersByTime(60_000);
     });
     await flushLifecycleTrigger();

--- a/apps/frontend/src/features/devices-sync/hooks/use-active-app-sync-trigger.ts
+++ b/apps/frontend/src/features/devices-sync/hooks/use-active-app-sync-trigger.ts
@@ -1,0 +1,93 @@
+import { syncTriggerCycle } from "@/adapters";
+import { useEffect, useRef } from "react";
+import { syncStorage } from "../storage/keyring";
+
+const ACTIVE_APP_SYNC_THROTTLE_MS = 30_000;
+const VISIBLE_SYNC_INTERVAL_MS = 60_000;
+
+interface UseActiveAppSyncTriggerOptions {
+  enabled: boolean;
+}
+
+type ActiveAppSyncReason = "focus" | "online" | "visible";
+
+export function useActiveAppSyncTrigger({ enabled }: UseActiveAppSyncTriggerOptions) {
+  // The backend starts the background sync loop on app startup; seed the
+  // throttle so startup focus/online events do not queue a duplicate cycle.
+  const lastAttemptAtRef = useRef(Date.now());
+  const lastOnlineRecoveryAttemptAtRef = useRef(Number.NEGATIVE_INFINITY);
+  const lastAttemptFailedRef = useRef(false);
+  const inFlightRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const triggerSync = (reason: ActiveAppSyncReason) => {
+      const now = Date.now();
+      const shouldBypassThrottle =
+        reason === "online" &&
+        lastAttemptFailedRef.current &&
+        now - lastOnlineRecoveryAttemptAtRef.current >= ACTIVE_APP_SYNC_THROTTLE_MS;
+      if (inFlightRef.current) {
+        return;
+      }
+      if (!shouldBypassThrottle && now - lastAttemptAtRef.current < ACTIVE_APP_SYNC_THROTTLE_MS) {
+        return;
+      }
+
+      lastAttemptAtRef.current = now;
+      if (shouldBypassThrottle) {
+        lastOnlineRecoveryAttemptAtRef.current = now;
+      }
+      inFlightRef.current = true;
+      void (async () => {
+        const deviceId = await syncStorage.getDeviceId();
+        if (!deviceId) {
+          lastAttemptFailedRef.current = false;
+          return;
+        }
+
+        const rootKey = await syncStorage.getRootKey();
+        if (!rootKey) {
+          lastAttemptFailedRef.current = false;
+          return;
+        }
+
+        await syncTriggerCycle();
+        lastAttemptFailedRef.current = false;
+      })()
+        .catch(() => {
+          lastAttemptFailedRef.current = true;
+        })
+        .finally(() => {
+          inFlightRef.current = false;
+        });
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        triggerSync("visible");
+      }
+    };
+    const handleFocus = () => triggerSync("focus");
+    const handleOnline = () => triggerSync("online");
+    const visibleIntervalId = window.setInterval(() => {
+      if (document.visibilityState === "visible") {
+        triggerSync("visible");
+      }
+    }, VISIBLE_SYNC_INTERVAL_MS);
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    window.addEventListener("focus", handleFocus);
+    window.addEventListener("online", handleOnline);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("focus", handleFocus);
+      window.removeEventListener("online", handleOnline);
+      window.clearInterval(visibleIntervalId);
+    };
+  }, [enabled]);
+}

--- a/apps/frontend/src/features/devices-sync/hooks/use-active-app-sync-trigger.ts
+++ b/apps/frontend/src/features/devices-sync/hooks/use-active-app-sync-trigger.ts
@@ -7,11 +7,15 @@ const VISIBLE_SYNC_INTERVAL_MS = 60_000;
 
 interface UseActiveAppSyncTriggerOptions {
   enabled: boolean;
+  requireWindowFocusForInterval?: boolean;
 }
 
 type ActiveAppSyncReason = "focus" | "online" | "visible";
 
-export function useActiveAppSyncTrigger({ enabled }: UseActiveAppSyncTriggerOptions) {
+export function useActiveAppSyncTrigger({
+  enabled,
+  requireWindowFocusForInterval = false,
+}: UseActiveAppSyncTriggerOptions) {
   // The backend starts the background sync loop on app startup; seed the
   // throttle so startup focus/online events do not queue a duplicate cycle.
   const lastAttemptAtRef = useRef(Date.now());
@@ -66,15 +70,23 @@ export function useActiveAppSyncTrigger({ enabled }: UseActiveAppSyncTriggerOpti
         });
     };
 
+    const isActiveForInterval = () =>
+      document.visibilityState === "visible" &&
+      (!requireWindowFocusForInterval || document.hasFocus());
+
     const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible") {
+      if (isActiveForInterval()) {
         triggerSync("visible");
       }
     };
-    const handleFocus = () => triggerSync("focus");
+    const handleFocus = () => {
+      if (document.visibilityState === "visible") {
+        triggerSync("focus");
+      }
+    };
     const handleOnline = () => triggerSync("online");
     const visibleIntervalId = window.setInterval(() => {
-      if (document.visibilityState === "visible") {
+      if (isActiveForInterval()) {
         triggerSync("visible");
       }
     }, VISIBLE_SYNC_INTERVAL_MS);
@@ -89,5 +101,5 @@ export function useActiveAppSyncTrigger({ enabled }: UseActiveAppSyncTriggerOpti
       window.removeEventListener("online", handleOnline);
       window.clearInterval(visibleIntervalId);
     };
-  }, [enabled]);
+  }, [enabled, requireWindowFocusForInterval]);
 }

--- a/apps/frontend/src/features/devices-sync/hooks/use-pairing-claimer.test.tsx
+++ b/apps/frontend/src/features/devices-sync/hooks/use-pairing-claimer.test.tsx
@@ -1,0 +1,123 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { usePairingClaimer } from "./use-pairing-claimer";
+
+const adapterMocks = vi.hoisted(() => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+  },
+  beginPairingConfirm: vi.fn(),
+  getPairingFlowState: vi.fn(),
+  cancelPairingFlow: vi.fn(),
+  approvePairingOverwrite: vi.fn(),
+}));
+
+const serviceMocks = vi.hoisted(() => ({
+  syncService: {
+    claimPairingSession: vi.fn(),
+    pollForKeyBundle: vi.fn(),
+    cancelPairing: vi.fn(),
+    clearSyncData: vi.fn(),
+  },
+}));
+
+const storageMocks = vi.hoisted(() => ({
+  syncStorage: {
+    setE2EECredentials: vi.fn(),
+  },
+}));
+
+const cryptoMocks = vi.hoisted(() => ({
+  computeSAS: vi.fn(),
+  hmacSha256: vi.fn(),
+}));
+
+vi.mock("@/adapters", () => adapterMocks);
+vi.mock("../services/sync-service", () => serviceMocks);
+vi.mock("../storage/keyring", () => storageMocks);
+vi.mock("../crypto", () => cryptoMocks);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("usePairingClaimer", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    serviceMocks.syncService.claimPairingSession.mockResolvedValue({
+      pairingId: "pair-1",
+      code: "ABC123",
+      ephemeralSecretKey: "ephemeral-secret",
+      ephemeralPublicKey: "ephemeral-public",
+      issuerPublicKey: "issuer-public",
+      sessionKey: "session-key",
+      e2eeKeyVersion: 2,
+      requireSas: true,
+      expiresAt: new Date("2026-04-29T12:00:00Z"),
+      status: "approved",
+    });
+    serviceMocks.syncService.pollForKeyBundle.mockResolvedValue({
+      received: true,
+      keyBundle: {
+        version: 1,
+        rootKey: "root-key",
+        keyVersion: 2,
+      },
+      keyBundleCreatedAt: "2026-04-29T12:01:00Z",
+      status: "completed",
+    });
+    serviceMocks.syncService.cancelPairing.mockResolvedValue({ success: true });
+    serviceMocks.syncService.clearSyncData.mockResolvedValue(undefined);
+    storageMocks.syncStorage.setE2EECredentials.mockResolvedValue(undefined);
+    cryptoMocks.computeSAS.mockResolvedValue("123456");
+    cryptoMocks.hmacSha256.mockResolvedValue("proof");
+    adapterMocks.beginPairingConfirm.mockResolvedValue({
+      flowId: "flow-1",
+      phase: {
+        phase: "overwrite_required",
+        info: { localRows: 3, nonEmptyTables: [{ table: "accounts", rows: 1 }] },
+      },
+    });
+    adapterMocks.cancelPairingFlow.mockResolvedValue({
+      flowId: "flow-1",
+      phase: { phase: "success" },
+    });
+  });
+
+  it("clears local sync data when cancelling after overwrite consent is reached", async () => {
+    const { result } = renderHook(() => usePairingClaimer(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.submitCode("ABC123");
+    });
+
+    await waitFor(() => expect(result.current.step).toBe("overwrite_required"));
+
+    await act(async () => {
+      await result.current.cancel();
+    });
+
+    expect(adapterMocks.cancelPairingFlow).toHaveBeenCalledWith("flow-1");
+    expect(serviceMocks.syncService.clearSyncData).toHaveBeenCalledTimes(1);
+    expect(serviceMocks.syncService.cancelPairing).not.toHaveBeenCalled();
+    expect(result.current.step).toBe("enter_code");
+  });
+});

--- a/apps/frontend/src/features/devices-sync/hooks/use-pairing-claimer.ts
+++ b/apps/frontend/src/features/devices-sync/hooks/use-pairing-claimer.ts
@@ -1,10 +1,15 @@
 // usePairingClaimer
 // Self-contained hook for the claimer (new device) pairing flow.
 // Uses backend-owned pairing flow coordinator for the post-SAS phase.
-// Overwrite consent is handled by the auto-bootstrap AlertDialog after pairing.
 // ================================================================
 
-import { logger, beginPairingConfirm, getPairingFlowState, cancelPairingFlow } from "@/adapters";
+import {
+  logger,
+  beginPairingConfirm,
+  getPairingFlowState,
+  cancelPairingFlow,
+  approvePairingOverwrite,
+} from "@/adapters";
 import type { PairingFlowPhase } from "@/adapters";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -13,12 +18,25 @@ import { syncService } from "../services/sync-service";
 import { syncStorage } from "../storage/keyring";
 import type { ClaimerSession, KeyBundlePayload } from "../types";
 
-type ClaimerPhase = "idle" | "connecting" | "claimed" | "flow_active" | "complete" | "error";
+type ClaimerPhase =
+  | "idle"
+  | "connecting"
+  | "claimed"
+  | "flow_active"
+  | "overwrite_required"
+  | "complete"
+  | "error";
+
+export interface PairingOverwriteInfo {
+  localRows: number;
+  nonEmptyTables: { table: string; rows: number }[];
+}
 
 export type ClaimerStep =
   | "enter_code"
   | "connecting"
   | "waiting_keys"
+  | "overwrite_required"
   | "syncing"
   | "success"
   | "error";
@@ -29,6 +47,8 @@ export function usePairingClaimer() {
   const [session, setSession] = useState<ClaimerSession | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [flowId, setFlowId] = useState<string | null>(null);
+  const [overwriteInfo, setOverwriteInfo] = useState<PairingOverwriteInfo | null>(null);
+  const [isApprovingOverwrite, setIsApprovingOverwrite] = useState(false);
 
   // Guard against auto-proceed firing twice
   const autoProceedFired = useRef(false);
@@ -67,6 +87,7 @@ export function usePairingClaimer() {
   const step: ClaimerStep = useMemo(() => {
     if (phase === "error") return "error";
     if (phase === "complete") return "success";
+    if (phase === "overwrite_required") return "overwrite_required";
     if (phase === "flow_active") {
       if (flowPoll.error) return "error";
       return "syncing";
@@ -90,6 +111,32 @@ export function usePairingClaimer() {
     }
     return null;
   }, [error, keyPoll.error, flowPoll.error]);
+
+  const processFlowPhase = useCallback(
+    (flowPhase: PairingFlowPhase) => {
+      switch (flowPhase.phase) {
+        case "overwrite_required":
+          setOverwriteInfo(flowPhase.info);
+          setPhase("overwrite_required");
+          break;
+        case "syncing":
+          setOverwriteInfo(null);
+          setPhase("flow_active");
+          break;
+        case "success":
+          setOverwriteInfo(null);
+          setPhase("complete");
+          queryClient.invalidateQueries({ queryKey: ["sync"] });
+          break;
+        case "error":
+          setOverwriteInfo(null);
+          setError(flowPhase.message);
+          setPhase("error");
+          break;
+      }
+    },
+    [queryClient],
+  );
 
   // Auto-proceed: when key bundle received, store credentials + call beginPairingConfirm
   useEffect(() => {
@@ -126,7 +173,7 @@ export function usePairingClaimer() {
         setPhase("error");
       }
     })();
-  }, [phase, keyPoll.data, session]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [phase, keyPoll.data, session, processFlowPhase]);
 
   // Process flow poll results
   useEffect(() => {
@@ -134,25 +181,7 @@ export function usePairingClaimer() {
     const data = flowPoll.data;
     if (!data) return;
     processFlowPhase(data.phase);
-  }, [phase, flowPoll.data]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  function processFlowPhase(flowPhase: PairingFlowPhase) {
-    switch (flowPhase.phase) {
-      case "overwrite_required":
-        // Backend no longer sends this during pairing — treat as syncing
-        break;
-      case "syncing":
-        break;
-      case "success":
-        setPhase("complete");
-        queryClient.invalidateQueries({ queryKey: ["sync"] });
-        break;
-      case "error":
-        setError(flowPhase.message);
-        setPhase("error");
-        break;
-    }
-  }
+  }, [phase, flowPoll.data, processFlowPhase]);
 
   const submitCode = useCallback(async (code: string) => {
     logger.info(`[usePairingClaimer] Submitting code`);
@@ -163,6 +192,7 @@ export function usePairingClaimer() {
       const s = await syncService.claimPairingSession(code);
       logger.info(`[usePairingClaimer] Session claimed, pairingId=${s.pairingId}`);
       setSession(s);
+      setOverwriteInfo(null);
       setPhase("claimed");
     } catch (err) {
       logger.error(`[usePairingClaimer] Claim error: ${err}`);
@@ -171,15 +201,42 @@ export function usePairingClaimer() {
     }
   }, []);
 
-  const cancel = useCallback(async () => {
-    if (flowId) {
-      await cancelPairingFlow(flowId).catch(() => {});
+  const approveOverwrite = useCallback(async () => {
+    if (!flowId || isApprovingOverwrite) return;
+    setError(null);
+    setIsApprovingOverwrite(true);
+    try {
+      const result = await approvePairingOverwrite(flowId);
+      setFlowId(result.flowId);
+      processFlowPhase(result.phase);
+    } catch (err) {
+      logger.error(`[usePairingClaimer] Overwrite approval error: ${err}`);
+      setError(err instanceof Error ? err.message : String(err));
+      setPhase("error");
+    } finally {
+      setIsApprovingOverwrite(false);
     }
-    if (session) {
+  }, [flowId, isApprovingOverwrite, processFlowPhase]);
+
+  const cancel = useCallback(async () => {
+    const hadConfirmedFlow = !!flowId;
+    if (flowId) {
+      await cancelPairingFlow(flowId).catch((err) => {
+        logger.warn(`[usePairingClaimer] Failed to cancel pairing flow: ${err}`);
+      });
+    } else if (session) {
       await syncService.cancelPairing(session.pairingId).catch(() => {});
+    }
+    if (hadConfirmedFlow) {
+      await syncService.clearSyncData().catch((err) => {
+        logger.warn(
+          `[usePairingClaimer] Failed to clear local sync data after pairing cancel: ${err}`,
+        );
+      });
     }
     setSession(null);
     setFlowId(null);
+    setOverwriteInfo(null);
     setPhase("idle");
     setError(null);
     autoProceedFired.current = false;
@@ -188,6 +245,7 @@ export function usePairingClaimer() {
   const retry = useCallback(() => {
     setSession(null);
     setFlowId(null);
+    setOverwriteInfo(null);
     setPhase("idle");
     setError(null);
     autoProceedFired.current = false;
@@ -197,7 +255,10 @@ export function usePairingClaimer() {
     step,
     error: errorMessage,
     sas: sasQuery.data ?? null,
+    overwriteInfo,
+    isApprovingOverwrite,
     submitCode,
+    approveOverwrite,
     cancel,
     retry,
   };

--- a/apps/frontend/src/features/devices-sync/services/sync-service.pairing.test.ts
+++ b/apps/frontend/src/features/devices-sync/services/sync-service.pairing.test.ts
@@ -208,4 +208,28 @@ describe("syncService pairing", () => {
       message: "Waiting for a fresh snapshot",
     });
   });
+
+  it("does not treat skipped_not_ready reconcile as applied", async () => {
+    adapterMocks.deviceSyncReconcileReadyState.mockResolvedValue({
+      status: "skipped_not_ready",
+      message: "Device is not in READY state",
+      bootstrapAction: "NO_BOOTSTRAP",
+      bootstrapStatus: "not_attempted",
+      bootstrapMessage: null,
+      bootstrapSnapshotId: null,
+      cycleStatus: null,
+      cycleNeedsBootstrap: false,
+      retryAttempted: false,
+      retryCycleStatus: null,
+      backgroundStatus: "skipped",
+    });
+
+    const result = await syncService.bootstrapWithOverwriteCheck(true);
+
+    expect(adapterMocks.deviceSyncReconcileReadyState).toHaveBeenCalledWith(true);
+    expect(result).toEqual({
+      status: "not_ready",
+      message: "Device is not in READY state",
+    });
+  });
 });

--- a/apps/frontend/src/features/devices-sync/services/sync-service.ts
+++ b/apps/frontend/src/features/devices-sync/services/sync-service.ts
@@ -72,6 +72,7 @@ export type BootstrapCheckResult =
       localRows: number;
       nonEmptyTables: { table: string; rows: number }[];
     }
+  | { status: "not_ready"; message: string }
   | { status: "waiting_snapshot"; message: string }
   | { status: "applied"; message: string }
   | { status: "error"; message: string };
@@ -552,6 +553,9 @@ class SyncService {
     const result = await deviceSyncReconcileReadyStateApi(allowOverwrite);
     if (result.status === "error") {
       return { status: "error", message: result.message };
+    }
+    if (result.status === "skipped_not_ready" || result.bootstrapStatus === "skipped_not_ready") {
+      return { status: "not_ready", message: result.message };
     }
 
     const waitingForSnapshot =

--- a/apps/frontend/src/features/goals/retirement-planner/components/retirement-snapshot-table.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/components/retirement-snapshot-table.tsx
@@ -151,7 +151,7 @@ export function RetirementSnapshotTable({
                   {mobileMetrics.map((metric) => (
                     <div key={metric.label} className="min-w-0">
                       <div className="text-muted-foreground leading-3">{metric.label}</div>
-                      <div className="truncate font-medium leading-4 tabular-nums">
+                      <div className="truncate font-medium tabular-nums leading-4">
                         <SnapshotAmount
                           value={metric.value}
                           age={snap.age}

--- a/apps/frontend/src/features/goals/retirement-planner/components/retirement-snapshot-table.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/components/retirement-snapshot-table.tsx
@@ -7,11 +7,32 @@ import {
   CardHeader,
   CardTitle,
   formatAmount,
+  formatCompactAmount,
 } from "@wealthfolio/ui";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
 import { useState } from "react";
 
 const PAGE_SIZE = 10;
+
+function SnapshotAmount({
+  value,
+  age,
+  currency,
+  scaleForModeAtAge,
+  compact = false,
+  empty = "—",
+}: {
+  value: number;
+  age: number;
+  currency: string;
+  scaleForModeAtAge: (value: number, age: number) => number;
+  compact?: boolean;
+  empty?: string;
+}) {
+  if (value <= 0) return empty;
+  const scaledValue = scaleForModeAtAge(value, age);
+  return compact ? formatCompactAmount(scaledValue, currency) : formatAmount(scaledValue, currency);
+}
 
 export function RetirementSnapshotTable({
   snapshots,
@@ -77,85 +98,179 @@ export function RetirementSnapshotTable({
           </div>
         )}
       </CardHeader>
-      <CardContent className="overflow-x-auto">
-        <table className="w-full text-xs">
-          <thead>
-            <tr className="text-muted-foreground border-b">
-              <th className="pb-2 text-left">Age</th>
-              <th className="pb-2 text-left">Year</th>
-              <th className="pb-2 text-left">Phase</th>
-              <th className="pb-2 text-right">End Portfolio</th>
-              {hasPensionFunds && <th className="pb-2 text-right">Pension Fund</th>}
-              <th className="pb-2 text-right">Contribution/yr</th>
-              <th className="pb-2 text-right">Retirement income/yr</th>
-              <th className="pb-2 text-right">Planned spending/yr</th>
-              <th className="pb-2 text-right">Portfolio withdrawal/yr</th>
-            </tr>
-          </thead>
-          <tbody>
-            {pagedSnapshots.map((snap) => {
-              const isFire = snap.phase === "fire";
-              const isFireRow = snap.age === fiAge;
-              const isIncomeRow = incomeStartAges.has(snap.age);
-              return (
-                <tr
-                  key={snap.age}
-                  className={`border-b last:border-0 ${
-                    isFireRow
-                      ? "bg-green-50 font-semibold dark:bg-green-950/20"
-                      : isIncomeRow
-                        ? "bg-blue-50 dark:bg-blue-950/20"
-                        : ""
-                  }`}
-                >
-                  <td className="py-1.5">{snap.age}</td>
-                  <td className="py-1.5">{snap.year}</td>
-                  <td className="py-1.5">
-                    <Badge variant={isFire ? "default" : "secondary"} className="text-xs">
-                      {isFire ? phaseLabel : "Acc."}
+      <CardContent>
+        <div className="overflow-hidden rounded-lg border md:hidden">
+          {pagedSnapshots.map((snap) => {
+            const isFire = snap.phase === "fire";
+            const isFireRow = snap.age === fiAge;
+            const isIncomeRow = incomeStartAges.has(snap.age);
+            const plannedSpending = snap.plannedExpenses ?? snap.annualExpenses;
+            const rowClassName = isFireRow
+              ? "border-l-green-500 bg-green-50/70 dark:bg-green-950/20"
+              : isIncomeRow
+                ? "border-l-blue-500 bg-blue-50/70 dark:bg-blue-950/20"
+                : "border-l-transparent bg-background/40";
+            const phaseText = isFire ? phaseLabel : "Acc.";
+            const mobileMetrics = [
+              { label: "Contrib", value: snap.annualContribution },
+              { label: "Income", value: snap.annualIncome },
+              { label: "Spend", value: plannedSpending },
+              { label: "Draw", value: snap.netWithdrawalFromPortfolio },
+            ];
+
+            return (
+              <div
+                key={snap.age}
+                className={`border-border border-b border-l-2 px-3 py-2.5 last:border-b-0 ${rowClassName}`}
+              >
+                <div className="grid grid-cols-[2.25rem_minmax(0,1fr)_auto] items-center gap-2">
+                  <div className="text-muted-foreground text-xs font-semibold tabular-nums">
+                    {snap.age}
+                  </div>
+                  <div className="flex min-w-0 items-center gap-1.5">
+                    <span className="text-xs font-medium tabular-nums">{snap.year}</span>
+                    <Badge
+                      variant={isFire ? "default" : "secondary"}
+                      className="h-5 shrink-0 px-2 text-[10px]"
+                    >
+                      {phaseText}
                     </Badge>
-                  </td>
-                  <td className="py-1.5 text-right">
-                    {formatAmount(scaleForModeAtAge(snap.portfolioEnd, snap.age), currency)}
-                  </td>
+                  </div>
+                  <div className="text-right text-sm font-semibold tabular-nums">
+                    <SnapshotAmount
+                      value={snap.portfolioEnd}
+                      age={snap.age}
+                      currency={currency}
+                      scaleForModeAtAge={scaleForModeAtAge}
+                      compact
+                    />
+                  </div>
+                </div>
+
+                <div className="mt-1.5 grid grid-cols-4 gap-2 pl-[2.75rem] text-[10px]">
+                  {mobileMetrics.map((metric) => (
+                    <div key={metric.label} className="min-w-0">
+                      <div className="text-muted-foreground leading-3">{metric.label}</div>
+                      <div className="truncate font-medium leading-4 tabular-nums">
+                        <SnapshotAmount
+                          value={metric.value}
+                          age={snap.age}
+                          currency={currency}
+                          scaleForModeAtAge={scaleForModeAtAge}
+                          compact
+                        />
+                      </div>
+                    </div>
+                  ))}
                   {hasPensionFunds && (
-                    <td className="py-1.5 text-right">
-                      {snap.pensionAssets > 0
-                        ? formatAmount(scaleForModeAtAge(snap.pensionAssets, snap.age), currency)
-                        : "—"}
-                    </td>
+                    <div className="col-span-4 min-w-0">
+                      <span className="text-muted-foreground mr-1">Fund</span>
+                      <span className="font-medium tabular-nums">
+                        <SnapshotAmount
+                          value={snap.pensionAssets}
+                          age={snap.age}
+                          currency={currency}
+                          scaleForModeAtAge={scaleForModeAtAge}
+                          compact
+                        />
+                      </span>
+                    </div>
                   )}
-                  <td className="py-1.5 text-right">
-                    {snap.annualContribution > 0
-                      ? formatAmount(scaleForModeAtAge(snap.annualContribution, snap.age), currency)
-                      : "—"}
-                  </td>
-                  <td className="py-1.5 text-right">
-                    {snap.annualIncome > 0
-                      ? formatAmount(scaleForModeAtAge(snap.annualIncome, snap.age), currency)
-                      : "—"}
-                  </td>
-                  <td className="py-1.5 text-right">
-                    {(snap.plannedExpenses ?? snap.annualExpenses) > 0
-                      ? formatAmount(
-                          scaleForModeAtAge(snap.plannedExpenses ?? snap.annualExpenses, snap.age),
-                          currency,
-                        )
-                      : "—"}
-                  </td>
-                  <td className="py-1.5 text-right">
-                    {snap.netWithdrawalFromPortfolio > 0
-                      ? formatAmount(
-                          scaleForModeAtAge(snap.netWithdrawalFromPortfolio, snap.age),
-                          currency,
-                        )
-                      : "—"}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="hidden overflow-x-auto md:block">
+          <table className="w-full min-w-[860px] text-xs">
+            <thead>
+              <tr className="text-muted-foreground border-b">
+                <th className="pb-2 text-left">Age</th>
+                <th className="pb-2 text-left">Year</th>
+                <th className="pb-2 text-left">Phase</th>
+                <th className="pb-2 text-right">End Portfolio</th>
+                {hasPensionFunds && <th className="pb-2 text-right">Pension Fund</th>}
+                <th className="pb-2 text-right">Contribution/yr</th>
+                <th className="pb-2 text-right">Retirement income/yr</th>
+                <th className="pb-2 text-right">Planned spending/yr</th>
+                <th className="pb-2 text-right">Portfolio withdrawal/yr</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pagedSnapshots.map((snap) => {
+                const isFire = snap.phase === "fire";
+                const isFireRow = snap.age === fiAge;
+                const isIncomeRow = incomeStartAges.has(snap.age);
+                return (
+                  <tr
+                    key={snap.age}
+                    className={`border-b last:border-0 ${
+                      isFireRow
+                        ? "bg-green-50 font-semibold dark:bg-green-950/20"
+                        : isIncomeRow
+                          ? "bg-blue-50 dark:bg-blue-950/20"
+                          : ""
+                    }`}
+                  >
+                    <td className="py-1.5">{snap.age}</td>
+                    <td className="py-1.5">{snap.year}</td>
+                    <td className="py-1.5">
+                      <Badge variant={isFire ? "default" : "secondary"} className="text-xs">
+                        {isFire ? phaseLabel : "Acc."}
+                      </Badge>
+                    </td>
+                    <td className="py-1.5 text-right">
+                      {formatAmount(scaleForModeAtAge(snap.portfolioEnd, snap.age), currency)}
+                    </td>
+                    {hasPensionFunds && (
+                      <td className="py-1.5 text-right">
+                        <SnapshotAmount
+                          value={snap.pensionAssets}
+                          age={snap.age}
+                          currency={currency}
+                          scaleForModeAtAge={scaleForModeAtAge}
+                        />
+                      </td>
+                    )}
+                    <td className="py-1.5 text-right">
+                      <SnapshotAmount
+                        value={snap.annualContribution}
+                        age={snap.age}
+                        currency={currency}
+                        scaleForModeAtAge={scaleForModeAtAge}
+                      />
+                    </td>
+                    <td className="py-1.5 text-right">
+                      <SnapshotAmount
+                        value={snap.annualIncome}
+                        age={snap.age}
+                        currency={currency}
+                        scaleForModeAtAge={scaleForModeAtAge}
+                      />
+                    </td>
+                    <td className="py-1.5 text-right">
+                      <SnapshotAmount
+                        value={snap.plannedExpenses ?? snap.annualExpenses}
+                        age={snap.age}
+                        currency={currency}
+                        scaleForModeAtAge={scaleForModeAtAge}
+                      />
+                    </td>
+                    <td className="py-1.5 text-right">
+                      <SnapshotAmount
+                        value={snap.netWithdrawalFromPortfolio}
+                        age={snap.age}
+                        currency={currency}
+                        scaleForModeAtAge={scaleForModeAtAge}
+                      />
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
       </CardContent>
     </Card>
   );

--- a/apps/frontend/src/pages/account/account-holdings.tsx
+++ b/apps/frontend/src/pages/account/account-holdings.tsx
@@ -161,7 +161,7 @@ const AccountHoldings = ({
 
   return (
     <div>
-      <div className="flex items-center justify-between py-4">
+      <div className="flex items-center justify-between gap-3">
         <h3 className="text-lg font-bold">Holdings</h3>
         {canEditHoldingsDirectly && onAddHoldings && (
           <TooltipProvider>

--- a/apps/frontend/src/pages/account/account-page.tsx
+++ b/apps/frontend/src/pages/account/account-page.tsx
@@ -8,6 +8,7 @@ import {
   CardTitle,
   GainAmount,
   GainPercent,
+  AnimatedToggleGroup,
   IntervalSelector,
   Page,
   PageContent,
@@ -26,7 +27,7 @@ import { useAccounts } from "@/hooks/use-accounts";
 import { useRecalculatePortfolioMutation } from "@/hooks/use-calculate-portfolio";
 import { useValuationHistory } from "@/hooks/use-valuation-history";
 import { canAddHoldings } from "@/lib/activity-restrictions";
-import { AccountType } from "@/lib/constants";
+import { AccountType, HoldingType } from "@/lib/constants";
 import { QueryKeys } from "@/lib/query-keys";
 import { useSettingsContext } from "@/lib/settings-provider";
 import {
@@ -70,6 +71,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { AccountContributionLimit } from "./account-contribution-limit";
 import AccountHoldings from "./account-holdings";
 import AccountMetrics from "./account-metrics";
+import AccountSnapshotHistory from "./account-snapshot-history";
 
 interface HistoryChartData {
   date: string;
@@ -77,6 +79,8 @@ interface HistoryChartData {
   netContribution: number;
   currency: string;
 }
+
+type AccountDetailTab = "holdings" | "snapshots";
 
 // Map account types to icons for visual distinction
 const accountTypeIcons: Record<AccountType, Icon> = {
@@ -120,6 +124,7 @@ const AccountPage = () => {
   const [selectedActivityDate, setSelectedActivityDate] = useState<string | null>(null);
   const [isActivitySheetOpen, setIsActivitySheetOpen] = useState(false);
   const [showBulkHoldingsForm, setShowBulkHoldingsForm] = useState(false);
+  const [accountDetailTab, setAccountDetailTab] = useState<AccountDetailTab>("holdings");
 
   const recalculatePortfolioMutation = useRecalculatePortfolioMutation();
   const { accounts, isLoading: isAccountsLoading } = useAccounts();
@@ -147,6 +152,28 @@ const AccountPage = () => {
     if (!holdings) return false;
     return holdings.length > 0;
   }, [holdings]);
+
+  const hasNonCashHoldings = useMemo(() => {
+    if (!holdings) return false;
+    return holdings.some((holding) => holding.holdingType !== HoldingType.CASH);
+  }, [holdings]);
+
+  const shouldShowSnapshotHistory = isHoldingsMode && hasHoldings && !isHoldingsLoading;
+
+  const accountDetailTabs = useMemo(() => {
+    if (!shouldShowSnapshotHistory) return [];
+
+    const tabs: { value: AccountDetailTab; label: string }[] = [];
+    if (hasNonCashHoldings) {
+      tabs.push({ value: "holdings", label: "Holdings" });
+    }
+    tabs.push({ value: "snapshots", label: "Snapshots" });
+    return tabs;
+  }, [shouldShowSnapshotHistory, hasNonCashHoldings]);
+
+  const activeAccountDetailTab = accountDetailTabs.some((tab) => tab.value === accountDetailTab)
+    ? accountDetailTab
+    : (accountDetailTabs[0]?.value ?? "holdings");
 
   // Format date range for snapshot query
   const snapshotDateFrom = dateRange?.from ? format(dateRange.from, "yyyy-MM-dd") : undefined;
@@ -625,7 +652,35 @@ const AccountPage = () => {
               </div>
             </div>
 
-            <AccountHoldings accountId={id} onAddHoldings={() => setIsEditingHoldings(true)} />
+            {shouldShowSnapshotHistory && account ? (
+              <div className="space-y-4">
+                <AnimatedToggleGroup<AccountDetailTab>
+                  items={accountDetailTabs}
+                  value={activeAccountDetailTab}
+                  onValueChange={setAccountDetailTab}
+                  className="text-sm"
+                />
+
+                {activeAccountDetailTab === "holdings" ? (
+                  <AccountHoldings
+                    accountId={id}
+                    showEmptyState={false}
+                    onAddHoldings={() => setIsEditingHoldings(true)}
+                  />
+                ) : (
+                  <AccountSnapshotHistory
+                    account={account}
+                    canEditSnapshots={canEditHoldingsDirectly}
+                    onAddSnapshot={() => {
+                      setEditingSnapshotDate(null);
+                      setIsEditingHoldings(true);
+                    }}
+                  />
+                )}
+              </div>
+            ) : (
+              <AccountHoldings accountId={id} onAddHoldings={() => setIsEditingHoldings(true)} />
+            )}
           </>
         ) : (
           <AccountHoldings

--- a/apps/frontend/src/pages/account/account-snapshot-history.tsx
+++ b/apps/frontend/src/pages/account/account-snapshot-history.tsx
@@ -1,0 +1,323 @@
+import { deleteSnapshot, getSnapshots } from "@/adapters";
+import { useIsMobileViewport } from "@/hooks/use-platform";
+import { QueryKeys } from "@/lib/query-keys";
+import type { Account, SnapshotInfo } from "@/lib/types";
+import { formatDate } from "@/lib/utils";
+import { HoldingsEditMode } from "@/pages/holdings/components/holdings-edit-mode";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@wealthfolio/ui/components/ui/alert-dialog";
+import { Badge } from "@wealthfolio/ui/components/ui/badge";
+import { Button } from "@wealthfolio/ui/components/ui/button";
+import { Icons } from "@wealthfolio/ui/components/ui/icons";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@wealthfolio/ui/components/ui/sheet";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@wealthfolio/ui/components/ui/table";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@wealthfolio/ui/components/ui/tooltip";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+
+interface AccountSnapshotHistoryProps {
+  account: Account;
+  canEditSnapshots: boolean;
+  onAddSnapshot?: () => void;
+}
+
+export function AccountSnapshotHistory({
+  account,
+  canEditSnapshots,
+  onAddSnapshot,
+}: AccountSnapshotHistoryProps) {
+  const queryClient = useQueryClient();
+  const isMobile = useIsMobileViewport();
+  const [editingDate, setEditingDate] = useState<string | null>(null);
+  const [deletingSnapshot, setDeletingSnapshot] = useState<SnapshotInfo | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const { data: snapshots = [], isLoading } = useQuery<SnapshotInfo[], Error>({
+    queryKey: QueryKeys.snapshots(account.id),
+    queryFn: () => getSnapshots(account.id),
+    enabled: !!account.id,
+  });
+
+  const orderedSnapshots = useMemo(() => {
+    return snapshots
+      .filter((snapshot) => snapshot.source !== "SYNTHETIC")
+      .sort((a, b) => b.snapshotDate.localeCompare(a.snapshotDate));
+  }, [snapshots]);
+
+  const invalidateSnapshotQueries = (date?: string) => {
+    queryClient.invalidateQueries({ queryKey: QueryKeys.snapshots(account.id) });
+    queryClient.invalidateQueries({ queryKey: [QueryKeys.HOLDINGS, account.id] });
+    queryClient.invalidateQueries({ queryKey: [QueryKeys.HOLDINGS] });
+    queryClient.invalidateQueries({ queryKey: [QueryKeys.ACCOUNTS_SIMPLE_PERFORMANCE] });
+    queryClient.invalidateQueries({ queryKey: [QueryKeys.PERFORMANCE_HISTORY] });
+    queryClient.invalidateQueries({ queryKey: [QueryKeys.PERFORMANCE_SUMMARY] });
+    queryClient.invalidateQueries({ queryKey: QueryKeys.valuationHistory(account.id) });
+    queryClient.invalidateQueries({ queryKey: [QueryKeys.HISTORY_VALUATION] });
+    queryClient.invalidateQueries({ queryKey: [QueryKeys.latestValuations] });
+    if (date) {
+      queryClient.invalidateQueries({ queryKey: QueryKeys.snapshotHoldings(account.id, date) });
+    }
+  };
+
+  const handleEditClose = () => {
+    invalidateSnapshotQueries(editingDate ?? undefined);
+    setEditingDate(null);
+  };
+
+  const handleDeleteSnapshot = async () => {
+    if (!deletingSnapshot) return;
+    setIsDeleting(true);
+    try {
+      await deleteSnapshot(account.id, deletingSnapshot.snapshotDate);
+      invalidateSnapshotQueries(deletingSnapshot.snapshotDate);
+      toast.success("Snapshot deleted");
+      setDeletingSnapshot(null);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to delete snapshot");
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const canManageSnapshot = (snapshot: SnapshotInfo) =>
+    canEditSnapshots && snapshot.source !== "CALCULATED" && snapshot.source !== "SYNTHETIC";
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Icons.Spinner className="text-muted-foreground size-5 animate-spin" />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-lg font-bold">Snapshot History</h3>
+          <p className="text-muted-foreground text-sm">
+            Review saved holdings and cash balances by date.
+          </p>
+        </div>
+        {canEditSnapshots && onAddSnapshot && (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={onAddSnapshot}
+                  aria-label="Add snapshot"
+                >
+                  <Icons.Plus className="size-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Add snapshot</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
+      </div>
+
+      {orderedSnapshots.length === 0 ? (
+        <div className="flex items-center justify-center py-12">
+          <div className="space-y-3 text-center">
+            <div className="bg-muted mx-auto flex size-12 items-center justify-center rounded-full">
+              <Icons.History className="text-muted-foreground size-5" />
+            </div>
+            <div>
+              <p className="font-medium">No snapshots yet</p>
+              <p className="text-muted-foreground text-sm">
+                Snapshot history will appear once holdings are saved or imported.
+              </p>
+            </div>
+          </div>
+        </div>
+      ) : isMobile ? (
+        <div className="space-y-2">
+          {orderedSnapshots.map((snapshot) => (
+            <div
+              key={snapshot.id}
+              className="flex items-center gap-3 rounded-lg border px-3 py-2.5"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <p className="truncate text-sm font-medium">
+                    {formatDate(snapshot.snapshotDate)}
+                  </p>
+                  <Badge variant="outline" className="shrink-0 px-1.5 py-0 text-[10px]">
+                    {formatSnapshotSource(snapshot.source)}
+                  </Badge>
+                </div>
+                <p className="text-muted-foreground text-xs">{formatSnapshotCounts(snapshot)}</p>
+              </div>
+              {canManageSnapshot(snapshot) && (
+                <div className="flex shrink-0 items-center gap-0.5">
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-8"
+                    aria-label={`Edit snapshot from ${formatDate(snapshot.snapshotDate)}`}
+                    onClick={() => setEditingDate(snapshot.snapshotDate)}
+                  >
+                    <Icons.Pencil className="size-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="text-destructive size-8"
+                    aria-label={`Delete snapshot from ${formatDate(snapshot.snapshotDate)}`}
+                    onClick={() => setDeletingSnapshot(snapshot)}
+                  >
+                    <Icons.Trash className="size-4" />
+                  </Button>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="rounded-md border">
+          <Table>
+            <TableHeader className="bg-muted/50">
+              <TableRow>
+                <TableHead>Date</TableHead>
+                <TableHead>Source</TableHead>
+                <TableHead className="text-right">Positions</TableHead>
+                <TableHead className="text-right">Cash</TableHead>
+                <TableHead className="w-[96px]" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {orderedSnapshots.map((snapshot) => (
+                <TableRow key={snapshot.id}>
+                  <TableCell className="font-medium">{formatDate(snapshot.snapshotDate)}</TableCell>
+                  <TableCell>
+                    <Badge variant="outline" className="px-1.5 py-0 text-[10px]">
+                      {formatSnapshotSource(snapshot.source)}
+                    </Badge>
+                  </TableCell>
+                  <TableCell className="text-right">{snapshot.positionCount}</TableCell>
+                  <TableCell className="text-right">{snapshot.cashCurrencyCount}</TableCell>
+                  <TableCell className="text-right">
+                    {canManageSnapshot(snapshot) && (
+                      <div className="flex items-center justify-end gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="size-8"
+                          aria-label={`Edit snapshot from ${formatDate(snapshot.snapshotDate)}`}
+                          onClick={() => setEditingDate(snapshot.snapshotDate)}
+                        >
+                          <Icons.Pencil className="size-4" />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          className="text-destructive size-8"
+                          aria-label={`Delete snapshot from ${formatDate(snapshot.snapshotDate)}`}
+                          onClick={() => setDeletingSnapshot(snapshot)}
+                        >
+                          <Icons.Trash className="size-4" />
+                        </Button>
+                      </div>
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      {editingDate && (
+        <Sheet open={!!editingDate} onOpenChange={() => handleEditClose()}>
+          <SheetContent side="right" className="flex h-full w-full flex-col p-0 sm:max-w-2xl">
+            <SheetHeader className="border-b px-6 py-4">
+              <SheetTitle>Update Snapshot</SheetTitle>
+            </SheetHeader>
+            <div className="flex-1 overflow-hidden px-6">
+              <HoldingsEditMode
+                holdings={[]}
+                account={account}
+                isLoading={false}
+                onClose={handleEditClose}
+                existingSnapshotDate={editingDate}
+              />
+            </div>
+          </SheetContent>
+        </Sheet>
+      )}
+
+      <AlertDialog open={!!deletingSnapshot} onOpenChange={() => setDeletingSnapshot(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete Snapshot</AlertDialogTitle>
+            <AlertDialogDescription>
+              Delete the snapshot from{" "}
+              {deletingSnapshot ? formatDate(deletingSnapshot.snapshotDate) : ""}? This removes the
+              positions and cash balances saved for that date.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteSnapshot}
+              disabled={isDeleting}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {isDeleting ? "Deleting..." : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+function formatSnapshotSource(source: string): string {
+  switch (source) {
+    case "MANUAL_ENTRY":
+      return "Manual";
+    case "CSV_IMPORT":
+      return "CSV";
+    case "BROKER_IMPORTED":
+      return "Broker";
+    case "CALCULATED":
+      return "Calculated";
+    case "SYNTHETIC":
+      return "Synthetic";
+    default:
+      return source;
+  }
+}
+
+function formatSnapshotCounts(snapshot: SnapshotInfo): string {
+  const positionLabel = snapshot.positionCount === 1 ? "position" : "positions";
+  const cashLabel = snapshot.cashCurrencyCount === 1 ? "cash balance" : "cash balances";
+  return `${snapshot.positionCount} ${positionLabel}, ${snapshot.cashCurrencyCount} ${cashLabel}`;
+}
+
+export default AccountSnapshotHistory;

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid.tsx
@@ -9,6 +9,7 @@ import { useCallback, useMemo, useRef, useState } from "react";
 import { resolveSymbolQuote } from "@/adapters";
 import { CreateCustomAssetDialog } from "@/components/create-custom-asset-dialog";
 import { ActivityType } from "@/lib/constants";
+import { generateId } from "@/lib/id";
 import { LinkTransferModal } from "../link-transfer-modal";
 import { useActivityMutations } from "../../hooks/use-activity-mutations";
 import { ActivityDataGridPagination } from "./activity-data-grid-pagination";
@@ -166,6 +167,8 @@ export function ActivityDataGrid({
         createdAt: now,
         updatedAt: now,
         isNew: true,
+        comment: "Duplicated",
+        idempotencyKey: generateId("manual-duplicate"),
       };
       setLocalTransactions((prev) => [duplicated, ...prev]);
       markDirtyBatch([duplicated.id]);

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.test.ts
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.test.ts
@@ -362,6 +362,30 @@ describe("activity-utils", () => {
       );
     });
 
+    it("should preserve explicit idempotency keys for new manual duplicates", () => {
+      const transactions: LocalTransaction[] = [
+        createMockTransaction({
+          id: "temp-new-1",
+          isNew: true,
+          idempotencyKey: "manual-duplicate-123",
+        }),
+      ];
+      const dirtyIds = new Set(["temp-new-1"]);
+
+      const result = buildSavePayload(
+        transactions,
+        dirtyIds,
+        new Set(),
+        mockResolveTransactionCurrency,
+        dirtyCurrencyLookup,
+        assetCurrencyLookup,
+        "USD",
+      );
+
+      expect(result.creates).toHaveLength(1);
+      expect(result.creates[0].idempotencyKey).toBe("manual-duplicate-123");
+    });
+
     it("should include quoteCcy hint for existing assets when symbol is unchanged", () => {
       const transactions: LocalTransaction[] = [
         createMockTransaction({

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.ts
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.ts
@@ -483,6 +483,10 @@ export function buildSavePayload(
     if (isNew) {
       // Build CREATE payload - NO asset.id allowed, only asset.symbol + asset.exchangeMic
       const createPayload: ActivityCreatePayload = { ...basePayload };
+      const idempotencyKey = normalizeOptionalString(transaction.idempotencyKey);
+      if (idempotencyKey) {
+        createPayload.idempotencyKey = idempotencyKey;
+      }
 
       if (!isCash) {
         // For NEW market activities: send asset with symbol + exchangeMic

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/types.ts
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/types.ts
@@ -168,6 +168,8 @@ export interface SymbolInput {
  * IMPORTANT: symbol.id is NOT allowed for creates - backend generates canonical IDs
  */
 export interface ActivityCreatePayload extends ActivityBasePayload {
+  /** Explicit key for intentional manual duplicates. */
+  idempotencyKey?: string;
   /** Symbol input - consolidates id, symbol, exchangeMic, kind, name, quoteMode */
   symbol?: SymbolInput;
 }

--- a/apps/frontend/src/pages/activity/components/forms/__tests__/form-schemas.test.ts
+++ b/apps/frontend/src/pages/activity/components/forms/__tests__/form-schemas.test.ts
@@ -9,6 +9,7 @@ import { splitFormSchema } from "../split-form";
 import { feeFormSchema } from "../fee-form";
 import { interestFormSchema } from "../interest-form";
 import { taxFormSchema } from "../tax-form";
+import { newActivitySchema } from "../schemas";
 import { ACTIVITY_FORM_CONFIG } from "../../../config/activity-form-config";
 
 describe("Form Schemas Validation", () => {
@@ -863,6 +864,40 @@ describe("Form Schemas Validation", () => {
 
       const payload = ACTIVITY_FORM_CONFIG.TRANSFER.toPayload(formData as any) as any;
       expect(payload.unitPrice).toBeUndefined();
+    });
+  });
+
+  describe("newActivitySchema extended mobile edit types", () => {
+    it("accepts credit activities", () => {
+      const result = newActivitySchema.safeParse({
+        accountId: "acc-123",
+        activityType: "CREDIT",
+        activityDate: new Date(),
+        amount: 25,
+        currency: "USD",
+        exchangeMic: null,
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts adjustment activities with zero unit price", () => {
+      const result = newActivitySchema.safeParse({
+        accountId: "acc-123",
+        activityType: "ADJUSTMENT",
+        activityDate: new Date(),
+        assetId: "AAPL",
+        quantity: 1,
+        unitPrice: 0,
+        currency: "USD",
+        assetMetadata: {
+          name: null,
+          kind: null,
+          exchangeMic: null,
+        },
+      });
+
+      expect(result.success).toBe(true);
     });
   });
 });

--- a/apps/frontend/src/pages/activity/components/forms/schemas.ts
+++ b/apps/frontend/src/pages/activity/components/forms/schemas.ts
@@ -4,9 +4,9 @@ import { z } from "zod";
 // Asset metadata schema for custom assets
 export const assetMetadataSchema = z
   .object({
-    name: z.string().optional(),
-    kind: z.string().optional(),
-    exchangeMic: z.string().optional(),
+    name: z.string().nullable().optional(),
+    kind: z.string().nullable().optional(),
+    exchangeMic: z.string().nullable().optional(),
   })
   .optional();
 
@@ -23,13 +23,13 @@ export const baseActivitySchema = z.object({
     .optional()
     .nullable(),
   // Exchange MIC for canonical asset ID generation (e.g., "XNAS", "XTSE")
-  exchangeMic: z.string().optional(),
+  exchangeMic: z.string().nullable().optional(),
   // Asset metadata for custom assets (name, etc.)
   assetMetadata: assetMetadataSchema,
   // Optional symbol-level quote currency hint from search/provider (e.g., "GBp")
-  symbolQuoteCcy: z.string().optional(),
+  symbolQuoteCcy: z.string().nullable().optional(),
   // Optional symbol-level instrument type hint from search/provider (e.g., "EQUITY", "CRYPTO")
-  symbolInstrumentType: z.string().optional(),
+  symbolInstrumentType: z.string().nullable().optional(),
 });
 
 // Transfer schema: TRANSFER_IN/OUT supports both cash (amount) and securities (assetId + quantity + unitPrice)
@@ -192,12 +192,48 @@ export const otherActivitySchema = baseActivitySchema.extend({
     .optional(),
 });
 
+export const creditActivitySchema = baseActivitySchema.extend({
+  activityType: z.enum([ActivityType.CREDIT]),
+  amount: z.coerce
+    .number({
+      required_error: "Please enter a valid amount.",
+      invalid_type_error: "Amount must be a positive number.",
+    })
+    .positive(),
+  fee: z.coerce
+    .number({
+      invalid_type_error: "Fee must be a positive number.",
+    })
+    .min(0, { message: "Fee must be a non-negative number." })
+    .default(0)
+    .optional(),
+  quoteMode: z.enum([QuoteMode.MARKET, QuoteMode.MANUAL]).default(QuoteMode.MANUAL),
+});
+
+export const adjustmentActivitySchema = baseActivitySchema.extend({
+  activityType: z.enum([ActivityType.ADJUSTMENT]),
+  assetId: z.string().min(1, { message: "Please select a security" }),
+  quantity: z.coerce.number().nonnegative().optional().nullable(),
+  unitPrice: z.coerce.number().nonnegative().optional().nullable(),
+  amount: z.coerce.number().optional().nullable(),
+  fee: z.coerce
+    .number({
+      invalid_type_error: "Fee must be a positive number.",
+    })
+    .min(0, { message: "Fee must be a non-negative number." })
+    .default(0)
+    .optional(),
+  quoteMode: z.enum([QuoteMode.MARKET, QuoteMode.MANUAL]).default(QuoteMode.MARKET),
+});
+
 export const newActivitySchema = z
   .discriminatedUnion("activityType", [
     tradeActivitySchema,
     cashActivitySchema,
     incomeActivitySchema,
     otherActivitySchema,
+    creditActivitySchema,
+    adjustmentActivitySchema,
     transferActivitySchema,
   ])
   .and(

--- a/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
@@ -20,7 +20,7 @@ import { useState } from "react";
 import { useForm, type Resolver, type SubmitHandler } from "react-hook-form";
 import { toast } from "sonner";
 import { useActivityMutations } from "../../hooks/use-activity-mutations";
-import type { AccountSelectOption } from "../forms/fields";
+import { showValidationToast, type AccountSelectOption } from "../forms/fields";
 import { newActivitySchema, type NewActivityFormValues } from "../forms/schemas";
 import { MobileActivitySteps } from "./mobile-activity-steps";
 
@@ -152,6 +152,7 @@ export function MobileActivityForm({ accounts, activity, open, onClose }: Mobile
           "TRANSFER_OUT",
           "FEE",
           "TAX",
+          "CREDIT",
           "ADJUSTMENT",
         ].includes(type)
       : false;
@@ -400,7 +401,11 @@ export function MobileActivityForm({ accounts, activity, open, onClose }: Mobile
       }
 
       if (id) {
-        await updateActivityMutation.mutateAsync({ id, ...submitData });
+        await updateActivityMutation.mutateAsync({
+          id,
+          existingAssetId: activity?.assetId,
+          ...submitData,
+        } as NewActivityFormValues & { id: string; existingAssetId?: string });
       } else {
         await addActivityMutation.mutateAsync(submitData);
       }
@@ -416,6 +421,9 @@ export function MobileActivityForm({ accounts, activity, open, onClose }: Mobile
       return;
     }
   };
+  const handleValidatedSubmit = form.handleSubmit(onSubmit, (errors) => {
+    showValidationToast(errors, form.getValues);
+  });
 
   const handleNext = async () => {
     const fields = getFieldsForStep(currentStep);
@@ -446,11 +454,18 @@ export function MobileActivityForm({ accounts, activity, open, onClose }: Mobile
           }
           return [...baseFields, "assetId", "quantity", "unitPrice", "fee"];
         }
-        if (["DEPOSIT", "WITHDRAWAL", "TRANSFER_IN", "TRANSFER_OUT"].includes(activityType ?? "")) {
+        if (
+          ["DEPOSIT", "WITHDRAWAL", "TRANSFER_IN", "TRANSFER_OUT", "CREDIT"].includes(
+            activityType ?? "",
+          )
+        ) {
           return [...baseFields, "amount", "fee"];
         }
         if (["DIVIDEND", "INTEREST"].includes(activityType ?? "")) {
           return [...baseFields, "assetId", "amount"];
+        }
+        if (activityType === "ADJUSTMENT") {
+          return [...baseFields, "assetId"];
         }
         return ["amount", ...baseFields];
       }
@@ -488,7 +503,7 @@ export function MobileActivityForm({ accounts, activity, open, onClose }: Mobile
         <div className="flex-1 overflow-y-auto">
           <div className="p-4">
             <Form {...form}>
-              <form onSubmit={form.handleSubmit(onSubmit)} className="flex h-full flex-col">
+              <form onSubmit={handleValidatedSubmit} className="flex h-full flex-col">
                 <MobileActivitySteps
                   currentStep={currentStep}
                   accounts={accounts}
@@ -529,7 +544,7 @@ export function MobileActivityForm({ accounts, activity, open, onClose }: Mobile
               <Button
                 type="button"
                 size="default"
-                onClick={form.handleSubmit(onSubmit)}
+                onClick={handleValidatedSubmit}
                 className="flex-1 font-medium"
                 disabled={isLoading}
               >

--- a/apps/frontend/src/pages/activity/components/mobile-forms/mobile-details-step.tsx
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/mobile-details-step.tsx
@@ -92,16 +92,20 @@ export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileD
   const subtype = watch("subtype");
   const isDrip = activityType === "DIVIDEND" && subtype === ACTIVITY_SUBTYPES.DRIP;
 
+  const isCreditActivity = activityType === "CREDIT";
+  const isAdjustmentActivity = activityType === "ADJUSTMENT";
   const isFeeActivity = activityType === "FEE";
   const isTaxActivity = activityType === "TAX";
   const needsAssetSymbol =
-    ["BUY", "SELL", "DIVIDEND", "SPLIT"].includes(activityType) || isSecuritiesTransfer;
-  const needsQuantity = ["BUY", "SELL"].includes(activityType) || isSecuritiesTransfer;
+    ["BUY", "SELL", "DIVIDEND", "SPLIT", "ADJUSTMENT"].includes(activityType) ||
+    isSecuritiesTransfer;
+  const needsQuantity =
+    ["BUY", "SELL"].includes(activityType) || isSecuritiesTransfer || isAdjustmentActivity;
   const needsUnitPrice =
     ["BUY", "SELL"].includes(activityType) ||
     (isSecuritiesTransfer && isExternal && direction === "in");
   const needsAmount =
-    ["DEPOSIT", "WITHDRAWAL", "DIVIDEND", "INTEREST", "TAX"].includes(activityType) ||
+    ["DEPOSIT", "WITHDRAWAL", "DIVIDEND", "INTEREST", "TAX", "CREDIT"].includes(activityType) ||
     isCashTransfer;
   const needsFee = [
     "BUY",
@@ -483,7 +487,9 @@ export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileD
                         ? "Interest Amount"
                         : isTaxActivity
                           ? "Tax Amount"
-                          : "Amount"}
+                          : isCreditActivity
+                            ? "Credit Amount"
+                            : "Amount"}
                   </FormLabel>
                   <FormControl>
                     <MoneyInput {...field} />

--- a/apps/frontend/src/pages/layouts/app-layout.tsx
+++ b/apps/frontend/src/pages/layouts/app-layout.tsx
@@ -3,6 +3,7 @@ import { MobileLoadingIndicator } from "@/components/mobile-loading-indicator";
 import { Toaster } from "@/components/sonner";
 import { UpdateDialog } from "@/components/update-dialog";
 import { PortfolioSyncProvider } from "@/context/portfolio-sync-context";
+import { useActiveAppSyncTrigger } from "@/features/devices-sync/hooks/use-active-app-sync-trigger";
 import useNavigationEventListener from "@/hooks/use-navigation-event-listener";
 import { useIsMobileViewport, usePlatform } from "@/hooks/use-platform";
 import { useSettings } from "@/hooks/use-settings";
@@ -21,7 +22,7 @@ const AppLayoutContent = () => {
   const { data: settings, isSuccess: isSettingsReady } = useSettings();
   const location = useLocation();
   const navigation = useNavigation();
-  const { isMobile } = usePlatform();
+  const { isMobile, isTauri } = usePlatform();
   const isMobileViewport = useIsMobileViewport();
   const isIPad =
     typeof window !== "undefined" &&
@@ -36,6 +37,7 @@ const AppLayoutContent = () => {
 
   useGlobalEventListener();
   useNavigationEventListener();
+  useActiveAppSyncTrigger({ enabled: isTauri });
 
   if (!isSettingsReady) {
     return (

--- a/apps/frontend/src/pages/layouts/app-layout.tsx
+++ b/apps/frontend/src/pages/layouts/app-layout.tsx
@@ -37,7 +37,7 @@ const AppLayoutContent = () => {
 
   useGlobalEventListener();
   useNavigationEventListener();
-  useActiveAppSyncTrigger({ enabled: isTauri });
+  useActiveAppSyncTrigger({ enabled: isTauri, requireWindowFocusForInterval: !isMobile });
 
   if (!isSettingsReady) {
     return (

--- a/apps/server/src/api/connect.rs
+++ b/apps/server/src/api/connect.rs
@@ -303,6 +303,46 @@ async fn store_sync_session(
     let _ = state.secret_store.delete_secret(CLOUD_ACCESS_TOKEN_KEY);
     state.token_lifecycle.clear_cache().await;
 
+    if crate::features::device_sync_enabled() {
+        let engine_state = Arc::clone(&state);
+        tokio::spawn(async move {
+            let token = match mint_access_token(&engine_state).await {
+                Ok(token) => token,
+                Err(err) => {
+                    debug!(
+                        "[Connect] Skipping post-login device sync background start: {}",
+                        err
+                    );
+                    return;
+                }
+            };
+
+            match engine_state
+                .device_enroll_service
+                .get_sync_state(&token)
+                .await
+            {
+                Ok(sync_state) if sync_state.state == SyncState::Ready => {
+                    if let Err(err) =
+                        device_sync_engine::ensure_background_engine_started(engine_state).await
+                    {
+                        debug!(
+                            "[Connect] Failed to start device sync background engine after login: {}",
+                            err
+                        );
+                    }
+                }
+                Ok(_) => {}
+                Err(err) => {
+                    debug!(
+                        "[Connect] Skipping post-login device sync background start: {}",
+                        err.message
+                    );
+                }
+            }
+        });
+    }
+
     Ok(Json(()))
 }
 

--- a/apps/server/src/api/device_sync_engine.rs
+++ b/apps/server/src/api/device_sync_engine.rs
@@ -33,6 +33,7 @@ fn transport_err_from_sync(e: wealthfolio_device_sync::DeviceSyncError) -> Trans
 use wealthfolio_storage_sqlite::sync::{SqliteSyncEngineDbPorts, SyncTableRowCount};
 
 const SYNC_IDENTITY_KEY: &str = "sync_identity";
+const DEVICE_ID_KEY: &str = "sync_device_id";
 static MIN_SNAPSHOT_CREATED_AT: OnceLock<Mutex<HashMap<String, String>>> = OnceLock::new();
 static READY_STATE_OVERWRITE_APPROVALS: OnceLock<Mutex<HashMap<String, bool>>> = OnceLock::new();
 static PAIRING_OVERWRITE_APPROVALS: OnceLock<Mutex<HashMap<String, bool>>> = OnceLock::new();
@@ -194,6 +195,10 @@ fn get_sync_identity_from_store(state: &AppState) -> Option<SyncIdentity> {
     })
 }
 
+fn sync_identity_can_run_background(identity: &SyncIdentity) -> bool {
+    identity.device_id.is_some() && identity.root_key.is_some()
+}
+
 fn min_snapshot_created_at_state() -> &'static Mutex<HashMap<String, String>> {
     MIN_SNAPSHOT_CREATED_AT.get_or_init(|| Mutex::new(HashMap::new()))
 }
@@ -275,6 +280,65 @@ fn clear_pairing_overwrite_approval(pairing_id: &str) {
     if let Ok(mut guard) = pairing_overwrite_approval_state().lock() {
         guard.remove(pairing_id);
     }
+}
+
+fn pairing_bootstrap_phase(
+    bootstrap: &SyncBootstrapResult,
+) -> Result<Option<PairingFlowPhase>, String> {
+    match bootstrap.status.as_str() {
+        "requested" => Ok(Some(PairingFlowPhase::Syncing {
+            detail: "waiting_snapshot".to_string(),
+        })),
+        "applied" | "skipped" => Ok(None),
+        "skipped_not_ready" => Err(bootstrap.message.clone()),
+        other => Err(format!(
+            "Snapshot bootstrap did not complete (status={}): {}",
+            other, bootstrap.message
+        )),
+    }
+}
+
+async fn abort_pairing_flow_local_state(state: &Arc<AppState>, pairing_id: &str) {
+    clear_pairing_overwrite_approval(pairing_id);
+
+    let device_id = get_sync_identity_from_store(state).and_then(|identity| identity.device_id);
+    if let Some(device_id) = device_id.as_deref() {
+        if let Ok(token) = crate::api::connect::mint_access_token(state).await {
+            let client = create_client();
+            let _ = client.cancel_pairing(&token, device_id, pairing_id).await;
+            if let Err(err) = client.delete_device(&token, device_id).await {
+                tracing::warn!(
+                    "[DeviceSync] Failed to delete confirmed pairing device while cancelling flow: {}",
+                    err
+                );
+            }
+        }
+        remove_min_snapshot_created_at_from_store(device_id);
+        let _ = state
+            .app_sync_repository
+            .clear_min_snapshot_created_at(device_id.to_string())
+            .await;
+    }
+
+    if let Err(err) = ensure_background_engine_stopped(Arc::clone(state)).await {
+        tracing::warn!(
+            "[DeviceSync] Failed to stop engine while cancelling pairing flow: {}",
+            err
+        );
+    }
+    if let Err(err) = state.device_enroll_service.clear_sync_data() {
+        tracing::warn!(
+            "[DeviceSync] Failed to clear local sync identity while cancelling pairing flow: {}",
+            err.message
+        );
+    }
+    let _ = state.app_sync_repository.reset_local_sync_session().await;
+    let _ = state.secret_store.delete_secret(DEVICE_ID_KEY);
+    clear_min_snapshot_created_at_from_store();
+    let _ = state
+        .app_sync_repository
+        .clear_all_min_snapshot_created_at()
+        .await;
 }
 
 fn should_keep_ready_state_overwrite_approval(result: &engine::SyncReadyReconcileResult) -> bool {
@@ -485,6 +549,14 @@ impl ReplayStore for ServerEnginePorts {
 
     async fn mark_engine_error(&self, message: String) -> Result<(), String> {
         self.db.mark_engine_error(message).await
+    }
+
+    async fn prune_sync_outbox(
+        &self,
+        sent_before: chrono::DateTime<chrono::Utc>,
+        dead_before: chrono::DateTime<chrono::Utc>,
+    ) -> Result<usize, String> {
+        self.db.prune_sync_outbox(sent_before, dead_before).await
     }
 
     async fn prune_applied_events_up_to_seq(&self, seq: i64) -> Result<(), String> {
@@ -725,7 +797,7 @@ pub async fn get_bootstrap_overwrite_check(
 
     let summary = state
         .app_sync_repository
-        .get_local_sync_data_summary()
+        .get_local_sync_overwrite_risk_summary()
         .map_err(|e| e.to_string())?;
 
     Ok(SyncBootstrapOverwriteCheckResult {
@@ -834,7 +906,10 @@ pub async fn reconcile_ready_state(
 
 pub async fn ensure_background_engine_started(state: Arc<AppState>) -> Result<(), String> {
     ensure_device_sync_enabled()?;
-    if get_sync_identity_from_store(&state).is_none() {
+    let Some(identity) = get_sync_identity_from_store(&state) else {
+        return Ok(());
+    };
+    if !sync_identity_can_run_background(&identity) {
         return Ok(());
     }
     let ports = Arc::new(ServerEnginePorts::new(Arc::clone(&state)));
@@ -1003,7 +1078,7 @@ pub async fn sync_bootstrap_snapshot_if_needed(
         .map_err(|e| e.message)?;
     if sync_state.state != SyncState::Ready {
         return Ok(SyncBootstrapResult {
-            status: "skipped".to_string(),
+            status: "skipped_not_ready".to_string(),
             message: "Device is not in READY state".to_string(),
             snapshot_id: None,
             cursor: None,
@@ -1618,7 +1693,7 @@ pub async fn confirm_pairing_with_bootstrap(
     if !overwrite_approved {
         let summary = state
             .app_sync_repository
-            .get_local_sync_data_summary()
+            .get_local_sync_overwrite_risk_summary()
             .map_err(|e| e.to_string())?;
         if summary.total_rows > 0 {
             return Ok(ConfirmPairingWithBootstrapResult {
@@ -1681,7 +1756,9 @@ pub async fn confirm_pairing_with_bootstrap(
 // Pairing Flow Coordinator
 // ─────────────────────────────────────────────────────────────────────────────
 
-use wealthfolio_device_sync::engine::{PairingFlowPhase, PairingFlowResponse};
+use wealthfolio_device_sync::engine::{
+    OverwriteInfo, OverwriteTableInfo, PairingFlowPhase, PairingFlowResponse,
+};
 
 pub async fn begin_pairing_confirm(
     state: Arc<AppState>,
@@ -1753,26 +1830,36 @@ pub async fn begin_pairing_confirm(
         });
     }
 
-    // 4. If local data exists, defer bootstrap to auto-bootstrap AlertDialog
-    //    (which offers "Back up first" option). Pairing is done at this point.
+    // 4. If real local portfolio data exists, keep consent inside the pairing flow.
     let summary = state
         .app_sync_repository
-        .get_local_sync_data_summary()
+        .get_local_sync_overwrite_risk_summary()
         .map_err(|e| e.to_string())?;
     if summary.total_rows > 0 {
-        tracing::info!("[DeviceSync] begin_pairing_confirm: local data found ({} rows), deferring bootstrap to auto-bootstrap", summary.total_rows);
-        return Ok(PairingFlowResponse {
-            flow_id: uuid::Uuid::new_v4().to_string(),
-            phase: PairingFlowPhase::Success,
-        });
+        tracing::info!(
+            "[DeviceSync] begin_pairing_confirm: overwrite risk found ({} rows)",
+            summary.total_rows
+        );
+        let phase = PairingFlowPhase::OverwriteRequired {
+            info: OverwriteInfo {
+                local_rows: summary.total_rows,
+                non_empty_tables: summary
+                    .non_empty_tables
+                    .into_iter()
+                    .map(|t| OverwriteTableInfo {
+                        table: t.table,
+                        rows: t.rows,
+                    })
+                    .collect(),
+            },
+        };
+        let flow_id = runtime.create_flow(pairing_id, phase.clone());
+        return Ok(PairingFlowResponse { flow_id, phase });
     }
 
     // 5. Bootstrap snapshot
     let bootstrap = sync_bootstrap_snapshot_if_needed(Arc::clone(&state)).await?;
-    if bootstrap.status == "requested" {
-        let phase = PairingFlowPhase::Syncing {
-            detail: "waiting_snapshot".to_string(),
-        };
+    if let Some(phase) = pairing_bootstrap_phase(&bootstrap)? {
         let flow_id = runtime.create_flow(pairing_id, phase.clone());
         return Ok(PairingFlowResponse { flow_id, phase });
     }
@@ -1807,8 +1894,12 @@ pub async fn get_pairing_flow_state_handler(
     if let PairingFlowPhase::Syncing { ref detail } = phase {
         if detail == "waiting_snapshot" {
             match sync_bootstrap_snapshot_if_needed(Arc::clone(&state)).await {
-                Ok(bootstrap) => {
-                    if bootstrap.status != "requested" {
+                Ok(bootstrap) => match pairing_bootstrap_phase(&bootstrap) {
+                    Ok(Some(phase)) => {
+                        runtime.set_flow_phase(&flow_id, phase.clone());
+                        return Ok(PairingFlowResponse { flow_id, phase });
+                    }
+                    Ok(None) => {
                         let _ = run_sync_cycle(Arc::clone(&state), true).await;
                         let engine_state = Arc::clone(&state);
                         tokio::spawn(async move {
@@ -1828,7 +1919,17 @@ pub async fn get_pairing_flow_state_handler(
                             phase: PairingFlowPhase::Success,
                         });
                     }
-                }
+                    Err(e) => {
+                        if let Some(pid) = runtime.get_flow_pairing_id(&flow_id) {
+                            clear_pairing_overwrite_approval(&pid);
+                        }
+                        runtime.remove_flow(&flow_id);
+                        return Ok(PairingFlowResponse {
+                            flow_id,
+                            phase: PairingFlowPhase::Error { message: e },
+                        });
+                    }
+                },
                 Err(e) => {
                     if let Some(pid) = runtime.get_flow_pairing_id(&flow_id) {
                         clear_pairing_overwrite_approval(&pid);
@@ -1875,10 +1976,17 @@ pub async fn approve_pairing_overwrite_handler(
 
     match sync_bootstrap_snapshot_if_needed(Arc::clone(&state)).await {
         Ok(bootstrap) => {
-            if bootstrap.status == "requested" {
-                let phase = PairingFlowPhase::Syncing {
-                    detail: "waiting_snapshot".to_string(),
-                };
+            if let Some(phase) = match pairing_bootstrap_phase(&bootstrap) {
+                Ok(phase) => phase,
+                Err(e) => {
+                    clear_pairing_overwrite_approval(&pairing_id);
+                    runtime.remove_flow(&flow_id);
+                    return Ok(PairingFlowResponse {
+                        flow_id,
+                        phase: PairingFlowPhase::Error { message: e },
+                    });
+                }
+            } {
                 runtime.set_flow_phase(&flow_id, phase.clone());
                 return Ok(PairingFlowResponse { flow_id, phase });
             }
@@ -1915,7 +2023,7 @@ pub async fn cancel_pairing_flow_handler(
     let runtime = &state.device_sync_runtime;
 
     if let Some(pairing_id) = runtime.get_flow_pairing_id(&flow_id) {
-        clear_pairing_overwrite_approval(&pairing_id);
+        abort_pairing_flow_local_state(&state, &pairing_id).await;
     }
 
     runtime.remove_flow(&flow_id);

--- a/apps/server/src/domain_events/sink.rs
+++ b/apps/server/src/domain_events/sink.rs
@@ -136,8 +136,8 @@ mod tests {
     use super::*;
     use tokio::sync::mpsc;
 
-    #[test]
-    fn test_sink_sends_events() {
+    #[tokio::test]
+    async fn test_sink_sends_events() {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let sink = WebDomainEventSink::with_sender(tx);
 
@@ -152,10 +152,12 @@ mod tests {
             }
             _ => panic!("Expected AssetsCreated event"),
         }
+
+        assert!(rx.try_recv().is_err());
     }
 
-    #[test]
-    fn test_sink_batch_sends_all_events() {
+    #[tokio::test]
+    async fn test_sink_batch_sends_all_events() {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let sink = WebDomainEventSink::with_sender(tx);
 
@@ -173,5 +175,20 @@ mod tests {
 
         assert!(matches!(event1, DomainEvent::AssetsCreated { .. }));
         assert!(matches!(event2, DomainEvent::AssetsCreated { .. }));
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn pull_complete_is_sent_to_queue() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let sink = WebDomainEventSink::with_sender(tx);
+
+        sink.emit(DomainEvent::device_sync_pull_complete());
+
+        assert!(matches!(
+            rx.try_recv().unwrap(),
+            DomainEvent::DeviceSyncPullComplete
+        ));
+        assert!(rx.try_recv().is_err());
     }
 }

--- a/apps/server/src/main_lib.rs
+++ b/apps/server/src/main_lib.rs
@@ -5,7 +5,7 @@ use crate::{
     ai_environment::ServerAiEnvironment, auth::AuthManager, config::Config,
     domain_events::WebDomainEventSink, events::EventBus, secrets::build_secret_store,
 };
-use tracing::error;
+use tracing::{error, warn};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{fmt, EnvFilter};
 use wealthfolio_ai::{AiProviderService, AiProviderServiceTrait, ChatConfig, ChatService};
@@ -121,6 +121,32 @@ pub fn init_tracing() {
     }
 }
 
+#[cfg(feature = "device-sync")]
+fn start_sync_outbox_wake_worker(
+    mut receiver: tokio::sync::mpsc::Receiver<()>,
+    state: Arc<AppState>,
+) {
+    tokio::spawn(async move {
+        while receiver.recv().await.is_some() {
+            while receiver.try_recv().is_ok() {}
+            let was_running = state.device_sync_runtime.is_background_running().await;
+            if let Err(err) =
+                crate::api::device_sync_engine::ensure_background_engine_started(Arc::clone(&state))
+                    .await
+            {
+                warn!(
+                    "Failed to start background device sync engine after local outbox write: {}",
+                    err
+                );
+                continue;
+            }
+            if was_running {
+                state.device_sync_runtime.notify_sync_work_available();
+            }
+        }
+    });
+}
+
 pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
     // Ensure DATABASE_URL aligns with WF_DB_PATH so core picks the right file
     std::env::set_var("DATABASE_URL", &config.db_path);
@@ -150,7 +176,14 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
     db::run_migrations(&db_path)?;
 
     let pool = db::create_pool(&db_path)?;
-    let writer = write_actor::spawn_writer((*pool).clone()).map_err(|e| {
+    let (sync_outbox_wake_sender, sync_outbox_wake_receiver) = tokio::sync::mpsc::channel(128);
+    let writer = write_actor::spawn_writer_with_outbox_observer(
+        (*pool).clone(),
+        Arc::new(move || {
+            let _ = sync_outbox_wake_sender.try_send(());
+        }),
+    )
+    .map_err(|e| {
         error!("Failed to initialize writer actor: {}", e);
         e
     })?;
@@ -420,6 +453,16 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
     let event_bus = EventBus::new(256);
     let device_sync_runtime = Arc::new(DeviceSyncRuntimeState::new());
     let token_lifecycle = Arc::new(TokenLifecycleState::new());
+    let now = chrono::Utc::now();
+    if let Err(err) = app_sync_repository
+        .prune_sync_outbox(
+            now - chrono::Duration::days(7),
+            now - chrono::Duration::days(30),
+        )
+        .await
+    {
+        warn!("Failed to prune local sync outbox: {}", err);
+    }
 
     // Domain event sink - Phase 2: Start the worker now that all services are ready
     domain_event_sink.start_worker(
@@ -450,7 +493,7 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
         .transpose()?
         .map(Arc::new);
 
-    Ok(Arc::new(AppState {
+    let state = Arc::new(AppState {
         domain_event_sink,
         account_service,
         settings_service,
@@ -488,5 +531,10 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
         health_service,
         token_lifecycle,
         custom_provider_service,
-    }))
+    });
+
+    #[cfg(feature = "device-sync")]
+    start_sync_outbox_wake_worker(sync_outbox_wake_receiver, Arc::clone(&state));
+
+    Ok(state)
 }

--- a/apps/tauri/gen/apple/project.yml
+++ b/apps/tauri/gen/apple/project.yml
@@ -51,8 +51,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 3.1.0
-        CFBundleVersion: "3.1.0"
+        CFBundleShortVersionString: 3.3.0
+        CFBundleVersion: "3.3.0"
     entitlements:
       path: wealthfolio-app_iOS/wealthfolio-app_iOS.entitlements
     scheme:

--- a/apps/tauri/gen/apple/wealthfolio-app_iOS/Info.plist
+++ b/apps/tauri/gen/apple/wealthfolio-app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.1</string>
+	<string>3.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>3.2.1</string>
+	<string>3.3.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/apps/tauri/src/commands/device_sync/engine.rs
+++ b/apps/tauri/src/commands/device_sync/engine.rs
@@ -38,7 +38,7 @@ use wealthfolio_storage_sqlite::sync::SqliteSyncEngineDbPorts;
 
 use super::{
     create_client, decrypt_sync_payload, encrypt_sync_payload, get_sync_identity_from_store,
-    persist_device_config_from_identity, SyncCycleResult,
+    persist_device_config_from_identity, sync_identity_can_run_background, SyncCycleResult,
 };
 
 struct TauriEnginePorts {
@@ -152,6 +152,14 @@ impl ReplayStore for TauriEnginePorts {
 
     async fn mark_engine_error(&self, message: String) -> Result<(), String> {
         self.db.mark_engine_error(message).await
+    }
+
+    async fn prune_sync_outbox(
+        &self,
+        sent_before: chrono::DateTime<chrono::Utc>,
+        dead_before: chrono::DateTime<chrono::Utc>,
+    ) -> Result<usize, String> {
+        self.db.prune_sync_outbox(sent_before, dead_before).await
     }
 
     async fn prune_applied_events_up_to_seq(&self, seq: i64) -> Result<(), String> {
@@ -318,7 +326,10 @@ pub(super) async fn run_sync_cycle(
 }
 
 pub async fn ensure_background_engine_started(context: Arc<ServiceContext>) -> Result<(), String> {
-    if get_sync_identity_from_store().is_none() {
+    let Some(identity) = get_sync_identity_from_store() else {
+        return Ok(());
+    };
+    if !sync_identity_can_run_background(&identity) {
         return Ok(());
     }
 

--- a/apps/tauri/src/commands/device_sync/mod.rs
+++ b/apps/tauri/src/commands/device_sync/mod.rs
@@ -7,7 +7,7 @@ mod engine;
 mod snapshot;
 
 use async_trait::async_trait;
-use log::{debug, info};
+use log::{debug, info, warn};
 use std::collections::HashMap;
 use std::process::Command;
 use std::sync::atomic::Ordering;
@@ -90,6 +90,10 @@ fn get_sync_identity_from_store() -> Option<SyncIdentity> {
             None
         }
     }
+}
+
+fn sync_identity_can_run_background(identity: &SyncIdentity) -> bool {
+    identity.device_id.is_some() && identity.root_key.is_some()
 }
 
 fn get_device_id_from_store() -> Option<String> {
@@ -215,6 +219,68 @@ fn clear_pairing_overwrite_approval(pairing_id: &str) {
     if let Ok(mut guard) = pairing_overwrite_approval_state().lock() {
         guard.remove(pairing_id);
     }
+}
+
+fn pairing_bootstrap_phase(
+    bootstrap: &SyncBootstrapResult,
+) -> Result<Option<PairingFlowPhase>, String> {
+    match bootstrap.status.as_str() {
+        "requested" => Ok(Some(PairingFlowPhase::Syncing {
+            detail: "waiting_snapshot".to_string(),
+        })),
+        "applied" | "skipped" => Ok(None),
+        "skipped_not_ready" => Err(bootstrap.message.clone()),
+        other => Err(format!(
+            "Snapshot bootstrap did not complete (status={}): {}",
+            other, bootstrap.message
+        )),
+    }
+}
+
+async fn abort_pairing_flow_local_state(context: &Arc<ServiceContext>, pairing_id: &str) {
+    clear_pairing_overwrite_approval(pairing_id);
+
+    let device_id = get_device_id_from_store();
+    if let Some(device_id) = device_id.as_deref() {
+        if let Ok(token) = get_access_token(context).await {
+            if let Ok(client) = create_client() {
+                let _ = client.cancel_pairing(&token, device_id, pairing_id).await;
+                if let Err(err) = client.delete_device(&token, device_id).await {
+                    warn!(
+                        "[DeviceSync] Failed to delete confirmed pairing device while cancelling flow: {}",
+                        err
+                    );
+                }
+            }
+        }
+        remove_min_snapshot_created_at_from_store(device_id);
+        let _ = context
+            .app_sync_repository()
+            .clear_min_snapshot_created_at(device_id.to_string())
+            .await;
+    }
+
+    if let Err(err) = ensure_background_engine_stopped(Arc::clone(context)).await {
+        warn!(
+            "[DeviceSync] Failed to stop engine while cancelling pairing flow: {}",
+            err
+        );
+    }
+    if let Err(err) = context.device_enroll_service().clear_sync_data() {
+        warn!(
+            "[DeviceSync] Failed to clear local sync identity while cancelling pairing flow: {}",
+            err.message
+        );
+    }
+    let _ = context
+        .app_sync_repository()
+        .reset_local_sync_session()
+        .await;
+    clear_min_snapshot_created_at_from_store();
+    let _ = context
+        .app_sync_repository()
+        .clear_all_min_snapshot_created_at()
+        .await;
 }
 
 fn should_keep_ready_state_overwrite_approval(
@@ -918,7 +984,7 @@ pub async fn device_sync_bootstrap_overwrite_check(
     }
 
     let summary = sync_repo
-        .get_local_sync_data_summary()
+        .get_local_sync_overwrite_risk_summary()
         .map_err(|e| e.to_string())?;
 
     Ok(SyncBootstrapOverwriteCheckResult {
@@ -1059,13 +1125,27 @@ pub async fn device_sync_bootstrap_snapshot_if_needed(
 ) -> Result<SyncBootstrapResult, String> {
     let context = Arc::clone(state.inner());
     let result = snapshot::sync_bootstrap_snapshot_if_needed(handle, &context).await?;
-    let token = context.connect_service().get_valid_access_token().await?;
-    let should_start_engine = context
-        .device_enroll_service()
-        .get_sync_state(&token)
-        .await
-        .map(|sync_state| sync_state.state == wealthfolio_device_sync::SyncState::Ready)
-        .unwrap_or(false);
+    let should_start_engine = match context.connect_service().get_valid_access_token().await {
+        Ok(token) => context
+            .device_enroll_service()
+            .get_sync_state(&token)
+            .await
+            .map(|sync_state| sync_state.state == wealthfolio_device_sync::SyncState::Ready)
+            .unwrap_or_else(|err| {
+                log::warn!(
+                    "[DeviceSync] Post-bootstrap sync state check failed: {}",
+                    err.message
+                );
+                false
+            }),
+        Err(err) => {
+            log::warn!(
+                "[DeviceSync] Post-bootstrap token refresh failed while starting engine: {}",
+                err
+            );
+            false
+        }
+    };
 
     // Start the background sync engine whenever this device is READY.
     if should_start_engine {
@@ -1432,7 +1512,7 @@ pub async fn confirm_pairing_with_bootstrap(
     if !overwrite_approved {
         let summary = context
             .app_sync_repository()
-            .get_local_sync_data_summary()
+            .get_local_sync_overwrite_risk_summary()
             .map_err(|e| e.to_string())?;
         if summary.total_rows > 0 {
             return Ok(ConfirmPairingWithBootstrapResult {
@@ -1493,7 +1573,9 @@ pub async fn confirm_pairing_with_bootstrap(
 // Pairing Flow Coordinator Commands
 // ─────────────────────────────────────────────────────────────────────────────
 
-use wealthfolio_device_sync::engine::{PairingFlowPhase, PairingFlowResponse};
+use wealthfolio_device_sync::engine::{
+    OverwriteInfo, OverwriteTableInfo, PairingFlowPhase, PairingFlowResponse,
+};
 
 /// Begin the post-SAS confirm+bootstrap phase. Creates a flow entry and returns its state.
 #[tauri::command(rename_all = "camelCase")]
@@ -1563,26 +1645,33 @@ pub async fn begin_pairing_confirm(
         });
     }
 
-    // 4. If local data exists, defer bootstrap to auto-bootstrap AlertDialog
-    //    (which offers "Back up first" option). Pairing is done at this point.
+    // 4. If real local portfolio data exists, keep consent inside the pairing flow.
     let summary = context
         .app_sync_repository()
-        .get_local_sync_data_summary()
+        .get_local_sync_overwrite_risk_summary()
         .map_err(|e| e.to_string())?;
     if summary.total_rows > 0 {
-        info!("[DeviceSync] begin_pairing_confirm: local data found ({} rows), deferring bootstrap to auto-bootstrap", summary.total_rows);
-        return Ok(PairingFlowResponse {
-            flow_id: uuid::Uuid::new_v4().to_string(),
-            phase: PairingFlowPhase::Success,
-        });
+        info!(
+            "[DeviceSync] begin_pairing_confirm: overwrite risk found ({} rows)",
+            summary.total_rows
+        );
+        let phase = PairingFlowPhase::OverwriteRequired {
+            info: OverwriteInfo {
+                local_rows: summary.total_rows,
+                non_empty_tables: summary
+                    .non_empty_tables
+                    .into_iter()
+                    .map(|SyncTableRowCount { table, rows }| OverwriteTableInfo { table, rows })
+                    .collect(),
+            },
+        };
+        let flow_id = runtime.create_flow(pairing_id, phase.clone());
+        return Ok(PairingFlowResponse { flow_id, phase });
     }
 
     // 5. Bootstrap snapshot
     let bootstrap = snapshot::sync_bootstrap_snapshot_if_needed(handle, &context).await?;
-    if bootstrap.status == "requested" {
-        let phase = PairingFlowPhase::Syncing {
-            detail: "waiting_snapshot".to_string(),
-        };
+    if let Some(phase) = pairing_bootstrap_phase(&bootstrap)? {
         let flow_id = runtime.create_flow(pairing_id, phase.clone());
         return Ok(PairingFlowResponse { flow_id, phase });
     }
@@ -1620,8 +1709,12 @@ pub async fn get_pairing_flow_state(
     if let PairingFlowPhase::Syncing { ref detail } = phase {
         if detail == "waiting_snapshot" {
             match snapshot::sync_bootstrap_snapshot_if_needed(handle, &context).await {
-                Ok(bootstrap) => {
-                    if bootstrap.status != "requested" {
+                Ok(bootstrap) => match pairing_bootstrap_phase(&bootstrap) {
+                    Ok(Some(phase)) => {
+                        runtime.set_flow_phase(&flow_id, phase.clone());
+                        return Ok(PairingFlowResponse { flow_id, phase });
+                    }
+                    Ok(None) => {
                         // Bootstrap applied — run sync cycle + start engine
                         let _ = engine::run_sync_cycle(Arc::clone(&context), true).await;
                         let engine_context = Arc::clone(state.inner());
@@ -1643,7 +1736,17 @@ pub async fn get_pairing_flow_state(
                             phase: PairingFlowPhase::Success,
                         });
                     }
-                }
+                    Err(e) => {
+                        if let Some(pid) = runtime.get_flow_pairing_id(&flow_id) {
+                            clear_pairing_overwrite_approval(&pid);
+                        }
+                        runtime.remove_flow(&flow_id);
+                        return Ok(PairingFlowResponse {
+                            flow_id,
+                            phase: PairingFlowPhase::Error { message: e },
+                        });
+                    }
+                },
                 Err(e) => {
                     if let Some(pid) = runtime.get_flow_pairing_id(&flow_id) {
                         clear_pairing_overwrite_approval(&pid);
@@ -1696,10 +1799,17 @@ pub async fn approve_pairing_overwrite(
     // Run bootstrap
     match snapshot::sync_bootstrap_snapshot_if_needed(handle, &context).await {
         Ok(bootstrap) => {
-            if bootstrap.status == "requested" {
-                let phase = PairingFlowPhase::Syncing {
-                    detail: "waiting_snapshot".to_string(),
-                };
+            if let Some(phase) = match pairing_bootstrap_phase(&bootstrap) {
+                Ok(phase) => phase,
+                Err(e) => {
+                    clear_pairing_overwrite_approval(&pairing_id);
+                    runtime.remove_flow(&flow_id);
+                    return Ok(PairingFlowResponse {
+                        flow_id,
+                        phase: PairingFlowPhase::Error { message: e },
+                    });
+                }
+            } {
                 runtime.set_flow_phase(&flow_id, phase.clone());
                 return Ok(PairingFlowResponse { flow_id, phase });
             }
@@ -1740,7 +1850,7 @@ pub async fn cancel_pairing_flow(
     let runtime = context.device_sync_runtime();
 
     if let Some(pairing_id) = runtime.get_flow_pairing_id(&flow_id) {
-        clear_pairing_overwrite_approval(&pairing_id);
+        abort_pairing_flow_local_state(&context, &pairing_id).await;
     }
 
     runtime.remove_flow(&flow_id);

--- a/apps/tauri/src/commands/device_sync/snapshot.rs
+++ b/apps/tauri/src/commands/device_sync/snapshot.rs
@@ -285,7 +285,7 @@ pub async fn sync_bootstrap_snapshot_if_needed(
         .map_err(|e| e.message)?;
     if sync_state.state != SyncState::Ready {
         return Ok(SyncBootstrapResult {
-            status: "skipped".to_string(),
+            status: "skipped_not_ready".to_string(),
             message: "Device is not in READY state".to_string(),
             snapshot_id: None,
             cursor: None,

--- a/apps/tauri/src/context/providers.rs
+++ b/apps/tauri/src/context/providers.rs
@@ -3,7 +3,7 @@ use super::registry::ServiceContext;
 use crate::domain_events::TauriDomainEventSink;
 use crate::secret_store::shared_secret_store;
 use crate::services::ConnectService;
-use log::error;
+use log::{error, warn};
 use std::sync::{Arc, RwLock};
 use tokio::sync::mpsc;
 use wealthfolio_ai::{AiProviderService, ChatConfig, ChatService};
@@ -54,6 +54,7 @@ use wealthfolio_storage_sqlite::{
 pub struct ContextInitResult {
     pub context: ServiceContext,
     pub event_receiver: mpsc::UnboundedReceiver<DomainEvent>,
+    pub sync_outbox_wake_receiver: mpsc::Receiver<()>,
 }
 
 pub async fn initialize_context(
@@ -63,7 +64,14 @@ pub async fn initialize_context(
     db::run_migrations(&db_path)?;
 
     let pool = db::create_pool(&db_path)?;
-    let writer = write_actor::spawn_writer(pool.as_ref().clone()).map_err(|e| {
+    let (sync_outbox_wake_sender, sync_outbox_wake_receiver) = mpsc::channel(128);
+    let writer = write_actor::spawn_writer_with_outbox_observer(
+        pool.as_ref().clone(),
+        Arc::new(move || {
+            let _ = sync_outbox_wake_sender.try_send(());
+        }),
+    )
+    .map_err(|e| {
         error!("Failed to initialize writer actor: {}", e);
         e
     })?;
@@ -335,6 +343,16 @@ pub async fn initialize_context(
         app_version,
     ));
     let device_sync_runtime = Arc::new(DeviceSyncRuntimeState::new());
+    let now = chrono::Utc::now();
+    if let Err(err) = app_sync_repository
+        .prune_sync_outbox(
+            now - chrono::Duration::days(7),
+            now - chrono::Duration::days(30),
+        )
+        .await
+    {
+        warn!("Failed to prune local sync outbox: {}", err);
+    }
 
     Ok(ContextInitResult {
         context: ServiceContext {
@@ -371,6 +389,7 @@ pub async fn initialize_context(
             custom_provider_service,
         },
         event_receiver,
+        sync_outbox_wake_receiver,
     })
 }
 

--- a/apps/tauri/src/domain_events/sink.rs
+++ b/apps/tauri/src/domain_events/sink.rs
@@ -76,8 +76,8 @@ impl DomainEventSink for TauriDomainEventSink {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_new_returns_sender_and_receiver() {
+    #[tokio::test]
+    async fn test_new_returns_sender_and_receiver() {
         let (sink, mut receiver) = TauriDomainEventSink::new();
 
         let event = DomainEvent::AssetsCreated {
@@ -96,10 +96,12 @@ mod tests {
             }
             _ => panic!("Expected AssetsCreated event"),
         }
+
+        assert!(receiver.try_recv().is_err());
     }
 
-    #[test]
-    fn test_emit_batch_sends_all_events() {
+    #[tokio::test]
+    async fn test_emit_batch_sends_all_events() {
         let (sink, mut receiver) = TauriDomainEventSink::new();
 
         let events = vec![
@@ -113,9 +115,27 @@ mod tests {
 
         sink.emit_batch(events);
 
-        // Check that both events were sent
-        assert!(receiver.try_recv().is_ok());
-        assert!(receiver.try_recv().is_ok());
+        assert!(matches!(
+            receiver.try_recv().unwrap(),
+            DomainEvent::AssetsCreated { .. }
+        ));
+        assert!(matches!(
+            receiver.try_recv().unwrap(),
+            DomainEvent::AssetsCreated { .. }
+        ));
         assert!(receiver.try_recv().is_err()); // No more events
+    }
+
+    #[tokio::test]
+    async fn pull_complete_is_sent_to_queue() {
+        let (sink, mut receiver) = TauriDomainEventSink::new();
+
+        sink.emit(DomainEvent::device_sync_pull_complete());
+
+        assert!(matches!(
+            receiver.try_recv().unwrap(),
+            DomainEvent::DeviceSyncPullComplete
+        ));
+        assert!(receiver.try_recv().is_err());
     }
 }

--- a/apps/tauri/src/lib.rs
+++ b/apps/tauri/src/lib.rs
@@ -26,6 +26,32 @@ use tauri::{AppHandle, Emitter, Manager};
 use events::emit_app_ready;
 use tauri_plugin_deep_link::DeepLinkExt;
 
+#[cfg(feature = "device-sync")]
+fn start_sync_outbox_wake_worker(
+    mut receiver: tokio::sync::mpsc::Receiver<()>,
+    context: Arc<context::ServiceContext>,
+) {
+    tauri::async_runtime::spawn(async move {
+        while receiver.recv().await.is_some() {
+            while receiver.try_recv().is_ok() {}
+            let was_running = context.device_sync_runtime().is_background_running().await;
+            if let Err(err) =
+                crate::commands::device_sync::ensure_background_engine_started(Arc::clone(&context))
+                    .await
+            {
+                warn!(
+                    "Failed to start background device sync engine after local outbox write: {}",
+                    err
+                );
+                continue;
+            }
+            if was_running {
+                context.device_sync_runtime().notify_sync_work_available();
+            }
+        }
+    });
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Desktop-only setup
 // ─────────────────────────────────────────────────────────────────────────────
@@ -66,9 +92,13 @@ mod desktop {
         })?;
         let context = Arc::new(init_result.context);
         let event_receiver = init_result.event_receiver;
+        let sync_outbox_wake_receiver = init_result.sync_outbox_wake_receiver;
 
         // Make context available to all commands
         handle.manage(Arc::clone(&context));
+
+        #[cfg(feature = "device-sync")]
+        start_sync_outbox_wake_worker(sync_outbox_wake_receiver, Arc::clone(&context));
 
         // Start the domain event queue worker now that context is managed
         // This must be done in an async context since it spawns a tokio task
@@ -155,8 +185,12 @@ mod mobile {
                 Ok(init_result) => {
                     let context = Arc::new(init_result.context);
                     let event_receiver = init_result.event_receiver;
+                    let sync_outbox_wake_receiver = init_result.sync_outbox_wake_receiver;
 
                     handle.manage(Arc::clone(&context));
+
+                    #[cfg(feature = "device-sync")]
+                    start_sync_outbox_wake_worker(sync_outbox_wake_receiver, Arc::clone(&context));
 
                     // Start the domain event queue worker now that context is managed
                     domain_events::TauriDomainEventSink::start_queue_worker(
@@ -167,8 +201,28 @@ mod mobile {
 
                     // Notify frontend that app is ready
                     // The frontend will trigger the initial portfolio update after it's mounted
-                    // For mobile, foreground sync is triggered from frontend via app lifecycle events
                     emit_app_ready(&handle);
+
+                    // Start background device sync while the mobile app is active.
+                    // The loop self-skips when identity is not configured, and frontend lifecycle
+                    // triggers still cover resume/online cases after iOS suspends the process.
+                    #[cfg(feature = "device-sync")]
+                    {
+                        let device_sync_context = Arc::clone(&context);
+                        tauri::async_runtime::spawn(async move {
+                            if let Err(err) =
+                                crate::commands::device_sync::ensure_background_engine_started(
+                                    device_sync_context,
+                                )
+                                .await
+                            {
+                                log::warn!(
+                                    "Failed to start background device sync engine: {}",
+                                    err
+                                );
+                            }
+                        });
+                    }
                 }
                 Err(e) => {
                     error!("Failed to initialize context on mobile: {}", e);

--- a/apps/tauri/tauri.conf.json
+++ b/apps/tauri/tauri.conf.json
@@ -32,7 +32,7 @@
   },
   "productName": "Wealthfolio",
   "mainBinaryName": "Wealthfolio",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "identifier": "com.teymz.wealthfolio",
   "plugins": {
     "updater": {

--- a/crates/core/src/sync/app_sync_model.rs
+++ b/crates/core/src/sync/app_sync_model.rs
@@ -113,6 +113,7 @@ pub struct SyncEntityMetadata {
     pub entity_id: String,
     pub last_event_id: String,
     pub last_client_timestamp: String,
+    pub last_op: SyncOperation,
     pub last_seq: i64,
 }
 

--- a/crates/device-sync/src/engine/mod.rs
+++ b/crates/device-sync/src/engine/mod.rs
@@ -1,6 +1,7 @@
 use chrono::Utc;
 use log::{debug, info, warn};
 use std::sync::Arc;
+use std::time::Duration;
 use uuid::Uuid;
 use wealthfolio_core::sync::{SyncEntity, SyncOperation};
 
@@ -15,14 +16,26 @@ pub use ports::{
     TransportError,
 };
 pub use runtime::{
-    DeviceSyncRuntimeState, OverwriteInfo, OverwriteTableInfo, PairingFlowPhase,
-    PairingFlowResponse, PairingFlowState,
+    DeviceSyncRuntimeState, DeviceSyncWakeHandle, OverwriteInfo, OverwriteTableInfo,
+    PairingFlowPhase, PairingFlowResponse, PairingFlowState,
 };
 
-/// Foreground pull cadence in seconds.
-pub const DEVICE_SYNC_FOREGROUND_INTERVAL_SECS: u64 = 5 * 60;
+/// Default periodic sync cadence for the background engine.
+pub const DEVICE_SYNC_PERIODIC_INTERVAL_SECS: u64 = 5 * 60;
 /// Maximum jitter (seconds) added to periodic cycle intervals.
 pub const DEVICE_SYNC_INTERVAL_JITTER_SECS: u64 = 5;
+/// Quiet period after a local wake signal before the next cycle starts.
+pub const DEVICE_SYNC_WAKE_DEBOUNCE_MS: u64 = 1_000;
+/// Maximum time a continuous write stream can keep delaying a wake-triggered cycle.
+pub const DEVICE_SYNC_WAKE_DEBOUNCE_MAX_WAIT_MS: u64 = 30_000;
+/// Number of repeated not_ready/config_error cycles before extending the periodic delay.
+pub const DEVICE_SYNC_NOT_READY_BACKOFF_AFTER: u32 = 5;
+/// Maximum repeated not_ready/config_error background delay.
+pub const DEVICE_SYNC_NOT_READY_BACKOFF_CAP_SECS: u64 = 60 * 60;
+/// Cadence for local sync outbox hygiene while the background engine stays alive.
+pub const DEVICE_SYNC_OUTBOX_PRUNE_INTERVAL_SECS: u64 = 24 * 60 * 60;
+pub const DEVICE_SYNC_SENT_OUTBOX_RETENTION_DAYS: i64 = 7;
+pub const DEVICE_SYNC_DEAD_OUTBOX_RETENTION_DAYS: i64 = 30;
 
 /// Exponential backoff in seconds with cap.
 pub fn backoff_seconds(consecutive_failures: i32) -> i64 {
@@ -86,6 +99,18 @@ fn parse_event_operation(event_type: &str) -> Option<SyncOperation> {
         "delete" => Some(SyncOperation::Delete),
         _ => None,
     }
+}
+
+fn sync_identity_is_revoked(identity: Option<SyncIdentity>) -> bool {
+    identity
+        .as_ref()
+        .is_some_and(|identity| identity.root_key.is_none() && identity.device_id.is_some())
+}
+
+fn sync_identity_can_run_background(identity: Option<SyncIdentity>) -> bool {
+    identity
+        .as_ref()
+        .is_some_and(|identity| identity.device_id.is_some() && identity.root_key.is_some())
 }
 
 fn millis_until_rfc3339(target: &str) -> Option<u64> {
@@ -1073,7 +1098,7 @@ async fn compute_cycle_delay_ms<P>(ports: &P, jitter_ms: u64) -> u64
 where
     P: OutboxStore + ReplayStore + Send + Sync,
 {
-    let mut delay_ms = DEVICE_SYNC_FOREGROUND_INTERVAL_SECS.saturating_mul(1000) + jitter_ms;
+    let mut delay_ms = DEVICE_SYNC_PERIODIC_INTERVAL_SECS.saturating_mul(1000) + jitter_ms;
 
     if let Ok(engine_status) = ports.get_engine_status().await {
         if let Some(next_retry_at) = engine_status.next_retry_at.as_deref() {
@@ -1090,13 +1115,93 @@ where
     delay_ms
 }
 
-pub async fn run_background_loop<P>(ports: Arc<P>)
+fn not_ready_backoff_ms(consecutive_not_ready: u32) -> u64 {
+    if consecutive_not_ready <= DEVICE_SYNC_NOT_READY_BACKOFF_AFTER {
+        return 0;
+    }
+
+    let exponent = (consecutive_not_ready - DEVICE_SYNC_NOT_READY_BACKOFF_AFTER).min(4);
+    let delay_secs = DEVICE_SYNC_PERIODIC_INTERVAL_SECS
+        .saturating_mul(1_u64 << exponent)
+        .min(DEVICE_SYNC_NOT_READY_BACKOFF_CAP_SECS);
+    delay_secs.saturating_mul(1000)
+}
+
+async fn prune_sync_outbox_if_due<P>(ports: &P, next_prune_at: &mut tokio::time::Instant)
+where
+    P: ReplayStore + Send + Sync,
+{
+    let now_instant = tokio::time::Instant::now();
+    if now_instant < *next_prune_at {
+        return;
+    }
+
+    *next_prune_at = now_instant + Duration::from_secs(DEVICE_SYNC_OUTBOX_PRUNE_INTERVAL_SECS);
+    let now = Utc::now();
+    match ports
+        .prune_sync_outbox(
+            now - chrono::Duration::days(DEVICE_SYNC_SENT_OUTBOX_RETENTION_DAYS),
+            now - chrono::Duration::days(DEVICE_SYNC_DEAD_OUTBOX_RETENTION_DAYS),
+        )
+        .await
+    {
+        Ok(deleted) if deleted > 0 => {
+            debug!("[DeviceSync] Pruned {} old sync outbox row(s)", deleted);
+        }
+        Ok(_) => {}
+        Err(err) => warn!("[DeviceSync] Failed to prune sync outbox: {}", err),
+    }
+}
+
+async fn wait_for_wake_debounce(runtime: &DeviceSyncRuntimeState) {
+    wait_for_wake_debounce_with_limits(
+        runtime,
+        Duration::from_millis(DEVICE_SYNC_WAKE_DEBOUNCE_MS),
+        Duration::from_millis(DEVICE_SYNC_WAKE_DEBOUNCE_MAX_WAIT_MS),
+    )
+    .await;
+}
+
+async fn wait_for_wake_debounce_with_limits(
+    runtime: &DeviceSyncRuntimeState,
+    quiet_for: Duration,
+    max_wait: Duration,
+) {
+    let quiet_sleep = tokio::time::sleep(quiet_for);
+    let max_sleep = tokio::time::sleep(max_wait);
+    tokio::pin!(quiet_sleep);
+    tokio::pin!(max_sleep);
+
+    loop {
+        tokio::select! {
+            _ = &mut max_sleep => break,
+            _ = &mut quiet_sleep => break,
+            _ = runtime.wait_for_sync_work() => {
+                quiet_sleep.as_mut().reset(tokio::time::Instant::now() + quiet_for);
+            }
+        }
+    }
+}
+
+pub async fn run_background_loop<P>(runtime: Arc<DeviceSyncRuntimeState>, ports: Arc<P>)
 where
     P: OutboxStore + ReplayStore + SyncTransport + CredentialStore + Send + Sync,
 {
     let mut consecutive_not_ready: u32 = 0;
+    let mut next_prune_at =
+        tokio::time::Instant::now() + Duration::from_secs(DEVICE_SYNC_OUTBOX_PRUNE_INTERVAL_SECS);
     loop {
-        let cycle_result = run_sync_cycle(ports.as_ref(), false).await;
+        let identity = ports.get_sync_identity();
+        if !sync_identity_can_run_background(identity.clone()) {
+            if sync_identity_is_revoked(identity) {
+                info!("[DeviceSync] Device appears revoked. Stopping background engine.");
+            } else {
+                debug!("[DeviceSync] Sync identity is not configured. Stopping background engine.");
+            }
+            break;
+        }
+
+        let cycle_result = runtime.run_cycle_serialized(ports.as_ref(), false).await;
         if let Err(err) = &cycle_result {
             warn!("[DeviceSync] Background cycle failed: {}", err);
             consecutive_not_ready = 0;
@@ -1112,27 +1217,36 @@ where
             );
             if result.status == "not_ready" || result.status == "config_error" {
                 consecutive_not_ready += 1;
-                if let Some(identity) = ports.get_sync_identity() {
-                    if identity.root_key.is_none() && identity.device_id.is_some() {
-                        info!("[DeviceSync] Device appears revoked. Stopping background engine.");
-                        break;
-                    }
+                if sync_identity_is_revoked(ports.get_sync_identity()) {
+                    info!("[DeviceSync] Device appears revoked. Stopping background engine.");
+                    break;
                 }
-                if consecutive_not_ready >= 5 {
+                if consecutive_not_ready == 5 {
                     info!(
-                        "[DeviceSync] {} consecutive not_ready/config_error cycles. Stopping background engine.",
+                        "[DeviceSync] {} consecutive not_ready/config_error cycles. Keeping background engine alive.",
                         consecutive_not_ready
                     );
-                    break;
                 }
             } else {
                 consecutive_not_ready = 0;
             }
         }
 
+        prune_sync_outbox_if_due(ports.as_ref(), &mut next_prune_at).await;
+
         let jitter_ms = compute_jitter_ms();
-        let delay_ms = compute_cycle_delay_ms(ports.as_ref(), jitter_ms).await;
-        tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+        let mut delay_ms = compute_cycle_delay_ms(ports.as_ref(), jitter_ms).await;
+        let not_ready_delay_ms = not_ready_backoff_ms(consecutive_not_ready);
+        if not_ready_delay_ms > 0 {
+            delay_ms = delay_ms.max(not_ready_delay_ms);
+        }
+        let woke_for_work = tokio::select! {
+            _ = tokio::time::sleep(Duration::from_millis(delay_ms)) => false,
+            _ = runtime.wait_for_sync_work() => true,
+        };
+        if woke_for_work {
+            wait_for_wake_debounce(&runtime).await;
+        }
     }
 }
 
@@ -1140,6 +1254,7 @@ where
 mod tests {
     use super::*;
     use async_trait::async_trait;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
     use tokio::sync::Mutex;
     use wealthfolio_core::sync::SyncEngineStatus;
@@ -1157,6 +1272,10 @@ mod tests {
         persisted_trust_states: Arc<Mutex<Vec<String>>>,
         cycle_outcomes: Arc<Mutex<Vec<String>>>,
         engine_errors: Arc<Mutex<Vec<String>>>,
+        prune_calls: Arc<AtomicUsize>,
+        reconcile_delay_ms: u64,
+        active_reconcile_count: Arc<AtomicUsize>,
+        max_active_reconcile_count: Arc<AtomicUsize>,
     }
 
     impl TestPorts {
@@ -1177,7 +1296,16 @@ mod tests {
                 persisted_trust_states: Arc::new(Mutex::new(Vec::new())),
                 cycle_outcomes: Arc::new(Mutex::new(Vec::new())),
                 engine_errors: Arc::new(Mutex::new(Vec::new())),
+                prune_calls: Arc::new(AtomicUsize::new(0)),
+                reconcile_delay_ms: 0,
+                active_reconcile_count: Arc::new(AtomicUsize::new(0)),
+                max_active_reconcile_count: Arc::new(AtomicUsize::new(0)),
             }
+        }
+
+        fn with_reconcile_delay_ms(mut self, delay_ms: u64) -> Self {
+            self.reconcile_delay_ms = delay_ms;
+            self
         }
     }
 
@@ -1283,6 +1411,15 @@ mod tests {
             Ok(())
         }
 
+        async fn prune_sync_outbox(
+            &self,
+            _sent_before: chrono::DateTime<chrono::Utc>,
+            _dead_before: chrono::DateTime<chrono::Utc>,
+        ) -> Result<usize, String> {
+            self.prune_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(0)
+        }
+
         async fn prune_applied_events_up_to_seq(&self, _seq: i64) -> Result<(), String> {
             Ok(())
         }
@@ -1342,6 +1479,24 @@ mod tests {
             _token: &str,
             _device_id: &str,
         ) -> Result<crate::ReconcileReadyStateResponse, TransportError> {
+            let active = self.active_reconcile_count.fetch_add(1, Ordering::SeqCst) + 1;
+            loop {
+                let current_max = self.max_active_reconcile_count.load(Ordering::SeqCst);
+                if active <= current_max {
+                    break;
+                }
+                if self
+                    .max_active_reconcile_count
+                    .compare_exchange(current_max, active, Ordering::SeqCst, Ordering::SeqCst)
+                    .is_ok()
+                {
+                    break;
+                }
+            }
+            if self.reconcile_delay_ms > 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(self.reconcile_delay_ms)).await;
+            }
+            self.active_reconcile_count.fetch_sub(1, Ordering::SeqCst);
             Ok(self.reconcile_response.clone())
         }
     }
@@ -1400,6 +1555,291 @@ mod tests {
             ports.cycle_outcomes.lock().await.as_slice(),
             ["config_error"]
         );
+    }
+
+    async fn wait_for_cycle_outcomes(ports: &TestPorts, count: usize, timeout_ms: u64) {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+        loop {
+            if ports.cycle_outcomes.lock().await.len() >= count {
+                return;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for {count} cycle outcomes"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+    }
+
+    async fn wait_for_active_reconcile(ports: &TestPorts, timeout_ms: u64) {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+        loop {
+            if ports.active_reconcile_count.load(Ordering::SeqCst) > 0 {
+                return;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for active reconcile"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    }
+
+    async fn wait_for_background_stopped(runtime: &DeviceSyncRuntimeState, timeout_ms: u64) {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(timeout_ms);
+        loop {
+            if !runtime.is_background_running().await {
+                return;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "timed out waiting for background loop to stop"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn background_loop_wakes_from_long_delay_when_notified() {
+        let identity = SyncIdentity {
+            device_id: Some("019cb093-06a8-7534-8677-546317b17957".to_string()),
+            root_key: Some("root-key".to_string()),
+            key_version: Some(1),
+        };
+        let ports = Arc::new(TestPorts::new(Some(identity), Ok(SyncState::Ready)));
+        let runtime = Arc::new(DeviceSyncRuntimeState::new());
+
+        runtime.ensure_background_started(Arc::clone(&ports)).await;
+        wait_for_cycle_outcomes(ports.as_ref(), 1, 1_000).await;
+
+        runtime.notify_sync_work_available();
+        wait_for_cycle_outcomes(ports.as_ref(), 2, 3_000).await;
+        runtime.ensure_background_stopped().await;
+    }
+
+    #[tokio::test]
+    async fn repeated_wake_notifications_are_debounced() {
+        let identity = SyncIdentity {
+            device_id: Some("019cb093-06a8-7534-8677-546317b17957".to_string()),
+            root_key: Some("root-key".to_string()),
+            key_version: Some(1),
+        };
+        let ports = Arc::new(TestPorts::new(Some(identity), Ok(SyncState::Ready)));
+        let runtime = Arc::new(DeviceSyncRuntimeState::new());
+
+        runtime.ensure_background_started(Arc::clone(&ports)).await;
+        wait_for_cycle_outcomes(ports.as_ref(), 1, 1_000).await;
+
+        runtime.notify_sync_work_available();
+        runtime.notify_sync_work_available();
+        runtime.notify_sync_work_available();
+
+        wait_for_cycle_outcomes(ports.as_ref(), 2, 3_000).await;
+        tokio::time::sleep(std::time::Duration::from_millis(1_300)).await;
+        assert_eq!(ports.cycle_outcomes.lock().await.len(), 2);
+        runtime.ensure_background_stopped().await;
+    }
+
+    #[tokio::test]
+    async fn wake_debounce_has_max_wait_even_when_writes_continue() {
+        let runtime = Arc::new(DeviceSyncRuntimeState::new());
+        let notifier = Arc::clone(&runtime);
+        let spammer = tokio::spawn(async move {
+            loop {
+                notifier.notify_sync_work_available();
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        });
+        tokio::task::yield_now().await;
+
+        let started = tokio::time::Instant::now();
+        tokio::time::timeout(
+            std::time::Duration::from_millis(300),
+            wait_for_wake_debounce_with_limits(
+                runtime.as_ref(),
+                std::time::Duration::from_millis(50),
+                std::time::Duration::from_millis(120),
+            ),
+        )
+        .await
+        .expect("debounce should stop at max wait");
+        spammer.abort();
+
+        assert!(
+            started.elapsed() >= std::time::Duration::from_millis(100),
+            "continuous wake stream should be capped by max wait, not quiet sleep"
+        );
+    }
+
+    #[tokio::test]
+    async fn wake_during_active_cycle_is_not_lost() {
+        let identity = SyncIdentity {
+            device_id: Some("019cb093-06a8-7534-8677-546317b17957".to_string()),
+            root_key: Some("root-key".to_string()),
+            key_version: Some(1),
+        };
+        let ports = Arc::new(
+            TestPorts::new(Some(identity), Ok(SyncState::Ready)).with_reconcile_delay_ms(100),
+        );
+        let runtime = Arc::new(DeviceSyncRuntimeState::new());
+
+        runtime.ensure_background_started(Arc::clone(&ports)).await;
+        wait_for_active_reconcile(ports.as_ref(), 1_000).await;
+        runtime.notify_sync_work_available();
+
+        wait_for_cycle_outcomes(ports.as_ref(), 2, 3_000).await;
+        runtime.ensure_background_stopped().await;
+    }
+
+    #[tokio::test]
+    async fn manual_and_background_cycles_do_not_overlap() {
+        let identity = SyncIdentity {
+            device_id: Some("019cb093-06a8-7534-8677-546317b17957".to_string()),
+            root_key: Some("root-key".to_string()),
+            key_version: Some(1),
+        };
+        let ports = Arc::new(
+            TestPorts::new(Some(identity), Ok(SyncState::Ready)).with_reconcile_delay_ms(100),
+        );
+        let runtime = Arc::new(DeviceSyncRuntimeState::new());
+
+        runtime.ensure_background_started(Arc::clone(&ports)).await;
+        wait_for_active_reconcile(ports.as_ref(), 1_000).await;
+
+        let manual = {
+            let runtime = Arc::clone(&runtime);
+            let ports = Arc::clone(&ports);
+            tokio::spawn(async move { runtime.run_cycle_serialized(ports.as_ref(), false).await })
+        };
+
+        wait_for_cycle_outcomes(ports.as_ref(), 2, 3_000).await;
+        manual.await.expect("manual join").expect("manual cycle");
+        runtime.ensure_background_stopped().await;
+
+        assert_eq!(ports.max_active_reconcile_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn background_loop_continues_after_repeated_not_ready_when_not_revoked() {
+        let identity = SyncIdentity {
+            device_id: Some("019cb093-06a8-7534-8677-546317b17957".to_string()),
+            root_key: Some("root-key".to_string()),
+            key_version: Some(1),
+        };
+        let ports = Arc::new(TestPorts::new(Some(identity), Ok(SyncState::Registered)));
+        let runtime = Arc::new(DeviceSyncRuntimeState::new());
+
+        runtime.ensure_background_started(Arc::clone(&ports)).await;
+        for expected_count in 1..=5 {
+            wait_for_cycle_outcomes(ports.as_ref(), expected_count, 3_000).await;
+            if expected_count < 5 {
+                runtime.notify_sync_work_available();
+            }
+        }
+
+        assert!(runtime.is_background_running().await);
+        runtime.ensure_background_stopped().await;
+    }
+
+    #[tokio::test]
+    async fn background_loop_exits_when_identity_is_revoked() {
+        let identity = SyncIdentity {
+            device_id: Some("019cb093-06a8-7534-8677-546317b17957".to_string()),
+            root_key: None,
+            key_version: Some(1),
+        };
+        let ports = Arc::new(TestPorts::new(Some(identity), Ok(SyncState::Registered)));
+        let runtime = Arc::new(DeviceSyncRuntimeState::new());
+
+        runtime.ensure_background_started(Arc::clone(&ports)).await;
+        wait_for_background_stopped(runtime.as_ref(), 1_000).await;
+        assert!(ports.cycle_outcomes.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn background_loop_exits_when_identity_is_not_configured() {
+        let identity = SyncIdentity {
+            device_id: None,
+            root_key: None,
+            key_version: Some(0),
+        };
+        let ports = Arc::new(TestPorts::new(Some(identity), Ok(SyncState::Ready)));
+        let runtime = Arc::new(DeviceSyncRuntimeState::new());
+
+        runtime.ensure_background_started(Arc::clone(&ports)).await;
+        wait_for_background_stopped(runtime.as_ref(), 1_000).await;
+        assert!(ports.cycle_outcomes.lock().await.is_empty());
+    }
+
+    #[test]
+    fn revoked_identity_requires_device_id_without_root_key() {
+        assert!(!sync_identity_is_revoked(None));
+        assert!(!sync_identity_is_revoked(Some(SyncIdentity {
+            device_id: None,
+            root_key: None,
+            key_version: None,
+        })));
+        assert!(!sync_identity_is_revoked(Some(SyncIdentity {
+            device_id: Some("device-1".to_string()),
+            root_key: Some("root-key".to_string()),
+            key_version: None,
+        })));
+        assert!(sync_identity_is_revoked(Some(SyncIdentity {
+            device_id: Some("device-1".to_string()),
+            root_key: None,
+            key_version: None,
+        })));
+    }
+
+    #[test]
+    fn background_runnable_identity_requires_device_id_and_root_key() {
+        assert!(!sync_identity_can_run_background(None));
+        assert!(!sync_identity_can_run_background(Some(SyncIdentity {
+            device_id: None,
+            root_key: None,
+            key_version: None,
+        })));
+        assert!(!sync_identity_can_run_background(Some(SyncIdentity {
+            device_id: Some("device-1".to_string()),
+            root_key: None,
+            key_version: None,
+        })));
+        assert!(!sync_identity_can_run_background(Some(SyncIdentity {
+            device_id: None,
+            root_key: Some("root-key".to_string()),
+            key_version: None,
+        })));
+        assert!(sync_identity_can_run_background(Some(SyncIdentity {
+            device_id: Some("device-1".to_string()),
+            root_key: Some("root-key".to_string()),
+            key_version: None,
+        })));
+    }
+
+    #[test]
+    fn not_ready_backoff_starts_after_threshold_and_caps() {
+        assert_eq!(not_ready_backoff_ms(0), 0);
+        assert_eq!(not_ready_backoff_ms(DEVICE_SYNC_NOT_READY_BACKOFF_AFTER), 0);
+        assert_eq!(
+            not_ready_backoff_ms(DEVICE_SYNC_NOT_READY_BACKOFF_AFTER + 1),
+            DEVICE_SYNC_PERIODIC_INTERVAL_SECS * 2 * 1000
+        );
+        assert_eq!(
+            not_ready_backoff_ms(DEVICE_SYNC_NOT_READY_BACKOFF_AFTER + 20),
+            DEVICE_SYNC_NOT_READY_BACKOFF_CAP_SECS * 1000
+        );
+    }
+
+    #[tokio::test]
+    async fn prune_sync_outbox_runs_only_when_due() {
+        let ports = TestPorts::new(None, Ok(SyncState::Ready));
+        let mut next_prune_at = tokio::time::Instant::now() - std::time::Duration::from_millis(1);
+
+        prune_sync_outbox_if_due(&ports, &mut next_prune_at).await;
+        assert_eq!(ports.prune_calls.load(Ordering::SeqCst), 1);
+
+        prune_sync_outbox_if_due(&ports, &mut next_prune_at).await;
+        assert_eq!(ports.prune_calls.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/crates/device-sync/src/engine/ports.rs
+++ b/crates/device-sync/src/engine/ports.rs
@@ -124,6 +124,11 @@ pub trait ReplayStore: Send + Sync {
         next_retry_at: Option<String>,
     ) -> Result<(), String>;
     async fn mark_engine_error(&self, message: String) -> Result<(), String>;
+    async fn prune_sync_outbox(
+        &self,
+        sent_before: chrono::DateTime<chrono::Utc>,
+        dead_before: chrono::DateTime<chrono::Utc>,
+    ) -> Result<usize, String>;
     async fn prune_applied_events_up_to_seq(&self, seq: i64) -> Result<(), String>;
     async fn get_engine_status(&self) -> Result<SyncEngineStatus, String>;
     /// Called after a sync cycle completes with pulled changes.

--- a/crates/device-sync/src/engine/runtime.rs
+++ b/crates/device-sync/src/engine/runtime.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+use tokio::sync::Notify;
 use tokio::task::JoinHandle;
 
 use super::{
@@ -51,19 +52,52 @@ pub struct PairingFlowResponse {
 
 // ─────────────────────────────────────────────────────────────────────────────
 
+#[derive(Debug, Clone)]
+pub struct DeviceSyncWakeHandle {
+    notify: Arc<Notify>,
+}
+
+impl DeviceSyncWakeHandle {
+    pub fn new() -> Self {
+        Self {
+            notify: Arc::new(Notify::new()),
+        }
+    }
+
+    pub fn notify_work_available(&self) {
+        self.notify.notify_one();
+    }
+
+    pub async fn wait_for_work(&self) {
+        self.notify.notified().await;
+    }
+}
+
+impl Default for DeviceSyncWakeHandle {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[derive(Debug)]
 pub struct DeviceSyncRuntimeState {
     cycle_mutex: Mutex<()>,
     background_task: Mutex<Option<JoinHandle<()>>>,
+    wake_handle: DeviceSyncWakeHandle,
     pub snapshot_upload_cancelled: AtomicBool,
     pairing_flows: std::sync::Mutex<HashMap<String, PairingFlowState>>,
 }
 
 impl DeviceSyncRuntimeState {
     pub fn new() -> Self {
+        Self::with_wake_handle(DeviceSyncWakeHandle::new())
+    }
+
+    pub fn with_wake_handle(wake_handle: DeviceSyncWakeHandle) -> Self {
         Self {
             cycle_mutex: Mutex::new(()),
             background_task: Mutex::new(None),
+            wake_handle,
             snapshot_upload_cancelled: AtomicBool::new(false),
             pairing_flows: std::sync::Mutex::new(HashMap::new()),
         }
@@ -77,7 +111,7 @@ impl Default for DeviceSyncRuntimeState {
 }
 
 impl DeviceSyncRuntimeState {
-    pub async fn run_cycle<P>(
+    pub async fn run_cycle_serialized<P>(
         &self,
         ports: &P,
         post_bootstrap: bool,
@@ -89,7 +123,26 @@ impl DeviceSyncRuntimeState {
         run_sync_cycle(ports, post_bootstrap).await
     }
 
-    pub async fn ensure_background_started<P>(&self, ports: Arc<P>)
+    pub async fn run_cycle<P>(
+        &self,
+        ports: &P,
+        post_bootstrap: bool,
+    ) -> Result<SyncCycleResult, String>
+    where
+        P: OutboxStore + ReplayStore + SyncTransport + CredentialStore + Send + Sync,
+    {
+        self.run_cycle_serialized(ports, post_bootstrap).await
+    }
+
+    pub fn notify_sync_work_available(&self) {
+        self.wake_handle.notify_work_available();
+    }
+
+    pub(crate) async fn wait_for_sync_work(&self) {
+        self.wake_handle.wait_for_work().await;
+    }
+
+    pub async fn ensure_background_started<P>(self: &Arc<Self>, ports: Arc<P>)
     where
         P: OutboxStore + ReplayStore + SyncTransport + CredentialStore + Send + Sync + 'static,
     {
@@ -101,8 +154,9 @@ impl DeviceSyncRuntimeState {
             guard.take();
         }
 
+        let runtime = Arc::clone(self);
         let handle = tokio::spawn(async move {
-            run_background_loop(ports).await;
+            run_background_loop(runtime, ports).await;
         });
         *guard = Some(handle);
     }

--- a/crates/storage-sqlite/migrations/2026-04-29-000001_sync_entity_metadata_last_op/down.sql
+++ b/crates/storage-sqlite/migrations/2026-04-29-000001_sync_entity_metadata_last_op/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sync_entity_metadata DROP COLUMN last_op;

--- a/crates/storage-sqlite/migrations/2026-04-29-000001_sync_entity_metadata_last_op/up.sql
+++ b/crates/storage-sqlite/migrations/2026-04-29-000001_sync_entity_metadata_last_op/up.sql
@@ -1,0 +1,145 @@
+ALTER TABLE sync_entity_metadata ADD COLUMN last_op TEXT NOT NULL DEFAULT 'update';
+
+UPDATE sync_entity_metadata
+SET last_op = COALESCE(
+    (
+        SELECT sync_outbox.op
+        FROM sync_outbox
+        WHERE sync_outbox.event_id = sync_entity_metadata.last_event_id
+        LIMIT 1
+    ),
+    last_op
+);
+
+INSERT INTO sync_entity_metadata (
+    entity,
+    entity_id,
+    last_event_id,
+    last_client_timestamp,
+    last_op,
+    last_seq
+)
+SELECT
+    latest.entity,
+    latest.entity_id,
+    latest.event_id,
+    latest.client_timestamp,
+    latest.op,
+    0
+FROM sync_outbox AS latest
+WHERE latest.event_id = (
+    SELECT candidate.event_id
+    FROM sync_outbox AS candidate
+    WHERE candidate.entity = latest.entity
+      AND candidate.entity_id = latest.entity_id
+    ORDER BY candidate.client_timestamp DESC, candidate.event_id DESC
+    LIMIT 1
+)
+ON CONFLICT(entity, entity_id) DO UPDATE SET
+    last_event_id = excluded.last_event_id,
+    last_client_timestamp = excluded.last_client_timestamp,
+    last_op = excluded.last_op,
+    last_seq = sync_entity_metadata.last_seq
+WHERE excluded.last_client_timestamp > sync_entity_metadata.last_client_timestamp
+   OR (
+       excluded.last_client_timestamp = sync_entity_metadata.last_client_timestamp
+       AND excluded.last_event_id > sync_entity_metadata.last_event_id
+   );
+
+-- Older metadata rows did not store the last operation. Rows whose entity no
+-- longer exists are tombstones, including remote-pulled deletes that never had
+-- a local sync_outbox entry to join above.
+UPDATE sync_entity_metadata
+SET last_op = 'delete'
+WHERE entity = 'account'
+  AND NOT EXISTS (SELECT 1 FROM "accounts" WHERE "accounts"."id" = sync_entity_metadata.entity_id);
+
+UPDATE sync_entity_metadata
+SET last_op = 'delete'
+WHERE entity = 'asset'
+  AND NOT EXISTS (SELECT 1 FROM "assets" WHERE "assets"."id" = sync_entity_metadata.entity_id);
+
+UPDATE sync_entity_metadata
+SET last_op = 'delete'
+WHERE entity = 'quote'
+  AND NOT EXISTS (SELECT 1 FROM "quotes" WHERE "quotes"."id" = sync_entity_metadata.entity_id);
+
+UPDATE sync_entity_metadata
+SET last_op = 'delete'
+WHERE entity = 'asset_taxonomy_assignment'
+  AND NOT EXISTS (SELECT 1 FROM "asset_taxonomy_assignments" WHERE "asset_taxonomy_assignments"."id" = sync_entity_metadata.entity_id);
+
+UPDATE sync_entity_metadata
+SET last_op = 'delete'
+WHERE entity = 'activity'
+  AND NOT EXISTS (SELECT 1 FROM "activities" WHERE "activities"."id" = sync_entity_metadata.entity_id);
+
+UPDATE sync_entity_metadata
+SET last_op = 'delete'
+WHERE entity = 'activity_import_profile'
+  AND NOT EXISTS (SELECT 1 FROM "import_account_templates" WHERE "import_account_templates"."id" = sync_entity_metadata.entity_id);
+
+UPDATE sync_entity_metadata
+SET last_op = 'delete'
+WHERE entity = 'import_template'
+  AND NOT EXISTS (SELECT 1 FROM "import_templates" WHERE "import_templates"."id" = sync_entity_metadata.entity_id);
+
+UPDATE sync_entity_metadata
+SET last_op = 'delete'
+WHERE entity = 'goal'
+  AND NOT EXISTS (SELECT 1 FROM "goals" WHERE "goals"."id" = sync_entity_metadata.entity_id);
+
+UPDATE sync_entity_metadata
+SET last_op = 'delete'
+WHERE entity = 'goal_plan'
+  AND NOT EXISTS (SELECT 1 FROM "goal_plans" WHERE "goal_plans"."goal_id" = sync_entity_metadata.entity_id);
+
+UPDATE sync_entity_metadata
+SET last_op = 'delete'
+WHERE entity = 'goals_allocation'
+  AND NOT EXISTS (SELECT 1 FROM "goals_allocation" WHERE "goals_allocation"."id" = sync_entity_metadata.entity_id);
+
+UPDATE sync_entity_metadata
+SET last_op = 'delete'
+WHERE entity = 'ai_thread'
+  AND NOT EXISTS (SELECT 1 FROM "ai_threads" WHERE "ai_threads"."id" = sync_entity_metadata.entity_id);
+
+UPDATE sync_entity_metadata
+SET last_op = 'delete'
+WHERE entity = 'ai_message'
+  AND NOT EXISTS (SELECT 1 FROM "ai_messages" WHERE "ai_messages"."id" = sync_entity_metadata.entity_id);
+
+UPDATE sync_entity_metadata
+SET last_op = 'delete'
+WHERE entity = 'ai_thread_tag'
+  AND NOT EXISTS (SELECT 1 FROM "ai_thread_tags" WHERE "ai_thread_tags"."id" = sync_entity_metadata.entity_id);
+
+UPDATE sync_entity_metadata
+SET last_op = 'delete'
+WHERE entity = 'contribution_limit'
+  AND NOT EXISTS (SELECT 1 FROM "contribution_limits" WHERE "contribution_limits"."id" = sync_entity_metadata.entity_id);
+
+UPDATE sync_entity_metadata
+SET last_op = 'delete'
+WHERE entity = 'platform'
+  AND NOT EXISTS (SELECT 1 FROM "platforms" WHERE "platforms"."id" = sync_entity_metadata.entity_id);
+
+UPDATE sync_entity_metadata
+SET last_op = 'delete'
+WHERE entity = 'snapshot'
+  AND NOT EXISTS (SELECT 1 FROM "holdings_snapshots" WHERE "holdings_snapshots"."id" = sync_entity_metadata.entity_id);
+
+UPDATE sync_entity_metadata
+SET last_op = 'delete'
+WHERE entity = 'custom_provider'
+  AND NOT EXISTS (SELECT 1 FROM "market_data_custom_providers" WHERE "market_data_custom_providers"."id" = sync_entity_metadata.entity_id);
+
+UPDATE sync_entity_metadata
+SET last_op = 'delete'
+WHERE entity = 'custom_taxonomy'
+  AND NOT EXISTS (SELECT 1 FROM "taxonomies" WHERE "taxonomies"."id" = sync_entity_metadata.entity_id);
+
+UPDATE sync_entity_metadata
+SET last_op = 'delete'
+WHERE entity = 'import_run'
+  AND NOT EXISTS (SELECT 1 FROM "import_runs" WHERE "import_runs"."id" = sync_entity_metadata.entity_id);

--- a/crates/storage-sqlite/src/db/write_actor.rs
+++ b/crates/storage-sqlite/src/db/write_actor.rs
@@ -4,15 +4,24 @@ use crate::sync::app_sync::ProjectedChange;
 use crate::sync::{flush_projected_outbox, OutboxWriteRequest, SyncOutboxModel};
 use diesel::SqliteConnection;
 use std::any::Any;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot};
 use wealthfolio_core::errors::{DatabaseError, Error, Result};
 use wealthfolio_core::sync::SyncOperation;
 
+struct WriteJobResult {
+    value: Box<dyn Any + Send + 'static>,
+    outbox_writes: usize,
+}
+
 // Type alias for the job to be executed by the writer actor.
 // It takes a mutable reference to a SqliteConnection and returns a Result.
 // We use core::Result here since that's what callers expect.
-type Job<T> = Box<dyn FnOnce(&mut SqliteConnection) -> Result<T> + Send + 'static>;
+type Job = Box<dyn FnOnce(&mut SqliteConnection) -> Result<WriteJobResult> + Send + 'static>;
+/// Called synchronously by the writer actor after a transaction commits outbox rows.
+/// Implementations must stay non-blocking; use this only to signal lightweight wakeups.
+pub type OutboxObserver = Arc<dyn Fn() + Send + Sync + 'static>;
 
 /// Handle for sending jobs to the writer actor.
 #[derive(Clone)]
@@ -21,10 +30,7 @@ pub struct WriteHandle {
     // Each job is a boxed closure, and a oneshot sender is used for the reply.
     // The Box<dyn Any + Send> is used for type erasure of the job's return type.
     #[allow(clippy::type_complexity)]
-    tx: mpsc::Sender<(
-        Job<Box<dyn Any + Send + 'static>>,
-        oneshot::Sender<Result<Box<dyn Any + Send + 'static>>>,
-    )>,
+    tx: mpsc::Sender<(Job, oneshot::Sender<Result<Box<dyn Any + Send + 'static>>>)>,
 }
 
 impl WriteHandle {
@@ -41,22 +47,27 @@ impl WriteHandle {
         F: FnOnce(&mut SqliteConnection) -> Result<T> + Send + 'static,
         T: Send + 'static + Any, // Add Any bound for T
     {
-        // Create a oneshot channel for receiving the result from the actor.
+        self.exec_job(move |conn| {
+            job(conn).map(|value| WriteJobResult {
+                value: Box::new(value) as Box<dyn Any + Send>,
+                outbox_writes: 0,
+            })
+        })
+        .await
+    }
+
+    async fn exec_job<F, T>(&self, job: F) -> Result<T>
+    where
+        F: FnOnce(&mut SqliteConnection) -> Result<WriteJobResult> + Send + 'static,
+        T: Send + 'static + Any,
+    {
         let (ret_tx, ret_rx) = oneshot::channel();
 
-        // Send the job to the writer actor.
-        // The job is wrapped to return a Box<dyn Any + Send> for type erasure.
         self.tx
-            .send((
-                Box::new(move |c| job(c).map(|v| Box::new(v) as Box<dyn Any + Send>)), // Cast to Box<dyn Any + Send>
-                ret_tx,
-            ))
+            .send((Box::new(job), ret_tx))
             .await
             .expect("Writer actor's receiving channel was closed, indicating the actor stopped.");
 
-        // Await the result from the writer actor.
-        // The outer expect handles potential disconnection of the oneshot channel.
-        // The inner map unwraps the Box<dyn Any + Send> back to the original type T.
         ret_rx
             .await
             .expect("Writer actor dropped the reply sender without sending a result.")
@@ -73,11 +84,14 @@ impl WriteHandle {
         F: FnOnce(&mut SqliteConnection, &mut WriteProjection) -> Result<T> + Send + 'static,
         T: Send + 'static + Any,
     {
-        self.exec(move |conn| {
+        self.exec_job(move |conn| {
             let mut projection = WriteProjection::default();
             let result = job(conn, &mut projection)?;
-            projection.flush(conn)?;
-            Ok(result)
+            let outbox_writes = projection.flush(conn)?;
+            Ok(WriteJobResult {
+                value: Box::new(result) as Box<dyn Any + Send>,
+                outbox_writes,
+            })
         })
         .await
     }
@@ -88,7 +102,7 @@ impl WriteHandle {
         F: FnOnce(&mut DbWriteTx<'_>) -> Result<T> + Send + 'static,
         T: Send + 'static + Any,
     {
-        self.exec(move |conn| {
+        self.exec_job(move |conn| {
             let mut projection = WriteProjection::default();
             let result = {
                 let mut tx = DbWriteTx {
@@ -97,8 +111,11 @@ impl WriteHandle {
                 };
                 job(&mut tx)?
             };
-            projection.flush(conn)?;
-            Ok(result)
+            let outbox_writes = projection.flush(conn)?;
+            Ok(WriteJobResult {
+                value: Box::new(result) as Box<dyn Any + Send>,
+                outbox_writes,
+            })
         })
         .await
     }
@@ -186,7 +203,7 @@ impl WriteProjection {
         }
     }
 
-    fn flush(self, conn: &mut SqliteConnection) -> Result<()> {
+    fn flush(self, conn: &mut SqliteConnection) -> Result<usize> {
         flush_projected_outbox(conn, self.outbox_requests, self.projected_changes)
     }
 }
@@ -200,6 +217,20 @@ impl WriteProjection {
 /// # Returns
 /// A `WriteHandle` to send jobs to the spawned actor.
 pub fn spawn_writer(pool: DbPool) -> Result<WriteHandle> {
+    spawn_writer_inner(pool, None)
+}
+
+pub fn spawn_writer_with_outbox_observer(
+    pool: DbPool,
+    outbox_observer: OutboxObserver,
+) -> Result<WriteHandle> {
+    spawn_writer_inner(pool, Some(outbox_observer))
+}
+
+fn spawn_writer_inner(
+    pool: DbPool,
+    outbox_observer: Option<OutboxObserver>,
+) -> Result<WriteHandle> {
     fn acquire_writer_connection(pool: &DbPool) -> Result<super::DbConnection> {
         const PER_ATTEMPT_TIMEOUT: Duration = Duration::from_millis(800);
         const RETRY_SLEEP: Duration = Duration::from_millis(200);
@@ -236,10 +267,8 @@ pub fn spawn_writer(pool: DbPool) -> Result<WriteHandle> {
 
     // Create an MPSC channel for sending jobs to the actor.
     // The channel is bounded; 1024 is an arbitrary size.
-    let (tx, mut rx) = mpsc::channel::<(
-        Job<Box<dyn Any + Send + 'static>>,
-        oneshot::Sender<Result<Box<dyn Any + Send + 'static>>>,
-    )>(1024);
+    let (tx, mut rx) =
+        mpsc::channel::<(Job, oneshot::Sender<Result<Box<dyn Any + Send + 'static>>>)>(1024);
 
     tokio::spawn(async move {
         // Loop to receive and process jobs.
@@ -247,12 +276,21 @@ pub fn spawn_writer(pool: DbPool) -> Result<WriteHandle> {
             // Execute the job within an immediate database transaction.
             // We wrap the job to return StorageError which implements From<diesel::result::Error>.
             // Then convert back to core::Error at the boundary.
-            let result: Result<Box<dyn Any + Send + 'static>> = conn
+            let result: Result<WriteJobResult> = conn
                 .immediate_transaction::<_, StorageError, _>(|c| {
                     // Call the job and convert its error to StorageError if needed
                     job(c).map_err(StorageError::from)
                 })
                 .map_err(|e: StorageError| e.into());
+
+            let result = result.map(|job_result| {
+                if job_result.outbox_writes > 0 {
+                    if let Some(observer) = &outbox_observer {
+                        observer();
+                    }
+                }
+                job_result.value
+            });
 
             // Send the result back to the requester.
             // Ignore error if the receiver has dropped (e.g., request timed out or was cancelled).
@@ -267,3 +305,121 @@ pub fn spawn_writer(pool: DbPool) -> Result<WriteHandle> {
 
 // Note: DbConnection (PooledConnection) derefs to SqliteConnection.
 // The immediate_transaction method is on SqliteConnection via the Connection trait.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{create_pool, init, run_migrations};
+    use crate::sync::OutboxWriteRequest;
+    use serde_json::json;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tempfile::tempdir;
+    use tokio::sync::oneshot as tokio_oneshot;
+    use wealthfolio_core::sync::{SyncEntity, SyncOperation};
+
+    fn setup_pool() -> DbPool {
+        let app_data = tempdir()
+            .expect("tempdir")
+            .keep()
+            .to_string_lossy()
+            .to_string();
+        let db_path = init(&app_data).expect("init db");
+        run_migrations(&db_path).expect("migrate db");
+        create_pool(&db_path).expect("create pool").as_ref().clone()
+    }
+
+    #[tokio::test]
+    async fn notifies_observer_once_for_transaction_with_multiple_outbox_rows() {
+        let notify_count = Arc::new(AtomicUsize::new(0));
+        let observer_count = notify_count.clone();
+        let writer = spawn_writer_with_outbox_observer(
+            setup_pool(),
+            Arc::new(move || {
+                observer_count.fetch_add(1, Ordering::SeqCst);
+            }),
+        )
+        .expect("spawn writer");
+
+        writer
+            .exec_projected(|_conn, projection| {
+                projection.queue_outbox(OutboxWriteRequest::new(
+                    SyncEntity::CustomProvider,
+                    "provider-1",
+                    SyncOperation::Create,
+                    json!({ "id": "provider-1", "name": "Provider 1" }),
+                ));
+                projection.queue_outbox(OutboxWriteRequest::new(
+                    SyncEntity::CustomProvider,
+                    "provider-2",
+                    SyncOperation::Create,
+                    json!({ "id": "provider-2", "name": "Provider 2" }),
+                ));
+                Ok(())
+            })
+            .await
+            .expect("projected write");
+
+        assert_eq!(notify_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn notifies_observer_even_if_caller_is_cancelled() {
+        let notify_count = Arc::new(AtomicUsize::new(0));
+        let observer_count = notify_count.clone();
+        let writer = spawn_writer_with_outbox_observer(
+            setup_pool(),
+            Arc::new(move || {
+                observer_count.fetch_add(1, Ordering::SeqCst);
+            }),
+        )
+        .expect("spawn writer");
+
+        let (started_tx, started_rx) = tokio_oneshot::channel();
+        let writer_for_task = writer.clone();
+        let task = tokio::spawn(async move {
+            writer_for_task
+                .exec_projected(move |_conn, projection| {
+                    started_tx.send(()).expect("signal writer started");
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                    projection.queue_outbox(OutboxWriteRequest::new(
+                        SyncEntity::CustomProvider,
+                        "provider-cancelled",
+                        SyncOperation::Create,
+                        json!({ "id": "provider-cancelled", "name": "Provider Cancelled" }),
+                    ));
+                    Ok(())
+                })
+                .await
+        });
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), started_rx)
+            .await
+            .expect("writer job started")
+            .expect("writer start signal sent");
+        task.abort();
+        let _ = task.await;
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        assert_eq!(notify_count.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn does_not_notify_observer_when_transaction_writes_no_outbox_rows() {
+        let notify_count = Arc::new(AtomicUsize::new(0));
+        let observer_count = notify_count.clone();
+        let writer = spawn_writer_with_outbox_observer(
+            setup_pool(),
+            Arc::new(move || {
+                observer_count.fetch_add(1, Ordering::SeqCst);
+            }),
+        )
+        .expect("spawn writer");
+
+        writer
+            .exec_tx(|tx| tx.run(|_conn| Ok(())))
+            .await
+            .expect("plain write");
+
+        assert_eq!(notify_count.load(Ordering::SeqCst), 0);
+    }
+}

--- a/crates/storage-sqlite/src/goals/repository.rs
+++ b/crates/storage-sqlite/src/goals/repository.rs
@@ -424,8 +424,7 @@ impl GoalRepositoryTrait for GoalRepository {
     ) -> Result<()> {
         let goal_id_owned = goal_id.to_string();
         self.writer
-            .exec_tx(move |tx| -> Result<()> {
-                let now = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
+            .exec(move |conn| -> Result<()> {
                 diesel::update(goals::table.find(&goal_id_owned))
                     .set((
                         goals::summary_target_amount.eq(update.summary_target_amount),
@@ -435,16 +434,9 @@ impl GoalRepositoryTrait for GoalRepository {
                         goals::projected_value_at_target_date
                             .eq(update.projected_value_at_target_date),
                         goals::status_health.eq(update.status_health),
-                        goals::updated_at.eq(now),
                     ))
-                    .execute(tx.conn())
+                    .execute(conn)
                     .map_err(StorageError::from)?;
-                // Re-read for sync outbox
-                let updated_db = goals::table
-                    .find(&goal_id_owned)
-                    .first::<GoalDB>(tx.conn())
-                    .map_err(StorageError::from)?;
-                tx.update(&updated_db)?;
                 Ok(())
             })
             .await

--- a/crates/storage-sqlite/src/schema.rs
+++ b/crates/storage-sqlite/src/schema.rs
@@ -418,6 +418,7 @@ diesel::table! {
         entity_id -> Text,
         last_event_id -> Text,
         last_client_timestamp -> Text,
+        last_op -> Text,
         last_seq -> BigInt,
     }
 }

--- a/crates/storage-sqlite/src/sync/app_sync/engine_ports.rs
+++ b/crates/storage-sqlite/src/sync/app_sync/engine_ports.rs
@@ -166,6 +166,17 @@ impl ReplayStore for SqliteSyncEngineDbPorts {
             .map_err(|e| e.to_string())
     }
 
+    async fn prune_sync_outbox(
+        &self,
+        sent_before: chrono::DateTime<chrono::Utc>,
+        dead_before: chrono::DateTime<chrono::Utc>,
+    ) -> Result<usize, String> {
+        self.repository
+            .prune_sync_outbox(sent_before, dead_before)
+            .await
+            .map_err(|e| e.to_string())
+    }
+
     async fn prune_applied_events_up_to_seq(&self, seq: i64) -> Result<(), String> {
         self.repository
             .prune_applied_events_up_to_seq(seq)

--- a/crates/storage-sqlite/src/sync/app_sync/mod.rs
+++ b/crates/storage-sqlite/src/sync/app_sync/mod.rs
@@ -14,6 +14,5 @@ pub use model::{
 };
 pub(crate) use outbox_projector::{flush_projected_outbox, ProjectedChange};
 pub use repository::{
-    insert_outbox_event, AppSyncRepository, OutboxWriteRequest, SyncLocalDataSummary,
-    SyncTableRowCount,
+    AppSyncRepository, OutboxWriteRequest, SyncLocalDataSummary, SyncTableRowCount,
 };

--- a/crates/storage-sqlite/src/sync/app_sync/model.rs
+++ b/crates/storage-sqlite/src/sync/app_sync/model.rs
@@ -110,6 +110,7 @@ pub struct SyncEntityMetadataDB {
     pub entity_id: String,
     pub last_event_id: String,
     pub last_client_timestamp: String,
+    pub last_op: String,
     pub last_seq: i64,
 }
 

--- a/crates/storage-sqlite/src/sync/app_sync/outbox_projector.rs
+++ b/crates/storage-sqlite/src/sync/app_sync/outbox_projector.rs
@@ -46,13 +46,15 @@ pub(crate) fn flush_projected_outbox(
     conn: &mut SqliteConnection,
     requests: Vec<OutboxWriteRequest>,
     projected_changes: Vec<ProjectedChange>,
-) -> Result<()> {
+) -> Result<usize> {
+    let mut inserted_count = 0;
     for request in requests.into_iter().chain(
         projected_changes
             .into_iter()
             .map(ProjectedChange::into_outbox_request),
     ) {
         insert_outbox_event(conn, request)?;
+        inserted_count += 1;
     }
-    Ok(())
+    Ok(inserted_count)
 }

--- a/crates/storage-sqlite/src/sync/app_sync/repository.rs
+++ b/crates/storage-sqlite/src/sync/app_sync/repository.rs
@@ -1,6 +1,6 @@
 //! Repository for app-side device sync tables.
 
-use chrono::{Duration, Utc};
+use chrono::{DateTime, Duration, Utc};
 use diesel::prelude::*;
 use diesel::r2d2::{self, Pool};
 use diesel::sqlite::SqliteConnection;
@@ -82,6 +82,41 @@ struct TableRowCountResult {
     #[diesel(sql_type = diesel::sql_types::BigInt)]
     count: i64,
 }
+
+const USER_SYNCABLE_HOLDINGS_SNAPSHOTS_FILTER: &str =
+    "source IN ('MANUAL_ENTRY', 'CSV_IMPORT', 'SYNTHETIC', 'BROKER_IMPORTED')";
+const MANUAL_QUOTES_FILTER: &str = "source = 'MANUAL'";
+const USER_IMPORT_RUNS_FILTER: &str =
+    "UPPER(run_type) = 'IMPORT' AND UPPER(source_system) IN ('CSV', 'MANUAL')";
+const USER_SYNCABLE_ACTIVITIES_FILTER: &str = "is_user_modified = 1 \
+     OR UPPER(COALESCE(source_system, '')) IN ('MANUAL', 'CSV') \
+     OR ((import_run_id IS NULL OR TRIM(import_run_id) = '') \
+         AND (source_record_id IS NULL OR TRIM(source_record_id) = ''))";
+
+const OVERWRITE_RISK_TABLE_COUNTS: &[(&str, Option<&str>)] = &[
+    ("platforms", None),
+    ("market_data_custom_providers", None),
+    ("accounts", None),
+    (
+        "assets",
+        Some("kind IN ('PROPERTY', 'VEHICLE', 'COLLECTIBLE', 'PRECIOUS_METAL', 'PRIVATE_EQUITY', 'LIABILITY', 'OTHER')"),
+    ),
+    ("quotes", Some(MANUAL_QUOTES_FILTER)),
+    ("goals", None),
+    ("goal_plans", None),
+    ("ai_threads", None),
+    ("ai_messages", None),
+    ("ai_thread_tags", None),
+    ("contribution_limits", None),
+    ("import_runs", Some(USER_IMPORT_RUNS_FILTER)),
+    ("activities", Some(USER_SYNCABLE_ACTIVITIES_FILTER)),
+    ("import_templates", Some("UPPER(scope) != 'SYSTEM'")),
+    ("import_account_templates", None),
+    ("taxonomies", Some("is_system = 0")),
+    ("taxonomy_categories", Some("taxonomy_id = 'custom_groups'")),
+    ("asset_taxonomy_assignments", None),
+    ("goals_allocation", None),
+];
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SyncTableRowCount {
@@ -401,28 +436,19 @@ fn normalize_outbox_payload(payload: serde_json::Value) -> Result<serde_json::Va
 const SYNC_TABLE_SNAPSHOT_FILTERS: &[(&str, &str)] = &[
     (
         "holdings_snapshots",
-        "source IN ('MANUAL_ENTRY', 'CSV_IMPORT', 'SYNTHETIC', 'BROKER_IMPORTED')",
+        USER_SYNCABLE_HOLDINGS_SNAPSHOTS_FILTER,
     ),
-    ("quotes", "source = 'MANUAL'"),
+    ("quotes", MANUAL_QUOTES_FILTER),
     // Taxonomy rows are all seeded by migrations — no user-created taxonomies yet.
     // Export nothing; the table is in APP_SYNC_TABLES for future custom taxonomy support.
     ("taxonomies", "is_system = 0"),
     // Only export user-created categories under custom_groups.
     ("taxonomy_categories", "taxonomy_id = 'custom_groups'"),
     // Only export user-initiated import runs (CSV/manual), matching the outbox policy.
-    (
-        "import_runs",
-        "UPPER(run_type) = 'IMPORT' AND UPPER(source_system) IN ('CSV', 'MANUAL')",
-    ),
+    ("import_runs", USER_IMPORT_RUNS_FILTER),
     // Activities: match the outbox policy so broker activities don't reference
     // filtered-out import_runs (which would cause FK violations on restore).
-    (
-        "activities",
-        "is_user_modified = 1 \
-         OR UPPER(COALESCE(source_system, '')) IN ('MANUAL', 'CSV') \
-         OR ((import_run_id IS NULL OR TRIM(import_run_id) = '') \
-             AND (source_record_id IS NULL OR TRIM(source_record_id) = ''))",
-    ),
+    ("activities", USER_SYNCABLE_ACTIVITIES_FILTER),
 ];
 
 fn snapshot_filter_for_table(table: &str) -> Option<&'static str> {
@@ -538,7 +564,77 @@ fn resolve_local_device_id(conn: &mut SqliteConnection) -> Option<String> {
         .unwrap_or(None)
 }
 
-pub fn insert_outbox_event(
+fn upsert_entity_metadata_tx(
+    conn: &mut SqliteConnection,
+    entity: SyncEntity,
+    entity_id: &str,
+    event_id: &str,
+    client_timestamp: &str,
+    op: SyncOperation,
+    seq: i64,
+) -> Result<()> {
+    let entity_db = enum_to_db(&entity)?;
+    let op_db = enum_to_db(&op)?;
+    diesel::insert_into(sync_entity_metadata::table)
+        .values(SyncEntityMetadataDB {
+            entity: entity_db,
+            entity_id: entity_id.to_string(),
+            last_event_id: event_id.to_string(),
+            last_client_timestamp: client_timestamp.to_string(),
+            last_op: op_db.clone(),
+            last_seq: seq,
+        })
+        .on_conflict((
+            sync_entity_metadata::entity,
+            sync_entity_metadata::entity_id,
+        ))
+        .do_update()
+        .set((
+            sync_entity_metadata::last_event_id.eq(event_id.to_string()),
+            sync_entity_metadata::last_client_timestamp.eq(client_timestamp.to_string()),
+            sync_entity_metadata::last_op.eq(op_db),
+            sync_entity_metadata::last_seq.eq(seq),
+        ))
+        .execute(conn)
+        .map_err(StorageError::from)?;
+    Ok(())
+}
+
+fn upsert_entity_metadata_preserving_seq_tx(
+    conn: &mut SqliteConnection,
+    entity: SyncEntity,
+    entity_id: &str,
+    event_id: &str,
+    client_timestamp: &str,
+    op: SyncOperation,
+) -> Result<()> {
+    let entity_db = enum_to_db(&entity)?;
+    let op_db = enum_to_db(&op)?;
+    diesel::insert_into(sync_entity_metadata::table)
+        .values(SyncEntityMetadataDB {
+            entity: entity_db,
+            entity_id: entity_id.to_string(),
+            last_event_id: event_id.to_string(),
+            last_client_timestamp: client_timestamp.to_string(),
+            last_op: op_db.clone(),
+            last_seq: 0,
+        })
+        .on_conflict((
+            sync_entity_metadata::entity,
+            sync_entity_metadata::entity_id,
+        ))
+        .do_update()
+        .set((
+            sync_entity_metadata::last_event_id.eq(event_id.to_string()),
+            sync_entity_metadata::last_client_timestamp.eq(client_timestamp.to_string()),
+            sync_entity_metadata::last_op.eq(op_db),
+        ))
+        .execute(conn)
+        .map_err(StorageError::from)?;
+    Ok(())
+}
+
+pub(in crate::sync::app_sync) fn insert_outbox_event(
     conn: &mut SqliteConnection,
     request: OutboxWriteRequest,
 ) -> Result<String> {
@@ -561,9 +657,9 @@ pub fn insert_outbox_event(
     let row = SyncOutboxEventDB {
         event_id: event_id.clone(),
         entity: enum_to_db(&entity)?,
-        entity_id,
+        entity_id: entity_id.clone(),
         op: enum_to_db(&op)?,
-        client_timestamp,
+        client_timestamp: client_timestamp.clone(),
         payload,
         payload_key_version,
         sent: 0,
@@ -580,6 +676,15 @@ pub fn insert_outbox_event(
         .values(&row)
         .execute(conn)
         .map_err(StorageError::from)?;
+
+    upsert_entity_metadata_preserving_seq_tx(
+        conn,
+        entity,
+        &entity_id,
+        &event_id,
+        &client_timestamp,
+        op,
+    )?;
 
     Ok(event_id)
 }
@@ -609,6 +714,7 @@ fn to_entity_metadata(row: SyncEntityMetadataDB) -> Result<SyncEntityMetadata> {
         entity_id: row.entity_id,
         last_event_id: row.last_event_id,
         last_client_timestamp: row.last_client_timestamp,
+        last_op: enum_from_db(&row.last_op)?,
         last_seq: row.last_seq,
     })
 }
@@ -837,12 +943,27 @@ fn apply_remote_event_lww_tx(
         .map_err(StorageError::from)?;
 
     let should_apply = match metadata_row.as_ref() {
-        Some(meta) => should_apply_lww(
-            &meta.last_client_timestamp,
-            &meta.last_event_id,
-            &client_timestamp_value,
-            &event_id_value,
-        ),
+        Some(meta) => {
+            let previous_op = enum_from_db::<SyncOperation>(&meta.last_op)?;
+            // Tombstones intentionally dominate all non-delete events for the same ID, and an
+            // incoming delete wins over a prior create/update even if its client timestamp is
+            // older. Reusing a UUID after deletion requires a full snapshot bootstrap/reset;
+            // otherwise stale updates from another device can resurrect rows the user deleted.
+            if op == SyncOperation::Delete && previous_op != SyncOperation::Delete {
+                true
+            } else if previous_op == SyncOperation::Delete
+                && matches!(op, SyncOperation::Create | SyncOperation::Update)
+            {
+                false
+            } else {
+                should_apply_lww(
+                    &meta.last_client_timestamp,
+                    &meta.last_event_id,
+                    &client_timestamp_value,
+                    &event_id_value,
+                )
+            }
+        }
         None => true,
     };
 
@@ -937,26 +1058,15 @@ fn apply_remote_event_lww_tx(
                 .map_err(StorageError::from)?;
         }
 
-        diesel::insert_into(sync_entity_metadata::table)
-            .values(SyncEntityMetadataDB {
-                entity: entity_db.clone(),
-                entity_id: entity_id_value.clone(),
-                last_event_id: event_id_value.clone(),
-                last_client_timestamp: client_timestamp_value.clone(),
-                last_seq: seq_value,
-            })
-            .on_conflict((
-                sync_entity_metadata::entity,
-                sync_entity_metadata::entity_id,
-            ))
-            .do_update()
-            .set((
-                sync_entity_metadata::last_event_id.eq(event_id_value.clone()),
-                sync_entity_metadata::last_client_timestamp.eq(client_timestamp_value.clone()),
-                sync_entity_metadata::last_seq.eq(seq_value),
-            ))
-            .execute(conn)
-            .map_err(StorageError::from)?;
+        upsert_entity_metadata_tx(
+            conn,
+            entity,
+            &entity_id_value,
+            &event_id_value,
+            &client_timestamp_value,
+            op,
+            seq_value,
+        )?;
     }
 
     diesel::insert_into(sync_applied_events::table)
@@ -1074,6 +1184,39 @@ impl AppSyncRepository {
         for table in APP_SYNC_TABLES {
             let table_ident = quote_identifier(table);
             let count_sql = format!("SELECT COUNT(*) AS count FROM {table_ident}");
+            let row = diesel::sql_query(count_sql)
+                .get_result::<TableRowCountResult>(&mut conn)
+                .map_err(StorageError::from)?;
+            total_rows += row.count;
+            if row.count > 0 {
+                non_empty_tables.push(SyncTableRowCount {
+                    table: table.to_string(),
+                    rows: row.count,
+                });
+            }
+        }
+
+        non_empty_tables.sort_by(|a, b| b.rows.cmp(&a.rows).then_with(|| a.table.cmp(&b.table)));
+
+        Ok(SyncLocalDataSummary {
+            total_rows,
+            non_empty_tables,
+        })
+    }
+
+    pub fn get_local_sync_overwrite_risk_summary(&self) -> Result<SyncLocalDataSummary> {
+        let mut conn = get_connection(&self.pool)?;
+        let mut total_rows = 0_i64;
+        let mut non_empty_tables = Vec::new();
+
+        for (table, filter) in OVERWRITE_RISK_TABLE_COUNTS {
+            let table_ident = quote_identifier(table);
+            let count_sql = match filter {
+                Some(filter) => {
+                    format!("SELECT COUNT(*) AS count FROM {table_ident} WHERE {filter}")
+                }
+                None => format!("SELECT COUNT(*) AS count FROM {table_ident}"),
+            };
             let row = diesel::sql_query(count_sql)
                 .get_result::<TableRowCountResult>(&mut conn)
                 .map_err(StorageError::from)?;
@@ -1395,6 +1538,7 @@ impl AppSyncRepository {
                     entity_id: metadata.entity_id.clone(),
                     last_event_id: metadata.last_event_id.clone(),
                     last_client_timestamp: metadata.last_client_timestamp.clone(),
+                    last_op: enum_to_db(&metadata.last_op)?,
                     last_seq: metadata.last_seq,
                 };
 
@@ -1409,6 +1553,7 @@ impl AppSyncRepository {
                         sync_entity_metadata::last_event_id.eq(row.last_event_id.clone()),
                         sync_entity_metadata::last_client_timestamp
                             .eq(row.last_client_timestamp.clone()),
+                        sync_entity_metadata::last_op.eq(row.last_op.clone()),
                         sync_entity_metadata::last_seq.eq(row.last_seq),
                     ))
                     .execute(conn)
@@ -1706,6 +1851,39 @@ impl AppSyncRepository {
                 .execute(conn)
                 .map_err(StorageError::from)?;
                 Ok(deleted)
+            })
+            .await
+    }
+
+    pub async fn prune_sync_outbox(
+        &self,
+        sent_before: DateTime<Utc>,
+        dead_before: DateTime<Utc>,
+    ) -> Result<usize> {
+        self.writer
+            .exec(move |conn| {
+                let sent_status = enum_to_db(&SyncOutboxStatus::Sent)?;
+                let dead_status = enum_to_db(&SyncOutboxStatus::Dead)?;
+                let sent_cutoff = sent_before.to_rfc3339();
+                let dead_cutoff = dead_before.to_rfc3339();
+
+                let sent_deleted = diesel::delete(
+                    sync_outbox::table
+                        .filter(sync_outbox::status.eq(sent_status))
+                        .filter(sync_outbox::created_at.lt(sent_cutoff)),
+                )
+                .execute(conn)
+                .map_err(StorageError::from)?;
+
+                let dead_deleted = diesel::delete(
+                    sync_outbox::table
+                        .filter(sync_outbox::status.eq(dead_status))
+                        .filter(sync_outbox::created_at.lt(dead_cutoff)),
+                )
+                .execute(conn)
+                .map_err(StorageError::from)?;
+
+                Ok(sent_deleted + dead_deleted)
             })
             .await
     }
@@ -2075,17 +2253,20 @@ impl AppSyncRepository {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use diesel::connection::SimpleConnection;
     use diesel::dsl::count_star;
     use diesel::Connection;
     use std::collections::BTreeSet;
     use tempfile::tempdir;
 
     use crate::db::{create_pool, get_connection, init, run_migrations, write_actor::spawn_writer};
+    use crate::goals::GoalRepository;
     use crate::schema::{
         accounts, assets, goals, goals_allocation, import_account_templates, import_templates,
         platforms, sync_applied_events, sync_device_config, sync_entity_metadata, sync_outbox,
         taxonomies, taxonomy_categories,
     };
+    use wealthfolio_core::goals::{GoalRepositoryTrait, GoalSummaryUpdate};
 
     fn setup_db() -> (
         Arc<Pool<r2d2::ConnectionManager<SqliteConnection>>>,
@@ -2106,10 +2287,127 @@ mod tests {
         (pool, writer)
     }
 
+    #[test]
+    fn last_op_migration_marks_missing_entities_as_tombstones() {
+        let mut conn = SqliteConnection::establish(":memory:").expect("memory db");
+        conn.batch_execute(
+            "
+            CREATE TABLE sync_entity_metadata (
+                entity TEXT NOT NULL,
+                entity_id TEXT NOT NULL,
+                last_event_id TEXT NOT NULL,
+                last_client_timestamp TEXT NOT NULL,
+                last_seq BIGINT NOT NULL DEFAULT 0,
+                PRIMARY KEY (entity, entity_id)
+            );
+            CREATE TABLE sync_outbox (
+                event_id TEXT PRIMARY KEY NOT NULL,
+                entity TEXT NOT NULL,
+                entity_id TEXT NOT NULL,
+                op TEXT NOT NULL,
+                client_timestamp TEXT NOT NULL
+            );
+            CREATE TABLE accounts (id TEXT PRIMARY KEY NOT NULL);
+            CREATE TABLE assets (id TEXT PRIMARY KEY NOT NULL);
+            CREATE TABLE quotes (id TEXT PRIMARY KEY NOT NULL);
+            CREATE TABLE asset_taxonomy_assignments (id TEXT PRIMARY KEY NOT NULL);
+            CREATE TABLE activities (id TEXT PRIMARY KEY NOT NULL);
+            CREATE TABLE import_account_templates (id TEXT PRIMARY KEY NOT NULL);
+            CREATE TABLE import_templates (id TEXT PRIMARY KEY NOT NULL);
+            CREATE TABLE goals (id TEXT PRIMARY KEY NOT NULL);
+            CREATE TABLE goal_plans (goal_id TEXT PRIMARY KEY NOT NULL);
+            CREATE TABLE goals_allocation (id TEXT PRIMARY KEY NOT NULL);
+            CREATE TABLE ai_threads (id TEXT PRIMARY KEY NOT NULL);
+            CREATE TABLE ai_messages (id TEXT PRIMARY KEY NOT NULL);
+            CREATE TABLE ai_thread_tags (id TEXT PRIMARY KEY NOT NULL);
+            CREATE TABLE contribution_limits (id TEXT PRIMARY KEY NOT NULL);
+            CREATE TABLE platforms (id TEXT PRIMARY KEY NOT NULL);
+            CREATE TABLE holdings_snapshots (id TEXT PRIMARY KEY NOT NULL);
+            CREATE TABLE market_data_custom_providers (id TEXT PRIMARY KEY NOT NULL);
+            CREATE TABLE taxonomies (id TEXT PRIMARY KEY NOT NULL);
+            CREATE TABLE import_runs (id TEXT PRIMARY KEY NOT NULL);
+
+            INSERT INTO accounts (id) VALUES ('existing-account');
+            INSERT INTO assets (id) VALUES ('existing-asset');
+
+            INSERT INTO sync_entity_metadata
+                (entity, entity_id, last_event_id, last_client_timestamp, last_seq)
+            VALUES
+                ('goal', 'deleted-goal', 'evt-remote-delete', '2026-02-12T00:00:10Z', 44),
+                ('account', 'existing-account', 'evt-remote-update', '2026-02-12T00:00:10Z', 55),
+                ('asset', 'existing-asset', 'evt-remote-old', '2026-02-12T00:00:10Z', 77);
+
+            INSERT INTO sync_outbox
+                (event_id, entity, entity_id, op, client_timestamp)
+            VALUES
+                ('evt-local-newer', 'asset', 'existing-asset', 'update', '2026-02-12T00:00:11Z');
+            ",
+        )
+        .expect("create pre-migration schema");
+
+        conn.batch_execute(include_str!(
+            "../../../migrations/2026-04-29-000001_sync_entity_metadata_last_op/up.sql"
+        ))
+        .expect("run last_op migration");
+
+        let deleted_goal = sync_entity_metadata::table
+            .filter(sync_entity_metadata::entity.eq("goal"))
+            .filter(sync_entity_metadata::entity_id.eq("deleted-goal"))
+            .first::<SyncEntityMetadataDB>(&mut conn)
+            .expect("deleted goal metadata");
+        assert_eq!(deleted_goal.last_op, "delete");
+        assert_eq!(deleted_goal.last_seq, 44);
+
+        let existing_account = sync_entity_metadata::table
+            .filter(sync_entity_metadata::entity.eq("account"))
+            .filter(sync_entity_metadata::entity_id.eq("existing-account"))
+            .first::<SyncEntityMetadataDB>(&mut conn)
+            .expect("existing account metadata");
+        assert_eq!(existing_account.last_op, "update");
+        assert_eq!(existing_account.last_seq, 55);
+
+        let existing_asset = sync_entity_metadata::table
+            .filter(sync_entity_metadata::entity.eq("asset"))
+            .filter(sync_entity_metadata::entity_id.eq("existing-asset"))
+            .first::<SyncEntityMetadataDB>(&mut conn)
+            .expect("existing asset metadata");
+        assert_eq!(existing_asset.last_event_id, "evt-local-newer");
+        assert_eq!(existing_asset.last_op, "update");
+        assert_eq!(existing_asset.last_seq, 77);
+    }
+
     fn insert_account_for_test(conn: &mut SqliteConnection, account_id: &str) -> Result<()> {
         let sql = format!(
             "INSERT INTO accounts (id, name, account_type, `group`, currency, is_default, is_active, created_at, updated_at, platform_id, account_number, meta, provider, provider_account_id, is_archived, tracking_mode) VALUES ('{}', 'Sync Test', 'cash', NULL, 'USD', 1, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL, NULL, NULL, NULL, NULL, 0, 'portfolio')",
             escape_sqlite_str(account_id)
+        );
+        diesel::sql_query(sql)
+            .execute(conn)
+            .map_err(StorageError::from)?;
+        Ok(())
+    }
+
+    fn insert_asset_kind_for_test(
+        conn: &mut SqliteConnection,
+        asset_id: &str,
+        kind: &str,
+    ) -> Result<()> {
+        let sql = format!(
+            "INSERT INTO assets (id, kind, name, display_code, notes, metadata, is_active, quote_mode, quote_ccy, instrument_type, instrument_symbol, instrument_exchange_mic, provider_config, created_at, updated_at) VALUES ('{}', '{}', 'Sync Test Asset', '{}', NULL, NULL, 1, 'MANUAL', 'USD', NULL, NULL, NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+            escape_sqlite_str(asset_id),
+            escape_sqlite_str(kind),
+            escape_sqlite_str(asset_id)
+        );
+        diesel::sql_query(sql)
+            .execute(conn)
+            .map_err(StorageError::from)?;
+        Ok(())
+    }
+
+    fn insert_goal_for_test(conn: &mut SqliteConnection, goal_id: &str) -> Result<()> {
+        let sql = format!(
+            "INSERT INTO goals (id, title, description, target_amount, goal_type, status_lifecycle, status_health, priority, cover_image_key, currency, start_date, target_date, summary_current_value, summary_progress, projected_completion_date, projected_value_at_target_date, created_at, updated_at, summary_target_amount) VALUES ('{}', 'Sync Goal', NULL, 1000, 'custom', 'active', 'on_track', 1, NULL, 'USD', NULL, NULL, 0, 0, NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 1000)",
+            escape_sqlite_str(goal_id)
         );
         diesel::sql_query(sql)
             .execute(conn)
@@ -2306,6 +2604,299 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn local_outbox_insert_updates_entity_metadata() {
+        let (pool, writer) = setup_db();
+        let repo = AppSyncRepository::new(pool, writer.clone());
+
+        writer
+            .exec_projected(|_conn, projection| {
+                let mut request = OutboxWriteRequest::new(
+                    SyncEntity::Goal,
+                    "goal-local-delete",
+                    SyncOperation::Delete,
+                    serde_json::json!({ "id": "goal-local-delete" }),
+                );
+                request.event_id = Some("evt-local-delete".to_string());
+                request.client_timestamp = "2026-02-12T00:00:10Z".to_string();
+                projection.queue_outbox(request);
+                Ok(())
+            })
+            .await
+            .expect("write local outbox");
+
+        let metadata = repo
+            .get_entity_metadata(SyncEntity::Goal, "goal-local-delete")
+            .expect("load metadata")
+            .expect("metadata should exist");
+        assert_eq!(metadata.last_event_id, "evt-local-delete");
+        assert_eq!(metadata.last_client_timestamp, "2026-02-12T00:00:10Z");
+        assert_eq!(metadata.last_op, SyncOperation::Delete);
+        assert_eq!(metadata.last_seq, 0);
+    }
+
+    #[tokio::test]
+    async fn remote_goal_update_does_not_resurrect_after_local_delete() {
+        let (pool, writer) = setup_db();
+        let repo = AppSyncRepository::new(pool.clone(), writer.clone());
+
+        writer
+            .exec_projected(|conn, projection| {
+                insert_goal_for_test(conn, "goal-delete-race")?;
+                diesel::delete(goals::table.find("goal-delete-race"))
+                    .execute(conn)
+                    .map_err(StorageError::from)?;
+
+                let mut request = OutboxWriteRequest::new(
+                    SyncEntity::Goal,
+                    "goal-delete-race",
+                    SyncOperation::Delete,
+                    serde_json::json!({ "id": "goal-delete-race" }),
+                );
+                request.event_id = Some("evt-local-goal-delete".to_string());
+                request.client_timestamp = "2026-02-12T00:00:10Z".to_string();
+                projection.queue_outbox(request);
+                Ok(())
+            })
+            .await
+            .expect("delete goal locally");
+
+        let applied = repo
+            .apply_remote_event_lww(
+                SyncEntity::Goal,
+                "goal-delete-race".to_string(),
+                SyncOperation::Update,
+                "evt-mobile-goal-update-after-delete".to_string(),
+                "2026-02-12T00:00:11Z".to_string(),
+                25,
+                serde_json::json!({
+                    "id": "goal-delete-race",
+                    "title": "Mobile copy touched after delete",
+                    "description": null,
+                    "target_amount": 1000.0,
+                    "goal_type": "custom",
+                    "status_lifecycle": "active",
+                    "status_health": "on_track",
+                    "priority": 1,
+                    "cover_image_key": null,
+                    "currency": "USD",
+                    "start_date": null,
+                    "target_date": null,
+                    "summary_current_value": 100.0,
+                    "summary_progress": 0.1,
+                    "projected_completion_date": null,
+                    "projected_value_at_target_date": null,
+                    "created_at": "2026-02-12T00:00:00Z",
+                    "updated_at": "2026-02-12T00:00:11Z",
+                    "summary_target_amount": 1000.0
+                }),
+            )
+            .await
+            .expect("apply remote update");
+
+        assert!(!applied, "remote update must be ignored after delete");
+        let mut conn = get_connection(&pool).expect("conn");
+        let goal_count: i64 = goals::table
+            .filter(goals::id.eq("goal-delete-race"))
+            .select(count_star())
+            .first(&mut conn)
+            .expect("count goals");
+        assert_eq!(goal_count, 0, "remote update must not resurrect the goal");
+    }
+
+    #[tokio::test]
+    async fn remote_goal_create_does_not_reuse_deleted_id() {
+        let (pool, writer) = setup_db();
+        let repo = AppSyncRepository::new(pool.clone(), writer.clone());
+
+        writer
+            .exec_projected(|conn, projection| {
+                insert_goal_for_test(conn, "goal-create-after-delete")?;
+                diesel::delete(goals::table.find("goal-create-after-delete"))
+                    .execute(conn)
+                    .map_err(StorageError::from)?;
+
+                let mut request = OutboxWriteRequest::new(
+                    SyncEntity::Goal,
+                    "goal-create-after-delete",
+                    SyncOperation::Delete,
+                    serde_json::json!({ "id": "goal-create-after-delete" }),
+                );
+                request.event_id = Some("evt-local-goal-delete-before-create".to_string());
+                request.client_timestamp = "2026-02-12T00:00:10Z".to_string();
+                projection.queue_outbox(request);
+                Ok(())
+            })
+            .await
+            .expect("delete goal locally");
+
+        let applied = repo
+            .apply_remote_event_lww(
+                SyncEntity::Goal,
+                "goal-create-after-delete".to_string(),
+                SyncOperation::Create,
+                "evt-remote-goal-create-after-delete".to_string(),
+                "2026-02-12T00:00:12Z".to_string(),
+                26,
+                serde_json::json!({
+                    "id": "goal-create-after-delete",
+                    "title": "Reused ID",
+                    "description": null,
+                    "target_amount": 1000.0,
+                    "goal_type": "custom",
+                    "status_lifecycle": "active",
+                    "status_health": "on_track",
+                    "priority": 1,
+                    "cover_image_key": null,
+                    "currency": "USD",
+                    "start_date": null,
+                    "target_date": null,
+                    "summary_current_value": 0.0,
+                    "summary_progress": 0.0,
+                    "projected_completion_date": null,
+                    "projected_value_at_target_date": null,
+                    "created_at": "2026-02-12T00:00:12Z",
+                    "updated_at": "2026-02-12T00:00:12Z",
+                    "summary_target_amount": 1000.0
+                }),
+            )
+            .await
+            .expect("apply remote create");
+
+        assert!(!applied, "remote create must not reuse a deleted ID");
+        let mut conn = get_connection(&pool).expect("conn");
+        let goal_count: i64 = goals::table
+            .filter(goals::id.eq("goal-create-after-delete"))
+            .select(count_star())
+            .first(&mut conn)
+            .expect("count goals");
+        assert_eq!(goal_count, 0, "remote create must not resurrect the goal");
+    }
+
+    #[tokio::test]
+    async fn remote_goal_delete_wins_over_local_update_marker() {
+        let (pool, writer) = setup_db();
+        let repo = AppSyncRepository::new(pool.clone(), writer.clone());
+
+        writer
+            .exec_projected(|conn, projection| {
+                insert_goal_for_test(conn, "goal-delete-wins")?;
+                let mut request = OutboxWriteRequest::new(
+                    SyncEntity::Goal,
+                    "goal-delete-wins",
+                    SyncOperation::Update,
+                    serde_json::json!({ "id": "goal-delete-wins" }),
+                );
+                request.event_id = Some("evt-local-goal-update".to_string());
+                request.client_timestamp = "2026-02-12T00:00:11Z".to_string();
+                projection.queue_outbox(request);
+                Ok(())
+            })
+            .await
+            .expect("write local update marker");
+
+        let applied = repo
+            .apply_remote_event_lww(
+                SyncEntity::Goal,
+                "goal-delete-wins".to_string(),
+                SyncOperation::Delete,
+                "evt-remote-goal-delete".to_string(),
+                "2026-02-12T00:00:10Z".to_string(),
+                26,
+                serde_json::json!({ "id": "goal-delete-wins" }),
+            )
+            .await
+            .expect("apply remote delete");
+
+        assert!(applied, "delete should win over a local update marker");
+        let mut conn = get_connection(&pool).expect("conn");
+        let goal_count: i64 = goals::table
+            .filter(goals::id.eq("goal-delete-wins"))
+            .select(count_star())
+            .first(&mut conn)
+            .expect("count goals");
+        assert_eq!(goal_count, 0, "delete must remove the goal");
+
+        let metadata = repo
+            .get_entity_metadata(SyncEntity::Goal, "goal-delete-wins")
+            .expect("load metadata")
+            .expect("metadata should exist");
+        assert_eq!(metadata.last_event_id, "evt-remote-goal-delete");
+        assert_eq!(metadata.last_op, SyncOperation::Delete);
+    }
+
+    #[tokio::test]
+    async fn goal_summary_refresh_stays_local_and_does_not_write_sync_outbox() {
+        let (pool, writer) = setup_db();
+        let goal_repo = GoalRepository::new(pool.clone(), writer.clone());
+
+        writer
+            .exec(|conn| {
+                insert_goal_for_test(conn, "goal-summary-cache")?;
+                Ok(())
+            })
+            .await
+            .expect("insert goal");
+
+        let before_updated_at: String = {
+            let mut conn = get_connection(&pool).expect("conn");
+            goals::table
+                .find("goal-summary-cache")
+                .select(goals::updated_at)
+                .first(&mut conn)
+                .expect("load initial updated_at")
+        };
+
+        goal_repo
+            .update_goal_summary_fields(
+                "goal-summary-cache",
+                GoalSummaryUpdate {
+                    summary_target_amount: Some(2_000.0),
+                    summary_current_value: Some(500.0),
+                    summary_progress: Some(0.25),
+                    projected_completion_date: Some("2026-12-31".to_string()),
+                    projected_value_at_target_date: Some(2_100.0),
+                    status_health: "on_track".to_string(),
+                },
+            )
+            .await
+            .expect("refresh summary");
+
+        let mut conn = get_connection(&pool).expect("conn");
+        let outbox_count: i64 = sync_outbox::table
+            .select(count_star())
+            .first(&mut conn)
+            .expect("count outbox");
+        let metadata_count: i64 = sync_entity_metadata::table
+            .filter(sync_entity_metadata::entity.eq(enum_to_db(&SyncEntity::Goal).expect("entity")))
+            .filter(sync_entity_metadata::entity_id.eq("goal-summary-cache"))
+            .select(count_star())
+            .first(&mut conn)
+            .expect("count metadata");
+        let (current_value, progress, status_health, after_updated_at): (
+            Option<f64>,
+            Option<f64>,
+            String,
+            String,
+        ) = goals::table
+            .find("goal-summary-cache")
+            .select((
+                goals::summary_current_value,
+                goals::summary_progress,
+                goals::status_health,
+                goals::updated_at,
+            ))
+            .first(&mut conn)
+            .expect("load summary fields");
+
+        assert_eq!(outbox_count, 0);
+        assert_eq!(metadata_count, 0);
+        assert_eq!(current_value, Some(500.0));
+        assert_eq!(progress, Some(0.25));
+        assert_eq!(status_health, "on_track");
+        assert_eq!(after_updated_at, before_updated_at);
+    }
+
+    #[tokio::test]
     async fn snapshot_restore_sets_cursor_and_is_idempotent() {
         let (pool, writer) = setup_db();
         let repo = AppSyncRepository::new(pool.clone(), writer);
@@ -2419,6 +3010,281 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn overwrite_risk_summary_ignores_seeded_system_rows() {
+        let (pool, writer) = setup_db();
+        let repo = AppSyncRepository::new(pool, writer);
+
+        let raw_summary = repo
+            .get_local_sync_data_summary()
+            .expect("raw sync summary");
+        let risk_summary = repo
+            .get_local_sync_overwrite_risk_summary()
+            .expect("overwrite risk summary");
+
+        assert!(
+            raw_summary.total_rows > 0,
+            "migrations should seed sync tables"
+        );
+        assert_eq!(risk_summary.total_rows, 0);
+        assert!(risk_summary.non_empty_tables.is_empty());
+    }
+
+    #[tokio::test]
+    async fn overwrite_risk_summary_counts_accounts_and_goals() {
+        let (pool, writer) = setup_db();
+        let repo = AppSyncRepository::new(pool.clone(), writer);
+
+        {
+            let mut conn = get_connection(&pool).expect("conn");
+            insert_account_for_test(&mut conn, "acc-overwrite-risk").expect("insert account");
+            insert_goal_for_test(&mut conn, "goal-overwrite-risk").expect("insert goal");
+        }
+
+        let summary = repo
+            .get_local_sync_overwrite_risk_summary()
+            .expect("overwrite risk summary");
+
+        assert_eq!(summary.total_rows, 2);
+        assert!(summary
+            .non_empty_tables
+            .iter()
+            .any(|row| row.table == "accounts" && row.rows == 1));
+        assert!(summary
+            .non_empty_tables
+            .iter()
+            .any(|row| row.table == "goals" && row.rows == 1));
+    }
+
+    #[tokio::test]
+    async fn overwrite_risk_summary_counts_only_standalone_asset_kinds() {
+        let (pool, writer) = setup_db();
+        let repo = AppSyncRepository::new(pool.clone(), writer);
+        let counted_kinds = [
+            "PROPERTY",
+            "VEHICLE",
+            "COLLECTIBLE",
+            "PRECIOUS_METAL",
+            "PRIVATE_EQUITY",
+            "LIABILITY",
+            "OTHER",
+        ];
+
+        {
+            let mut conn = get_connection(&pool).expect("conn");
+            for kind in counted_kinds {
+                insert_asset_kind_for_test(
+                    &mut conn,
+                    &format!("asset-{}", kind.to_ascii_lowercase()),
+                    kind,
+                )
+                .expect("insert counted asset");
+            }
+            insert_asset_kind_for_test(&mut conn, "asset-investment", "INVESTMENT")
+                .expect("insert investment asset");
+            insert_asset_kind_for_test(&mut conn, "asset-fx", "FX").expect("insert fx asset");
+        }
+
+        let summary = repo
+            .get_local_sync_overwrite_risk_summary()
+            .expect("overwrite risk summary");
+
+        assert_eq!(summary.total_rows, counted_kinds.len() as i64);
+        assert_eq!(
+            summary
+                .non_empty_tables
+                .iter()
+                .find(|row| row.table == "assets")
+                .map(|row| row.rows),
+            Some(counted_kinds.len() as i64)
+        );
+    }
+
+    #[tokio::test]
+    async fn overwrite_risk_summary_counts_user_curated_sync_tables() {
+        let (pool, writer) = setup_db();
+        let repo = AppSyncRepository::new(pool.clone(), writer);
+
+        {
+            let mut conn = get_connection(&pool).expect("conn");
+            insert_asset_kind_for_test(&mut conn, "asset-supporting-table", "INVESTMENT")
+                .expect("insert investment asset");
+            insert_account_for_test(&mut conn, "acc-supporting-table").expect("insert account");
+            insert_goal_for_test(&mut conn, "goal-supporting-table").expect("insert goal");
+            diesel::sql_query(
+                "INSERT INTO platforms (id, name, url, external_id, kind, website_url, logo_url) \
+                 VALUES ('platform-risk', 'Platform Risk', '', NULL, 'BROKERAGE', NULL, NULL)",
+            )
+            .execute(&mut conn)
+            .expect("insert platform");
+            diesel::sql_query(
+                "INSERT INTO market_data_custom_providers \
+                 (id, code, name, description, enabled, priority, config, created_at, updated_at) \
+                 VALUES ('provider-risk', 'RISK', 'Risk Provider', '', 1, 1, NULL, \
+                         '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z')",
+            )
+            .execute(&mut conn)
+            .expect("insert custom provider");
+            diesel::sql_query(
+                "INSERT INTO quotes \
+                 (id, asset_id, day, source, open, high, low, close, adjclose, volume, currency, notes, created_at, timestamp) \
+                 VALUES ('quote-risk', 'asset-supporting-table', '2026-02-12', 'MANUAL', NULL, NULL, NULL, \
+                         '10.00', NULL, NULL, 'USD', NULL, '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z')",
+            )
+            .execute(&mut conn)
+            .expect("insert manual quote");
+            diesel::sql_query(
+                "INSERT INTO goal_plans \
+                 (goal_id, plan_kind, planner_mode, settings_json, summary_json, version, created_at, updated_at) \
+                 VALUES ('goal-supporting-table', 'retirement', NULL, '{}', '{}', 1, \
+                         '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z')",
+            )
+            .execute(&mut conn)
+            .expect("insert goal plan");
+            diesel::sql_query(
+                "INSERT INTO goals_allocation \
+                 (id, goal_id, account_id, share_percent, tax_bucket, created_at, updated_at) \
+                 VALUES ('allocation-risk', 'goal-supporting-table', 'acc-supporting-table', 100.0, NULL, \
+                         '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z')",
+            )
+            .execute(&mut conn)
+            .expect("insert goal allocation");
+            diesel::sql_query(
+                "INSERT INTO ai_threads (id, title, config_snapshot, is_pinned, created_at, updated_at) \
+                 VALUES ('thread-risk', 'Risk Thread', NULL, 0, '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z')",
+            )
+            .execute(&mut conn)
+            .expect("insert ai thread");
+            diesel::sql_query(
+                "INSERT INTO ai_messages (id, thread_id, role, content_json, created_at) \
+                 VALUES ('message-risk', 'thread-risk', 'user', '{\"text\":\"risk\"}', '2026-02-12T00:00:00Z')",
+            )
+            .execute(&mut conn)
+            .expect("insert ai message");
+            diesel::sql_query(
+                "INSERT INTO ai_thread_tags (id, thread_id, tag, created_at) \
+                 VALUES ('tag-risk', 'thread-risk', 'tax', '2026-02-12T00:00:00Z')",
+            )
+            .execute(&mut conn)
+            .expect("insert ai thread tag");
+            diesel::sql_query(
+                "INSERT INTO contribution_limits \
+                 (id, group_name, contribution_year, limit_amount, account_ids, created_at, updated_at, start_date, end_date) \
+                 VALUES ('limit-risk', 'TFSA', 2026, 7000, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL, NULL)",
+            )
+            .execute(&mut conn)
+            .expect("insert contribution limit");
+            diesel::sql_query(
+                "INSERT INTO import_templates \
+                 (id, name, scope, kind, source_system, config_version, config, created_at, updated_at) \
+                 VALUES ('template-risk', 'Risk Template', 'USER', 'CSV_ACTIVITY', '', 1, '{}', \
+                         CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+            )
+            .execute(&mut conn)
+            .expect("insert user import template");
+            diesel::sql_query(
+                "INSERT INTO import_account_templates \
+                 (id, account_id, context_kind, source_system, template_id, created_at, updated_at) \
+                 VALUES ('profile-risk', 'acc-supporting-table', 'account', 'CSV', 'template-risk', \
+                         CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+            )
+            .execute(&mut conn)
+            .expect("insert import account template");
+            diesel::sql_query(
+                "INSERT INTO import_runs \
+                 (id, account_id, source_system, run_type, mode, status, started_at, finished_at, \
+                  review_mode, applied_at, checkpoint_in, checkpoint_out, summary, warnings, error, created_at, updated_at) \
+                 VALUES ('run-risk', 'acc-supporting-table', 'CSV', 'IMPORT', 'INCREMENTAL', 'APPLIED', \
+                         '2026-02-12T00:00:00Z', '2026-02-12T00:01:00Z', 'NEVER', '2026-02-12T00:01:00Z', \
+                         NULL, NULL, NULL, NULL, NULL, '2026-02-12T00:00:00Z', '2026-02-12T00:01:00Z')",
+            )
+            .execute(&mut conn)
+            .expect("insert import run");
+            diesel::sql_query(
+                "INSERT INTO activities \
+                 (id, account_id, asset_id, activity_type, activity_type_override, source_type, subtype, status, \
+                  activity_date, settlement_date, quantity, unit_price, amount, fee, currency, fx_rate, notes, metadata, \
+                  source_system, source_record_id, source_group_id, idempotency_key, import_run_id, is_user_modified, \
+                  needs_review, created_at, updated_at) \
+                 VALUES \
+                 ('activity-risk', 'acc-supporting-table', NULL, 'DEPOSIT', NULL, NULL, NULL, 'COMPLETED', \
+                  '2026-02-12', NULL, NULL, NULL, '100.00', NULL, 'USD', NULL, NULL, NULL, \
+                  'CSV', 'row-1', NULL, NULL, 'run-risk', 1, 0, '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z'), \
+                 ('activity-broker-ignore', 'acc-supporting-table', NULL, 'DEPOSIT', NULL, NULL, NULL, 'COMPLETED', \
+                  '2026-02-12', NULL, NULL, NULL, '100.00', NULL, 'USD', NULL, NULL, NULL, \
+                  'BROKER', 'broker-row-1', NULL, NULL, NULL, 0, 0, '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z')",
+            )
+            .execute(&mut conn)
+            .expect("insert activities");
+            diesel::sql_query(
+                "INSERT INTO taxonomies \
+                 (id, name, color, description, is_system, is_single_select, sort_order, created_at, updated_at) \
+                 VALUES ('taxonomy-risk', 'Risk Taxonomy', '#000000', NULL, 0, 0, 0, \
+                         '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z')",
+            )
+            .execute(&mut conn)
+            .expect("insert custom taxonomy");
+            diesel::sql_query(
+                "INSERT INTO taxonomy_categories \
+                 (id, taxonomy_id, parent_id, name, key, color, description, sort_order, created_at, updated_at) \
+                 VALUES ('category-risk', 'custom_groups', NULL, 'Risk Category', 'risk_category', '#000000', NULL, 0, \
+                         '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z')",
+            )
+            .execute(&mut conn)
+            .expect("insert custom group category");
+            diesel::sql_query(
+                "INSERT INTO asset_taxonomy_assignments \
+                 (id, asset_id, taxonomy_id, category_id, weight, source, created_at, updated_at) \
+                 VALUES ('assignment-risk', 'asset-supporting-table', 'custom_groups', 'category-risk', 10000, 'manual', \
+                         '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z')",
+            )
+            .execute(&mut conn)
+            .expect("insert asset taxonomy assignment");
+        }
+
+        let summary = repo
+            .get_local_sync_overwrite_risk_summary()
+            .expect("overwrite risk summary");
+        let expected_tables = [
+            "platforms",
+            "market_data_custom_providers",
+            "accounts",
+            "quotes",
+            "goals",
+            "goal_plans",
+            "goals_allocation",
+            "ai_threads",
+            "ai_messages",
+            "ai_thread_tags",
+            "contribution_limits",
+            "import_runs",
+            "activities",
+            "import_templates",
+            "import_account_templates",
+            "taxonomies",
+            "taxonomy_categories",
+            "asset_taxonomy_assignments",
+        ];
+
+        assert_eq!(summary.total_rows, expected_tables.len() as i64);
+        for table in expected_tables {
+            assert!(
+                summary
+                    .non_empty_tables
+                    .iter()
+                    .any(|row| row.table == table && row.rows == 1),
+                "expected overwrite risk for {table}"
+            );
+        }
+        assert!(
+            summary
+                .non_empty_tables
+                .iter()
+                .all(|row| row.table != "assets"),
+            "investment support asset should not count as overwrite risk"
+        );
+    }
+
+    #[tokio::test]
     async fn ok_cycle_outcome_clears_previous_engine_error() {
         let (pool, writer) = setup_db();
         let repo = AppSyncRepository::new(pool, writer);
@@ -2501,6 +3367,7 @@ mod tests {
             entity_id: "acc-local-dirty".to_string(),
             last_event_id: "evt-local".to_string(),
             last_client_timestamp: chrono::Utc::now().to_rfc3339(),
+            last_op: SyncOperation::Update,
             last_seq: 123,
         })
         .await
@@ -2568,6 +3435,7 @@ mod tests {
             entity_id: "acc-dirty".to_string(),
             last_event_id: "evt-dirty".to_string(),
             last_client_timestamp: chrono::Utc::now().to_rfc3339(),
+            last_op: SyncOperation::Update,
             last_seq: 42,
         })
         .await
@@ -2685,6 +3553,160 @@ mod tests {
         let pending = repo.list_pending_outbox(10).expect("list pending");
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].payload_key_version, 3);
+    }
+
+    #[tokio::test]
+    async fn local_outbox_metadata_preserves_remote_last_seq() {
+        let (pool, writer) = setup_db();
+        let repo = AppSyncRepository::new(pool, writer.clone());
+
+        repo.upsert_entity_metadata(SyncEntityMetadata {
+            entity: SyncEntity::Account,
+            entity_id: "acc-seq-preserve".to_string(),
+            last_event_id: "evt-remote".to_string(),
+            last_client_timestamp: "2026-02-12T00:00:00Z".to_string(),
+            last_op: SyncOperation::Update,
+            last_seq: 123,
+        })
+        .await
+        .expect("seed remote metadata");
+
+        writer
+            .exec(|conn| {
+                let mut request = OutboxWriteRequest::new(
+                    SyncEntity::Account,
+                    "acc-seq-preserve",
+                    SyncOperation::Update,
+                    serde_json::json!({ "id": "acc-seq-preserve" }),
+                );
+                request.event_id = Some("evt-local".to_string());
+                request.client_timestamp = "2026-02-12T00:00:01Z".to_string();
+                insert_outbox_event(conn, request)?;
+                Ok(())
+            })
+            .await
+            .expect("write local outbox");
+
+        let metadata = repo
+            .get_entity_metadata(SyncEntity::Account, "acc-seq-preserve")
+            .expect("load metadata")
+            .expect("metadata exists");
+        assert_eq!(metadata.last_event_id, "evt-local");
+        assert_eq!(metadata.last_seq, 123);
+    }
+
+    async fn insert_outbox_row_for_prune_test(
+        repo: &AppSyncRepository,
+        writer: &WriteHandle,
+        event_id: &str,
+        status: SyncOutboxStatus,
+        created_at: chrono::DateTime<Utc>,
+    ) {
+        let event_id_value = event_id.to_string();
+        writer
+            .exec(move |conn| {
+                let mut request = OutboxWriteRequest::new(
+                    SyncEntity::Account,
+                    format!("019cb093-06a8-7534-8677-{}", &event_id_value[0..12]),
+                    SyncOperation::Update,
+                    serde_json::json!({ "id": event_id_value }),
+                );
+                request.event_id = Some(event_id_value.clone());
+                insert_outbox_event(conn, request)?;
+                diesel::update(sync_outbox::table.find(event_id_value))
+                    .set((
+                        sync_outbox::status.eq(enum_to_db(&status)?),
+                        sync_outbox::sent.eq(if status == SyncOutboxStatus::Sent {
+                            1
+                        } else {
+                            0
+                        }),
+                        sync_outbox::created_at.eq(created_at.to_rfc3339()),
+                    ))
+                    .execute(conn)
+                    .map_err(StorageError::from)?;
+                Ok(())
+            })
+            .await
+            .expect("insert prune test outbox row");
+
+        assert!(
+            repo.list_pending_outbox(100).is_ok(),
+            "repo remains usable after prune test insert"
+        );
+    }
+
+    #[tokio::test]
+    async fn prune_sync_outbox_deletes_only_old_sent_and_dead_rows() {
+        let (_pool, writer) = setup_db();
+        let repo = AppSyncRepository::new(_pool, writer.clone());
+        let now = Utc::now();
+
+        insert_outbox_row_for_prune_test(
+            &repo,
+            &writer,
+            "sent-old-0001",
+            SyncOutboxStatus::Sent,
+            now - chrono::Duration::days(8),
+        )
+        .await;
+        insert_outbox_row_for_prune_test(
+            &repo,
+            &writer,
+            "sent-new-0001",
+            SyncOutboxStatus::Sent,
+            now - chrono::Duration::days(6),
+        )
+        .await;
+        insert_outbox_row_for_prune_test(
+            &repo,
+            &writer,
+            "dead-old-0001",
+            SyncOutboxStatus::Dead,
+            now - chrono::Duration::days(31),
+        )
+        .await;
+        insert_outbox_row_for_prune_test(
+            &repo,
+            &writer,
+            "dead-new-0001",
+            SyncOutboxStatus::Dead,
+            now - chrono::Duration::days(29),
+        )
+        .await;
+        insert_outbox_row_for_prune_test(
+            &repo,
+            &writer,
+            "pending-old1",
+            SyncOutboxStatus::Pending,
+            now - chrono::Duration::days(90),
+        )
+        .await;
+
+        let deleted = repo
+            .prune_sync_outbox(
+                now - chrono::Duration::days(7),
+                now - chrono::Duration::days(30),
+            )
+            .await
+            .expect("prune sync outbox");
+
+        assert_eq!(deleted, 2);
+
+        let mut conn = get_connection(&repo.pool).expect("conn");
+        let remaining_ids = sync_outbox::table
+            .select(sync_outbox::event_id)
+            .order(sync_outbox::event_id.asc())
+            .load::<String>(&mut conn)
+            .expect("remaining ids");
+        assert_eq!(
+            remaining_ids,
+            vec![
+                "dead-new-0001".to_string(),
+                "pending-old1".to_string(),
+                "sent-new-0001".to_string(),
+            ]
+        );
     }
 
     #[test]

--- a/crates/storage-sqlite/src/sync/mod.rs
+++ b/crates/storage-sqlite/src/sync/mod.rs
@@ -24,8 +24,8 @@ pub mod broker_ingest {
 // Re-export for convenience
 pub(crate) use app_sync::flush_projected_outbox;
 pub use app_sync::{
-    insert_outbox_event, AppSyncRepository, OutboxWriteRequest, SqliteSyncEngineDbPorts,
-    SyncLocalDataSummary, SyncTableRowCount,
+    AppSyncRepository, OutboxWriteRequest, SqliteSyncEngineDbPorts, SyncLocalDataSummary,
+    SyncTableRowCount,
 };
 pub use import_run::{ImportRunDB, ImportRunRepository};
 pub use platform::{Platform, PlatformDB, PlatformRepository};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wealthfolio-app",
   "private": true,
-  "version": "3.2.1",
+  "version": "3.3.0",
   "type": "module",
   "workspaces": [
     "apps/frontend",

--- a/packages/addon-dev-tools/package.json
+++ b/packages/addon-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/addon-dev-tools",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "Development tools for Wealthfolio addons - hot reload server and CLI",
   "main": "index.js",
   "bin": {

--- a/packages/addon-sdk/package-lock.json
+++ b/packages/addon-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wealthfolio/addon-sdk",
-  "version": "1.0.0",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wealthfolio/addon-sdk",
-      "version": "1.0.0",
+      "version": "3.3.0",
       "devDependencies": {
         "tsup": "^7.2.0",
         "typescript": "^5.4.0"

--- a/packages/addon-sdk/package.json
+++ b/packages/addon-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/addon-sdk",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "type": "module",
   "description": "TypeScript SDK for building Wealthfolio addons with enhanced functionality and type safety",
   "main": "dist/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/ui",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "type": "module",
   "description": "Wealthfolio UI components based on shadcn/ui and Tailwind CSS",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Bump the app and package versions to 3.3.0.
- Add account snapshot history management and polish related account holdings flows.
- Improve device sync liveness, pairing safety, and foreground sync behavior across desktop and web.
- Fix manual activity duplicate saves and tighten mobile activity update validation.
- Adjust history chart Y-axis scaling so material portfolio moves keep zero-context while low-volatility ranges stay readable.

## Root Cause

This branch collects follow-up fixes for the 3.3 release line. The latest chart issue came from the history chart using a very tight Y-domain for material one-sided value ranges, which made a drop such as 2000 to 1500 consume most of the chart height.

## Impact

Users get safer sync behavior, a snapshot history workflow for accounts, more reliable activity editing, and less visually exaggerated history charts for meaningful portfolio moves.

## Validation

- `pnpm --filter frontend test -- history-chart-scale`
- `pnpm --filter frontend type-check`
- `git diff --check origin/main...HEAD`