### PR TITLE
Fix quote sync position lifecycle

### DIFF
--- a/apps/frontend/src/use-global-event-listener.ts
+++ b/apps/frontend/src/use-global-event-listener.ts
@@ -126,7 +126,9 @@ const useGlobalEventListener = () => {
             onClick: () => navigateRef.current("/health"),
           },
         });
-      } else if (skipped_reasons.length > 0) {
+      }
+
+      if (skipped_reasons.length > 0) {
         const [assetId, reason] = skipped_reasons[0];
         const suffix =
           skipped_reasons.length === 1

--- a/apps/frontend/src/use-global-event-listener.ts
+++ b/apps/frontend/src/use-global-event-listener.ts
@@ -64,6 +64,10 @@ function getSyncFailures(payload?: MarketSyncCompletePayload | null): [string, s
   return Array.isArray(payload?.failed_syncs) ? payload.failed_syncs : [];
 }
 
+function getSyncSkips(payload?: MarketSyncCompletePayload | null): [string, string][] {
+  return Array.isArray(payload?.skipped_reasons) ? payload.skipped_reasons : [];
+}
+
 const useGlobalEventListener = () => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
@@ -103,6 +107,7 @@ const useGlobalEventListener = () => {
 
     const handleMarketSyncComplete = (event: { payload: MarketSyncCompletePayload | null }) => {
       const failed_syncs = getSyncFailures(event.payload);
+      const skipped_reasons = getSyncSkips(event.payload);
 
       if (isMobileViewportRef.current && syncContextRef.current) {
         syncContextRef.current.setIdle();
@@ -120,6 +125,16 @@ const useGlobalEventListener = () => {
             label: "View",
             onClick: () => navigateRef.current("/health"),
           },
+        });
+      } else if (skipped_reasons.length > 0) {
+        const [assetId, reason] = skipped_reasons[0];
+        const suffix =
+          skipped_reasons.length === 1
+            ? `${assetId}: ${reason}`
+            : `${skipped_reasons.length} assets skipped`;
+        toast.info("Price update skipped", {
+          description: suffix,
+          duration: 7000,
         });
       }
     };

