### PR TITLE
Fix macOS release Rust target setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,10 @@ jobs:
             ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' ||
             '' }}
 
+      - name: Install macOS Rust targets
+        if: contains(matrix.platform, 'macos')
+        run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
+
       - name: pnpm Setup
         run: npm install -g pnpm
 


### PR DESCRIPTION
## Summary
- explicitly install macOS Rust targets after Rust setup so the pinned rust-toolchain.toml toolchain has both darwin targets
- fixes release builds targeting x86_64-apple-darwin on macos-latest

## Verification
- pnpm exec prettier --check .github/workflows/release.yml
- git diff --cached --check