### PR TITLE
Run container as non-root user (UID/GID 1000)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,16 @@ ENV WF_DB_PATH=/data/wealthfolio.db
 # Wealthfolio Connect API URL (can be overridden at runtime via -e or docker-compose)
 ARG CONNECT_API_URL=
 ENV CONNECT_API_URL=${CONNECT_API_URL}
+
+# Run as non-root. chown /data BEFORE the VOLUME directive so named volumes
+# inherit ownership on first creation. Existing volumes from older images
+# need a one-time chown — see docs/self-host/README.md.
+RUN addgroup -S -g 1000 wealthfolio \
+ && adduser -S -u 1000 -G wealthfolio -H -s /sbin/nologin wealthfolio \
+ && mkdir -p /data \
+ && chown -R wealthfolio:wealthfolio /data
+USER 1000:1000
+
 VOLUME ["/data"]
 EXPOSE 8080
 CMD ["/usr/local/bin/wealthfolio-server"]

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ docker run --rm -d \
   --name wealthfolio \
   --env-file .env.docker \
   -p 8088:8088 \
-  -v "$(pwd)/wealthfolio-data:/data" \
+  -v wealthfolio-data:/data \
   afadil/wealthfolio:latest
 ```
 
@@ -423,7 +423,7 @@ docker run --rm -d \
   -e WF_LISTEN_ADDR=0.0.0.0:8088 \
   -e WF_DB_PATH=/data/wealthfolio.db \
   -p 8088:8088 \
-  -v "$(pwd)/wealthfolio-data:/data" \
+  -v wealthfolio-data:/data \
   afadil/wealthfolio:latest
 ```
 
@@ -436,7 +436,7 @@ docker run --rm -it \
   -e WF_DB_PATH=/data/wealthfolio.db \
   -e WF_CORS_ALLOW_ORIGINS=http://localhost:1420 \
   -p 8088:8088 \
-  -v "$(pwd)/wealthfolio-data:/data" \
+  -v wealthfolio-data:/data \
   afadil/wealthfolio:latest
 ```
 
@@ -449,7 +449,7 @@ docker run --rm -d \
   -e WF_DB_PATH=/data/wealthfolio.db \
   -e WF_SECRET_KEY=$(openssl rand -base64 32) \
   -p 8088:8088 \
-  -v "$(pwd)/wealthfolio-data:/data" \
+  -v wealthfolio-data:/data \
   afadil/wealthfolio:latest
 ```
 

