### PR TITLE
Fix bond provider quote sync state

### DIFF
--- a/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
+++ b/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
@@ -55,23 +55,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { type Path, useFieldArray, useForm, useWatch } from "react-hook-form";
 import * as z from "zod";
 import { toast } from "@wealthfolio/ui/components/ui/use-toast";
+import { serializeProviderConfig } from "./asset-provider-config";
 import { useAssetProfileMutations } from "./hooks/use-asset-profile-mutations";
 
-// Schema for a single provider override (type is derived from asset kind)
+// Schema for a single provider override (type is derived from instrument type)
 const providerOverrideSchema = z.object({
   provider: z.string(),
   symbol: z.string(),
 });
-
-// Derive override type from asset kind
-function getOverrideTypeForKind(kind: string): "equity_symbol" | "crypto_symbol" | "fx_symbol" {
-  switch (kind) {
-    case "FX":
-      return "fx_symbol";
-    default:
-      return "equity_symbol";
-  }
-}
 
 // QuoteMode values matching Rust enum
 const QuoteMode = {
@@ -173,41 +164,6 @@ function parsePreferredProvider(
     return typeof code === "string" ? `CUSTOM:${code}` : pref;
   }
   return pref;
-}
-
-// Serialize form values to nested provider config JSON
-function serializeProviderConfig(
-  preferredProvider: string | undefined,
-  overrides: ProviderOverride[],
-  assetKind: string,
-): Record<string, unknown> | null {
-  const overrideType = getOverrideTypeForKind(assetKind);
-  const overridesMap: Record<string, unknown> = {};
-  for (const override of overrides ?? []) {
-    if (override.provider && override.symbol) {
-      overridesMap[override.provider] = {
-        type: overrideType,
-        symbol: override.symbol,
-      };
-    }
-  }
-  const hasOverrides = Object.keys(overridesMap).length > 0;
-
-  // Handle CUSTOM:<code> format
-  let actualProvider = preferredProvider;
-  let customProviderCode: string | undefined;
-  if (preferredProvider?.startsWith("CUSTOM:")) {
-    actualProvider = "CUSTOM_SCRAPER";
-    customProviderCode = preferredProvider.slice("CUSTOM:".length);
-  }
-
-  const hasPref = !!actualProvider;
-  if (!hasOverrides && !hasPref) return null;
-  const result: Record<string, unknown> = {};
-  if (hasPref) result.preferred_provider = actualProvider;
-  if (customProviderCode) result.custom_provider_code = customProviderCode;
-  if (hasOverrides) result.overrides = overridesMap;
-  return result;
 }
 
 type EditTab = "general" | "classification" | "market-data" | "fx-settings";
