### PR TITLE
fix(frontend): Savings input utilizing user's currency & minor UI fix

### DIFF
--- a/apps/frontend/src/features/goals/save-up/components/save-up-detail.tsx
+++ b/apps/frontend/src/features/goals/save-up/components/save-up-detail.tsx
@@ -801,7 +801,7 @@ function LeverRow({
               onValueChange={(next) => onChange(Math.min(max, Math.max(min, next ?? 0)))}
               thousandSeparator
               maxDecimalPlaces={0}
-              className="text-foreground h-auto min-w-0 flex-1 rounded-none border-0 bg-transparent p-0 text-right text-sm tabular-nums shadow-none outline-none ring-0 focus-visible:ring-0 dark:bg-input/0"
+              className="text-foreground dark:bg-input/0 h-auto min-w-0 flex-1 rounded-none border-0 bg-transparent p-0 text-right text-sm tabular-nums shadow-none outline-none ring-0 focus-visible:ring-0"
             />
           ) : (
             <input

--- a/apps/frontend/src/features/goals/save-up/components/save-up-detail.tsx
+++ b/apps/frontend/src/features/goals/save-up/components/save-up-detail.tsx
@@ -424,7 +424,7 @@ export default function SaveUpDetailPage({ goal, plan, overview }: Props) {
                 min={0}
                 max={sliderMaxFor(Math.max(targetAmount, currentValue), 100_000, 25_000)}
                 step={100}
-                prefix="$"
+                prefix={currency}
                 format={(v) => Math.round(v).toLocaleString()}
               />
               <DateRow
@@ -442,7 +442,7 @@ export default function SaveUpDetailPage({ goal, plan, overview }: Props) {
                 min={0}
                 max={sliderMaxFor(monthlyContribution, 5_000, 500)}
                 step={25}
-                prefix="$"
+                prefix={currency}
                 format={(v) => Math.round(v).toLocaleString()}
               />
               <LeverRow

--- a/apps/frontend/src/features/goals/save-up/components/save-up-detail.tsx
+++ b/apps/frontend/src/features/goals/save-up/components/save-up-detail.tsx
@@ -801,7 +801,7 @@ function LeverRow({
               onValueChange={(next) => onChange(Math.min(max, Math.max(min, next ?? 0)))}
               thousandSeparator
               maxDecimalPlaces={0}
-              className="text-foreground h-auto min-w-0 flex-1 rounded-none border-0 bg-transparent p-0 text-right text-sm tabular-nums shadow-none outline-none ring-0 focus-visible:ring-0"
+              className="text-foreground h-auto min-w-0 flex-1 rounded-none border-0 bg-transparent p-0 text-right text-sm tabular-nums shadow-none outline-none ring-0 focus-visible:ring-0 dark:bg-input/0"
             />
           ) : (
             <input


### PR DESCRIPTION
Fixes [#909](https://github.com/afadil/wealthfolio/issues/909)

- Use the currency instead of always defaulting to `$` in savings plan.
- Remove the weird grey box in dark mode around MoneyInput.

## Screenshots
|   Light | Dark|
|---|---|
|<img width="350" height="350" alt="Fixed SS" src="https://github.com/user-attachments/assets/fc185963-334a-4142-a00e-4362c4281f35" />   |   <img width="350" height="350" alt="image" src="https://github.com/user-attachments/assets/f373fe37-c465-4084-804d-52543af266d2" />|


## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).