--- a/docs/self-host/README.md
+++ b/docs/self-host/README.md
@@ -22,6 +22,27 @@ Multi-arch (`linux/amd64`, `linux/arm64`), published on every `v*.*.*` tag:
 docker pull afadil/wealthfolio:latest
 ```
 
+## Permissions
+
+The container runs as a non-root user (UID/GID **1000:1000**).
+
+**Fresh install:** Docker named volumes work out of the box. For a bind mount,
+make the host directory writable by UID 1000:
+
+```bash
+mkdir -p ./data && sudo chown -R 1000:1000 ./data
+```
+
+**Upgrading from an older image:** existing data is owned by `root` and must be
+chowned once. Pick the line that matches your setup:
+
+```bash
+# named volume
+docker run --rm -v <your-volume>:/data alpine chown -R 1000:1000 /data
+# bind mount
+sudo chown -R 1000:1000 /path/to/your/data
+```
+
 ## Platform pointers
 
 - [**Docker / Docker Compose**](https://wealthfolio.app/docs/guide/self-hosting):

--- a/docs/self-host/unraid/README.md
+++ b/docs/self-host/unraid/README.md
@@ -30,3 +30,17 @@ Then **Docker → Add Container → Template → User templates → wealthfolio*
 
 See the website guide for required values, the password hash recipe, reverse
 proxy setup, backups, and troubleshooting.
+
+## Permissions
+
+The image runs as a non-root user (UID 1000) by default. The Unraid template
+overrides this via `--user=99:100` in `<ExtraParams>` so the container matches
+Unraid's standard `nobody:users` appdata ownership — fresh installs work without
+any host-side `chown`.
+
+**Upgrading from an older image** (pre-`v3.4.0`): existing data was written as
+`root:root`. Run once on the Unraid host:
+
+```bash
+chown -R 99:100 /mnt/user/appdata/wealthfolio
+```

--- a/docs/self-host/unraid/template.xml
+++ b/docs/self-host/unraid/template.xml
@@ -23,7 +23,7 @@ Full guide: https://github.com/afadil/wealthfolio/blob/main/docs/self-host/unrai
   <WebUI>http://[IP]:[PORT:8088]/</WebUI>
   <TemplateURL>https://raw.githubusercontent.com/afadil/wealthfolio/main/docs/self-host/unraid/template.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/afadil/wealthfolio/main/assets/brand/icon.png</Icon>
-  <ExtraParams>--health-cmd="wget --quiet --tries=1 --spider http://127.0.0.1:8088/api/v1/healthz || exit 1" --health-interval=30s --health-timeout=10s --health-retries=3 --health-start-period=15s</ExtraParams>
+  <ExtraParams>--user=99:100 --health-cmd="wget --quiet --tries=1 --spider http://127.0.0.1:8088/api/v1/healthz || exit 1" --health-interval=30s --health-timeout=10s --health-retries=3 --health-start-period=15s</ExtraParams>
   <PostArgs/>
   <CPUset/>
   <DateInstalled/>


### PR DESCRIPTION
Closes #919.

## Summary

The published Docker image now runs as a fixed non-root user (UID/GID **1000:1000**), satisfying Kubernetes Pod Security Standard "restricted" (`runAsNonRoot=true`) and matching peer self-hosted projects (Ghostfolio, Paperless-ngx, Maybe Finance, Gitea — all run as UID 1000).

| Surface | Change |
| --- | --- |
| `Dockerfile` | Adds `wealthfolio` system user (UID 1000), pre-creates and chowns `/data` before `VOLUME`, sets `USER 1000:1000` |
| `README.md` | Quickstart docker examples switched from bind mount → named volume so fresh installs work without host-side chown |
| `docs/self-host/README.md` | New **Permissions** section with fresh-install + upgrade migration commands |
| `docs/self-host/unraid/template.xml` | Adds `--user=99:100` to `<ExtraParams>` so Unraid CA installs match the platform's `nobody:users` (99:100) appdata ownership convention — no chown needed for fresh installs. Pattern verified against existing Unraid templates (`cross-seed`, `upsnap`, etc.) |
| `docs/self-host/unraid/README.md` | New **Permissions** section explaining the override + the upgrade chown path |

The Unraid template uses `--user=99:100` because Wealthfolio has no PUID/PGID entrypoint hook; the override is the established Unraid idiom for static-USER images.

## Breaking change

Existing deployments must chown `/data` once on upgrade — old data was written as `root:root`. Migration commands are documented in `docs/self-host/README.md` (generic) and `docs/self-host/unraid/README.md` (Unraid).

Suggested release note line:

> **BREAKING:** the container now runs as UID 1000. Upgrading users must chown their data directory once before restarting — see [self-host docs](docs/self-host/README.md#permissions) for the exact command.

Suggested version bump: **`3.4.0`** (minor with prominent BREAKING notes — matches Paperless-ngx / Gitea precedent for the same migration).

## Test plan

- [x] Image builds locally on `linux/arm64` (Apple Silicon)
- [x] `docker inspect` confirms `User=1000:1000`
- [x] `docker run --rm wealthfolio:nonroot id` → `uid=1000(wealthfolio) gid=1000(wealthfolio)`
- [x] Named-volume smoke test: server starts, `GET /api/v1/healthz` → `200 OK`, DB files in `/data` owned by `1000:1000`
- [x] Cryptic `attempt to write a readonly database` error reproduced when host directory is owned by another UID — confirms the documented chown is the correct remediation
- [ ] Verify on `linux/amd64` (CI multi-arch publish)
- [ ] Verify on Unraid via Community Apps install (fresh) — should require zero chown