### PR TITLE
ci(docker): publish to wealthfolio/wealthfolio, keep afadil mirror

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,12 +5,6 @@ on:
     # Publish semver tags as releases.
     tags: ["v*.*.*"]
 
-env:
-  # Use docker.io for Docker Hub if empty
-  REGISTRY: docker.io
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/wealthfolio
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -33,13 +27,14 @@ jobs:
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
 
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
-      - name: Log into registry ${{ env.REGISTRY }}
+      # Login to Docker Hub. The token below belongs to the `wealthfolio`
+      # account and has push rights to both `wealthfolio/wealthfolio` (owner)
+      # and `afadil/wealthfolio` (collaborator), so a single login covers both.
+      - name: Log into Docker Hub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
@@ -58,7 +53,8 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+            docker.io/wealthfolio/wealthfolio
+            docker.io/afadil/wealthfolio
             ghcr.io/${{ github.repository_owner }}/wealthfolio
           tags: |
             type=semver,pattern={{version}}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,9 +27,6 @@ jobs:
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
 
-      # Login to Docker Hub. The token below belongs to the `wealthfolio`
-      # account and has push rights to both `wealthfolio/wealthfolio` (owner)
-      # and `afadil/wealthfolio` (collaborator), so a single login covers both.
       - name: Log into Docker Hub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3

--- a/README.md
+++ b/README.md
@@ -342,11 +342,15 @@ You can either pull the official Docker image or build it yourself locally.
 The latest server build is published to Docker Hub.
 
 ```bash
-docker pull afadil/wealthfolio:latest
+docker pull wealthfolio/wealthfolio:latest
 ```
 
-After pulling, use `afadil/wealthfolio:latest` in the run commands below. If you
-build the image locally, swap the image name back to `wealthfolio`.
+After pulling, use `wealthfolio/wealthfolio:latest` in the run commands below.
+If you build the image locally, swap the image name back to `wealthfolio`.
+
+> **Legacy image:** the same build is also mirrored to `afadil/wealthfolio` so
+> existing `compose.yml` files keep working. New deployments should prefer
+> `wealthfolio/wealthfolio`.
 
 ### Building the Image
 
@@ -401,8 +405,8 @@ See examples below for inline configuration.
 
 ### Running the Container
 
-All examples below use the published image (`afadil/wealthfolio:latest`). If you
-built locally, substitute your local tag (e.g., `wealthfolio`).
+All examples below use the published image (`wealthfolio/wealthfolio:latest`).
+If you built locally, substitute your local tag (e.g., `wealthfolio`).
 
 **Using environment file** (recommended):
 
@@ -412,7 +416,7 @@ docker run --rm -d \
   --env-file .env.docker \
   -p 8088:8088 \
   -v wealthfolio-data:/data \
-  afadil/wealthfolio:latest
+  wealthfolio/wealthfolio:latest
 ```
 
 **Basic usage** (inline environment variables):
@@ -424,7 +428,7 @@ docker run --rm -d \
   -e WF_DB_PATH=/data/wealthfolio.db \
   -p 8088:8088 \
   -v wealthfolio-data:/data \
-  afadil/wealthfolio:latest
+  wealthfolio/wealthfolio:latest
 ```
 
 **Development mode** (with CORS for local Vite dev server):
@@ -437,7 +441,7 @@ docker run --rm -it \
   -e WF_CORS_ALLOW_ORIGINS=http://localhost:1420 \
   -p 8088:8088 \
   -v wealthfolio-data:/data \
-  afadil/wealthfolio:latest
+  wealthfolio/wealthfolio:latest
 ```
 
 **Production with encryption** (recommended):
@@ -450,7 +454,7 @@ docker run --rm -d \
   -e WF_SECRET_KEY=$(openssl rand -base64 32) \
   -p 8088:8088 \
   -v wealthfolio-data:/data \
-  afadil/wealthfolio:latest
+  wealthfolio/wealthfolio:latest
 ```
 
 ### Environment Variables

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -9,7 +9,7 @@ Run locally (Rust only)
   - `cargo run --manifest-path src-server/Cargo.toml`
 
 Docker image
-- Pull the latest published server image with `docker pull afadil/wealthfolio:latest`.
+- Pull the latest published server image with `docker pull wealthfolio/wealthfolio:latest`.
 - Use that tag (or your locally built image) in the Docker run examples inside the root `README.md`.
 
 Key environment variables

--- a/compose.yml
+++ b/compose.yml
@@ -8,7 +8,7 @@
 
 services:
   wealthfolio:
-    image: afadil/wealthfolio:latest
+    image: wealthfolio/wealthfolio:latest
     container_name: wealthfolio
     restart: unless-stopped
     expose:

--- a/docs/self-host/README.md
+++ b/docs/self-host/README.md
@@ -13,14 +13,19 @@ pointers per platform.
 
 Multi-arch (`linux/amd64`, `linux/arm64`), published on every `v*.*.*` tag:
 
