### PR TITLE
Support asset-backed income subtypes

### DIFF
--- a/apps/frontend/src/lib/activity-utils.test.ts
+++ b/apps/frontend/src/lib/activity-utils.test.ts
@@ -1,9 +1,11 @@
-import { ActivityType } from "./constants";
+import { ACTIVITY_SUBTYPES, ActivityType } from "./constants";
 import {
   isCashActivity,
   isCashTransfer,
   isIncomeActivity,
   isAssetBackedIncomeActivity,
+  isAssetBackedIncomeSubtype,
+  isAssetIdentityRequired,
   needsImportAssetResolution,
   calculateActivityValue,
   formatSplitRatio,
@@ -66,6 +68,29 @@ describe("Activity Utilities", () => {
     it("should return false for non-income types", () => {
       expect(isAssetBackedIncomeActivity(ActivityType.BUY, "AAPL", "AAPL")).toBe(false);
       expect(isAssetBackedIncomeActivity(ActivityType.DEPOSIT, "SOL", "SOL")).toBe(false);
+    });
+  });
+
+  describe("isAssetBackedIncomeSubtype", () => {
+    it("identifies calculation subtypes that carry asset quantities", () => {
+      expect(
+        isAssetBackedIncomeSubtype(ActivityType.INTEREST, ACTIVITY_SUBTYPES.STAKING_REWARD),
+      ).toBe(true);
+      expect(isAssetBackedIncomeSubtype(ActivityType.DIVIDEND, ACTIVITY_SUBTYPES.DRIP)).toBe(true);
+      expect(
+        isAssetBackedIncomeSubtype(ActivityType.DIVIDEND, ACTIVITY_SUBTYPES.DIVIDEND_IN_KIND),
+      ).toBe(true);
+      expect(isAssetBackedIncomeSubtype(ActivityType.INTEREST, null)).toBe(false);
+      expect(isAssetBackedIncomeSubtype(ActivityType.DIVIDEND, null)).toBe(false);
+    });
+  });
+
+  describe("isAssetIdentityRequired", () => {
+    it("requires assets for staking rewards even though interest is normally cash-like", () => {
+      expect(isAssetIdentityRequired(ActivityType.INTEREST, ACTIVITY_SUBTYPES.STAKING_REWARD)).toBe(
+        true,
+      );
+      expect(isAssetIdentityRequired(ActivityType.INTEREST, null)).toBe(false);
     });
   });
 
@@ -160,6 +185,36 @@ describe("Activity Utilities", () => {
 
       // 300 - 3 = 297
       expect(calculateActivityValue(activity)).toBe(297);
+    });
+
+    it("should derive staking reward value from quantity and FMV when amount is empty", () => {
+      const activity = createActivity({
+        activityType: ActivityType.INTEREST,
+        subtype: ACTIVITY_SUBTYPES.STAKING_REWARD,
+        quantity: "0.01",
+        unitPrice: "200",
+        amount: "0",
+        fee: "0",
+        assetSymbol: "SOL",
+        assetId: "SOL",
+      });
+
+      expect(calculateActivityValue(activity)).toBe(2);
+    });
+
+    it("should derive dividend in kind value from quantity and FMV when amount is empty", () => {
+      const activity = createActivity({
+        activityType: ActivityType.DIVIDEND,
+        subtype: ACTIVITY_SUBTYPES.DIVIDEND_IN_KIND,
+        quantity: "2",
+        unitPrice: "50",
+        amount: "0",
+        fee: "0",
+        assetSymbol: "AAPL",
+        assetId: "AAPL",
+      });
+
+      expect(calculateActivityValue(activity)).toBe(100);
     });
 
     it("should calculate WITHDRAWAL activity value correctly", () => {

--- a/apps/frontend/src/lib/activity-utils.ts
+++ b/apps/frontend/src/lib/activity-utils.ts
@@ -48,6 +48,31 @@ export const isSymbolRequired = (activityType: string): boolean => {
 };
 
 /**
+ * Subtypes that make income activities asset-backed rather than cash-only.
+ */
+export const isAssetBackedIncomeSubtype = (
+  activityType: string,
+  subtype?: string | null,
+): boolean => {
+  const normalizedActivityType = activityType?.trim().toUpperCase();
+  const normalizedSubtype = subtype?.trim().toUpperCase();
+  return (
+    (normalizedActivityType === ActivityType.DIVIDEND &&
+      (normalizedSubtype === ACTIVITY_SUBTYPES.DRIP ||
+        normalizedSubtype === ACTIVITY_SUBTYPES.DIVIDEND_IN_KIND)) ||
+    (normalizedActivityType === ActivityType.INTEREST &&
+      normalizedSubtype === ACTIVITY_SUBTYPES.STAKING_REWARD)
+  );
+};
+
+/**
+ * Activity/subtype pairs that must carry a market asset identity.
+ */
+export const isAssetIdentityRequired = (activityType: string, subtype?: string | null): boolean => {
+  return isSymbolRequired(activityType) || isAssetBackedIncomeSubtype(activityType, subtype);
+};
+
+/**
  * Import-time asset resolution can also be required by subtype even when the
  * base activity type is normally cash-oriented (e.g. staking rewards).
  */
@@ -55,13 +80,7 @@ export const needsImportAssetResolution = (
   activityType: string,
   subtype?: string | null,
 ): boolean => {
-  const normalizedSubtype = subtype?.trim().toUpperCase();
-  return (
-    isSymbolRequired(activityType) ||
-    normalizedSubtype === ACTIVITY_SUBTYPES.DRIP ||
-    normalizedSubtype === ACTIVITY_SUBTYPES.DIVIDEND_IN_KIND ||
-    normalizedSubtype === ACTIVITY_SUBTYPES.STAKING_REWARD
-  );
+  return isAssetIdentityRequired(activityType, subtype);
 };
 
 /**
@@ -255,7 +274,7 @@ export const getUnitPrice = (activity: ActivityDetails): number => {
  * @returns The calculated value
  */
 export const calculateActivityValue = (activity: ActivityDetails): number => {
-  const { activityType, assetSymbol, assetId } = activity;
+  const { activityType, assetSymbol, assetId, subtype } = activity;
 
   // Handle special cases first
   if (activityType === ActivityType.SPLIT) {
@@ -278,8 +297,15 @@ export const calculateActivityValue = (activity: ActivityDetails): number => {
     isCashTransfer(activityType, assetSymbol, assetId) ||
     isIncomeActivity(activityType)
   ) {
-    const amount = getAmount(activity);
+    let amount = getAmount(activity);
     const fee = getFee(activity);
+
+    if (isAssetBackedIncomeSubtype(activityType, subtype) && amount === 0) {
+      const derivedAmount = getQuantity(activity) * getUnitPrice(activity);
+      if (Number.isFinite(derivedAmount) && derivedAmount > 0) {
+        amount = derivedAmount;
+      }
+    }
 
     // For outgoing cash activities, subtract fee from amount
     if (activityType === ActivityType.WITHDRAWAL || activityType === ActivityType.TRANSFER_OUT) {

--- a/apps/frontend/src/lib/constants.ts
+++ b/apps/frontend/src/lib/constants.ts
@@ -224,20 +224,20 @@ export type ActivityType = (typeof ActivityType)[keyof typeof ActivityType];
 
 // Array of all activity types for iteration
 export const ACTIVITY_TYPES = [
-  "BUY",
-  "SELL",
-  "SPLIT",
-  "DIVIDEND",
-  "INTEREST",
-  "DEPOSIT",
-  "WITHDRAWAL",
-  "TRANSFER_IN",
-  "TRANSFER_OUT",
-  "FEE",
-  "TAX",
-  "CREDIT",
-  "ADJUSTMENT",
-  "UNKNOWN",
+  ActivityType.BUY,
+  ActivityType.SELL,
+  ActivityType.SPLIT,
+  ActivityType.DIVIDEND,
+  ActivityType.INTEREST,
+  ActivityType.DEPOSIT,
+  ActivityType.WITHDRAWAL,
+  ActivityType.TRANSFER_IN,
+  ActivityType.TRANSFER_OUT,
+  ActivityType.FEE,
+  ActivityType.TAX,
+  ActivityType.CREDIT,
+  ActivityType.ADJUSTMENT,
+  ActivityType.UNKNOWN,
 ] as const;
 
 export const TRADING_ACTIVITY_TYPES = [
@@ -306,12 +306,11 @@ export const ActivityStatus = {
 export type ActivityStatus = (typeof ActivityStatus)[keyof typeof ActivityStatus];
 
 // Subtypes that affect calculations (compiler expansion or flow classification)
-// Other subtypes are just labels - the backend accepts any string value
 export const ACTIVITY_SUBTYPES = {
   // DIVIDEND subtypes
   // DRIP: cash dividend → immediately reinvested as BUY of same ticker
   DRIP: "DRIP",
-  // DIVIDEND_IN_KIND: dividend paid in asset (not cash), e.g., spinoff shares
+  // DIVIDEND_IN_KIND: dividend paid as additional units of the same asset
   DIVIDEND_IN_KIND: "DIVIDEND_IN_KIND",
 
   // INTEREST subtypes - STAKING_REWARD expands to INTEREST + BUY
@@ -324,18 +323,23 @@ export const ACTIVITY_SUBTYPES = {
   REBATE: "REBATE",
   // REFUND: internal flow (fee correction/reversal, no net_contribution change)
   REFUND: "REFUND",
+
+  // ADJUSTMENT subtypes
+  // OPTION_EXPIRY: removes option lots with no cash effect
+  OPTION_EXPIRY: "OPTION_EXPIRY",
 } as const;
 
 export type ActivitySubtype = (typeof ACTIVITY_SUBTYPES)[keyof typeof ACTIVITY_SUBTYPES];
 
 // Display names for subtypes
 export const SUBTYPE_DISPLAY_NAMES: Record<string, string> = {
-  DRIP: "Dividend Reinvested (DRIP)",
-  DIVIDEND_IN_KIND: "Dividend in Kind",
-  STAKING_REWARD: "Staking Reward",
-  BONUS: "Bonus",
-  REBATE: "Trading Rebate",
-  REFUND: "Fee Refund",
+  [ACTIVITY_SUBTYPES.DRIP]: "Dividend Reinvested (DRIP)",
+  [ACTIVITY_SUBTYPES.DIVIDEND_IN_KIND]: "Dividend in Kind",
+  [ACTIVITY_SUBTYPES.STAKING_REWARD]: "Staking Reward",
+  [ACTIVITY_SUBTYPES.BONUS]: "Bonus",
+  [ACTIVITY_SUBTYPES.REBATE]: "Trading Rebate",
+  [ACTIVITY_SUBTYPES.REFUND]: "Fee Refund",
+  [ACTIVITY_SUBTYPES.OPTION_EXPIRY]: "Option Expiry",
 };
 
 // Suggested subtypes per activity type
@@ -347,6 +351,7 @@ export const SUBTYPES_BY_ACTIVITY_TYPE: Record<string, string[]> = {
     ACTIVITY_SUBTYPES.REBATE,
     ACTIVITY_SUBTYPES.REFUND,
   ],
+  [ActivityType.ADJUSTMENT]: [ACTIVITY_SUBTYPES.OPTION_EXPIRY],
 };
 
 // Asset kinds for behavior classification

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid.tsx
@@ -62,6 +62,15 @@ function shouldApplyResolvedActivityCurrency(result: SymbolSearchResult): boolea
   return !result.currency?.trim() || result.currencySource === "exchange_inferred";
 }
 
+const ACTIVITY_GRID_COLUMN_VISIBILITY_KEY = "activity-datagrid-column-visibility";
+
+const DEFAULT_COLUMN_VISIBILITY: VisibilityState = {
+  subtype: true,
+  isExternal: true,
+  instrumentType: false,
+  activityStatus: false,
+};
+
 /**
  * Activity data grid component with inline editing, bulk operations, and optimistic updates
  */
@@ -94,15 +103,10 @@ export function ActivityDataGrid({
     resetChangeState,
   } = useActivityGridState({ activities });
 
-  // Persist column visibility preferences
+  // Persist column visibility preferences.
   const [columnVisibility, setColumnVisibility] = usePersistentState<VisibilityState>(
-    "activity-datagrid-column-visibility",
-    {
-      subtype: true,
-      isExternal: true,
-      instrumentType: false,
-      activityStatus: false,
-    },
+    ACTIVITY_GRID_COLUMN_VISIBILITY_KEY,
+    DEFAULT_COLUMN_VISIBILITY,
   );
 
   const { assets } = useAssets();

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.test.ts
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.test.ts
@@ -8,6 +8,7 @@ import {
   createDraftTransaction,
   resolveAssetIdForTransaction,
   TRACKED_FIELDS,
+  validateTransactionsForSave,
   valuesAreEqual,
 } from "./activity-utils";
 import type { LocalTransaction } from "./types";
@@ -120,6 +121,16 @@ describe("activity-utils", () => {
       });
       // Backend now generates CASH:{currency} IDs, frontend returns undefined
       expect(resolveAssetIdForTransaction(tx, "GBP")).toBeUndefined();
+    });
+
+    it("should return assetId for staking reward interest", () => {
+      const tx = createMockTransaction({
+        activityType: ActivityType.INTEREST,
+        subtype: ACTIVITY_SUBTYPES.STAKING_REWARD,
+        assetId: "ETH",
+        assetSymbol: "ETH",
+      });
+      expect(resolveAssetIdForTransaction(tx, "USD")).toBe("ETH");
     });
 
     it("should return undefined for non-cash activities without asset", () => {
@@ -360,6 +371,79 @@ describe("activity-utils", () => {
           instrumentType: "EQUITY",
         }),
       );
+    });
+
+    it("should save staking rewards as asset-backed income", () => {
+      const transactions: LocalTransaction[] = [
+        createMockTransaction({
+          id: "temp-staking-1",
+          isNew: true,
+          activityType: ActivityType.INTEREST,
+          subtype: ACTIVITY_SUBTYPES.STAKING_REWARD,
+          assetId: "",
+          assetSymbol: "ETH",
+          quantity: "0.25",
+          unitPrice: "4000",
+          amount: "1000",
+          pendingQuoteCcy: "USD",
+          pendingInstrumentType: "CRYPTO",
+        }),
+      ];
+      const dirtyIds = new Set(["temp-staking-1"]);
+
+      const result = buildSavePayload(
+        transactions,
+        dirtyIds,
+        new Set(),
+        mockResolveTransactionCurrency,
+        dirtyCurrencyLookup,
+        assetCurrencyLookup,
+        "USD",
+      );
+
+      expect(result.creates).toHaveLength(1);
+      expect(result.creates[0]).toEqual(
+        expect.objectContaining({
+          activityType: ActivityType.INTEREST,
+          subtype: ACTIVITY_SUBTYPES.STAKING_REWARD,
+          quantity: "0.25",
+          unitPrice: "4000",
+          amount: "1000",
+        }),
+      );
+      expect(result.creates[0].asset).toEqual(
+        expect.objectContaining({
+          symbol: "ETH",
+          quoteCcy: "USD",
+          instrumentType: "CRYPTO",
+        }),
+      );
+    });
+
+    it("should send an empty subtype marker when clearing subtype on an existing row", () => {
+      const transactions: LocalTransaction[] = [
+        createMockTransaction({
+          id: "existing-interest-1",
+          isNew: false,
+          activityType: ActivityType.INTEREST,
+          subtype: undefined,
+          amount: "25",
+        }),
+      ];
+      const dirtyIds = new Set(["existing-interest-1"]);
+
+      const result = buildSavePayload(
+        transactions,
+        dirtyIds,
+        new Set(),
+        mockResolveTransactionCurrency,
+        dirtyCurrencyLookup,
+        assetCurrencyLookup,
+        "USD",
+      );
+
+      expect(result.updates).toHaveLength(1);
+      expect(result.updates[0].subtype).toBe("");
     });
 
     it("should preserve explicit idempotency keys for new manual duplicates", () => {
@@ -728,6 +812,135 @@ describe("activity-utils", () => {
       expect(updated.amount).toBe("0.02");
     });
 
+    it("should keep staking rewards asset-backed when subtype is selected", () => {
+      const accountLookup = new Map<string, { id: string; name: string; currency: string }>([
+        ["account-1", { id: "account-1", name: "Test Account", currency: "USD" }],
+      ]);
+      const assetCurrencyLookup = new Map<string, string>();
+      const tx = createMockTransaction({
+        activityType: ActivityType.INTEREST,
+        assetSymbol: "CASH",
+        assetId: "",
+        quantity: null,
+        unitPrice: null,
+        amount: "100",
+      });
+
+      const updated = applyTransactionUpdate({
+        transaction: tx,
+        field: "subtype",
+        value: ACTIVITY_SUBTYPES.STAKING_REWARD,
+        accountLookup,
+        assetCurrencyLookup,
+        fallbackCurrency: "USD",
+        resolveTransactionCurrency: () => "USD",
+      });
+
+      expect(updated.subtype).toBe(ACTIVITY_SUBTYPES.STAKING_REWARD);
+      expect(updated.assetSymbol).toBe("");
+      expect(updated.assetId).toBe("");
+      expect(updated.quantity).toBeNull();
+      expect(updated.unitPrice).toBeNull();
+    });
+
+    it("should clear asset-backed-only fields when removing a dividend subtype", () => {
+      const accountLookup = new Map<string, { id: string; name: string; currency: string }>([
+        ["account-1", { id: "account-1", name: "Test Account", currency: "USD" }],
+      ]);
+      const assetCurrencyLookup = new Map<string, string>();
+      const tx = createMockTransaction({
+        activityType: ActivityType.DIVIDEND,
+        subtype: ACTIVITY_SUBTYPES.DIVIDEND_IN_KIND,
+        assetSymbol: "AAPL",
+        quantity: "2",
+        unitPrice: "100",
+        amount: "200",
+      });
+
+      const updated = applyTransactionUpdate({
+        transaction: tx,
+        field: "subtype",
+        value: "",
+        accountLookup,
+        assetCurrencyLookup,
+        fallbackCurrency: "USD",
+        resolveTransactionCurrency: () => "USD",
+      });
+
+      expect(updated.subtype).toBeUndefined();
+      expect(updated.quantity).toBeNull();
+      expect(updated.unitPrice).toBeNull();
+      expect(updated.amount).toBe("200");
+    });
+
+    it("should clear invalid staking subtype fields when changing to dividend", () => {
+      const accountLookup = new Map<string, { id: string; name: string; currency: string }>([
+        ["account-1", { id: "account-1", name: "Test Account", currency: "USD" }],
+      ]);
+      const assetCurrencyLookup = new Map<string, string>();
+      const tx = createMockTransaction({
+        activityType: ActivityType.INTEREST,
+        subtype: ACTIVITY_SUBTYPES.STAKING_REWARD,
+        assetSymbol: "ETH",
+        assetId: "ETH",
+        quantity: "0.25",
+        unitPrice: "3000",
+        amount: "750",
+      });
+
+      const updated = applyTransactionUpdate({
+        transaction: tx,
+        field: "activityType",
+        value: ActivityType.DIVIDEND,
+        accountLookup,
+        assetCurrencyLookup,
+        fallbackCurrency: "USD",
+        resolveTransactionCurrency: () => "USD",
+      });
+
+      expect(updated.activityType).toBe(ActivityType.DIVIDEND);
+      expect(updated.subtype).toBeUndefined();
+      expect(updated.quantity).toBeNull();
+      expect(updated.unitPrice).toBeNull();
+      expect(updated.amount).toBe("750");
+      expect(updated.assetSymbol).toBe("ETH");
+      expect(updated.assetId).toBe("ETH");
+    });
+
+    it("should clear invalid dividend-in-kind subtype fields when changing to a market type", () => {
+      const accountLookup = new Map<string, { id: string; name: string; currency: string }>([
+        ["account-1", { id: "account-1", name: "Test Account", currency: "USD" }],
+      ]);
+      const assetCurrencyLookup = new Map<string, string>();
+      const tx = createMockTransaction({
+        activityType: ActivityType.DIVIDEND,
+        subtype: ACTIVITY_SUBTYPES.DIVIDEND_IN_KIND,
+        assetSymbol: "AAPL",
+        assetId: "AAPL",
+        quantity: "2",
+        unitPrice: "100",
+        amount: "200",
+      });
+
+      const updated = applyTransactionUpdate({
+        transaction: tx,
+        field: "activityType",
+        value: ActivityType.BUY,
+        accountLookup,
+        assetCurrencyLookup,
+        fallbackCurrency: "USD",
+        resolveTransactionCurrency: () => "USD",
+      });
+
+      expect(updated.activityType).toBe(ActivityType.BUY);
+      expect(updated.subtype).toBeUndefined();
+      expect(updated.quantity).toBeNull();
+      expect(updated.unitPrice).toBeNull();
+      expect(updated.amount).toBe("200");
+      expect(updated.assetSymbol).toBe("AAPL");
+      expect(updated.assetId).toBe("AAPL");
+    });
+
     it("should not force transfer activity rows to CASH", () => {
       const accountLookup = new Map<string, { id: string; name: string; currency: string }>([
         ["account-1", { id: "account-1", name: "Test Account", currency: "USD" }],
@@ -751,6 +964,74 @@ describe("activity-utils", () => {
 
       expect(updated.assetSymbol).toBe("AAPL");
       expect(updated.assetId).toBe("AAPL");
+    });
+  });
+
+  describe("validateTransactionsForSave", () => {
+    it("should require asset-backed income fields for staking rewards", () => {
+      const transactions: LocalTransaction[] = [
+        createMockTransaction({
+          id: "staking-1",
+          activityType: ActivityType.INTEREST,
+          subtype: ACTIVITY_SUBTYPES.STAKING_REWARD,
+          assetSymbol: "ETH",
+          assetId: "ETH",
+          quantity: null,
+          unitPrice: null,
+          amount: "100",
+        }),
+      ];
+
+      const result = validateTransactionsForSave(transactions, new Set(["staking-1"]));
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.objectContaining({ field: "quantity" })]),
+      );
+      expect(result.errors).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ field: "unitPrice" })]),
+      );
+    });
+
+    it("should allow asset-backed income with amount instead of unit price", () => {
+      const transactions: LocalTransaction[] = [
+        createMockTransaction({
+          id: "staking-amount-only",
+          activityType: ActivityType.INTEREST,
+          subtype: ACTIVITY_SUBTYPES.STAKING_REWARD,
+          assetSymbol: "ETH",
+          assetId: "ETH",
+          quantity: "0.05",
+          unitPrice: null,
+          amount: "200",
+        }),
+      ];
+
+      const result = validateTransactionsForSave(transactions, new Set(["staking-amount-only"]));
+
+      expect(result.isValid).toBe(true);
+    });
+
+    it("should require an amount or unit price for asset-backed income", () => {
+      const transactions: LocalTransaction[] = [
+        createMockTransaction({
+          id: "staking-missing-value",
+          activityType: ActivityType.INTEREST,
+          subtype: ACTIVITY_SUBTYPES.STAKING_REWARD,
+          assetSymbol: "ETH",
+          assetId: "ETH",
+          quantity: "0.05",
+          unitPrice: null,
+          amount: null,
+        }),
+      ];
+
+      const result = validateTransactionsForSave(transactions, new Set(["staking-missing-value"]));
+
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toEqual(
+        expect.arrayContaining([expect.objectContaining({ field: "unitPrice" })]),
+      );
     });
   });
 

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.ts
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.ts
@@ -1,6 +1,12 @@
-import { isCashActivity, isCashTransfer, isIncomeActivity } from "@/lib/activity-utils";
+import {
+  isAssetBackedIncomeSubtype,
+  isAssetIdentityRequired,
+  isCashActivity,
+  isCashTransfer,
+  isIncomeActivity,
+} from "@/lib/activity-utils";
 import { buildAssetResolutionInput, normalizeOptionalString } from "@/lib/asset-resolution-input";
-import { ACTIVITY_SUBTYPES, ActivityType } from "@/lib/constants";
+import { ActivityType, SUBTYPES_BY_ACTIVITY_TYPE } from "@/lib/constants";
 import type { Account } from "@/lib/types";
 import { normalizeDecimalString, parseLocalDateTime, toPayloadNumber } from "@/lib/utils";
 import type {
@@ -22,17 +28,28 @@ const isTransferActivity = (activityType: string | undefined): boolean => {
   return activityType === ActivityType.TRANSFER_IN || activityType === ActivityType.TRANSFER_OUT;
 };
 
-/** Subtypes where amount = quantity × unitPrice (DRIP, DIVIDEND_IN_KIND, STAKING_REWARD). */
-const isAssetBackedSubtype = (subtype: string | null | undefined): boolean =>
-  subtype === ACTIVITY_SUBTYPES.DRIP ||
-  subtype === ACTIVITY_SUBTYPES.DIVIDEND_IN_KIND ||
-  subtype === ACTIVITY_SUBTYPES.STAKING_REWARD;
+const isSubtypeAllowedForActivityType = (
+  activityType: string | undefined,
+  subtype: string | null | undefined,
+): boolean => {
+  if (!subtype) {
+    return true;
+  }
+  return (SUBTYPES_BY_ACTIVITY_TYPE[activityType ?? ""] ?? []).includes(subtype);
+};
 
-const isAlwaysCashActivity = (activityType: string | undefined): boolean => {
+const isAlwaysCashActivity = (
+  activityType: string | undefined,
+  subtype?: string | null,
+): boolean => {
   if (!activityType) {
     return false;
   }
-  return isCashActivity(activityType) && !isTransferActivity(activityType);
+  return (
+    isCashActivity(activityType) &&
+    !isTransferActivity(activityType) &&
+    !isAssetBackedIncomeSubtype(activityType, subtype)
+  );
 };
 
 /**
@@ -95,7 +112,7 @@ export function resolveAssetIdForTransaction(
   _fallbackCurrency: string,
 ): string | undefined {
   // For cash activities, don't return an assetId - backend will generate CASH:{currency}
-  if (isAlwaysCashActivity(transaction.activityType)) {
+  if (isAlwaysCashActivity(transaction.activityType, transaction.subtype)) {
     return undefined;
   }
 
@@ -158,7 +175,7 @@ function applyCashDefaults(
   resolveTransactionCurrency: TransactionUpdateParams["resolveTransactionCurrency"],
   fallbackCurrency: string,
 ): LocalTransaction {
-  if (!isAlwaysCashActivity(transaction.activityType)) {
+  if (!isAlwaysCashActivity(transaction.activityType, transaction.subtype)) {
     return transaction;
   }
   const derivedCurrency = resolveTransactionCurrency(transaction) ?? fallbackCurrency;
@@ -234,7 +251,11 @@ export function applyTransactionUpdate(params: TransactionUpdateParams): LocalTr
   } else if (field === "quantity") {
     const newQty = normalizedDecimalOrNull(value);
     updated = { ...updated, quantity: newQty };
-    if (isAssetBackedSubtype(updated.subtype) && newQty != null && updated.unitPrice != null) {
+    if (
+      isAssetBackedIncomeSubtype(updated.activityType, updated.subtype) &&
+      newQty != null &&
+      updated.unitPrice != null
+    ) {
       const computedAmount = getAssetBackedAmount(newQty, updated.unitPrice);
       if (computedAmount != null) {
         updated = { ...updated, amount: computedAmount };
@@ -246,9 +267,10 @@ export function applyTransactionUpdate(params: TransactionUpdateParams): LocalTr
     updated = { ...updated, unitPrice: newUnitPrice };
     if (
       newUnitPrice != null &&
-      (isAlwaysCashActivity(updated.activityType) || isIncomeActivity(updated.activityType))
+      (isAlwaysCashActivity(updated.activityType, updated.subtype) ||
+        isIncomeActivity(updated.activityType))
     ) {
-      if (isAssetBackedSubtype(updated.subtype)) {
+      if (isAssetBackedIncomeSubtype(updated.activityType, updated.subtype)) {
         const computedAmount = getAssetBackedAmount(updated.quantity, newUnitPrice);
         if (computedAmount != null) {
           updated = { ...updated, amount: computedAmount };
@@ -290,7 +312,16 @@ export function applyTransactionUpdate(params: TransactionUpdateParams): LocalTr
       }
     }
   } else if (field === "activityType") {
-    updated = { ...updated, activityType: value as ActivityType };
+    const nextActivityType = value as ActivityType;
+    const wasAssetBacked = isAssetBackedIncomeSubtype(updated.activityType, updated.subtype);
+    const nextSubtype = isSubtypeAllowedForActivityType(nextActivityType, updated.subtype)
+      ? updated.subtype
+      : undefined;
+
+    updated = { ...updated, activityType: nextActivityType, subtype: nextSubtype };
+    if (wasAssetBacked && !isAssetBackedIncomeSubtype(nextActivityType, nextSubtype)) {
+      updated = { ...updated, quantity: null, unitPrice: null };
+    }
     updated = applyCashDefaults(updated, resolveTransactionCurrency, fallbackCurrency);
     updated = applySplitDefaults(updated);
   } else if (field === "accountId") {
@@ -314,14 +345,28 @@ export function applyTransactionUpdate(params: TransactionUpdateParams): LocalTr
   } else if (field === "fxRate") {
     updated = { ...updated, fxRate: normalizeDecimalString(value) };
   } else if (field === "subtype") {
+    const wasAssetBacked = isAssetBackedIncomeSubtype(updated.activityType, updated.subtype);
     const newSubtype = typeof value === "string" && value ? value : undefined;
     updated = { ...updated, subtype: newSubtype };
-    if (isAssetBackedSubtype(newSubtype) && updated.quantity != null && updated.unitPrice != null) {
+    if (
+      isAssetBackedIncomeSubtype(updated.activityType, newSubtype) &&
+      updated.assetSymbol === "CASH"
+    ) {
+      updated = { ...updated, assetSymbol: "", assetId: "" };
+    }
+    if (
+      isAssetBackedIncomeSubtype(updated.activityType, newSubtype) &&
+      updated.quantity != null &&
+      updated.unitPrice != null
+    ) {
       const computedAmount = getAssetBackedAmount(updated.quantity, updated.unitPrice);
       if (computedAmount != null) {
         updated = { ...updated, amount: computedAmount };
       }
+    } else if (wasAssetBacked) {
+      updated = { ...updated, quantity: null, unitPrice: null };
     }
+    updated = applyCashDefaults(updated, resolveTransactionCurrency, fallbackCurrency);
   } else if (field === "isExternal") {
     // isExternal flag for TRANSFER_IN/TRANSFER_OUT (stored in metadata.flow.is_external)
     updated = { ...updated, isExternal: Boolean(value) };
@@ -422,7 +467,7 @@ export function buildSavePayload(
     const assetSymbol = (transaction.assetSymbol || "").trim();
     const isCash = isTransfer
       ? isCashTransfer(transaction.activityType, assetSymbol) || !assetSymbol
-      : isAlwaysCashActivity(transaction.activityType);
+      : isAlwaysCashActivity(transaction.activityType, transaction.subtype);
     // For assets not in our lookup (new assets), send undefined currency to let the backend
     // derive it from the asset and properly register the FX pair if needed.
     // Only use account currency fallback for cash activities where the currency is deterministic.
@@ -502,7 +547,10 @@ export function buildSavePayload(
       creates.push(createPayload);
     } else {
       // Build UPDATE payload
-      const updatePayload: ActivityUpdatePayload = { ...basePayload };
+      const updatePayload: ActivityUpdatePayload = {
+        ...basePayload,
+        subtype: transaction.subtype ?? "",
+      };
 
       if (!isCash) {
         const currentSymbol = (transaction.assetSymbol || "").trim().toUpperCase();
@@ -640,14 +688,36 @@ function validateTransaction(transaction: LocalTransaction): TransactionValidati
     });
   }
 
-  // Non-cash activities require a symbol
-  if (!isCashActivity(transaction.activityType)) {
+  // Non-cash and asset-backed income activities require a symbol
+  if (isAssetIdentityRequired(transaction.activityType, transaction.subtype)) {
     const hasSymbol = transaction.assetSymbol?.trim() || transaction.assetId?.trim();
     if (!hasSymbol) {
       errors.push({
         transactionId: transaction.id,
         field: "assetSymbol",
         message: "Symbol is required for this activity type",
+      });
+    }
+  }
+
+  if (isAssetBackedIncomeSubtype(transaction.activityType, transaction.subtype)) {
+    const quantity = transaction.quantity != null ? Number.parseFloat(transaction.quantity) : NaN;
+    const unitPrice =
+      transaction.unitPrice != null ? Number.parseFloat(transaction.unitPrice) : NaN;
+    const amount = transaction.amount != null ? Number.parseFloat(transaction.amount) : NaN;
+
+    if (!(quantity > 0)) {
+      errors.push({
+        transactionId: transaction.id,
+        field: "quantity",
+        message: "Received quantity is required",
+      });
+    }
+    if (!(unitPrice > 0) && !(amount > 0)) {
+      errors.push({
+        transactionId: transaction.id,
+        field: "unitPrice",
+        message: "Either income amount or FMV per unit is required",
       });
     }
   }

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/use-activity-columns.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/use-activity-columns.tsx
@@ -1,5 +1,9 @@
 import { searchTicker } from "@/adapters";
-import { isCashActivity, isSymbolRequired } from "@/lib/activity-utils";
+import {
+  isAssetBackedIncomeSubtype,
+  isAssetIdentityRequired,
+  isCashActivity,
+} from "@/lib/activity-utils";
 import {
   ActivityStatus,
   ActivityType,
@@ -33,6 +37,9 @@ const STATUS_DISPLAY: Record<
 const isTransferActivity = (activityType: string | undefined): boolean => {
   return activityType === ActivityType.TRANSFER_IN || activityType === ActivityType.TRANSFER_OUT;
 };
+
+const UNIT_PRICE_HELP_TEXT =
+  "For buys and sells, enter the trade price. For staking rewards and in-kind dividends, enter the fair market value per unit at receipt; it sets income amount and cost basis.";
 
 interface UseActivityColumnsOptions {
   accounts: Account[];
@@ -169,8 +176,12 @@ export function useActivityColumns({
           cell: {
             variant: "select",
             options: activityTypeOptions,
-            valueRenderer: (value: string) => (
-              <ActivityTypeBadge type={value as ActivityType} className="text-xs font-normal" />
+            valueRenderer: (value: string, _option, rowData) => (
+              <ActivityTypeBadge
+                type={value as ActivityType}
+                subtype={(rowData as LocalTransaction | undefined)?.subtype}
+                className="text-xs font-normal"
+              />
             ),
           },
         },
@@ -236,7 +247,9 @@ export function useActivityColumns({
             isDisabled: (rowData: unknown) => {
               const row = rowData as LocalTransaction;
               return (
-                isCashActivity(row.activityType ?? "") && !isTransferActivity(row.activityType)
+                isCashActivity(row.activityType ?? "") &&
+                !isAssetBackedIncomeSubtype(row.activityType ?? "", row.subtype) &&
+                !isTransferActivity(row.activityType)
               );
             },
             getDisplayContext: (rowData: unknown) => {
@@ -258,7 +271,7 @@ export function useActivityColumns({
             },
             isClearable: (rowData: unknown) => {
               const row = rowData as LocalTransaction;
-              return !isSymbolRequired(row.activityType ?? "");
+              return !isAssetIdentityRequired(row.activityType ?? "", row.subtype);
             },
             onSearch: handleSymbolSearch,
             onSelect: onSymbolSelect
@@ -309,7 +322,10 @@ export function useActivityColumns({
         header: "Price",
         size: 120,
         enableSorting: false,
-        meta: { cell: { variant: "number", step: 0.000001, valueType: "string" } },
+        meta: {
+          helpText: UNIT_PRICE_HELP_TEXT,
+          cell: { variant: "number", step: 0.000001, valueType: "string" },
+        },
       },
       // 10. Amount (most important money column)
       {

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
@@ -192,7 +192,11 @@ export const ActivityTableMobile = ({
 
                 <div className="flex items-center justify-between">
                   <span className="text-muted-foreground">Type</span>
-                  <ActivityTypeBadge type={activity.activityType} className="text-xs font-normal" />
+                  <ActivityTypeBadge
+                    type={activity.activityType}
+                    subtype={activity.subtype}
+                    className="text-xs font-normal"
+                  />
                 </div>
 
                 {/* Quantity (if applicable) */}

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
@@ -115,6 +115,7 @@ export const ActivityTable = ({
             <div className="flex items-center text-sm">
               <ActivityTypeBadge
                 type={activityType as ActivityType}
+                subtype={row.original.subtype}
                 className="whitespace-nowrap text-xs font-normal"
               />
             </div>

--- a/apps/frontend/src/pages/activity/components/activity-type-badge.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-type-badge.tsx
@@ -1,9 +1,10 @@
 import { Badge } from "@wealthfolio/ui/components/ui/badge";
-import { ActivityType, ActivityTypeNames } from "@/lib/constants";
+import { ActivityType, ActivityTypeNames, SUBTYPE_DISPLAY_NAMES } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
 interface ActivityTypeBadgeProps {
   type: ActivityType;
+  subtype?: string | null;
   className?: string;
 }
 
@@ -29,12 +30,21 @@ function getActivityBadgeVariant(type: ActivityType) {
   }
 }
 
-export function ActivityTypeBadge({ type, className }: ActivityTypeBadgeProps) {
+export function ActivityTypeBadge({ type, subtype, className }: ActivityTypeBadgeProps) {
   const variant = getActivityBadgeVariant(type);
+  const normalizedSubtype = subtype?.trim().toUpperCase();
+  const subtypeLabel = normalizedSubtype
+    ? (SUBTYPE_DISPLAY_NAMES[normalizedSubtype] ?? subtype)
+    : undefined;
 
   return (
-    <Badge variant={variant} className={cn("rounded-sm", className)}>
-      {ActivityTypeNames[type]}
-    </Badge>
+    <span className="inline-flex min-w-0 items-center gap-1.5">
+      <Badge variant={variant} className={cn("rounded-sm", className)}>
+        {ActivityTypeNames[type]}
+      </Badge>
+      {subtypeLabel && (
+        <span className="text-muted-foreground truncate text-xs font-normal">{subtypeLabel}</span>
+      )}
+    </span>
   );
 }

--- a/apps/frontend/src/pages/activity/components/activity-type-picker.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-type-picker.tsx
@@ -8,16 +8,21 @@ import {
   type CarouselApi,
 } from "@wealthfolio/ui/components/ui/carousel";
 import { Icons, type IconName } from "@wealthfolio/ui/components/ui/icons";
+import { ActivityType as CanonicalActivityType } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 
 export type PrimaryActivityType =
-  | "BUY"
-  | "SELL"
-  | "DEPOSIT"
-  | "WITHDRAWAL"
-  | "DIVIDEND"
+  | typeof CanonicalActivityType.BUY
+  | typeof CanonicalActivityType.SELL
+  | typeof CanonicalActivityType.DEPOSIT
+  | typeof CanonicalActivityType.WITHDRAWAL
+  | typeof CanonicalActivityType.DIVIDEND
   | "TRANSFER";
-export type SecondaryActivityType = "SPLIT" | "FEE" | "INTEREST" | "TAX";
+export type SecondaryActivityType =
+  | typeof CanonicalActivityType.SPLIT
+  | typeof CanonicalActivityType.FEE
+  | typeof CanonicalActivityType.INTEREST
+  | typeof CanonicalActivityType.TAX;
 export type ActivityType = PrimaryActivityType | SecondaryActivityType;
 
 interface ActivityTypeConfig<T extends string> {
@@ -27,19 +32,19 @@ interface ActivityTypeConfig<T extends string> {
 }
 
 const PRIMARY_ACTIVITY_TYPES: ActivityTypeConfig<PrimaryActivityType>[] = [
-  { value: "BUY", label: "Buy", icon: "TrendingUp" },
-  { value: "SELL", label: "Sell", icon: "TrendingDown" },
-  { value: "DEPOSIT", label: "Deposit", icon: "ArrowDownLeft" },
-  { value: "WITHDRAWAL", label: "Withdrawal", icon: "ArrowUpRight" },
-  { value: "DIVIDEND", label: "Dividend", icon: "Coins" },
+  { value: CanonicalActivityType.BUY, label: "Buy", icon: "TrendingUp" },
+  { value: CanonicalActivityType.SELL, label: "Sell", icon: "TrendingDown" },
+  { value: CanonicalActivityType.DEPOSIT, label: "Deposit", icon: "ArrowDownLeft" },
+  { value: CanonicalActivityType.WITHDRAWAL, label: "Withdrawal", icon: "ArrowUpRight" },
+  { value: CanonicalActivityType.DIVIDEND, label: "Dividend", icon: "Coins" },
   { value: "TRANSFER", label: "Transfer", icon: "ArrowLeftRight" },
 ];
 
 const SECONDARY_ACTIVITY_TYPES: ActivityTypeConfig<SecondaryActivityType>[] = [
-  { value: "SPLIT", label: "Split", icon: "Split" },
-  { value: "FEE", label: "Fee", icon: "Receipt" },
-  { value: "INTEREST", label: "Interest", icon: "Percent" },
-  { value: "TAX", label: "Tax", icon: "ReceiptText" },
+  { value: CanonicalActivityType.SPLIT, label: "Split", icon: "Split" },
+  { value: CanonicalActivityType.FEE, label: "Fee", icon: "Receipt" },
+  { value: CanonicalActivityType.INTEREST, label: "Interest", icon: "Percent" },
+  { value: CanonicalActivityType.TAX, label: "Tax", icon: "ReceiptText" },
 ];
 
 const ALL_ACTIVITY_TYPES = [...PRIMARY_ACTIVITY_TYPES, ...SECONDARY_ACTIVITY_TYPES];

--- a/apps/frontend/src/pages/activity/components/cash-balance-warning.tsx
+++ b/apps/frontend/src/pages/activity/components/cash-balance-warning.tsx
@@ -1,5 +1,6 @@
 import { useFormContext } from "react-hook-form";
 import { Alert, AlertDescription, Icons } from "@wealthfolio/ui";
+import { ActivityType } from "@/lib/constants";
 import { useCashBalanceValidation } from "../hooks/use-cash-balance-validation";
 import { NewActivityFormValues } from "./forms/schemas";
 
@@ -9,7 +10,7 @@ export function CashBalanceWarning() {
   const { isValid, warning, isLoading, hasAccount, hasValues } = useCashBalanceValidation();
 
   // Only show for BUY activities with insufficient funds
-  if (activityType !== "BUY" || !hasAccount || !hasValues || isLoading || isValid) {
+  if (activityType !== ActivityType.BUY || !hasAccount || !hasValues || isLoading || isValid) {
     return null;
   }
 

--- a/apps/frontend/src/pages/activity/components/forms/__tests__/dividend-split-forms.test.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/__tests__/dividend-split-forms.test.tsx
@@ -109,7 +109,43 @@ vi.mock("@wealthfolio/ui/components/ui/icons", () => ({
     Spinner: () => <span data-testid="spinner">Loading...</span>,
     Check: () => <span data-testid="check-icon">Check</span>,
     Plus: () => <span data-testid="plus-icon">Plus</span>,
+    ChevronDown: () => <span data-testid="chevron-down-icon" />,
+    Circle: () => <span data-testid="circle-icon" />,
   },
+}));
+
+vi.mock("@wealthfolio/ui/components/ui/radio-group", () => ({
+  RadioGroup: ({ children }: { children: React.ReactNode }) => (
+    <div role="radiogroup">{children}</div>
+  ),
+  RadioGroupItem: ({ value, id }: { value: string; id: string }) => (
+    <input type="radio" value={value} id={id} readOnly />
+  ),
+}));
+
+vi.mock("@wealthfolio/ui/components/ui/animated-toggle-group", () => ({
+  AnimatedToggleGroup: ({
+    items,
+    value,
+    onValueChange,
+  }: {
+    items: { value: string; label: string }[];
+    value?: string;
+    onValueChange?: (value: string) => void;
+  }) => (
+    <div data-testid="animated-toggle-group">
+      {items.map((item) => (
+        <button
+          key={item.value}
+          type="button"
+          aria-pressed={value === item.value}
+          onClick={() => onValueChange?.(item.value)}
+        >
+          {item.label}
+        </button>
+      ))}
+    </div>
+  ),
 }));
 
 const mockAccounts: AccountSelectOption[] = [

--- a/apps/frontend/src/pages/activity/components/forms/__tests__/form-schemas.test.ts
+++ b/apps/frontend/src/pages/activity/components/forms/__tests__/form-schemas.test.ts
@@ -3,15 +3,15 @@ import { buyFormSchema } from "../buy-form";
 import { sellFormSchema } from "../sell-form";
 import { depositFormSchema } from "../deposit-form";
 import { withdrawalFormSchema } from "../withdrawal-form";
-import { dividendFormSchema } from "../dividend-form";
+import { dividendFormSchema, type DividendFormValues } from "../dividend-form";
 import { transferFormSchema } from "../transfer-form";
 import { splitFormSchema } from "../split-form";
 import { feeFormSchema } from "../fee-form";
-import { interestFormSchema } from "../interest-form";
+import { interestFormSchema, type InterestFormValues } from "../interest-form";
 import { taxFormSchema } from "../tax-form";
 import { newActivitySchema } from "../schemas";
 import { ACTIVITY_FORM_CONFIG } from "../../../config/activity-form-config";
-import { ActivityType } from "@/lib/constants";
+import { ACTIVITY_SUBTYPES, ActivityType } from "@/lib/constants";
 
 describe("Form Schemas Validation", () => {
   describe("buyFormSchema", () => {
@@ -903,6 +903,84 @@ describe("Form Schemas Validation", () => {
     });
   });
 
+  describe("income toPayload", () => {
+    it("clears stale asset-backed dividend values when switching back to cash", () => {
+      const formData = {
+        accountId: "acc-123",
+        activityDate: new Date(),
+        symbol: "AAPL",
+        amount: 12,
+        quantity: 2,
+        unitPrice: 6,
+        subtype: null,
+        currency: "USD",
+      } satisfies DividendFormValues;
+
+      const payload = ACTIVITY_FORM_CONFIG.DIVIDEND.toPayload(formData);
+
+      expect(payload).toMatchObject({ subtype: null, quantity: null, unitPrice: null });
+    });
+
+    it("keeps asset-backed values for dividend in kind", () => {
+      const formData = {
+        accountId: "acc-123",
+        activityDate: new Date(),
+        symbol: "AAPL",
+        amount: 12,
+        quantity: 2,
+        unitPrice: 6,
+        subtype: ACTIVITY_SUBTYPES.DIVIDEND_IN_KIND,
+        currency: "USD",
+      } satisfies DividendFormValues;
+
+      const payload = ACTIVITY_FORM_CONFIG.DIVIDEND.toPayload(formData);
+
+      expect(payload).toMatchObject({
+        subtype: ACTIVITY_SUBTYPES.DIVIDEND_IN_KIND,
+        quantity: 2,
+        unitPrice: 6,
+      });
+    });
+
+    it("clears stale staking values when switching interest back to cash", () => {
+      const formData = {
+        accountId: "acc-123",
+        activityDate: new Date(),
+        symbol: "ETH",
+        amount: 12,
+        quantity: 2,
+        unitPrice: 6,
+        subtype: null,
+        currency: "USD",
+      } satisfies InterestFormValues;
+
+      const payload = ACTIVITY_FORM_CONFIG.INTEREST.toPayload(formData);
+
+      expect(payload).toMatchObject({ subtype: null, quantity: null, unitPrice: null });
+    });
+
+    it("keeps asset-backed values for staking rewards", () => {
+      const formData = {
+        accountId: "acc-123",
+        activityDate: new Date(),
+        symbol: "ETH",
+        amount: 12,
+        quantity: 2,
+        unitPrice: 6,
+        subtype: ACTIVITY_SUBTYPES.STAKING_REWARD,
+        currency: "USD",
+      } satisfies InterestFormValues;
+
+      const payload = ACTIVITY_FORM_CONFIG.INTEREST.toPayload(formData);
+
+      expect(payload).toMatchObject({
+        subtype: ACTIVITY_SUBTYPES.STAKING_REWARD,
+        quantity: 2,
+        unitPrice: 6,
+      });
+    });
+  });
+
   describe("asset identity payloads", () => {
     it("omits stale selected asset id for option payloads", () => {
       const payload = ACTIVITY_FORM_CONFIG.BUY.toPayload({
@@ -928,6 +1006,22 @@ describe("Form Schemas Validation", () => {
         activityType: "CREDIT",
         activityDate: new Date(),
         amount: 25,
+        currency: "USD",
+        exchangeMic: null,
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts cash interest after asset-backed fields are cleared", () => {
+      const result = newActivitySchema.safeParse({
+        accountId: "acc-123",
+        activityType: "INTEREST",
+        activityDate: new Date(),
+        subtype: null,
+        amount: 25,
+        quantity: undefined,
+        unitPrice: undefined,
         currency: "USD",
         exchangeMic: null,
       });

--- a/apps/frontend/src/pages/activity/components/forms/__tests__/simple-forms.test.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/__tests__/simple-forms.test.tsx
@@ -37,6 +37,12 @@ vi.mock("../fields", () => ({
       <input data-testid={`input-${name}`} name={name} type="number" id={name} />
     </div>
   ),
+  QuantityInput: ({ name, label }: { name: string; label: string }) => (
+    <div>
+      <label htmlFor={name}>{label}</label>
+      <input data-testid={`input-${name}`} name={name} type="number" id={name} />
+    </div>
+  ),
   NotesInput: ({ name, label }: { name: string; label: string }) => (
     <div>
       <label htmlFor={name}>{label}</label>
@@ -89,7 +95,43 @@ vi.mock("@wealthfolio/ui/components/ui/icons", () => ({
     Check: () => <span data-testid="check-icon">Check</span>,
     Plus: () => <span data-testid="plus-icon">Plus</span>,
     MinusCircle: () => <span data-testid="minus-icon">Minus</span>,
+    ChevronDown: () => <span data-testid="chevron-down-icon" />,
+    Circle: () => <span data-testid="circle-icon" />,
   },
+}));
+
+vi.mock("@wealthfolio/ui/components/ui/animated-toggle-group", () => ({
+  AnimatedToggleGroup: ({
+    items,
+    value,
+    onValueChange,
+  }: {
+    items: { value: string; label: string }[];
+    value?: string;
+    onValueChange?: (value: string) => void;
+  }) => (
+    <div data-testid="animated-toggle-group">
+      {items.map((item) => (
+        <button
+          key={item.value}
+          type="button"
+          aria-pressed={value === item.value}
+          onClick={() => onValueChange?.(item.value)}
+        >
+          {item.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock("@wealthfolio/ui/components/ui/radio-group", () => ({
+  RadioGroup: ({ children }: { children: React.ReactNode }) => (
+    <div role="radiogroup">{children}</div>
+  ),
+  RadioGroupItem: ({ value, id }: { value: string; id: string }) => (
+    <input type="radio" value={value} id={id} readOnly />
+  ),
 }));
 
 const mockAccounts: AccountSelectOption[] = [

--- a/apps/frontend/src/pages/activity/components/forms/dividend-form.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/dividend-form.tsx
@@ -1,10 +1,13 @@
 import { useSettings } from "@/hooks/use-settings";
 import { ACTIVITY_SUBTYPES, ActivityType } from "@/lib/constants";
+import { roundDecimal } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@wealthfolio/ui/components/ui/button";
 import { Card, CardContent } from "@wealthfolio/ui/components/ui/card";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
-import { useMemo } from "react";
+import { Label } from "@wealthfolio/ui/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@wealthfolio/ui/components/ui/radio-group";
+import { useEffect, useMemo } from "react";
 import { FormProvider, useForm, type Resolver } from "react-hook-form";
 import { z } from "zod";
 import {
@@ -19,45 +22,71 @@ import {
   type AccountSelectOption,
 } from "./fields";
 
+const FMV_PER_UNIT_HELP_TEXT =
+  "Fair market value per share or token at the time you received it. Used to calculate income amount and cost basis.";
+const INCOME_MODE_CASH = "CASH";
+
 // Zod schema for DividendForm validation
-export const dividendFormSchema = z.object({
-  accountId: z.string().min(1, { message: "Please select an account." }),
-  symbol: z.string().min(1, { message: "Please enter a symbol." }),
-  existingAssetId: z.string().nullable().optional(),
-  exchangeMic: z.string().nullable().optional(),
-  activityDate: z.date({ required_error: "Please select a date." }),
-  amount: z.coerce
-    .number({
-      required_error: "Please enter an amount.",
-      invalid_type_error: "Amount must be a number.",
-    })
-    .positive({ message: "Amount must be greater than 0." }),
-  comment: z.string().optional().nullable(),
-  // Advanced options
-  currency: z.string().min(1, { message: "Currency is required." }),
-  fxRate: z.coerce
-    .number({
-      invalid_type_error: "FX Rate must be a number.",
-    })
-    .positive({ message: "FX Rate must be positive." })
-    .optional(),
-  subtype: z.string().optional().nullable(),
-  // DRIP fields (price & quantity of reinvested shares)
-  unitPrice: z.coerce
-    .number({
-      invalid_type_error: "Price must be a number.",
-    })
-    .positive({ message: "Price must be greater than 0." })
-    .optional(),
-  quantity: z.coerce
-    .number({
-      invalid_type_error: "Quantity must be a number.",
-    })
-    .positive({ message: "Quantity must be greater than 0." })
-    .optional(),
-  symbolQuoteCcy: z.string().nullable().optional(),
-  symbolInstrumentType: z.string().nullable().optional(),
-});
+export const dividendFormSchema = z
+  .object({
+    accountId: z.string().min(1, { message: "Please select an account." }),
+    symbol: z.string().min(1, { message: "Please enter a symbol." }),
+    existingAssetId: z.string().nullable().optional(),
+    exchangeMic: z.string().nullable().optional(),
+    activityDate: z.date({ required_error: "Please select a date." }),
+    amount: z.coerce
+      .number({
+        required_error: "Please enter an amount.",
+        invalid_type_error: "Amount must be a number.",
+      })
+      .positive({ message: "Amount must be greater than 0." }),
+    comment: z.string().optional().nullable(),
+    // Advanced options
+    currency: z.string().min(1, { message: "Currency is required." }),
+    fxRate: z.coerce
+      .number({
+        invalid_type_error: "FX Rate must be a number.",
+      })
+      .positive({ message: "FX Rate must be positive." })
+      .optional(),
+    subtype: z.string().optional().nullable(),
+    unitPrice: z.coerce
+      .number({
+        invalid_type_error: "FMV per unit must be a number.",
+      })
+      .positive({ message: "FMV per unit must be greater than 0." })
+      .optional(),
+    quantity: z.coerce
+      .number({
+        invalid_type_error: "Received quantity must be a number.",
+      })
+      .positive({ message: "Received quantity must be greater than 0." })
+      .optional(),
+    symbolQuoteCcy: z.string().nullable().optional(),
+    symbolInstrumentType: z.string().nullable().optional(),
+  })
+  .superRefine((data, ctx) => {
+    const isAssetBacked =
+      data.subtype === ACTIVITY_SUBTYPES.DRIP ||
+      data.subtype === ACTIVITY_SUBTYPES.DIVIDEND_IN_KIND;
+    if (!isAssetBacked) return;
+
+    if (!data.quantity) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["quantity"],
+        message: "Received quantity is required.",
+      });
+    }
+    if (!data.unitPrice) {
+      if (data.amount) return;
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["unitPrice"],
+        message: "Enter either dividend amount or FMV per unit.",
+      });
+    }
+  });
 
 export type DividendFormValues = z.infer<typeof dividendFormSchema>;
 
@@ -111,10 +140,46 @@ export function DividendForm({
   });
 
   const { watch } = form;
+  const { getFieldState, getValues, setValue } = form;
   const accountId = watch("accountId");
   const currency = watch("currency");
   const subtype = watch("subtype");
-  const isDrip = subtype === ACTIVITY_SUBTYPES.DRIP;
+  const quantity = watch("quantity");
+  const unitPrice = watch("unitPrice");
+  const isAssetBacked =
+    subtype === ACTIVITY_SUBTYPES.DRIP || subtype === ACTIVITY_SUBTYPES.DIVIDEND_IN_KIND;
+  const dividendMode = subtype ?? INCOME_MODE_CASH;
+
+  useEffect(() => {
+    if (!isAssetBacked) return;
+    const q = Number(quantity);
+    const p = Number(unitPrice);
+    const currentAmount = Number(getValues("amount"));
+    const quantityIsDirty = getFieldState("quantity").isDirty;
+    const unitPriceIsDirty = getFieldState("unitPrice").isDirty;
+    const shouldAutoSetAmount =
+      quantityIsDirty || unitPriceIsDirty || !(Number.isFinite(currentAmount) && currentAmount > 0);
+    if (q > 0 && p > 0 && shouldAutoSetAmount) {
+      const computedAmount = roundDecimal(q * p);
+      if (currentAmount !== computedAmount) {
+        setValue("amount", computedAmount, {
+          shouldDirty: quantityIsDirty || unitPriceIsDirty,
+          shouldValidate: false,
+        });
+      }
+    }
+  }, [getFieldState, getValues, isAssetBacked, quantity, setValue, unitPrice]);
+
+  const handleDividendModeChange = (value: string) => {
+    setValue("subtype", value === INCOME_MODE_CASH ? null : value, {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
+    if (value === INCOME_MODE_CASH) {
+      setValue("quantity", undefined, { shouldDirty: true, shouldValidate: false });
+      setValue("unitPrice", undefined, { shouldDirty: true, shouldValidate: false });
+    }
+  };
 
   // Get account currency from selected account
   const selectedAccount = useMemo(
@@ -135,10 +200,50 @@ export function DividendForm({
             {/* Account Selection */}
             <AccountSelect name="accountId" accounts={accounts} currencyName="currency" />
 
+            <div className="space-y-2">
+              <div className="text-sm font-medium">Dividend type</div>
+              <RadioGroup
+                value={dividendMode}
+                onValueChange={handleDividendModeChange}
+                className="flex flex-wrap gap-4"
+              >
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value={INCOME_MODE_CASH} id="dividend-type-cash" />
+                  <Label
+                    htmlFor="dividend-type-cash"
+                    className="cursor-pointer text-sm font-normal"
+                  >
+                    Cash
+                  </Label>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value={ACTIVITY_SUBTYPES.DRIP} id="dividend-type-drip" />
+                  <Label
+                    htmlFor="dividend-type-drip"
+                    className="cursor-pointer text-sm font-normal"
+                  >
+                    DRIP
+                  </Label>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem
+                    value={ACTIVITY_SUBTYPES.DIVIDEND_IN_KIND}
+                    id="dividend-type-in-kind"
+                  />
+                  <Label
+                    htmlFor="dividend-type-in-kind"
+                    className="cursor-pointer text-sm font-normal"
+                  >
+                    In kind
+                  </Label>
+                </div>
+              </RadioGroup>
+            </div>
+
             {/* Symbol Search/Input */}
             <SymbolSearch
               name="symbol"
-              label="Symbol"
+              label="Asset"
               isManualAsset={isManualSymbol}
               exchangeMicName="exchangeMic"
               currencyName="currency"
@@ -154,32 +259,42 @@ export function DividendForm({
             <DatePicker name="activityDate" label="Date" />
 
             {/* Amount */}
-            <AmountInput name="amount" label="Amount" currency={currency} />
+            {isAssetBacked && (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <QuantityInput
+                  name="quantity"
+                  label={
+                    subtype === ACTIVITY_SUBTYPES.DRIP ? "Reinvested quantity" : "Received quantity"
+                  }
+                />
+                <AmountInput
+                  name="unitPrice"
+                  label={subtype === ACTIVITY_SUBTYPES.DRIP ? "Reinvestment price" : "FMV per unit"}
+                  labelHelpText={
+                    subtype === ACTIVITY_SUBTYPES.DRIP ? undefined : FMV_PER_UNIT_HELP_TEXT
+                  }
+                  maxDecimalPlaces={4}
+                  currency={currency}
+                />
+              </div>
+            )}
+
+            <AmountInput
+              name="amount"
+              label={isAssetBacked ? "Dividend amount" : "Amount"}
+              currency={currency}
+            />
 
             {/* Advanced Options */}
             <AdvancedOptionsSection
               currencyName="currency"
               fxRateName="fxRate"
-              subtypeName="subtype"
               activityType={ActivityType.DIVIDEND}
               assetCurrency={assetCurrency}
               accountCurrency={accountCurrency}
               baseCurrency={baseCurrency}
-              defaultOpen={isDrip}
+              showSubtype={false}
             />
-
-            {/* DRIP: Price & Quantity of reinvested shares */}
-            {isDrip && (
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-                <AmountInput
-                  name="unitPrice"
-                  label="Price"
-                  maxDecimalPlaces={4}
-                  currency={currency}
-                />
-                <QuantityInput name="quantity" label="Quantity" />
-              </div>
-            )}
 
             {/* Notes */}
             <NotesInput name="comment" label="Notes" placeholder="Add an optional note..." />

--- a/apps/frontend/src/pages/activity/components/forms/fields/amount-input.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/fields/amount-input.tsx
@@ -4,16 +4,21 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
+  Icons,
   InputGroup,
   InputGroupAddon,
   InputGroupText,
   MoneyInput,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from "@wealthfolio/ui";
 import { useFormContext, type FieldPath, type FieldValues } from "react-hook-form";
 
 interface AmountInputProps<TFieldValues extends FieldValues = FieldValues> {
   name: FieldPath<TFieldValues>;
   label?: string;
+  labelHelpText?: string;
   placeholder?: string;
   /** Maximum decimal places (default: 2 for currency) */
   maxDecimalPlaces?: number;
@@ -24,6 +29,7 @@ interface AmountInputProps<TFieldValues extends FieldValues = FieldValues> {
 export function AmountInput<TFieldValues extends FieldValues = FieldValues>({
   name,
   label = "Amount",
+  labelHelpText,
   placeholder = "0.00",
   maxDecimalPlaces = 2,
   currency,
@@ -36,7 +42,23 @@ export function AmountInput<TFieldValues extends FieldValues = FieldValues>({
       name={name}
       render={({ field }) => (
         <FormItem>
-          <FormLabel>{label}</FormLabel>
+          <div className="flex items-center gap-1.5">
+            <FormLabel>{label}</FormLabel>
+            {labelHelpText && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className="text-muted-foreground/70 hover:text-foreground inline-flex rounded-full transition-colors"
+                    aria-label={`More info about ${label}`}
+                  >
+                    <Icons.Info className="h-3 w-3" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs text-xs">{labelHelpText}</TooltipContent>
+              </Tooltip>
+            )}
+          </div>
           <FormControl>
             {currency ? (
               <InputGroup className="bg-input-bg h-input-height shadow-xs rounded-md">

--- a/apps/frontend/src/pages/activity/components/forms/interest-form.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/interest-form.tsx
@@ -1,10 +1,13 @@
 import { useSettings } from "@/hooks/use-settings";
-import { ActivityType } from "@/lib/constants";
+import { ACTIVITY_SUBTYPES, ActivityType } from "@/lib/constants";
+import { roundDecimal } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@wealthfolio/ui/components/ui/button";
 import { Card, CardContent } from "@wealthfolio/ui/components/ui/card";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
-import { useMemo } from "react";
+import { Label } from "@wealthfolio/ui/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@wealthfolio/ui/components/ui/radio-group";
+import { useEffect, useMemo } from "react";
 import { FormProvider, useForm, type Resolver } from "react-hook-form";
 import { z } from "zod";
 import {
@@ -14,37 +17,81 @@ import {
   createValidatedSubmit,
   DatePicker,
   NotesInput,
+  QuantityInput,
   SymbolSearch,
   type AccountSelectOption,
 } from "./fields";
 
+const FMV_PER_UNIT_HELP_TEXT =
+  "Fair market value per share or token at the time you received it. Used to calculate income amount and cost basis.";
+const INCOME_MODE_CASH = "CASH";
+
 // Zod schema for InterestForm validation
-export const interestFormSchema = z.object({
-  accountId: z.string().min(1, { message: "Please select an account." }),
-  activityDate: z.date({ required_error: "Please select a date." }),
-  // Optional symbol (e.g., for bond interest)
-  symbol: z.string().optional().nullable(),
-  existingAssetId: z.string().nullable().optional(),
-  exchangeMic: z.string().nullable().optional(),
-  amount: z.coerce
-    .number({
-      required_error: "Please enter an amount.",
-      invalid_type_error: "Amount must be a number.",
-    })
-    .positive({ message: "Amount must be greater than 0." }),
-  comment: z.string().optional().nullable(),
-  // Advanced options
-  currency: z.string().min(1, { message: "Currency is required." }),
-  fxRate: z.coerce
-    .number({
-      invalid_type_error: "FX Rate must be a number.",
-    })
-    .positive({ message: "FX Rate must be positive." })
-    .optional(),
-  subtype: z.string().optional().nullable(),
-  symbolQuoteCcy: z.string().nullable().optional(),
-  symbolInstrumentType: z.string().nullable().optional(),
-});
+export const interestFormSchema = z
+  .object({
+    accountId: z.string().min(1, { message: "Please select an account." }),
+    activityDate: z.date({ required_error: "Please select a date." }),
+    symbol: z.string().optional().nullable(),
+    existingAssetId: z.string().nullable().optional(),
+    exchangeMic: z.string().nullable().optional(),
+    amount: z.coerce
+      .number({
+        required_error: "Please enter an amount.",
+        invalid_type_error: "Amount must be a number.",
+      })
+      .positive({ message: "Amount must be greater than 0." }),
+    unitPrice: z.coerce
+      .number({
+        invalid_type_error: "FMV per unit must be a number.",
+      })
+      .positive({ message: "FMV per unit must be greater than 0." })
+      .optional(),
+    quantity: z.coerce
+      .number({
+        invalid_type_error: "Received quantity must be a number.",
+      })
+      .positive({ message: "Received quantity must be greater than 0." })
+      .optional(),
+    comment: z.string().optional().nullable(),
+    // Advanced options
+    currency: z.string().min(1, { message: "Currency is required." }),
+    fxRate: z.coerce
+      .number({
+        invalid_type_error: "FX Rate must be a number.",
+      })
+      .positive({ message: "FX Rate must be positive." })
+      .optional(),
+    subtype: z.string().optional().nullable(),
+    symbolQuoteCcy: z.string().nullable().optional(),
+    symbolInstrumentType: z.string().nullable().optional(),
+  })
+  .superRefine((data, ctx) => {
+    const isStakingReward = data.subtype === ACTIVITY_SUBTYPES.STAKING_REWARD;
+    if (!isStakingReward) return;
+
+    if (!data.symbol?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["symbol"],
+        message: "Reward asset is required.",
+      });
+    }
+    if (!data.quantity) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["quantity"],
+        message: "Received quantity is required.",
+      });
+    }
+    if (!data.unitPrice) {
+      if (data.amount) return;
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["unitPrice"],
+        message: "Enter either interest amount or FMV per unit.",
+      });
+    }
+  });
 
 export type InterestFormValues = z.infer<typeof interestFormSchema>;
 
@@ -82,6 +129,8 @@ export function InterestForm({
       activityDate: new Date(),
       symbol: null,
       amount: undefined,
+      quantity: undefined,
+      unitPrice: undefined,
       comment: null,
       fxRate: undefined,
       subtype: null,
@@ -91,8 +140,45 @@ export function InterestForm({
   });
 
   const { watch } = form;
+  const { getFieldState, getValues, setValue } = form;
   const accountId = watch("accountId");
   const currency = watch("currency");
+  const subtype = watch("subtype");
+  const quantity = watch("quantity");
+  const unitPrice = watch("unitPrice");
+  const isStakingReward = subtype === ACTIVITY_SUBTYPES.STAKING_REWARD;
+  const interestMode = subtype ?? INCOME_MODE_CASH;
+
+  useEffect(() => {
+    if (!isStakingReward) return;
+    const q = Number(quantity);
+    const p = Number(unitPrice);
+    const currentAmount = Number(getValues("amount"));
+    const quantityIsDirty = getFieldState("quantity").isDirty;
+    const unitPriceIsDirty = getFieldState("unitPrice").isDirty;
+    const shouldAutoSetAmount =
+      quantityIsDirty || unitPriceIsDirty || !(Number.isFinite(currentAmount) && currentAmount > 0);
+    if (q > 0 && p > 0 && shouldAutoSetAmount) {
+      const computedAmount = roundDecimal(q * p);
+      if (currentAmount !== computedAmount) {
+        setValue("amount", computedAmount, {
+          shouldDirty: quantityIsDirty || unitPriceIsDirty,
+          shouldValidate: false,
+        });
+      }
+    }
+  }, [getFieldState, getValues, isStakingReward, quantity, setValue, unitPrice]);
+
+  const handleInterestModeChange = (value: string) => {
+    setValue("subtype", value === INCOME_MODE_CASH ? null : value, {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
+    if (value === INCOME_MODE_CASH) {
+      setValue("quantity", undefined, { shouldDirty: true, shouldValidate: false });
+      setValue("unitPrice", undefined, { shouldDirty: true, shouldValidate: false });
+    }
+  };
 
   // Get account currency from selected account
   const selectedAccount = useMemo(
@@ -113,10 +199,41 @@ export function InterestForm({
             {/* Account Selection */}
             <AccountSelect name="accountId" accounts={accounts} currencyName="currency" />
 
+            <div className="space-y-2">
+              <div className="text-sm font-medium">Interest type</div>
+              <RadioGroup
+                value={interestMode}
+                onValueChange={handleInterestModeChange}
+                className="flex flex-wrap gap-4"
+              >
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem value={INCOME_MODE_CASH} id="interest-type-cash" />
+                  <Label
+                    htmlFor="interest-type-cash"
+                    className="cursor-pointer text-sm font-normal"
+                  >
+                    Cash
+                  </Label>
+                </div>
+                <div className="flex items-center space-x-2">
+                  <RadioGroupItem
+                    value={ACTIVITY_SUBTYPES.STAKING_REWARD}
+                    id="interest-type-staking-reward"
+                  />
+                  <Label
+                    htmlFor="interest-type-staking-reward"
+                    className="cursor-pointer text-sm font-normal"
+                  >
+                    Staking reward
+                  </Label>
+                </div>
+              </RadioGroup>
+            </div>
+
             {/* Optional Symbol (e.g., for bond interest) */}
             <SymbolSearch
               name="symbol"
-              label="Symbol (optional)"
+              label={isStakingReward ? "Reward asset" : "Symbol (optional)"}
               exchangeMicName="exchangeMic"
               currencyName="currency"
               quoteCcyName="symbolQuoteCcy"
@@ -130,17 +247,33 @@ export function InterestForm({
             {/* Date Picker */}
             <DatePicker name="activityDate" label="Date" />
 
-            {/* Amount */}
-            <AmountInput name="amount" label="Amount" currency={currency} />
+            {isStakingReward && (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <QuantityInput name="quantity" label="Received quantity" />
+                <AmountInput
+                  name="unitPrice"
+                  label="FMV per unit"
+                  labelHelpText={FMV_PER_UNIT_HELP_TEXT}
+                  maxDecimalPlaces={4}
+                  currency={currency}
+                />
+              </div>
+            )}
+
+            <AmountInput
+              name="amount"
+              label={isStakingReward ? "Interest amount" : "Amount"}
+              currency={currency}
+            />
 
             {/* Advanced Options */}
             <AdvancedOptionsSection
               currencyName="currency"
               fxRateName="fxRate"
-              subtypeName="subtype"
               activityType={ActivityType.INTEREST}
               accountCurrency={accountCurrency}
               baseCurrency={baseCurrency}
+              showSubtype={false}
             />
 
             {/* Notes */}

--- a/apps/frontend/src/pages/activity/components/mobile-forms/__tests__/validate-transfer-fields.test.ts
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/__tests__/validate-transfer-fields.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { validateTransferFields, type TransferValidationInput } from "../mobile-activity-form";
+import {
+  applyMobileIncomeUpdateClears,
+  validateTransferFields,
+  type TransferValidationInput,
+} from "../mobile-activity-form";
 
 const base: TransferValidationInput = {
   activityType: "TRANSFER_OUT",
@@ -228,5 +232,56 @@ describe("validateTransferFields", () => {
       });
       expect(outResult).toEqual(inResult);
     });
+  });
+});
+
+describe("applyMobileIncomeUpdateClears", () => {
+  it("sends explicit clears when an existing staking reward is switched back to cash interest", () => {
+    const data: Record<string, unknown> = {
+      activityType: "INTEREST",
+      subtype: null,
+    };
+
+    applyMobileIncomeUpdateClears(data, true);
+
+    expect(data.quantity).toBeNull();
+    expect(data.unitPrice).toBeNull();
+  });
+
+  it("sends explicit clears when an existing dividend in kind is switched back to cash dividend", () => {
+    const data: Record<string, unknown> = {
+      activityType: "DIVIDEND",
+      subtype: null,
+      assetId: "AAPL",
+    };
+
+    applyMobileIncomeUpdateClears(data, true);
+
+    expect(data.quantity).toBeNull();
+    expect(data.unitPrice).toBeNull();
+    expect(data.assetId).toBe("AAPL");
+  });
+
+  it("does not clear asset-backed income or creates", () => {
+    const stakingUpdate: Record<string, unknown> = {
+      activityType: "INTEREST",
+      subtype: "STAKING_REWARD",
+      quantity: 0.01,
+      unitPrice: 200,
+    };
+    const cashCreate: Record<string, unknown> = {
+      activityType: "INTEREST",
+      subtype: null,
+      quantity: undefined,
+      unitPrice: undefined,
+    };
+
+    applyMobileIncomeUpdateClears(stakingUpdate, true);
+    applyMobileIncomeUpdateClears(cashCreate, false);
+
+    expect(stakingUpdate.quantity).toBe(0.01);
+    expect(stakingUpdate.unitPrice).toBe(200);
+    expect(cashCreate.quantity).toBeUndefined();
+    expect(cashCreate.unitPrice).toBeUndefined();
   });
 });

--- a/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
@@ -11,8 +11,17 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@wealthfolio/ui/components/ui/sheet";
-import { ActivityType, METADATA_CONTRACT_MULTIPLIER, QuoteMode } from "@/lib/constants";
-import { isSecuritiesTransfer, isSymbolRequired } from "@/lib/activity-utils";
+import {
+  ACTIVITY_SUBTYPES,
+  ActivityType,
+  METADATA_CONTRACT_MULTIPLIER,
+  QuoteMode,
+} from "@/lib/constants";
+import {
+  isAssetBackedIncomeSubtype,
+  isSecuritiesTransfer,
+  isSymbolRequired,
+} from "@/lib/activity-utils";
 import { buildOccSymbol, parseOccSymbol } from "@/lib/occ-symbol";
 import { generateId } from "@/lib/id";
 import type { ActivityCreate, ActivityDetails } from "@/lib/types";
@@ -49,6 +58,35 @@ export interface TransferValidationError {
   message: string;
 }
 
+const TRADE_ACTIVITY_TYPES: readonly string[] = [ActivityType.BUY, ActivityType.SELL];
+const TRANSFER_ACTIVITY_TYPES: readonly string[] = [
+  ActivityType.TRANSFER_IN,
+  ActivityType.TRANSFER_OUT,
+];
+const MOBILE_ACTIVITY_TYPES: readonly string[] = [
+  ActivityType.BUY,
+  ActivityType.SELL,
+  ActivityType.DEPOSIT,
+  ActivityType.WITHDRAWAL,
+  ActivityType.INTEREST,
+  ActivityType.DIVIDEND,
+  ActivityType.SPLIT,
+  ActivityType.TRANSFER_IN,
+  ActivityType.TRANSFER_OUT,
+  ActivityType.FEE,
+  ActivityType.TAX,
+  ActivityType.CREDIT,
+  ActivityType.ADJUSTMENT,
+];
+const CASH_AMOUNT_ACTIVITY_TYPES: readonly string[] = [
+  ActivityType.DEPOSIT,
+  ActivityType.WITHDRAWAL,
+  ActivityType.TRANSFER_IN,
+  ActivityType.TRANSFER_OUT,
+  ActivityType.CREDIT,
+];
+const INCOME_ACTIVITY_TYPES: readonly string[] = [ActivityType.DIVIDEND, ActivityType.INTEREST];
+
 /**
  * Validates transfer-specific fields that the Zod schema can't enforce
  * (transferActivitySchema lives inside a discriminatedUnion which doesn't support superRefine).
@@ -57,7 +95,7 @@ export interface TransferValidationError {
 export function validateTransferFields(
   input: TransferValidationInput,
 ): TransferValidationError | null {
-  const isTransfer = ["TRANSFER_IN", "TRANSFER_OUT"].includes(input.activityType);
+  const isTransfer = TRANSFER_ACTIVITY_TYPES.includes(input.activityType);
   if (!isTransfer) return null;
 
   const mode = input.transferMode ?? "cash";
@@ -95,7 +133,7 @@ export function validateTransferFields(
  */
 function validateTradeFields(data: Record<string, unknown>): TransferValidationError | null {
   const activityType = data.activityType as string;
-  if (!["BUY", "SELL"].includes(activityType)) return null;
+  if (!TRADE_ACTIVITY_TYPES.includes(activityType)) return null;
 
   const assetType = (data.assetType as string) ?? "stock";
 
@@ -121,6 +159,46 @@ function validateTradeFields(data: Record<string, unknown>): TransferValidationE
   return null;
 }
 
+function validateAssetBackedIncomeFields(
+  data: Record<string, unknown>,
+): TransferValidationError | null {
+  const activityType = data.activityType as string;
+  const subtype = data.subtype as string | null | undefined;
+  if (!isAssetBackedIncomeSubtype(activityType, subtype)) return null;
+
+  if (!(data.assetId as string)?.trim()) {
+    return {
+      field: "assetId",
+      message:
+        subtype === ACTIVITY_SUBTYPES.STAKING_REWARD
+          ? "Please select a reward asset."
+          : "Please select a symbol.",
+    };
+  }
+  if (!data.quantity || Number(data.quantity) <= 0) {
+    return { field: "quantity", message: "Please enter the received quantity." };
+  }
+  const hasUnitPrice = Number(data.unitPrice) > 0;
+  const hasAmount = Number(data.amount) > 0;
+  if (!hasUnitPrice && !hasAmount) {
+    return { field: "unitPrice", message: "Please enter the income amount or FMV per unit." };
+  }
+
+  return null;
+}
+
+export function applyMobileIncomeUpdateClears(data: Record<string, unknown>, isUpdate: boolean) {
+  if (!isUpdate) return;
+
+  const activityType = typeof data.activityType === "string" ? data.activityType : "";
+  if (activityType !== ActivityType.DIVIDEND && activityType !== ActivityType.INTEREST) return;
+  if (data.subtype) return;
+  if (isAssetBackedIncomeSubtype(activityType, data.subtype as string | null | undefined)) return;
+
+  data.quantity = null;
+  data.unitPrice = null;
+}
+
 function extractErrorMessage(error: unknown): string {
   if (typeof error === "string" && error.trim()) return error;
   if (error instanceof Error && error.message.trim()) return error.message;
@@ -140,28 +218,13 @@ export function MobileActivityForm({ accounts, activity, open, onClose }: Mobile
   const isValidActivityType = (
     type: string | undefined,
   ): type is NewActivityFormValues["activityType"] => {
-    return type
-      ? [
-          "BUY",
-          "SELL",
-          "DEPOSIT",
-          "WITHDRAWAL",
-          "INTEREST",
-          "DIVIDEND",
-          "SPLIT",
-          "TRANSFER_IN",
-          "TRANSFER_OUT",
-          "FEE",
-          "TAX",
-          "CREDIT",
-          "ADJUSTMENT",
-        ].includes(type)
-      : false;
+    return type ? MOBILE_ACTIVITY_TYPES.includes(type) : false;
   };
 
   // Derive transfer mode from existing activity data
   const isTransferType =
-    activity?.activityType === "TRANSFER_IN" || activity?.activityType === "TRANSFER_OUT";
+    activity?.activityType === ActivityType.TRANSFER_IN ||
+    activity?.activityType === ActivityType.TRANSFER_OUT;
   const isSecurityTransferActivity =
     isTransferType &&
     isSecuritiesTransfer(activity?.activityType ?? "", activity?.assetSymbol, activity?.assetId);
@@ -191,6 +254,7 @@ export function MobileActivityForm({ accounts, activity, open, onClose }: Mobile
           : undefined,
     fee: activity?.fee ? Number(activity.fee) : 0,
     comment: activity?.comment ?? null,
+    subtype: activity?.subtype ?? null,
     assetId:
       isTransferType && !isSecurityTransferActivity
         ? undefined
@@ -203,13 +267,13 @@ export function MobileActivityForm({ accounts, activity, open, onClose }: Mobile
           return date;
         })(),
     currency: activity?.currency ?? "",
-    quoteMode: activity?.assetQuoteMode === "MANUAL" ? "MANUAL" : "MARKET",
+    quoteMode: activity?.assetQuoteMode === QuoteMode.MANUAL ? QuoteMode.MANUAL : QuoteMode.MARKET,
     exchangeMic: activity?.exchangeMic,
     showCurrencySelect: false,
     ...(isTransferType && {
       transferMode: initialTransferMode,
       isExternal: true,
-      direction: activity?.activityType === "TRANSFER_IN" ? "in" : "out",
+      direction: activity?.activityType === ActivityType.TRANSFER_IN ? "in" : "out",
       toAccountId: "",
     }),
     // Option defaults when editing an option activity
@@ -272,13 +336,23 @@ export function MobileActivityForm({ accounts, activity, open, onClose }: Mobile
         ...submitData
       } = data as any;
       const account = accounts.find((a) => a.value === submitData.accountId);
-      const isTransferActivity = ["TRANSFER_IN", "TRANSFER_OUT"].includes(submitData.activityType);
+      const isTransferActivity = TRANSFER_ACTIVITY_TYPES.includes(submitData.activityType);
       const isSecuritiesTransfer = isTransferActivity && (_tm ?? "cash") === "securities";
+      const isAssetBackedIncome = isAssetBackedIncomeSubtype(
+        submitData.activityType,
+        submitData.subtype,
+      );
 
       // Validate trade fields (assetId for stocks, option fields for options)
       const tradeError = validateTradeFields(data as any);
       if (tradeError) {
         form.setError(tradeError.field as any, { message: tradeError.message });
+        return;
+      }
+
+      const assetIncomeError = validateAssetBackedIncomeFields(submitData);
+      if (assetIncomeError) {
+        form.setError(assetIncomeError.field as any, { message: assetIncomeError.message });
         return;
       }
 
@@ -401,7 +475,11 @@ export function MobileActivityForm({ accounts, activity, open, onClose }: Mobile
 
       // For non-symbol activities (cash deposits, withdrawals, etc.) and cash transfers:
       // Clear assetId so backend generates CASH:{currency}
-      if (!isSymbolRequired(submitData.activityType) && !isSecuritiesTransfer) {
+      if (
+        !isSymbolRequired(submitData.activityType) &&
+        !isSecuritiesTransfer &&
+        !isAssetBackedIncome
+      ) {
         delete (submitData as Record<string, unknown>).assetId;
         delete (submitData as Record<string, unknown>).quantity;
         delete (submitData as Record<string, unknown>).unitPrice;
@@ -409,6 +487,7 @@ export function MobileActivityForm({ accounts, activity, open, onClose }: Mobile
           submitData.currency = account.currency;
         }
       }
+      applyMobileIncomeUpdateClears(submitData, Boolean(id));
 
       if ("quoteMode" in submitData && submitData.quoteMode === QuoteMode.MANUAL && account) {
         submitData.currency = submitData.currency ?? account.currency;
@@ -420,10 +499,17 @@ export function MobileActivityForm({ accounts, activity, open, onClose }: Mobile
       }
 
       if (id) {
+        const wasAssetBackedIncome = isAssetBackedIncomeSubtype(
+          activity?.activityType ?? "",
+          activity?.subtype,
+        );
+        const currentAssetId =
+          wasAssetBackedIncome && !isAssetBackedIncome ? undefined : activity?.assetId;
+
         await updateActivityMutation.mutateAsync({
           id,
           ...submitData,
-          currentAssetId: activity?.assetId,
+          currentAssetId,
         } as NewActivityFormValues & { id: string; currentAssetId?: string });
       } else {
         await addActivityMutation.mutateAsync(submitData);
@@ -466,24 +552,26 @@ export function MobileActivityForm({ accounts, activity, open, onClose }: Mobile
         const activityType = form.watch("activityType");
         const assetType = (form.getValues() as any).assetType ?? "stock";
         const baseFields = ["accountId", "activityDate"];
-        if (["BUY", "SELL"].includes(activityType ?? "")) {
+        if (TRADE_ACTIVITY_TYPES.includes(activityType ?? "")) {
           // Options: validate underlying instead of assetId (OCC built at submit)
           if (assetType === "option") {
             return [...baseFields, "underlyingSymbol", "quantity", "unitPrice", "fee"];
           }
           return [...baseFields, "assetId", "quantity", "unitPrice", "fee"];
         }
-        if (
-          ["DEPOSIT", "WITHDRAWAL", "TRANSFER_IN", "TRANSFER_OUT", "CREDIT"].includes(
-            activityType ?? "",
-          )
-        ) {
+        if (CASH_AMOUNT_ACTIVITY_TYPES.includes(activityType ?? "")) {
           return [...baseFields, "amount", "fee"];
         }
-        if (["DIVIDEND", "INTEREST"].includes(activityType ?? "")) {
-          return [...baseFields, "assetId", "amount"];
+        if (INCOME_ACTIVITY_TYPES.includes(activityType ?? "")) {
+          const subtype = form.getValues("subtype");
+          if (isAssetBackedIncomeSubtype(activityType ?? "", subtype)) {
+            return [...baseFields, "assetId", "quantity", "unitPrice", "amount"];
+          }
+          return activityType === ActivityType.DIVIDEND
+            ? [...baseFields, "assetId", "amount"]
+            : [...baseFields, "amount"];
         }
-        if (activityType === "ADJUSTMENT") {
+        if (activityType === ActivityType.ADJUSTMENT) {
           return [...baseFields, "assetId"];
         }
         return ["amount", ...baseFields];

--- a/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-type-step.tsx
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-type-step.tsx
@@ -2,6 +2,7 @@ import { FormControl, FormField, FormItem } from "@wealthfolio/ui/components/ui/
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
 import { RadioGroup, RadioGroupItem } from "@wealthfolio/ui/components/ui/radio-group";
 import { ScrollArea } from "@wealthfolio/ui/components/ui/scroll-area";
+import { ActivityType } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 import { useFormContext } from "react-hook-form";
 
@@ -10,13 +11,13 @@ const activityTypes = [
     category: "Trade",
     types: [
       {
-        value: "BUY",
+        value: ActivityType.BUY,
         label: "Buy",
         icon: "ArrowDown" as const,
         description: "Purchase an asset",
       },
       {
-        value: "SELL",
+        value: ActivityType.SELL,
         label: "Sell",
         icon: "ArrowUp" as const,
         description: "Sell an asset",
@@ -27,19 +28,19 @@ const activityTypes = [
     category: "Cash",
     types: [
       {
-        value: "DEPOSIT",
+        value: ActivityType.DEPOSIT,
         label: "Deposit",
         icon: "ArrowDown" as const,
         description: "Add funds to account",
       },
       {
-        value: "WITHDRAWAL",
+        value: ActivityType.WITHDRAWAL,
         label: "Withdrawal",
         icon: "ArrowUp" as const,
         description: "Remove funds from account",
       },
       {
-        value: "TRANSFER_OUT",
+        value: ActivityType.TRANSFER_OUT,
         label: "Transfer",
         icon: "ArrowLeftRight" as const,
         description: "Move cash or securities between accounts",
@@ -50,13 +51,13 @@ const activityTypes = [
     category: "Income",
     types: [
       {
-        value: "DIVIDEND",
+        value: ActivityType.DIVIDEND,
         label: "Dividend",
         icon: "Income" as const,
         description: "Dividend payment received",
       },
       {
-        value: "INTEREST",
+        value: ActivityType.INTEREST,
         label: "Interest",
         icon: "Percent" as const,
         description: "Interest earned",
@@ -67,25 +68,25 @@ const activityTypes = [
     category: "Other",
     types: [
       {
-        value: "FEE",
+        value: ActivityType.FEE,
         label: "Fee",
         icon: "DollarSign" as const,
         description: "Account or transaction fee",
       },
       {
-        value: "TAX",
+        value: ActivityType.TAX,
         label: "Tax",
         icon: "Receipt" as const,
         description: "Tax payment",
       },
       {
-        value: "SPLIT",
+        value: ActivityType.SPLIT,
         label: "Stock Split",
         icon: "Split" as const,
         description: "Stock split adjustment",
       },
       {
-        value: "ADJUSTMENT",
+        value: ActivityType.ADJUSTMENT,
         label: "Adjustment",
         icon: "RefreshCw" as const,
         description: "Non-trade correction or adjustment",

--- a/apps/frontend/src/pages/activity/components/mobile-forms/mobile-details-step.tsx
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/mobile-details-step.tsx
@@ -1,7 +1,7 @@
 import { ScrollArea } from "@wealthfolio/ui/components/ui/scroll-area";
 import { Textarea } from "@wealthfolio/ui/components/ui/textarea";
 import { AnimatedToggleGroup } from "@wealthfolio/ui/components/ui/animated-toggle-group";
-import { ACTIVITY_SUBTYPES, QuoteMode, type ActivityType } from "@/lib/constants";
+import { ACTIVITY_SUBTYPES, ActivityType, QuoteMode } from "@/lib/constants";
 import { useSettingsContext } from "@/lib/settings-provider";
 import {
   AdvancedOptionsSection,
@@ -30,16 +30,73 @@ import {
   SheetDescription,
   SheetHeader,
   SheetTitle,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from "@wealthfolio/ui";
 import { useEffect, useMemo, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import { restrictionAllowsType } from "@/lib/activity-restrictions";
+import { roundDecimal } from "@/lib/utils";
 import type { NewActivityFormValues } from "../forms/schemas";
 
 interface MobileDetailsStepProps {
   accounts: AccountSelectOption[];
   activityType: string;
   isEditing?: boolean;
+}
+
+const FMV_PER_UNIT_HELP_TEXT =
+  "Fair market value per share or token at the time you received it. Used to calculate income amount and cost basis.";
+const INCOME_MODE_CASH = "CASH";
+const TRADE_ACTIVITY_TYPES: readonly string[] = [ActivityType.BUY, ActivityType.SELL];
+const TRANSFER_ACTIVITY_TYPES: readonly string[] = [
+  ActivityType.TRANSFER_IN,
+  ActivityType.TRANSFER_OUT,
+];
+const SYMBOL_FIELD_ACTIVITY_TYPES: readonly string[] = [
+  ActivityType.BUY,
+  ActivityType.SELL,
+  ActivityType.DIVIDEND,
+  ActivityType.SPLIT,
+  ActivityType.ADJUSTMENT,
+];
+const AMOUNT_FIELD_ACTIVITY_TYPES: readonly string[] = [
+  ActivityType.DEPOSIT,
+  ActivityType.WITHDRAWAL,
+  ActivityType.DIVIDEND,
+  ActivityType.INTEREST,
+  ActivityType.TAX,
+  ActivityType.CREDIT,
+];
+const FEE_FIELD_ACTIVITY_TYPES: readonly string[] = [
+  ActivityType.BUY,
+  ActivityType.SELL,
+  ActivityType.DEPOSIT,
+  ActivityType.WITHDRAWAL,
+  ActivityType.TRANSFER_IN,
+  ActivityType.TRANSFER_OUT,
+  ActivityType.INTEREST,
+];
+
+function FmvPerUnitLabel() {
+  return (
+    <div className="flex items-center gap-1.5">
+      <FormLabel className="text-base font-medium">FMV per unit</FormLabel>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className="text-muted-foreground/70 hover:text-foreground inline-flex rounded-full transition-colors"
+            aria-label="More info about FMV per unit"
+          >
+            <Icons.Info className="h-3.5 w-3.5" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent className="max-w-xs text-xs">{FMV_PER_UNIT_HELP_TEXT}</TooltipContent>
+      </Tooltip>
+    </div>
+  );
 }
 
 export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileDetailsStepProps) {
@@ -49,6 +106,8 @@ export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileD
   const isManualAsset = watch("quoteMode") === QuoteMode.MANUAL;
   const accountId = watch("accountId");
   const currency = watch("currency");
+  const quantity = watch("quantity");
+  const unitPrice = watch("unitPrice");
 
   // Filter accounts by activity type (exclude HOLDINGS accounts for unsupported types)
   const filteredAccounts = useMemo(
@@ -59,7 +118,7 @@ export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileD
   const [accountSheetOpen, setAccountSheetOpen] = useState(false);
 
   // BUY/SELL asset type (stock/option/bond)
-  const isBuyOrSell = ["BUY", "SELL"].includes(activityType);
+  const isBuyOrSell = TRADE_ACTIVITY_TYPES.includes(activityType);
   const assetType = isBuyOrSell ? ((watch("assetType" as any) as string) ?? "stock") : "stock";
   const isOption = assetType === "option";
   const isBond = assetType === "bond";
@@ -77,11 +136,11 @@ export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileD
     const p = Number(optUnitPrice) || 0;
     const f = Number(optFee) || 0;
     const m = Number(optMultiplier) || 100;
-    return activityType === "BUY" ? q * p * m + f : q * p * m - f;
+    return activityType === ActivityType.BUY ? q * p * m + f : q * p * m - f;
   }, [isOption, optQuantity, optUnitPrice, optFee, optMultiplier, activityType]);
 
   // Transfer state
-  const isTransfer = ["TRANSFER_IN", "TRANSFER_OUT"].includes(activityType);
+  const isTransfer = TRANSFER_ACTIVITY_TYPES.includes(activityType);
   const transferMode = isTransfer ? ((watch("transferMode" as any) as string) ?? "cash") : null;
   const isExternal = isTransfer ? ((watch("isExternal" as any) as boolean) ?? false) : false;
   const direction = isTransfer ? ((watch("direction" as any) as string) ?? "out") : null;
@@ -90,39 +149,61 @@ export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileD
   const [toAccountSheetOpen, setToAccountSheetOpen] = useState(false);
 
   const subtype = watch("subtype");
-  const isDrip = activityType === "DIVIDEND" && subtype === ACTIVITY_SUBTYPES.DRIP;
+  const isDividendActivity = activityType === ActivityType.DIVIDEND;
+  const isInterestActivity = activityType === ActivityType.INTEREST;
+  const isDividendAssetIncome =
+    isDividendActivity &&
+    (subtype === ACTIVITY_SUBTYPES.DRIP || subtype === ACTIVITY_SUBTYPES.DIVIDEND_IN_KIND);
+  const isStakingReward = isInterestActivity && subtype === ACTIVITY_SUBTYPES.STAKING_REWARD;
+  const isAssetBackedIncome = isDividendAssetIncome || isStakingReward;
+  const incomeMode = subtype ?? INCOME_MODE_CASH;
 
-  const isCreditActivity = activityType === "CREDIT";
-  const isAdjustmentActivity = activityType === "ADJUSTMENT";
-  const isFeeActivity = activityType === "FEE";
-  const isTaxActivity = activityType === "TAX";
+  const isCreditActivity = activityType === ActivityType.CREDIT;
+  const isAdjustmentActivity = activityType === ActivityType.ADJUSTMENT;
+  const isFeeActivity = activityType === ActivityType.FEE;
+  const isTaxActivity = activityType === ActivityType.TAX;
   const needsAssetSymbol =
-    ["BUY", "SELL", "DIVIDEND", "SPLIT", "ADJUSTMENT"].includes(activityType) ||
-    isSecuritiesTransfer;
+    SYMBOL_FIELD_ACTIVITY_TYPES.includes(activityType) || isStakingReward || isSecuritiesTransfer;
   const needsQuantity =
-    ["BUY", "SELL"].includes(activityType) || isSecuritiesTransfer || isAdjustmentActivity;
+    TRADE_ACTIVITY_TYPES.includes(activityType) ||
+    isSecuritiesTransfer ||
+    isAdjustmentActivity ||
+    isAssetBackedIncome;
   const needsUnitPrice =
-    ["BUY", "SELL"].includes(activityType) ||
+    TRADE_ACTIVITY_TYPES.includes(activityType) ||
+    isAssetBackedIncome ||
     (isSecuritiesTransfer && isExternal && direction === "in");
-  const needsAmount =
-    ["DEPOSIT", "WITHDRAWAL", "DIVIDEND", "INTEREST", "TAX", "CREDIT"].includes(activityType) ||
-    isCashTransfer;
-  const needsFee = [
-    "BUY",
-    "SELL",
-    "DEPOSIT",
-    "WITHDRAWAL",
-    "TRANSFER_IN",
-    "TRANSFER_OUT",
-    "INTEREST",
-  ].includes(activityType);
+  const needsAmount = AMOUNT_FIELD_ACTIVITY_TYPES.includes(activityType) || isCashTransfer;
+  const needsFee = FEE_FIELD_ACTIVITY_TYPES.includes(activityType);
 
-  const needsSplitRatio = activityType === "SPLIT";
+  const needsSplitRatio = activityType === ActivityType.SPLIT;
 
   const transferModeItems = [
     { value: "cash" as const, label: "Cash" },
     { value: "securities" as const, label: "Securities" },
   ];
+
+  const dividendModeItems = [
+    { value: INCOME_MODE_CASH, label: "Cash" },
+    { value: ACTIVITY_SUBTYPES.DRIP, label: "DRIP" },
+    { value: ACTIVITY_SUBTYPES.DIVIDEND_IN_KIND, label: "In kind" },
+  ];
+
+  const interestModeItems = [
+    { value: INCOME_MODE_CASH, label: "Cash" },
+    { value: ACTIVITY_SUBTYPES.STAKING_REWARD, label: "Staking reward" },
+  ];
+
+  const handleIncomeModeChange = (mode: string) => {
+    setValue("subtype" as any, mode === INCOME_MODE_CASH ? null : mode, {
+      shouldDirty: true,
+      shouldValidate: true,
+    });
+    if (mode === INCOME_MODE_CASH) {
+      setValue("quantity" as any, undefined, { shouldDirty: true, shouldValidate: false });
+      setValue("unitPrice" as any, undefined, { shouldDirty: true, shouldValidate: false });
+    }
+  };
 
   const handleTransferModeChange = (mode: string) => {
     setValue("transferMode" as any, mode, { shouldValidate: false });
@@ -157,9 +238,11 @@ export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileD
   const handleDirectionChange = (value: string) => {
     setValue("direction" as any, value, { shouldValidate: false });
     // Update activityType based on direction
-    setValue("activityType", value === "in" ? ("TRANSFER_IN" as any) : ("TRANSFER_OUT" as any), {
-      shouldValidate: false,
-    });
+    setValue(
+      "activityType",
+      value === "in" ? (ActivityType.TRANSFER_IN as any) : (ActivityType.TRANSFER_OUT as any),
+      { shouldValidate: false },
+    );
   };
 
   const handleAssetTypeChange = (value: AssetType) => {
@@ -209,9 +292,43 @@ export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileD
     });
   }, [accountId, currency, filteredAccounts, getFieldState, setValue]);
 
+  useEffect(() => {
+    if (!isAssetBackedIncome) return;
+    const q = Number(quantity);
+    const p = Number(unitPrice);
+    const currentAmount = Number(getValues("amount"));
+    const quantityIsDirty = getFieldState("quantity").isDirty;
+    const unitPriceIsDirty = getFieldState("unitPrice").isDirty;
+    const shouldAutoSetAmount =
+      quantityIsDirty || unitPriceIsDirty || !(Number.isFinite(currentAmount) && currentAmount > 0);
+    if (q > 0 && p > 0 && shouldAutoSetAmount) {
+      const computedAmount = roundDecimal(q * p);
+      if (currentAmount !== computedAmount) {
+        setValue("amount" as any, computedAmount, {
+          shouldDirty: quantityIsDirty || unitPriceIsDirty,
+          shouldValidate: false,
+        });
+      }
+    }
+  }, [getFieldState, getValues, isAssetBackedIncome, quantity, setValue, unitPrice]);
+
   // Quantity label adapts to asset type
-  const quantityLabel = isOption ? "Contracts" : isBond ? "Bonds" : "Shares";
-  const priceLabel = isOption ? "Premium/Share" : isSecuritiesTransfer ? "Cost Basis" : "Price";
+  const quantityLabel = isAssetBackedIncome
+    ? "Received quantity"
+    : isOption
+      ? "Contracts"
+      : isBond
+        ? "Bonds"
+        : "Shares";
+  const priceLabel = isAssetBackedIncome
+    ? subtype === ACTIVITY_SUBTYPES.DRIP
+      ? "Reinvestment price"
+      : "FMV per unit"
+    : isOption
+      ? "Premium/Share"
+      : isSecuritiesTransfer
+        ? "Cost Basis"
+        : "Price";
 
   return (
     <div className="flex h-full flex-col">
@@ -283,6 +400,52 @@ export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileD
               name={"assetType" as any}
               onValueChange={handleAssetTypeChange}
             />
+          )}
+
+          {isDividendActivity && (
+            <div className="space-y-2">
+              <FormLabel className="text-base font-medium">Dividend type</FormLabel>
+              <RadioGroup
+                value={incomeMode}
+                onValueChange={handleIncomeModeChange}
+                className="flex flex-wrap gap-4"
+              >
+                {dividendModeItems.map((item) => {
+                  const id = `mobile-dividend-type-${item.value.toLowerCase().replaceAll("_", "-")}`;
+                  return (
+                    <div key={item.value} className="flex items-center space-x-2">
+                      <RadioGroupItem value={item.value} id={id} />
+                      <Label htmlFor={id} className="cursor-pointer text-sm font-normal">
+                        {item.label}
+                      </Label>
+                    </div>
+                  );
+                })}
+              </RadioGroup>
+            </div>
+          )}
+
+          {isInterestActivity && (
+            <div className="space-y-2">
+              <FormLabel className="text-base font-medium">Interest type</FormLabel>
+              <RadioGroup
+                value={incomeMode}
+                onValueChange={handleIncomeModeChange}
+                className="flex flex-wrap gap-4"
+              >
+                {interestModeItems.map((item) => {
+                  const id = `mobile-interest-type-${item.value.toLowerCase().replaceAll("_", "-")}`;
+                  return (
+                    <div key={item.value} className="flex items-center space-x-2">
+                      <RadioGroupItem value={item.value} id={id} />
+                      <Label htmlFor={id} className="cursor-pointer text-sm font-normal">
+                        {item.label}
+                      </Label>
+                    </div>
+                  );
+                })}
+              </RadioGroup>
+            </div>
           )}
 
           {/* Account — for transfers, label changes based on external/direction */}
@@ -390,7 +553,7 @@ export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileD
             ) : (
               <SymbolSearch
                 name="assetId"
-                label="Symbol"
+                label={isStakingReward ? "Reward asset" : "Symbol"}
                 isManualAsset={isManualForType}
                 exchangeMicName="exchangeMic"
                 quoteModeName="quoteMode"
@@ -426,7 +589,11 @@ export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileD
                     name="unitPrice"
                     render={({ field }) => (
                       <FormItem>
-                        <FormLabel className="text-base font-medium">{priceLabel}</FormLabel>
+                        {priceLabel === "FMV per unit" ? (
+                          <FmvPerUnitLabel />
+                        ) : (
+                          <FormLabel className="text-base font-medium">{priceLabel}</FormLabel>
+                        )}
                         <FormControl>
                           <MoneyInput {...field} />
                         </FormControl>
@@ -460,14 +627,14 @@ export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileD
               <div className="flex items-center justify-between">
                 <div className="min-w-0 flex-1">
                   <span className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
-                    {activityType === "BUY" ? "Total Debit" : "Total Credit"}
+                    {activityType === ActivityType.BUY ? "Total Debit" : "Total Credit"}
                   </span>
                   <p className="text-muted-foreground mt-0.5 truncate text-xs tabular-nums">
                     {Number(optQuantity)} × {Number(optUnitPrice)} × {Number(optMultiplier) || 100}
                     {Number(optFee) > 0 && (
                       <>
                         {" "}
-                        {activityType === "BUY" ? "+" : "−"} {Number(optFee)}
+                        {activityType === ActivityType.BUY ? "+" : "−"} {Number(optFee)}
                       </>
                     )}
                   </p>
@@ -492,9 +659,9 @@ export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileD
               render={({ field }) => (
                 <FormItem>
                   <FormLabel className="text-base font-medium">
-                    {activityType === "DIVIDEND"
+                    {activityType === ActivityType.DIVIDEND
                       ? "Dividend Amount"
-                      : activityType === "INTEREST"
+                      : activityType === ActivityType.INTEREST
                         ? "Interest Amount"
                         : isTaxActivity
                           ? "Tax Amount"
@@ -573,56 +740,8 @@ export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileD
             assetCurrency={assetCurrency}
             accountCurrency={accountCurrency}
             baseCurrency={baseCurrency}
-            defaultOpen={isDrip}
+            showSubtype={!isDividendActivity && !isInterestActivity}
           />
-
-          {/* DRIP: Price & Quantity of reinvested shares */}
-          {isDrip && (
-            <div className="grid grid-cols-1 gap-4">
-              <FormField
-                control={control}
-                name="unitPrice"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="text-base font-medium">Price</FormLabel>
-                    <FormControl>
-                      <MoneyInput
-                        ref={field.ref}
-                        name={field.name}
-                        value={field.value}
-                        onValueChange={field.onChange}
-                        placeholder="0.00"
-                        maxDecimalPlaces={4}
-                        className="h-12 text-base sm:text-sm"
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={control}
-                name="quantity"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel className="text-base font-medium">Quantity</FormLabel>
-                    <FormControl>
-                      <QuantityInput
-                        ref={field.ref}
-                        name={field.name}
-                        value={field.value}
-                        onValueChange={field.onChange}
-                        placeholder="0.00"
-                        maxDecimalPlaces={8}
-                        className="h-12 text-base sm:text-sm"
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-          )}
 
           {/* Comment */}
           <FormField

--- a/apps/frontend/src/pages/activity/config/activity-form-config.ts
+++ b/apps/frontend/src/pages/activity/config/activity-form-config.ts
@@ -1,5 +1,6 @@
 import type { ComponentType } from "react";
 import {
+  ACTIVITY_SUBTYPES,
   ActivityType,
   InstrumentType,
   METADATA_CONTRACT_MULTIPLIER,
@@ -23,16 +24,16 @@ import type { NewActivityFormValues } from "../components/forms/schemas";
 
 // Picker activity types (TRANSFER_IN/OUT merged into TRANSFER)
 export type PickerActivityType =
-  | "BUY"
-  | "SELL"
-  | "DEPOSIT"
-  | "WITHDRAWAL"
-  | "DIVIDEND"
+  | typeof ActivityType.BUY
+  | typeof ActivityType.SELL
+  | typeof ActivityType.DEPOSIT
+  | typeof ActivityType.WITHDRAWAL
+  | typeof ActivityType.DIVIDEND
   | "TRANSFER"
-  | "SPLIT"
-  | "FEE"
-  | "INTEREST"
-  | "TAX";
+  | typeof ActivityType.SPLIT
+  | typeof ActivityType.FEE
+  | typeof ActivityType.INTEREST
+  | typeof ActivityType.TAX;
 
 // Form values union type
 export type ActivityFormValues =
@@ -93,7 +94,7 @@ function selectedExistingAsset(
   instrumentType?: string | null,
 ) {
   if (!assetSymbol?.trim()) return {};
-  if (instrumentType?.trim().toUpperCase() === "OPTION") return {};
+  if (instrumentType?.trim().toUpperCase() === InstrumentType.OPTION) return {};
 
   const id = existingAssetId?.trim();
   return id ? { existingAssetId: id } : {};
@@ -115,7 +116,7 @@ export const ACTIVITY_FORM_CONFIG: Record<
         unitPrice: absNum(activity?.unitPrice),
         amount: absNum(activity?.amount),
         fee: absNum(activity?.fee) ?? 0,
-        quoteMode: activity?.assetQuoteMode === "MANUAL" ? QuoteMode.MANUAL : QuoteMode.MARKET,
+        quoteMode: activity?.assetQuoteMode === QuoteMode.MANUAL ? QuoteMode.MANUAL : QuoteMode.MARKET,
         // Advanced options
         currency: activity?.currency,
         fxRate: activity?.fxRate ?? undefined,
@@ -123,13 +124,13 @@ export const ACTIVITY_FORM_CONFIG: Record<
       };
 
       // Populate option-specific fields from OCC symbol when editing
-      if (activity?.instrumentType === "OPTION") {
+      if (activity?.instrumentType === InstrumentType.OPTION) {
         const parsed = parseOccSymbol(activity.assetSymbol ?? "");
         return {
           ...base,
           assetType: "option" as const,
-          assetKind: "OPTION",
-          symbolInstrumentType: "OPTION",
+          assetKind: InstrumentType.OPTION,
+          symbolInstrumentType: InstrumentType.OPTION,
           symbolQuoteCcy: activity?.currency ?? undefined,
           underlyingSymbol: parsed?.underlying ?? "",
           strikePrice: parsed?.strikePrice,
@@ -140,12 +141,12 @@ export const ACTIVITY_FORM_CONFIG: Record<
       }
 
       // Populate bond-specific fields when editing
-      if (activity?.instrumentType === "BOND") {
+      if (activity?.instrumentType === InstrumentType.BOND) {
         return {
           ...base,
           assetType: "bond" as const,
-          assetKind: "BOND",
-          symbolInstrumentType: "BOND",
+          assetKind: InstrumentType.BOND,
+          symbolInstrumentType: InstrumentType.BOND,
           symbolQuoteCcy: activity?.currency ?? undefined,
         };
       }
@@ -197,7 +198,7 @@ export const ACTIVITY_FORM_CONFIG: Record<
         unitPrice: absNum(activity?.unitPrice),
         amount: absNum(activity?.amount),
         fee: absNum(activity?.fee) ?? 0,
-        quoteMode: activity?.assetQuoteMode === "MANUAL" ? QuoteMode.MANUAL : QuoteMode.MARKET,
+        quoteMode: activity?.assetQuoteMode === QuoteMode.MANUAL ? QuoteMode.MANUAL : QuoteMode.MARKET,
         // Advanced options
         currency: activity?.currency,
         fxRate: activity?.fxRate ?? undefined,
@@ -205,13 +206,13 @@ export const ACTIVITY_FORM_CONFIG: Record<
       };
 
       // Populate option-specific fields from OCC symbol when editing
-      if (activity?.instrumentType === "OPTION") {
+      if (activity?.instrumentType === InstrumentType.OPTION) {
         const parsed = parseOccSymbol(activity.assetSymbol ?? "");
         return {
           ...base,
           assetType: "option" as const,
-          assetKind: "OPTION",
-          symbolInstrumentType: "OPTION",
+          assetKind: InstrumentType.OPTION,
+          symbolInstrumentType: InstrumentType.OPTION,
           symbolQuoteCcy: activity?.currency ?? undefined,
           underlyingSymbol: parsed?.underlying ?? "",
           strikePrice: parsed?.strikePrice,
@@ -222,12 +223,12 @@ export const ACTIVITY_FORM_CONFIG: Record<
       }
 
       // Populate bond-specific fields when editing
-      if (activity?.instrumentType === "BOND") {
+      if (activity?.instrumentType === InstrumentType.BOND) {
         return {
           ...base,
           assetType: "bond" as const,
-          assetKind: "BOND",
-          symbolInstrumentType: "BOND",
+          assetKind: InstrumentType.BOND,
+          symbolInstrumentType: InstrumentType.BOND,
           symbolQuoteCcy: activity?.currency ?? undefined,
         };
       }
@@ -331,16 +332,18 @@ export const ACTIVITY_FORM_CONFIG: Record<
     }),
     toPayload: (data) => {
       const d = data as DividendFormValues;
+      const isAssetBackedDividend =
+        d.subtype === ACTIVITY_SUBTYPES.DRIP || d.subtype === ACTIVITY_SUBTYPES.DIVIDEND_IN_KIND;
       return {
         accountId: d.accountId,
         activityDate: d.activityDate,
         assetId: d.symbol,
         ...selectedExistingAsset(d.symbol, d.existingAssetId, d.symbolInstrumentType),
         amount: d.amount,
-        unitPrice: d.unitPrice,
-        quantity: d.quantity,
+        unitPrice: isAssetBackedDividend ? d.unitPrice : null,
+        quantity: isAssetBackedDividend ? d.quantity : null,
         comment: d.comment,
-        subtype: d.subtype ?? undefined,
+        subtype: d.subtype ?? null,
         currency: d.currency,
         fxRate: d.fxRate,
         exchangeMic: d.exchangeMic ?? undefined,
@@ -383,7 +386,7 @@ export const ACTIVITY_FORM_CONFIG: Record<
         currency: activity?.currency,
         fxRate: activity?.fxRate ?? undefined,
         subtype: activity?.subtype ?? null,
-        quoteMode: activity?.assetQuoteMode === "MANUAL" ? QuoteMode.MANUAL : QuoteMode.MARKET,
+        quoteMode: activity?.assetQuoteMode === QuoteMode.MANUAL ? QuoteMode.MANUAL : QuoteMode.MARKET,
         exchangeMic: activity?.exchangeMic,
       };
     },
@@ -399,7 +402,7 @@ export const ACTIVITY_FORM_CONFIG: Record<
         quantity: d.quantity ?? undefined,
         unitPrice: d.unitPrice ?? undefined,
         comment: d.comment ?? undefined,
-        subtype: d.subtype ?? undefined,
+        subtype: d.subtype ?? null,
         currency: d.currency,
         fxRate: d.fxRate,
         quoteMode: d.quoteMode,
@@ -439,7 +442,7 @@ export const ACTIVITY_FORM_CONFIG: Record<
         ...selectedExistingAsset(d.symbol, d.existingAssetId, d.symbolInstrumentType),
         amount: d.splitRatio,
         comment: d.comment,
-        subtype: d.subtype ?? undefined,
+        subtype: d.subtype ?? null,
         currency: d.currency,
         exchangeMic: d.exchangeMic ?? undefined,
         symbolQuoteCcy: d.symbolQuoteCcy ?? undefined,
@@ -478,6 +481,8 @@ export const ACTIVITY_FORM_CONFIG: Record<
       ...getBaseDefaults(activity, accounts),
       symbol: activity?.assetSymbol ?? activity?.assetId ?? null,
       amount: absNum(activity?.amount),
+      unitPrice: absNum(activity?.unitPrice),
+      quantity: absNum(activity?.quantity),
       // Advanced options
       currency: activity?.currency,
       fxRate: (activity?.fxRate ?? undefined) as unknown as number | undefined,
@@ -486,12 +491,15 @@ export const ACTIVITY_FORM_CONFIG: Record<
     }),
     toPayload: (data) => {
       const d = data as InterestFormValues;
+      const isStakingReward = d.subtype === ACTIVITY_SUBTYPES.STAKING_REWARD;
       return {
         accountId: d.accountId,
         activityDate: d.activityDate,
         assetId: d.symbol?.trim() || undefined,
         ...selectedExistingAsset(d.symbol, d.existingAssetId, d.symbolInstrumentType),
         amount: d.amount,
+        unitPrice: isStakingReward ? d.unitPrice : null,
+        quantity: isStakingReward ? d.quantity : null,
         comment: d.comment,
         subtype: d.subtype,
         currency: d.currency,

--- a/apps/frontend/src/pages/activity/config/activity-form-config.ts
+++ b/apps/frontend/src/pages/activity/config/activity-form-config.ts
@@ -116,7 +116,8 @@ export const ACTIVITY_FORM_CONFIG: Record<
         unitPrice: absNum(activity?.unitPrice),
         amount: absNum(activity?.amount),
         fee: absNum(activity?.fee) ?? 0,
-        quoteMode: activity?.assetQuoteMode === QuoteMode.MANUAL ? QuoteMode.MANUAL : QuoteMode.MARKET,
+        quoteMode:
+          activity?.assetQuoteMode === QuoteMode.MANUAL ? QuoteMode.MANUAL : QuoteMode.MARKET,
         // Advanced options
         currency: activity?.currency,
         fxRate: activity?.fxRate ?? undefined,
@@ -198,7 +199,8 @@ export const ACTIVITY_FORM_CONFIG: Record<
         unitPrice: absNum(activity?.unitPrice),
         amount: absNum(activity?.amount),
         fee: absNum(activity?.fee) ?? 0,
-        quoteMode: activity?.assetQuoteMode === QuoteMode.MANUAL ? QuoteMode.MANUAL : QuoteMode.MARKET,
+        quoteMode:
+          activity?.assetQuoteMode === QuoteMode.MANUAL ? QuoteMode.MANUAL : QuoteMode.MARKET,
         // Advanced options
         currency: activity?.currency,
         fxRate: activity?.fxRate ?? undefined,
@@ -386,7 +388,8 @@ export const ACTIVITY_FORM_CONFIG: Record<
         currency: activity?.currency,
         fxRate: activity?.fxRate ?? undefined,
         subtype: activity?.subtype ?? null,
-        quoteMode: activity?.assetQuoteMode === QuoteMode.MANUAL ? QuoteMode.MANUAL : QuoteMode.MARKET,
+        quoteMode:
+          activity?.assetQuoteMode === QuoteMode.MANUAL ? QuoteMode.MANUAL : QuoteMode.MARKET,
         exchangeMic: activity?.exchangeMic,
       };
     },

--- a/apps/frontend/src/pages/activity/hooks/use-activity-mutations.ts
+++ b/apps/frontend/src/pages/activity/hooks/use-activity-mutations.ts
@@ -205,6 +205,7 @@ export function useActivityMutations(
       // Build nested asset object
       const updatePayload: ActivityUpdate = {
         ...rest,
+        subtype: rest.subtype === null ? "" : rest.subtype,
         quantity: toDecimalPayload(quantity),
         unitPrice: toDecimalPayload(unitPrice),
         amount: toDecimalPayload(amount),

--- a/apps/frontend/src/pages/activity/hooks/use-cash-balance-validation.ts
+++ b/apps/frontend/src/pages/activity/hooks/use-cash-balance-validation.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import { useLatestValuations } from "@/hooks/use-latest-valuations";
+import { ActivityType } from "@/lib/constants";
 import { NewActivityFormValues } from "../components/forms/schemas";
 
 export interface CashBalanceValidationResult {
@@ -42,7 +43,7 @@ export function useCashBalanceValidation(): CashBalanceValidationResult {
     const hasValues = Boolean(quantity && unitPrice && quantity > 0 && unitPrice > 0);
 
     // Only validate for BUY activities
-    if (activityType !== "BUY") {
+    if (activityType !== ActivityType.BUY) {
       setValidationResult({
         isValid: true,
         currentBalance: 0,

--- a/apps/frontend/src/pages/activity/import/components/import-columns.tsx
+++ b/apps/frontend/src/pages/activity/import/components/import-columns.tsx
@@ -11,6 +11,9 @@ import {
 import { needsImportAssetResolution } from "@/lib/activity-utils";
 import { ActivityTypeBadge } from "../../components/activity-type-badge";
 
+const UNIT_PRICE_HELP_TEXT =
+  "For buys and sells, enter the trade price. For staking rewards and in-kind dividends, enter the fair market value per unit at receipt; it sets income amount and cost basis.";
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Shared Import Row Type
 // ─────────────────────────────────────────────────────────────────────────────
@@ -202,8 +205,12 @@ export function useImportColumns<T extends ImportRowData>({
         cell: {
           variant: "select",
           options: activityTypeOptions,
-          valueRenderer: (value: string) => (
-            <ActivityTypeBadge type={value as ActivityType} className="text-xs font-normal" />
+          valueRenderer: (value: string, _option, rowData) => (
+            <ActivityTypeBadge
+              type={value as ActivityType}
+              subtype={(rowData as T | undefined)?.subtype}
+              className="text-xs font-normal"
+            />
           ),
         },
       },
@@ -308,7 +315,10 @@ export function useImportColumns<T extends ImportRowData>({
       header: "Price",
       size: 120,
       enableSorting: false,
-      meta: { cell: { variant: "number", step: 0.000001, valueType: "string" } },
+      meta: {
+        helpText: UNIT_PRICE_HELP_TEXT,
+        cell: { variant: "number", step: 0.000001, valueType: "string" },
+      },
     });
 
     // 11. Amount

--- a/apps/frontend/src/pages/activity/import/components/import-review-grid.tsx
+++ b/apps/frontend/src/pages/activity/import/components/import-review-grid.tsx
@@ -27,6 +27,9 @@ import { searchTicker } from "@/adapters";
 import { CreateCustomAssetDialog } from "@/components/create-custom-asset-dialog";
 import { useSettingsContext } from "@/lib/settings-provider";
 
+const UNIT_PRICE_HELP_TEXT =
+  "For buys and sells, enter the trade price. For staking rewards and in-kind dividends, enter the fair market value per unit at receipt; it sets income amount and cost basis.";
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
 // ─────────────────────────────────────────────────────────────────────────────
@@ -298,8 +301,12 @@ function useImportReviewColumns({
           cell: {
             variant: "select",
             options: activityTypeOptions,
-            valueRenderer: (value: string) => (
-              <ActivityTypeBadge type={value as ActivityType} className="text-xs font-normal" />
+            valueRenderer: (value: string, _option, rowData) => (
+              <ActivityTypeBadge
+                type={value as ActivityType}
+                subtype={(rowData as { subtype?: string } | undefined)?.subtype}
+                className="text-xs font-normal"
+              />
             ),
           },
         },
@@ -399,7 +406,10 @@ function useImportReviewColumns({
         header: "Price",
         size: 120,
         enableSorting: false,
-        meta: { cell: { variant: "number", step: 0.000001, valueType: "string" } },
+        meta: {
+          helpText: UNIT_PRICE_HELP_TEXT,
+          cell: { variant: "number", step: 0.000001, valueType: "string" },
+        },
       },
       // 10. Amount
       {

--- a/apps/frontend/src/pages/activity/import/utils/asset-review-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/asset-review-utils.ts
@@ -1,4 +1,5 @@
 import { isCashSymbol, needsImportAssetResolution } from "@/lib/activity-utils";
+import { ActivityType } from "@/lib/constants";
 import type {
   ImportAssetCandidate,
   ImportMappingData,
@@ -211,7 +212,7 @@ export function buildSyntheticDraftsFromHoldings(
       rowIndex: i,
       rawRow: row,
       activityDate: "2000-01-01",
-      activityType: "BUY",
+      activityType: ActivityType.BUY,
       symbol: resolvedSymbol,
       currency,
       accountId,

--- a/apps/frontend/src/pages/activity/import/utils/draft-utils.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/draft-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { ActivityType, ImportFormat } from "@/lib/constants";
-import { createDraftActivities } from "./draft-utils";
+import { ACTIVITY_SUBTYPES, ActivityType, ImportFormat } from "@/lib/constants";
+import { createDraftActivities, draftToActivityImport } from "./draft-utils";
 
 const headers = [
   ImportFormat.DATE,
@@ -177,5 +177,138 @@ describe("createDraftActivities explicit activity mapping", () => {
     expect(draft.activityType).toBeUndefined();
     expect(draft.status).toBe("error");
     expect(draft.errors.activityType).toContain("Activity type is required");
+  });
+
+  it("accepts dividend in kind with amount instead of unit price", () => {
+    const [draft] = createDraftActivities(
+      [["2024-03-15", "DIVIDEND", "AAPL", "2", "100", "USD", ACTIVITY_SUBTYPES.DIVIDEND_IN_KIND]],
+      [
+        ImportFormat.DATE,
+        ImportFormat.ACTIVITY_TYPE,
+        ImportFormat.SYMBOL,
+        ImportFormat.QUANTITY,
+        ImportFormat.AMOUNT,
+        ImportFormat.CURRENCY,
+        ImportFormat.SUBTYPE,
+      ],
+      {
+        ...baseMapping,
+        fieldMappings: {
+          [ImportFormat.DATE]: ImportFormat.DATE,
+          [ImportFormat.ACTIVITY_TYPE]: ImportFormat.ACTIVITY_TYPE,
+          [ImportFormat.SYMBOL]: ImportFormat.SYMBOL,
+          [ImportFormat.QUANTITY]: ImportFormat.QUANTITY,
+          [ImportFormat.AMOUNT]: ImportFormat.AMOUNT,
+          [ImportFormat.CURRENCY]: ImportFormat.CURRENCY,
+          [ImportFormat.SUBTYPE]: ImportFormat.SUBTYPE,
+        },
+        activityMappings: { [ActivityType.DIVIDEND]: ["DIVIDEND"] },
+      },
+      parseConfig,
+      "account-1",
+    );
+
+    expect(draft.errors).toEqual({});
+    expect(draft.status).toBe("valid");
+  });
+
+  it("keeps mismatched known subtype labels as inert metadata", () => {
+    const [draft] = createDraftActivities(
+      [["2024-03-15", "DIVIDEND", "AAPL", "100", "USD", ACTIVITY_SUBTYPES.STAKING_REWARD]],
+      [
+        ImportFormat.DATE,
+        ImportFormat.ACTIVITY_TYPE,
+        ImportFormat.SYMBOL,
+        ImportFormat.AMOUNT,
+        ImportFormat.CURRENCY,
+        ImportFormat.SUBTYPE,
+      ],
+      {
+        ...baseMapping,
+        fieldMappings: {
+          [ImportFormat.DATE]: ImportFormat.DATE,
+          [ImportFormat.ACTIVITY_TYPE]: ImportFormat.ACTIVITY_TYPE,
+          [ImportFormat.SYMBOL]: ImportFormat.SYMBOL,
+          [ImportFormat.AMOUNT]: ImportFormat.AMOUNT,
+          [ImportFormat.CURRENCY]: ImportFormat.CURRENCY,
+          [ImportFormat.SUBTYPE]: ImportFormat.SUBTYPE,
+        },
+        activityMappings: { [ActivityType.DIVIDEND]: ["DIVIDEND"] },
+      },
+      parseConfig,
+      "account-1",
+    );
+
+    expect(draft.status).toBe("valid");
+    expect(draft.errors.subtype).toBeUndefined();
+    expect(draft.subtype).toBe(ACTIVITY_SUBTYPES.STAKING_REWARD);
+    expect(draftToActivityImport(draft).subtype).toBe(ACTIVITY_SUBTYPES.STAKING_REWARD);
+  });
+
+  it("clears broker subtype labels that mirror the activity type", () => {
+    const [draft] = createDraftActivities(
+      [["2024-03-15", "DIVIDEND", "AAPL", "100", "USD", "DIVIDEND"]],
+      [
+        ImportFormat.DATE,
+        ImportFormat.ACTIVITY_TYPE,
+        ImportFormat.SYMBOL,
+        ImportFormat.AMOUNT,
+        ImportFormat.CURRENCY,
+        ImportFormat.SUBTYPE,
+      ],
+      {
+        ...baseMapping,
+        fieldMappings: {
+          [ImportFormat.DATE]: ImportFormat.DATE,
+          [ImportFormat.ACTIVITY_TYPE]: ImportFormat.ACTIVITY_TYPE,
+          [ImportFormat.SYMBOL]: ImportFormat.SYMBOL,
+          [ImportFormat.AMOUNT]: ImportFormat.AMOUNT,
+          [ImportFormat.CURRENCY]: ImportFormat.CURRENCY,
+          [ImportFormat.SUBTYPE]: ImportFormat.SUBTYPE,
+        },
+        activityMappings: { [ActivityType.DIVIDEND]: ["DIVIDEND"] },
+      },
+      parseConfig,
+      "account-1",
+    );
+
+    expect(draft.status).toBe("valid");
+    expect(draft.subtype).toBeUndefined();
+    expect(draftToActivityImport(draft).subtype).toBeUndefined();
+  });
+
+  it("allows unknown provider subtype labels without treating them as semantic subtype errors", () => {
+    const [draft] = createDraftActivities(
+      [["2024-03-15", "BUY", "AAPL251219C00200000", "1", "5", "USD", "BUY_TO_OPEN"]],
+      [
+        ImportFormat.DATE,
+        ImportFormat.ACTIVITY_TYPE,
+        ImportFormat.SYMBOL,
+        ImportFormat.QUANTITY,
+        ImportFormat.UNIT_PRICE,
+        ImportFormat.CURRENCY,
+        ImportFormat.SUBTYPE,
+      ],
+      {
+        ...baseMapping,
+        fieldMappings: {
+          [ImportFormat.DATE]: ImportFormat.DATE,
+          [ImportFormat.ACTIVITY_TYPE]: ImportFormat.ACTIVITY_TYPE,
+          [ImportFormat.SYMBOL]: ImportFormat.SYMBOL,
+          [ImportFormat.QUANTITY]: ImportFormat.QUANTITY,
+          [ImportFormat.UNIT_PRICE]: ImportFormat.UNIT_PRICE,
+          [ImportFormat.CURRENCY]: ImportFormat.CURRENCY,
+          [ImportFormat.SUBTYPE]: ImportFormat.SUBTYPE,
+        },
+        activityMappings: { [ActivityType.BUY]: ["BUY"] },
+      },
+      parseConfig,
+      "account-1",
+    );
+
+    expect(draft.status).toBe("valid");
+    expect(draft.errors.subtype).toBeUndefined();
+    expect(draft.subtype).toBe("BUY_TO_OPEN");
+    expect(draftToActivityImport(draft).subtype).toBe("BUY_TO_OPEN");
   });
 });

--- a/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
@@ -1,9 +1,4 @@
-import {
-  ACTIVITY_SUBTYPES,
-  ActivityType,
-  ImportFormat,
-  SUBTYPES_BY_ACTIVITY_TYPE,
-} from "@/lib/constants";
+import { ACTIVITY_SUBTYPES, ActivityType, ImportFormat } from "@/lib/constants";
 import type { ActivityImport } from "@/lib/types";
 import { tryParseDate } from "@/lib/utils";
 import { isValid, parse, parseISO } from "date-fns";
@@ -172,7 +167,7 @@ export function validateDraft(draft: Partial<DraftActivity>): {
   const warnings: Record<string, string[]> = {};
 
   const activityType = draft.activityType?.toUpperCase();
-  const subtype = draft.subtype?.toUpperCase();
+  const subtype = draft.subtype?.trim().toUpperCase();
 
   // Required field validation
   if (!draft.activityDate) {
@@ -194,15 +189,6 @@ export function validateDraft(draft: Partial<DraftActivity>): {
     errors.accountId = ["Account is required"];
   }
 
-  // Validate subtype is allowed for this activity type.
-  // Skip when subtype mirrors the activity type itself — brokers often export this as a no-op label.
-  if (subtype && activityType && subtype !== activityType) {
-    const allowedSubtypes = SUBTYPES_BY_ACTIVITY_TYPE[activityType] || [];
-    if (allowedSubtypes.length > 0 && !allowedSubtypes.includes(subtype)) {
-      warnings.subtype = [`'${subtype}' is not a recognized subtype for ${activityType}`];
-    }
-  }
-
   // Trade activities (BUY/SELL)
   if (activityType === ActivityType.BUY || activityType === ActivityType.SELL) {
     if (!draft.symbol) {
@@ -220,31 +206,27 @@ export function validateDraft(draft: Partial<DraftActivity>): {
   if (activityType === ActivityType.DIVIDEND) {
     if (subtype === ACTIVITY_SUBTYPES.DRIP) {
       // DRIP: cash dividend → reinvested as BUY of same ticker
-      // Needs: quantity (shares received), unit price (reinvest price)
-      // Amount is optional (dividend cash amount)
+      // Needs: symbol, quantity, and either amount or unit price.
       if (!draft.symbol) {
         errors.symbol = ["Symbol is required for DRIP dividends"];
       }
       if (!hasPositiveValue(draft.quantity)) {
         errors.quantity = ["Quantity is required for DRIP (shares received)"];
       }
-      if (!hasPositiveValue(draft.unitPrice)) {
-        errors.unitPrice = ["Unit price is required for DRIP (reinvestment price)"];
+      if (!hasNonZeroValue(draft.amount) && !hasPositiveValue(draft.unitPrice)) {
+        errors.unitPrice = ["Either amount or unit price is required for DRIP dividends"];
       }
     } else if (subtype === ACTIVITY_SUBTYPES.DIVIDEND_IN_KIND) {
-      // DIVIDEND_IN_KIND: dividend paid in asset (not cash)
-      // Needs: symbol (received asset), quantity, unit price (FMV), amount (value)
+      // DIVIDEND_IN_KIND: dividend paid as additional units of the same asset
+      // Needs: symbol, quantity, and either amount or unit price.
       if (!draft.symbol) {
         errors.symbol = ["Symbol is required for dividend in kind activities"];
       }
       if (!hasPositiveValue(draft.quantity)) {
         errors.quantity = ["Quantity is required for dividend in kind (shares received)"];
       }
-      if (!hasPositiveValue(draft.unitPrice)) {
-        errors.unitPrice = ["Unit price is required for dividend in kind (FMV at receipt)"];
-      }
-      if (!hasNonZeroValue(draft.amount)) {
-        errors.amount = ["Amount is required for dividend in kind (value of shares)"];
+      if (!hasNonZeroValue(draft.amount) && !hasPositiveValue(draft.unitPrice)) {
+        errors.unitPrice = ["Either amount or unit price is required for dividend in kind"];
       }
     } else {
       // Regular cash dividend - amount is required
@@ -264,9 +246,8 @@ export function validateDraft(draft: Partial<DraftActivity>): {
       if (!hasPositiveValue(draft.quantity)) {
         errors.quantity = ["Quantity is required for staking rewards (tokens received)"];
       }
-      // Amount is optional for staking - can be calculated from quantity * price
       if (!hasNonZeroValue(draft.amount) && !hasPositiveValue(draft.unitPrice)) {
-        warnings.amount = ["Either amount or unit price is recommended for staking rewards"];
+        errors.unitPrice = ["Either amount or unit price is required for staking rewards"];
       }
     } else {
       // Regular interest - amount is required
@@ -445,7 +426,9 @@ export function createDraftActivities(
     const fee = parseNumericValue(rawFee, decimalSeparator, thousandsSeparator);
     const comment = rawComment?.trim();
     const fxRate = parseNumericValue(rawFxRate, decimalSeparator, thousandsSeparator);
-    const subtype = rawSubtype?.trim().toUpperCase() || undefined;
+    const normalizedSubtype = rawSubtype?.trim().toUpperCase();
+    const subtype =
+      normalizedSubtype && normalizedSubtype !== activityType ? normalizedSubtype : undefined;
 
     // Resolve account ID: use CSV account mapping, or fall back to default
     let accountId = accountMappings[""] || defaultAccountId;
@@ -462,7 +445,7 @@ export function createDraftActivities(
 
     // For cash-like activities, some brokers (e.g. Schwab) put the dollar value
     // in the Quantity column instead of Amount.
-    const resolved = resolveCashActivityFields(activityType, quantity, amount, unitPrice);
+    const resolved = resolveCashActivityFields(activityType, quantity, amount, unitPrice, subtype);
 
     // Infer isExternal for transfers: external unless the raw CSV label says "INTERNAL"
     const isTransfer =
@@ -522,6 +505,9 @@ export function createDraftActivities(
 }
 
 export function draftToActivityImport(draft: DraftActivity): ActivityImport {
+  const activityType = draft.activityType?.trim().toUpperCase();
+  const subtype = draft.subtype?.trim().toUpperCase();
+
   return {
     id: undefined,
     accountId: draft.accountId,
@@ -536,7 +522,7 @@ export function draftToActivityImport(draft: DraftActivity): ActivityImport {
     unitPrice: draft.unitPrice,
     fee: draft.fee,
     fxRate: draft.fxRate,
-    subtype: draft.subtype,
+    subtype: subtype && subtype !== activityType ? subtype : undefined,
     exchangeMic: draft.exchangeMic,
     quoteCcy: draft.quoteCcy,
     instrumentType: draft.instrumentType,

--- a/apps/frontend/src/pages/activity/import/utils/review-draft-utils.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/review-draft-utils.test.ts
@@ -6,7 +6,7 @@ import {
   hasNonZeroValue,
   resolveCashActivityFields,
 } from "./review-draft-utils";
-import { ActivityType } from "@/lib/constants";
+import { ACTIVITY_SUBTYPES, ActivityType } from "@/lib/constants";
 
 describe("parseNumericValue", () => {
   const auto = "auto";
@@ -172,6 +172,18 @@ describe("resolveCashActivityFields", () => {
     it("should not swap when unit price is present (real qty * price)", () => {
       const result = resolveCashActivityFields(ActivityType.DIVIDEND, "10", undefined, "5.00");
       expect(result.quantity).toBe("10");
+      expect(result.amount).toBeUndefined();
+    });
+
+    it("should not swap staking reward quantity into cash amount", () => {
+      const result = resolveCashActivityFields(
+        ActivityType.INTEREST,
+        "0.25",
+        undefined,
+        undefined,
+        ACTIVITY_SUBTYPES.STAKING_REWARD,
+      );
+      expect(result.quantity).toBe("0.25");
       expect(result.amount).toBeUndefined();
     });
 

--- a/apps/frontend/src/pages/activity/import/utils/review-draft-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/review-draft-utils.ts
@@ -1,4 +1,5 @@
 import { ActivityType } from "@/lib/constants";
+import { isAssetBackedIncomeSubtype } from "@/lib/activity-utils";
 
 /**
  * Parse a numeric value from a string, handling various formats.
@@ -123,10 +124,12 @@ export function resolveCashActivityFields(
   quantity: string | undefined,
   amount: string | undefined,
   unitPrice: string | undefined,
+  subtype?: string,
 ): { quantity: string | undefined; amount: string | undefined } {
   if (
     activityType &&
     CASH_LIKE_TYPES.includes(activityType) &&
+    !isAssetBackedIncomeSubtype(activityType, subtype) &&
     !toNumber(amount) &&
     toNumber(quantity) &&
     !toNumber(unitPrice)

--- a/apps/frontend/src/pages/activity/import/utils/validation-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/validation-utils.ts
@@ -9,7 +9,7 @@ import {
 import { importActivitySchema } from "@/lib/schemas";
 import { tryParseDate } from "@/lib/utils";
 import { logger } from "@/adapters";
-import { SUBTYPES_BY_ACTIVITY_TYPE, SUBTYPE_DISPLAY_NAMES } from "@/lib/constants";
+import { SUBTYPE_DISPLAY_NAMES } from "@/lib/constants";
 import { looksLikeOccSymbol, normalizeOptionSymbol } from "@/lib/occ-symbol";
 import { looksLikeIsin } from "@/lib/isin";
 import { findMappedActivityType } from "./activity-type-mapping";
@@ -84,8 +84,8 @@ function normalizeSubtype(rawSubtype: string): string | undefined {
 }
 
 /**
- * Validates and returns the subtype if it's valid for the given activity type.
- * Returns undefined if the subtype is not valid for the activity type.
+ * Returns the subtype as metadata. Calculation paths only honor known valid
+ * type/subtype pairs, so import should not discard broker/provider labels here.
  */
 function validateSubtypeForActivityType(
   subtype: string | undefined,
@@ -93,19 +93,9 @@ function validateSubtypeForActivityType(
 ): string | undefined {
   if (!subtype || !activityType) return undefined;
 
-  const allowedSubtypes = SUBTYPES_BY_ACTIVITY_TYPE[activityType];
-  if (!allowedSubtypes || allowedSubtypes.length === 0) {
-    // Activity type doesn't support subtypes
-    return undefined;
-  }
+  if (subtype === activityType) return undefined;
 
-  // Check if the subtype is in the allowed list
-  if (allowedSubtypes.includes(subtype)) {
-    return subtype;
-  }
-
-  // Subtype not valid for this activity type
-  return undefined;
+  return subtype;
 }
 
 /**

--- a/apps/frontend/src/pages/activity/utils/activity-form-utils.ts
+++ b/apps/frontend/src/pages/activity/utils/activity-form-utils.ts
@@ -1,4 +1,13 @@
+import { ActivityType } from "@/lib/constants";
 import type { PickerActivityType } from "../config/activity-form-config";
+
+const PURE_CASH_ACTIVITY_TYPES: readonly string[] = [
+  ActivityType.DEPOSIT,
+  ActivityType.WITHDRAWAL,
+  ActivityType.FEE,
+  ActivityType.INTEREST,
+  ActivityType.TAX,
+];
 
 /**
  * Maps a database activity type to the picker activity type.
@@ -8,7 +17,7 @@ export function mapActivityTypeToPicker(
   activityType?: string | null,
 ): PickerActivityType | undefined {
   if (!activityType) return undefined;
-  if (activityType === "TRANSFER_IN" || activityType === "TRANSFER_OUT") {
+  if (activityType === ActivityType.TRANSFER_IN || activityType === ActivityType.TRANSFER_OUT) {
     return "TRANSFER";
   }
   return activityType as PickerActivityType;
@@ -19,5 +28,5 @@ export function mapActivityTypeToPicker(
  * Used to determine if account currency should be included in payload.
  */
 export function isPureCashActivity(activityType: string): boolean {
-  return ["DEPOSIT", "WITHDRAWAL", "FEE", "INTEREST", "TAX"].includes(activityType);
+  return PURE_CASH_ACTIVITY_TYPES.includes(activityType);
 }

--- a/crates/ai/src/system_prompt.txt
+++ b/crates/ai/src/system_prompt.txt
@@ -79,10 +79,10 @@ You have access to these tools:
    - Parameters:
      - activityType (required): BUY, SELL, DIVIDEND, DEPOSIT, WITHDRAWAL, TRANSFER_IN, TRANSFER_OUT, INTEREST, FEE, SPLIT, TAX
      - activityDate (required): ISO 8601 date (YYYY-MM-DD). Convert relative dates like "yesterday" to actual dates.
-     - symbol (required for trading): Pass the user's exact text — the backend resolves names to tickers automatically. See RECORD_ACTIVITY RULES below for full guidance.
+     - symbol (required for trading and asset-backed income): Pass the user's exact text — the backend resolves names to tickers automatically. See RECORD_ACTIVITY RULES below for full guidance.
      - quantity: number of shares/units
-     - unitPrice: price per unit
-     - amount: total amount (for DEPOSIT/WITHDRAWAL/DIVIDEND)
+     - unitPrice: price or fair market value per unit
+     - amount: total cash amount or taxable income amount
      - fee: transaction fee
      - account: account name from the accounts list in context
      - subtype: activity subtype (DRIP, DIVIDEND_IN_KIND, STAKING_REWARD, BONUS)
@@ -173,8 +173,9 @@ RECORD_ACTIVITY RULES:
   - Do NOT hand-convert names to tickers — models routinely hallucinate or use stale tickers (e.g. "Facebook" is now META, not FB). Trust the backend resolver.
 - For BUY/SELL, aim to provide at minimum: symbol and quantity.
 - For DEPOSIT/WITHDRAWAL, aim to provide at minimum: amount.
+- For DRIP, DIVIDEND_IN_KIND, and STAKING_REWARD, aim to provide: symbol, quantity, and either unitPrice or amount. DIVIDEND_IN_KIND uses the same asset identity for payer and received units.
 - The tool returns a draft preview. Any issues you flag in `validation.errors` appear as non-blocking hints above the form — they do not prevent save. Use them for "maybe check this" concerns, not hard blockers.
-- Use appropriate subtypes when user mentions: "reinvested dividend" → DRIP, "dividend in kind" or "spinoff dividend" → DIVIDEND_IN_KIND, "staking reward" → STAKING_REWARD, "bonus" → BONUS.
+- Use appropriate subtypes when user mentions: "reinvested dividend" → DRIP, "dividend in kind" or "dividend paid as shares/units" → DIVIDEND_IN_KIND, "staking reward" → STAKING_REWARD, "bonus" → BONUS.
 - Use the base currency from context when the user mentions amounts without a currency symbol.
 - Use `record_activities` instead of `record_activity` when recording 2 or more transactions in one user request.
 

--- a/crates/ai/src/tools/record_activities.rs
+++ b/crates/ai/src/tools/record_activities.rs
@@ -101,7 +101,7 @@ impl<E: AiEnvironment + 'static> Tool for RecordActivitiesTool<E> {
                                 },
                                 "symbol": {
                                     "type": "string",
-                                    "description": "Symbol or ticker (e.g., 'AAPL', 'BTC', 'VTI'). Required for BUY/SELL/DIVIDEND/SPLIT"
+                                    "description": "Symbol or ticker (e.g., 'AAPL', 'BTC', 'VTI'). Required for BUY/SELL/DIVIDEND/SPLIT and asset-backed income subtypes like DRIP, DIVIDEND_IN_KIND, and STAKING_REWARD"
                                 },
                                 "activityDate": {
                                     "type": "string",
@@ -109,15 +109,15 @@ impl<E: AiEnvironment + 'static> Tool for RecordActivitiesTool<E> {
                                 },
                                 "quantity": {
                                     "type": "number",
-                                    "description": "Number of shares or units. Required for BUY/SELL/SPLIT"
+                                    "description": "Number of shares or units. Required for BUY/SELL/SPLIT and asset-backed income subtypes like DRIP, DIVIDEND_IN_KIND, and STAKING_REWARD"
                                 },
                                 "unitPrice": {
                                     "type": "number",
-                                    "description": "Price per unit"
+                                    "description": "Price or fair market value per unit. For DRIP, DIVIDEND_IN_KIND, and STAKING_REWARD, provide either unitPrice or amount"
                                 },
                                 "amount": {
                                     "type": "number",
-                                    "description": "Total amount for cash-style activities"
+                                    "description": "Total cash amount or taxable income amount. For DRIP, DIVIDEND_IN_KIND, and STAKING_REWARD, provide either amount or unitPrice"
                                 },
                                 "fee": {
                                     "type": "number",
@@ -129,7 +129,7 @@ impl<E: AiEnvironment + 'static> Tool for RecordActivitiesTool<E> {
                                 },
                                 "subtype": {
                                     "type": "string",
-                                    "description": "Activity subtype: DRIP, DIVIDEND_IN_KIND, STAKING_REWARD, BONUS"
+                                    "description": "Activity subtype: DRIP, DIVIDEND_IN_KIND (additional units of the same asset), STAKING_REWARD (staking income received as more units of the same asset), BONUS"
                                 },
                                 "notes": {
                                     "type": "string",

--- a/crates/ai/src/tools/record_activity.rs
+++ b/crates/ai/src/tools/record_activity.rs
@@ -7,6 +7,14 @@ use log::debug;
 use rig::{completion::ToolDefinition, tool::Tool};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use wealthfolio_core::activities::{
+    ACTIVITY_SUBTYPE_BONUS, ACTIVITY_SUBTYPE_DIVIDEND_IN_KIND, ACTIVITY_SUBTYPE_DRIP,
+    ACTIVITY_SUBTYPE_STAKING_REWARD, ACTIVITY_TYPE_ADJUSTMENT, ACTIVITY_TYPE_BUY,
+    ACTIVITY_TYPE_CREDIT, ACTIVITY_TYPE_DEPOSIT, ACTIVITY_TYPE_DIVIDEND, ACTIVITY_TYPE_FEE,
+    ACTIVITY_TYPE_INTEREST, ACTIVITY_TYPE_SELL, ACTIVITY_TYPE_SPLIT, ACTIVITY_TYPE_TAX,
+    ACTIVITY_TYPE_TRANSFER_IN, ACTIVITY_TYPE_TRANSFER_OUT, ACTIVITY_TYPE_UNKNOWN,
+    ACTIVITY_TYPE_WITHDRAWAL,
+};
 use wealthfolio_core::utils::time_utils::{parse_user_timezone, DEFAULT_VALUATION_TZ};
 
 use crate::env::AiEnvironment;
@@ -177,20 +185,20 @@ pub struct SubtypeOption {
 
 /// Canonical activity types.
 const ACTIVITY_TYPES: &[&str] = &[
-    "BUY",
-    "SELL",
-    "SPLIT",
-    "DIVIDEND",
-    "INTEREST",
-    "DEPOSIT",
-    "WITHDRAWAL",
-    "TRANSFER_IN",
-    "TRANSFER_OUT",
-    "FEE",
-    "TAX",
-    "CREDIT",
-    "ADJUSTMENT",
-    "UNKNOWN",
+    ACTIVITY_TYPE_BUY,
+    ACTIVITY_TYPE_SELL,
+    ACTIVITY_TYPE_SPLIT,
+    ACTIVITY_TYPE_DIVIDEND,
+    ACTIVITY_TYPE_INTEREST,
+    ACTIVITY_TYPE_DEPOSIT,
+    ACTIVITY_TYPE_WITHDRAWAL,
+    ACTIVITY_TYPE_TRANSFER_IN,
+    ACTIVITY_TYPE_TRANSFER_OUT,
+    ACTIVITY_TYPE_FEE,
+    ACTIVITY_TYPE_TAX,
+    ACTIVITY_TYPE_CREDIT,
+    ACTIVITY_TYPE_ADJUSTMENT,
+    ACTIVITY_TYPE_UNKNOWN,
 ];
 
 // ============================================================================
@@ -202,24 +210,24 @@ const ACTIVITY_TYPES: &[&str] = &[
 fn get_subtypes_for_activity_type(activity_type: &str) -> Vec<SubtypeOption> {
     match activity_type.to_uppercase().as_str() {
         // DIVIDEND subtypes
-        "DIVIDEND" => vec![
+        s if s == ACTIVITY_TYPE_DIVIDEND => vec![
             SubtypeOption {
-                value: "DRIP".to_string(),
+                value: ACTIVITY_SUBTYPE_DRIP.to_string(),
                 label: "Dividend Reinvested (DRIP)".to_string(),
             },
             SubtypeOption {
-                value: "DIVIDEND_IN_KIND".to_string(),
+                value: ACTIVITY_SUBTYPE_DIVIDEND_IN_KIND.to_string(),
                 label: "Dividend in Kind".to_string(),
             },
         ],
         // STAKING_REWARD expands to INTEREST + BUY
-        "INTEREST" => vec![SubtypeOption {
-            value: "STAKING_REWARD".to_string(),
+        s if s == ACTIVITY_TYPE_INTEREST => vec![SubtypeOption {
+            value: ACTIVITY_SUBTYPE_STAKING_REWARD.to_string(),
             label: "Staking Reward".to_string(),
         }],
         // BONUS is external flow (affects TWR)
-        "CREDIT" => vec![SubtypeOption {
-            value: "BONUS".to_string(),
+        s if s == ACTIVITY_TYPE_CREDIT => vec![SubtypeOption {
+            value: ACTIVITY_SUBTYPE_BONUS.to_string(),
             label: "Bonus".to_string(),
         }],
         _ => vec![],
@@ -473,6 +481,13 @@ impl<E: AiEnvironment> RecordActivityTool<E> {
         let mut errors = Vec::new();
 
         let activity_type = draft.activity_type.to_uppercase();
+        let subtype = draft.subtype.as_deref().map(str::to_uppercase);
+        let is_dividend_asset_income = activity_type == ACTIVITY_TYPE_DIVIDEND
+            && subtype.as_deref().is_some_and(|subtype| {
+                subtype == ACTIVITY_SUBTYPE_DRIP || subtype == ACTIVITY_SUBTYPE_DIVIDEND_IN_KIND
+            });
+        let is_staking_reward = activity_type == ACTIVITY_TYPE_INTEREST
+            && subtype.as_deref() == Some(ACTIVITY_SUBTYPE_STAKING_REWARD);
 
         // Account is always required
         if draft.account_id.is_none() {
@@ -481,7 +496,7 @@ impl<E: AiEnvironment> RecordActivityTool<E> {
 
         // Validate based on activity type
         match activity_type.as_str() {
-            "BUY" | "SELL" => {
+            s if s == ACTIVITY_TYPE_BUY || s == ACTIVITY_TYPE_SELL => {
                 if draft.symbol.is_none() && draft.asset_id.is_none() {
                     missing_fields.push("symbol".to_string());
                 }
@@ -493,28 +508,46 @@ impl<E: AiEnvironment> RecordActivityTool<E> {
                     missing_fields.push("unit_price".to_string());
                 }
             }
-            "DEPOSIT" | "WITHDRAWAL" | "TAX" | "FEE" | "CREDIT" if draft.amount.is_none() => {
-                missing_fields.push("amount".to_string());
-            }
-            "DIVIDEND" => {
-                if draft.symbol.is_none() && draft.asset_id.is_none() {
-                    missing_fields.push("symbol".to_string());
-                }
-                // Either amount or (quantity + unit_price) is required
-                if draft.amount.is_none()
-                    && (draft.quantity.is_none() || draft.unit_price.is_none())
-                {
-                    missing_fields.push("amount".to_string());
-                }
-            }
-            // Amount is required, symbol is optional
-            "INTEREST"
-                if draft.amount.is_none()
-                    && (draft.quantity.is_none() || draft.unit_price.is_none()) =>
+            s if (s == ACTIVITY_TYPE_DEPOSIT
+                || s == ACTIVITY_TYPE_WITHDRAWAL
+                || s == ACTIVITY_TYPE_TAX
+                || s == ACTIVITY_TYPE_FEE
+                || s == ACTIVITY_TYPE_CREDIT)
+                && draft.amount.is_none() =>
             {
                 missing_fields.push("amount".to_string());
             }
-            "SPLIT" => {
+            s if s == ACTIVITY_TYPE_DIVIDEND => {
+                if draft.symbol.is_none() && draft.asset_id.is_none() {
+                    missing_fields.push("symbol".to_string());
+                }
+                if is_dividend_asset_income && draft.quantity.is_none() {
+                    missing_fields.push("quantity".to_string());
+                }
+                if is_dividend_asset_income && draft.amount.is_none() && draft.unit_price.is_none()
+                {
+                    missing_fields.push("unit_price".to_string());
+                }
+                if !is_dividend_asset_income && draft.amount.is_none() {
+                    missing_fields.push("amount".to_string());
+                }
+            }
+            s if s == ACTIVITY_TYPE_INTEREST => {
+                if is_staking_reward {
+                    if draft.symbol.is_none() && draft.asset_id.is_none() {
+                        missing_fields.push("symbol".to_string());
+                    }
+                    if draft.quantity.is_none() {
+                        missing_fields.push("quantity".to_string());
+                    }
+                    if draft.amount.is_none() && draft.unit_price.is_none() {
+                        missing_fields.push("unit_price".to_string());
+                    }
+                } else if draft.amount.is_none() {
+                    missing_fields.push("amount".to_string());
+                }
+            }
+            s if s == ACTIVITY_TYPE_SPLIT => {
                 if draft.symbol.is_none() && draft.asset_id.is_none() {
                     missing_fields.push("symbol".to_string());
                 }
@@ -523,7 +556,10 @@ impl<E: AiEnvironment> RecordActivityTool<E> {
                 }
             }
             // Either amount (for cash) or (symbol + quantity) for assets
-            "TRANSFER_IN" | "TRANSFER_OUT" if draft.amount.is_none() && draft.symbol.is_none() => {
+            s if (s == ACTIVITY_TYPE_TRANSFER_IN || s == ACTIVITY_TYPE_TRANSFER_OUT)
+                && draft.amount.is_none()
+                && draft.symbol.is_none() =>
+            {
                 missing_fields.push("amount".to_string());
             }
             _ => {}
@@ -623,7 +659,7 @@ impl<E: AiEnvironment + 'static> Tool for RecordActivityTool<E> {
                     },
                     "symbol": {
                         "type": "string",
-                        "description": "Symbol or ticker (e.g., 'AAPL', 'BTC', 'VTI'). Required for BUY/SELL/DIVIDEND/SPLIT"
+                        "description": "Symbol or ticker (e.g., 'AAPL', 'BTC', 'VTI'). Required for BUY/SELL/DIVIDEND/SPLIT and asset-backed income subtypes like DRIP, DIVIDEND_IN_KIND, and STAKING_REWARD"
                     },
                     "activityDate": {
                         "type": "string",
@@ -637,15 +673,15 @@ impl<E: AiEnvironment + 'static> Tool for RecordActivityTool<E> {
                     },
                     "quantity": {
                         "type": "number",
-                        "description": "Number of shares or units. Required for BUY/SELL/SPLIT"
+                        "description": "Number of shares or units. Required for BUY/SELL/SPLIT and asset-backed income subtypes like DRIP, DIVIDEND_IN_KIND, and STAKING_REWARD"
                     },
                     "unitPrice": {
                         "type": "number",
-                        "description": "Price per unit. If omitted for BUY/SELL, user will need to provide it"
+                        "description": "Price or fair market value per unit. Required for BUY/SELL unless amount is provided; for DRIP, DIVIDEND_IN_KIND, and STAKING_REWARD, provide either unitPrice or amount"
                     },
                     "amount": {
                         "type": "number",
-                        "description": "Total amount. For DEPOSIT/WITHDRAWAL/DIVIDEND or when quantity*price doesn't apply"
+                        "description": "Total cash amount or taxable income amount. For DRIP, DIVIDEND_IN_KIND, and STAKING_REWARD, provide either amount or unitPrice"
                     },
                     "fee": {
                         "type": "number",
@@ -657,7 +693,7 @@ impl<E: AiEnvironment + 'static> Tool for RecordActivityTool<E> {
                     },
                     "subtype": {
                         "type": "string",
-                        "description": "Activity subtype for semantic variations: DRIP (dividend reinvested), DIVIDEND_IN_KIND (dividend paid in asset), STAKING_REWARD (crypto staking), BONUS (promotional credit)"
+                        "description": "Activity subtype for semantic variations: DRIP (dividend reinvested), DIVIDEND_IN_KIND (dividend paid as additional units of the same asset), STAKING_REWARD (staking income received as more units of the same asset), BONUS (promotional credit)"
                     },
                     "notes": {
                         "type": "string",
@@ -770,6 +806,34 @@ mod tests {
         // Should have subtypes available for DIVIDEND
         assert!(!output.available_subtypes.is_empty());
         assert!(output.available_subtypes.iter().any(|s| s.value == "DRIP"));
+    }
+
+    #[tokio::test]
+    async fn test_record_activity_allows_unknown_provider_subtype_label() {
+        let env = Arc::new(MockEnvironment::new());
+        let tool = RecordActivityTool::new(env);
+
+        let output = tool
+            .call(RecordActivityArgs {
+                activity_type: "BUY".to_string(),
+                symbol: Some("AAPL".to_string()),
+                activity_date: "2026-01-17".to_string(),
+                quantity: Some(2.0),
+                unit_price: Some(100.0),
+                amount: None,
+                fee: None,
+                account: None,
+                subtype: Some("BUY_TO_OPEN".to_string()),
+                notes: None,
+            })
+            .await
+            .expect("tool should return an editable draft");
+
+        assert!(!output
+            .validation
+            .errors
+            .iter()
+            .any(|error| error.field == "subtype"));
     }
 
     #[tokio::test]

--- a/crates/connect/src/broker/service.rs
+++ b/crates/connect/src/broker/service.rs
@@ -23,7 +23,7 @@ use std::collections::{HashMap, HashSet};
 use wealthfolio_core::accounts::{Account, AccountServiceTrait, NewAccount, TrackingMode};
 use wealthfolio_core::activities::{
     compute_idempotency_key, ActivityRepositoryTrait, ActivityServiceTrait, ActivityUpsert,
-    NewActivity,
+    NewActivity, ACTIVITY_TYPE_BUY, ACTIVITY_TYPE_SELL,
 };
 use wealthfolio_core::assets::{
     build_option_metadata, parse_crypto_pair_symbol, parse_symbol_with_exchange_suffix, AssetKind,
@@ -376,7 +376,7 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 .unwrap_or_else(|_| Utc::now());
 
             // Collect quote data from BUY/SELL activities with a resolved asset and non-zero price
-            if matches!(act.activity_type.as_str(), "BUY" | "SELL") {
+            if act.activity_type == ACTIVITY_TYPE_BUY || act.activity_type == ACTIVITY_TYPE_SELL {
                 if let (Some(ref aid), Some(price)) = (&asset_id, act.unit_price) {
                     if price > Decimal::ZERO {
                         quote_data.push((

--- a/crates/core/src/activities/activities_constants.rs
+++ b/crates/core/src/activities/activities_constants.rs
@@ -232,8 +232,8 @@ pub const ACTIVITY_SUBTYPE_DRIP: &str = "DRIP";
 /// Expands to: INTEREST + BUY
 pub const ACTIVITY_SUBTYPE_STAKING_REWARD: &str = "STAKING_REWARD";
 
-/// Dividend in Kind: Dividend paid in a different asset (e.g., spinoff shares).
-/// Expands to: DIVIDEND + TRANSFER_IN (with metadata.flow.is_external=true)
+/// Dividend in Kind: Dividend paid as additional units of the same asset.
+/// Expands to: DIVIDEND + BUY
 pub const ACTIVITY_SUBTYPE_DIVIDEND_IN_KIND: &str = "DIVIDEND_IN_KIND";
 
 /// Bonus: External cash credit (new capital entering portfolio).

--- a/crates/core/src/activities/activities_model.rs
+++ b/crates/core/src/activities/activities_model.rs
@@ -1,5 +1,23 @@
 //! Activity domain models.
 
+use crate::activities::activities_constants::{
+    ACTIVITY_SUBTYPE_BONUS, ACTIVITY_SUBTYPE_DIVIDEND_IN_KIND, ACTIVITY_SUBTYPE_DRIP,
+    ACTIVITY_SUBTYPE_OPTION_EXPIRY, ACTIVITY_SUBTYPE_REBATE, ACTIVITY_SUBTYPE_REFUND,
+    ACTIVITY_SUBTYPE_STAKING_REWARD, ACTIVITY_TYPE_ADJUSTMENT, ACTIVITY_TYPE_BUY,
+    ACTIVITY_TYPE_CREDIT, ACTIVITY_TYPE_DEPOSIT, ACTIVITY_TYPE_DIVIDEND, ACTIVITY_TYPE_FEE,
+    ACTIVITY_TYPE_INTEREST, ACTIVITY_TYPE_SELL, ACTIVITY_TYPE_SPLIT, ACTIVITY_TYPE_TAX,
+    ACTIVITY_TYPE_TRANSFER_IN, ACTIVITY_TYPE_TRANSFER_OUT, ACTIVITY_TYPE_WITHDRAWAL,
+};
+use crate::activities::csv_parser::ParseConfig;
+use crate::assets::NewAsset;
+use crate::Result;
+use crate::{activities::activities_errors::ActivityError, QuoteMode};
+use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::str::FromStr;
+
 /// Discriminator values for `import_account_templates.context_kind`.
 pub mod import_type {
     pub const ACTIVITY: &str = "CSV_ACTIVITY";
@@ -43,16 +61,6 @@ pub fn normalize_context_kind_value(raw: &str) -> &str {
         _ => raw,
     }
 }
-
-use crate::activities::csv_parser::ParseConfig;
-use crate::assets::NewAsset;
-use crate::Result;
-use crate::{activities::activities_errors::ActivityError, QuoteMode};
-use chrono::{DateTime, NaiveDate, NaiveDateTime, Utc};
-use rust_decimal::Decimal;
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
-use std::str::FromStr;
 
 /// Helper function to parse a string into a Decimal,
 /// with support for scientific notation.
@@ -289,6 +297,91 @@ pub struct NewActivity {
 }
 
 impl NewActivity {
+    pub fn canonicalize_subtype(subtype: Option<&str>) -> Option<String> {
+        let subtype = subtype.map(str::trim).filter(|value| !value.is_empty())?;
+
+        let canonical = if subtype.eq_ignore_ascii_case(ACTIVITY_SUBTYPE_DRIP) {
+            ACTIVITY_SUBTYPE_DRIP
+        } else if subtype.eq_ignore_ascii_case(ACTIVITY_SUBTYPE_DIVIDEND_IN_KIND) {
+            ACTIVITY_SUBTYPE_DIVIDEND_IN_KIND
+        } else if subtype.eq_ignore_ascii_case(ACTIVITY_SUBTYPE_STAKING_REWARD) {
+            ACTIVITY_SUBTYPE_STAKING_REWARD
+        } else if subtype.eq_ignore_ascii_case(ACTIVITY_SUBTYPE_BONUS) {
+            ACTIVITY_SUBTYPE_BONUS
+        } else if subtype.eq_ignore_ascii_case(ACTIVITY_SUBTYPE_REBATE) {
+            ACTIVITY_SUBTYPE_REBATE
+        } else if subtype.eq_ignore_ascii_case(ACTIVITY_SUBTYPE_REFUND) {
+            ACTIVITY_SUBTYPE_REFUND
+        } else if subtype.eq_ignore_ascii_case(ACTIVITY_SUBTYPE_OPTION_EXPIRY) {
+            ACTIVITY_SUBTYPE_OPTION_EXPIRY
+        } else {
+            subtype
+        };
+
+        Some(canonical.to_string())
+    }
+
+    pub(crate) fn is_asset_backed_income_subtype(
+        activity_type: &str,
+        subtype: Option<&str>,
+    ) -> bool {
+        let Some(subtype) = subtype.map(str::trim).filter(|value| !value.is_empty()) else {
+            return false;
+        };
+
+        (activity_type.eq_ignore_ascii_case(ACTIVITY_TYPE_DIVIDEND)
+            && (subtype.eq_ignore_ascii_case(ACTIVITY_SUBTYPE_DRIP)
+                || subtype.eq_ignore_ascii_case(ACTIVITY_SUBTYPE_DIVIDEND_IN_KIND)))
+            || (activity_type.eq_ignore_ascii_case(ACTIVITY_TYPE_INTEREST)
+                && subtype.eq_ignore_ascii_case(ACTIVITY_SUBTYPE_STAKING_REWARD))
+    }
+
+    pub(crate) fn validate_asset_backed_income_values(
+        activity_type: &str,
+        subtype: Option<&str>,
+        quantity: Option<Decimal>,
+        unit_price: Option<Decimal>,
+        amount: Option<Decimal>,
+    ) -> std::result::Result<(), ActivityError> {
+        if !Self::is_asset_backed_income_subtype(activity_type, subtype) {
+            return Ok(());
+        }
+
+        match quantity {
+            Some(quantity) if quantity.is_sign_positive() && !quantity.is_zero() => {}
+            _ => {
+                return Err(ActivityError::InvalidData(
+                    "Asset-backed income activities require a positive quantity".to_string(),
+                ));
+            }
+        }
+
+        let has_positive_unit_price =
+            unit_price.is_some_and(|value| value.is_sign_positive() && !value.is_zero());
+        let has_positive_amount =
+            amount.is_some_and(|value| value.is_sign_positive() && !value.is_zero());
+
+        if !has_positive_unit_price && !has_positive_amount {
+            return Err(ActivityError::InvalidData(
+                "Asset-backed income activities require an amount or FMV per unit".to_string(),
+            ));
+        }
+
+        if unit_price.is_some_and(|value| value.is_sign_negative()) {
+            return Err(ActivityError::InvalidData(
+                "FMV per unit cannot be negative".to_string(),
+            ));
+        }
+
+        if amount.is_some_and(|value| value.is_sign_negative()) {
+            return Err(ActivityError::InvalidData(
+                "Income amount cannot be negative".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
     /// Validates the new activity data
     pub fn validate(&self) -> std::result::Result<(), ActivityError> {
         if self.account_id.trim().is_empty() {
@@ -310,6 +403,14 @@ impl NewActivity {
                 "Invalid date format. Expected ISO 8601/RFC3339 or YYYY-MM-DD".to_string(),
             ));
         }
+
+        Self::validate_asset_backed_income_values(
+            &self.activity_type,
+            self.subtype.as_deref(),
+            self.quantity,
+            self.unit_price,
+            self.amount,
+        )?;
 
         Ok(())
     }
@@ -376,6 +477,10 @@ pub struct ActivityUpdate {
     pub asset: Option<AssetResolutionInput>,
 
     pub activity_type: String,
+    #[serde(
+        default,
+        deserialize_with = "subtype_patch_format::deserialize_patch_subtype"
+    )]
     pub subtype: Option<String>, // Semantic variation (DRIP, STAKING_REWARD, etc.)
     pub activity_date: String,
     #[serde(
@@ -1006,19 +1111,23 @@ impl Default for ImportMappingData {
         );
 
         let mut activity_mappings = std::collections::HashMap::new();
-        activity_mappings.insert("BUY".to_string(), vec!["BUY".to_string()]);
-        activity_mappings.insert("SELL".to_string(), vec!["SELL".to_string()]);
-        activity_mappings.insert("DIVIDEND".to_string(), vec!["DIVIDEND".to_string()]);
-        activity_mappings.insert("INTEREST".to_string(), vec!["INTEREST".to_string()]);
-        activity_mappings.insert("DEPOSIT".to_string(), vec!["DEPOSIT".to_string()]);
-        activity_mappings.insert("WITHDRAWAL".to_string(), vec!["WITHDRAWAL".to_string()]);
-        activity_mappings.insert("TRANSFER_IN".to_string(), vec!["TRANSFER_IN".to_string()]);
-        activity_mappings.insert("TRANSFER_OUT".to_string(), vec!["TRANSFER_OUT".to_string()]);
-        activity_mappings.insert("SPLIT".to_string(), vec!["SPLIT".to_string()]);
-        activity_mappings.insert("FEE".to_string(), vec!["FEE".to_string()]);
-        activity_mappings.insert("TAX".to_string(), vec!["TAX".to_string()]);
-        activity_mappings.insert("CREDIT".to_string(), vec!["CREDIT".to_string()]);
-        activity_mappings.insert("ADJUSTMENT".to_string(), vec!["ADJUSTMENT".to_string()]);
+        for activity_type in [
+            ACTIVITY_TYPE_BUY,
+            ACTIVITY_TYPE_SELL,
+            ACTIVITY_TYPE_DIVIDEND,
+            ACTIVITY_TYPE_INTEREST,
+            ACTIVITY_TYPE_DEPOSIT,
+            ACTIVITY_TYPE_WITHDRAWAL,
+            ACTIVITY_TYPE_TRANSFER_IN,
+            ACTIVITY_TYPE_TRANSFER_OUT,
+            ACTIVITY_TYPE_SPLIT,
+            ACTIVITY_TYPE_FEE,
+            ACTIVITY_TYPE_TAX,
+            ACTIVITY_TYPE_CREDIT,
+            ACTIVITY_TYPE_ADJUSTMENT,
+        ] {
+            activity_mappings.insert(activity_type.to_string(), vec![activity_type.to_string()]);
+        }
 
         ImportMappingData {
             account_id: String::new(),
@@ -1351,6 +1460,19 @@ mod decimal_input_format {
                 .map_err(serde::de::Error::custom),
             _ => Err(serde::de::Error::custom("Invalid decimal value type")),
         }
+    }
+}
+
+mod subtype_patch_format {
+    use serde::{Deserialize, Deserializer};
+
+    pub fn deserialize_patch_subtype<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Some(
+            Option::<String>::deserialize(deserializer)?.unwrap_or_default(),
+        ))
     }
 }
 

--- a/crates/core/src/activities/activities_model_tests.rs
+++ b/crates/core/src/activities/activities_model_tests.rs
@@ -368,6 +368,107 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[test]
+    fn test_new_activity_validates_staking_reward_quantity() {
+        let mut activity = create_test_new_activity();
+        activity.activity_type = "INTEREST".to_string();
+        activity.subtype = Some("STAKING_REWARD".to_string());
+        activity.quantity = None;
+        activity.unit_price = Some(dec!(2000));
+        activity.amount = Some(dec!(20));
+
+        let result = activity.validate();
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("positive quantity"));
+    }
+
+    #[test]
+    fn test_new_activity_validates_dividend_in_kind_value_source() {
+        let mut activity = create_test_new_activity();
+        activity.activity_type = "DIVIDEND".to_string();
+        activity.subtype = Some("DIVIDEND_IN_KIND".to_string());
+        activity.quantity = Some(dec!(2));
+        activity.unit_price = None;
+        activity.amount = None;
+
+        let result = activity.validate();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("FMV per unit"));
+    }
+
+    #[test]
+    fn test_new_activity_allows_mismatched_subtype_as_metadata() {
+        let mut activity = create_test_new_activity();
+        activity.activity_type = "DIVIDEND".to_string();
+        activity.subtype = Some("STAKING_REWARD".to_string());
+        activity.quantity = Some(dec!(1));
+        activity.unit_price = Some(dec!(100));
+        activity.amount = Some(dec!(100));
+
+        let result = activity.validate();
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_new_activity_allows_unknown_provider_subtype_label() {
+        let mut activity = create_test_new_activity();
+        activity.activity_type = "BUY".to_string();
+        activity.subtype = Some("BUY_TO_OPEN".to_string());
+
+        let result = activity.validate();
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_new_activity_treats_zero_income_value_source_as_missing() {
+        let mut activity = create_test_new_activity();
+        activity.activity_type = "INTEREST".to_string();
+        activity.subtype = Some("STAKING_REWARD".to_string());
+        activity.quantity = Some(dec!(0.01));
+        activity.unit_price = Some(dec!(0));
+        activity.amount = Some(dec!(0));
+
+        let result = activity.validate();
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("FMV per unit"));
+    }
+
+    #[test]
+    fn test_new_activity_allows_zero_amount_with_positive_unit_price() {
+        let mut activity = create_test_new_activity();
+        activity.activity_type = "INTEREST".to_string();
+        activity.subtype = Some("STAKING_REWARD".to_string());
+        activity.quantity = Some(dec!(0.01));
+        activity.unit_price = Some(dec!(200));
+        activity.amount = Some(dec!(0));
+
+        let result = activity.validate();
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_new_activity_allows_asset_income_amount_without_unit_price() {
+        let mut activity = create_test_new_activity();
+        activity.activity_type = "INTEREST".to_string();
+        activity.subtype = Some("STAKING_REWARD".to_string());
+        activity.quantity = Some(dec!(0.01));
+        activity.unit_price = None;
+        activity.amount = Some(dec!(20));
+
+        let result = activity.validate();
+
+        assert!(result.is_ok());
+    }
+
     // ============================================================================
     // ActivityUpdate Validation Tests
     // ============================================================================
@@ -452,6 +553,7 @@ mod tests {
             "currency": "USD",
             "quantity": "1e-7",
             "unitPrice": 2.5e3,
+            "subtype": null,
             "fee": null
         });
 
@@ -465,6 +567,7 @@ mod tests {
             parsed.unit_price,
             Some(Some(Decimal::from_scientific("2.5e3").unwrap()))
         );
+        assert_eq!(parsed.subtype, Some(String::new()));
         assert_eq!(parsed.fee, Some(None));
         assert_eq!(parsed.amount, None);
     }

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -8,8 +8,7 @@ use std::sync::Arc;
 use crate::accounts::{Account, AccountServiceTrait};
 use crate::activities::activities_constants::{
     classify_import_activity, is_cash_symbol, is_garbage_symbol, requires_symbol,
-    ImportSymbolDisposition, ACTIVITY_SUBTYPE_DIVIDEND_IN_KIND, ACTIVITY_SUBTYPE_DRIP,
-    ACTIVITY_SUBTYPE_STAKING_REWARD, ACTIVITY_TYPE_SPLIT, ACTIVITY_TYPE_TRANSFER_IN,
+    ImportSymbolDisposition, ACTIVITY_TYPE_BUY, ACTIVITY_TYPE_SPLIT, ACTIVITY_TYPE_TRANSFER_IN,
     ACTIVITY_TYPE_TRANSFER_OUT, PRICE_BEARING_ACTIVITY_TYPES,
 };
 use crate::activities::activities_errors::ActivityError;
@@ -130,18 +129,118 @@ impl PreparationMode {
     fn allows_live_resolution(self) -> bool {
         matches!(self, Self::Sync)
     }
+
+    fn is_sync(self) -> bool {
+        matches!(self, Self::Sync)
+    }
 }
 
 impl ActivityService {
-    fn is_asset_backed_import_subtype(subtype: Option<&str>) -> bool {
-        subtype
+    fn normalize_new_activity_economic_signs(activity: &mut NewActivity) {
+        activity.quantity = activity.quantity.map(|v| v.abs());
+        activity.unit_price = activity.unit_price.map(|v| v.abs());
+        activity.amount = activity.amount.map(|v| v.abs());
+        activity.fee = activity.fee.map(|v| v.abs());
+    }
+
+    fn hydrate_and_validate_update_against_existing(
+        activity: &mut ActivityUpdate,
+        existing: &Activity,
+    ) -> Result<()> {
+        if activity
+            .subtype
+            .as_deref()
             .map(str::trim)
-            .filter(|subtype| !subtype.is_empty())
-            .is_some_and(|subtype| {
-                subtype.eq_ignore_ascii_case(ACTIVITY_SUBTYPE_DRIP)
-                    || subtype.eq_ignore_ascii_case(ACTIVITY_SUBTYPE_DIVIDEND_IN_KIND)
-                    || subtype.eq_ignore_ascii_case(ACTIVITY_SUBTYPE_STAKING_REWARD)
-            })
+            .is_some_and(|subtype| !subtype.is_empty())
+        {
+            activity.subtype = NewActivity::canonicalize_subtype(activity.subtype.as_deref());
+        }
+
+        let effective_subtype = match activity.subtype.as_deref().map(str::trim) {
+            Some("") => None,
+            Some(subtype) => Some(subtype),
+            None => existing.subtype.as_deref(),
+        };
+        let quantity = activity
+            .quantity
+            .unwrap_or(existing.quantity)
+            .map(|value| value.abs());
+        let unit_price = activity
+            .unit_price
+            .unwrap_or(existing.unit_price)
+            .map(|value| value.abs());
+        let amount = activity
+            .amount
+            .unwrap_or(existing.amount)
+            .map(|value| value.abs());
+
+        NewActivity::validate_asset_backed_income_values(
+            &activity.activity_type,
+            effective_subtype,
+            quantity,
+            unit_price,
+            amount,
+        )?;
+
+        Ok(())
+    }
+
+    fn validate_new_activity_income_values(activity: &NewActivity) -> Result<()> {
+        NewActivity::validate_asset_backed_income_values(
+            &activity.activity_type,
+            activity.subtype.as_deref(),
+            activity.quantity,
+            activity.unit_price,
+            activity.amount,
+        )?;
+
+        Ok(())
+    }
+
+    fn normalize_activity_for_preparation(mut activity: NewActivity) -> NewActivity {
+        activity.subtype = NewActivity::canonicalize_subtype(activity.subtype.as_deref());
+        Self::normalize_new_activity_economic_signs(&mut activity);
+        activity
+    }
+
+    fn downgrade_unresolvable_sync_asset_income(activity: &mut NewActivity) {
+        let should_derive_amount = activity.amount.is_none_or(|amount| amount.is_zero())
+            && activity
+                .quantity
+                .is_some_and(|quantity| quantity.is_sign_positive() && !quantity.is_zero())
+            && activity
+                .unit_price
+                .is_some_and(|unit_price| unit_price.is_sign_positive() && !unit_price.is_zero());
+
+        if should_derive_amount {
+            if let (Some(quantity), Some(unit_price)) = (activity.quantity, activity.unit_price) {
+                activity.amount = Some(quantity * unit_price);
+            }
+        }
+
+        activity.subtype = None;
+    }
+
+    fn sync_asset_income_needs_downgrade(
+        activity: &NewActivity,
+        resolved_asset_id: Option<&str>,
+    ) -> bool {
+        if !NewActivity::is_asset_backed_income_subtype(
+            &activity.activity_type,
+            activity.subtype.as_deref(),
+        ) {
+            return false;
+        }
+
+        resolved_asset_id.is_none()
+            || NewActivity::validate_asset_backed_income_values(
+                &activity.activity_type,
+                activity.subtype.as_deref(),
+                activity.quantity,
+                activity.unit_price,
+                activity.amount,
+            )
+            .is_err()
     }
 
     fn classify_import_symbol_disposition(
@@ -151,7 +250,7 @@ impl ActivityService {
         quantity: Option<Decimal>,
         unit_price: Option<Decimal>,
     ) -> ImportSymbolDisposition {
-        if Self::is_asset_backed_import_subtype(subtype) {
+        if NewActivity::is_asset_backed_income_subtype(activity_type, subtype) {
             ImportSymbolDisposition::ResolveAsset
         } else {
             classify_import_activity(activity_type, symbol, quantity, unit_price)
@@ -159,7 +258,8 @@ impl ActivityService {
     }
 
     fn requires_asset_identity(activity_type: &str, subtype: Option<&str>) -> bool {
-        requires_symbol(activity_type) || Self::is_asset_backed_import_subtype(subtype)
+        requires_symbol(activity_type)
+            || NewActivity::is_asset_backed_income_subtype(activity_type, subtype)
     }
 
     fn has_valid_split_ratio(amount: Option<Decimal>) -> bool {
@@ -1320,11 +1420,14 @@ impl ActivityService {
     }
 
     async fn prepare_new_activity(&self, mut activity: NewActivity) -> Result<NewActivity> {
+        activity.subtype = NewActivity::canonicalize_subtype(activity.subtype.as_deref());
+        Self::normalize_new_activity_economic_signs(&mut activity);
         let account: Account = self.account_service.get_account(&activity.account_id)?;
         let base_ccy = self.account_service.get_base_currency().unwrap_or_default();
         let account_currency = resolve_currency(&[&account.currency, &base_ccy]);
 
         let currency = resolve_currency(&[&activity.currency, &account_currency, &base_ccy]);
+        Self::validate_new_activity_income_values(&activity)?;
 
         if activity.activity_type == ACTIVITY_TYPE_SPLIT {
             activity.amount = activity.amount.map(|v| v.abs());
@@ -2406,6 +2509,44 @@ impl ActivityService {
         }
     }
 
+    fn normalize_import_activity_subtype(activity: &mut ActivityImport) {
+        activity.subtype = NewActivity::canonicalize_subtype(activity.subtype.as_deref());
+        if activity
+            .subtype
+            .as_deref()
+            .is_some_and(|subtype| subtype.eq_ignore_ascii_case(&activity.activity_type))
+        {
+            activity.subtype = None;
+        }
+    }
+
+    fn validate_import_asset_backed_income_values(
+        activity: &ActivityImport,
+    ) -> std::result::Result<(), (String, String)> {
+        let quantity = activity.quantity.map(|value| value.abs());
+        let unit_price = activity.unit_price.map(|value| value.abs());
+        let amount = activity.amount.map(|value| value.abs());
+
+        NewActivity::validate_asset_backed_income_values(
+            &activity.activity_type,
+            activity.subtype.as_deref(),
+            quantity,
+            unit_price,
+            amount,
+        )
+        .map_err(|err| {
+            let message = err.to_string();
+            let field = if message.contains("positive quantity") {
+                "quantity"
+            } else if message.contains("Income amount") {
+                "amount"
+            } else {
+                "unitPrice"
+            };
+            (field.to_string(), message)
+        })
+    }
+
     async fn check_activities_import_for_account(
         &self,
         account_id: String,
@@ -2463,8 +2604,20 @@ impl ActivityService {
                 activity.account_id = Some(account_id.clone());
             }
             self.hydrate_import_activity_from_asset_id(&mut activity);
+            Self::normalize_import_activity_subtype(&mut activity);
 
             let symbol = activity.symbol.trim().to_string();
+
+            if let Err((field, message)) =
+                Self::validate_import_asset_backed_income_values(&activity)
+            {
+                activity.is_valid = false;
+                let mut errors = std::collections::HashMap::new();
+                errors.insert(field, vec![message]);
+                activity.errors = Some(errors);
+                activities_with_status.push(activity);
+                continue;
+            }
 
             match Self::classify_import_symbol_disposition(
                 &activity.activity_type,
@@ -2815,6 +2968,8 @@ impl ActivityService {
     /// - CashMovement: clears symbol, exchange_mic, quote_ccy, instrument_type
     /// - SPLIT: falls back to `account_currency` when currency is missing or invalid
     fn normalize_for_insert(activity: &mut ActivityImport, account_currency: &str) {
+        Self::normalize_import_activity_subtype(activity);
+
         if Self::classify_import_symbol_disposition(
             &activity.activity_type,
             activity.subtype.as_deref(),
@@ -2926,10 +3081,11 @@ impl ActivityServiceTrait for ActivityService {
     }
 
     /// Updates an existing activity
-    async fn update_activity(&self, activity: ActivityUpdate) -> Result<Activity> {
+    async fn update_activity(&self, mut activity: ActivityUpdate) -> Result<Activity> {
         // Get the existing activity BEFORE the update to capture old account_id and asset_id
         // This ensures we emit events for both old and new locations if they changed
         let existing = self.activity_repository.get_activity(&activity.id)?;
+        Self::hydrate_and_validate_update_against_existing(&mut activity, &existing)?;
 
         let prepared = self.prepare_update_activity(activity).await?;
         let updated = self.activity_repository.update_activity(prepared).await?;
@@ -3099,6 +3255,7 @@ impl ActivityServiceTrait for ActivityService {
 
         // For updates: capture OLD values before preparing the update
         for update_request in request.updates {
+            let mut update_request = update_request;
             let target_id = update_request.id.clone();
             // Get the existing activity to capture old account_id and asset_id
             match self.activity_repository.get_activity(&target_id) {
@@ -3108,6 +3265,17 @@ impl ActivityServiceTrait for ActivityService {
                         old_asset_ids.insert(asset_id.clone());
                     }
                     old_currencies.insert(existing.currency.clone());
+                    if let Err(err) = Self::hydrate_and_validate_update_against_existing(
+                        &mut update_request,
+                        &existing,
+                    ) {
+                        errors.push(ActivityBulkMutationError {
+                            id: Some(target_id),
+                            action: "update".to_string(),
+                            message: err.to_string(),
+                        });
+                        continue;
+                    }
                 }
                 Err(_) => {
                     // Activity doesn't exist - will fail during prepare_update_activity
@@ -3301,7 +3469,7 @@ impl ActivityServiceTrait for ActivityService {
                 id: None,
                 date: "2000-01-01".to_string(),
                 symbol: candidate.symbol.clone(),
-                activity_type: "BUY".to_string(),
+                activity_type: ACTIVITY_TYPE_BUY.to_string(),
                 quantity: Some(Decimal::ONE),
                 unit_price: Some(Decimal::ONE),
                 currency: candidate.currency.clone().unwrap_or_default(),
@@ -3551,6 +3719,14 @@ impl ActivityServiceTrait for ActivityService {
                 has_validation_errors = true;
                 continue;
             }
+            if let Err((field, message)) =
+                Self::validate_import_asset_backed_income_values(activity)
+            {
+                activity.is_valid = false;
+                Self::add_activity_error(activity, &field, &message);
+                has_validation_errors = true;
+                continue;
+            }
             if let ImportSymbolDisposition::NeedsReview(message) = &symbol_disposition {
                 Self::add_activity_error(activity, "symbol", message);
                 activity.is_valid = false;
@@ -3647,6 +3823,8 @@ impl ActivityServiceTrait for ActivityService {
             .collect();
 
         for (new_act, src) in new_activities.iter_mut().zip(source_slice.iter()) {
+            new_act.subtype = NewActivity::canonicalize_subtype(new_act.subtype.as_deref());
+            Self::normalize_new_activity_economic_signs(new_act);
             new_act.idempotency_key = Self::build_import_idempotency_key(src, &new_act.account_id);
         }
 
@@ -4218,6 +4396,11 @@ impl ActivityService {
             return Ok(PrepareActivitiesResult::default());
         }
 
+        let activities: Vec<NewActivity> = activities
+            .into_iter()
+            .map(Self::normalize_activity_for_preparation)
+            .collect();
+
         let mut result = PrepareActivitiesResult::default();
         let base_ccy = self.account_service.get_base_currency().unwrap_or_default();
         let account_currency = resolve_currency(&[&account.currency, &base_ccy]);
@@ -4254,8 +4437,23 @@ impl ActivityService {
         let mut asset_specs: Vec<AssetSpec> = Vec::new();
         let mut activity_asset_map: Vec<Option<String>> = Vec::with_capacity(activities.len());
         let mut quote_ccy_cache: QuoteCcyCache = HashMap::new();
+        let mut sync_review_indices: HashSet<usize> = HashSet::new();
 
         for (idx, activity) in activities.iter().enumerate() {
+            if let Err(e) = activity.validate() {
+                if mode.is_sync() {
+                    warn!(
+                        "Broker sync activity at index {} failed validation and will be imported for review: {}",
+                        idx, e
+                    );
+                    sync_review_indices.insert(idx);
+                } else {
+                    result.errors.push((idx, e.to_string()));
+                    activity_asset_map.push(None);
+                    continue;
+                }
+            }
+
             match self
                 .build_asset_spec(
                     activity,
@@ -4277,7 +4475,15 @@ impl ActivityService {
                     activity_asset_map.push(None);
                 }
                 Err(e) => {
-                    result.errors.push((idx, e.to_string()));
+                    if mode.is_sync() {
+                        warn!(
+                            "Broker sync activity at index {} could not resolve an asset and will be imported for review: {}",
+                            idx, e
+                        );
+                        sync_review_indices.insert(idx);
+                    } else {
+                        result.errors.push((idx, e.to_string()));
+                    }
                     activity_asset_map.push(None);
                 }
             }
@@ -4395,8 +4601,23 @@ impl ActivityService {
 
             // Validate the activity
             if let Err(e) = activity.validate() {
-                result.errors.push((idx, e.to_string()));
-                continue;
+                if mode.is_sync() {
+                    warn!(
+                        "Broker sync activity at index {} failed final validation and will be imported for review: {}",
+                        idx, e
+                    );
+                    sync_review_indices.insert(idx);
+                } else {
+                    result.errors.push((idx, e.to_string()));
+                    continue;
+                }
+            }
+
+            if mode.is_sync()
+                && Self::sync_asset_income_needs_downgrade(&activity, resolved_asset_id.as_deref())
+            {
+                Self::downgrade_unresolvable_sync_asset_income(&mut activity);
+                sync_review_indices.insert(idx);
             }
 
             // Update activity's asset with resolved asset_id
@@ -4462,7 +4683,21 @@ impl ActivityService {
             activity.amount = activity.amount.map(|v| v.abs());
             activity.fee = activity.fee.map(|v| v.abs());
 
-            Self::validate_split_ratio(&activity.activity_type, activity.amount)?;
+            if let Err(e) = Self::validate_split_ratio(&activity.activity_type, activity.amount) {
+                if mode.is_sync() {
+                    warn!(
+                        "Broker sync activity at index {} has invalid split data and will be imported for review: {}",
+                        idx, e
+                    );
+                    sync_review_indices.insert(idx);
+                } else {
+                    return Err(e);
+                }
+            }
+
+            if mode.is_sync() && sync_review_indices.contains(&idx) {
+                activity.needs_review = Some(true);
+            }
 
             // Securities transfers derive monetary value from quantity × unit_price;
             // never persist an inbound `amount` for them when unit_price is present

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -692,7 +692,7 @@ mod tests {
                 activity_type: new_activity.activity_type,
                 activity_type_override: None,
                 source_type: None,
-                subtype: None,
+                subtype: new_activity.subtype,
                 status: new_activity.status.unwrap_or(ActivityStatus::Posted),
                 activity_date: Utc::now(),
                 settlement_date: None,
@@ -729,7 +729,11 @@ mod tests {
             existing.account_id = activity_update.account_id;
             existing.asset_id = asset_id;
             existing.activity_type = activity_update.activity_type;
-            existing.subtype = activity_update.subtype;
+            existing.subtype = match activity_update.subtype {
+                Some(subtype) if subtype.trim().is_empty() => None,
+                Some(subtype) => Some(subtype),
+                None => existing.subtype.clone(),
+            };
             existing.quantity = activity_update.quantity.unwrap_or(existing.quantity);
             existing.unit_price = activity_update.unit_price.unwrap_or(existing.unit_price);
             existing.amount = activity_update.amount.unwrap_or(existing.amount);
@@ -1653,6 +1657,261 @@ mod tests {
         assert_eq!(key.len(), 64, "key should be a sha256 hex string");
     }
 
+    #[tokio::test]
+    async fn test_bulk_update_preserves_existing_asset_backed_subtype_when_omitted() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        account_service.add_account(create_test_account("acc-1", "USD"));
+        asset_service.add_asset(create_test_asset_with_instrument(
+            "ETH",
+            "ETH",
+            None,
+            Some(InstrumentType::Crypto),
+            "USD",
+        ));
+
+        let mut existing = create_stored_activity("staking-1", "acc-1", Some("ETH"));
+        existing.activity_type = "INTEREST".to_string();
+        existing.subtype = Some("STAKING_REWARD".to_string());
+        existing.quantity = Some(dec!(1));
+        existing.unit_price = Some(dec!(100));
+        existing.amount = Some(dec!(100));
+        activity_repository.add_activity(existing);
+
+        let quote_service = Arc::new(MockQuoteService);
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            quote_service,
+        );
+
+        let mut update = create_test_activity_update(
+            "staking-1",
+            "acc-1",
+            Some(AssetResolutionInput {
+                id: Some("ETH".to_string()),
+                ..Default::default()
+            }),
+            "USD",
+        );
+        update.activity_type = "INTEREST".to_string();
+        update.subtype = None;
+        update.quantity = None;
+        update.unit_price = None;
+        update.amount = None;
+
+        let result = activity_service
+            .bulk_mutate_activities(ActivityBulkMutationRequest {
+                creates: vec![],
+                updates: vec![update],
+                delete_ids: vec![],
+            })
+            .await
+            .expect("bulk update should succeed");
+
+        assert!(result.errors.is_empty());
+        assert_eq!(result.updated.len(), 1);
+        assert_eq!(result.updated[0].subtype.as_deref(), Some("STAKING_REWARD"));
+        assert_eq!(result.updated[0].quantity, Some(dec!(1)));
+        assert_eq!(result.updated[0].unit_price, Some(dec!(100)));
+    }
+
+    #[tokio::test]
+    async fn test_bulk_update_clears_existing_subtype_when_explicitly_cleared() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        account_service.add_account(create_test_account("acc-1", "USD"));
+        asset_service.add_asset(create_test_asset_with_instrument(
+            "ETH",
+            "ETH",
+            None,
+            Some(InstrumentType::Crypto),
+            "USD",
+        ));
+
+        let mut existing = create_stored_activity("staking-1", "acc-1", Some("ETH"));
+        existing.activity_type = "INTEREST".to_string();
+        existing.subtype = Some("STAKING_REWARD".to_string());
+        existing.quantity = Some(dec!(1));
+        existing.unit_price = Some(dec!(100));
+        existing.amount = Some(dec!(100));
+        activity_repository.add_activity(existing);
+
+        let quote_service = Arc::new(MockQuoteService);
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            quote_service,
+        );
+
+        let mut update = create_test_activity_update(
+            "staking-1",
+            "acc-1",
+            Some(AssetResolutionInput {
+                id: Some("ETH".to_string()),
+                ..Default::default()
+            }),
+            "USD",
+        );
+        update.activity_type = "DIVIDEND".to_string();
+        update.subtype = Some(String::new());
+        update.quantity = None;
+        update.unit_price = None;
+        update.amount = Some(Some(dec!(100)));
+
+        let result = activity_service
+            .bulk_mutate_activities(ActivityBulkMutationRequest {
+                creates: vec![],
+                updates: vec![update],
+                delete_ids: vec![],
+            })
+            .await
+            .expect("bulk update should succeed");
+
+        assert!(result.errors.is_empty());
+        assert_eq!(result.updated.len(), 1);
+        assert_eq!(result.updated[0].activity_type, "DIVIDEND");
+        assert_eq!(result.updated[0].subtype, None);
+    }
+
+    #[tokio::test]
+    async fn test_bulk_update_preserves_provider_subtype_label_when_omitted() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        account_service.add_account(create_test_account("acc-1", "USD"));
+        asset_service.add_asset(create_test_asset_with_instrument(
+            "AAPL_OPT",
+            "AAPL251219C00200000",
+            None,
+            Some(InstrumentType::Option),
+            "USD",
+        ));
+
+        let mut existing = create_stored_activity("option-1", "acc-1", Some("AAPL_OPT"));
+        existing.activity_type = "BUY".to_string();
+        existing.subtype = Some("BUY_TO_OPEN".to_string());
+        activity_repository.add_activity(existing);
+
+        let quote_service = Arc::new(MockQuoteService);
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            quote_service,
+        );
+
+        let mut update = create_test_activity_update(
+            "option-1",
+            "acc-1",
+            Some(AssetResolutionInput {
+                id: Some("AAPL_OPT".to_string()),
+                ..Default::default()
+            }),
+            "USD",
+        );
+        update.activity_type = "BUY".to_string();
+        update.subtype = None;
+        update.quantity = None;
+        update.unit_price = None;
+        update.amount = None;
+
+        let result = activity_service
+            .bulk_mutate_activities(ActivityBulkMutationRequest {
+                creates: vec![],
+                updates: vec![update],
+                delete_ids: vec![],
+            })
+            .await
+            .expect("bulk update should succeed");
+
+        assert!(result.errors.is_empty());
+        assert_eq!(result.updated.len(), 1);
+        assert_eq!(result.updated[0].subtype.as_deref(), Some("BUY_TO_OPEN"));
+    }
+
+    #[tokio::test]
+    async fn test_bulk_update_rejects_asset_backed_subtype_without_quantity() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        account_service.add_account(create_test_account("acc-1", "USD"));
+        asset_service.add_asset(create_test_asset_with_instrument(
+            "ETH",
+            "ETH",
+            None,
+            Some(InstrumentType::Crypto),
+            "USD",
+        ));
+
+        let mut existing = create_stored_activity("interest-1", "acc-1", Some("ETH"));
+        existing.activity_type = "INTEREST".to_string();
+        existing.subtype = None;
+        existing.quantity = None;
+        existing.unit_price = None;
+        existing.amount = Some(dec!(25));
+        activity_repository.add_activity(existing);
+
+        let quote_service = Arc::new(MockQuoteService);
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            quote_service,
+        );
+
+        let mut update = create_test_activity_update(
+            "interest-1",
+            "acc-1",
+            Some(AssetResolutionInput {
+                id: Some("ETH".to_string()),
+                ..Default::default()
+            }),
+            "USD",
+        );
+        update.activity_type = "INTEREST".to_string();
+        update.subtype = Some("STAKING_REWARD".to_string());
+        update.quantity = None;
+        update.unit_price = Some(Some(dec!(100)));
+        update.amount = Some(Some(dec!(100)));
+
+        let result = activity_service
+            .bulk_mutate_activities(ActivityBulkMutationRequest {
+                creates: vec![],
+                updates: vec![update],
+                delete_ids: vec![],
+            })
+            .await
+            .expect("bulk mutation should return structured errors");
+
+        assert_eq!(result.updated.len(), 0);
+        assert_eq!(result.errors.len(), 1);
+        assert_eq!(result.errors[0].action, "update");
+        assert!(
+            result.errors[0]
+                .message
+                .contains("Asset-backed income activities require a positive quantity"),
+            "unexpected error: {}",
+            result.errors[0].message
+        );
+    }
+
     /// Test: When activity currency, asset currency, and account currency are all the same,
     /// no FX pair should be registered
     #[tokio::test]
@@ -1966,6 +2225,408 @@ mod tests {
             error.contains("Asset-backed activities need either asset_id or symbol"),
             "unexpected error: {error}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_create_canonicalizes_case_insensitive_subtype() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        account_service.add_account(create_test_account("acc-1", "USD"));
+        asset_service.add_asset(create_test_asset_with_instrument(
+            "ETH",
+            "ETH",
+            None,
+            Some(InstrumentType::Crypto),
+            "USD",
+        ));
+
+        let quote_service = Arc::new(MockQuoteService);
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            quote_service,
+        );
+
+        let activity = activity_service
+            .create_activity(NewActivity {
+                id: Some("staking-reward-lowercase".to_string()),
+                account_id: "acc-1".to_string(),
+                asset: Some(AssetResolutionInput {
+                    id: Some("ETH".to_string()),
+                    ..Default::default()
+                }),
+                activity_type: "INTEREST".to_string(),
+                subtype: Some("staking_reward".to_string()),
+                activity_date: "2024-01-15".to_string(),
+                quantity: Some(dec!(0.25)),
+                unit_price: Some(dec!(4000)),
+                currency: "USD".to_string(),
+                fee: Some(dec!(0)),
+                amount: Some(dec!(1000)),
+                status: None,
+                notes: None,
+                fx_rate: None,
+                metadata: None,
+                needs_review: None,
+                source_system: None,
+                source_record_id: None,
+                source_group_id: None,
+                idempotency_key: None,
+            })
+            .await
+            .expect("lowercase subtype should save");
+
+        assert_eq!(activity.subtype.as_deref(), Some("STAKING_REWARD"));
+    }
+
+    #[tokio::test]
+    async fn test_create_asset_backed_income_normalizes_negative_values_before_validation() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        account_service.add_account(create_test_account("acc-1", "USD"));
+        asset_service.add_asset(create_test_asset_with_instrument(
+            "ETH",
+            "ETH",
+            None,
+            Some(InstrumentType::Crypto),
+            "USD",
+        ));
+
+        let quote_service = Arc::new(MockQuoteService);
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            quote_service,
+        );
+
+        let activity = activity_service
+            .create_activity(NewActivity {
+                id: Some("staking-reward-negative".to_string()),
+                account_id: "acc-1".to_string(),
+                asset: Some(AssetResolutionInput {
+                    id: Some("ETH".to_string()),
+                    ..Default::default()
+                }),
+                activity_type: "INTEREST".to_string(),
+                subtype: Some("STAKING_REWARD".to_string()),
+                activity_date: "2024-01-15".to_string(),
+                quantity: Some(dec!(-0.25)),
+                unit_price: Some(dec!(-4000)),
+                currency: "USD".to_string(),
+                fee: Some(dec!(0)),
+                amount: Some(dec!(-1000)),
+                status: None,
+                notes: None,
+                fx_rate: None,
+                metadata: None,
+                needs_review: None,
+                source_system: None,
+                source_record_id: None,
+                source_group_id: None,
+                idempotency_key: None,
+            })
+            .await
+            .expect("negative provider-style signs should normalize before validation");
+
+        assert_eq!(activity.quantity, Some(dec!(0.25)));
+        assert_eq!(activity.unit_price, Some(dec!(4000)));
+        assert_eq!(activity.amount, Some(dec!(1000)));
+    }
+
+    #[tokio::test]
+    async fn test_sync_prepare_allows_provider_subtype_label() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let account = create_test_account("acc-1", "USD");
+        account_service.add_account(account.clone());
+        asset_service.add_asset(create_test_asset("AAPL_OPT", "USD"));
+
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            Arc::new(MockQuoteService),
+        );
+
+        let result = activity_service
+            .prepare_activities_for_sync(
+                vec![NewActivity {
+                    id: Some("option-buy".to_string()),
+                    account_id: "acc-1".to_string(),
+                    asset: Some(AssetResolutionInput {
+                        id: Some("AAPL_OPT".to_string()),
+                        ..Default::default()
+                    }),
+                    activity_type: "BUY".to_string(),
+                    subtype: Some("BUY_TO_OPEN".to_string()),
+                    activity_date: "2024-01-15".to_string(),
+                    quantity: Some(dec!(1)),
+                    unit_price: Some(dec!(100)),
+                    currency: "USD".to_string(),
+                    fee: Some(dec!(0)),
+                    amount: Some(dec!(100)),
+                    status: None,
+                    notes: None,
+                    fx_rate: None,
+                    metadata: None,
+                    needs_review: None,
+                    source_system: Some("SNAPTRADE".to_string()),
+                    source_record_id: Some("option-buy".to_string()),
+                    source_group_id: None,
+                    idempotency_key: None,
+                }],
+                &account,
+            )
+            .await
+            .expect("sync preparation should not reject provider subtype labels");
+
+        assert!(result.errors.is_empty());
+        assert_eq!(result.prepared.len(), 1);
+        assert_eq!(
+            result.prepared[0].activity.subtype.as_deref(),
+            Some("BUY_TO_OPEN")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sync_prepare_keeps_incomplete_valid_asset_backed_subtype_for_review() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let account = create_test_account("acc-1", "USD");
+        account_service.add_account(account.clone());
+
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            Arc::new(MockQuoteService),
+        );
+
+        let result = activity_service
+            .prepare_activities_for_sync(
+                vec![NewActivity {
+                    id: Some("staking-cash-only".to_string()),
+                    account_id: "acc-1".to_string(),
+                    asset: None,
+                    activity_type: "INTEREST".to_string(),
+                    subtype: Some("STAKING_REWARD".to_string()),
+                    activity_date: "2024-01-15".to_string(),
+                    quantity: None,
+                    unit_price: None,
+                    currency: "USD".to_string(),
+                    fee: Some(dec!(0)),
+                    amount: Some(dec!(25)),
+                    status: None,
+                    notes: None,
+                    fx_rate: None,
+                    metadata: None,
+                    needs_review: None,
+                    source_system: Some("SNAPTRADE".to_string()),
+                    source_record_id: Some("staking-cash-only".to_string()),
+                    source_group_id: None,
+                    idempotency_key: None,
+                }],
+                &account,
+            )
+            .await
+            .expect("sync preparation should keep broker rows for review");
+
+        assert!(result.errors.is_empty());
+        assert_eq!(result.prepared.len(), 1);
+        let prepared = &result.prepared[0].activity;
+        assert_eq!(prepared.activity_type, "INTEREST");
+        assert_eq!(prepared.subtype, None);
+        assert_eq!(prepared.amount, Some(dec!(25)));
+        assert_eq!(prepared.quantity, None);
+        assert_eq!(prepared.needs_review, Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_sync_prepare_keeps_unresolved_asset_backed_income_for_review() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let account = create_test_account("acc-1", "USD");
+        account_service.add_account(account.clone());
+
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            Arc::new(MockQuoteService),
+        );
+
+        let result = activity_service
+            .prepare_activities_for_sync(
+                vec![NewActivity {
+                    id: Some("staking-invalid-symbol".to_string()),
+                    account_id: "acc-1".to_string(),
+                    asset: Some(AssetResolutionInput {
+                        symbol: Some("$FOO".to_string()),
+                        ..Default::default()
+                    }),
+                    activity_type: "INTEREST".to_string(),
+                    subtype: Some("STAKING_REWARD".to_string()),
+                    activity_date: "2024-01-15".to_string(),
+                    quantity: Some(dec!(2)),
+                    unit_price: Some(dec!(12.50)),
+                    currency: "USD".to_string(),
+                    fee: Some(dec!(0)),
+                    amount: None,
+                    status: None,
+                    notes: None,
+                    fx_rate: None,
+                    metadata: None,
+                    needs_review: None,
+                    source_system: Some("SNAPTRADE".to_string()),
+                    source_record_id: Some("staking-invalid-symbol".to_string()),
+                    source_group_id: None,
+                    idempotency_key: None,
+                }],
+                &account,
+            )
+            .await
+            .expect("sync preparation should not drop unresolved broker rows");
+
+        assert!(result.errors.is_empty());
+        assert_eq!(result.prepared.len(), 1);
+        let prepared = &result.prepared[0];
+        assert_eq!(prepared.resolved_asset_id, None);
+        assert_eq!(prepared.activity.subtype, None);
+        assert_eq!(prepared.activity.amount, Some(dec!(25.00)));
+        assert_eq!(prepared.activity.needs_review, Some(true));
+    }
+
+    #[tokio::test]
+    async fn test_sync_prepare_keeps_mismatched_asset_backed_subtype_as_metadata() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let account = create_test_account("acc-1", "USD");
+        account_service.add_account(account.clone());
+
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            Arc::new(MockQuoteService),
+        );
+
+        let result = activity_service
+            .prepare_activities_for_sync(
+                vec![NewActivity {
+                    id: Some("interest-drip-label".to_string()),
+                    account_id: "acc-1".to_string(),
+                    asset: None,
+                    activity_type: "INTEREST".to_string(),
+                    subtype: Some("DRIP".to_string()),
+                    activity_date: "2024-01-15".to_string(),
+                    quantity: None,
+                    unit_price: None,
+                    currency: "USD".to_string(),
+                    fee: Some(dec!(0)),
+                    amount: Some(dec!(25)),
+                    status: None,
+                    notes: None,
+                    fx_rate: None,
+                    metadata: None,
+                    needs_review: None,
+                    source_system: Some("SNAPTRADE".to_string()),
+                    source_record_id: Some("interest-drip-label".to_string()),
+                    source_group_id: None,
+                    idempotency_key: None,
+                }],
+                &account,
+            )
+            .await
+            .expect("sync preparation should keep mismatched subtype as inert metadata");
+
+        assert!(result.errors.is_empty());
+        assert_eq!(result.prepared.len(), 1);
+        assert_eq!(result.prepared[0].activity.subtype.as_deref(), Some("DRIP"));
+        assert_eq!(result.prepared[0].activity.needs_review, None);
+        assert_eq!(result.prepared[0].activity.status, None);
+    }
+
+    #[tokio::test]
+    async fn test_sync_prepare_keeps_known_mismatched_subtype_as_metadata() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let account = create_test_account("acc-1", "USD");
+        account_service.add_account(account.clone());
+
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            Arc::new(MockQuoteService),
+        );
+
+        let result = activity_service
+            .prepare_activities_for_sync(
+                vec![NewActivity {
+                    id: Some("credit-staking-label".to_string()),
+                    account_id: "acc-1".to_string(),
+                    asset: None,
+                    activity_type: "CREDIT".to_string(),
+                    subtype: Some("STAKING_REWARD".to_string()),
+                    activity_date: "2024-01-15".to_string(),
+                    quantity: None,
+                    unit_price: None,
+                    currency: "USD".to_string(),
+                    fee: Some(dec!(0)),
+                    amount: Some(dec!(25)),
+                    status: None,
+                    notes: None,
+                    fx_rate: None,
+                    metadata: None,
+                    needs_review: None,
+                    source_system: Some("SNAPTRADE".to_string()),
+                    source_record_id: Some("credit-staking-label".to_string()),
+                    source_group_id: None,
+                    idempotency_key: None,
+                }],
+                &account,
+            )
+            .await
+            .expect("sync preparation should keep mismatched subtype as inert metadata");
+
+        assert!(result.errors.is_empty());
+        assert_eq!(result.prepared.len(), 1);
+        assert_eq!(
+            result.prepared[0].activity.subtype.as_deref(),
+            Some("STAKING_REWARD")
+        );
+        assert_eq!(result.prepared[0].activity.needs_review, None);
+        assert_eq!(result.prepared[0].activity.status, None);
     }
 
     #[tokio::test]
@@ -3914,6 +4575,129 @@ mod tests {
             .expect("expected import errors");
         assert!(errors.contains_key("quoteCcy"));
         assert!(errors.contains_key("instrumentType"));
+    }
+
+    #[tokio::test]
+    async fn test_import_keeps_mismatched_known_subtype_as_metadata() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let account = create_test_account("acc-1", "USD");
+        account_service.add_account(account);
+
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            Arc::new(MockQuoteService),
+        );
+
+        let mismatched_subtype = ActivityImport {
+            id: None,
+            date: "2024-01-15".to_string(),
+            symbol: "AAPL".to_string(),
+            activity_type: "DIVIDEND".to_string(),
+            quantity: Some(dec!(1)),
+            unit_price: Some(dec!(100)),
+            currency: "USD".to_string(),
+            fee: Some(dec!(0)),
+            amount: Some(dec!(100)),
+            comment: None,
+            account_id: Some("acc-1".to_string()),
+            account_name: None,
+            symbol_name: Some("Apple".to_string()),
+            exchange_mic: Some("XNAS".to_string()),
+            quote_ccy: Some("USD".to_string()),
+            instrument_type: Some("EQUITY".to_string()),
+            quote_mode: Some("MARKET".to_string()),
+            errors: None,
+            warnings: None,
+            duplicate_of_id: None,
+            duplicate_of_line_number: None,
+            is_draft: false,
+            is_valid: true,
+            line_number: Some(1),
+            fx_rate: None,
+            subtype: Some("STAKING_REWARD".to_string()),
+            asset_id: None,
+            isin: None,
+            force_import: false,
+        };
+
+        let result = activity_service
+            .import_activities(vec![mismatched_subtype])
+            .await
+            .expect("import should keep subtype labels as metadata");
+
+        assert!(result.summary.success);
+        assert_eq!(result.summary.imported, 1);
+        assert_eq!(
+            result.activities[0].subtype.as_deref(),
+            Some("STAKING_REWARD")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_import_allows_unknown_provider_subtype_label() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let account = create_test_account("acc-1", "USD");
+        account_service.add_account(account);
+
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            Arc::new(MockQuoteService),
+        );
+
+        let option_buy = ActivityImport {
+            id: None,
+            date: "2024-01-15".to_string(),
+            symbol: "AAPL251219C00200000".to_string(),
+            activity_type: "BUY".to_string(),
+            quantity: Some(dec!(1)),
+            unit_price: Some(dec!(5)),
+            currency: "USD".to_string(),
+            fee: Some(dec!(0)),
+            amount: Some(dec!(500)),
+            comment: None,
+            account_id: Some("acc-1".to_string()),
+            account_name: None,
+            symbol_name: Some("AAPL Dec 2025 200 Call".to_string()),
+            exchange_mic: None,
+            quote_ccy: Some("USD".to_string()),
+            instrument_type: Some("OPTION".to_string()),
+            quote_mode: Some("MARKET".to_string()),
+            errors: None,
+            warnings: None,
+            duplicate_of_id: None,
+            duplicate_of_line_number: None,
+            is_draft: false,
+            is_valid: true,
+            line_number: Some(1),
+            fx_rate: None,
+            subtype: Some("BUY_TO_OPEN".to_string()),
+            asset_id: None,
+            isin: None,
+            force_import: false,
+        };
+
+        let result = activity_service
+            .import_activities(vec![option_buy])
+            .await
+            .expect("import should accept provider subtype labels");
+
+        assert!(result.summary.success);
+        assert_eq!(result.summary.imported, 1);
+        assert_eq!(result.activities[0].subtype.as_deref(), Some("BUY_TO_OPEN"));
     }
 
     #[tokio::test]

--- a/crates/core/src/activities/compiler.rs
+++ b/crates/core/src/activities/compiler.rs
@@ -7,7 +7,7 @@
 //! - Stable calculator that only understands primitives
 
 use crate::activities::activities_constants::*;
-use crate::activities::Activity;
+use crate::activities::{Activity, NewActivity};
 use crate::Result;
 use rust_decimal::Decimal;
 
@@ -43,9 +43,9 @@ impl ActivityCompiler for DefaultActivityCompiler {
 
         // Use effective_type() to respect user overrides
         let activity_type = activity.effective_type();
-        let subtype = activity.subtype.as_deref();
+        let subtype = NewActivity::canonicalize_subtype(activity.subtype.as_deref());
 
-        match (activity_type, subtype) {
+        match (activity_type, subtype.as_deref()) {
             // DRIP: Dividend + Buy
             (ACTIVITY_TYPE_DIVIDEND, Some(ACTIVITY_SUBTYPE_DRIP)) => {
                 Ok(self.compile_drip(activity))
@@ -56,7 +56,7 @@ impl ActivityCompiler for DefaultActivityCompiler {
                 Ok(self.compile_staking_reward(activity))
             }
 
-            // Dividend in Kind: Dividend + Add Holding (different asset)
+            // Dividend in Kind: Dividend + Buy
             (ACTIVITY_TYPE_DIVIDEND, Some(ACTIVITY_SUBTYPE_DIVIDEND_IN_KIND)) => {
                 Ok(self.compile_dividend_in_kind(activity))
             }
@@ -87,31 +87,7 @@ impl DefaultActivityCompiler {
     ///
     /// Net cash effect: ~0 (dividend received = purchase cost)
     fn compile_drip(&self, activity: &Activity) -> Vec<Activity> {
-        // Leg 1: DIVIDEND (income recognition)
-        let mut dividend_leg = activity.clone();
-        dividend_leg.id = format!("{}:dividend", activity.id);
-        dividend_leg.subtype = None; // Clear subtype for calculator
-        dividend_leg.quantity = None;
-        dividend_leg.unit_price = None;
-        // if amount is missing, derive from qty * unit_price
-        // if provided, amount stays as-is for income tracking
-        if dividend_leg.amount.is_none() {
-            let qty = activity.quantity.unwrap_or(Decimal::ZERO);
-            let price = activity.unit_price.unwrap_or(Decimal::ZERO);
-            dividend_leg.amount = Some(qty * price);
-        }
-
-        // Leg 2: BUY (share acquisition)
-        let mut buy_leg = activity.clone();
-        buy_leg.id = format!("{}:buy", activity.id);
-        buy_leg.activity_type = ACTIVITY_TYPE_BUY.to_string();
-        buy_leg.activity_type_override = None;
-        buy_leg.subtype = None;
-        // quantity and unit_price stay as-is
-        buy_leg.amount = None; // BUY computes from qty * price
-        buy_leg.fee = Some(Decimal::ZERO); // Fee already in dividend leg
-
-        vec![dividend_leg, buy_leg]
+        self.compile_asset_income(activity, ACTIVITY_TYPE_DIVIDEND, "dividend")
     }
 
     /// Staking Reward: One stored row → INTEREST + BUY
@@ -129,66 +105,69 @@ impl DefaultActivityCompiler {
     ///
     /// Net cash effect: 0
     fn compile_staking_reward(&self, activity: &Activity) -> Vec<Activity> {
-        // Leg 1: INTEREST (income recognition)
-        let mut interest_leg = activity.clone();
-        interest_leg.id = format!("{}:interest", activity.id);
-        interest_leg.subtype = None;
-        interest_leg.quantity = None;
-        interest_leg.unit_price = None;
-        // amount stays for income tracking
-
-        // Leg 2: BUY (token acquisition)
-        let mut buy_leg = activity.clone();
-        buy_leg.id = format!("{}:buy", activity.id);
-        buy_leg.activity_type = ACTIVITY_TYPE_BUY.to_string();
-        buy_leg.activity_type_override = None;
-        buy_leg.subtype = None;
-        buy_leg.amount = None;
-        buy_leg.fee = Some(Decimal::ZERO);
-
-        vec![interest_leg, buy_leg]
+        self.compile_asset_income(activity, ACTIVITY_TYPE_INTEREST, "interest")
     }
 
-    /// Dividend in Kind: Stock dividend where you receive a different asset
+    /// Dividend in Kind: asset dividend where you receive additional units of the same asset
     ///
     /// Stored:
     ///   activity_type = DIVIDEND, subtype = DIVIDEND_IN_KIND
-    ///   asset_id = the asset that pays the dividend
-    ///   metadata.received_asset_id = the asset received
-    ///   quantity = shares received of the different asset
+    ///   asset_id = the asset that pays the dividend and is received
+    ///   quantity = shares received
     ///   unit_price = FMV at receipt
     ///   amount = value of shares received
     ///
     /// Compiled:
     ///   1. DIVIDEND: income recognition
-    ///   2. TRANSFER_IN (internal): receive different asset (cost basis from FMV, no portfolio-boundary contribution)
+    ///   2. BUY: share acquisition at FMV
     fn compile_dividend_in_kind(&self, activity: &Activity) -> Vec<Activity> {
-        // Get the received asset ID from metadata
-        let received_asset_id = activity
-            .get_meta::<String>("received_asset_id")
-            .or_else(|| activity.asset_id.clone());
+        self.compile_asset_income(activity, ACTIVITY_TYPE_DIVIDEND, "dividend")
+    }
 
-        // Leg 1: DIVIDEND (income recognition from the paying asset)
-        let mut dividend_leg = activity.clone();
-        dividend_leg.id = format!("{}:dividend", activity.id);
-        dividend_leg.subtype = None;
-        dividend_leg.quantity = None;
-        dividend_leg.unit_price = None;
+    fn compile_asset_income(
+        &self,
+        activity: &Activity,
+        income_activity_type: &str,
+        income_id_suffix: &str,
+    ) -> Vec<Activity> {
+        let quantity = activity.quantity.unwrap_or(Decimal::ZERO);
+        let derived_amount = activity.unit_price.map(|unit_price| quantity * unit_price);
+        let income_amount = activity
+            .amount
+            .filter(|amount| !amount.is_zero())
+            .or(derived_amount)
+            .or(activity.amount);
+        let acquisition_unit_price = income_amount
+            .and_then(|amount| {
+                if quantity.is_zero() {
+                    None
+                } else {
+                    Some(amount / quantity)
+                }
+            })
+            .or(activity.unit_price);
 
-        // Leg 2: TRANSFER_IN (receive the different asset)
-        let mut transfer_in_leg = activity.clone();
-        transfer_in_leg.id = format!("{}:transfer_in", activity.id);
-        transfer_in_leg.activity_type = ACTIVITY_TYPE_TRANSFER_IN.to_string();
-        transfer_in_leg.activity_type_override = None;
-        transfer_in_leg.subtype = None;
-        transfer_in_leg.asset_id = received_asset_id;
-        // quantity and unit_price define the cost basis
-        transfer_in_leg.amount = None;
-        transfer_in_leg.fee = Some(Decimal::ZERO);
-        // Strip metadata from the generated leg: dividend-in-kind is income, not a portfolio-boundary contribution.
-        transfer_in_leg.metadata = None;
+        // Leg 1: income recognition
+        let mut income_leg = activity.clone();
+        income_leg.id = format!("{}:{}", activity.id, income_id_suffix);
+        income_leg.activity_type = income_activity_type.to_string();
+        income_leg.activity_type_override = None;
+        income_leg.subtype = None;
+        income_leg.quantity = None;
+        income_leg.unit_price = None;
+        income_leg.amount = income_amount;
 
-        vec![dividend_leg, transfer_in_leg]
+        // Leg 2: BUY (asset acquisition at recognized income value)
+        let mut buy_leg = activity.clone();
+        buy_leg.id = format!("{}:buy", activity.id);
+        buy_leg.activity_type = ACTIVITY_TYPE_BUY.to_string();
+        buy_leg.activity_type_override = None;
+        buy_leg.subtype = None;
+        buy_leg.unit_price = acquisition_unit_price;
+        buy_leg.amount = None;
+        buy_leg.fee = Some(Decimal::ZERO);
+
+        vec![income_leg, buy_leg]
     }
 }
 
@@ -417,18 +396,91 @@ mod tests {
     }
 
     #[test]
+    fn test_compile_staking_reward_derives_amount_when_missing() {
+        let compiler = DefaultActivityCompiler::new();
+        let mut activity = create_test_activity();
+        activity.activity_type = ACTIVITY_TYPE_INTEREST.to_string();
+        activity.subtype = Some(ACTIVITY_SUBTYPE_STAKING_REWARD.to_string());
+        activity.asset_id = Some("ETH".to_string());
+        activity.quantity = Some(dec!(0.01));
+        activity.unit_price = Some(dec!(2000));
+        activity.amount = None;
+
+        let result = compiler.compile(&activity).unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].activity_type, ACTIVITY_TYPE_INTEREST);
+        assert_eq!(result[0].amount, Some(dec!(20)));
+        assert_eq!(result[1].activity_type, ACTIVITY_TYPE_BUY);
+        assert_eq!(result[1].quantity, Some(dec!(0.01)));
+        assert_eq!(result[1].unit_price, Some(dec!(2000)));
+        assert!(result[1].amount.is_none());
+    }
+
+    #[test]
+    fn test_compile_asset_backed_income_accepts_case_insensitive_subtype() {
+        let compiler = DefaultActivityCompiler::new();
+        let mut activity = create_test_activity();
+        activity.activity_type = ACTIVITY_TYPE_INTEREST.to_string();
+        activity.subtype = Some("staking_reward".to_string());
+        activity.asset_id = Some("ETH".to_string());
+        activity.quantity = Some(dec!(0.01));
+        activity.unit_price = Some(dec!(2000));
+        activity.amount = None;
+
+        let result = compiler.compile(&activity).unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].activity_type, ACTIVITY_TYPE_INTEREST);
+        assert_eq!(result[1].activity_type, ACTIVITY_TYPE_BUY);
+    }
+
+    #[test]
+    fn test_compile_staking_reward_derives_amount_when_explicit_amount_is_zero() {
+        let compiler = DefaultActivityCompiler::new();
+        let mut activity = create_test_activity();
+        activity.activity_type = ACTIVITY_TYPE_INTEREST.to_string();
+        activity.subtype = Some(ACTIVITY_SUBTYPE_STAKING_REWARD.to_string());
+        activity.asset_id = Some("ETH".to_string());
+        activity.quantity = Some(dec!(0.01));
+        activity.unit_price = Some(dec!(2000));
+        activity.amount = Some(dec!(0));
+
+        let result = compiler.compile(&activity).unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].amount, Some(dec!(20)));
+        assert_eq!(result[1].unit_price, Some(dec!(2000)));
+    }
+
+    #[test]
+    fn test_compile_staking_reward_derives_unit_price_when_missing() {
+        let compiler = DefaultActivityCompiler::new();
+        let mut activity = create_test_activity();
+        activity.activity_type = ACTIVITY_TYPE_INTEREST.to_string();
+        activity.subtype = Some(ACTIVITY_SUBTYPE_STAKING_REWARD.to_string());
+        activity.asset_id = Some("ETH".to_string());
+        activity.quantity = Some(dec!(0.01));
+        activity.unit_price = None;
+        activity.amount = Some(dec!(20));
+
+        let result = compiler.compile(&activity).unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].amount, Some(dec!(20)));
+        assert_eq!(result[1].unit_price, Some(dec!(2000)));
+    }
+
+    #[test]
     fn test_compile_dividend_in_kind_produces_two_legs() {
         let compiler = DefaultActivityCompiler::new();
         let mut activity = create_test_activity();
         activity.activity_type = ACTIVITY_TYPE_DIVIDEND.to_string();
         activity.subtype = Some(ACTIVITY_SUBTYPE_DIVIDEND_IN_KIND.to_string());
-        activity.asset_id = Some("PARENT_CO".to_string());
-        activity.quantity = Some(dec!(10)); // shares of spinoff received
+        activity.asset_id = Some("AAPL".to_string());
+        activity.quantity = Some(dec!(10)); // shares received
         activity.unit_price = Some(dec!(25)); // FMV at receipt
         activity.amount = Some(dec!(250)); // Value
-        activity.metadata = Some(serde_json::json!({
-            "received_asset_id": "SPINOFF_CO"
-        }));
 
         let result = compiler.compile(&activity).unwrap();
 
@@ -438,34 +490,36 @@ mod tests {
         assert_eq!(result[0].id, "test-1:dividend");
         assert_eq!(result[0].activity_type, ACTIVITY_TYPE_DIVIDEND);
         assert!(result[0].subtype.is_none());
-        assert_eq!(result[0].asset_id, Some("PARENT_CO".to_string()));
+        assert_eq!(result[0].asset_id, Some("AAPL".to_string()));
         assert_eq!(result[0].amount, Some(dec!(250)));
 
-        // Second leg: TRANSFER_IN (internal)
-        assert_eq!(result[1].id, "test-1:transfer_in");
-        assert_eq!(result[1].activity_type, ACTIVITY_TYPE_TRANSFER_IN);
+        // Second leg: BUY
+        assert_eq!(result[1].id, "test-1:buy");
+        assert_eq!(result[1].activity_type, ACTIVITY_TYPE_BUY);
         assert!(result[1].subtype.is_none());
-        assert_eq!(result[1].asset_id, Some("SPINOFF_CO".to_string()));
+        assert_eq!(result[1].asset_id, Some("AAPL".to_string()));
         assert_eq!(result[1].quantity, Some(dec!(10)));
         assert_eq!(result[1].unit_price, Some(dec!(25)));
         assert!(result[1].amount.is_none());
-        assert!(result[1].metadata.is_none());
     }
 
     #[test]
-    fn test_compile_dividend_in_kind_fallback_to_same_asset() {
+    fn test_compile_dividend_in_kind_derives_amount_when_missing() {
         let compiler = DefaultActivityCompiler::new();
         let mut activity = create_test_activity();
         activity.activity_type = ACTIVITY_TYPE_DIVIDEND.to_string();
         activity.subtype = Some(ACTIVITY_SUBTYPE_DIVIDEND_IN_KIND.to_string());
         activity.asset_id = Some("AAPL".to_string());
-        // No metadata with received_asset_id
+        activity.quantity = Some(dec!(4));
+        activity.unit_price = Some(dec!(12.50));
+        activity.amount = None;
 
         let result = compiler.compile(&activity).unwrap();
 
         assert_eq!(result.len(), 2);
-        // TRANSFER_IN should fall back to the original asset_id
+        assert_eq!(result[0].amount, Some(dec!(50.00)));
         assert_eq!(result[1].asset_id, Some("AAPL".to_string()));
+        assert_eq!(result[1].unit_price, Some(dec!(12.50)));
     }
 
     #[test]

--- a/crates/core/src/portfolio/performance/flow_classifier.rs
+++ b/crates/core/src/portfolio/performance/flow_classifier.rs
@@ -62,7 +62,9 @@ pub fn classify_flow_for_scope(activity: &Activity, scope: PerformanceScope) -> 
     if effective_type == ACTIVITY_TYPE_CREDIT {
         return match activity.subtype.as_deref() {
             // BONUS is external (new money entering portfolio)
-            Some(ACTIVITY_SUBTYPE_BONUS) => FlowType::External,
+            Some(subtype) if subtype.eq_ignore_ascii_case(ACTIVITY_SUBTYPE_BONUS) => {
+                FlowType::External
+            }
             // REBATE, REFUND, and other subtypes are internal
             // (corrections/refunds of existing transactions, not new money)
             _ => FlowType::Internal,
@@ -168,6 +170,13 @@ mod tests {
     fn test_credit_bonus_is_external() {
         let mut activity = create_test_activity("CREDIT");
         activity.subtype = Some("BONUS".to_string());
+        assert_eq!(classify_flow(&activity), FlowType::External);
+    }
+
+    #[test]
+    fn test_credit_bonus_subtype_is_case_insensitive() {
+        let mut activity = create_test_activity("CREDIT");
+        activity.subtype = Some("bonus".to_string());
         assert_eq!(classify_flow(&activity), FlowType::External);
     }
 

--- a/crates/core/src/portfolio/snapshot/holdings_calculator.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator.rs
@@ -839,7 +839,7 @@ impl HoldingsCalculator {
         use crate::activities::ACTIVITY_SUBTYPE_OPTION_EXPIRY;
 
         match activity.subtype.as_deref() {
-            Some(ACTIVITY_SUBTYPE_OPTION_EXPIRY) => {
+            Some(subtype) if subtype.eq_ignore_ascii_case(ACTIVITY_SUBTYPE_OPTION_EXPIRY) => {
                 let asset_id = activity.asset_id.as_deref().unwrap_or("");
                 if let Some(position) = state.positions.get_mut(asset_id) {
                     let qty = activity.qty();

--- a/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
@@ -1,7 +1,9 @@
 // Test cases for HoldingsCalculator will go here.
 #[cfg(test)]
 mod tests {
-    use crate::activities::{Activity, ActivityStatus, ActivityType};
+    use crate::activities::{
+        Activity, ActivityCompiler, ActivityStatus, ActivityType, DefaultActivityCompiler,
+    };
     use crate::assets::{
         Asset, AssetKind, AssetRepositoryTrait, InstrumentType, NewAsset, QuoteMode,
         UpdateAssetProfile,
@@ -583,6 +585,93 @@ mod tests {
 
         assert_eq!(next_state.cost_basis, dec!(1505));
         assert_eq!(next_state.net_contribution, dec!(0));
+    }
+
+    #[test]
+    fn test_dividend_in_kind_compiles_to_zero_cash_and_no_contribution() {
+        let mock_fx_service = MockFxService::new();
+        let account_currency = "USD";
+        let base_currency = Arc::new(RwLock::new(account_currency.to_string()));
+        let calculator = create_calculator(Arc::new(mock_fx_service), base_currency);
+
+        let target_date_str = "2023-01-01";
+        let target_date = NaiveDate::from_str(target_date_str).unwrap();
+        let previous_snapshot = create_initial_snapshot("acc_1", account_currency, "2022-12-31");
+
+        let mut dividend_in_kind = create_default_activity(
+            "div-in-kind-1",
+            ActivityType::Dividend,
+            "AAPL",
+            dec!(10),
+            dec!(25),
+            dec!(0),
+            account_currency,
+            target_date_str,
+        );
+        dividend_in_kind.subtype = Some("DIVIDEND_IN_KIND".to_string());
+        dividend_in_kind.amount = None;
+
+        let compiler = DefaultActivityCompiler::new();
+        let activities_today = compiler.compile(&dividend_in_kind).unwrap();
+
+        let result =
+            calculator.calculate_next_holdings(&previous_snapshot, &activities_today, target_date);
+        assert!(result.is_ok());
+        let next_state = result.unwrap().snapshot;
+
+        let position = next_state.positions.get("AAPL").unwrap();
+        assert_eq!(position.quantity, dec!(10));
+        assert_eq!(position.total_cost_basis, dec!(250));
+        assert_eq!(
+            next_state.cash_balances.get(account_currency),
+            Some(&dec!(0))
+        );
+        assert_eq!(next_state.net_contribution, dec!(0));
+        assert_eq!(next_state.net_contribution_base, dec!(0));
+    }
+
+    #[test]
+    fn test_staking_reward_compiles_to_fmv_cost_basis_without_cash_or_contribution() {
+        let mock_fx_service = MockFxService::new();
+        let account_currency = "USD";
+        let base_currency = Arc::new(RwLock::new(account_currency.to_string()));
+        let calculator = create_calculator(Arc::new(mock_fx_service), base_currency);
+
+        let target_date_str = "2026-05-05";
+        let target_date = NaiveDate::from_str(target_date_str).unwrap();
+        let previous_snapshot = create_initial_snapshot("acc_1", account_currency, "2026-05-04");
+
+        let mut staking_reward = create_default_activity(
+            "staking-reward-1",
+            ActivityType::Interest,
+            "SOL",
+            dec!(0.01),
+            dec!(200),
+            dec!(0),
+            account_currency,
+            target_date_str,
+        );
+        staking_reward.subtype = Some("STAKING_REWARD".to_string());
+        staking_reward.amount = None;
+
+        let compiler = DefaultActivityCompiler::new();
+        let activities_today = compiler.compile(&staking_reward).unwrap();
+
+        let result =
+            calculator.calculate_next_holdings(&previous_snapshot, &activities_today, target_date);
+        assert!(result.is_ok());
+        let next_state = result.unwrap().snapshot;
+
+        let position = next_state.positions.get("SOL").unwrap();
+        assert_eq!(position.quantity, dec!(0.01));
+        assert_eq!(position.average_cost, dec!(200));
+        assert_eq!(position.total_cost_basis, dec!(2));
+        assert_eq!(
+            next_state.cash_balances.get(account_currency),
+            Some(&dec!(0))
+        );
+        assert_eq!(next_state.net_contribution, dec!(0));
+        assert_eq!(next_state.net_contribution_base, dec!(0));
     }
 
     #[test]

--- a/crates/core/src/portfolio/snapshot/snapshot_service.rs
+++ b/crates/core/src/portfolio/snapshot/snapshot_service.rs
@@ -618,6 +618,27 @@ impl SnapshotService {
                 }
             }
 
+            if initial_snapshot_for_acc.is_some() {
+                if let (Some(min_activity_date), Some(split_date)) = (
+                    min_activity_date_for_account,
+                    Self::first_split_date_in_range(
+                        activities_by_account_date,
+                        acc_id,
+                        effective_start_date,
+                        calculation_end_date,
+                    ),
+                ) {
+                    if min_activity_date < effective_start_date {
+                        debug!(
+                            "Account {} has split activity on {} inside recalculation window. Restarting from earliest activity {} so historical lots are split-adjusted.",
+                            acc_id, split_date, min_activity_date
+                        );
+                        effective_start_date = min_activity_date;
+                        initial_snapshot_for_acc = None;
+                    }
+                }
+            }
+
             if effective_start_date <= calculation_end_date {
                 if let Some(snapshot) = initial_snapshot_for_acc {
                     start_keyframes.insert(acc_id.clone(), snapshot);
@@ -659,6 +680,29 @@ impl SnapshotService {
             effective_start_dates,
             overall_min_calc_date,
         ))
+    }
+
+    fn first_split_date_in_range(
+        activities_by_account_date: &ActivitiesByAccount,
+        account_id: &str,
+        start_date: NaiveDate,
+        end_date: NaiveDate,
+    ) -> Option<NaiveDate> {
+        use crate::activities::ACTIVITY_TYPE_SPLIT;
+
+        if start_date > end_date {
+            return None;
+        }
+
+        activities_by_account_date
+            .get(account_id)?
+            .range(start_date..=end_date)
+            .find_map(|(date, activities)| {
+                activities
+                    .iter()
+                    .any(|activity| activity.activity_type == ACTIVITY_TYPE_SPLIT)
+                    .then_some(*date)
+            })
     }
 
     // --- Step 7: Calculate daily holdings snapshots (in memory) and identify keyframes ---

--- a/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
+++ b/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
@@ -2599,6 +2599,121 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_split_added_after_snapshots_restarts_from_earliest_activity() {
+        let base = Arc::new(RwLock::new("USD".to_string()));
+
+        let mut account_repo = MockAccountRepository::new();
+        let acc = create_test_account("acc1", "USD", "Test Account");
+        account_repo.add_account(acc.clone());
+        let account_repo = Arc::new(account_repo);
+
+        let d1 = NaiveDate::from_ymd_opt(2025, 1, 10).unwrap();
+        let split_date = NaiveDate::from_ymd_opt(2025, 4, 29).unwrap();
+
+        let deposit = create_test_activity(
+            "dep1",
+            &acc.id,
+            Some("CASH:USD"),
+            "DEPOSIT",
+            d1,
+            None,
+            None,
+            Some(dec!(10000)),
+            "USD",
+        );
+
+        let buy = create_test_activity(
+            "buy1",
+            &acc.id,
+            Some("HDV"),
+            "BUY",
+            d1,
+            Some(dec!(10)),
+            Some(dec!(100)),
+            Some(dec!(1000)),
+            "USD",
+        );
+
+        let split = create_test_activity(
+            "split1",
+            &acc.id,
+            Some("HDV"),
+            "SPLIT",
+            split_date,
+            None,
+            None,
+            Some(dec!(5)),
+            "USD",
+        );
+
+        let fx = Arc::new(MockFxService::new());
+        let snapshot_repo = Arc::new(MockSnapshotRepository::new());
+        let asset_repo = Arc::new(MockAssetRepository::new());
+
+        let initial_activity_repo = Arc::new(MockActivityRepositoryWithData::new(vec![
+            deposit.clone(),
+            buy.clone(),
+        ]));
+        let initial_svc = SnapshotService::new(
+            base.clone(),
+            account_repo.clone(),
+            initial_activity_repo,
+            snapshot_repo.clone(),
+            asset_repo.clone(),
+            fx.clone(),
+        );
+
+        initial_svc
+            .recalculate_holdings_snapshots(
+                Some(std::slice::from_ref(&acc.id)),
+                SnapshotRecalcMode::Full,
+            )
+            .await
+            .unwrap();
+
+        let seeded = snapshot_repo
+            .get_latest_snapshot_before_date(&acc.id, split_date.pred_opt().unwrap())
+            .unwrap()
+            .unwrap();
+        assert_eq!(seeded.positions.get("HDV").unwrap().quantity, dec!(10));
+
+        let split_activity_repo = Arc::new(MockActivityRepositoryWithData::new(vec![
+            deposit, buy, split,
+        ]));
+        let split_svc = SnapshotService::new(
+            base,
+            account_repo,
+            split_activity_repo,
+            snapshot_repo.clone(),
+            asset_repo,
+            fx,
+        );
+
+        split_svc
+            .recalculate_holdings_snapshots(
+                Some(std::slice::from_ref(&acc.id)),
+                SnapshotRecalcMode::SinceDate(split_date),
+            )
+            .await
+            .unwrap();
+
+        let split_frame = snapshot_repo
+            .get_snapshots_by_account(&acc.id, Some(split_date), Some(split_date))
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
+        let pos = split_frame.positions.get("HDV").unwrap();
+        assert_eq!(
+            pos.quantity,
+            dec!(50),
+            "Backdated split recalc should not seed from pre-split snapshots"
+        );
+        assert_eq!(pos.total_cost_basis, dec!(1000));
+        assert_eq!(pos.average_cost, dec!(20));
+    }
+
+    #[tokio::test]
     async fn test_split_multi_account_no_double_counting() {
         // Regression: when the same asset is held in multiple accounts, sync_splits inserts
         // one SPLIT activity per account. calculate_split_factors must deduplicate by date so

--- a/crates/storage-sqlite/src/activities/model.rs
+++ b/crates/storage-sqlite/src/activities/model.rs
@@ -10,6 +10,10 @@ use wealthfolio_core::activities::{
     Activity, ActivityStatus, ActivityUpdate, ActivityUpsert, NewActivity,
 };
 
+fn normalize_subtype_for_storage(subtype: Option<String>) -> Option<String> {
+    NewActivity::canonicalize_subtype(subtype.as_deref())
+}
+
 /// Helper function to parse a string into a Decimal,
 /// with a fallback for scientific notation by parsing as f64 first.
 fn parse_decimal_string_tolerant(value_str: &str, field_name: &str) -> Decimal {
@@ -56,6 +60,7 @@ pub struct ActivityDB {
     pub activity_type: String,
     pub activity_type_override: Option<String>,
     pub source_type: Option<String>,
+    #[diesel(treat_none_as_null = true)]
     pub subtype: Option<String>,
     pub status: String,
 
@@ -524,7 +529,7 @@ impl From<NewActivity> for ActivityDB {
             activity_type: domain.activity_type,
             activity_type_override: None,
             source_type: None,
-            subtype: domain.subtype,
+            subtype: normalize_subtype_for_storage(domain.subtype),
             status,
 
             // Timing
@@ -602,6 +607,7 @@ impl From<ActivityUpdate> for ActivityDB {
 
         // Extract asset_id before consuming domain fields
         let asset_id = domain.get_symbol_id().map(|s| s.to_string());
+        let subtype = normalize_subtype_for_storage(domain.subtype);
 
         Self {
             id: domain.id,
@@ -612,7 +618,7 @@ impl From<ActivityUpdate> for ActivityDB {
             activity_type: domain.activity_type,
             activity_type_override: None,
             source_type: None,
-            subtype: domain.subtype,
+            subtype,
             status,
 
             // Timing
@@ -698,7 +704,7 @@ impl From<ActivityUpsert> for ActivityDB {
             activity_type: domain.activity_type,
             activity_type_override: None,
             source_type: None,
-            subtype: domain.subtype,
+            subtype: normalize_subtype_for_storage(domain.subtype),
             status,
 
             // Timing

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -333,6 +333,7 @@ impl ActivityRepositoryTrait for ActivityRepository {
         self.writer
             .exec_tx(move |tx| -> Result<Activity> {
                 let mut activity_to_update = activity_db_owned;
+                let subtype_patch = activity_update_owned.subtype.clone();
                 let existing = activities::table
                     .select(ActivityDB::as_select())
                     .find(&activity_id_owned)
@@ -393,9 +394,11 @@ impl ActivityRepositoryTrait for ActivityRepository {
                 if activity_to_update.source_type.is_none() {
                     activity_to_update.source_type = source_type;
                 }
-                if activity_to_update.subtype.is_none() {
-                    activity_to_update.subtype = subtype;
-                }
+                activity_to_update.subtype = match subtype_patch {
+                    Some(value) if value.trim().is_empty() => None,
+                    Some(value) => Some(value),
+                    None => subtype,
+                };
                 if activity_to_update.settlement_date.is_none() {
                     activity_to_update.settlement_date = settlement_date;
                 }
@@ -638,6 +641,7 @@ impl ActivityRepositoryTrait for ActivityRepository {
                 for update in updates {
                     update.validate()?;
                     let update_owned = update.clone();
+                    let subtype_patch = update_owned.subtype.clone();
                     let mut activity_db: ActivityDB = update.into();
                     let existing = activities::table
                         .select(ActivityDB::as_select())
@@ -694,9 +698,11 @@ impl ActivityRepositoryTrait for ActivityRepository {
                     if activity_db.source_type.is_none() {
                         activity_db.source_type = source_type;
                     }
-                    if activity_db.subtype.is_none() {
-                        activity_db.subtype = subtype;
-                    }
+                    activity_db.subtype = match subtype_patch {
+                        Some(value) if value.trim().is_empty() => None,
+                        Some(value) => Some(value),
+                        None => subtype,
+                    };
                     if activity_db.settlement_date.is_none() {
                         activity_db.settlement_date = settlement_date;
                     }
@@ -1322,7 +1328,7 @@ impl ActivityRepositoryTrait for ActivityRepository {
 
         // For income reporting, we need to handle different subtypes:
         // - Regular DIVIDEND/INTEREST: use the `amount` field directly
-        // - STAKING_REWARD/DRIP/DIVIDEND_IN_KIND subtypes: if amount is 0, calculate from:
+        // - Valid asset-backed income pairs: if amount is 0, calculate from:
         //   1. quantity * unit_price (if unit_price is available)
         //   2. quantity * market_price from quotes table (fallback)
         let account_filter = match account_id {
@@ -1341,7 +1347,10 @@ impl ActivityRepositoryTrait for ActivityRepository {
              a.account_id,
              acc.name as account_name,
              CASE
-                 WHEN a.subtype IN ('STAKING_REWARD', 'DRIP', 'DIVIDEND_IN_KIND')
+                 WHEN (
+                       (a.activity_type = 'INTEREST' AND UPPER(a.subtype) = 'STAKING_REWARD')
+                       OR (a.activity_type = 'DIVIDEND' AND UPPER(a.subtype) IN ('DRIP', 'DIVIDEND_IN_KIND'))
+                      )
                       AND (a.amount IS NULL OR CAST(a.amount AS REAL) = 0)
                  THEN CASE
                      WHEN a.unit_price IS NOT NULL AND CAST(a.unit_price AS REAL) > 0
@@ -2008,6 +2017,50 @@ mod tests {
             .expect("insert transfer activity");
     }
 
+    fn insert_activity_with_subtype(
+        conn: &mut SqliteConnection,
+        id: &str,
+        account_id: &str,
+        activity_type: &str,
+        asset_id: Option<&str>,
+        subtype: Option<&str>,
+    ) {
+        let activity = ActivityDB {
+            id: id.to_string(),
+            account_id: account_id.to_string(),
+            asset_id: asset_id.map(str::to_string),
+            activity_type: activity_type.to_string(),
+            activity_type_override: None,
+            source_type: None,
+            subtype: subtype.map(str::to_string),
+            status: "POSTED".to_string(),
+            activity_date: "2024-01-15T00:00:00+00:00".to_string(),
+            settlement_date: None,
+            quantity: Some("1".to_string()),
+            unit_price: Some("100".to_string()),
+            amount: Some("100".to_string()),
+            fee: Some("0".to_string()),
+            currency: "USD".to_string(),
+            fx_rate: None,
+            notes: None,
+            metadata: None,
+            source_system: Some("MANUAL".to_string()),
+            source_record_id: None,
+            source_group_id: None,
+            idempotency_key: Some(format!("{id}-idempotency")),
+            import_run_id: None,
+            is_user_modified: 0,
+            needs_review: 0,
+            created_at: "2024-01-15T00:00:00+00:00".to_string(),
+            updated_at: "2024-01-15T00:00:00+00:00".to_string(),
+        };
+
+        diesel::insert_into(activities::table)
+            .values(&activity)
+            .execute(conn)
+            .expect("insert activity with subtype");
+    }
+
     fn activity_metadata(conn: &mut SqliteConnection, id: &str) -> serde_json::Value {
         let metadata: Option<String> = activities::table
             .filter(activities::id.eq(id))
@@ -2024,6 +2077,93 @@ mod tests {
             .select(activities::is_user_modified)
             .first(conn)
             .expect("activity is_user_modified")
+    }
+
+    #[tokio::test]
+    async fn update_activity_empty_subtype_clears_existing_subtype() {
+        let (pool, writer) = setup_db();
+        let repo = ActivityRepository::new(pool.clone(), writer);
+        let mut conn = get_connection(&pool).expect("conn");
+
+        insert_account(&mut conn, "acc-subtype");
+        insert_activity_with_subtype(
+            &mut conn,
+            "activity-subtype",
+            "acc-subtype",
+            "DIVIDEND",
+            None,
+            Some("DRIP"),
+        );
+
+        let updated = repo
+            .update_activity(ActivityUpdate {
+                id: "activity-subtype".to_string(),
+                account_id: "acc-subtype".to_string(),
+                asset: None,
+                activity_type: "DIVIDEND".to_string(),
+                subtype: Some(String::new()),
+                activity_date: "2024-01-15".to_string(),
+                quantity: None,
+                unit_price: None,
+                currency: "USD".to_string(),
+                fee: None,
+                amount: None,
+                status: None,
+                notes: None,
+                fx_rate: None,
+                metadata: None,
+            })
+            .await
+            .expect("update activity");
+
+        assert_eq!(updated.subtype, None);
+    }
+
+    #[tokio::test]
+    async fn income_report_derives_asset_backed_amount_only_for_valid_type_subtype_pair() {
+        let (pool, writer) = setup_db();
+        let repo = ActivityRepository::new(pool.clone(), writer);
+        let mut conn = get_connection(&pool).expect("conn");
+
+        insert_account(&mut conn, "acc-income");
+        insert_activity_with_subtype(
+            &mut conn,
+            "valid-staking",
+            "acc-income",
+            "INTEREST",
+            None,
+            Some("STAKING_REWARD"),
+        );
+        insert_activity_with_subtype(
+            &mut conn,
+            "metadata-only",
+            "acc-income",
+            "DIVIDEND",
+            None,
+            Some("STAKING_REWARD"),
+        );
+
+        diesel::sql_query(
+            "UPDATE activities SET amount = '0', quantity = '2', unit_price = '50' \
+             WHERE id IN ('valid-staking', 'metadata-only')",
+        )
+        .execute(&mut conn)
+        .expect("zero income amounts");
+
+        let rows = repo
+            .get_income_activities_data(Some("acc-income"))
+            .expect("income data");
+        let staking_amount = rows
+            .iter()
+            .find(|row| row.income_type == "INTEREST")
+            .map(|row| row.amount);
+        let metadata_amount = rows
+            .iter()
+            .find(|row| row.income_type == "DIVIDEND")
+            .map(|row| row.amount);
+
+        assert_eq!(staking_amount, Some(Decimal::new(100, 0)));
+        assert_eq!(metadata_amount, Some(Decimal::ZERO));
     }
 
     /// Regression: re-linking the same (account_id, context_kind, source_system) must preserve the row `id`

--- a/docs/activities/activity-types.md
+++ b/docs/activities/activity-types.md
@@ -207,12 +207,12 @@ calculation.
 
 **Purpose**: Cash dividend paid into the account.
 
-| Impact               | Description                                      |
-| -------------------- | ------------------------------------------------ |
-| **Cash**             | Increases by `amount - fee` in activity currency |
-| **Holdings**         | No change (unless DRIP subtype)                  |
-| **Cost Basis**       | No change                                        |
-| **Net Contribution** | No change (income, not new capital)              |
+| Impact               | Description                                         |
+| -------------------- | --------------------------------------------------- |
+| **Cash**             | Increases by `amount - fee` in activity currency    |
+| **Holdings**         | No change (unless DRIP or DIVIDEND_IN_KIND subtype) |
+| **Cost Basis**       | No change                                           |
+| **Net Contribution** | No change (income, not new capital)                 |
 
 **Required Fields**: `asset`, `amount`, `currency` **Optional Fields**: `fee`,
 `quantity` (for per-share tracking)
@@ -362,7 +362,7 @@ The compiler expands these into canonical activity postings.
 | `QUALIFIED`         | Qualified dividend (tax classification)                        | DIVIDEND (pass-through)     |
 | `ORDINARY`          | Ordinary dividend (tax classification)                         | DIVIDEND (pass-through)     |
 | `RETURN_OF_CAPITAL` | Return of capital (reduces cost basis)                         | DIVIDEND (special handling) |
-| `DIVIDEND_IN_KIND`  | Dividend paid in different asset (e.g., spinoff shares)        | DIVIDEND + TRANSFER_IN      |
+| `DIVIDEND_IN_KIND`  | Dividend paid as additional units of the same asset            | DIVIDEND + BUY              |
 
 #### DRIP Expansion
 
@@ -396,21 +396,17 @@ The compiler expands these into canonical activity postings.
 {
   "activity_type": "DIVIDEND",
   "subtype": "DIVIDEND_IN_KIND",
-  "asset": { "id": "PARENT_CO" },
+  "asset": { "id": "AAPL" },
   "amount": 250,
-  "quantity": 10, // shares of spinoff received
-  "unit_price": 25, // FMV at receipt
-  "metadata": {
-    "received_asset_id": "SPINOFF_CO"
-  }
+  "quantity": 10, // shares received
+  "unit_price": 25 // FMV at receipt
 }
 ```
 
 **Compiled Postings**:
 
-1. **DIVIDEND**: `amount = $250` (income recognition from PARENT_CO)
-2. **TRANSFER_IN**: `asset = SPINOFF_CO, quantity = 10, unit_price = $25`
-   (receive spinoff shares)
+1. **DIVIDEND**: `amount = $250` (income recognition)
+2. **BUY**: `asset = AAPL, quantity = 10, unit_price = $25` (share acquisition)
 
 ---
 
@@ -465,7 +461,6 @@ Activities support a `metadata` JSON field for additional context:
   "flow": {
     "is_external": true
   },
-  "received_asset_id": "SPINOFF_CO",
   "split_ratio": "2:1",
   "source": {
     "broker": "Schwab",
@@ -476,13 +471,12 @@ Activities support a `metadata` JSON field for additional context:
 
 ### Key Metadata Fields
 
-| Field                  | Type    | Used By          | Description                                     |
-| ---------------------- | ------- | ---------------- | ----------------------------------------------- |
-| `flow.is_external`     | boolean | TRANSFER_IN/OUT  | Marks transfer as crossing portfolio boundary   |
-| `received_asset_id`    | string  | DIVIDEND_IN_KIND | Asset ID received (different from paying asset) |
-| `split_ratio`          | string  | SPLIT            | Human-readable split ratio (e.g., "2:1")        |
-| `source.broker`        | string  | All              | Original broker name                            |
-| `source.original_type` | string  | All              | Raw activity type from provider                 |
+| Field                  | Type    | Used By         | Description                                   |
+| ---------------------- | ------- | --------------- | --------------------------------------------- |
+| `flow.is_external`     | boolean | TRANSFER_IN/OUT | Marks transfer as crossing portfolio boundary |
+| `split_ratio`          | string  | SPLIT           | Human-readable split ratio (e.g., "2:1")      |
+| `source.broker`        | string  | All             | Original broker name                          |
+| `source.original_type` | string  | All             | Raw activity type from provider               |
 
 ---
 

--- a/e2e/02-activities.spec.ts
+++ b/e2e/02-activities.spec.ts
@@ -70,8 +70,10 @@ test.describe("Activity Creation Tests", () => {
         currency: "USD",
         symbol: "MSFT",
         amount: 15,
-        notes: "Dividend with no subtype",
-        subtype: "None",
+        quantity: 0.1,
+        unitPrice: 150,
+        notes: "Dividend in kind",
+        subtype: "In kind",
       },
       transfer: {
         fromAccount: "Test USD Account",
@@ -312,10 +314,12 @@ test.describe("Activity Creation Tests", () => {
   }
 
   async function selectSubtype(subtype: string) {
-    const subtypeSelect = page.getByTestId("subtype-select");
-    await expect(subtypeSelect).toBeVisible({ timeout: 5000 });
-    await subtypeSelect.click();
-    await page.getByRole("option", { name: subtype }).click();
+    const subtypeLabel = subtype === "None" ? "Cash" : subtype;
+    const dialog = page.getByRole("dialog", { name: "Add Activity" });
+    const subtypeRadio = dialog.getByRole("radio", { name: subtypeLabel, exact: true });
+    await expect(subtypeRadio).toBeVisible({ timeout: 5000 });
+    await subtypeRadio.click();
+    await expect(subtypeRadio).toBeChecked();
   }
 
   async function fillFxRate(rate: number) {
@@ -603,16 +607,26 @@ test.describe("Activity Creation Tests", () => {
     await selectAccount(dividend.account, dividend.currency);
     await searchAndSelectSymbol(dividend.symbol);
     await selectDate();
-    await fillAmount(dividend.amount);
 
-    // Expand advanced options and select subtype
-    await expandAdvancedOptions();
+    // Subtype is now a main form radio group, not an advanced select.
     await selectSubtype(dividend.subtype);
+    await page.getByTestId("received-quantity-input").fill(String(dividend.quantity));
+    await page.getByTestId("received-quantity-input").blur();
+    await page.getByTestId("fmv-per-unit-input").fill(String(dividend.unitPrice));
+    await page.getByTestId("fmv-per-unit-input").blur();
+    await fillAmount(dividend.amount, "dividend-amount-input");
 
     await fillNotes(dividend.notes);
 
     await submitActivity("Dividend");
     await verifyActivityInTable("DIVIDEND", dividend.symbol, { amount: dividend.amount });
+    await expect(
+      page
+        .locator("tr")
+        .filter({ hasText: "Dividend in Kind" })
+        .filter({ hasText: dividend.symbol })
+        .first(),
+    ).toBeVisible({ timeout: 10000 });
   });
 
   test("10. Create TRANSFER activity", async () => {

--- a/e2e/10-symbol-mapping-validation.spec.ts
+++ b/e2e/10-symbol-mapping-validation.spec.ts
@@ -1,5 +1,5 @@
 import { expect, Page, test } from "@playwright/test";
-import { BASE_URL, completeOnboardingIfNeeded, loginIfNeeded } from "./helpers";
+import { BASE_URL, TEST_PASSWORD, completeOnboardingIfNeeded, waitForSyncToast } from "./helpers";
 
 test.describe.configure({ mode: "serial" });
 
@@ -72,18 +72,21 @@ test.describe("Symbol Mapping Validation", () => {
       await page.waitForTimeout(500);
     }
 
-    const assetRow = page.getByRole("row").filter({ hasText: ASSET_SYMBOL }).first();
-    await expect(assetRow).toBeVisible({ timeout: 10000 });
-
-    const actionsBtn = assetRow.getByRole("button", { name: "Open actions" });
+    await waitForSyncToast(page, 60_000);
 
     // The table can re-render (quote updates) causing the dropdown to close before the click lands.
-    // toPass() retries the whole sequence automatically until it succeeds.
+    // Retry opening the menu and clicking Edit as one atomic sequence so the menuitem cannot detach
+    // between a visibility assertion and a later click.
     await expect(async () => {
+      const assetRow = page.getByRole("row").filter({ hasText: ASSET_SYMBOL }).first();
+      await expect(assetRow).toBeVisible({ timeout: 3000 });
+      const actionsBtn = assetRow.getByRole("button", { name: "Open actions" });
       await actionsBtn.click();
-      await expect(page.getByRole("menuitem", { name: "Edit" })).toBeVisible({ timeout: 2000 });
-    }).toPass({ timeout: 15000 });
-    await page.getByRole("menuitem", { name: "Edit" }).click();
+      const editItem = page.getByRole("menuitem", { name: "Edit" });
+      await expect(editItem).toBeVisible({ timeout: 2000 });
+      await editItem.click();
+      await expect(page.getByRole("dialog").first()).toBeVisible({ timeout: 3000 });
+    }).toPass({ timeout: 30_000 });
 
     const editSheet = page.getByRole("dialog").first();
     await expect(editSheet).toBeVisible({ timeout: 5000 });
@@ -220,8 +223,27 @@ test.describe("Symbol Mapping Validation", () => {
 
   test("0. Setup: login and create test asset", async () => {
     test.setTimeout(180000);
+
+    await page.goto(BASE_URL, { waitUntil: "domcontentloaded" });
+
+    const loginInput = page.getByPlaceholder("Enter your password");
+    const continueButton = page.getByRole("button", { name: "Continue" });
+    const dashboardHeading = page.getByRole("heading", { name: "Dashboard" });
+    const accountsHeading = page.getByRole("heading", { name: "Accounts" });
+
+    await expect(
+      loginInput.or(continueButton).or(dashboardHeading).or(accountsHeading),
+    ).toBeVisible({ timeout: 120000 });
+
+    if (await loginInput.isVisible()) {
+      await loginInput.fill(TEST_PASSWORD);
+      await page.getByRole("button", { name: "Sign In" }).click();
+      await expect(continueButton.or(dashboardHeading).or(accountsHeading)).toBeVisible({
+        timeout: 30000,
+      });
+    }
+
     await completeOnboardingIfNeeded(page);
-    await loginIfNeeded(page);
     await ensureAssetExists();
   });
 

--- a/e2e/12-asset-backed-income-subtypes.spec.ts
+++ b/e2e/12-asset-backed-income-subtypes.spec.ts
@@ -1,0 +1,308 @@
+import { expect, Page, test } from "@playwright/test";
+import {
+  BASE_URL,
+  TEST_PASSWORD,
+  completeOnboardingIfNeeded,
+  createAccount,
+  fillDateField,
+  openAddActivitySheet,
+  searchAndSelectSymbol,
+  selectActivityType,
+  waitForSyncToast,
+} from "./helpers";
+
+test.describe.configure({ mode: "serial" });
+
+interface AccountResponse {
+  id: string;
+  name: string;
+  currency: string;
+}
+
+interface HoldingLotResponse {
+  quantity: number;
+  costBasis: number;
+  acquisitionPrice: number;
+  acquisitionFees: number;
+}
+
+interface HoldingResponse {
+  quantity: number;
+  localCurrency: string;
+  instrument?: {
+    id?: string | null;
+    symbol?: string | null;
+  } | null;
+  costBasis?: {
+    local: number;
+  } | null;
+  lots?: HoldingLotResponse[] | null;
+}
+
+interface ExpectedHolding {
+  symbol: string;
+  quantity: number;
+  costBasis: number;
+  averageCost: number;
+}
+
+test.describe("Asset-backed income subtypes update holdings", () => {
+  let page: Page;
+  const runId = Date.now().toString(36);
+  const accountName = `Asset-backed Income ${runId}`;
+  const currency = "USD";
+
+  const dividendInKind = {
+    symbol: "MSFT",
+    subtype: "In kind",
+    tableSubtype: "Dividend in Kind",
+    quantity: 0.125,
+    unitPrice: 80,
+    amount: 10,
+    notes: "Dividend paid in shares",
+  };
+
+  const stakingReward = {
+    symbol: "AAPL",
+    subtype: "Staking reward",
+    tableSubtype: "Staking Reward",
+    quantity: 0.02,
+    unitPrice: 200,
+    amount: 4,
+    notes: "Asset staking reward",
+  };
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  function round(value: number | null | undefined, decimals: number) {
+    if (typeof value !== "number" || !Number.isFinite(value)) return null;
+    const factor = 10 ** decimals;
+    return Math.round(value * factor) / factor;
+  }
+
+  async function getAccountId() {
+    const response = await page.request.get(`${BASE_URL}/api/v1/accounts`);
+    expect(response.ok()).toBeTruthy();
+    const accounts = (await response.json()) as AccountResponse[];
+    const account = accounts.find(
+      (item) => item.name === accountName && item.currency === currency,
+    );
+    expect(account, `Expected account ${accountName} to exist`).toBeTruthy();
+    return account!.id;
+  }
+
+  async function getHoldings() {
+    const accountId = await getAccountId();
+    const response = await page.request.get(
+      `${BASE_URL}/api/v1/holdings?accountId=${encodeURIComponent(accountId)}`,
+    );
+    expect(response.ok()).toBeTruthy();
+    return (await response.json()) as HoldingResponse[];
+  }
+
+  async function getDetailedHolding(accountId: string, assetId: string) {
+    const params = new URLSearchParams({ accountId, assetId });
+    const response = await page.request.get(`${BASE_URL}/api/v1/holdings/item?${params}`);
+    expect(response.ok()).toBeTruthy();
+    return (await response.json()) as HoldingResponse | null;
+  }
+
+  async function gotoActivities() {
+    await page.goto(`${BASE_URL}/activities`, { waitUntil: "domcontentloaded" });
+    await expect(page.getByRole("heading", { name: "Activity" })).toBeVisible({
+      timeout: 10000,
+    });
+  }
+
+  async function selectAccount() {
+    const accountSelect = page.getByTestId("account-select");
+    await accountSelect.click();
+    await page
+      .getByRole("option", { name: new RegExp(`${accountName}.*\\(${currency}\\)`) })
+      .first()
+      .click();
+  }
+
+  async function selectSubtype(subtype: string) {
+    const dialog = page.getByRole("dialog", { name: "Add Activity" });
+    const subtypeRadio = dialog.getByRole("radio", { name: subtype, exact: true });
+    await expect(subtypeRadio).toBeVisible({ timeout: 5000 });
+    await subtypeRadio.click();
+    await expect(subtypeRadio).toBeChecked();
+  }
+
+  async function fillNumber(testId: string, value: number) {
+    const input = page.getByTestId(testId);
+    await input.fill(String(value));
+    await input.blur();
+  }
+
+  async function fillNotes(notes: string) {
+    const input = page.getByTestId("notes-input");
+    await input.fill(notes);
+    await input.blur();
+  }
+
+  async function submitActivity(buttonName: RegExp) {
+    const submitButton = page.getByRole("button", { name: buttonName });
+    await expect(submitButton).toBeEnabled({ timeout: 5000 });
+    await submitButton.click();
+    await expect(page.getByRole("heading", { name: "Add Activity" })).not.toBeVisible({
+      timeout: 20000,
+    });
+    await page.waitForTimeout(500);
+  }
+
+  async function expectActivityRow(type: string, subtype: string, symbol: string) {
+    await expect(
+      page
+        .locator("tr")
+        .filter({ hasText: type })
+        .filter({ hasText: subtype })
+        .filter({ hasText: symbol })
+        .filter({ hasText: accountName }),
+    ).toBeVisible({ timeout: 10000 });
+  }
+
+  async function expectHolding(expected: ExpectedHolding) {
+    await waitForSyncToast(page, 60_000);
+
+    await expect
+      .poll(
+        async () => {
+          const accountId = await getAccountId();
+          const holdings = await getHoldings();
+          const listHolding = holdings.find(
+            (item) => item.instrument?.symbol?.toUpperCase() === expected.symbol,
+          );
+          const assetId = listHolding?.instrument?.id;
+          const holding = assetId ? await getDetailedHolding(accountId, assetId) : listHolding;
+          const lot = holding?.lots?.[0];
+          const costBasis = holding?.costBasis?.local;
+
+          return {
+            quantity: round(holding?.quantity, 4),
+            costBasis: round(costBasis, 2),
+            averageCost: round(
+              typeof costBasis === "number" && holding?.quantity
+                ? costBasis / holding.quantity
+                : null,
+              2,
+            ),
+            lotCount: holding?.lots?.length ?? 0,
+            lotQuantity: round(lot?.quantity, 4),
+            lotCostBasis: round(lot?.costBasis, 2),
+            lotAcquisitionPrice: round(lot?.acquisitionPrice, 2),
+            lotAcquisitionFees: round(lot?.acquisitionFees, 2),
+          };
+        },
+        { timeout: 90_000, intervals: [1000, 2000, 5000] },
+      )
+      .toEqual({
+        quantity: expected.quantity,
+        costBasis: expected.costBasis,
+        averageCost: expected.averageCost,
+        lotCount: 1,
+        lotQuantity: expected.quantity,
+        lotCostBasis: expected.costBasis,
+        lotAcquisitionPrice: expected.averageCost,
+        lotAcquisitionFees: 0,
+      });
+  }
+
+  async function expectHoldingVisibleInAccount(symbol: string, quantity: number) {
+    await page.goto(`${BASE_URL}/settings/accounts`, { waitUntil: "domcontentloaded" });
+    const accountLink = page.getByRole("link", { name: accountName });
+    await expect(accountLink).toBeVisible({ timeout: 10000 });
+    await accountLink.click();
+    await expect(page).toHaveURL(/\/accounts\/[^/]+/, { timeout: 10000 });
+
+    const row = page.locator("tbody tr").filter({ hasText: symbol }).first();
+    await expect(row).toBeVisible({ timeout: 15000 });
+    await expect(row).toContainText(new RegExp(`${quantity}\\s*shares`));
+  }
+
+  test("1. Setup: login/onboard and create isolated account", async () => {
+    test.setTimeout(180_000);
+
+    await page.goto(BASE_URL, { waitUntil: "domcontentloaded" });
+
+    const loginInput = page.getByPlaceholder("Enter your password");
+    const continueButton = page.getByRole("button", { name: "Continue" });
+    const dashboardHeading = page.getByRole("heading", { name: "Dashboard" });
+    const accountsHeading = page.getByRole("heading", { name: "Accounts" });
+
+    await expect(
+      loginInput.or(continueButton).or(dashboardHeading).or(accountsHeading),
+    ).toBeVisible({ timeout: 120_000 });
+
+    if (await loginInput.isVisible()) {
+      await loginInput.fill(TEST_PASSWORD);
+      await page.getByRole("button", { name: "Sign In" }).click();
+      await expect(continueButton.or(dashboardHeading).or(accountsHeading)).toBeVisible({
+        timeout: 30_000,
+      });
+    }
+
+    await completeOnboardingIfNeeded(page);
+    await createAccount(page, accountName, currency);
+  });
+
+  test("2. Dividend in kind creates shares with matching cost basis", async () => {
+    test.setTimeout(120_000);
+
+    await gotoActivities();
+    await openAddActivitySheet(page);
+    await selectActivityType(page, "Dividend");
+    await selectAccount();
+    await searchAndSelectSymbol(page, dividendInKind.symbol);
+    await fillDateField(page, 10);
+    await selectSubtype(dividendInKind.subtype);
+    await fillNumber("received-quantity-input", dividendInKind.quantity);
+    await fillNumber("fmv-per-unit-input", dividendInKind.unitPrice);
+    await fillNumber("dividend-amount-input", dividendInKind.amount);
+    await fillNotes(dividendInKind.notes);
+    await submitActivity(/Add Dividend/i);
+
+    await expectActivityRow("Dividend", dividendInKind.tableSubtype, dividendInKind.symbol);
+    await expectHolding({
+      symbol: dividendInKind.symbol,
+      quantity: dividendInKind.quantity,
+      costBasis: dividendInKind.amount,
+      averageCost: dividendInKind.unitPrice,
+    });
+    await expectHoldingVisibleInAccount(dividendInKind.symbol, dividendInKind.quantity);
+  });
+
+  test("3. Staking reward creates reward units with matching cost basis", async () => {
+    test.setTimeout(120_000);
+
+    await gotoActivities();
+    await openAddActivitySheet(page);
+    await selectActivityType(page, "Interest");
+    await selectAccount();
+    await selectSubtype(stakingReward.subtype);
+    await searchAndSelectSymbol(page, stakingReward.symbol);
+    await fillDateField(page, 9);
+    await fillNumber("received-quantity-input", stakingReward.quantity);
+    await fillNumber("fmv-per-unit-input", stakingReward.unitPrice);
+    await fillNumber("interest-amount-input", stakingReward.amount);
+    await fillNotes(stakingReward.notes);
+    await submitActivity(/Add Interest/i);
+
+    await expectActivityRow("Interest", stakingReward.tableSubtype, stakingReward.symbol);
+    await expectHolding({
+      symbol: stakingReward.symbol,
+      quantity: stakingReward.quantity,
+      costBasis: stakingReward.amount,
+      averageCost: stakingReward.unitPrice,
+    });
+    await expectHoldingVisibleInAccount(stakingReward.symbol, stakingReward.quantity);
+  });
+});

--- a/packages/ui/src/components/data-grid/data-grid-cell-variants.tsx
+++ b/packages/ui/src/components/data-grid/data-grid-cell-variants.tsx
@@ -975,7 +975,7 @@ export function SelectCell<TData>({
     if (valueRenderer) {
       // Don't wrap in data-slot="grid-cell-content" - let valueRenderer control its own styling
       // This prevents line-clamp from truncating badges/custom renderers
-      return valueRenderer(value, selectedOption);
+      return valueRenderer(value, selectedOption, cell.row.original);
     }
 
     return (

--- a/packages/ui/src/components/data-grid/data-grid-column-header.tsx
+++ b/packages/ui/src/components/data-grid/data-grid-column-header.tsx
@@ -34,6 +34,7 @@ export function DataGridColumnHeader<TData, TValue>({
     : typeof column.columnDef.header === "string"
       ? column.columnDef.header
       : column.id;
+  const helpText = column.columnDef.meta?.helpText;
 
   const isAnyColumnResizing = table.getState().columnSizingInfo.isResizingColumn;
 
@@ -110,6 +111,16 @@ export function DataGridColumnHeader<TData, TValue>({
               </Tooltip>
             )}
             <span className="truncate">{label}</span>
+            {helpText && (
+              <Tooltip delayDuration={100}>
+                <TooltipTrigger asChild>
+                  <Icons.Info className="text-muted-foreground/70 hover:text-foreground size-3.5 shrink-0" />
+                </TooltipTrigger>
+                <TooltipContent side="top" className="max-w-xs text-xs">
+                  {helpText}
+                </TooltipContent>
+              </Tooltip>
+            )}
           </div>
           <Icons.ChevronDown className="text-muted-foreground shrink-0" />
         </DropdownMenuTrigger>

--- a/packages/ui/src/components/data-grid/data-grid-types.ts
+++ b/packages/ui/src/components/data-grid/data-grid-types.ts
@@ -53,7 +53,11 @@ export type CellOpts =
       /** Static options or function to get options dynamically based on row data */
       options: CellSelectOption[] | ((rowData: unknown) => CellSelectOption[]);
       /** Custom renderer for the selected value in display mode */
-      valueRenderer?: (value: string, option?: CellSelectOption) => React.ReactNode;
+      valueRenderer?: (
+        value: string,
+        option?: CellSelectOption,
+        rowData?: unknown,
+      ) => React.ReactNode;
       /** Whether to allow clearing the selection (adds empty option) */
       allowEmpty?: boolean;
       /** Label for the empty option (default: "None") */
@@ -116,6 +120,7 @@ declare module "@tanstack/react-table" {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   interface ColumnMeta<TData extends RowData, TValue> {
     label?: string;
+    helpText?: string;
     cell?: CellOpts;
   }
 

--- a/packages/ui/src/components/data-grid/index.tsx
+++ b/packages/ui/src/components/data-grid/index.tsx
@@ -1,3 +1,5 @@
+import type {} from "./data-grid-types";
+
 // Re-export types from the types directory
 export type {
   BooleanFilterOperator,


### PR DESCRIPTION
## Summary
- support DRIP, dividend-in-kind, and staking reward as asset-backed income activities that expand into income plus acquisition legs
- normalize known subtype strings while keeping provider/import/AI subtype labels permissive metadata when they are not known calculation pairs
- update desktop/mobile forms, activity grids, import review, AI tools, broker sync prep, docs, and e2e coverage for the new flows
- add persistence safeguards for subtype patch clears and split recalculation from earlier activity history

## Validation
- pnpm exec prettier --write e2e/10-symbol-mapping-validation.spec.ts e2e/12-asset-backed-income-subtypes.spec.ts
- pnpm exec playwright test --list e2e/10-symbol-mapping-validation.spec.ts e2e/12-asset-backed-income-subtypes.spec.ts
- pnpm test:e2e -- e2e/10-symbol-mapping-validation.spec.ts e2e/12-asset-backed-income-subtypes.spec.ts --reporter=line
- git diff --check

Focused e2e result: 8 passed.