@@ -632,7 +588,7 @@ export function AssetEditSheet({
       const serializedOverrides = serializeProviderConfig(
         values.preferredProvider,
         values.providerConfig ?? [],
-        asset.kind ?? "INVESTMENT",
+        values.instrumentType || asset.instrumentType,
       );
       const normalizedMic = normalizeMic(values.instrumentExchangeMic);
 

--- a/apps/frontend/src/pages/asset/asset-provider-config.test.ts
+++ b/apps/frontend/src/pages/asset/asset-provider-config.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { getOverrideTypeForInstrumentType, serializeProviderConfig } from "./asset-provider-config";
+
+describe("asset provider config", () => {
+  it("serializes bond overrides as bond ISIN mappings", () => {
+    expect(
+      serializeProviderConfig(
+        "BOERSE_FRANKFURT",
+        [{ provider: "BOERSE_FRANKFURT", symbol: "IT0005415291" }],
+        "BOND",
+      ),
+    ).toEqual({
+      preferred_provider: "BOERSE_FRANKFURT",
+      overrides: {
+        BOERSE_FRANKFURT: {
+          type: "bond_isin",
+          symbol: "IT0005415291",
+        },
+      },
+    });
+  });
+
+  it("maps market instrument types to provider override variants", () => {
+    expect(getOverrideTypeForInstrumentType("BOND")).toBe("bond_isin");
+    expect(getOverrideTypeForInstrumentType("CRYPTO")).toBe("crypto_symbol");
+    expect(getOverrideTypeForInstrumentType("CRYPTOCURRENCY")).toBe("crypto_symbol");
+    expect(getOverrideTypeForInstrumentType("FX")).toBe("fx_symbol");
+    expect(getOverrideTypeForInstrumentType("EQUITY")).toBe("equity_symbol");
+    expect(getOverrideTypeForInstrumentType("OPTION")).toBe("equity_symbol");
+  });
+});

--- a/apps/frontend/src/pages/asset/asset-provider-config.ts
+++ b/apps/frontend/src/pages/asset/asset-provider-config.ts
@@ -1,0 +1,55 @@
+export type ProviderOverrideType = "equity_symbol" | "crypto_symbol" | "fx_symbol" | "bond_isin";
+
+export interface ProviderOverrideConfig {
+  provider: string;
+  symbol: string;
+}
+
+export function getOverrideTypeForInstrumentType(
+  instrumentType: string | null | undefined,
+): ProviderOverrideType {
+  switch (instrumentType) {
+    case "BOND":
+      return "bond_isin";
+    case "CRYPTO":
+    case "CRYPTOCURRENCY":
+      return "crypto_symbol";
+    case "FX":
+      return "fx_symbol";
+    default:
+      return "equity_symbol";
+  }
+}
+
+export function serializeProviderConfig(
+  preferredProvider: string | undefined,
+  overrides: ProviderOverrideConfig[],
+  instrumentType: string | null | undefined,
+): Record<string, unknown> | null {
+  const overrideType = getOverrideTypeForInstrumentType(instrumentType);
+  const overridesMap: Record<string, unknown> = {};
+  for (const override of overrides ?? []) {
+    if (override.provider && override.symbol) {
+      overridesMap[override.provider] = {
+        type: overrideType,
+        symbol: override.symbol,
+      };
+    }
+  }
+  const hasOverrides = Object.keys(overridesMap).length > 0;
+
+  let actualProvider = preferredProvider;
+  let customProviderCode: string | undefined;
+  if (preferredProvider?.startsWith("CUSTOM:")) {
+    actualProvider = "CUSTOM_SCRAPER";
+    customProviderCode = preferredProvider.slice("CUSTOM:".length);
+  }
+
+  const hasPref = !!actualProvider;
+  if (!hasOverrides && !hasPref) return null;
+  const result: Record<string, unknown> = {};
+  if (hasPref) result.preferred_provider = actualProvider;
+  if (customProviderCode) result.custom_provider_code = customProviderCode;
+  if (hasOverrides) result.overrides = overridesMap;
+  return result;
+}

--- a/crates/core/src/assets/assets_model.rs
+++ b/crates/core/src/assets/assets_model.rs
@@ -409,42 +409,68 @@ impl Asset {
             .and_then(|v| serde_json::from_value(v.clone()).ok())
     }
 
+    fn metadata_identifier(&self, key: &str) -> Option<&str> {
+        self.metadata
+            .as_ref()
+            .and_then(|m| m.get("identifiers"))
+            .and_then(|v| v.as_object())
+            .and_then(|ids| ids.get(key))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+    }
+
     /// Convert to canonical instrument for market data resolution.
     /// Returns None for asset kinds that are not resolvable to market data.
     pub fn to_instrument_id(&self) -> Option<InstrumentId> {
         let inst_type = self.instrument_type.as_ref()?;
-        let symbol = self.instrument_symbol.as_ref()?;
 
         match inst_type {
-            InstrumentType::Equity => Some(InstrumentId::Equity {
-                ticker: Arc::from(symbol.as_str()),
-                mic: self
-                    .instrument_exchange_mic
-                    .as_ref()
-                    .map(|s| Cow::Owned(s.clone())),
-            }),
-            InstrumentType::Crypto => Some(InstrumentId::Crypto {
-                base: Arc::from(symbol.as_str()),
-                quote: Cow::Owned(self.quote_ccy.clone()),
-            }),
-            InstrumentType::Fx => Some(InstrumentId::Fx {
-                base: Cow::Owned(symbol.clone()),
-                quote: Cow::Owned(self.quote_ccy.clone()),
-            }),
-            InstrumentType::Metal => Some(InstrumentId::Metal {
-                code: Arc::from(symbol.as_str()),
-                quote: Cow::Owned(self.quote_ccy.clone()),
-            }),
+            InstrumentType::Equity => {
+                let symbol = self.instrument_symbol.as_ref()?;
+                Some(InstrumentId::Equity {
+                    ticker: Arc::from(symbol.as_str()),
+                    mic: self
+                        .instrument_exchange_mic
+                        .as_ref()
+                        .map(|s| Cow::Owned(s.clone())),
+                })
+            }
+            InstrumentType::Crypto => {
+                let symbol = self.instrument_symbol.as_ref()?;
+                Some(InstrumentId::Crypto {
+                    base: Arc::from(symbol.as_str()),
+                    quote: Cow::Owned(self.quote_ccy.clone()),
+                })
+            }
+            InstrumentType::Fx => {
+                let symbol = self.instrument_symbol.as_ref()?;
+                Some(InstrumentId::Fx {
+                    base: Cow::Owned(symbol.clone()),
+                    quote: Cow::Owned(self.quote_ccy.clone()),
+                })
+            }
+            InstrumentType::Metal => {
+                let symbol = self.instrument_symbol.as_ref()?;
+                Some(InstrumentId::Metal {
+                    code: Arc::from(symbol.as_str()),
+                    quote: Cow::Owned(self.quote_ccy.clone()),
+                })
+            }
             InstrumentType::Option => {
+                let symbol = self.instrument_symbol.as_ref()?;
                 // OCC symbol is stored as instrument_symbol
                 Some(InstrumentId::Option {
                     occ_symbol: Arc::from(symbol.as_str()),
                 })
             }
             InstrumentType::Bond => {
-                // ISIN is stored as instrument_symbol
+                let isin = self
+                    .metadata_identifier("isin")
+                    .map(|isin| isin.to_uppercase())
+                    .or_else(|| self.instrument_symbol.as_ref().map(|s| s.to_uppercase()))?;
                 Some(InstrumentId::Bond {
-                    isin: Arc::from(symbol.as_str()),
+                    isin: Arc::from(isin),
                 })
             }
         }

--- a/crates/core/src/assets/assets_model_tests.rs
+++ b/crates/core/src/assets/assets_model_tests.rs
@@ -432,6 +432,46 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_bond_to_instrument_id_prefers_metadata_isin() {
+        let asset = Asset {
+            instrument_type: Some(InstrumentType::Bond),
+            instrument_symbol: Some("BBG00VM3B640".to_string()),
+            metadata: Some(json!({
+                "identifiers": {
+                    "isin": "IT0005415291"
+                }
+            })),
+            ..create_test_asset(AssetKind::Investment)
+        };
+
+        let id = asset.to_instrument_id().unwrap();
+        match id {
+            crate::assets::InstrumentId::Bond { ref isin } => {
+                assert_eq!(isin.as_ref(), "IT0005415291");
+            }
+            _ => panic!("expected InstrumentId::Bond"),
+        }
+    }
+
+    #[test]
+    fn test_bond_to_instrument_id_falls_back_to_symbol() {
+        let asset = Asset {
+            instrument_type: Some(InstrumentType::Bond),
+            instrument_symbol: Some("US912797NQ65".to_string()),
+            metadata: Some(json!({ "identifiers": {} })),
+            ..create_test_asset(AssetKind::Investment)
+        };
+
+        let id = asset.to_instrument_id().unwrap();
+        match id {
+            crate::assets::InstrumentId::Bond { ref isin } => {
+                assert_eq!(isin.as_ref(), "US912797NQ65");
+            }
+            _ => panic!("expected InstrumentId::Bond"),
+        }
+    }
+
     // Helper function
     fn create_test_asset(kind: AssetKind) -> Asset {
         let quote_mode = match kind {

--- a/crates/core/src/assets/assets_service.rs
+++ b/crates/core/src/assets/assets_service.rs
@@ -155,6 +155,31 @@ impl AssetService {
         }
     }
 
+    fn metadata_identifier<'a>(
+        metadata: Option<&'a serde_json::Value>,
+        key: &str,
+    ) -> Option<&'a str> {
+        metadata
+            .and_then(|m| m.get("identifiers"))
+            .and_then(|v| v.as_object())
+            .and_then(|ids| ids.get(key))
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+    }
+
+    fn should_reset_sync_state_after_profile_change(before: &Asset, after: &Asset) -> bool {
+        before.quote_mode != after.quote_mode
+            || before.quote_ccy != after.quote_ccy
+            || before.instrument_type != after.instrument_type
+            || before.instrument_symbol != after.instrument_symbol
+            || before.instrument_exchange_mic != after.instrument_exchange_mic
+            || before.provider_config != after.provider_config
+            || ((before.is_bond() || after.is_bond())
+                && Self::metadata_identifier(before.metadata.as_ref(), "isin")
+                    != Self::metadata_identifier(after.metadata.as_ref(), "isin"))
+    }
+
     /// Creates a new AssetService instance
     pub fn new(
         asset_repository: Arc<dyn AssetRepositoryTrait>,
@@ -379,6 +404,19 @@ impl AssetServiceTrait for AssetService {
             .asset_repository
             .update_profile(asset_id, payload)
             .await?;
+
+        if Self::should_reset_sync_state_after_profile_change(&existing_asset, &asset) {
+            if let Err(err) = self
+                .quote_service
+                .reset_sync_state_for_profile_change(&asset.id)
+                .await
+            {
+                warn!(
+                    "Failed to reset quote sync state after asset profile update for {}: {}",
+                    asset.id, err
+                );
+            }
+        }
 
         self.event_sink
             .emit(DomainEvent::assets_updated(vec![asset.id.clone()]));
@@ -1351,7 +1389,7 @@ impl AssetServiceTrait for AssetService {
 
 #[cfg(test)]
 mod tests {
-    use super::super::assets_model::InstrumentType;
+    use super::super::assets_model::{Asset, AssetKind, InstrumentType};
     use super::{AssetService, QuoteMode};
 
     #[test]
@@ -1440,5 +1478,73 @@ mod tests {
             Some(serde_json::json!({ "preferred_provider": "BOERSE_FRANKFURT" })),
             "ISIN-backed XETR/XFRA equities should prefer Boerse Frankfurt"
         );
+    }
+
+    #[test]
+    fn test_profile_provider_change_resets_sync_state() {
+        let before = Asset {
+            provider_config: Some(serde_json::json!({ "preferred_provider": "YAHOO" })),
+            ..test_market_asset()
+        };
+        let after = Asset {
+            provider_config: Some(serde_json::json!({
+                "preferred_provider": "BOERSE_FRANKFURT"
+            })),
+            ..before.clone()
+        };
+
+        assert!(AssetService::should_reset_sync_state_after_profile_change(
+            &before, &after
+        ));
+    }
+
+    #[test]
+    fn test_bond_isin_metadata_change_resets_sync_state() {
+        let before = Asset {
+            instrument_type: Some(InstrumentType::Bond),
+            metadata: Some(serde_json::json!({
+                "identifiers": {
+                    "isin": "US912797NQ65"
+                }
+            })),
+            ..test_market_asset()
+        };
+        let after = Asset {
+            metadata: Some(serde_json::json!({
+                "identifiers": {
+                    "isin": "IT0005415291"
+                }
+            })),
+            ..before.clone()
+        };
+
+        assert!(AssetService::should_reset_sync_state_after_profile_change(
+            &before, &after
+        ));
+    }
+
+    #[test]
+    fn test_notes_change_does_not_reset_sync_state() {
+        let before = test_market_asset();
+        let after = Asset {
+            notes: Some("Updated notes".to_string()),
+            ..before.clone()
+        };
+
+        assert!(!AssetService::should_reset_sync_state_after_profile_change(
+            &before, &after
+        ));
+    }
+
+    fn test_market_asset() -> Asset {
+        Asset {
+            id: "asset-1".to_string(),
+            kind: AssetKind::Investment,
+            quote_mode: QuoteMode::Market,
+            quote_ccy: "USD".to_string(),
+            instrument_type: Some(InstrumentType::Equity),
+            instrument_symbol: Some("AAPL".to_string()),
+            ..Default::default()
+        }
     }
 }

--- a/crates/core/src/quotes/service.rs
+++ b/crates/core/src/quotes/service.rs
@@ -391,6 +391,12 @@ pub trait QuoteServiceTrait: Send + Sync {
     /// Reset sync error counts for the given asset IDs, allowing retry.
     async fn reset_sync_errors(&self, asset_ids: &[String]) -> Result<()>;
 
+    /// Reset stale sync routing/error state after a market identity or provider profile change.
+    async fn reset_sync_state_for_profile_change(&self, asset_id: &str) -> Result<()> {
+        let _ = asset_id;
+        Ok(())
+    }
+
     /// Update position status (active/inactive) based on current holdings.
     async fn update_position_status_from_holdings(
         &self,
@@ -1451,6 +1457,17 @@ where
         Ok(())
     }
 
+    async fn reset_sync_state_for_profile_change(&self, asset_id: &str) -> Result<()> {
+        if let Some(mut state) = self.sync_state_store.get_by_asset_id(asset_id)? {
+            state.error_count = 0;
+            state.last_error = None;
+            state.data_source.clear();
+            state.updated_at = Utc::now();
+            self.sync_state_store.upsert(&state).await?;
+        }
+        Ok(())
+    }
+
     // =========================================================================
     // Provider Settings
     // =========================================================================
@@ -2076,7 +2093,7 @@ mod tests {
     use async_trait::async_trait;
     use rust_decimal_macros::dec;
     use std::collections::HashMap;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn test_instrument_key_from_bf_search_result_uses_isin_and_mic() {
@@ -2216,6 +2233,7 @@ mod tests {
     struct MockSyncStateStore {
         provider_sync_stats: Vec<ProviderSyncStats>,
         with_errors: Vec<QuoteSyncState>,
+        states: Arc<Mutex<HashMap<String, QuoteSyncState>>>,
     }
 
     #[async_trait]
@@ -2228,8 +2246,8 @@ mod tests {
             unimplemented!("unused in this test")
         }
 
-        fn get_by_asset_id(&self, _asset_id: &str) -> Result<Option<QuoteSyncState>> {
-            unimplemented!("unused in this test")
+        fn get_by_asset_id(&self, asset_id: &str) -> Result<Option<QuoteSyncState>> {
+            Ok(self.states.lock().unwrap().get(asset_id).cloned())
         }
 
         fn get_by_asset_ids(
@@ -2247,8 +2265,12 @@ mod tests {
             unimplemented!("unused in this test")
         }
 
-        async fn upsert(&self, _state: &QuoteSyncState) -> Result<QuoteSyncState> {
-            unimplemented!("unused in this test")
+        async fn upsert(&self, state: &QuoteSyncState) -> Result<QuoteSyncState> {
+            self.states
+                .lock()
+                .unwrap()
+                .insert(state.asset_id.clone(), state.clone());
+            Ok(state.clone())
         }
 
         async fn upsert_batch(&self, _states: &[QuoteSyncState]) -> Result<usize> {
@@ -2683,6 +2705,7 @@ mod tests {
                 created_at: now,
                 updated_at: now,
             }],
+            states: Arc::new(Mutex::new(HashMap::new())),
         });
 
         let service = QuoteService::new(
@@ -2714,6 +2737,54 @@ mod tests {
             Some(finnhub_error.as_str())
         );
         assert_eq!(finnhub.unique_errors, vec![finnhub_error]);
+    }
+
+    #[tokio::test]
+    async fn test_reset_sync_state_for_profile_change_clears_errors_and_provider_binding() {
+        let now = Utc::now();
+        let state = QuoteSyncState {
+            asset_id: "asset_1".to_string(),
+            is_active: true,
+            position_closed_date: None,
+            last_synced_at: Some(now),
+            data_source: "YAHOO".to_string(),
+            sync_priority: 100,
+            error_count: 10,
+            last_error: Some("old failure".to_string()),
+            profile_enriched_at: Some(now),
+            created_at: now,
+            updated_at: now,
+        };
+        let states = Arc::new(Mutex::new(HashMap::from([(
+            state.asset_id.clone(),
+            state.clone(),
+        )])));
+        let sync_state_store = Arc::new(MockSyncStateStore {
+            provider_sync_stats: vec![],
+            with_errors: vec![],
+            states: Arc::clone(&states),
+        });
+        let service = QuoteService::new(
+            Arc::new(NoopQuoteStore),
+            sync_state_store,
+            Arc::new(MockProviderSettingsStore { providers: vec![] }),
+            Arc::new(NoopAssetRepository),
+            Arc::new(NoopActivityRepository),
+            Arc::new(MockSecretStore),
+        )
+        .await
+        .unwrap();
+
+        QuoteServiceTrait::reset_sync_state_for_profile_change(&service, "asset_1")
+            .await
+            .unwrap();
+
+        let updated = states.lock().unwrap().get("asset_1").cloned().unwrap();
+        assert_eq!(updated.data_source, "");
+        assert_eq!(updated.error_count, 0);
+        assert!(updated.last_error.is_none());
+        assert_eq!(updated.last_synced_at, state.last_synced_at);
+        assert_eq!(updated.profile_enriched_at, state.profile_enriched_at);
     }
 
     #[test]


### PR DESCRIPTION
Closes #918.

## Summary
- Resolve bond market data identity from metadata ISIN before falling back to instrument symbol.
- Serialize asset provider overrides by instrument type so bond mappings use `bond_isin`.
- Clear stale quote sync provider/error state after market identity or provider profile changes.

## Root Cause
Bond provider overrides were derived from asset kind, so bonds were sent as equity symbol overrides. Separately, persisted quote sync `data_source` and error state could keep routing a changed asset profile through stale provider state.

## Validation
- `cargo test -p wealthfolio-core`
- `pnpm --filter frontend type-check`
- `cargo fmt --check`
- `pnpm --filter frontend exec prettier --check src/pages/asset/asset-edit-sheet.tsx src/pages/asset/asset-provider-config.ts src/pages/asset/asset-provider-config.test.ts`
- `git diff --cached --check`