### PR TITLE
Fix ALL-time chart gain understating inception P&L for transaction accounts

### DIFF
--- a/apps/frontend/src/addons/type-bridge.ts
+++ b/apps/frontend/src/addons/type-bridge.ts
@@ -106,8 +106,8 @@ export interface InternalHostAPI {
   calculatePerformanceHistory(
     itemType: "account" | "symbol",
     itemId: string,
-    startDate: string,
-    endDate: string,
+    startDate?: string,
+    endDate?: string,
   ): Promise<PerformanceMetrics>;
   calculatePerformanceSummary(args: {
     itemType: "account" | "symbol";

--- a/apps/frontend/src/pages/account/account-page.tsx
+++ b/apps/frontend/src/pages/account/account-page.tsx
@@ -257,6 +257,9 @@ const AccountPage = () => {
     return undefined;
   }, [account]);
 
+  const performanceDateRange =
+    selectedIntervalCode === "ALL" ? undefined : dateRange;
+
   // Pass tracking mode to the performance hook for SOTA calculations
   const {
     data: performanceResponse,
@@ -265,7 +268,7 @@ const AccountPage = () => {
     errorMessages: performanceErrorMessages,
   } = useCalculatePerformanceHistory({
     selectedItems: accountTrackedItem ? [accountTrackedItem] : [],
-    dateRange: dateRange,
+    dateRange: performanceDateRange,
     trackingMode: isHoldingsMode ? "HOLDINGS" : "TRANSACTIONS",
   });
 
@@ -280,7 +283,7 @@ const AccountPage = () => {
 
   // Use period gain and return from backend (SOTA calculations for HOLDINGS mode)
   const frontendGainLossAmount = accountPerformance?.periodGain ?? 0;
-  const frontendSimpleReturn = accountPerformance?.periodReturn ?? 0;
+  const frontendSimpleReturn = accountPerformance?.periodReturn ?? null;
 
   const chartData: HistoryChartData[] = useMemo(() => {
     if (!valuationHistory) return [];
@@ -315,9 +318,9 @@ const AccountPage = () => {
     }
     // For other intervals, if accountPerformance is available, use cumulativeMwr
     if (accountPerformance) {
-      return accountPerformance.cumulativeMwr ?? 0;
+      return accountPerformance.cumulativeMwr ?? null;
     }
-    return 0; // Default if no specific logic matches or data is unavailable
+    return null; // Default if no specific logic matches or data is unavailable
   }, [accountPerformance, selectedIntervalCode, frontendSimpleReturn, isHoldingsMode]);
 
   const handleAccountSwitch = (selectedAccount: Account) => {
@@ -569,11 +572,13 @@ const AccountPage = () => {
                                 currency={account?.currency ?? baseCurrency}
                                 displayCurrency={false}
                               />
-                              <GainPercent
-                                value={percentageToDisplay}
-                                variant="badge"
-                                className="text-xs"
-                              />
+                              {percentageToDisplay !== null && (
+                                <GainPercent
+                                  value={percentageToDisplay}
+                                  variant="badge"
+                                  className="text-xs"
+                                />
+                              )}
                             </div>
                           )}
                         </div>

--- a/apps/frontend/src/pages/account/account-page.tsx
+++ b/apps/frontend/src/pages/account/account-page.tsx
@@ -257,8 +257,7 @@ const AccountPage = () => {
     return undefined;
   }, [account]);
 
-  const performanceDateRange =
-    selectedIntervalCode === "ALL" ? undefined : dateRange;
+  const performanceDateRange = selectedIntervalCode === "ALL" ? undefined : dateRange;
 
   // Pass tracking mode to the performance hook for SOTA calculations
   const {

--- a/apps/frontend/src/pages/performance/hooks/use-performance-data.test.tsx
+++ b/apps/frontend/src/pages/performance/hooks/use-performance-data.test.tsx
@@ -69,4 +69,45 @@ describe("useCalculatePerformanceHistory", () => {
     expect(ends.every((e) => e === "2026-03-10")).toBe(true);
     expect(starts.some((s) => s === "2026-03-09")).toBe(false);
   });
+
+  it("allows all-time performance queries without explicit dates", async () => {
+    renderHook(
+      () =>
+        useCalculatePerformanceHistory({
+          selectedItems: [{ id: "TOTAL", type: "account", name: "Total Portfolio" }],
+          dateRange: undefined,
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(mocks.calculatePerformanceHistory).toHaveBeenCalled();
+    });
+
+    expect(mocks.calculatePerformanceHistory).toHaveBeenCalledWith(
+      "account",
+      "TOTAL",
+      undefined,
+      undefined,
+      undefined,
+    );
+  });
+
+  it("does not query when the date range is only partially populated", async () => {
+    renderHook(
+      () =>
+        useCalculatePerformanceHistory({
+          selectedItems: [{ id: "TOTAL", type: "account", name: "Total Portfolio" }],
+          dateRange: {
+            from: new Date(2026, 2, 4),
+            to: undefined,
+          },
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(mocks.calculatePerformanceHistory).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/frontend/src/pages/performance/hooks/use-performance-data.ts
+++ b/apps/frontend/src/pages/performance/hooks/use-performance-data.ts
@@ -7,7 +7,8 @@ import { TrackedItem } from "@/lib/types";
 
 /**
  * Hook to calculate cumulative returns for a list of comparison items.
- * Uses the user-selected date range directly for all queries.
+ * Uses the user-selected date range directly for queries, except when the
+ * caller passes `undefined` to request all-time performance.
  *
  * @param selectedItems List of comparison items to calculate cumulative returns for.
  * @param dateRange The date range for the calculation period.
@@ -35,7 +36,8 @@ export function useCalculatePerformanceHistory({
       item && typeof item.id === "string" && item.id && typeof item.type === "string" && item.type,
   );
 
-  // Get the formatted date range for API calls, keep as undefined if not present
+  // Keep dates undefined for all-time queries so the backend can apply
+  // inception semantics instead of treating "ALL" as an explicit bounded range.
   const startDate = dateRange?.from ? format(dateRange.from, "yyyy-MM-dd") : undefined;
   const endDate = dateRange?.to ? format(dateRange.to, "yyyy-MM-dd") : undefined;
 
@@ -58,8 +60,8 @@ export function useCalculatePerformanceHistory({
           // Only pass trackingMode for accounts, not for symbols
           item.type === "account" ? trackingMode : undefined,
         ),
-      // Enable query only if dates are present (item validation done above).
-      enabled: !!startDate && !!endDate,
+      // Enable query for all-time (`dateRange === undefined`) or valid bounded ranges.
+      enabled: dateRange === undefined || (!!startDate && !!endDate),
       staleTime: 30 * 1000,
       retry: false,
       placeholderData: keepPreviousData,

--- a/crates/core/src/portfolio/performance/performance_service.rs
+++ b/crates/core/src/portfolio/performance/performance_service.rs
@@ -234,6 +234,37 @@ impl PerformanceService {
         (period_gain, period_return)
     }
 
+    fn compute_transactions_period_metrics(
+        start_point: &DailyAccountValuation,
+        end_point: &DailyAccountValuation,
+        start_date_opt: Option<NaiveDate>,
+        cumulative_mwr: Decimal,
+    ) -> (Decimal, Option<Decimal>) {
+        let gain_loss_amount =
+            end_point.total_value - start_point.total_value - end_point.net_contribution
+                + start_point.net_contribution;
+
+        if start_date_opt.is_none() {
+            // ALL is special for transactions accounts: the first stored
+            // valuation row can already reflect post-trade market movement, so
+            // users expect inception P/L from contributed capital instead.
+            //
+            // Keep the dollar gain even when the user has withdrawn more than
+            // they contributed overall (net contribution <= 0): realized profit
+            // already taken out still belongs in lifetime P/L, but a return
+            // percentage no longer has a meaningful invested-capital denominator.
+            let period_gain = end_point.total_value - end_point.net_contribution;
+            let period_return = if end_point.net_contribution <= Decimal::ZERO {
+                None
+            } else {
+                Some(period_gain / end_point.net_contribution)
+            };
+            (period_gain, period_return)
+        } else {
+            (gain_loss_amount, Some(cumulative_mwr))
+        }
+    }
+
     /// Full account performance calculation including per-day `returns[]`,
     /// volatility, and max-drawdown. Used by the account-detail page.
     async fn calculate_account_performance(
@@ -439,7 +470,13 @@ impl PerformanceService {
             );
             (gain, Some(ret))
         } else {
-            (gain_loss_amount, Some(cumulative_mwr))
+            let (gain, ret) = Self::compute_transactions_period_metrics(
+                start_point,
+                end_point,
+                start_date_opt,
+                cumulative_mwr,
+            );
+            (gain, ret)
         };
 
         let wrap_non_holdings = |value: Decimal| {
@@ -1032,6 +1069,48 @@ mod tests {
         history
     }
 
+    fn fixture_all_time_embedded_first_row_gain() -> Vec<DailyAccountValuation> {
+        vec![
+            valuation("2026-01-10", dec!(1015), dec!(1000), dec!(915), dec!(900)),
+            valuation("2026-01-11", dec!(1025), dec!(1000), dec!(925), dec!(900)),
+            valuation("2026-01-12", dec!(1040), dec!(1000), dec!(940), dec!(900)),
+        ]
+    }
+
+    fn fixture_all_time_with_withdrawal_and_realized_gain() -> Vec<DailyAccountValuation> {
+        vec![
+            valuation("2026-02-01", dec!(1030), dec!(1000), dec!(930), dec!(900)),
+            valuation("2026-02-10", dec!(1250), dec!(1200), dec!(1050), dec!(900)),
+            valuation("2026-02-20", dec!(1180), dec!(900), dec!(780), dec!(700)),
+        ]
+    }
+
+    fn fixture_all_time_profit_fully_withdrawn() -> Vec<DailyAccountValuation> {
+        vec![
+            valuation(
+                "2026-02-01",
+                dec!(1030),
+                dec!(1000),
+                dec!(930),
+                dec!(900),
+            ),
+            valuation(
+                "2026-02-10",
+                dec!(1400),
+                dec!(1000),
+                dec!(1200),
+                dec!(900),
+            ),
+            valuation(
+                "2026-02-20",
+                dec!(50),
+                dec!(-400),
+                dec!(50),
+                Decimal::ZERO,
+            ),
+        ]
+    }
+
     fn date(s: &str) -> NaiveDate {
         NaiveDate::parse_from_str(s, "%Y-%m-%d").unwrap()
     }
@@ -1077,6 +1156,80 @@ mod tests {
         // path before the refactor).
         assert!(result.cumulative_twr.is_some());
         assert!(result.cumulative_mwr.is_some());
+    }
+
+    #[test]
+    fn perf_all_time_transactions_gain_uses_inception_pnl() {
+        let history = fixture_all_time_embedded_first_row_gain();
+
+        let result = PerformanceService::compute_account_performance(
+            &history,
+            Some(TrackingMode::Transactions),
+            None,
+            false,
+        )
+        .expect("all-time summary should compute");
+
+        assert_eq!(result.period_gain, dec!(40));
+        assert_eq!(result.period_return, Some(dec!(0.04)));
+        assert_eq!(result.gain_loss_amount, Some(dec!(25)));
+        assert_ne!(result.period_gain, result.gain_loss_amount.unwrap());
+    }
+
+    #[test]
+    fn perf_bounded_transactions_gain_keeps_point_to_point_math() {
+        let history = fixture_all_time_embedded_first_row_gain();
+
+        let result = PerformanceService::compute_account_performance(
+            &history,
+            Some(TrackingMode::Transactions),
+            Some(date("2026-01-10")),
+            false,
+        )
+        .expect("bounded summary should compute");
+
+        assert_eq!(result.period_gain, dec!(25));
+        assert_eq!(result.period_return, result.cumulative_mwr);
+        assert_eq!(result.gain_loss_amount, Some(dec!(25)));
+    }
+
+    #[test]
+    fn perf_all_time_transactions_gain_reflects_account_pnl_after_withdrawal() {
+        let history = fixture_all_time_with_withdrawal_and_realized_gain();
+
+        let result = PerformanceService::compute_account_performance(
+            &history,
+            Some(TrackingMode::Transactions),
+            None,
+            false,
+        )
+        .expect("all-time summary should compute");
+
+        assert_eq!(result.period_gain, dec!(280));
+        assert_eq!(
+            result.period_return,
+            Some((dec!(280) / dec!(900)).round_dp(DECIMAL_PRECISION))
+        );
+        assert_eq!(result.gain_loss_amount, Some(dec!(250)));
+        assert_ne!(result.period_gain, result.gain_loss_amount.unwrap());
+    }
+
+    #[test]
+    fn perf_all_time_transactions_with_negative_net_contribution_keeps_gain_but_hides_percent() {
+        let history = fixture_all_time_profit_fully_withdrawn();
+
+        let result = PerformanceService::compute_account_performance(
+            &history,
+            Some(TrackingMode::Transactions),
+            None,
+            false,
+        )
+        .expect("all-time summary should compute");
+
+        assert_eq!(result.period_gain, dec!(450));
+        assert_eq!(result.period_return, None);
+        assert_eq!(result.gain_loss_amount, Some(dec!(420)));
+        assert_ne!(result.period_gain, result.gain_loss_amount.unwrap());
     }
 
     /// Invariant: summary and full paths must agree on `period_return`. This is

--- a/crates/core/src/portfolio/performance/performance_service.rs
+++ b/crates/core/src/portfolio/performance/performance_service.rs
@@ -1087,27 +1087,9 @@ mod tests {
 
     fn fixture_all_time_profit_fully_withdrawn() -> Vec<DailyAccountValuation> {
         vec![
-            valuation(
-                "2026-02-01",
-                dec!(1030),
-                dec!(1000),
-                dec!(930),
-                dec!(900),
-            ),
-            valuation(
-                "2026-02-10",
-                dec!(1400),
-                dec!(1000),
-                dec!(1200),
-                dec!(900),
-            ),
-            valuation(
-                "2026-02-20",
-                dec!(50),
-                dec!(-400),
-                dec!(50),
-                Decimal::ZERO,
-            ),
+            valuation("2026-02-01", dec!(1030), dec!(1000), dec!(930), dec!(900)),
+            valuation("2026-02-10", dec!(1400), dec!(1000), dec!(1200), dec!(900)),
+            valuation("2026-02-20", dec!(50), dec!(-400), dec!(50), Decimal::ZERO),
         ]
     }
 

--- a/packages/addon-sdk/src/host-api.ts
+++ b/packages/addon-sdk/src/host-api.ts
@@ -320,8 +320,8 @@ export interface PerformanceAPI {
   calculateHistory(
     itemType: 'account' | 'symbol',
     itemId: string,
-    startDate: string,
-    endDate: string,
+    startDate?: string,
+    endDate?: string,
   ): Promise<PerformanceMetrics>;
 
   /**


### PR DESCRIPTION
## Description

For transaction-tracked accounts, the ALL-time period gain was computed
using point-to-point math:

    end.total_value − start.total_value − net_cash_flow

The problem: the first stored valuation row can already embed post-trade
market appreciation (it is created after the first buy and may already
reflect price movement). Subtracting from this row silently omits that
embedded gain, causing the ALL-time figure to understate lifetime P&L.

**Fix:** for ALL-time queries only, switch to inception P&L:

    period_gain = end.total_value − end.net_contribution

This measures total profit relative to all capital ever contributed,
regardless of what the first row's value happened to be.

**Edge case — net_contribution ≤ 0:** when cumulative withdrawals exceed
deposits, the return percentage has no meaningful invested-capital
denominator. In that case `period_return` is returned as `None` and the
percentage badge is hidden rather than displaying a misleading figure.

**Frontend:** the account page now passes `undefined` dates when the
interval is ALL, so the backend receives `None` for `start_date` and
applies inception semantics. The `GainPercent` badge is conditionally
rendered to handle the `None` return cleanly.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).