-| Registry   | Image                               |
-| ---------- | ----------------------------------- |
-| Docker Hub | `afadil/wealthfolio:latest`         |
-| GHCR       | `ghcr.io/afadil/wealthfolio:latest` |
+| Registry   | Image                                         |
+| ---------- | --------------------------------------------- |
+| Docker Hub | `wealthfolio/wealthfolio:latest` _(primary)_  |
+| Docker Hub | `afadil/wealthfolio:latest` _(legacy mirror)_ |
+| GHCR       | `ghcr.io/afadil/wealthfolio:latest`           |
 
 ```bash
-docker pull afadil/wealthfolio:latest
+docker pull wealthfolio/wealthfolio:latest
 ```
+
+Existing deployments that pin `afadil/wealthfolio:latest` keep working — both
+Docker Hub repos receive the same multi-arch build from CI. New deployments
+should prefer `wealthfolio/wealthfolio`.
 
 ## Permissions
 

--- a/docs/self-host/unraid/template.xml
+++ b/docs/self-host/unraid/template.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>wealthfolio</Name>
-  <Repository>afadil/wealthfolio:latest</Repository>
-  <Registry>https://hub.docker.com/r/afadil/wealthfolio</Registry>
+  <Repository>wealthfolio/wealthfolio:latest</Repository>
+  <Registry>https://hub.docker.com/r/wealthfolio/wealthfolio</Registry>
   <Network>bridge</Network>
   <MyIP/>
   <Shell>sh</Shell>


### PR DESCRIPTION
## Summary

Migrate the published Docker image from `afadil/wealthfolio` to `wealthfolio/wealthfolio` while keeping the old name working as a mirror so existing `compose.yml` files and Unraid installs don't break.

- **CI** (`.github/workflows/docker-publish.yml`): every `v*.*.*` tag now pushes the multi-arch build to **three** destinations:
  - `docker.io/wealthfolio/wealthfolio` *(new primary)*
  - `docker.io/afadil/wealthfolio` *(legacy mirror)*
  - `ghcr.io/${{ github.repository_owner }}/wealthfolio` *(unchanged — auto-follows the GitHub repo on transfer)*
- **Docs** (`README.md`, `compose.yml`, `docs/self-host/README.md`, `docs/self-host/unraid/template.xml`, `apps/server/README.md`): primary docker pull/run examples now use `wealthfolio/wealthfolio`. The legacy image is called out so users on `afadil/wealthfolio:latest` know they don't need to change anything yet.

## What this PR does *not* do

- **GitHub repo transfer** — separate manual step (Settings → Transfer ownership) once you're ready. After transfer, `ghcr.io/wealthfolio/wealthfolio` will start receiving the next build automatically.
- **Rewriting `https://github.com/afadil/wealthfolio` URLs** in READMEs / Cargo.toml / package.json — left alone on purpose. Flipping them before the transfer would 404 those links; after transfer GitHub redirects, so a follow-up PR can update them at leisure.

## Required setup before the next release tag

Single Docker Hub login covers both repos because `wealthfolio` is now a collaborator on `afadil/wealthfolio`. Make sure the repo secrets in `afadil/wealthfolio` (or whichever owns the workflow when the next tag is cut) are:

- `DOCKERHUB_USERNAME` = `wealthfolio`
- `DOCKERHUB_TOKEN` = a PAT minted under the `wealthfolio` Docker Hub account with **Read & Write** (or Read/Write/Delete)

Also: pre-create the public `wealthfolio/wealthfolio` repo on Docker Hub (with description copied from `afadil/wealthfolio`) so the first push lands in an existing public repo rather than auto-creating a possibly-private one.

## Heads-up on `:latest`

Until the next `v*.*.*` tag is cut after merge, `wealthfolio/wealthfolio:latest` will not exist on Docker Hub. The README points users there, so plan to either:

1. Cut a release tag soon after merging, **or**
2. Manually mirror the current `afadil/wealthfolio:latest` over to `wealthfolio/wealthfolio:latest` once (e.g. via `docker buildx imagetools create`) before announcing.

## Test plan

- [ ] Pre-create `wealthfolio/wealthfolio` (Public) on Docker Hub
- [ ] Update `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` repo secrets
- [ ] Cut a test pre-release tag (e.g. `v0.0.0-docker-migration.1`) and confirm the workflow pushes to all three destinations
- [ ] `docker pull wealthfolio/wealthfolio:<that-tag>` succeeds
- [ ] `docker pull afadil/wealthfolio:<that-tag>` still succeeds
- [ ] `docker pull ghcr.io/afadil/wealthfolio:<that-tag>` still succeeds
- [ ] After GitHub repo transfer, the next tag also publishes to `ghcr.io/wealthfolio/wealthfolio`