### PR TITLE
fix(ai): drop top_k/top_p Anthropic defaults; refresh Opus to 4.7

### DIFF
--- a/crates/ai/src/ai_providers.json
+++ b/crates/ai/src/ai_providers.json
@@ -187,7 +187,7 @@
         "claude-haiku-4-5-20251001": {
           "capabilities": { "tools": true, "thinking": false, "vision": true }
         },
-        "claude-opus-4-6": {
+        "claude-opus-4-7": {
           "capabilities": { "tools": true, "thinking": false, "vision": true }
         }
       },
@@ -196,11 +196,7 @@
       "documentationUrl": "https://docs.anthropic.com/en/api/getting-started",
       "tuning": {
         "maxTokens": 16384,
-        "maxTokensThinking": 32000,
-        "extraOptions": {
-          "top_p": 1.0,
-          "top_k": 0
-        }
+        "maxTokensThinking": 32000
       }
     },
     "openai": {

--- a/crates/ai/src/provider_model.rs
+++ b/crates/ai/src/provider_model.rs
@@ -123,6 +123,18 @@ pub struct ProviderTuningOverrides {
 }
 
 impl ProviderTuningOverrides {
+    /// Remove provider-specific overrides that should not reach runtime params.
+    pub fn sanitized_for_provider(mut self, provider_id: &str) -> Self {
+        if provider_id == "anthropic" {
+            // Claude rejects top_k/top_p on current Anthropic models. Users may
+            // still have these as orphaned overrides from older catalogs, so
+            // drop them before merging to avoid rebuilding unsupported params.
+            self.extra_option_overrides.remove("top_k");
+            self.extra_option_overrides.remove("top_p");
+        }
+        self
+    }
+
     /// Whether every field is empty — in which case this override is a no-op
     /// and should be cleared from the user settings to keep things tidy.
     pub fn is_empty(&self) -> bool {
@@ -589,4 +601,54 @@ pub struct ListModelsResponse {
     /// Whether the provider supports dynamic model listing.
     /// If false, only catalog models are available.
     pub supports_listing: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    #[test]
+    fn sanitized_for_provider_removes_unsupported_anthropic_sampling_overrides() {
+        let overrides = ProviderTuningOverrides {
+            extra_option_overrides: HashMap::from([
+                ("top_k".to_string(), json!(0)),
+                ("top_p".to_string(), json!(1.0)),
+                ("seed".to_string(), json!(42)),
+            ]),
+            ..Default::default()
+        };
+
+        let sanitized = overrides.sanitized_for_provider("anthropic");
+
+        assert!(!sanitized.extra_option_overrides.contains_key("top_k"));
+        assert!(!sanitized.extra_option_overrides.contains_key("top_p"));
+        assert_eq!(
+            sanitized.extra_option_overrides.get("seed"),
+            Some(&json!(42))
+        );
+    }
+
+    #[test]
+    fn sanitized_for_provider_preserves_other_provider_sampling_overrides() {
+        let overrides = ProviderTuningOverrides {
+            extra_option_overrides: HashMap::from([
+                ("top_k".to_string(), json!(40)),
+                ("top_p".to_string(), json!(0.9)),
+            ]),
+            ..Default::default()
+        };
+
+        let sanitized = overrides.sanitized_for_provider("ollama");
+
+        assert_eq!(
+            sanitized.extra_option_overrides.get("top_k"),
+            Some(&json!(40))
+        );
+        assert_eq!(
+            sanitized.extra_option_overrides.get("top_p"),
+            Some(&json!(0.9))
+        );
+    }
 }

--- a/crates/ai/src/provider_service.rs
+++ b/crates/ai/src/provider_service.rs
@@ -301,7 +301,10 @@ impl AiProviderServiceTrait for AiProviderService {
                 // user-only, and the effective merged value the runtime uses.
                 let catalog_tuning = catalog_provider.tuning.clone();
                 let tuning_overrides = user.tuning_overrides.clone();
-                let resolved_tuning = match (&catalog_tuning, &tuning_overrides) {
+                let sanitized_overrides = tuning_overrides
+                    .clone()
+                    .map(|ovr| ovr.sanitized_for_provider(id));
+                let resolved_tuning = match (&catalog_tuning, &sanitized_overrides) {
                     (Some(cat), Some(ovr)) => Some(cat.apply_overrides(ovr)),
                     (Some(cat), None) => Some(cat.clone()),
                     (None, Some(ovr)) => Some(ProviderTuning::default().apply_overrides(ovr)),
@@ -513,7 +516,10 @@ impl AiProviderServiceTrait for AiProviderService {
             .get(provider_id)
             .and_then(|s| s.tuning_overrides.clone());
         match user_overrides {
-            Some(ovr) => catalog_tuning.apply_overrides(&ovr),
+            Some(ovr) => {
+                let sanitized = ovr.sanitized_for_provider(provider_id);
+                catalog_tuning.apply_overrides(&sanitized)
+            }
             None => catalog_tuning,
         }
     }

--- a/crates/ai/src/providers.rs
+++ b/crates/ai/src/providers.rs
@@ -403,7 +403,10 @@ impl<E: AiEnvironment> ProviderService<E> {
             .and_then(|p| p.tuning_overrides.clone());
 
         match user_overrides {
-            Some(ovr) => catalog_tuning.apply_overrides(&ovr),
+            Some(ovr) => {
+                let sanitized = ovr.sanitized_for_provider(provider_id);
+                catalog_tuning.apply_overrides(&sanitized)
+            }
             None => catalog_tuning,
         }
     }


### PR DESCRIPTION
## Description

Fixes #933.

### What

- Remove `top_k: 0` and `top_p: 1.0` from the Anthropic provider's `tuning.extraOptions` in [`crates/ai/src/ai_providers.json`](https://github.com/afadil/wealthfolio/blob/main/crates/ai/src/ai_providers.json).
- Rename the cataloged Opus model from `claude-opus-4-6` to `claude-opus-4-7`.

### Why

**`top_k` error.** Catalog `extraOptions` flow into `additional_params` via `combine_params` in `crates/ai/src/chat.rs`, and rig-core's Anthropic completion request flattens that JSON straight into the request body. So every Anthropic call was being sent with `top_k: 0`, which the API rejects (`Error: top_k must be unset when using Claude Models`). Per the current Messages API docs, neither `top_k` nor `top_p` are documented sampling params for Claude 4.x — only `temperature` is. These keys were catalog-only (no UI override path for Anthropic), so dropping them is the cleanest fix.

**Opus 4.7 not Recommended.** The "Recommended" star in the model picker is driven by `isCatalog` (`provider-settings-card.tsx`). Listing `claude-opus-4-7` in the catalog gives it the star.

### Notes for reviewer

- `defaultModel` (`claude-sonnet-4-6`) and `titleModelId` (`claude-haiku-4-5-20251001`) are unchanged; the catalog integrity test (`test_catalog_default_models_are_cataloged`) still passes.
- Backward compat: users with `claude-opus-4-6` saved in `chat_selected_model` localStorage will fall back to `defaultModel` per `use-chat-model.ts:65-81` since the model is no longer in catalog/favorites — acceptable, since calls with that model would have been hitting the `top_k` error anyway.
- `cargo check -p wealthfolio-ai` passes; provider catalog tests pass.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).