--- a/apps/server/src/api/health.rs
+++ b/apps/server/src/api/health.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use crate::{error::ApiResult, main_lib::AppState};
+use crate::{
+    error::{ApiError, ApiResult},
+    main_lib::AppState,
+};
 use axum::{
     extract::State,
     http::HeaderMap,
@@ -135,6 +138,11 @@ async fn execute_health_fix(
     if action.id == "sync_prices" || action.id == "retry_sync" {
         let asset_ids: Vec<String> = serde_json::from_value(action.payload.clone())
             .map_err(|e| anyhow::anyhow!("Invalid payload for {}: {}", action.id, e))?;
+        if asset_ids.is_empty() {
+            return Err(ApiError::BadRequest(
+                "No assets selected for price sync".to_string(),
+            ));
+        }
 
         state
             .quote_service

--- a/apps/server/src/api/holdings/handlers.rs
+++ b/apps/server/src/api/holdings/handlers.rs
@@ -8,13 +8,12 @@ use chrono::{NaiveDate, Utc};
 use rust_decimal::Decimal;
 use wealthfolio_core::{
     accounts::AccountServiceTrait,
-    constants::PORTFOLIO_TOTAL_ACCOUNT_ID,
     portfolio::{
         allocation::{AllocationHoldings, PortfolioAllocations},
         holdings::Holding,
         snapshot::{
-            CashBalanceInput, ManualHoldingInput, ManualSnapshotRequest, ManualSnapshotService,
-            SnapshotRecalcMode, SnapshotSource,
+            reconcile_quote_sync_from_latest_total_snapshot, CashBalanceInput, ManualHoldingInput,
+            ManualSnapshotRequest, ManualSnapshotService, SnapshotRecalcMode, SnapshotSource,
         },
         valuation::{DailyAccountValuation, ValuationRecalcMode},
     },
@@ -270,28 +269,17 @@ pub async fn delete_snapshot_handler(
         tracing::warn!("Failed to recalculate TOTAL snapshots after delete: {}", e);
     }
 
-    // Update position status from TOTAL snapshot for quote sync planning
-    if let Ok(Some(total_snapshot)) = state
-        .snapshot_service
-        .get_latest_holdings_snapshot(PORTFOLIO_TOTAL_ACCOUNT_ID)
+    // Update position status from TOTAL snapshot for quote sync planning.
+    if let Err(e) = reconcile_quote_sync_from_latest_total_snapshot(
+        state.snapshot_service.as_ref(),
+        state.quote_service.as_ref(),
+    )
+    .await
     {
-        let current_holdings: std::collections::HashMap<String, rust_decimal::Decimal> =
-            total_snapshot
-                .positions
-                .iter()
-                .map(|(asset_id, position)| (asset_id.clone(), position.quantity))
-                .collect();
-
-        if let Err(e) = state
-            .quote_service
-            .update_position_status_from_holdings(&current_holdings)
-            .await
-        {
-            tracing::warn!(
-                "Failed to update position status from holdings after delete: {}",
-                e
-            );
-        }
+        tracing::warn!(
+            "Failed to update position status from holdings after delete: {}",
+            e
+        );
     }
 
     // Recalculate valuations for the TOTAL portfolio

--- a/apps/server/src/api/shared.rs
+++ b/apps/server/src/api/shared.rs
@@ -14,7 +14,10 @@ use serde_json::json;
 use wealthfolio_core::{
     accounts::AccountServiceTrait,
     constants::PORTFOLIO_TOTAL_ACCOUNT_ID,
-    portfolio::{snapshot::SnapshotRecalcMode, valuation::ValuationRecalcMode},
+    portfolio::{
+        snapshot::{reconcile_quote_sync_from_latest_total_snapshot, SnapshotRecalcMode},
+        valuation::ValuationRecalcMode,
+    },
     quotes::MarketSyncMode,
 };
 
@@ -132,6 +135,18 @@ pub async fn process_portfolio_job(
 
     // Only perform market sync if the mode requires it
     if config.market_sync_mode.requires_sync() {
+        if let Err(e) = reconcile_quote_sync_from_latest_total_snapshot(
+            state.snapshot_service.as_ref(),
+            state.quote_service.as_ref(),
+        )
+        .await
+        {
+            tracing::warn!(
+                "Failed to reconcile quote sync state from latest holdings: {}. Quote sync planning may be affected.",
+                e
+            );
+        }
+
         event_bus.publish(ServerEvent::new(MARKET_SYNC_START));
 
         let sync_start = std::time::Instant::now();
@@ -240,30 +255,17 @@ pub async fn process_portfolio_job(
         return Err(crate::error::ApiError::Anyhow(anyhow!(err_msg)));
     }
 
-    // Update position status from TOTAL snapshot
-    // This derives open/closed position transitions for quote sync planning
-    if let Ok(Some(total_snapshot)) = state
-        .snapshot_service
-        .get_latest_holdings_snapshot(PORTFOLIO_TOTAL_ACCOUNT_ID)
+    // Update position status from TOTAL snapshot for quote sync planning.
+    if let Err(e) = reconcile_quote_sync_from_latest_total_snapshot(
+        state.snapshot_service.as_ref(),
+        state.quote_service.as_ref(),
+    )
+    .await
     {
-        // Extract asset quantities from the TOTAL snapshot
-        let current_holdings: std::collections::HashMap<String, rust_decimal::Decimal> =
-            total_snapshot
-                .positions
-                .iter()
-                .map(|(asset_id, position)| (asset_id.clone(), position.quantity))
-                .collect();
-
-        if let Err(e) = state
-            .quote_service
-            .update_position_status_from_holdings(&current_holdings)
-            .await
-        {
-            tracing::warn!(
-                "Failed to update position status from holdings: {}. Quote sync planning may be affected.",
-                e
-            );
-        }
+        tracing::warn!(
+            "Failed to update position status from holdings: {}. Quote sync planning may be affected.",
+            e
+        );
     }
 
     if !account_ids

--- a/apps/server/src/domain_events/queue_worker.rs
+++ b/apps/server/src/domain_events/queue_worker.rs
@@ -272,6 +272,7 @@ async fn run_portfolio_job(
     use serde_json::json;
     use wealthfolio_core::accounts::AccountServiceTrait;
     use wealthfolio_core::constants::PORTFOLIO_TOTAL_ACCOUNT_ID;
+    use wealthfolio_core::portfolio::snapshot::reconcile_quote_sync_from_latest_total_snapshot;
 
     let event_bus = deps.event_bus.clone();
     let snapshot_mode = config
@@ -285,6 +286,18 @@ async fn run_portfolio_job(
 
     // Only perform market sync if the mode requires it
     if config.market_sync_mode.requires_sync() {
+        if let Err(e) = reconcile_quote_sync_from_latest_total_snapshot(
+            deps.snapshot_service.as_ref(),
+            deps.quote_service.as_ref(),
+        )
+        .await
+        {
+            tracing::warn!(
+                "Failed to reconcile quote sync state from latest holdings: {}. Quote sync planning may be affected.",
+                e
+            );
+        }
+
         event_bus.publish(ServerEvent::new(MARKET_SYNC_START));
 
         let sync_start = std::time::Instant::now();
@@ -392,28 +405,17 @@ async fn run_portfolio_job(
         return;
     }
 
-    // Update position status from TOTAL snapshot
-    if let Ok(Some(total_snapshot)) = deps
-        .snapshot_service
-        .get_latest_holdings_snapshot(PORTFOLIO_TOTAL_ACCOUNT_ID)
+    // Update position status from TOTAL snapshot for quote sync planning.
+    if let Err(e) = reconcile_quote_sync_from_latest_total_snapshot(
+        deps.snapshot_service.as_ref(),
+        deps.quote_service.as_ref(),
+    )
+    .await
     {
-        let current_holdings: std::collections::HashMap<String, rust_decimal::Decimal> =
-            total_snapshot
-                .positions
-                .iter()
-                .map(|(asset_id, position)| (asset_id.clone(), position.quantity))
-                .collect();
-
-        if let Err(e) = deps
-            .quote_service
-            .update_position_status_from_holdings(&current_holdings)
-            .await
-        {
-            tracing::warn!(
-                "Failed to update position status from holdings: {}. Quote sync planning may be affected.",
-                e
-            );
-        }
+        tracing::warn!(
+            "Failed to update position status from holdings: {}. Quote sync planning may be affected.",
+            e
+        );
     }
 
     if !account_ids

--- a/apps/tauri/src/commands/health.rs
+++ b/apps/tauri/src/commands/health.rs
@@ -126,6 +126,9 @@ pub async fn execute_health_fix(
     if action.id == "sync_prices" || action.id == "retry_sync" {
         let asset_ids: Vec<String> = serde_json::from_value(action.payload.clone())
             .map_err(|e| format!("Failed to parse asset IDs: {}", e))?;
+        if asset_ids.is_empty() {
+            return Err("No assets selected for price sync".to_string());
+        }
 
         info!(
             "Syncing market data for {} assets: {:?}",

--- a/apps/tauri/src/domain_events/queue_worker.rs
+++ b/apps/tauri/src/domain_events/queue_worker.rs
@@ -14,7 +14,9 @@ use tokio::sync::mpsc;
 use wealthfolio_core::constants::PORTFOLIO_TOTAL_ACCOUNT_ID;
 use wealthfolio_core::events::DomainEvent;
 use wealthfolio_core::health::HealthServiceTrait;
-use wealthfolio_core::portfolio::snapshot::SnapshotRecalcMode;
+use wealthfolio_core::portfolio::snapshot::{
+    reconcile_quote_sync_from_latest_total_snapshot, SnapshotRecalcMode,
+};
 use wealthfolio_core::portfolio::valuation::ValuationRecalcMode;
 
 #[cfg(feature = "connect-sync")]
@@ -260,6 +262,19 @@ async fn run_portfolio_job(
     // Only perform market sync if the mode requires it
     if market_sync_mode.requires_sync() {
         let market_data_service = context.quote_service();
+        let snapshot_service = context.snapshot_service();
+
+        if let Err(e) = reconcile_quote_sync_from_latest_total_snapshot(
+            snapshot_service.as_ref(),
+            market_data_service.as_ref(),
+        )
+        .await
+        {
+            warn!(
+                "Failed to reconcile quote sync state from latest holdings: {}. Quote sync planning may be affected.",
+                e
+            );
+        }
 
         // Emit sync start event
         if let Err(e) = app_handle.emit(MARKET_SYNC_START, &()) {
@@ -406,27 +421,18 @@ async fn run_portfolio_calculation(
         return;
     }
 
-    // Update position status from TOTAL snapshot
-    if let Ok(Some(total_snapshot)) =
-        snapshot_service.get_latest_holdings_snapshot(PORTFOLIO_TOTAL_ACCOUNT_ID)
+    // Update position status from TOTAL snapshot for quote sync planning.
+    let quote_service = context.quote_service();
+    if let Err(e) = reconcile_quote_sync_from_latest_total_snapshot(
+        snapshot_service.as_ref(),
+        quote_service.as_ref(),
+    )
+    .await
     {
-        let current_holdings: std::collections::HashMap<String, rust_decimal::Decimal> =
-            total_snapshot
-                .positions
-                .iter()
-                .map(|(asset_id, position)| (asset_id.clone(), position.quantity))
-                .collect();
-
-        let quote_service = context.quote_service();
-        if let Err(e) = quote_service
-            .update_position_status_from_holdings(&current_holdings)
-            .await
-        {
-            warn!(
-                "Failed to update position status from holdings: {}. Quote sync planning may be affected.",
-                e
-            );
-        }
+        warn!(
+            "Failed to update position status from holdings: {}. Quote sync planning may be affected.",
+            e
+        );
     }
 
     // Ensure TOTAL is included in valuation calculation

--- a/apps/tauri/src/listeners.rs
+++ b/apps/tauri/src/listeners.rs
@@ -5,7 +5,9 @@ use std::time::Instant;
 use tauri::{async_runtime::spawn, AppHandle, Emitter, Listener, Manager};
 use wealthfolio_core::constants::PORTFOLIO_TOTAL_ACCOUNT_ID;
 use wealthfolio_core::health::HealthServiceTrait;
-use wealthfolio_core::portfolio::snapshot::SnapshotRecalcMode;
+use wealthfolio_core::portfolio::snapshot::{
+    reconcile_quote_sync_from_latest_total_snapshot, SnapshotRecalcMode,
+};
 use wealthfolio_core::portfolio::valuation::ValuationRecalcMode;
 use wealthfolio_core::quotes::MarketSyncMode;
 
@@ -54,6 +56,19 @@ fn handle_portfolio_request(handle: AppHandle, payload_str: &str, force_recalc: 
                     // Only perform market sync if the mode requires it
                     if market_sync_mode.requires_sync() {
                         let market_data_service = context.quote_service();
+                        let snapshot_service = context.snapshot_service();
+
+                        if let Err(e) = reconcile_quote_sync_from_latest_total_snapshot(
+                            snapshot_service.as_ref(),
+                            market_data_service.as_ref(),
+                        )
+                        .await
+                        {
+                            warn!(
+                                "Failed to reconcile quote sync state from latest holdings: {}. Quote sync planning may be affected.",
+                                e
+                            );
+                        }
 
                         // Emit sync start event
                         if let Err(e) = handle_clone.emit(MARKET_SYNC_START, &()) {
@@ -278,29 +293,17 @@ fn handle_portfolio_calculation(
         }
 
         // --- Step 2.5: Update position status from TOTAL snapshot ---
-        // This derives open/closed position transitions for quote sync planning
-        if let Ok(Some(total_snapshot)) =
-            snapshot_service.get_latest_holdings_snapshot(PORTFOLIO_TOTAL_ACCOUNT_ID)
+        let quote_service = context.quote_service();
+        if let Err(e) = reconcile_quote_sync_from_latest_total_snapshot(
+            snapshot_service.as_ref(),
+            quote_service.as_ref(),
+        )
+        .await
         {
-            let quote_service = context.quote_service();
-
-            // Extract asset quantities from the TOTAL snapshot
-            let current_holdings: std::collections::HashMap<String, rust_decimal::Decimal> =
-                total_snapshot
-                    .positions
-                    .iter()
-                    .map(|(asset_id, position)| (asset_id.clone(), position.quantity))
-                    .collect();
-
-            if let Err(e) = quote_service
-                .update_position_status_from_holdings(&current_holdings)
-                .await
-            {
-                warn!(
-                    "Failed to update position status from holdings: {}. Quote sync planning may be affected.",
-                    e
-                );
-            }
+            warn!(
+                "Failed to update position status from holdings: {}. Quote sync planning may be affected.",
+                e
+            );
         }
 
         // --- Step 3: Calculate Valuation History ---

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -973,6 +973,18 @@ mod tests {
             Ok(std::collections::HashMap::new())
         }
 
+        fn get_holdings_snapshot_bounds_for_assets(
+            &self,
+            _asset_ids: &[String],
+        ) -> Result<
+            std::collections::HashMap<
+                String,
+                (Option<chrono::NaiveDate>, Option<chrono::NaiveDate>),
+            >,
+        > {
+            Ok(std::collections::HashMap::new())
+        }
+
         fn check_existing_duplicates(
             &self,
             idempotency_keys: &[String],

--- a/crates/core/src/activities/activities_traits.rs
+++ b/crates/core/src/activities/activities_traits.rs
@@ -114,6 +114,17 @@ pub trait ActivityRepositoryTrait: Send + Sync {
         asset_ids: &[String],
     ) -> Result<HashMap<String, (Option<NaiveDate>, Option<NaiveDate>)>>;
 
+    /// Gets the first and last non-archived holdings snapshot dates where each
+    /// asset appears.
+    ///
+    /// Holdings-mode assets can have historical valuation exposure without any
+    /// activity rows, so quote planning must include these bounds too.
+    #[allow(clippy::type_complexity)]
+    fn get_holdings_snapshot_bounds_for_assets(
+        &self,
+        asset_ids: &[String],
+    ) -> Result<HashMap<String, (Option<NaiveDate>, Option<NaiveDate>)>>;
+
     /// Checks for existing activities with the given idempotency keys.
     ///
     /// Returns a map of {idempotency_key: existing_activity_id} for keys that already exist.

--- a/crates/core/src/assets/assets_traits.rs
+++ b/crates/core/src/assets/assets_traits.rs
@@ -192,6 +192,14 @@ pub trait AssetRepositoryTrait: Send + Sync {
     /// Used when new activities reference a previously deactivated asset.
     async fn reactivate(&self, asset_id: &str) -> Result<()>;
 
+    /// Reactivates multiple assets.
+    async fn reactivate_batch(&self, asset_ids: &[String]) -> Result<()> {
+        for asset_id in asset_ids {
+            self.reactivate(asset_id).await?;
+        }
+        Ok(())
+    }
+
     /// Copies user-editable fields from source asset to target asset.
     /// Used during UNKNOWN asset merge to preserve user customizations.
     async fn copy_user_metadata(&self, source_id: &str, target_id: &str) -> Result<()>;

--- a/crates/core/src/limits/limits_service.rs
+++ b/crates/core/src/limits/limits_service.rs
@@ -444,6 +444,12 @@ mod tests {
         ) -> Result<HashMap<String, (Option<NaiveDate>, Option<NaiveDate>)>> {
             unimplemented!()
         }
+        fn get_holdings_snapshot_bounds_for_assets(
+            &self,
+            _: &[String],
+        ) -> Result<HashMap<String, (Option<NaiveDate>, Option<NaiveDate>)>> {
+            unimplemented!()
+        }
         fn check_existing_duplicates(&self, _: &[String]) -> Result<HashMap<String, String>> {
             unimplemented!()
         }

--- a/crates/core/src/portfolio/snapshot/mod.rs
+++ b/crates/core/src/portfolio/snapshot/mod.rs
@@ -3,6 +3,7 @@
 pub mod holdings_calculator;
 pub mod manual_snapshot_service;
 mod positions_model;
+mod quote_sync_reconciliation;
 mod snapshot_model;
 pub mod snapshot_service;
 mod snapshot_traits;
@@ -10,6 +11,7 @@ mod snapshot_traits;
 pub use holdings_calculator::*;
 pub use manual_snapshot_service::*;
 pub use positions_model::*;
+pub use quote_sync_reconciliation::*;
 pub use snapshot_model::*;
 pub use snapshot_service::*;
 pub use snapshot_traits::*;

--- a/crates/core/src/portfolio/snapshot/quote_sync_reconciliation.rs
+++ b/crates/core/src/portfolio/snapshot/quote_sync_reconciliation.rs
@@ -1,0 +1,41 @@
+use std::collections::HashMap;
+
+use rust_decimal::Decimal;
+
+use crate::constants::PORTFOLIO_TOTAL_ACCOUNT_ID;
+use crate::errors::Result;
+use crate::quotes::QuoteServiceTrait;
+
+use super::{AccountStateSnapshot, SnapshotServiceTrait};
+
+pub fn holdings_quantities(snapshot: &AccountStateSnapshot) -> HashMap<String, Decimal> {
+    snapshot
+        .positions
+        .iter()
+        .map(|(asset_id, position)| (asset_id.clone(), position.quantity))
+        .collect()
+}
+
+pub async fn reconcile_quote_sync_from_snapshot(
+    quote_service: &dyn QuoteServiceTrait,
+    snapshot: &AccountStateSnapshot,
+) -> Result<()> {
+    let current_holdings = holdings_quantities(snapshot);
+    quote_service
+        .update_position_status_from_holdings(&current_holdings)
+        .await
+}
+
+pub async fn reconcile_quote_sync_from_latest_total_snapshot(
+    snapshot_service: &dyn SnapshotServiceTrait,
+    quote_service: &dyn QuoteServiceTrait,
+) -> Result<bool> {
+    let Some(total_snapshot) =
+        snapshot_service.get_latest_holdings_snapshot(PORTFOLIO_TOTAL_ACCOUNT_ID)?
+    else {
+        return Ok(false);
+    };
+
+    reconcile_quote_sync_from_snapshot(quote_service, &total_snapshot).await?;
+    Ok(true)
+}

--- a/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
+++ b/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
@@ -501,6 +501,18 @@ mod tests {
             Ok(std::collections::HashMap::new())
         }
 
+        fn get_holdings_snapshot_bounds_for_assets(
+            &self,
+            _asset_ids: &[String],
+        ) -> AppResult<
+            std::collections::HashMap<
+                String,
+                (Option<chrono::NaiveDate>, Option<chrono::NaiveDate>),
+            >,
+        > {
+            Ok(std::collections::HashMap::new())
+        }
+
         fn check_existing_duplicates(
             &self,
             _idempotency_keys: &[String],
@@ -707,6 +719,18 @@ mod tests {
         }
 
         fn get_activity_bounds_for_assets(
+            &self,
+            _asset_ids: &[String],
+        ) -> AppResult<
+            std::collections::HashMap<
+                String,
+                (Option<chrono::NaiveDate>, Option<chrono::NaiveDate>),
+            >,
+        > {
+            Ok(std::collections::HashMap::new())
+        }
+
+        fn get_holdings_snapshot_bounds_for_assets(
             &self,
             _asset_ids: &[String],
         ) -> AppResult<

--- a/crates/core/src/quotes/service.rs
+++ b/crates/core/src/quotes/service.rs
@@ -22,7 +22,7 @@ use super::import::{ImportValidationStatus, QuoteConverter, QuoteImport, QuoteVa
 use super::model::{LatestQuotePair, Quote, ResolvedQuote, SymbolSearchResult};
 use super::store::{ProviderSettingsStore, QuoteStore};
 use super::sync::{QuoteSyncService, QuoteSyncServiceTrait, SyncResult};
-use super::sync_state::{QuoteSyncState, SymbolSyncPlan, SyncMode, SyncStateStore};
+use super::sync_state::{QuoteSyncState, SymbolSyncPlan, SyncCategory, SyncMode, SyncStateStore};
 use super::types::{quote_id, AssetId, Day, QuoteSource};
 use crate::activities::ActivityRepositoryTrait;
 use crate::assets::{
@@ -365,6 +365,7 @@ pub trait QuoteServiceTrait: Send + Sync {
     async fn sync(&self, mode: SyncMode, asset_ids: Option<Vec<String>>) -> Result<SyncResult>;
 
     /// Force resync for specific asset IDs (or all if None) using BackfillHistory mode.
+    /// An empty asset ID list is treated as sync nothing.
     async fn resync(&self, asset_ids: Option<Vec<String>>) -> Result<SyncResult>;
 
     /// Refresh sync state from holdings/activities.
@@ -1495,9 +1496,74 @@ where
         use rust_decimal::Decimal;
 
         let today = Utc::now().date_naive();
+        let open_asset_ids: Vec<String> = current_holdings
+            .iter()
+            .filter_map(|(asset_id, quantity)| {
+                if *quantity > Decimal::ZERO {
+                    Some(asset_id.clone())
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if !open_asset_ids.is_empty() {
+            let open_assets = self.asset_repo.list_by_asset_ids(&open_asset_ids)?;
+            let open_sync_states = self.sync_state_store.get_by_asset_ids(&open_asset_ids)?;
+            let mut states_to_upsert = Vec::new();
+
+            for asset in open_assets {
+                if asset.kind == AssetKind::Fx {
+                    continue;
+                }
+
+                if !asset.is_active {
+                    debug!(
+                        "Reactivating asset {} from current holdings before quote sync",
+                        asset.id
+                    );
+                    self.asset_repo.reactivate(&asset.id).await?;
+                }
+
+                if asset.quote_mode != QuoteMode::Market {
+                    continue;
+                }
+
+                match open_sync_states.get(&asset.id).cloned() {
+                    Some(mut state) if !state.is_active || state.position_closed_date.is_some() => {
+                        debug!("Marking sync state active for open position {}", asset.id);
+                        state.mark_active();
+                        states_to_upsert.push(state);
+                    }
+                    Some(_) => {}
+                    None => {
+                        debug!("Creating sync state for open position {}", asset.id);
+                        let mut state = QuoteSyncState::new(asset.id.clone(), String::new());
+                        state.sync_priority = SyncCategory::Active.default_priority();
+                        states_to_upsert.push(state);
+                    }
+                }
+            }
+
+            if !states_to_upsert.is_empty() {
+                self.sync_state_store
+                    .upsert_batch(&states_to_upsert)
+                    .await?;
+            }
+        }
 
         // Get all sync states to determine previous active/inactive status
         let all_sync_states = self.sync_state_store.get_all()?;
+        let sync_state_asset_ids: Vec<String> = all_sync_states
+            .iter()
+            .map(|state| state.asset_id.clone())
+            .collect();
+        let assets_by_id: HashMap<String, Asset> = self
+            .asset_repo
+            .list_by_asset_ids(&sync_state_asset_ids)?
+            .into_iter()
+            .map(|asset| (asset.id.clone(), asset))
+            .collect();
 
         let mut marked_active = 0;
         let mut marked_inactive = 0;
@@ -1508,10 +1574,11 @@ where
             // Skip FX assets - they don't have "positions" in the holdings sense.
             // FX rates are always needed for currency conversion as long as there are
             // foreign-currency activities or holdings. Their lifecycle is managed separately.
-            if let Ok(asset) = self.asset_repo.get_by_id(asset_id) {
-                if asset.kind == AssetKind::Fx {
-                    continue;
-                }
+            let Some(asset) = assets_by_id.get(asset_id) else {
+                continue;
+            };
+            if asset.kind == AssetKind::Fx {
+                continue;
             }
 
             let current_qty = current_holdings
@@ -1529,7 +1596,6 @@ where
                         asset_id, current_qty
                     );
                     self.sync_state_store.mark_active(asset_id).await?;
-                    self.asset_repo.reactivate(asset_id).await?;
                     marked_active += 1;
                 }
                 // If already active, no change needed
@@ -1539,7 +1605,6 @@ where
                     // Was active, now closed - mark as inactive with today's date
                     debug!("Marking asset {} as inactive (position closed)", asset_id);
                     self.sync_state_store.mark_inactive(asset_id, today).await?;
-                    self.asset_repo.deactivate(asset_id).await?;
                     marked_inactive += 1;
                 }
                 // If already inactive, no change needed (preserve existing closed date)
@@ -2473,7 +2538,7 @@ mod tests {
         }
 
         fn get_all(&self) -> Result<Vec<QuoteSyncState>> {
-            unimplemented!("unused in this test")
+            Ok(self.states.lock().unwrap().values().cloned().collect())
         }
 
         fn get_by_asset_id(&self, asset_id: &str) -> Result<Option<QuoteSyncState>> {
@@ -2512,8 +2577,12 @@ mod tests {
             Ok(state.clone())
         }
 
-        async fn upsert_batch(&self, _states: &[QuoteSyncState]) -> Result<usize> {
-            unimplemented!("unused in this test")
+        async fn upsert_batch(&self, states: &[QuoteSyncState]) -> Result<usize> {
+            let mut stored = self.states.lock().unwrap();
+            for state in states {
+                stored.insert(state.asset_id.clone(), state.clone());
+            }
+            Ok(states.len())
         }
 
         async fn update_after_sync(&self, _asset_id: &str) -> Result<()> {
@@ -2524,12 +2593,18 @@ mod tests {
             unimplemented!("unused in this test")
         }
 
-        async fn mark_inactive(&self, _asset_id: &str, _closed_date: NaiveDate) -> Result<()> {
-            unimplemented!("unused in this test")
+        async fn mark_inactive(&self, asset_id: &str, closed_date: NaiveDate) -> Result<()> {
+            if let Some(state) = self.states.lock().unwrap().get_mut(asset_id) {
+                state.mark_closed(closed_date);
+            }
+            Ok(())
         }
 
-        async fn mark_active(&self, _asset_id: &str) -> Result<()> {
-            unimplemented!("unused in this test")
+        async fn mark_active(&self, asset_id: &str) -> Result<()> {
+            if let Some(state) = self.states.lock().unwrap().get_mut(asset_id) {
+                state.mark_active();
+            }
+            Ok(())
         }
 
         async fn delete(&self, _asset_id: &str) -> Result<()> {
@@ -2638,6 +2713,87 @@ mod tests {
 
         async fn reactivate(&self, _asset_id: &str) -> Result<()> {
             unimplemented!("unused in this test")
+        }
+
+        async fn copy_user_metadata(&self, _source_id: &str, _target_id: &str) -> Result<()> {
+            unimplemented!("unused in this test")
+        }
+
+        async fn deactivate_orphaned_investments(&self) -> Result<Vec<String>> {
+            unimplemented!("unused in this test")
+        }
+    }
+
+    struct PositionStatusAssetRepository {
+        assets: HashMap<String, Asset>,
+        reactivated: Arc<Mutex<Vec<String>>>,
+        deactivated: Arc<Mutex<Vec<String>>>,
+    }
+
+    #[async_trait]
+    impl AssetRepositoryTrait for PositionStatusAssetRepository {
+        async fn create(&self, _new_asset: NewAsset) -> Result<Asset> {
+            unimplemented!("unused in this test")
+        }
+
+        async fn create_batch(&self, _new_assets: Vec<NewAsset>) -> Result<Vec<Asset>> {
+            unimplemented!("unused in this test")
+        }
+
+        async fn update_profile(
+            &self,
+            _asset_id: &str,
+            _payload: UpdateAssetProfile,
+        ) -> Result<Asset> {
+            unimplemented!("unused in this test")
+        }
+
+        async fn update_quote_mode(&self, _asset_id: &str, _quote_mode: &str) -> Result<Asset> {
+            unimplemented!("unused in this test")
+        }
+
+        fn get_by_id(&self, asset_id: &str) -> Result<Asset> {
+            self.assets
+                .get(asset_id)
+                .cloned()
+                .ok_or_else(|| crate::Error::Unexpected(format!("asset not found: {}", asset_id)))
+        }
+
+        fn list(&self) -> Result<Vec<Asset>> {
+            Ok(self.assets.values().cloned().collect())
+        }
+
+        fn list_by_asset_ids(&self, asset_ids: &[String]) -> Result<Vec<Asset>> {
+            Ok(asset_ids
+                .iter()
+                .filter_map(|asset_id| self.assets.get(asset_id).cloned())
+                .collect())
+        }
+
+        async fn delete(&self, _asset_id: &str) -> Result<()> {
+            unimplemented!("unused in this test")
+        }
+
+        fn search_by_symbol(&self, _query: &str) -> Result<Vec<Asset>> {
+            unimplemented!("unused in this test")
+        }
+
+        fn find_by_instrument_key(&self, _instrument_key: &str) -> Result<Option<Asset>> {
+            unimplemented!("unused in this test")
+        }
+
+        async fn cleanup_legacy_metadata(&self, _asset_id: &str) -> Result<()> {
+            unimplemented!("unused in this test")
+        }
+
+        async fn deactivate(&self, asset_id: &str) -> Result<()> {
+            self.deactivated.lock().unwrap().push(asset_id.to_string());
+            Ok(())
+        }
+
+        async fn reactivate(&self, asset_id: &str) -> Result<()> {
+            self.reactivated.lock().unwrap().push(asset_id.to_string());
+            Ok(())
         }
 
         async fn copy_user_metadata(&self, _source_id: &str, _target_id: &str) -> Result<()> {
@@ -2841,6 +2997,13 @@ mod tests {
             unimplemented!("unused in this test")
         }
 
+        fn get_holdings_snapshot_bounds_for_assets(
+            &self,
+            _asset_ids: &[String],
+        ) -> Result<HashMap<String, (Option<NaiveDate>, Option<NaiveDate>)>> {
+            unimplemented!("unused in this test")
+        }
+
         fn check_existing_duplicates(
             &self,
             _idempotency_keys: &[String],
@@ -3024,6 +3187,181 @@ mod tests {
         assert!(updated.last_error.is_none());
         assert_eq!(updated.last_synced_at, state.last_synced_at);
         assert_eq!(updated.profile_enriched_at, state.profile_enriched_at);
+    }
+
+    #[tokio::test]
+    async fn test_update_position_status_creates_sync_state_for_open_inactive_asset() {
+        let asset_id = "asset_1".to_string();
+        let asset = Asset {
+            id: asset_id.clone(),
+            kind: AssetKind::Investment,
+            quote_mode: QuoteMode::Market,
+            is_active: false,
+            ..Default::default()
+        };
+        let reactivated = Arc::new(Mutex::new(Vec::new()));
+        let deactivated = Arc::new(Mutex::new(Vec::new()));
+        let asset_repo = PositionStatusAssetRepository {
+            assets: HashMap::from([(asset_id.clone(), asset)]),
+            reactivated: Arc::clone(&reactivated),
+            deactivated: Arc::clone(&deactivated),
+        };
+        let states = Arc::new(Mutex::new(HashMap::new()));
+        let sync_state_store = Arc::new(MockSyncStateStore {
+            provider_sync_stats: vec![],
+            with_errors: vec![],
+            states: Arc::clone(&states),
+        });
+        let service = QuoteService::new(
+            Arc::new(NoopQuoteStore),
+            sync_state_store,
+            Arc::new(MockProviderSettingsStore { providers: vec![] }),
+            Arc::new(asset_repo),
+            Arc::new(NoopActivityRepository),
+            Arc::new(MockSecretStore),
+        )
+        .await
+        .unwrap();
+        let current_holdings = HashMap::from([(asset_id.clone(), dec!(1))]);
+
+        service
+            .update_position_status_from_holdings(&current_holdings)
+            .await
+            .unwrap();
+
+        assert_eq!(*reactivated.lock().unwrap(), vec![asset_id.clone()]);
+        assert!(deactivated.lock().unwrap().is_empty());
+
+        let stored = states.lock().unwrap().get(&asset_id).cloned().unwrap();
+        assert!(stored.is_active);
+        assert!(stored.position_closed_date.is_none());
+        assert_eq!(
+            stored.sync_priority,
+            SyncCategory::Active.default_priority()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_position_status_reopens_existing_sync_state() {
+        let asset_id = "asset_1".to_string();
+        let now = Utc::now();
+        let asset = Asset {
+            id: asset_id.clone(),
+            kind: AssetKind::Investment,
+            quote_mode: QuoteMode::Market,
+            is_active: true,
+            ..Default::default()
+        };
+        let closed_state = QuoteSyncState {
+            asset_id: asset_id.clone(),
+            is_active: false,
+            position_closed_date: Some(NaiveDate::from_ymd_opt(2026, 1, 1).unwrap()),
+            last_synced_at: Some(now),
+            data_source: "YAHOO".to_string(),
+            sync_priority: 50,
+            error_count: 0,
+            last_error: None,
+            profile_enriched_at: None,
+            created_at: now,
+            updated_at: now,
+        };
+        let states = Arc::new(Mutex::new(HashMap::from([(
+            asset_id.clone(),
+            closed_state,
+        )])));
+        let asset_repo = PositionStatusAssetRepository {
+            assets: HashMap::from([(asset_id.clone(), asset)]),
+            reactivated: Arc::new(Mutex::new(Vec::new())),
+            deactivated: Arc::new(Mutex::new(Vec::new())),
+        };
+        let service = QuoteService::new(
+            Arc::new(NoopQuoteStore),
+            Arc::new(MockSyncStateStore {
+                provider_sync_stats: vec![],
+                with_errors: vec![],
+                states: Arc::clone(&states),
+            }),
+            Arc::new(MockProviderSettingsStore { providers: vec![] }),
+            Arc::new(asset_repo),
+            Arc::new(NoopActivityRepository),
+            Arc::new(MockSecretStore),
+        )
+        .await
+        .unwrap();
+        let current_holdings = HashMap::from([(asset_id.clone(), dec!(1))]);
+
+        service
+            .update_position_status_from_holdings(&current_holdings)
+            .await
+            .unwrap();
+
+        let stored = states.lock().unwrap().get(&asset_id).cloned().unwrap();
+        assert!(stored.is_active);
+        assert!(stored.position_closed_date.is_none());
+        assert_eq!(
+            stored.sync_priority,
+            SyncCategory::Active.default_priority()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_update_position_status_closes_sync_state_without_deactivating_asset() {
+        let asset_id = "asset_1".to_string();
+        let now = Utc::now();
+        let asset = Asset {
+            id: asset_id.clone(),
+            kind: AssetKind::Investment,
+            quote_mode: QuoteMode::Market,
+            is_active: true,
+            ..Default::default()
+        };
+        let active_state = QuoteSyncState {
+            asset_id: asset_id.clone(),
+            is_active: true,
+            position_closed_date: None,
+            last_synced_at: Some(now),
+            data_source: "YAHOO".to_string(),
+            sync_priority: SyncCategory::Active.default_priority(),
+            error_count: 0,
+            last_error: None,
+            profile_enriched_at: None,
+            created_at: now,
+            updated_at: now,
+        };
+        let states = Arc::new(Mutex::new(HashMap::from([(
+            asset_id.clone(),
+            active_state,
+        )])));
+        let deactivated = Arc::new(Mutex::new(Vec::new()));
+        let asset_repo = PositionStatusAssetRepository {
+            assets: HashMap::from([(asset_id.clone(), asset)]),
+            reactivated: Arc::new(Mutex::new(Vec::new())),
+            deactivated: Arc::clone(&deactivated),
+        };
+        let service = QuoteService::new(
+            Arc::new(NoopQuoteStore),
+            Arc::new(MockSyncStateStore {
+                provider_sync_stats: vec![],
+                with_errors: vec![],
+                states: Arc::clone(&states),
+            }),
+            Arc::new(MockProviderSettingsStore { providers: vec![] }),
+            Arc::new(asset_repo),
+            Arc::new(NoopActivityRepository),
+            Arc::new(MockSecretStore),
+        )
+        .await
+        .unwrap();
+
+        service
+            .update_position_status_from_holdings(&HashMap::new())
+            .await
+            .unwrap();
+
+        let stored = states.lock().unwrap().get(&asset_id).cloned().unwrap();
+        assert!(!stored.is_active);
+        assert!(stored.position_closed_date.is_some());
+        assert!(deactivated.lock().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/core/src/quotes/service.rs
+++ b/crates/core/src/quotes/service.rs
@@ -32,6 +32,7 @@ use crate::assets::{
 };
 use crate::errors::Result;
 use crate::fx::currency::{get_normalization_rule, normalize_currency_code};
+use crate::portfolio::snapshot::is_quantity_significant;
 use crate::secrets::SecretStore;
 
 use wealthfolio_market_data::{exchanges_for_currency, mic_to_exchange_name};
@@ -136,6 +137,10 @@ fn extract_provider_id_from_sync_error(error: &str) -> Option<&'static str> {
     super::constants::MARKET_DATA_PROVIDER_IDS
         .into_iter()
         .find(|provider_id| error.contains(provider_id))
+}
+
+fn has_open_position_quantity(quantity: &rust_decimal::Decimal) -> bool {
+    !quantity.is_zero() && is_quantity_significant(quantity)
 }
 
 fn provider_config_for_symbol_resolution(
@@ -1499,7 +1504,7 @@ where
         let open_asset_ids: Vec<String> = current_holdings
             .iter()
             .filter_map(|(asset_id, quantity)| {
-                if *quantity > Decimal::ZERO {
+                if has_open_position_quantity(quantity) {
                     Some(asset_id.clone())
                 } else {
                     None
@@ -1510,7 +1515,8 @@ where
         if !open_asset_ids.is_empty() {
             let open_assets = self.asset_repo.list_by_asset_ids(&open_asset_ids)?;
             let open_sync_states = self.sync_state_store.get_by_asset_ids(&open_asset_ids)?;
-            let mut states_to_upsert = Vec::new();
+            let mut open_states_to_upsert = Vec::new();
+            let mut assets_to_reactivate = Vec::new();
 
             for asset in open_assets {
                 if asset.kind == AssetKind::Fx {
@@ -1519,10 +1525,10 @@ where
 
                 if !asset.is_active {
                     debug!(
-                        "Reactivating asset {} from current holdings before quote sync",
+                        "Queueing asset {} for reactivation from current holdings before quote sync",
                         asset.id
                     );
-                    self.asset_repo.reactivate(&asset.id).await?;
+                    assets_to_reactivate.push(asset.id.clone());
                 }
 
                 if asset.quote_mode != QuoteMode::Market {
@@ -1533,21 +1539,27 @@ where
                     Some(mut state) if !state.is_active || state.position_closed_date.is_some() => {
                         debug!("Marking sync state active for open position {}", asset.id);
                         state.mark_active();
-                        states_to_upsert.push(state);
+                        open_states_to_upsert.push(state);
                     }
                     Some(_) => {}
                     None => {
                         debug!("Creating sync state for open position {}", asset.id);
                         let mut state = QuoteSyncState::new(asset.id.clone(), String::new());
                         state.sync_priority = SyncCategory::Active.default_priority();
-                        states_to_upsert.push(state);
+                        open_states_to_upsert.push(state);
                     }
                 }
             }
 
-            if !states_to_upsert.is_empty() {
+            if !assets_to_reactivate.is_empty() {
+                self.asset_repo
+                    .reactivate_batch(&assets_to_reactivate)
+                    .await?;
+            }
+
+            if !open_states_to_upsert.is_empty() {
                 self.sync_state_store
-                    .upsert_batch(&states_to_upsert)
+                    .upsert_batch(&open_states_to_upsert)
                     .await?;
             }
         }
@@ -1567,6 +1579,7 @@ where
 
         let mut marked_active = 0;
         let mut marked_inactive = 0;
+        let mut lifecycle_states_to_upsert = Vec::new();
 
         for sync_state in all_sync_states {
             let asset_id = &sync_state.asset_id;
@@ -1585,17 +1598,19 @@ where
                 .get(asset_id)
                 .copied()
                 .unwrap_or(Decimal::ZERO);
-            let has_open_position = current_qty > Decimal::ZERO;
+            let has_open_position = has_open_position_quantity(&current_qty);
 
             if has_open_position {
-                // Asset has an open position
+                // Any non-zero held quantity means the catalog asset must remain usable.
                 if !sync_state.is_active {
                     // Was inactive, now has a position - mark as active (re-opened)
                     debug!(
                         "Marking asset {} as active (re-opened position, qty={})",
                         asset_id, current_qty
                     );
-                    self.sync_state_store.mark_active(asset_id).await?;
+                    let mut state = sync_state.clone();
+                    state.mark_active();
+                    lifecycle_states_to_upsert.push(state);
                     marked_active += 1;
                 }
                 // If already active, no change needed
@@ -1604,11 +1619,19 @@ where
                 if sync_state.is_active {
                     // Was active, now closed - mark as inactive with today's date
                     debug!("Marking asset {} as inactive (position closed)", asset_id);
-                    self.sync_state_store.mark_inactive(asset_id, today).await?;
+                    let mut state = sync_state.clone();
+                    state.mark_closed(today);
+                    lifecycle_states_to_upsert.push(state);
                     marked_inactive += 1;
                 }
                 // If already inactive, no change needed (preserve existing closed date)
             }
+        }
+
+        if !lifecycle_states_to_upsert.is_empty() {
+            self.sync_state_store
+                .upsert_batch(&lifecycle_states_to_upsert)
+                .await?;
         }
 
         if marked_active > 0 || marked_inactive > 0 {
@@ -3239,6 +3262,50 @@ mod tests {
             stored.sync_priority,
             SyncCategory::Active.default_priority()
         );
+    }
+
+    #[tokio::test]
+    async fn test_update_position_status_treats_negative_quantity_as_open() {
+        let asset_id = "asset_1".to_string();
+        let asset = Asset {
+            id: asset_id.clone(),
+            kind: AssetKind::Investment,
+            quote_mode: QuoteMode::Market,
+            is_active: false,
+            ..Default::default()
+        };
+        let reactivated = Arc::new(Mutex::new(Vec::new()));
+        let asset_repo = PositionStatusAssetRepository {
+            assets: HashMap::from([(asset_id.clone(), asset)]),
+            reactivated: Arc::clone(&reactivated),
+            deactivated: Arc::new(Mutex::new(Vec::new())),
+        };
+        let states = Arc::new(Mutex::new(HashMap::new()));
+        let service = QuoteService::new(
+            Arc::new(NoopQuoteStore),
+            Arc::new(MockSyncStateStore {
+                provider_sync_stats: vec![],
+                with_errors: vec![],
+                states: Arc::clone(&states),
+            }),
+            Arc::new(MockProviderSettingsStore { providers: vec![] }),
+            Arc::new(asset_repo),
+            Arc::new(NoopActivityRepository),
+            Arc::new(MockSecretStore),
+        )
+        .await
+        .unwrap();
+        let current_holdings = HashMap::from([(asset_id.clone(), dec!(-1))]);
+
+        service
+            .update_position_status_from_holdings(&current_holdings)
+            .await
+            .unwrap();
+
+        assert_eq!(*reactivated.lock().unwrap(), vec![asset_id.clone()]);
+        let stored = states.lock().unwrap().get(&asset_id).cloned().unwrap();
+        assert!(stored.is_active);
+        assert!(stored.position_closed_date.is_none());
     }
 
     #[tokio::test]

--- a/crates/core/src/quotes/service.rs
+++ b/crates/core/src/quotes/service.rs
@@ -1515,7 +1515,8 @@ where
         if !open_asset_ids.is_empty() {
             let open_assets = self.asset_repo.list_by_asset_ids(&open_asset_ids)?;
             let open_sync_states = self.sync_state_store.get_by_asset_ids(&open_asset_ids)?;
-            let mut open_states_to_upsert = Vec::new();
+            let mut open_states_to_mark_active = Vec::new();
+            let mut new_open_states = Vec::new();
             let mut assets_to_reactivate = Vec::new();
 
             for asset in open_assets {
@@ -1524,6 +1525,9 @@ where
                 }
 
                 if !asset.is_active {
+                    // Catalog active state follows actual holdings: a user-hidden asset
+                    // must become selectable again while it is held. Closing the position
+                    // only closes quote sync state; it does not auto-hide the asset.
                     debug!(
                         "Queueing asset {} for reactivation from current holdings before quote sync",
                         asset.id
@@ -1536,17 +1540,16 @@ where
                 }
 
                 match open_sync_states.get(&asset.id).cloned() {
-                    Some(mut state) if !state.is_active || state.position_closed_date.is_some() => {
+                    Some(state) if !state.is_active || state.position_closed_date.is_some() => {
                         debug!("Marking sync state active for open position {}", asset.id);
-                        state.mark_active();
-                        open_states_to_upsert.push(state);
+                        open_states_to_mark_active.push(asset.id.clone());
                     }
                     Some(_) => {}
                     None => {
                         debug!("Creating sync state for open position {}", asset.id);
                         let mut state = QuoteSyncState::new(asset.id.clone(), String::new());
                         state.sync_priority = SyncCategory::Active.default_priority();
-                        open_states_to_upsert.push(state);
+                        new_open_states.push(state);
                     }
                 }
             }
@@ -1557,10 +1560,14 @@ where
                     .await?;
             }
 
-            if !open_states_to_upsert.is_empty() {
+            if !open_states_to_mark_active.is_empty() {
                 self.sync_state_store
-                    .upsert_batch(&open_states_to_upsert)
+                    .mark_active_batch(&open_states_to_mark_active)
                     .await?;
+            }
+
+            if !new_open_states.is_empty() {
+                self.sync_state_store.upsert_batch(&new_open_states).await?;
             }
         }
 
@@ -1579,7 +1586,8 @@ where
 
         let mut marked_active = 0;
         let mut marked_inactive = 0;
-        let mut lifecycle_states_to_upsert = Vec::new();
+        let mut lifecycle_states_to_mark_active = Vec::new();
+        let mut lifecycle_states_to_mark_inactive = Vec::new();
 
         for sync_state in all_sync_states {
             let asset_id = &sync_state.asset_id;
@@ -1608,9 +1616,7 @@ where
                         "Marking asset {} as active (re-opened position, qty={})",
                         asset_id, current_qty
                     );
-                    let mut state = sync_state.clone();
-                    state.mark_active();
-                    lifecycle_states_to_upsert.push(state);
+                    lifecycle_states_to_mark_active.push(asset_id.clone());
                     marked_active += 1;
                 }
                 // If already active, no change needed
@@ -1619,18 +1625,22 @@ where
                 if sync_state.is_active {
                     // Was active, now closed - mark as inactive with today's date
                     debug!("Marking asset {} as inactive (position closed)", asset_id);
-                    let mut state = sync_state.clone();
-                    state.mark_closed(today);
-                    lifecycle_states_to_upsert.push(state);
+                    lifecycle_states_to_mark_inactive.push(asset_id.clone());
                     marked_inactive += 1;
                 }
                 // If already inactive, no change needed (preserve existing closed date)
             }
         }
 
-        if !lifecycle_states_to_upsert.is_empty() {
+        if !lifecycle_states_to_mark_active.is_empty() {
             self.sync_state_store
-                .upsert_batch(&lifecycle_states_to_upsert)
+                .mark_active_batch(&lifecycle_states_to_mark_active)
+                .await?;
+        }
+
+        if !lifecycle_states_to_mark_inactive.is_empty() {
+            self.sync_state_store
+                .mark_inactive_batch(&lifecycle_states_to_mark_inactive, today)
                 .await?;
         }
 

--- a/crates/core/src/quotes/sync.rs
+++ b/crates/core/src/quotes/sync.rs
@@ -287,10 +287,7 @@ fn calculate_targeted_closed_incremental_window(
     inputs: &SyncPlanningInputs,
     fetch_end_date: NaiveDate,
 ) -> Option<(NaiveDate, NaiveDate)> {
-    let end_date = inputs
-        .position_closed_date
-        .map(|closed_date| closed_date.min(fetch_end_date))
-        .unwrap_or(fetch_end_date);
+    let end_date = fetch_end_date;
     let start_date = inputs
         .quote_max
         .map(|quote_max| quote_max - Duration::days(OVERLAP_DAYS))
@@ -2167,7 +2164,7 @@ mod tests {
     }
 
     #[test]
-    fn test_targeted_closed_incremental_window_caps_at_close_date() {
+    fn test_targeted_closed_incremental_window_fetches_through_fetch_end_date() {
         let inputs = SyncPlanningInputs {
             is_active: false,
             position_closed_date: Some(NaiveDate::from_ymd_opt(2026, 2, 15).unwrap()),
@@ -2184,7 +2181,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(start, NaiveDate::from_ymd_opt(2026, 1, 27).unwrap());
-        assert_eq!(end, NaiveDate::from_ymd_opt(2026, 2, 15).unwrap());
+        assert_eq!(end, NaiveDate::from_ymd_opt(2026, 5, 6).unwrap());
     }
 
     #[test]
@@ -2195,7 +2192,7 @@ mod tests {
             activity_min: Some(NaiveDate::from_ymd_opt(2025, 1, 1).unwrap()),
             activity_max: Some(NaiveDate::from_ymd_opt(2026, 2, 15).unwrap()),
             quote_min: Some(NaiveDate::from_ymd_opt(2025, 1, 1).unwrap()),
-            quote_max: Some(NaiveDate::from_ymd_opt(2026, 3, 1).unwrap()),
+            quote_max: Some(NaiveDate::from_ymd_opt(2026, 6, 1).unwrap()),
         };
 
         assert_eq!(

--- a/crates/core/src/quotes/sync.rs
+++ b/crates/core/src/quotes/sync.rs
@@ -157,7 +157,8 @@ fn asset_skip_reason(asset: &Asset, allow_inactive: bool) -> Option<AssetSkipRea
         return Some(AssetSkipReason::ManualPricing);
     }
 
-    // Broad/background sync should not fetch prices for inactive catalog assets.
+    // This only covers catalog lifecycle. Closed positions on still-active catalog
+    // assets are handled later after sync category planning.
     // Targeted row-level sync can opt in so users can refresh deactivated assets.
     if !allow_inactive && !asset.is_active {
         return Some(AssetSkipReason::Inactive);
@@ -274,6 +275,27 @@ fn should_allow_inactive_asset(
 
 fn should_purge_provider_quotes(mode: SyncMode, inputs: &SyncPlanningInputs) -> bool {
     matches!(mode, SyncMode::BackfillHistory { .. }) && inputs.activity_min.is_some()
+}
+
+fn calculate_targeted_closed_incremental_window(
+    inputs: &SyncPlanningInputs,
+    fetch_end_date: NaiveDate,
+) -> (NaiveDate, NaiveDate) {
+    let end_date = inputs
+        .position_closed_date
+        .map(|closed_date| closed_date.min(fetch_end_date))
+        .unwrap_or(fetch_end_date);
+    let start_date = inputs
+        .quote_max
+        .map(|quote_max| quote_max - Duration::days(OVERLAP_DAYS))
+        .or_else(|| {
+            inputs
+                .activity_min
+                .map(|activity_min| activity_min - Duration::days(QUOTE_HISTORY_BUFFER_DAYS))
+        })
+        .unwrap_or_else(|| end_date - Duration::days(MIN_SYNC_LOOKBACK_DAYS));
+
+    (start_date, end_date)
 }
 
 // Test helpers - expose lock functions for testing
@@ -531,60 +553,6 @@ where
         }
     }
 
-    /// Build sync plan for a list of assets.
-    ///
-    /// Determines the date ranges needed for each asset based on:
-    /// - First activity date (for backfill)
-    /// - Last synced date (for incremental sync)
-    /// - Current sync category (active, new, needs backfill, etc.)
-    pub fn build_sync_plan(&self, assets: &[Asset]) -> Vec<SymbolSyncPlan> {
-        let now = Utc::now();
-        let asset_ids: Vec<String> = assets.iter().map(|asset| asset.id.clone()).collect();
-        let existing_states = self
-            .sync_state_store
-            .get_by_asset_ids(&asset_ids)
-            .unwrap_or_default();
-        let activity_bounds = self
-            .activity_repo
-            .get_activity_bounds_for_assets(&asset_ids)
-            .unwrap_or_default();
-        let holdings_bounds = self
-            .activity_repo
-            .get_holdings_snapshot_bounds_for_assets(&asset_ids)
-            .unwrap_or_default();
-
-        // Compute quote bounds per provider
-        // Group assets by preferred_provider and batch query
-        let mut quote_bounds: HashMap<String, (NaiveDate, NaiveDate)> = HashMap::new();
-        let mut assets_by_provider: HashMap<String, Vec<String>> = HashMap::new();
-        for asset in assets.iter().filter(|a| self.should_sync_asset(a)) {
-            let provider = effective_provider(existing_states.get(&asset.id), asset);
-            assets_by_provider
-                .entry(provider)
-                .or_default()
-                .push(asset.id.clone());
-        }
-        for (provider, ids) in &assets_by_provider {
-            if let Ok(bounds) = self.quote_store.get_quote_bounds_for_assets(ids, provider) {
-                quote_bounds.extend(bounds);
-            }
-        }
-
-        assets
-            .iter()
-            .filter(|a| self.should_sync_asset(a))
-            .filter_map(|asset| {
-                self.build_asset_sync_plan(
-                    asset,
-                    now,
-                    &activity_bounds,
-                    &holdings_bounds,
-                    &quote_bounds,
-                )
-            })
-            .collect()
-    }
-
     /// Check if an asset should be synced.
     fn should_sync_asset(&self, asset: &Asset) -> bool {
         self.get_skip_reason(asset, false).is_none()
@@ -656,82 +624,6 @@ where
                 );
             }
         }
-    }
-
-    /// Build sync plan for a single asset.
-    fn build_asset_sync_plan(
-        &self,
-        asset: &Asset,
-        now: DateTime<Utc>,
-        activity_bounds: &HashMap<String, (Option<NaiveDate>, Option<NaiveDate>)>,
-        holdings_bounds: &HashMap<String, (Option<NaiveDate>, Option<NaiveDate>)>,
-        quote_bounds: &HashMap<String, (NaiveDate, NaiveDate)>,
-    ) -> Option<SymbolSyncPlan> {
-        let effective_today = effective_market_today(now, asset.instrument_exchange_mic.as_deref());
-        let fetch_end_date = market_fetch_end_date(now, asset.instrument_exchange_mic.as_deref());
-        // Get existing sync state
-        let state = self
-            .sync_state_store
-            .get_by_asset_id(&asset.id)
-            .ok()
-            .flatten();
-
-        // Build SyncPlanningInputs from computed bounds
-        let (activity_min, activity_max) = merge_bounds(
-            activity_bounds.get(&asset.id).copied(),
-            holdings_bounds.get(&asset.id).copied(),
-        );
-
-        let (quote_min, quote_max) = quote_bounds
-            .get(&asset.id)
-            .map(|(min, max)| (Some(*min), Some(*max)))
-            .unwrap_or((None, None));
-
-        let inputs = SyncPlanningInputs {
-            is_active: state
-                .as_ref()
-                .map(|s| s.is_active)
-                .unwrap_or(asset.is_active),
-            position_closed_date: state.as_ref().and_then(|s| s.position_closed_date),
-            activity_min,
-            activity_max,
-            quote_min,
-            quote_max,
-        };
-
-        let category =
-            determine_sync_category(&inputs, CLOSED_POSITION_GRACE_PERIOD_DAYS, effective_today);
-
-        // Skip closed positions
-        if matches!(category, SyncCategory::Closed) {
-            return None;
-        }
-
-        // Use the new calculate_sync_window function
-        let (start_date, end_date) = calculate_sync_window(&category, &inputs, effective_today)?;
-        let end_date = clamp_end_date_for_fetch(&category, end_date, fetch_end_date);
-
-        // Validate date range
-        if start_date > end_date {
-            return None;
-        }
-
-        Some(SymbolSyncPlan {
-            asset_id: asset.id.clone(),
-            category,
-            start_date,
-            end_date,
-            priority: state
-                .as_ref()
-                .map(|s| s.sync_priority)
-                .unwrap_or_else(|| SyncCategory::New.default_priority()),
-            data_source: asset
-                .preferred_provider()
-                .unwrap_or_else(|| DATA_SOURCE_YAHOO.to_string()),
-            quote_symbol: None, // Derived from asset during fetch
-            currency: asset.quote_ccy.clone(),
-            purge_provider_quotes: false,
-        })
     }
 
     /// Calculate the date range for syncing an asset based on SyncMode.
@@ -1487,19 +1379,6 @@ where
 
         let now = Utc::now();
         let syncable_ids: Vec<String> = syncable.iter().map(|asset| asset.id.clone()).collect();
-        let ensure_state_assets: Vec<Asset> = syncable
-            .iter()
-            .filter(|asset| asset.is_active || targeted_sync)
-            .map(|asset| (*asset).clone())
-            .collect();
-
-        if let Err(e) = self
-            .ensure_sync_states_for_assets(&ensure_state_assets, true)
-            .await
-        {
-            warn!("Failed to ensure sync states: {:?}", e);
-        }
-
         let existing_states = self.sync_state_store.get_by_asset_ids(&syncable_ids)?;
 
         // Compute quote bounds per provider
@@ -1572,6 +1451,7 @@ where
                 effective_today,
             );
             let mut planning_inputs = inputs.clone();
+            let mut targeted_closed_incremental = false;
 
             if matches!(category, SyncCategory::Closed) {
                 if !include_closed_positions {
@@ -1580,9 +1460,13 @@ where
                 }
 
                 if targeted_sync && matches!(mode, SyncMode::Incremental) {
-                    category = SyncCategory::Active;
+                    info!(
+                        "Planning targeted quote refresh for closed position {}",
+                        asset.id
+                    );
+                    category = SyncCategory::RecentlyClosed;
                     planning_inputs.is_active = true;
-                    planning_inputs.position_closed_date = None;
+                    targeted_closed_incremental = true;
                 }
             }
 
@@ -1633,13 +1517,17 @@ where
                 continue;
             }
 
-            let (start_date, end_date) = self.calculate_date_range_for_mode(
-                &planning_inputs,
-                mode,
-                effective_today,
-                fetch_end_date,
-                asset,
-            );
+            let (start_date, end_date) = if targeted_closed_incremental {
+                calculate_targeted_closed_incremental_window(&planning_inputs, fetch_end_date)
+            } else {
+                self.calculate_date_range_for_mode(
+                    &planning_inputs,
+                    mode,
+                    effective_today,
+                    fetch_end_date,
+                    asset,
+                )
+            };
 
             plans.push(SymbolSyncPlan {
                 asset_id: asset.id.clone(),
@@ -1662,6 +1550,21 @@ where
                 result.skipped
             );
             return Ok(result);
+        }
+
+        let planned_asset_ids: HashSet<String> =
+            plans.iter().map(|plan| plan.asset_id.clone()).collect();
+        let ensure_state_assets: Vec<Asset> = syncable
+            .iter()
+            .filter(|asset| planned_asset_ids.contains(&asset.id))
+            .map(|asset| (*asset).clone())
+            .collect();
+
+        if let Err(e) = self
+            .ensure_sync_states_for_assets(&ensure_state_assets, true)
+            .await
+        {
+            warn!("Failed to ensure sync states: {:?}", e);
         }
 
         info!(
@@ -2212,6 +2115,26 @@ mod tests {
             SyncMode::RefetchRecent { days: 30 },
             &inputs_with_history_start
         ));
+    }
+
+    #[test]
+    fn test_targeted_closed_incremental_window_caps_at_close_date() {
+        let inputs = SyncPlanningInputs {
+            is_active: false,
+            position_closed_date: Some(NaiveDate::from_ymd_opt(2026, 2, 15).unwrap()),
+            activity_min: Some(NaiveDate::from_ymd_opt(2025, 1, 1).unwrap()),
+            activity_max: Some(NaiveDate::from_ymd_opt(2026, 2, 15).unwrap()),
+            quote_min: Some(NaiveDate::from_ymd_opt(2025, 1, 1).unwrap()),
+            quote_max: Some(NaiveDate::from_ymd_opt(2026, 2, 1).unwrap()),
+        };
+
+        let (start, end) = calculate_targeted_closed_incremental_window(
+            &inputs,
+            NaiveDate::from_ymd_opt(2026, 5, 6).unwrap(),
+        );
+
+        assert_eq!(start, NaiveDate::from_ymd_opt(2026, 1, 27).unwrap());
+        assert_eq!(end, NaiveDate::from_ymd_opt(2026, 2, 15).unwrap());
     }
 
     #[test]

--- a/crates/core/src/quotes/sync.rs
+++ b/crates/core/src/quotes/sync.rs
@@ -120,8 +120,14 @@ fn clamp_end_date_for_fetch(
     }
 }
 
-fn should_treat_fetch_error_as_non_fatal(category: &SyncCategory, error: &Error) -> bool {
-    if !matches!(category, SyncCategory::NeedsBackfill | SyncCategory::Closed) {
+fn should_treat_fetch_error_as_non_fatal(
+    category: &SyncCategory,
+    error: &Error,
+    suppress_closed_fetch_errors: bool,
+) -> bool {
+    if !matches!(category, SyncCategory::NeedsBackfill)
+        && !(matches!(category, SyncCategory::Closed) && suppress_closed_fetch_errors)
+    {
         return false;
     }
 
@@ -280,7 +286,7 @@ fn should_purge_provider_quotes(mode: SyncMode, inputs: &SyncPlanningInputs) -> 
 fn calculate_targeted_closed_incremental_window(
     inputs: &SyncPlanningInputs,
     fetch_end_date: NaiveDate,
-) -> (NaiveDate, NaiveDate) {
+) -> Option<(NaiveDate, NaiveDate)> {
     let end_date = inputs
         .position_closed_date
         .map(|closed_date| closed_date.min(fetch_end_date))
@@ -295,7 +301,11 @@ fn calculate_targeted_closed_incremental_window(
         })
         .unwrap_or_else(|| end_date - Duration::days(MIN_SYNC_LOOKBACK_DAYS));
 
-    (start_date, end_date)
+    if start_date > end_date {
+        None
+    } else {
+        Some((start_date, end_date))
+    }
 }
 
 // Test helpers - expose lock functions for testing
@@ -357,6 +367,8 @@ pub enum AssetSkipReason {
     SyncInProgress,
     /// Too many consecutive sync failures (exceeds MAX_SYNC_ERRORS).
     TooManyErrors,
+    /// No fetchable quote window remains for the requested sync.
+    NoQuoteWindow,
     /// Bond has matured — price is par, no further sync needed.
     MaturedBond,
     /// Option has expired — no further quotes available.
@@ -373,6 +385,7 @@ impl std::fmt::Display for AssetSkipReason {
             AssetSkipReason::NotFound => write!(f, "Asset not found"),
             AssetSkipReason::SyncInProgress => write!(f, "Sync already in progress"),
             AssetSkipReason::TooManyErrors => write!(f, "Too many consecutive sync failures"),
+            AssetSkipReason::NoQuoteWindow => write!(f, "No quote refresh needed"),
             AssetSkipReason::MaturedBond => write!(f, "Bond has matured (price is par)"),
             AssetSkipReason::ExpiredOption => write!(f, "Option has expired"),
         }
@@ -941,7 +954,11 @@ where
                 let sync_failure_message =
                     format_sync_failure_message(&error, fetch_error.provider_id.as_deref());
 
-                if should_treat_fetch_error_as_non_fatal(&plan.category, &error) {
+                if should_treat_fetch_error_as_non_fatal(
+                    &plan.category,
+                    &error,
+                    plan.suppress_closed_fetch_errors,
+                ) {
                     if let Err(state_err) = self.sync_state_store.update_after_sync(&asset.id).await
                     {
                         warn!(
@@ -1189,6 +1206,7 @@ where
                             quote_symbol: None,
                             currency: asset.quote_ccy.clone(),
                             purge_provider_quotes: false,
+                            suppress_closed_fetch_errors: false,
                         });
                     }
                 }
@@ -1216,6 +1234,7 @@ where
                             quote_symbol: None,
                             currency: asset.quote_ccy.clone(),
                             purge_provider_quotes: false,
+                            suppress_closed_fetch_errors: false,
                         });
                     }
                 }
@@ -1252,6 +1271,7 @@ where
                 quote_symbol: None,
                 currency: asset.quote_ccy.clone(),
                 purge_provider_quotes: false,
+                suppress_closed_fetch_errors: false,
             });
         }
 
@@ -1493,6 +1513,7 @@ where
                             quote_symbol: None,
                             currency: asset.quote_ccy.clone(),
                             purge_provider_quotes: false,
+                            suppress_closed_fetch_errors: false,
                         });
                     }
                 }
@@ -1511,6 +1532,7 @@ where
                             quote_symbol: None,
                             currency: asset.quote_ccy.clone(),
                             purge_provider_quotes: false,
+                            suppress_closed_fetch_errors: false,
                         });
                     }
                 }
@@ -1518,7 +1540,13 @@ where
             }
 
             let (start_date, end_date) = if targeted_closed_incremental {
-                calculate_targeted_closed_incremental_window(&planning_inputs, fetch_end_date)
+                let Some(window) =
+                    calculate_targeted_closed_incremental_window(&planning_inputs, fetch_end_date)
+                else {
+                    result.add_skipped(asset.id.clone(), AssetSkipReason::NoQuoteWindow);
+                    continue;
+                };
+                window
             } else {
                 self.calculate_date_range_for_mode(
                     &planning_inputs,
@@ -1539,6 +1567,8 @@ where
                 quote_symbol: None,
                 currency: asset.quote_ccy.clone(),
                 purge_provider_quotes: should_purge_provider_quotes(mode, &planning_inputs),
+                suppress_closed_fetch_errors: matches!(category, SyncCategory::Closed)
+                    && !targeted_sync,
             });
         }
 
@@ -1722,7 +1752,8 @@ mod tests {
         let err = Error::MarketData(MarketDataError::NoData);
         assert!(should_treat_fetch_error_as_non_fatal(
             &SyncCategory::NeedsBackfill,
-            &err
+            &err,
+            false
         ));
     }
 
@@ -1731,7 +1762,8 @@ mod tests {
         let err = Error::MarketData(MarketDataError::NotFound("No data found".to_string()));
         assert!(should_treat_fetch_error_as_non_fatal(
             &SyncCategory::NeedsBackfill,
-            &err
+            &err,
+            false
         ));
     }
 
@@ -1742,7 +1774,8 @@ mod tests {
         ));
         assert!(should_treat_fetch_error_as_non_fatal(
             &SyncCategory::NeedsBackfill,
-            &err
+            &err,
+            false
         ));
     }
 
@@ -1751,7 +1784,18 @@ mod tests {
         let err = Error::MarketData(MarketDataError::NoData);
         assert!(should_treat_fetch_error_as_non_fatal(
             &SyncCategory::Closed,
-            &err
+            &err,
+            true
+        ));
+    }
+
+    #[test]
+    fn test_targeted_closed_history_no_data_error_remains_fatal() {
+        let err = Error::MarketData(MarketDataError::NoData);
+        assert!(!should_treat_fetch_error_as_non_fatal(
+            &SyncCategory::Closed,
+            &err,
+            false
         ));
     }
 
@@ -1760,7 +1804,8 @@ mod tests {
         let err = Error::MarketData(MarketDataError::NoData);
         assert!(!should_treat_fetch_error_as_non_fatal(
             &SyncCategory::Active,
-            &err
+            &err,
+            true
         ));
     }
 
@@ -2029,6 +2074,10 @@ mod tests {
             AssetSkipReason::SyncInProgress.to_string(),
             "Sync already in progress"
         );
+        assert_eq!(
+            AssetSkipReason::NoQuoteWindow.to_string(),
+            "No quote refresh needed"
+        );
     }
 
     #[test]
@@ -2131,10 +2180,31 @@ mod tests {
         let (start, end) = calculate_targeted_closed_incremental_window(
             &inputs,
             NaiveDate::from_ymd_opt(2026, 5, 6).unwrap(),
-        );
+        )
+        .unwrap();
 
         assert_eq!(start, NaiveDate::from_ymd_opt(2026, 1, 27).unwrap());
         assert_eq!(end, NaiveDate::from_ymd_opt(2026, 2, 15).unwrap());
+    }
+
+    #[test]
+    fn test_targeted_closed_incremental_window_returns_none_when_already_current() {
+        let inputs = SyncPlanningInputs {
+            is_active: false,
+            position_closed_date: Some(NaiveDate::from_ymd_opt(2026, 2, 15).unwrap()),
+            activity_min: Some(NaiveDate::from_ymd_opt(2025, 1, 1).unwrap()),
+            activity_max: Some(NaiveDate::from_ymd_opt(2026, 2, 15).unwrap()),
+            quote_min: Some(NaiveDate::from_ymd_opt(2025, 1, 1).unwrap()),
+            quote_max: Some(NaiveDate::from_ymd_opt(2026, 3, 1).unwrap()),
+        };
+
+        assert_eq!(
+            calculate_targeted_closed_incremental_window(
+                &inputs,
+                NaiveDate::from_ymd_opt(2026, 5, 6).unwrap(),
+            ),
+            None
+        );
     }
 
     #[test]

--- a/crates/core/src/quotes/sync.rs
+++ b/crates/core/src/quotes/sync.rs
@@ -125,8 +125,8 @@ fn should_treat_fetch_error_as_non_fatal(
     error: &Error,
     suppress_closed_fetch_errors: bool,
 ) -> bool {
-    if !matches!(category, SyncCategory::NeedsBackfill)
-        && !(matches!(category, SyncCategory::Closed) && suppress_closed_fetch_errors)
+    if !(matches!(category, SyncCategory::NeedsBackfill)
+        || matches!(category, SyncCategory::Closed) && suppress_closed_fetch_errors)
     {
         return false;
     }

--- a/crates/core/src/quotes/sync.rs
+++ b/crates/core/src/quotes/sync.rs
@@ -120,8 +120,8 @@ fn clamp_end_date_for_fetch(
     }
 }
 
-fn should_treat_backfill_error_as_non_fatal(category: &SyncCategory, error: &Error) -> bool {
-    if !matches!(category, SyncCategory::NeedsBackfill) {
+fn should_treat_fetch_error_as_non_fatal(category: &SyncCategory, error: &Error) -> bool {
+    if !matches!(category, SyncCategory::NeedsBackfill | SyncCategory::Closed) {
         return false;
     }
 
@@ -149,6 +149,131 @@ fn format_sync_failure_message(error: &Error, provider_id: Option<&str>) -> Stri
         Some(provider_id) if !provider_id.is_empty() => format!("{}: {}", provider_id, message),
         _ => message,
     }
+}
+
+fn asset_skip_reason(asset: &Asset, allow_inactive: bool) -> Option<AssetSkipReason> {
+    // Only sync market-priced assets (including FX rates for currency conversion)
+    if asset.quote_mode != QuoteMode::Market {
+        return Some(AssetSkipReason::ManualPricing);
+    }
+
+    // Broad/background sync should not fetch prices for inactive catalog assets.
+    // Targeted row-level sync can opt in so users can refresh deactivated assets.
+    if !allow_inactive && !asset.is_active {
+        return Some(AssetSkipReason::Inactive);
+    }
+
+    // Skip matured bonds — price is par, no sync needed
+    if asset.is_bond() {
+        if let Some(spec) = asset.bond_spec() {
+            if let Some(maturity) = spec.maturity_date {
+                if maturity < Utc::now().date_naive() {
+                    return Some(AssetSkipReason::MaturedBond);
+                }
+            }
+        }
+    }
+
+    // Skip expired options — no further quotes available
+    if asset.is_option() {
+        if let Some(spec) = asset.option_spec() {
+            if spec.expiration < Utc::now().date_naive() {
+                return Some(AssetSkipReason::ExpiredOption);
+            }
+        }
+    }
+
+    None
+}
+
+fn is_empty_asset_target(asset_ids: Option<&[String]>) -> bool {
+    asset_ids.is_some_and(|ids| ids.is_empty())
+}
+
+fn is_targeted_asset_sync(asset_ids: Option<&[String]>) -> bool {
+    asset_ids.is_some_and(|ids| !ids.is_empty())
+}
+
+fn should_allow_inactive_assets(mode: SyncMode, targeted_sync: bool) -> bool {
+    targeted_sync
+        || matches!(
+            mode,
+            SyncMode::RefetchRecent { .. } | SyncMode::BackfillHistory { .. }
+        )
+}
+
+fn should_include_closed_positions(mode: SyncMode, targeted_sync: bool) -> bool {
+    targeted_sync
+        || matches!(
+            mode,
+            SyncMode::RefetchRecent { .. } | SyncMode::BackfillHistory { .. }
+        )
+}
+
+fn min_optional_date(left: Option<NaiveDate>, right: Option<NaiveDate>) -> Option<NaiveDate> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.min(right)),
+        (Some(date), None) | (None, Some(date)) => Some(date),
+        (None, None) => None,
+    }
+}
+
+fn max_optional_date(left: Option<NaiveDate>, right: Option<NaiveDate>) -> Option<NaiveDate> {
+    match (left, right) {
+        (Some(left), Some(right)) => Some(left.max(right)),
+        (Some(date), None) | (None, Some(date)) => Some(date),
+        (None, None) => None,
+    }
+}
+
+fn merge_bounds(
+    activity_bounds: Option<(Option<NaiveDate>, Option<NaiveDate>)>,
+    holdings_bounds: Option<(Option<NaiveDate>, Option<NaiveDate>)>,
+) -> (Option<NaiveDate>, Option<NaiveDate>) {
+    let (activity_min, activity_max) = activity_bounds.unwrap_or((None, None));
+    let (holdings_min, holdings_max) = holdings_bounds.unwrap_or((None, None));
+
+    (
+        min_optional_date(activity_min, holdings_min),
+        max_optional_date(activity_max, holdings_max),
+    )
+}
+
+fn has_bounds_reference(bounds: Option<&(Option<NaiveDate>, Option<NaiveDate>)>) -> bool {
+    bounds.is_some_and(|(min_date, max_date)| min_date.is_some() || max_date.is_some())
+}
+
+fn has_historical_reference(
+    asset_id: &str,
+    existing_states: &HashMap<String, QuoteSyncState>,
+    activity_bounds: &HashMap<String, (Option<NaiveDate>, Option<NaiveDate>)>,
+    holdings_bounds: &HashMap<String, (Option<NaiveDate>, Option<NaiveDate>)>,
+) -> bool {
+    existing_states.contains_key(asset_id)
+        || has_bounds_reference(activity_bounds.get(asset_id))
+        || has_bounds_reference(holdings_bounds.get(asset_id))
+}
+
+fn should_allow_inactive_asset(
+    asset_id: &str,
+    mode: SyncMode,
+    targeted_sync: bool,
+    existing_states: &HashMap<String, QuoteSyncState>,
+    activity_bounds: &HashMap<String, (Option<NaiveDate>, Option<NaiveDate>)>,
+    holdings_bounds: &HashMap<String, (Option<NaiveDate>, Option<NaiveDate>)>,
+) -> bool {
+    targeted_sync
+        || (should_allow_inactive_assets(mode, targeted_sync)
+            && has_historical_reference(
+                asset_id,
+                existing_states,
+                activity_bounds,
+                holdings_bounds,
+            ))
+}
+
+fn should_purge_provider_quotes(mode: SyncMode, inputs: &SyncPlanningInputs) -> bool {
+    matches!(mode, SyncMode::BackfillHistory { .. }) && inputs.activity_min.is_some()
 }
 
 // Test helpers - expose lock functions for testing
@@ -336,7 +461,7 @@ pub trait QuoteSyncServiceTrait: Send + Sync {
     /// Force resync of quotes for specific assets using BackfillHistory mode.
     ///
     /// This is a convenience wrapper that calls `sync(SyncMode::BackfillHistory { days: DEFAULT_HISTORY_DAYS }, asset_ids)`.
-    /// If asset_ids is None or empty, resync all syncable assets.
+    /// If asset_ids is None, resync all syncable assets. If asset_ids is empty, sync nothing.
     async fn resync(&self, asset_ids: Option<Vec<String>>) -> Result<SyncResult>;
 
     /// Handle a new activity being created.
@@ -423,6 +548,10 @@ where
             .activity_repo
             .get_activity_bounds_for_assets(&asset_ids)
             .unwrap_or_default();
+        let holdings_bounds = self
+            .activity_repo
+            .get_holdings_snapshot_bounds_for_assets(&asset_ids)
+            .unwrap_or_default();
 
         // Compute quote bounds per provider
         // Group assets by preferred_provider and batch query
@@ -445,50 +574,26 @@ where
             .iter()
             .filter(|a| self.should_sync_asset(a))
             .filter_map(|asset| {
-                self.build_asset_sync_plan(asset, now, &activity_bounds, &quote_bounds)
+                self.build_asset_sync_plan(
+                    asset,
+                    now,
+                    &activity_bounds,
+                    &holdings_bounds,
+                    &quote_bounds,
+                )
             })
             .collect()
     }
 
     /// Check if an asset should be synced.
     fn should_sync_asset(&self, asset: &Asset) -> bool {
-        self.get_skip_reason(asset).is_none()
+        self.get_skip_reason(asset, false).is_none()
     }
 
     /// Get the reason why an asset should be skipped, if any.
     /// Returns None if the asset should be synced.
-    fn get_skip_reason(&self, asset: &Asset) -> Option<AssetSkipReason> {
-        // Only sync market-priced assets (including FX rates for currency conversion)
-        if asset.quote_mode != QuoteMode::Market {
-            return Some(AssetSkipReason::ManualPricing);
-        }
-
-        // Only sync active assets
-        if !asset.is_active {
-            return Some(AssetSkipReason::Inactive);
-        }
-
-        // Skip matured bonds — price is par, no sync needed
-        if asset.is_bond() {
-            if let Some(spec) = asset.bond_spec() {
-                if let Some(maturity) = spec.maturity_date {
-                    if maturity < Utc::now().date_naive() {
-                        return Some(AssetSkipReason::MaturedBond);
-                    }
-                }
-            }
-        }
-
-        // Skip expired options — no further quotes available
-        if asset.is_option() {
-            if let Some(spec) = asset.option_spec() {
-                if spec.expiration < Utc::now().date_naive() {
-                    return Some(AssetSkipReason::ExpiredOption);
-                }
-            }
-        }
-
-        None
+    fn get_skip_reason(&self, asset: &Asset, allow_inactive: bool) -> Option<AssetSkipReason> {
+        asset_skip_reason(asset, allow_inactive)
     }
 
     /// Ensure a matured bond has a par-value quote so it doesn't show as "no data"
@@ -559,6 +664,7 @@ where
         asset: &Asset,
         now: DateTime<Utc>,
         activity_bounds: &HashMap<String, (Option<NaiveDate>, Option<NaiveDate>)>,
+        holdings_bounds: &HashMap<String, (Option<NaiveDate>, Option<NaiveDate>)>,
         quote_bounds: &HashMap<String, (NaiveDate, NaiveDate)>,
     ) -> Option<SymbolSyncPlan> {
         let effective_today = effective_market_today(now, asset.instrument_exchange_mic.as_deref());
@@ -571,10 +677,10 @@ where
             .flatten();
 
         // Build SyncPlanningInputs from computed bounds
-        let (activity_min, activity_max) = activity_bounds
-            .get(&asset.id)
-            .copied()
-            .unwrap_or((None, None));
+        let (activity_min, activity_max) = merge_bounds(
+            activity_bounds.get(&asset.id).copied(),
+            holdings_bounds.get(&asset.id).copied(),
+        );
 
         let (quote_min, quote_max) = quote_bounds
             .get(&asset.id)
@@ -582,7 +688,10 @@ where
             .unwrap_or((None, None));
 
         let inputs = SyncPlanningInputs {
-            is_active: state.as_ref().map(|s| s.is_active).unwrap_or(true),
+            is_active: state
+                .as_ref()
+                .map(|s| s.is_active)
+                .unwrap_or(asset.is_active),
             position_closed_date: state.as_ref().and_then(|s| s.position_closed_date),
             activity_min,
             activity_max,
@@ -940,7 +1049,7 @@ where
                 let sync_failure_message =
                     format_sync_failure_message(&error, fetch_error.provider_id.as_deref());
 
-                if should_treat_backfill_error_as_non_fatal(&plan.category, &error) {
+                if should_treat_fetch_error_as_non_fatal(&plan.category, &error) {
                     if let Err(state_err) = self.sync_state_store.update_after_sync(&asset.id).await
                     {
                         warn!(
@@ -1109,6 +1218,9 @@ where
         let activity_bounds = self
             .activity_repo
             .get_activity_bounds_for_assets(&asset_ids)?;
+        let holdings_bounds = self
+            .activity_repo
+            .get_holdings_snapshot_bounds_for_assets(&asset_ids)?;
 
         // Compute quote bounds on-the-fly from quotes table, filtered by provider
         // Group states by data_source to batch quote bounds queries
@@ -1136,10 +1248,10 @@ where
             };
 
             // Build SyncPlanningInputs from computed bounds
-            let (activity_min, activity_max) = activity_bounds
-                .get(&state.asset_id)
-                .copied()
-                .unwrap_or((None, None));
+            let (activity_min, activity_max) = merge_bounds(
+                activity_bounds.get(&state.asset_id).copied(),
+                holdings_bounds.get(&state.asset_id).copied(),
+            );
 
             let (quote_min, quote_max) = quote_bounds_by_source
                 .get(&state.data_source)
@@ -1257,12 +1369,19 @@ where
     }
 
     /// Ensure sync states exist for the given assets.
-    async fn ensure_sync_states_for_assets(&self, assets: &[Asset]) -> Result<()> {
+    async fn ensure_sync_states_for_assets(
+        &self,
+        assets: &[Asset],
+        allow_inactive: bool,
+    ) -> Result<()> {
         debug!("Ensuring sync states for {} assets...", assets.len());
 
         let mut new_states = Vec::new();
 
-        for asset in assets.iter().filter(|a| self.should_sync_asset(a)) {
+        for asset in assets
+            .iter()
+            .filter(|asset| self.get_skip_reason(asset, allow_inactive).is_none())
+        {
             let existing = self.sync_state_store.get_by_asset_id(&asset.id)?;
             if existing.is_none() {
                 // Don't set data_source here - it will be populated after first successful sync
@@ -1287,7 +1406,7 @@ where
     /// Ensure sync states exist for all syncable assets.
     async fn ensure_sync_states_for_all_assets(&self) -> Result<()> {
         let assets = self.asset_repo.list()?;
-        self.ensure_sync_states_for_assets(&assets).await
+        self.ensure_sync_states_for_assets(&assets, false).await
     }
 }
 
@@ -1302,21 +1421,41 @@ where
     async fn sync(&self, mode: SyncMode, asset_ids: Option<Vec<String>>) -> Result<SyncResult> {
         debug!("Starting sync (mode: {}) for {:?}", mode, asset_ids);
 
-        let assets = match asset_ids {
-            Some(ids) if !ids.is_empty() => self.asset_repo.list_by_asset_ids(&ids)?,
-            _ => self.asset_repo.list()?,
+        if is_empty_asset_target(asset_ids.as_deref()) {
+            info!("No asset IDs requested for sync; skipping");
+            return Ok(SyncResult::default());
+        }
+
+        let targeted_sync = is_targeted_asset_sync(asset_ids.as_deref());
+        let include_closed_positions = should_include_closed_positions(mode, targeted_sync);
+        let assets = match asset_ids.as_ref() {
+            Some(ids) => self.asset_repo.list_by_asset_ids(ids)?,
+            None => self.asset_repo.list()?,
         };
 
-        if let Err(e) = self.ensure_sync_states_for_assets(&assets).await {
-            warn!("Failed to ensure sync states: {:?}", e);
-        }
+        let all_asset_ids: Vec<String> = assets.iter().map(|asset| asset.id.clone()).collect();
+        let initial_states = self.sync_state_store.get_by_asset_ids(&all_asset_ids)?;
+        let activity_bounds = self
+            .activity_repo
+            .get_activity_bounds_for_assets(&all_asset_ids)?;
+        let holdings_bounds = self
+            .activity_repo
+            .get_holdings_snapshot_bounds_for_assets(&all_asset_ids)?;
 
         // Initialize result to track skipped assets
         let mut result = SyncResult::default();
         let mut syncable: Vec<&Asset> = Vec::new();
 
         for asset in &assets {
-            if let Some(reason) = self.get_skip_reason(asset) {
+            let allow_inactive_asset = should_allow_inactive_asset(
+                &asset.id,
+                mode,
+                targeted_sync,
+                &initial_states,
+                &activity_bounds,
+                &holdings_bounds,
+            );
+            if let Some(reason) = self.get_skip_reason(asset, allow_inactive_asset) {
                 debug!("Skipping asset {} for sync: {}", asset.id, reason);
                 if matches!(reason, AssetSkipReason::MaturedBond) {
                     self.ensure_matured_bond_par_quote(asset).await;
@@ -1348,10 +1487,20 @@ where
 
         let now = Utc::now();
         let syncable_ids: Vec<String> = syncable.iter().map(|asset| asset.id.clone()).collect();
+        let ensure_state_assets: Vec<Asset> = syncable
+            .iter()
+            .filter(|asset| asset.is_active || targeted_sync)
+            .map(|asset| (*asset).clone())
+            .collect();
+
+        if let Err(e) = self
+            .ensure_sync_states_for_assets(&ensure_state_assets, true)
+            .await
+        {
+            warn!("Failed to ensure sync states: {:?}", e);
+        }
+
         let existing_states = self.sync_state_store.get_by_asset_ids(&syncable_ids)?;
-        let activity_bounds = self
-            .activity_repo
-            .get_activity_bounds_for_assets(&syncable_ids)?;
 
         // Compute quote bounds per provider
         let mut quote_bounds: HashMap<String, (NaiveDate, NaiveDate)> = HashMap::new();
@@ -1394,10 +1543,10 @@ where
             }
 
             // Build SyncPlanningInputs from computed bounds
-            let (activity_min, activity_max) = activity_bounds
-                .get(&asset.id)
-                .copied()
-                .unwrap_or((None, None));
+            let (activity_min, activity_max) = merge_bounds(
+                activity_bounds.get(&asset.id).copied(),
+                holdings_bounds.get(&asset.id).copied(),
+            );
 
             let (quote_min, quote_max) = quote_bounds
                 .get(&asset.id)
@@ -1405,7 +1554,10 @@ where
                 .unwrap_or((None, None));
 
             let inputs = SyncPlanningInputs {
-                is_active: state.as_ref().map(|s| s.is_active).unwrap_or(true),
+                is_active: state
+                    .as_ref()
+                    .map(|s| s.is_active)
+                    .unwrap_or(asset.is_active),
                 position_closed_date: state.as_ref().and_then(|s| s.position_closed_date),
                 activity_min,
                 activity_max,
@@ -1414,19 +1566,33 @@ where
             };
 
             // Determine category for priority
-            let category = determine_sync_category(
+            let mut category = determine_sync_category(
                 &inputs,
                 CLOSED_POSITION_GRACE_PERIOD_DAYS,
                 effective_today,
             );
+            let mut planning_inputs = inputs.clone();
+
+            if matches!(category, SyncCategory::Closed) {
+                if !include_closed_positions {
+                    result.add_skipped(asset.id.clone(), AssetSkipReason::ClosedPosition);
+                    continue;
+                }
+
+                if targeted_sync && matches!(mode, SyncMode::Incremental) {
+                    category = SyncCategory::Active;
+                    planning_inputs.is_active = true;
+                    planning_inputs.position_closed_date = None;
+                }
+            }
 
             if matches!(mode, SyncMode::Incremental)
                 && matches!(category, SyncCategory::NeedsBackfill)
-                && inputs.is_active
+                && planning_inputs.is_active
             {
                 let recent_category = SyncCategory::Active;
                 if let Some((start_date, end_date)) =
-                    calculate_sync_window(&recent_category, &inputs, effective_today)
+                    calculate_sync_window(&recent_category, &planning_inputs, effective_today)
                 {
                     if start_date <= end_date {
                         plans.push(SymbolSyncPlan {
@@ -1448,7 +1614,7 @@ where
                 }
 
                 if let Some((start_date, end_date)) =
-                    calculate_sync_window(&category, &inputs, effective_today)
+                    calculate_sync_window(&category, &planning_inputs, effective_today)
                 {
                     if start_date <= end_date {
                         plans.push(SymbolSyncPlan {
@@ -1468,7 +1634,7 @@ where
             }
 
             let (start_date, end_date) = self.calculate_date_range_for_mode(
-                &inputs,
+                &planning_inputs,
                 mode,
                 effective_today,
                 fetch_end_date,
@@ -1484,7 +1650,7 @@ where
                 data_source,
                 quote_symbol: None,
                 currency: asset.quote_ccy.clone(),
-                purge_provider_quotes: matches!(mode, SyncMode::BackfillHistory { .. }),
+                purge_provider_quotes: should_purge_provider_quotes(mode, &planning_inputs),
             });
         }
 
@@ -1651,7 +1817,7 @@ mod tests {
     #[test]
     fn test_backfill_no_data_error_is_non_fatal() {
         let err = Error::MarketData(MarketDataError::NoData);
-        assert!(should_treat_backfill_error_as_non_fatal(
+        assert!(should_treat_fetch_error_as_non_fatal(
             &SyncCategory::NeedsBackfill,
             &err
         ));
@@ -1660,7 +1826,7 @@ mod tests {
     #[test]
     fn test_backfill_not_found_error_is_non_fatal() {
         let err = Error::MarketData(MarketDataError::NotFound("No data found".to_string()));
-        assert!(should_treat_backfill_error_as_non_fatal(
+        assert!(should_treat_fetch_error_as_non_fatal(
             &SyncCategory::NeedsBackfill,
             &err
         ));
@@ -1671,16 +1837,25 @@ mod tests {
         let err = Error::MarketData(MarketDataError::ProviderExhausted(
             "All providers failed".to_string(),
         ));
-        assert!(should_treat_backfill_error_as_non_fatal(
+        assert!(should_treat_fetch_error_as_non_fatal(
             &SyncCategory::NeedsBackfill,
             &err
         ));
     }
 
     #[test]
-    fn test_non_backfill_no_data_error_remains_fatal() {
+    fn test_closed_history_no_data_error_is_non_fatal() {
         let err = Error::MarketData(MarketDataError::NoData);
-        assert!(!should_treat_backfill_error_as_non_fatal(
+        assert!(should_treat_fetch_error_as_non_fatal(
+            &SyncCategory::Closed,
+            &err
+        ));
+    }
+
+    #[test]
+    fn test_active_no_data_error_remains_fatal() {
+        let err = Error::MarketData(MarketDataError::NoData);
+        assert!(!should_treat_fetch_error_as_non_fatal(
             &SyncCategory::Active,
             &err
         ));
@@ -1951,6 +2126,160 @@ mod tests {
             AssetSkipReason::SyncInProgress.to_string(),
             "Sync already in progress"
         );
+    }
+
+    #[test]
+    fn test_inactive_asset_skipped_for_broad_sync() {
+        let asset = Asset {
+            is_active: false,
+            quote_mode: QuoteMode::Market,
+            kind: AssetKind::Investment,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            asset_skip_reason(&asset, false),
+            Some(AssetSkipReason::Inactive)
+        );
+    }
+
+    #[test]
+    fn test_inactive_asset_allowed_for_targeted_sync() {
+        let asset = Asset {
+            is_active: false,
+            quote_mode: QuoteMode::Market,
+            kind: AssetKind::Investment,
+            ..Default::default()
+        };
+
+        assert_eq!(asset_skip_reason(&asset, true), None);
+    }
+
+    #[test]
+    fn test_empty_asset_target_is_explicit_noop() {
+        let empty_ids: Vec<String> = Vec::new();
+        let targeted_ids = vec!["AAPL".to_string()];
+
+        assert!(!is_empty_asset_target(None));
+        assert!(is_empty_asset_target(Some(&empty_ids)));
+        assert!(!is_empty_asset_target(Some(&targeted_ids)));
+
+        assert!(!is_targeted_asset_sync(None));
+        assert!(!is_targeted_asset_sync(Some(&empty_ids)));
+        assert!(is_targeted_asset_sync(Some(&targeted_ids)));
+    }
+
+    #[test]
+    fn test_activity_and_holdings_bounds_are_merged_for_history_planning() {
+        let activity_min = NaiveDate::from_ymd_opt(2026, 2, 1).unwrap();
+        let activity_max = NaiveDate::from_ymd_opt(2026, 3, 1).unwrap();
+        let holdings_min = NaiveDate::from_ymd_opt(2025, 11, 1).unwrap();
+        let holdings_max = NaiveDate::from_ymd_opt(2026, 1, 15).unwrap();
+
+        assert_eq!(
+            merge_bounds(
+                Some((Some(activity_min), Some(activity_max))),
+                Some((Some(holdings_min), Some(holdings_max))),
+            ),
+            (Some(holdings_min), Some(activity_max))
+        );
+    }
+
+    #[test]
+    fn test_backfill_purge_requires_authoritative_history_start() {
+        let inputs_without_history_start = SyncPlanningInputs {
+            is_active: true,
+            position_closed_date: None,
+            activity_min: None,
+            activity_max: None,
+            quote_min: None,
+            quote_max: None,
+        };
+        let inputs_with_history_start = SyncPlanningInputs {
+            activity_min: Some(NaiveDate::from_ymd_opt(2025, 11, 1).unwrap()),
+            ..inputs_without_history_start.clone()
+        };
+
+        assert!(!should_purge_provider_quotes(
+            SyncMode::BackfillHistory { days: 365 },
+            &inputs_without_history_start
+        ));
+        assert!(should_purge_provider_quotes(
+            SyncMode::BackfillHistory { days: 365 },
+            &inputs_with_history_start
+        ));
+        assert!(!should_purge_provider_quotes(
+            SyncMode::RefetchRecent { days: 30 },
+            &inputs_with_history_start
+        ));
+    }
+
+    #[test]
+    fn test_inactive_asset_policy_is_mode_aware() {
+        assert!(!should_allow_inactive_assets(SyncMode::Incremental, false));
+        assert!(should_allow_inactive_assets(SyncMode::Incremental, true));
+        assert!(should_allow_inactive_assets(
+            SyncMode::RefetchRecent { days: 30 },
+            false
+        ));
+        assert!(should_allow_inactive_assets(
+            SyncMode::BackfillHistory { days: 365 },
+            false
+        ));
+    }
+
+    #[test]
+    fn test_broad_history_allows_inactive_only_with_reference() {
+        let asset_id = "asset_1".to_string();
+        let states = HashMap::new();
+        let activity_bounds = HashMap::new();
+        let empty_holdings_bounds = HashMap::new();
+        let holdings_bounds = HashMap::from([(
+            asset_id.clone(),
+            (Some(NaiveDate::from_ymd_opt(2025, 11, 1).unwrap()), None),
+        )]);
+
+        assert!(!should_allow_inactive_asset(
+            &asset_id,
+            SyncMode::BackfillHistory { days: 365 },
+            false,
+            &states,
+            &activity_bounds,
+            &empty_holdings_bounds,
+        ));
+        assert!(should_allow_inactive_asset(
+            &asset_id,
+            SyncMode::BackfillHistory { days: 365 },
+            false,
+            &states,
+            &activity_bounds,
+            &holdings_bounds,
+        ));
+        assert!(should_allow_inactive_asset(
+            &asset_id,
+            SyncMode::Incremental,
+            true,
+            &states,
+            &activity_bounds,
+            &empty_holdings_bounds,
+        ));
+    }
+
+    #[test]
+    fn test_closed_position_policy_is_mode_aware() {
+        assert!(!should_include_closed_positions(
+            SyncMode::Incremental,
+            false
+        ));
+        assert!(should_include_closed_positions(SyncMode::Incremental, true));
+        assert!(should_include_closed_positions(
+            SyncMode::RefetchRecent { days: 30 },
+            false
+        ));
+        assert!(should_include_closed_positions(
+            SyncMode::BackfillHistory { days: 365 },
+            false
+        ));
     }
 
     // =========================================================================

--- a/crates/core/src/quotes/sync_state.rs
+++ b/crates/core/src/quotes/sync_state.rs
@@ -333,6 +333,10 @@ pub struct SymbolSyncPlan {
     /// When true, delete all non-manual quotes before upserting fresh data.
     /// Set for BackfillHistory mode to remove stale/wrong dates.
     pub purge_provider_quotes: bool,
+    /// When true, tolerate provider "no data" style failures for closed positions.
+    /// Broad history jobs use this to keep old closed/delisted assets best-effort;
+    /// targeted user requests keep errors visible.
+    pub suppress_closed_fetch_errors: bool,
 }
 
 /// Domain model for quote sync state.

--- a/crates/core/src/quotes/sync_state.rs
+++ b/crates/core/src/quotes/sync_state.rs
@@ -507,8 +507,28 @@ pub trait SyncStateStore: Send + Sync {
     /// Mark asset as inactive (position closed).
     async fn mark_inactive(&self, asset_id: &str, closed_date: NaiveDate) -> Result<()>;
 
+    /// Mark multiple assets as inactive (position closed).
+    async fn mark_inactive_batch(
+        &self,
+        asset_ids: &[String],
+        closed_date: NaiveDate,
+    ) -> Result<()> {
+        for asset_id in asset_ids {
+            self.mark_inactive(asset_id, closed_date).await?;
+        }
+        Ok(())
+    }
+
     /// Mark asset as active.
     async fn mark_active(&self, asset_id: &str) -> Result<()>;
+
+    /// Mark multiple assets as active.
+    async fn mark_active_batch(&self, asset_ids: &[String]) -> Result<()> {
+        for asset_id in asset_ids {
+            self.mark_active(asset_id).await?;
+        }
+        Ok(())
+    }
 
     /// Delete sync state for an asset.
     async fn delete(&self, asset_id: &str) -> Result<()>;

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -2,6 +2,9 @@ use chrono::{DateTime, NaiveDate, Utc};
 use diesel::expression_methods::ExpressionMethods;
 use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, Pool};
+use diesel::sql_query;
+use diesel::sql_types::{Nullable, Text};
+use diesel::sqlite::Sqlite;
 use diesel::sqlite::SqliteConnection;
 use rust_decimal::Decimal;
 use std::collections::{HashMap, HashSet};
@@ -1526,6 +1529,67 @@ impl ActivityRepositoryTrait for ActivityRepository {
                 });
 
                 result_map.insert(asset_id, (first_date, last_date));
+            }
+        }
+
+        Ok(result_map)
+    }
+
+    fn get_holdings_snapshot_bounds_for_assets(
+        &self,
+        asset_ids: &[String],
+    ) -> Result<HashMap<String, (Option<NaiveDate>, Option<NaiveDate>)>> {
+        if asset_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        #[derive(QueryableByName)]
+        struct HoldingsBoundsRow {
+            #[diesel(sql_type = Text)]
+            asset_id: String,
+            #[diesel(sql_type = Nullable<Text>)]
+            min_date: Option<String>,
+            #[diesel(sql_type = Nullable<Text>)]
+            max_date: Option<String>,
+        }
+
+        let mut conn = get_connection(&self.pool)?;
+        let mut result_map: HashMap<String, (Option<NaiveDate>, Option<NaiveDate>)> =
+            HashMap::new();
+
+        for chunk in chunk_for_sqlite(asset_ids) {
+            let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+            let sql = format!(
+                "SELECT position.key AS asset_id, \
+                        MIN(snapshot.snapshot_date) AS min_date, \
+                        MAX(snapshot.snapshot_date) AS max_date \
+                 FROM holdings_snapshots snapshot \
+                 JOIN accounts account ON account.id = snapshot.account_id \
+                 JOIN json_each(snapshot.positions) position \
+                 WHERE account.is_archived = 0 \
+                   AND position.key IN ({}) \
+                 GROUP BY position.key",
+                placeholders
+            );
+
+            let mut query_builder = Box::new(sql_query(sql)).into_boxed::<Sqlite>();
+            for asset_id in chunk {
+                query_builder = query_builder.bind::<Text, _>(asset_id);
+            }
+
+            let rows: Vec<HoldingsBoundsRow> = query_builder
+                .load::<HoldingsBoundsRow>(&mut conn)
+                .map_err(StorageError::from)?;
+
+            for row in rows {
+                let first_date = row
+                    .min_date
+                    .and_then(|date| NaiveDate::parse_from_str(&date, "%Y-%m-%d").ok());
+                let last_date = row
+                    .max_date
+                    .and_then(|date| NaiveDate::parse_from_str(&date, "%Y-%m-%d").ok());
+
+                result_map.insert(row.asset_id, (first_date, last_date));
             }
         }
 

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -1568,6 +1568,7 @@ impl ActivityRepositoryTrait for ActivityRepository {
                  JOIN json_each(snapshot.positions) position \
                  WHERE account.is_archived = 0 \
                    AND position.key IN ({}) \
+                   AND CAST(COALESCE(json_extract(position.value, '$.quantity'), '0') AS REAL) <> 0 \
                  GROUP BY position.key",
                 placeholders
             );
@@ -2016,15 +2017,42 @@ mod tests {
     }
 
     fn insert_account(conn: &mut SqliteConnection, account_id: &str) {
+        insert_account_with_archived(conn, account_id, false);
+    }
+
+    fn insert_account_with_archived(conn: &mut SqliteConnection, account_id: &str, archived: bool) {
         diesel::sql_query(format!(
             "INSERT INTO accounts (id, name, account_type, `group`, currency, is_default, is_active, \
              created_at, updated_at, platform_id, account_number, meta, provider, provider_account_id, \
              is_archived, tracking_mode) VALUES ('{}', 'Test', 'cash', NULL, 'USD', 1, 1, \
-             CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL, NULL, NULL, NULL, NULL, 0, 'portfolio')",
-            account_id
+             CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL, NULL, NULL, NULL, NULL, {}, 'portfolio')",
+            account_id,
+            if archived { 1 } else { 0 }
         ))
         .execute(conn)
         .expect("insert account");
+    }
+
+    fn insert_holdings_snapshot(
+        conn: &mut SqliteConnection,
+        account_id: &str,
+        snapshot_date: &str,
+        positions: &str,
+    ) {
+        let snapshot_id = format!("{}_{}", account_id, snapshot_date);
+        sql_query(
+            "INSERT INTO holdings_snapshots (
+                id, account_id, snapshot_date, currency, positions, cash_balances, cost_basis,
+                net_contribution, calculated_at, net_contribution_base,
+                cash_total_account_currency, cash_total_base_currency, source
+             ) VALUES (?, ?, ?, 'USD', ?, '{}', '0', '0', '2026-01-01T00:00:00Z', '0', '0', '0', 'CALCULATED')",
+        )
+        .bind::<Text, _>(snapshot_id)
+        .bind::<Text, _>(account_id)
+        .bind::<Text, _>(snapshot_date)
+        .bind::<Text, _>(positions)
+        .execute(conn)
+        .expect("insert holdings snapshot");
     }
 
     fn insert_template(conn: &mut SqliteConnection, template_id: &str) {
@@ -2141,6 +2169,67 @@ mod tests {
             .select(activities::is_user_modified)
             .first(conn)
             .expect("activity is_user_modified")
+    }
+
+    #[tokio::test]
+    async fn holdings_snapshot_bounds_ignore_zero_quantity_and_archived_accounts() {
+        let (pool, writer) = setup_db();
+        let repo = ActivityRepository::new(pool.clone(), writer);
+        let mut conn = get_connection(&pool).expect("conn");
+        insert_account(&mut conn, "acc-open");
+        insert_account_with_archived(&mut conn, "acc-archived", true);
+
+        insert_holdings_snapshot(
+            &mut conn,
+            "acc-open",
+            "2026-01-01",
+            r#"{"AAPL":{"quantity":"3"},"MSFT":{"quantity":"0"}}"#,
+        );
+        insert_holdings_snapshot(
+            &mut conn,
+            "acc-open",
+            "2026-02-01",
+            r#"{"AAPL":{"quantity":"0"},"MSFT":{"quantity":"4"}}"#,
+        );
+        insert_holdings_snapshot(
+            &mut conn,
+            "acc-open",
+            "2026-03-01",
+            r#"{"AAPL":{"quantity":"2"}}"#,
+        );
+        insert_holdings_snapshot(
+            &mut conn,
+            "acc-archived",
+            "2026-01-01",
+            r#"{"ARCH":{"quantity":"5"}}"#,
+        );
+
+        let asset_ids = vec![
+            "AAPL".to_string(),
+            "MSFT".to_string(),
+            "ARCH".to_string(),
+            "NONE".to_string(),
+        ];
+        let bounds = repo
+            .get_holdings_snapshot_bounds_for_assets(&asset_ids)
+            .expect("holdings bounds");
+
+        assert_eq!(
+            bounds.get("AAPL"),
+            Some(&(
+                Some(NaiveDate::from_ymd_opt(2026, 1, 1).unwrap()),
+                Some(NaiveDate::from_ymd_opt(2026, 3, 1).unwrap())
+            ))
+        );
+        assert_eq!(
+            bounds.get("MSFT"),
+            Some(&(
+                Some(NaiveDate::from_ymd_opt(2026, 2, 1).unwrap()),
+                Some(NaiveDate::from_ymd_opt(2026, 2, 1).unwrap())
+            ))
+        );
+        assert!(!bounds.contains_key("ARCH"));
+        assert!(!bounds.contains_key("NONE"));
     }
 
     #[tokio::test]

--- a/crates/storage-sqlite/src/assets/repository.rs
+++ b/crates/storage-sqlite/src/assets/repository.rs
@@ -431,6 +431,33 @@ impl AssetRepositoryTrait for AssetRepository {
             .await
     }
 
+    async fn reactivate_batch(&self, asset_ids: &[String]) -> Result<()> {
+        if asset_ids.is_empty() {
+            return Ok(());
+        }
+
+        let asset_ids = asset_ids.to_vec();
+        self.writer
+            .exec_tx(move |tx| -> Result<()> {
+                diesel::update(assets::table.filter(assets::id.eq_any(&asset_ids)))
+                    .set(assets::is_active.eq(1))
+                    .execute(tx.conn())
+                    .map_err(StorageError::from)?;
+
+                let updated_rows = assets::table
+                    .filter(assets::id.eq_any(&asset_ids))
+                    .select(AssetDB::as_select())
+                    .load::<AssetDB>(tx.conn())
+                    .map_err(StorageError::from)?;
+                for updated in updated_rows {
+                    tx.update(&updated)?;
+                }
+
+                Ok(())
+            })
+            .await
+    }
+
     async fn copy_user_metadata(&self, source_id: &str, target_id: &str) -> Result<()> {
         let source_id_owned = source_id.to_string();
         let target_id_owned = target_id.to_string();
@@ -464,7 +491,8 @@ impl AssetRepositoryTrait for AssetRepository {
         self.writer
             .exec_tx(move |tx| -> Result<Vec<String>> {
                 // Find active INVESTMENT assets with no activities and no holdings history in
-                // non-archived accounts.
+                // non-archived accounts. Any historical snapshot reference is enough to keep
+                // the asset active because old valuations may still need its quote history.
                 let orphan_ids: Vec<String> = assets::table
                     .select(assets::id)
                     .filter(assets::kind.eq("INVESTMENT"))
@@ -507,5 +535,157 @@ impl AssetRepositoryTrait for AssetRepository {
                 Ok(orphan_ids)
             })
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{create_pool, get_connection, init, run_migrations, write_actor::spawn_writer};
+    use diesel::r2d2::ConnectionManager;
+    use diesel::sql_query;
+    use diesel::sql_types::Text;
+    use std::sync::Arc;
+    use tempfile::tempdir;
+
+    fn setup_db() -> (Arc<Pool<ConnectionManager<SqliteConnection>>>, WriteHandle) {
+        std::env::set_var("CONNECT_API_URL", "http://test.local");
+        let app_data = tempdir()
+            .expect("tempdir")
+            .keep()
+            .to_string_lossy()
+            .to_string();
+        let db_path = init(&app_data).expect("init db");
+        run_migrations(&db_path).expect("migrate db");
+        let pool = create_pool(&db_path).expect("create pool");
+        let writer = spawn_writer(pool.as_ref().clone()).expect("spawn writer");
+        (pool, writer)
+    }
+
+    fn insert_asset(conn: &mut SqliteConnection, asset_id: &str) {
+        sql_query(
+            "INSERT INTO assets (
+                id, kind, name, display_code, is_active, quote_mode, quote_ccy,
+                created_at, updated_at
+             ) VALUES (?, 'INVESTMENT', ?, ?, 1, 'MARKET', 'USD', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+        )
+        .bind::<Text, _>(asset_id)
+        .bind::<Text, _>(asset_id)
+        .bind::<Text, _>(asset_id)
+        .execute(conn)
+        .expect("insert asset");
+    }
+
+    fn insert_account(conn: &mut SqliteConnection, account_id: &str, archived: bool) {
+        sql_query(format!(
+            "INSERT INTO accounts (id, name, account_type, `group`, currency, is_default, is_active, \
+             created_at, updated_at, platform_id, account_number, meta, provider, provider_account_id, \
+             is_archived, tracking_mode) VALUES ('{}', 'Test', 'cash', NULL, 'USD', 1, 1, \
+             CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL, NULL, NULL, NULL, NULL, {}, 'portfolio')",
+            account_id,
+            if archived { 1 } else { 0 }
+        ))
+        .execute(conn)
+        .expect("insert account");
+    }
+
+    fn insert_activity(
+        conn: &mut SqliteConnection,
+        activity_id: &str,
+        account_id: &str,
+        asset_id: &str,
+    ) {
+        sql_query(
+            "INSERT INTO activities (
+                id, account_id, asset_id, activity_type, status, activity_date,
+                quantity, unit_price, amount, fee, currency,
+                is_user_modified, needs_review, created_at, updated_at
+             ) VALUES (?, ?, ?, 'BUY', 'POSTED', '2026-01-01T00:00:00Z',
+                '1', '1', '1', '0', 'USD', 0, 0, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
+        )
+        .bind::<Text, _>(activity_id)
+        .bind::<Text, _>(account_id)
+        .bind::<Text, _>(asset_id)
+        .execute(conn)
+        .expect("insert activity");
+    }
+
+    fn insert_holdings_snapshot(
+        conn: &mut SqliteConnection,
+        account_id: &str,
+        snapshot_date: &str,
+        positions: &str,
+    ) {
+        let snapshot_id = format!("{}_{}", account_id, snapshot_date);
+        sql_query(
+            "INSERT INTO holdings_snapshots (
+                id, account_id, snapshot_date, currency, positions, cash_balances, cost_basis,
+                net_contribution, calculated_at, net_contribution_base,
+                cash_total_account_currency, cash_total_base_currency, source
+             ) VALUES (?, ?, ?, 'USD', ?, '{}', '0', '0', '2026-01-01T00:00:00Z', '0', '0', '0', 'CALCULATED')",
+        )
+        .bind::<Text, _>(snapshot_id)
+        .bind::<Text, _>(account_id)
+        .bind::<Text, _>(snapshot_date)
+        .bind::<Text, _>(positions)
+        .execute(conn)
+        .expect("insert holdings snapshot");
+    }
+
+    fn is_active(conn: &mut SqliteConnection, asset_id: &str) -> i32 {
+        assets::table
+            .filter(assets::id.eq(asset_id))
+            .select(assets::is_active)
+            .first(conn)
+            .expect("asset active flag")
+    }
+
+    #[tokio::test]
+    async fn orphan_cleanup_preserves_non_archived_snapshot_history() {
+        let (pool, writer) = setup_db();
+        let repo = AssetRepository::new(pool.clone(), writer);
+        let mut conn = get_connection(&pool).expect("conn");
+
+        insert_account(&mut conn, "acc-open", false);
+        insert_account(&mut conn, "acc-archived", true);
+        for asset_id in [
+            "snapshot_only",
+            "archived_only",
+            "with_activity",
+            "plain_orphan",
+        ] {
+            insert_asset(&mut conn, asset_id);
+        }
+
+        insert_holdings_snapshot(
+            &mut conn,
+            "acc-open",
+            "2026-01-01",
+            r#"{"snapshot_only":{"quantity":"0"}}"#,
+        );
+        insert_holdings_snapshot(
+            &mut conn,
+            "acc-archived",
+            "2026-01-01",
+            r#"{"archived_only":{"quantity":"5"}}"#,
+        );
+        insert_activity(&mut conn, "activity-1", "acc-open", "with_activity");
+        drop(conn);
+
+        let orphan_ids = repo
+            .deactivate_orphaned_investments()
+            .await
+            .expect("cleanup orphans");
+
+        assert!(!orphan_ids.contains(&"snapshot_only".to_string()));
+        assert!(!orphan_ids.contains(&"with_activity".to_string()));
+        assert!(orphan_ids.contains(&"archived_only".to_string()));
+        assert!(orphan_ids.contains(&"plain_orphan".to_string()));
+
+        let mut conn = get_connection(&pool).expect("conn");
+        assert_eq!(is_active(&mut conn, "snapshot_only"), 1);
+        assert_eq!(is_active(&mut conn, "with_activity"), 1);
+        assert_eq!(is_active(&mut conn, "archived_only"), 0);
+        assert_eq!(is_active(&mut conn, "plain_orphan"), 0);
     }
 }

--- a/crates/storage-sqlite/src/assets/repository.rs
+++ b/crates/storage-sqlite/src/assets/repository.rs
@@ -439,18 +439,20 @@ impl AssetRepositoryTrait for AssetRepository {
         let asset_ids = asset_ids.to_vec();
         self.writer
             .exec_tx(move |tx| -> Result<()> {
-                diesel::update(assets::table.filter(assets::id.eq_any(&asset_ids)))
-                    .set(assets::is_active.eq(1))
-                    .execute(tx.conn())
-                    .map_err(StorageError::from)?;
+                for chunk in chunk_for_sqlite(&asset_ids) {
+                    diesel::update(assets::table.filter(assets::id.eq_any(chunk)))
+                        .set(assets::is_active.eq(1))
+                        .execute(tx.conn())
+                        .map_err(StorageError::from)?;
 
-                let updated_rows = assets::table
-                    .filter(assets::id.eq_any(&asset_ids))
-                    .select(AssetDB::as_select())
-                    .load::<AssetDB>(tx.conn())
-                    .map_err(StorageError::from)?;
-                for updated in updated_rows {
-                    tx.update(&updated)?;
+                    let updated_rows = assets::table
+                        .filter(assets::id.eq_any(chunk))
+                        .select(AssetDB::as_select())
+                        .load::<AssetDB>(tx.conn())
+                        .map_err(StorageError::from)?;
+                    for updated in updated_rows {
+                        tx.update(&updated)?;
+                    }
                 }
 
                 Ok(())
@@ -542,6 +544,7 @@ impl AssetRepositoryTrait for AssetRepository {
 mod tests {
     use super::*;
     use crate::db::{create_pool, get_connection, init, run_migrations, write_actor::spawn_writer};
+    use crate::utils::SQLITE_MAX_PARAMS_CHUNK;
     use diesel::r2d2::ConnectionManager;
     use diesel::sql_query;
     use diesel::sql_types::Text;
@@ -687,5 +690,33 @@ mod tests {
         assert_eq!(is_active(&mut conn, "with_activity"), 1);
         assert_eq!(is_active(&mut conn, "archived_only"), 0);
         assert_eq!(is_active(&mut conn, "plain_orphan"), 0);
+    }
+
+    #[tokio::test]
+    async fn reactivate_batch_handles_more_than_one_sqlite_chunk() {
+        let (pool, writer) = setup_db();
+        let repo = AssetRepository::new(pool.clone(), writer);
+        let mut conn = get_connection(&pool).expect("conn");
+        let asset_ids: Vec<String> = (0..(SQLITE_MAX_PARAMS_CHUNK * 2 + 1))
+            .map(|i| format!("asset-{i}"))
+            .collect();
+
+        for asset_id in &asset_ids {
+            insert_asset(&mut conn, asset_id);
+            diesel::update(assets::table.filter(assets::id.eq(asset_id)))
+                .set(assets::is_active.eq(0))
+                .execute(&mut conn)
+                .expect("deactivate asset");
+        }
+        drop(conn);
+
+        repo.reactivate_batch(&asset_ids)
+            .await
+            .expect("reactivate assets");
+
+        let mut conn = get_connection(&pool).expect("conn");
+        for asset_id in &asset_ids {
+            assert_eq!(is_active(&mut conn, asset_id), 1);
+        }
     }
 }

--- a/crates/storage-sqlite/src/assets/repository.rs
+++ b/crates/storage-sqlite/src/assets/repository.rs
@@ -519,18 +519,20 @@ impl AssetRepositoryTrait for AssetRepository {
                     .map_err(StorageError::from)?;
 
                 if !orphan_ids.is_empty() {
-                    diesel::update(assets::table.filter(assets::id.eq_any(&orphan_ids)))
-                        .set(assets::is_active.eq(0))
-                        .execute(tx.conn())
-                        .map_err(StorageError::from)?;
+                    for chunk in chunk_for_sqlite(&orphan_ids) {
+                        diesel::update(assets::table.filter(assets::id.eq_any(chunk)))
+                            .set(assets::is_active.eq(0))
+                            .execute(tx.conn())
+                            .map_err(StorageError::from)?;
 
-                    let updated_rows = assets::table
-                        .filter(assets::id.eq_any(&orphan_ids))
-                        .select(AssetDB::as_select())
-                        .load::<AssetDB>(tx.conn())
-                        .map_err(StorageError::from)?;
-                    for updated in updated_rows {
-                        tx.update(&updated)?;
+                        let updated_rows = assets::table
+                            .filter(assets::id.eq_any(chunk))
+                            .select(AssetDB::as_select())
+                            .load::<AssetDB>(tx.conn())
+                            .map_err(StorageError::from)?;
+                        for updated in updated_rows {
+                            tx.update(&updated)?;
+                        }
                     }
                 }
 
@@ -717,6 +719,33 @@ mod tests {
         let mut conn = get_connection(&pool).expect("conn");
         for asset_id in &asset_ids {
             assert_eq!(is_active(&mut conn, asset_id), 1);
+        }
+    }
+
+    #[tokio::test]
+    async fn orphan_cleanup_handles_more_than_one_sqlite_chunk() {
+        let (pool, writer) = setup_db();
+        let repo = AssetRepository::new(pool.clone(), writer);
+        let mut conn = get_connection(&pool).expect("conn");
+        let asset_ids: Vec<String> = (0..(SQLITE_MAX_PARAMS_CHUNK * 2 + 1))
+            .map(|i| format!("orphan-{i}"))
+            .collect();
+
+        for asset_id in &asset_ids {
+            insert_asset(&mut conn, asset_id);
+        }
+        drop(conn);
+
+        let orphan_ids = repo
+            .deactivate_orphaned_investments()
+            .await
+            .expect("cleanup orphans");
+
+        assert_eq!(orphan_ids.len(), asset_ids.len());
+
+        let mut conn = get_connection(&pool).expect("conn");
+        for asset_id in &asset_ids {
+            assert_eq!(is_active(&mut conn, asset_id), 0);
         }
     }
 }

--- a/crates/storage-sqlite/src/assets/repository.rs
+++ b/crates/storage-sqlite/src/assets/repository.rs
@@ -463,24 +463,36 @@ impl AssetRepositoryTrait for AssetRepository {
     async fn deactivate_orphaned_investments(&self) -> Result<Vec<String>> {
         self.writer
             .exec_tx(move |tx| -> Result<Vec<String>> {
-                // Find active INVESTMENT assets with zero activities
+                // Find active INVESTMENT assets with no activities and no holdings history in
+                // non-archived accounts.
                 let orphan_ids: Vec<String> = assets::table
                     .select(assets::id)
                     .filter(assets::kind.eq("INVESTMENT"))
                     .filter(assets::is_active.eq(1))
                     .filter(diesel::dsl::sql::<diesel::sql_types::Bool>(
-                        "id NOT IN (SELECT DISTINCT asset_id FROM activities WHERE asset_id IS NOT NULL)",
+                        r#"
+                        NOT EXISTS (
+                            SELECT 1
+                            FROM activities activity
+                            WHERE activity.asset_id = assets.id
+                        )
+                        AND assets.id NOT IN (
+                            SELECT DISTINCT position.key
+                            FROM holdings_snapshots snapshot
+                            JOIN accounts account ON account.id = snapshot.account_id
+                            JOIN json_each(snapshot.positions) position
+                            WHERE account.is_archived = 0
+                        )
+                        "#,
                     ))
                     .load::<String>(tx.conn())
                     .map_err(StorageError::from)?;
 
                 if !orphan_ids.is_empty() {
-                    diesel::update(
-                        assets::table.filter(assets::id.eq_any(&orphan_ids)),
-                    )
-                    .set(assets::is_active.eq(0))
-                    .execute(tx.conn())
-                    .map_err(StorageError::from)?;
+                    diesel::update(assets::table.filter(assets::id.eq_any(&orphan_ids)))
+                        .set(assets::is_active.eq(0))
+                        .execute(tx.conn())
+                        .map_err(StorageError::from)?;
 
                     let updated_rows = assets::table
                         .filter(assets::id.eq_any(&orphan_ids))

--- a/crates/storage-sqlite/src/market_data/quote_sync_state_repository.rs
+++ b/crates/storage-sqlite/src/market_data/quote_sync_state_repository.rs
@@ -320,6 +320,42 @@ impl SyncStateStore for QuoteSyncStateRepository {
             .await
     }
 
+    async fn mark_inactive_batch(
+        &self,
+        asset_ids: &[String],
+        closed_date: NaiveDate,
+    ) -> Result<()> {
+        if asset_ids.is_empty() {
+            return Ok(());
+        }
+
+        let asset_ids = asset_ids.to_vec();
+        let closed_date_str = closed_date.format("%Y-%m-%d").to_string();
+        let now = Utc::now().to_rfc3339();
+
+        self.writer
+            .exec(move |conn: &mut SqliteConnection| -> Result<()> {
+                for chunk in chunk_for_sqlite(&asset_ids) {
+                    let update = QuoteSyncStateUpdateDB {
+                        position_closed_date: Some(Some(closed_date_str.clone())),
+                        sync_priority: Some(50), // RecentlyClosed priority
+                        updated_at: Some(now.clone()),
+                        ..Default::default()
+                    };
+
+                    diesel::update(
+                        qss_dsl::quote_sync_state.filter(qss_dsl::asset_id.eq_any(chunk)),
+                    )
+                    .set(&update)
+                    .execute(conn)
+                    .map_err(StorageError::from)?;
+                }
+
+                Ok(())
+            })
+            .await
+    }
+
     async fn mark_active(&self, asset_id: &str) -> Result<()> {
         let asset_id_owned = asset_id.to_string();
         let now = Utc::now().to_rfc3339();
@@ -342,6 +378,37 @@ impl SyncStateStore for QuoteSyncStateRepository {
                 .set(&update)
                 .execute(conn)
                 .map_err(StorageError::from)?;
+
+                Ok(())
+            })
+            .await
+    }
+
+    async fn mark_active_batch(&self, asset_ids: &[String]) -> Result<()> {
+        if asset_ids.is_empty() {
+            return Ok(());
+        }
+
+        let asset_ids = asset_ids.to_vec();
+        let now = Utc::now().to_rfc3339();
+
+        self.writer
+            .exec(move |conn: &mut SqliteConnection| -> Result<()> {
+                for chunk in chunk_for_sqlite(&asset_ids) {
+                    let update = QuoteSyncStateUpdateDB {
+                        position_closed_date: Some(None),
+                        sync_priority: Some(100), // Active priority
+                        updated_at: Some(now.clone()),
+                        ..Default::default()
+                    };
+
+                    diesel::update(
+                        qss_dsl::quote_sync_state.filter(qss_dsl::asset_id.eq_any(chunk)),
+                    )
+                    .set(&update)
+                    .execute(conn)
+                    .map_err(StorageError::from)?;
+                }
 
                 Ok(())
             })


### PR DESCRIPTION
## Summary
- decouple asset catalog active state from open/closed quote position state
- reconcile quote sync state from TOTAL holdings before market sync across server and Tauri entry points
- make quote sync filtering mode-aware for targeted, inactive, closed, and empty target requests
- include holdings-snapshot exposure in quote history planning and protect holdings-only assets from orphan cleanup
- surface skipped quote sync feedback in the frontend

## Validation
- cargo test -p wealthfolio-core quotes::sync
- cargo test -p wealthfolio-core update_position_status
- cargo check -p wealthfolio-core
- cargo check -p wealthfolio-storage-sqlite
- cargo check -p wealthfolio-server
- cargo check -p wealthfolio-app
- pnpm --filter frontend type-check
- cargo fmt --check
- git diff --check

## Notes
- Created as draft for review of the quote sync lifecycle architecture and remaining DB integration test discussion.