### PR TITLE
Fix CSV import symbol mapping with padded values

### DIFF
--- a/apps/frontend/src/pages/activity/import/components/mapping-editor.tsx
+++ b/apps/frontend/src/pages/activity/import/components/mapping-editor.tsx
@@ -72,7 +72,7 @@ export function CsvMappingEditor(props: CsvMappingEditorProps) {
     const symbolMap = new Map<string, { row: CsvRowData; count: number }>();
 
     props.data.forEach((row) => {
-      const symbol = props.getMappedValue(row, ImportFormat.SYMBOL);
+      const symbol = props.getMappedValue(row, ImportFormat.SYMBOL)?.trim();
       if (!symbol) return;
 
       if (!symbolMap.has(symbol)) {

--- a/apps/frontend/src/pages/activity/import/components/mapping-table-cells.tsx
+++ b/apps/frontend/src/pages/activity/import/components/mapping-table-cells.tsx
@@ -395,19 +395,21 @@ export function MappingCell({
   }
 
   if (field === ImportFormat.SYMBOL) {
+    const symbol = value.trim();
+
     // Skip symbol display when not required (pure cash types, cash symbols)
     const csvType = getMappedValue(row, ImportFormat.ACTIVITY_TYPE)?.trim();
     const csvSubtype = getMappedValue(row, ImportFormat.SUBTYPE)?.trim();
     const appType = csvType ? findMappedActivityType(csvType, mapping.activityMappings) : null;
-    if (appType && (!needsImportAssetResolution(appType, csvSubtype) || isCashSymbol(value))) {
+    if (appType && (!needsImportAssetResolution(appType, csvSubtype) || isCashSymbol(symbol))) {
       return <span className="text-muted-foreground text-xs">-</span>;
     }
 
-    const isInvalid = invalidSymbols.includes(value || ""); // handle empty string case for invalidSymbols check
-    const mappedSymbol = mapping.symbolMappings[value];
+    const isInvalid = invalidSymbols.includes(symbol);
+    const mappedSymbol = mapping.symbolMappings[symbol];
     return (
       <SymbolDisplayCell
-        csvSymbol={value}
+        csvSymbol={symbol}
         mappedSymbol={mappedSymbol}
         isInvalid={isInvalid}
         handleSymbolMapping={handleSymbolMapping}

--- a/apps/frontend/src/pages/activity/import/components/mapping-table-cells.tsx
+++ b/apps/frontend/src/pages/activity/import/components/mapping-table-cells.tsx
@@ -371,7 +371,7 @@ export function MappingCell({
   // Nothing to display if value is empty and not a special field
   if (!value || value.trim() === "") {
     // For symbol field, if it's invalid (e.g. empty but required), we might still want to render SymbolDisplayCell
-    if (field === ImportFormat.SYMBOL && invalidSymbols.includes(value || "")) {
+    if (field === ImportFormat.SYMBOL && invalidSymbols.includes(value.trim())) {
       // Fall through to SymbolDisplayCell rendering
     } else if (field === ImportFormat.ACCOUNT) {
       // Fall through so the row shows the missing-account state.

--- a/apps/frontend/src/pages/activity/import/components/mapping-table.test.tsx
+++ b/apps/frontend/src/pages/activity/import/components/mapping-table.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ActivityType, ImportFormat, ImportType } from "@/lib/types";
+import type { CsvRowData, ImportMappingData } from "@/lib/types";
+import { MappingTable } from "./mapping-table";
+
+vi.mock("@/components/account-selector", () => ({
+  AccountSelector: () => <div data-testid="account-selector" />,
+}));
+
+vi.mock("@/components/ticker-search", () => ({
+  default: () => <input placeholder="Map symbol" />,
+}));
+
+describe("MappingTable symbol mappings", () => {
+  it("uses trimmed CSV symbols when displaying saved symbol mappings", () => {
+    const mapping: ImportMappingData = {
+      accountId: "account-1",
+      importType: ImportType.ACTIVITY,
+      name: "",
+      fieldMappings: {
+        [ImportFormat.DATE]: "Date",
+        [ImportFormat.ACTIVITY_TYPE]: "Type",
+        [ImportFormat.SYMBOL]: "Security",
+        [ImportFormat.QUANTITY]: "Quantity",
+      },
+      activityMappings: {
+        [ActivityType.BUY]: ["BUY"],
+      },
+      symbolMappings: {
+        "Long Fund Name": "VTI",
+      },
+      accountMappings: {},
+      symbolMappingMeta: {},
+    };
+    const row: CsvRowData = {
+      lineNumber: "1",
+      Date: "2026-01-15",
+      Type: "BUY",
+      Security: "  Long Fund Name  ",
+      Quantity: "1",
+    };
+    const getMappedValue = (csvRow: CsvRowData, field: ImportFormat) => {
+      const mappedHeader = mapping.fieldMappings[field];
+      if (!mappedHeader) return "";
+      if (Array.isArray(mappedHeader)) {
+        for (const header of mappedHeader) {
+          const value = csvRow[header]?.trim();
+          if (value) return value;
+        }
+        return "";
+      }
+      return csvRow[mappedHeader] || "";
+    };
+
+    render(
+      <MappingTable
+        mapping={mapping}
+        headers={["Date", "Type", "Security", "Quantity"]}
+        data={[row]}
+        accounts={[]}
+        handleColumnMapping={vi.fn()}
+        handleActivityTypeMapping={vi.fn()}
+        handleSymbolMapping={vi.fn()}
+        handleAccountIdMapping={vi.fn()}
+        getMappedValue={getMappedValue}
+        invalidSymbols={["Long Fund Name"]}
+        invalidAccounts={[]}
+      />,
+    );
+
+    expect(screen.getByText("VTI")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/pages/activity/import/steps/mapping-step-unified.tsx
+++ b/apps/frontend/src/pages/activity/import/steps/mapping-step-unified.tsx
@@ -313,11 +313,11 @@ export function MappingStepUnified() {
     const symbolMap = new Map<string, { row: CsvRowData; count: number }>();
 
     data.forEach((row) => {
-      const symbol = getMappedValue(row, ImportFormat.SYMBOL);
+      const symbol = getMappedValue(row, ImportFormat.SYMBOL)?.trim();
       if (!symbol) return;
 
       // Skip symbols that only appear on cash activity rows
-      if (!nonCashSymbolSet.has(symbol.trim())) return;
+      if (!nonCashSymbolSet.has(symbol)) return;
 
       if (!symbolMap.has(symbol)) {
         symbolMap.set(symbol, { row, count: 1 });

--- a/apps/frontend/src/pages/activity/import/utils/validation-utils.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/validation-utils.test.ts
@@ -137,6 +137,38 @@ describe("validation-utils", () => {
       expect(activity.fee).toBe(5.0);
     });
 
+    it("should apply symbol mappings using trimmed CSV symbol keys", () => {
+      const testData = [
+        {
+          lineNumber: "1",
+          date: "2024-01-01T00:00:00.000Z",
+          symbol: "  Long Fund Name  ",
+          activityType: "BUY",
+          quantity: "10",
+          unitPrice: "25.00",
+          amount: "250.00",
+          fee: "0",
+          currency: "USD",
+        },
+      ];
+
+      const result = validateActivityImport(
+        testData,
+        {
+          ...testMapping,
+          symbolMappings: {
+            "Long Fund Name": "VTI",
+          },
+        },
+        "test-account",
+        "USD",
+      );
+
+      expect(result.activities).toHaveLength(1);
+      expect(result.activities[0].symbol).toBe("VTI");
+      expect(result.activities[0].isValid).toBe(true);
+    });
+
     it("should convert negative values to positive for SELL activities", () => {
       const testData = [
         {

--- a/apps/frontend/src/pages/activity/import/utils/validation-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/validation-utils.ts
@@ -468,8 +468,9 @@ function transformRowToActivity(
   const normalizedSubtype = normalizeSubtype(rawSubtype || "");
 
   // Apply Symbol Mapping BEFORE determining activity type logic
-  if (activity.symbol && mapping.symbolMappings[activity.symbol]) {
-    activity.symbol = mapping.symbolMappings[activity.symbol];
+  if (activity.symbol) {
+    const symbolKey = activity.symbol.trim();
+    activity.symbol = mapping.symbolMappings[symbolKey] || symbolKey;
   }
 
   // Support typed symbol format (e.g. bond:US037833DU14)


### PR DESCRIPTION
## Summary
- Normalize CSV symbol values before mapping table display and symbol mapping lookups.
- Keep validation-time symbol mapping aligned with the mapping UI by trimming symbol keys before lookup.
- Trim unmapped imported activity symbols as part of validation normalization, so padded CSV values do not leak into later import steps.
- Add regression tests for padded broker fund names resolving through saved symbol mappings.

## Root Cause
CSV import symbol mappings were saved with trimmed keys, but parts of the mapping preview looked up raw cell values. A security name with leading or trailing whitespace could be considered unresolved by the wizard gate while no unmapped row appeared in the Activity Preview.

Fixes #926.

## Validation
- `pnpm exec prettier --check apps/frontend/src/pages/activity/import/components/mapping-editor.tsx apps/frontend/src/pages/activity/import/components/mapping-table-cells.tsx apps/frontend/src/pages/activity/import/components/mapping-table.test.tsx apps/frontend/src/pages/activity/import/steps/mapping-step-unified.tsx apps/frontend/src/pages/activity/import/utils/validation-utils.ts apps/frontend/src/pages/activity/import/utils/validation-utils.test.ts`
- `pnpm --filter frontend exec eslint src/pages/activity/import/components/mapping-editor.tsx src/pages/activity/import/components/mapping-table-cells.tsx src/pages/activity/import/components/mapping-table.test.tsx src/pages/activity/import/steps/mapping-step-unified.tsx src/pages/activity/import/utils/validation-utils.ts src/pages/activity/import/utils/validation-utils.test.ts`
- `pnpm --filter frontend lint:quiet`
- `pnpm --filter frontend exec vitest run src/pages/activity/import/components/mapping-table.test.tsx src/pages/activity/import/utils/validation-utils.test.ts src/pages/activity/import/utils/draft-utils.test.ts`
- `pnpm --filter frontend type-check`
- `git diff --check`