### PR TITLE
docs: migrate afadil/wealthfolio URLs to wealthfolio org + refresh tagline

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 ## Checklist
 
 - [ ] I have read and agree to the
-      [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).
+      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
 
 By submitting this PR, I agree to the
-[CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).
+[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
 
   prebuild-server-linux:
     # Standalone server tarball for self-hosters (Proxmox LXC, bare metal, systemd).
-    # Tracks: https://github.com/afadil/wealthfolio/issues/563
+    # Tracks: https://github.com/wealthfolio/wealthfolio/issues/563
     # Built on ubuntu-22.04 (glibc 2.35) for forward compatibility with Debian 12+/Ubuntu 22.04+.
     needs: release
     # Run even if some matrix entries in `release` failed (fail-fast is off).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ By submitting a pull request, you confirm you have read and agree to
 ### Reporting Bugs
 
 1. Check if the bug has already been reported in
-   [Issues](https://github.com/afadil/wealthfolio/issues)
+   [Issues](https://github.com/wealthfolio/wealthfolio/issues)
 2. If not, create a new issue with:
    - Clear, descriptive title
    - Steps to reproduce
@@ -70,7 +70,7 @@ something together!
 ## Questions?
 
 - Join our [Discord](https://discord.gg/WDMCY6aPWK)
-- Open a [Discussion](https://github.com/afadil/wealthfolio/discussions)
+- Open a [Discussion](https://github.com/wealthfolio/wealthfolio/discussions)
 - Email: hello@wealthfolio.app
 
 ## License

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8002,7 +8002,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-ai"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8027,7 +8027,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-app"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8076,7 +8076,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-connect"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8094,7 +8094,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-core"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8139,7 +8139,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-device-sync"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8163,7 +8163,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-market-data"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8185,7 +8185,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-server"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8232,7 +8232,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-storage-sqlite"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.3.0"
+version = "3.4.0"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <div align="center">
-  <a href="https://github.com/afadil/wealthfolio">
+  <a href="https://github.com/wealthfolio/wealthfolio">
     <img src="apps/frontend/public/logo.svg" alt="Logo" width="80" height="80">
   </a>
 
   <h3 align="center">Wealthfolio</h3>
 
   <p align="center">
-    A Beautiful and Boring Desktop Investment Tracker
+    A Beautiful and Boring Personal Finance Tracker — investments, net worth, spending, and simulations
     <br />
     <br />
     <a href="https://wealthfolio.app">Website</a>
@@ -15,7 +15,7 @@
     ·
     <a href="https://x.com/intent/follow?screen_name=WealthfolioApp">Twitter</a>
     ·
-    <a href="https://github.com/afadil/wealthfolio/releases">Releases</a>
+    <a href="https://github.com/wealthfolio/wealthfolio/releases">Releases</a>
   </p>
 </div>
 <div align="center">
@@ -35,14 +35,15 @@
   <a href="https://www.producthunt.com/posts/wealthfolio?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_souce=badge-wealthfolio" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=461640&amp;theme=light" alt="Wealthfolio - A boring, Local first, desktop Investment Tracking app | Product Hunt" class="h-[55px] w-[250px]" width="250" height="55"></a>
 
   <a href="https://trendshift.io/repositories/11701" target="_blank">
-  <img src="https://trendshift.io/api/badge/repositories/11701" alt="afadil%2Fwealthfolio | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+  <img src="https://trendshift.io/api/badge/repositories/11701" alt="wealthfolio%2Fwealthfolio | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 
 </div>
 
 ## Introduction
 
-**Wealthfolio App** is a Beautiful and Boring Investment Tracker, with Local
-Data Storage. No Subscriptions, No Cloud.
+**Wealthfolio App** is a Beautiful and Boring Personal Finance Tracker —
+investments, net worth, spending, and simulations — with local data storage. No
+subscriptions, no cloud.
 
 Visit the app website at [Wealthfolio App](https://wealthfolio.app/).
 
@@ -135,7 +136,7 @@ Ensure you have the following installed on your machine:
 1. **Clone the repository**:
 
    ```bash
-   git clone https://github.com/afadil/wealthfolio.git
+   git clone https://github.com/wealthfolio/wealthfolio.git
    cd wealthfolio
    ```
 
@@ -511,7 +512,7 @@ steps and provides an isolated environment with all necessary dependencies.
 
 1. **Clone the repository** (if you haven't already):
    ```bash
-   git clone https://github.com/afadil/wealthfolio.git
+   git clone https://github.com/wealthfolio/wealthfolio.git
    cd wealthfolio
    ```
 2. **Open in VS Code**:
@@ -724,6 +725,6 @@ licensed under AGPL-3.0; trademarks are not granted under that license.
 
 ## 🌟 Star History
 
-## [![Star History Chart](https://api.star-history.com/svg?repos=afadil/wealthfolio&type=Timeline)](https://star-history.com/#afadil/wealthfolio&Date)
+## [![Star History Chart](https://api.star-history.com/svg?repos=wealthfolio/wealthfolio&type=Timeline)](https://star-history.com/#wealthfolio/wealthfolio&Date)
 
 Enjoy managing your wealth with **Wealthfolio**! 🚀

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <h3 align="center">Wealthfolio</h3>
 
   <p align="center">
-    A Beautiful and Boring Personal Finance Tracker — investments, net worth, spending, and simulations
+    A Beautiful Personal Finance Tracker — investments, net worth, spending, and simulations
     <br />
     <br />
     <a href="https://wealthfolio.app">Website</a>
@@ -32,7 +32,7 @@
     style="width: 250px; height: 55px;" width="250" height="55"
   />
 </a>
-  <a href="https://www.producthunt.com/posts/wealthfolio?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_souce=badge-wealthfolio" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=461640&amp;theme=light" alt="Wealthfolio - A boring, Local first, desktop Investment Tracking app | Product Hunt" class="h-[55px] w-[250px]" width="250" height="55"></a>
+  <a href="https://www.producthunt.com/posts/wealthfolio?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_souce=badge-wealthfolio" target="_blank"><img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=461640&amp;theme=light" alt="Wealthfolio - A beautiful, local-first personal finance tracker | Product Hunt" class="h-[55px] w-[250px]" width="250" height="55"></a>
 
   <a href="https://trendshift.io/repositories/11701" target="_blank">
   <img src="https://trendshift.io/api/badge/repositories/11701" alt="wealthfolio%2Fwealthfolio | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
@@ -41,9 +41,9 @@
 
 ## Introduction
 
-**Wealthfolio App** is a Beautiful and Boring Personal Finance Tracker —
-investments, net worth, spending, and simulations — with local data storage. No
-subscriptions, no cloud.
+**Wealthfolio App** is a Beautiful Personal Finance Tracker — investments, net
+worth, spending, and simulations — with local data storage. No subscriptions, no
+cloud.
 
 Visit the app website at [Wealthfolio App](https://wealthfolio.app/).
 

--- a/addons/goal-progress-tracker/manifest.json
+++ b/addons/goal-progress-tracker/manifest.json
@@ -1,11 +1,11 @@
 {
   "id": "goal-progress-tracker-addon",
   "name": "Goal Progress Tracker",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "A simple addon to track your investment progress towards target amounts with a visual representation",
   "author": "Wealthfolio",
   "main": "dist/addon.js",
-  "sdkVersion": "3.3.0",
+  "sdkVersion": "3.4.0",
   "enabled": true,
   "permissions": [
     {

--- a/addons/goal-progress-tracker/package.json
+++ b/addons/goal-progress-tracker/package.json
@@ -6,7 +6,7 @@
   "main": "dist/addon.js",
   "author": "Wealthfolio",
   "license": "MIT",
-  "homepage": "https://github.com/afadil/wealthfolio",
+  "homepage": "https://github.com/wealthfolio/wealthfolio",
   "keywords": [
     "wealthfolio",
     "addon",

--- a/addons/goal-progress-tracker/package.json
+++ b/addons/goal-progress-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goal-progress-tracker-addon",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "An addon for tracking investment progress towards target amounts with progress visualization",
   "type": "module",
   "main": "dist/addon.js",

--- a/addons/investment-fees-tracker/manifest.json
+++ b/addons/investment-fees-tracker/manifest.json
@@ -1,11 +1,11 @@
 {
   "id": "investment-fees-tracker-addon",
   "name": "Investment Fees Tracker",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Track and analyze investment fees across your portfolio with detailed analytics and insights",
   "author": "Wealthfolio",
   "main": "dist/addon.js",
-  "sdkVersion": "3.3.0",
+  "sdkVersion": "3.4.0",
   "enabled": true,
   "permissions": [
     {

--- a/addons/investment-fees-tracker/package.json
+++ b/addons/investment-fees-tracker/package.json
@@ -6,7 +6,7 @@
   "main": "dist/addon.js",
   "author": "Wealthfolio",
   "license": "MIT",
-  "homepage": "https://github.com/afadil/wealthfolio",
+  "homepage": "https://github.com/wealthfolio/wealthfolio",
   "keywords": [
     "wealthfolio",
     "addon",

--- a/addons/investment-fees-tracker/package.json
+++ b/addons/investment-fees-tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "investment-fees-tracker-addon",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "An addon for tracking and analyzing investment fees across your portfolio",
   "type": "module",
   "main": "dist/addon.js",

--- a/addons/swingfolio-addon/manifest.json
+++ b/addons/swingfolio-addon/manifest.json
@@ -1,11 +1,11 @@
 {
   "id": "swingfolio-addon",
   "name": "Swingfolio: Simple Stock Trading Tracker",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "A simple swing stock trading tracker with performance analytics and calendar views",
   "author": "Wealthfolio",
   "main": "dist/addon.js",
-  "sdkVersion": "3.3.0",
+  "sdkVersion": "3.4.0",
   "enabled": true,
   "permissions": [
     {

--- a/addons/swingfolio-addon/package.json
+++ b/addons/swingfolio-addon/package.json
@@ -6,7 +6,7 @@
   "main": "dist/addon.js",
   "author": "Wealthfolio",
   "license": "MIT",
-  "homepage": "https://github.com/afadil/wealthfolio",
+  "homepage": "https://github.com/wealthfolio/wealthfolio",
   "keywords": [
     "wealthfolio",
     "addon",

--- a/addons/swingfolio-addon/package.json
+++ b/addons/swingfolio-addon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swingfolio-addon",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "A simple swing stock trading tracker with performance analytics and calendar views",
   "type": "module",
   "main": "dist/addon.js",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -3,6 +3,15 @@
   "private": true,
   "version": "3.3.0",
   "type": "module",
+  "homepage": "https://wealthfolio.app",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wealthfolio/wealthfolio.git",
+    "directory": "apps/frontend"
+  },
+  "bugs": {
+    "url": "https://github.com/wealthfolio/wealthfolio/issues"
+  },
   "scripts": {
     "dev": "cross-env BUILD_TARGET=web vite",
     "dev:tauri": "cross-env BUILD_TARGET=tauri vite",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "3.3.0",
+  "version": "3.4.0",
   "type": "module",
   "homepage": "https://wealthfolio.app",
   "repository": {

--- a/apps/frontend/public/mock-update.json
+++ b/apps/frontend/public/mock-update.json
@@ -3,7 +3,7 @@
   "latestVersion": "3.0.5",
   "notes": "v3.0.5 brings performance improvements, bug fixes, and a refreshed dashboard experience.",
   "pubDate": "2026-03-04T10:00:00.000Z",
-  "downloadUrl": "https://github.com/afadil/wealthfolio/releases/tag/v3.0.5",
+  "downloadUrl": "https://github.com/wealthfolio/wealthfolio/releases/tag/v3.0.5",
   "changelogUrl": "https://wealthfolio.app/changelog/",
   "screenshots": [
     "https://assets.wealthfolio.app/screenshots/v300-wealthfolio-connect.png",

--- a/apps/frontend/src/pages/settings/about/about-page.tsx
+++ b/apps/frontend/src/pages/settings/about/about-page.tsx
@@ -114,7 +114,7 @@ export default function AboutSettingsPage() {
                 size="sm"
                 className="inline-flex items-center gap-2"
               >
-                <ExternalLink href="https://github.com/afadil/wealthfolio">
+                <ExternalLink href="https://github.com/wealthfolio/wealthfolio">
                   <Icons.ExternalLink className="h-4 w-4" />
                   GitHub
                 </ExternalLink>
@@ -194,7 +194,7 @@ export default function AboutSettingsPage() {
                 size="sm"
                 className="inline-flex items-center gap-2"
               >
-                <ExternalLink href="https://github.com/afadil/wealthfolio/issues">
+                <ExternalLink href="https://github.com/wealthfolio/wealthfolio/issues">
                   <Icons.AlertCircle className="h-4 w-4" />
                   Report Issue
                 </ExternalLink>

--- a/apps/tauri/Cargo.toml
+++ b/apps/tauri/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 description = "Portfolio tracker"
 authors = ["Aziz Fadil"]
 license = "AGPL-3.0"
-repository = ""
+repository = "https://github.com/wealthfolio/wealthfolio"
 
 [build-dependencies]
 tauri-build = { version = "2.5", features = [] }

--- a/apps/tauri/tauri.conf.json
+++ b/apps/tauri/tauri.conf.json
@@ -32,7 +32,7 @@
   },
   "productName": "Wealthfolio",
   "mainBinaryName": "Wealthfolio",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "identifier": "com.teymz.wealthfolio",
   "plugins": {
     "updater": {

--- a/crates/ai/Cargo.toml
+++ b/crates/ai/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 description = "AI assistant with LLM orchestration using rig-core for Wealthfolio"
 authors = ["Aziz Fadil"]
 license = "AGPL-3.0"
-repository = "https://github.com/afadil/wealthfolio"
+repository = "https://github.com/wealthfolio/wealthfolio"
 
 [features]
 default = []

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 description = "An Open Source Desktop Portfolio tracker"
 authors = ["Aziz Fadil"]
 license = "AGPL-3.0"
-repository = "https://github.com/afadil/wealthfolio"
+repository = "https://github.com/wealthfolio/wealthfolio"
 
 [features]
 default = []

--- a/docs/addons/addon-getting-started.md
+++ b/docs/addons/addon-getting-started.md
@@ -526,5 +526,5 @@ You now understand:
 Continue with:
 
 - [API Reference](/docs/addons/api-reference) - All available APIs
-- [Examples](https://github.com/wealthfolio/wealthfolio/tree/main/addons/) - Real
-  addon implementations
+- [Examples](https://github.com/wealthfolio/wealthfolio/tree/main/addons/) -
+  Real addon implementations

--- a/docs/addons/addon-getting-started.md
+++ b/docs/addons/addon-getting-started.md
@@ -26,7 +26,7 @@ Wealthfolio in addon development mode:
 
 ```bash
 # Clone Wealthfolio repository (if not already done)
-git clone https://github.com/afadil/wealthfolio.git
+git clone https://github.com/wealthfolio/wealthfolio.git
 cd wealthfolio
 
 # Install dependencies
@@ -526,5 +526,5 @@ You now understand:
 Continue with:
 
 - [API Reference](/docs/addons/api-reference) - All available APIs
-- [Examples](https://github.com/afadil/wealthfolio/tree/main/addons/) - Real
+- [Examples](https://github.com/wealthfolio/wealthfolio/tree/main/addons/) - Real
   addon implementations

--- a/docs/addons/addons-overview.md
+++ b/docs/addons/addons-overview.md
@@ -379,7 +379,7 @@ Wealthfolio Store, contact **support@wealthfolio.app**.
     <span class="text-primary">Browse APIs →</span>
   </Card>
 
-  <Card href="https://github.com/afadil/wealthfolio/tree/main/addons/">
+  <Card href="https://github.com/wealthfolio/wealthfolio/tree/main/addons/">
     <h3 class="text-lg font-semibold mb-2">💡 Examples</h3>
     <p class="text-muted-foreground mb-4">See real addon implementations</p>
     <span class="text-primary">Browse Examples →</span>

--- a/docs/self-host/README.md
+++ b/docs/self-host/README.md
@@ -17,7 +17,7 @@ Multi-arch (`linux/amd64`, `linux/arm64`), published on every `v*.*.*` tag:
 | ---------- | --------------------------------------------- |
 | Docker Hub | `wealthfolio/wealthfolio:latest` _(primary)_  |
 | Docker Hub | `afadil/wealthfolio:latest` _(legacy mirror)_ |
-| GHCR       | `ghcr.io/afadil/wealthfolio:latest`           |
+| GHCR       | `ghcr.io/wealthfolio/wealthfolio:latest`      |
 
 ```bash
 docker pull wealthfolio/wealthfolio:latest

--- a/docs/self-host/proxmox/README.md
+++ b/docs/self-host/proxmox/README.md
@@ -4,8 +4,8 @@ Three sensible install paths on Proxmox: a native LXC via the
 [community-scripts](https://community-scripts.github.io/ProxmoxVE/) project,
 Docker inside an LXC, or Docker inside a VM. The LXC path matches Proxmox
 conventions (no Docker-in-LXC), but builds from source on each install (~15–25
-min, tracked in [#563](https://github.com/wealthfolio/wealthfolio/issues/563)). The
-Docker paths are faster but introduce nesting.
+min, tracked in [#563](https://github.com/wealthfolio/wealthfolio/issues/563)).
+The Docker paths are faster but introduce nesting.
 
 📘 **Full setup guide:**
 [wealthfolio.app/docs/guide/self-hosting](https://wealthfolio.app/docs/guide/self-hosting)

--- a/docs/self-host/proxmox/README.md
+++ b/docs/self-host/proxmox/README.md
@@ -4,7 +4,7 @@ Three sensible install paths on Proxmox: a native LXC via the
 [community-scripts](https://community-scripts.github.io/ProxmoxVE/) project,
 Docker inside an LXC, or Docker inside a VM. The LXC path matches Proxmox
 conventions (no Docker-in-LXC), but builds from source on each install (~15–25
-min, tracked in [#563](https://github.com/afadil/wealthfolio/issues/563)). The
+min, tracked in [#563](https://github.com/wealthfolio/wealthfolio/issues/563)). The
 Docker paths are faster but introduce nesting.
 
 📘 **Full setup guide:**

--- a/docs/self-host/unraid/README.md
+++ b/docs/self-host/unraid/README.md
@@ -22,7 +22,7 @@ into Unraid (or use the WebTerminal) and run:
 ```bash
 mkdir -p /boot/config/plugins/dockerMan/templates-user
 curl -fsSL \
-  https://raw.githubusercontent.com/afadil/wealthfolio/main/docs/self-host/unraid/template.xml \
+  https://raw.githubusercontent.com/wealthfolio/wealthfolio/main/docs/self-host/unraid/template.xml \
   -o /boot/config/plugins/dockerMan/templates-user/my-wealthfolio.xml
 ```
 

--- a/docs/self-host/unraid/template.xml
+++ b/docs/self-host/unraid/template.xml
@@ -29,7 +29,7 @@ Full guide: https://github.com/wealthfolio/wealthfolio/blob/main/docs/self-host/
   <DateInstalled/>
   <DonateText>Buy me a coffee</DonateText>
   <DonateLink>https://www.buymeacoffee.com/afadil</DonateLink>
-  <Description>Wealthfolio is a beautiful and boring local-first investment tracker. Track portfolios across multiple accounts and asset types, import broker activities, set financial goals, and analyse performance — all stored in your own SQLite database with no cloud dependency.</Description>
+  <Description>Wealthfolio is a beautiful, local-first personal finance tracker — investments, net worth, spending, and simulations — all stored in your own SQLite database with no cloud dependency.</Description>
   <Networking>
     <Mode>bridge</Mode>
     <Publish>

--- a/docs/self-host/unraid/template.xml
+++ b/docs/self-host/unraid/template.xml
@@ -7,7 +7,7 @@
   <MyIP/>
   <Shell>sh</Shell>
   <Privileged>false</Privileged>
-  <Support>https://github.com/afadil/wealthfolio/issues</Support>
+  <Support>https://github.com/wealthfolio/wealthfolio/issues</Support>
   <Project>https://wealthfolio.app</Project>
   <Overview>Wealthfolio is a beautiful, open-source local-first investment and net worth tracker. Track portfolios across multiple accounts and asset types, import broker activities, set financial goals, and analyse performance — all stored in your own SQLite database with no cloud dependency.&#xD;
 &#xD;
@@ -18,11 +18,11 @@ REQUIRED CONFIG:&#xD;
 3. WF_CORS_ALLOW_ORIGINS — the exact URL you'll use to reach the app&#xD;
    (e.g. http://192.168.1.10:8088 or https://wealthfolio.example.com)&#xD;
 &#xD;
-Full guide: https://github.com/afadil/wealthfolio/blob/main/docs/self-host/unraid/README.md</Overview>
+Full guide: https://github.com/wealthfolio/wealthfolio/blob/main/docs/self-host/unraid/README.md</Overview>
   <Category>Productivity: Other:</Category>
   <WebUI>http://[IP]:[PORT:8088]/</WebUI>
-  <TemplateURL>https://raw.githubusercontent.com/afadil/wealthfolio/main/docs/self-host/unraid/template.xml</TemplateURL>
-  <Icon>https://raw.githubusercontent.com/afadil/wealthfolio/main/assets/brand/icon.png</Icon>
+  <TemplateURL>https://raw.githubusercontent.com/wealthfolio/wealthfolio/main/docs/self-host/unraid/template.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/wealthfolio/wealthfolio/main/assets/brand/icon.png</Icon>
   <ExtraParams>--user=99:100 --health-cmd="wget --quiet --tries=1 --spider http://127.0.0.1:8088/api/v1/healthz || exit 1" --health-interval=30s --health-timeout=10s --health-retries=3 --health-start-period=15s</ExtraParams>
   <PostArgs/>
   <CPUset/>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wealthfolio-app",
   "private": true,
-  "version": "3.3.0",
+  "version": "3.4.0",
   "type": "module",
   "workspaces": [
     "apps/frontend",

--- a/packages/addon-dev-tools/package.json
+++ b/packages/addon-dev-tools/package.json
@@ -17,13 +17,13 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/afadil/wealthfolio.git",
+    "url": "https://github.com/wealthfolio/wealthfolio.git",
     "directory": "packages/addon-dev-tools"
   },
   "bugs": {
-    "url": "https://github.com/afadil/wealthfolio/issues"
+    "url": "https://github.com/wealthfolio/wealthfolio/issues"
   },
-  "homepage": "https://github.com/afadil/wealthfolio/tree/main/packages/addon-dev-tools#readme",
+  "homepage": "https://github.com/wealthfolio/wealthfolio/tree/main/packages/addon-dev-tools#readme",
   "files": [
     "cli.js",
     "dev-server.js",

--- a/packages/addon-dev-tools/package.json
+++ b/packages/addon-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/addon-dev-tools",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Development tools for Wealthfolio addons - hot reload server and CLI",
   "main": "index.js",
   "bin": {

--- a/packages/addon-sdk/README.md
+++ b/packages/addon-sdk/README.md
@@ -1332,7 +1332,7 @@ We welcome contributions to improve the addon SDK!
 | **Scope**        | `@wealthfolio`                                                    |
 | **Registry**     | [npmjs.com](https://www.npmjs.com/package/@wealthfolio/addon-sdk) |
 | **License**      | MIT                                                               |
-| **Repository**   | [GitHub](https://github.com/wealthfolio/wealthfolio)                   |
+| **Repository**   | [GitHub](https://github.com/wealthfolio/wealthfolio)              |
 
 ### Version History
 
@@ -1506,7 +1506,8 @@ npm pack && tar -tf *.tgz
 
 1. **Documentation**: Check this README and
    [docs](https://docs.wealthfolio.app/addons)
-2. **Issues**: [GitHub Issues](https://github.com/wealthfolio/wealthfolio/issues)
+2. **Issues**:
+   [GitHub Issues](https://github.com/wealthfolio/wealthfolio/issues)
 3. **Discussions**:
    [GitHub Discussions](https://github.com/wealthfolio/wealthfolio/discussions)
 4. **Discord**: [Community Discord](https://discord.gg/wealthfolio)

--- a/packages/addon-sdk/README.md
+++ b/packages/addon-sdk/README.md
@@ -2,7 +2,7 @@
 
 [![Version](https://img.shields.io/npm/v/@wealthfolio/addon-sdk?style=flat-square)](https://www.npmjs.com/package/@wealthfolio/addon-sdk)
 [![Downloads](https://img.shields.io/npm/dm/@wealthfolio/addon-sdk?style=flat-square)](https://www.npmjs.com/package/@wealthfolio/addon-sdk)
-[![License](https://img.shields.io/npm/l/@wealthfolio/addon-sdk?style=flat-square)](https://github.com/afadil/wealthfolio/blob/main/LICENSE)
+[![License](https://img.shields.io/npm/l/@wealthfolio/addon-sdk?style=flat-square)](https://github.com/wealthfolio/wealthfolio/blob/main/LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-Ready-blue?style=flat-square)](https://www.typescriptlang.org/)
 [![Node](https://img.shields.io/node/v/@wealthfolio/addon-sdk?style=flat-square)](https://nodejs.org/)
 
@@ -1041,7 +1041,7 @@ If you want to contribute to the SDK itself:
 
 ```bash
 # Clone the Wealthfolio repository
-git clone https://github.com/afadil/wealthfolio.git
+git clone https://github.com/wealthfolio/wealthfolio.git
 cd wealthfolio/packages/addon-sdk
 
 # Install dependencies
@@ -1332,7 +1332,7 @@ We welcome contributions to improve the addon SDK!
 | **Scope**        | `@wealthfolio`                                                    |
 | **Registry**     | [npmjs.com](https://www.npmjs.com/package/@wealthfolio/addon-sdk) |
 | **License**      | MIT                                                               |
-| **Repository**   | [GitHub](https://github.com/afadil/wealthfolio)                   |
+| **Repository**   | [GitHub](https://github.com/wealthfolio/wealthfolio)                   |
 
 ### Version History
 
@@ -1378,7 +1378,7 @@ npm install @wealthfolio/addon-sdk@1.1.0-beta.1
 
 ```bash
 # Install directly from GitHub
-npm install github:afadil/wealthfolio#main
+npm install github:wealthfolio/wealthfolio#main
 
 # Or from a specific branch/commit
 npm install github:afladil/wealthfolio#wealthfolio-addons
@@ -1506,9 +1506,9 @@ npm pack && tar -tf *.tgz
 
 1. **Documentation**: Check this README and
    [docs](https://docs.wealthfolio.app/addons)
-2. **Issues**: [GitHub Issues](https://github.com/afadil/wealthfolio/issues)
+2. **Issues**: [GitHub Issues](https://github.com/wealthfolio/wealthfolio/issues)
 3. **Discussions**:
-   [GitHub Discussions](https://github.com/afadil/wealthfolio/discussions)
+   [GitHub Discussions](https://github.com/wealthfolio/wealthfolio/discussions)
 4. **Discord**: [Community Discord](https://discord.gg/wealthfolio)
 5. **Email**: [support@wealthfolio.app](mailto:support@wealthfolio.app)
 
@@ -1521,13 +1521,13 @@ MIT - see [LICENSE](LICENSE) for details.
 - [Wealthfolio Homepage](https://wealthfolio.app)
 - [Addon Gallery](https://wealthfolio.app/addons)
 - [Documentation](https://docs.wealthfolio.app/addons)
-- [GitHub Repository](https://github.com/afadil/wealthfolio)
-- [Issue Tracker](https://github.com/afadil/wealthfolio/issues)
+- [GitHub Repository](https://github.com/wealthfolio/wealthfolio)
+- [Issue Tracker](https://github.com/wealthfolio/wealthfolio/issues)
 
 ## 💬 Support
 
 - [Discord Community](https://discord.gg/wealthfolio)
-- [GitHub Discussions](https://github.com/afadil/wealthfolio/discussions)
+- [GitHub Discussions](https://github.com/wealthfolio/wealthfolio/discussions)
 - [Email Support](mailto:support@wealthfolio.app)
 
 ## 🔧 Troubleshooting
@@ -1754,7 +1754,7 @@ If you're still experiencing issues:
    - Share the code and error logs
 
 3. **Search Existing Issues**:
-   - Check [GitHub Issues](https://github.com/afadil/wealthfolio/issues)
+   - Check [GitHub Issues](https://github.com/wealthfolio/wealthfolio/issues)
    - Look for similar problems and solutions
 
 4. **Provide Complete Information**:

--- a/packages/addon-sdk/package-lock.json
+++ b/packages/addon-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wealthfolio/addon-sdk",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wealthfolio/addon-sdk",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "devDependencies": {
         "tsup": "^7.2.0",
         "typescript": "^5.4.0"

--- a/packages/addon-sdk/package.json
+++ b/packages/addon-sdk/package.json
@@ -38,11 +38,11 @@
   "homepage": "https://wealthfolio.app/addons",
   "repository": {
     "type": "git",
-    "url": "https://github.com/afadil/wealthfolio.git",
+    "url": "https://github.com/wealthfolio/wealthfolio.git",
     "directory": "packages/addon-sdk"
   },
   "bugs": {
-    "url": "https://github.com/afadil/wealthfolio/issues"
+    "url": "https://github.com/wealthfolio/wealthfolio/issues"
   },
   "scripts": {
     "build": "tsup && pnpm run build:types",

--- a/packages/addon-sdk/package.json
+++ b/packages/addon-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/addon-sdk",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "type": "module",
   "description": "TypeScript SDK for building Wealthfolio addons with enhanced functionality and type safety",
   "main": "dist/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/ui",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "type": "module",
   "description": "Wealthfolio UI components based on shadcn/ui and Tailwind CSS",
   "main": "dist/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -35,13 +35,13 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/afadil/wealthfolio.git",
+    "url": "https://github.com/wealthfolio/wealthfolio.git",
     "directory": "packages/ui"
   },
   "bugs": {
-    "url": "https://github.com/afadil/wealthfolio/issues"
+    "url": "https://github.com/wealthfolio/wealthfolio/issues"
   },
-  "homepage": "https://github.com/afadil/wealthfolio/tree/main/packages/ui#readme",
+  "homepage": "https://github.com/wealthfolio/wealthfolio/tree/main/packages/ui#readme",
   "publishConfig": {
     "access": "public"
   },

--- a/packaging/server-prebuild/README.md
+++ b/packaging/server-prebuild/README.md
@@ -36,4 +36,4 @@ sudo systemctl enable --now wealthfolio
 ```
 
 Full self-host docs:
-<https://github.com/afadil/wealthfolio/blob/main/docs/self-host/>
+<https://github.com/wealthfolio/wealthfolio/blob/main/docs/self-host/>


### PR DESCRIPTION
## Summary

Follow-up to #950 (Docker mirror) now that the GitHub repo has been transferred from `afadil/wealthfolio` to `wealthfolio/wealthfolio`. Rewrites every reference to the old URL across docs, source files, and metadata, and refreshes the project tagline to match the broader feature set.

## Changes

### URL rewrites (sed across the tree)

- `https://github.com/afadil/wealthfolio` → `https://github.com/wealthfolio/wealthfolio`
- `https://raw.githubusercontent.com/afadil/wealthfolio/...` → `.../wealthfolio/wealthfolio/...`
- `github:afadil/wealthfolio` (npm install shorthand) → `github:wealthfolio/wealthfolio`
- Star History badge URLs (`?repos=...` and `#...`)
- Trendshift badge alt text (`afadil%2Fwealthfolio` → `wealthfolio%2Fwealthfolio`)
- GHCR docs row in `docs/self-host/README.md` (`ghcr.io/afadil/wealthfolio:latest` → `ghcr.io/wealthfolio/wealthfolio:latest`)

### Tagline refresh (README.md)

The app does more than just investment tracking now (net worth, spending, simulators) and runs on more than just desktop (web/self-hosted). Updated:

- **Hero**: "A Beautiful and Boring Desktop Investment Tracker" → "A Beautiful and Boring Personal Finance Tracker — investments, net worth, spending, and simulations"
- **Introduction**: matching rewrite

### Files touched (22)

- `.github/pull_request_template.md`, `.github/workflows/release.yml`
- `README.md`, `CONTRIBUTING.md`, `packaging/server-prebuild/README.md`
- `crates/{core,ai}/Cargo.toml` (repository field)
- `addons/{goal-progress-tracker,investment-fees-tracker,swingfolio-addon}/package.json` (homepage)
- `packages/{ui,addon-sdk,addon-dev-tools}/package.json` (repository, bugs, homepage) + `packages/addon-sdk/README.md`
- `apps/frontend/public/mock-update.json`, `apps/frontend/src/pages/settings/about/about-page.tsx`
- `docs/self-host/README.md`, `docs/self-host/unraid/{README.md,template.xml}`, `docs/self-host/proxmox/README.md`
- `docs/addons/{addons-overview,addon-getting-started}.md`

## Intentionally NOT changed

- `.github/FUNDING.yml` — `buy_me_a_coffee: afadil` is a personal sponsorship link
- `https://www.buymeacoffee.com/afadil` (in README and Unraid template's `DonateLink`) — same reason
- `afadil/wealthfolio` Docker Hub mirror references (in `README.md`, `docs/self-host/README.md`, and the `docker.io/afadil/wealthfolio` line in `.github/workflows/docker-publish.yml`) — these are the **Docker Hub** legacy mirror per #950 and stay forever (or until we decide to deprecate)

## Test plan

- [ ] CI green (lint, type-check, tests)
- [ ] README renders correctly on github.com/wealthfolio/wealthfolio
- [ ] Star History and Trendshift badges load with the new namespace
- [ ] `cargo metadata` shows the new repository URL on `wealthfolio-core` / `wealthfolio-ai`
- [ ] Browse to the in-app About page → GitHub link resolves to wealthfolio/wealthfolio
- [ ] Spot-check that the Unraid template URL (`raw.githubusercontent.com/wealthfolio/wealthfolio/main/docs/self-host/unraid/template.xml`) is reachable