### PR TITLE
Add dev:web:log script to tee server output to file

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,10 +1,8 @@
 # Claude worktrees
 .claude/
 
-# Local tooling
-.air/
-.agents/
-.agent/
+# Local hidden directories
+.*
 
 # Build outputs
 dist/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,11 @@
 # Claude worktrees
 .claude/
 
+# Local tooling
+.air/
+.agents/
+.agent/
+
 # Build outputs
 dist/
 coverage/

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "dev:tauri": "pnpm --filter frontend dev:tauri",
     "dev:addons": "pnpm --filter frontend dev:addons",
     "dev:web": "node scripts/dev-web.mjs",
+    "dev:web:log": "node scripts/dev-web.mjs --file-log",
     "build": "pnpm --filter frontend build",
     "build:tauri": "pnpm --filter frontend build:tauri",
     "build:types": "pnpm -r run build:types",

--- a/scripts/dev-web.mjs
+++ b/scripts/dev-web.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
-import { readFileSync, existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { createWriteStream, readFileSync, existsSync, mkdirSync } from "node:fs";
+import { resolve, basename } from "node:path";
 
 function loadDotenvFile(file) {
   const p = resolve(process.cwd(), file);
@@ -32,11 +32,34 @@ loadDotenvFile(".env.web");
 // Set build target for web mode
 process.env.BUILD_TARGET = "web";
 
+const fileLog = process.argv.includes("--file-log");
+let logStream = null;
+
+if (fileLog) {
+  const dbUrl = process.env.WF_DB_PATH || process.env.DATABASE_URL || "app.db";
+  const dbName = basename(dbUrl, ".db");
+  mkdirSync("logs", { recursive: true });
+  logStream = createWriteStream(`logs/${dbName}.log`);
+}
+
 const children = new Map();
 let exiting = false;
 
 function spawnNamed(name, cmd, args, opts = {}) {
-  const child = spawn(cmd, args, { stdio: "inherit", shell: false, ...opts });
+  const stdio = logStream ? ["inherit", "pipe", "pipe"] : "inherit";
+  const child = spawn(cmd, args, { stdio, shell: false, ...opts });
+
+  if (logStream) {
+    child.stdout.on("data", (chunk) => {
+      process.stdout.write(chunk);
+      logStream.write(chunk);
+    });
+    child.stderr.on("data", (chunk) => {
+      process.stderr.write(chunk);
+      logStream.write(chunk);
+    });
+  }
+
   children.set(name, child);
   child.on("exit", (code, signal) => {
     if (exiting) return;


### PR DESCRIPTION
## Summary

- Adds `--file-log` flag to `scripts/dev-web.mjs`: derives log filename from `WF_DB_PATH` (or `DATABASE_URL` fallback), creates `logs/<db>.log`, and tees stdout+stderr of all child processes to it
- Adds `dev:web:log` npm script as convenience wrapper
- Excludes all hidden directories (`.*`) from Prettier checks in `.prettierignore`

## Test plan

- [x] Run `pnpm dev:web:log` and verify `logs/app-dev.log` (or matching your `WF_DB_PATH`) is created
- [x] Verify output appears both on screen and in the log file
- [x] Verify `pnpm dev:web` still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)