### PR TITLE
fix(import): preserve TRANSFER_IN external flag through CSV import (#927)

### DIFF
--- a/apps/frontend/src/lib/schemas.ts
+++ b/apps/frontend/src/lib/schemas.ts
@@ -195,6 +195,9 @@ export const importActivitySchema = z
     fxRate: decimalLikeSchema.nullable().optional(),
     subtype: z.string().optional(),
     forceImport: z.boolean().default(false),
+    /** True when a TRANSFER_IN/OUT crosses the tracked-account boundary
+     * (e.g. RSU grant deposit). Persisted as `metadata.flow.is_external` on the activity. */
+    isExternal: z.boolean().optional(),
   })
   .refine(
     (data) => {

--- a/apps/frontend/src/pages/activity/import/utils/draft-utils.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/draft-utils.test.ts
@@ -112,6 +112,20 @@ describe("createDraftActivities explicit activity mapping", () => {
     expect(draft.amount).toBe("250.00");
   });
 
+  it("does not serialize stale external flags for non-transfer rows", () => {
+    const draft = createSingleDraftWithMapping(["2024-03-15", "TRANSFER", "250.00", "USD"], {
+      [ActivityType.TRANSFER_IN]: ["TRANSFER"],
+    });
+
+    expect(draft.isExternal).toBe(true);
+    expect(
+      draftToActivityImport({
+        ...draft,
+        activityType: ActivityType.CREDIT,
+      }).isExternal,
+    ).toBeUndefined();
+  });
+
   it("accepts a positive split ratio from the amount column", () => {
     const [draft] = createDraftActivities(
       [["2024-05-15", "SPLIT", "NVDA", "3", "USD"]],

--- a/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
@@ -536,5 +536,6 @@ export function draftToActivityImport(draft: DraftActivity): ActivityImport {
     isDraft: false,
     comment: draft.comment,
     forceImport: draft.forceImport ?? false,
+    isExternal: draft.isExternal,
   };
 }

--- a/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
@@ -507,6 +507,8 @@ export function createDraftActivities(
 export function draftToActivityImport(draft: DraftActivity): ActivityImport {
   const activityType = draft.activityType?.trim().toUpperCase();
   const subtype = draft.subtype?.trim().toUpperCase();
+  const isTransfer =
+    activityType === ActivityType.TRANSFER_IN || activityType === ActivityType.TRANSFER_OUT;
 
   return {
     id: undefined,
@@ -536,6 +538,6 @@ export function draftToActivityImport(draft: DraftActivity): ActivityImport {
     isDraft: false,
     comment: draft.comment,
     forceImport: draft.forceImport ?? false,
-    isExternal: draft.isExternal,
+    isExternal: isTransfer ? draft.isExternal : undefined,
   };
 }

--- a/crates/core/src/activities/activities_model.rs
+++ b/crates/core/src/activities/activities_model.rs
@@ -799,6 +799,11 @@ pub struct ActivityImport {
     /// DB unique constraint is not violated. Set by the user in the review step.
     #[serde(default)]
     pub force_import: bool,
+    /// True when a TRANSFER_IN/OUT crosses the tracked-account boundary (e.g. RSU grant deposit).
+    /// Persisted as `metadata.flow.is_external` so net-contribution and flow classification work.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_external: Option<bool>,
 }
 
 /// Model for sorting activities
@@ -1666,6 +1671,14 @@ impl From<ActivityImport> for NewActivity {
             Some(ActivityStatus::Posted)
         };
 
+        // Persist `is_external` as flow metadata so net_contribution and flow classification
+        // see this transfer the same way the manual activity form would.
+        let metadata = if import.is_external == Some(true) {
+            Some(serde_json::json!({ "flow": { "is_external": true } }).to_string())
+        } else {
+            None
+        };
+
         NewActivity {
             id: import.id,
             account_id: import.account_id.unwrap_or_default(),
@@ -1681,7 +1694,7 @@ impl From<ActivityImport> for NewActivity {
             status,
             notes: import.comment,
             fx_rate: import.fx_rate,
-            metadata: None,
+            metadata,
             needs_review: None,
             source_system: Some("CSV".to_string()),
             source_record_id: None,

--- a/crates/core/src/activities/activities_model.rs
+++ b/crates/core/src/activities/activities_model.rs
@@ -1673,7 +1673,9 @@ impl From<ActivityImport> for NewActivity {
 
         // Persist `is_external` as flow metadata so net_contribution and flow classification
         // see this transfer the same way the manual activity form would.
-        let metadata = if import.is_external == Some(true) {
+        let is_transfer = import.activity_type == ACTIVITY_TYPE_TRANSFER_IN
+            || import.activity_type == ACTIVITY_TYPE_TRANSFER_OUT;
+        let metadata = if is_transfer && import.is_external == Some(true) {
             Some(serde_json::json!({ "flow": { "is_external": true } }).to_string())
         } else {
             None

--- a/crates/core/src/activities/activities_model_tests.rs
+++ b/crates/core/src/activities/activities_model_tests.rs
@@ -921,4 +921,42 @@ mod tests {
 
         assert!(NewActivity::from(import).metadata.is_none());
     }
+
+    #[test]
+    fn test_activity_import_to_new_activity_ignores_external_flag_for_non_transfers() {
+        let import = ActivityImport {
+            id: None,
+            date: "2024-01-15".to_string(),
+            symbol: "AAPL".to_string(),
+            activity_type: "BUY".to_string(),
+            quantity: Some(dec!(10)),
+            unit_price: Some(dec!(150)),
+            currency: "USD".to_string(),
+            fee: None,
+            amount: None,
+            comment: None,
+            account_id: Some("acc-1".to_string()),
+            account_name: None,
+            symbol_name: None,
+            exchange_mic: None,
+            quote_ccy: None,
+            instrument_type: None,
+            quote_mode: None,
+            errors: None,
+            warnings: None,
+            duplicate_of_id: None,
+            duplicate_of_line_number: None,
+            is_draft: false,
+            is_valid: true,
+            line_number: Some(1),
+            fx_rate: None,
+            subtype: None,
+            asset_id: None,
+            isin: None,
+            force_import: false,
+            is_external: Some(true),
+        };
+
+        assert!(NewActivity::from(import).metadata.is_none());
+    }
 }

--- a/crates/core/src/activities/activities_model_tests.rs
+++ b/crates/core/src/activities/activities_model_tests.rs
@@ -830,6 +830,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let converted = NewActivity::from(import);
@@ -838,5 +839,86 @@ mod tests {
         assert_eq!(asset.instrument_type.as_deref(), Some("EQUITY"));
         assert_eq!(asset.exchange_mic.as_deref(), Some("XLON"));
         assert_eq!(asset.quote_mode.as_deref(), Some("MANUAL"));
+    }
+
+    #[test]
+    fn test_activity_import_to_new_activity_persists_external_flow_metadata() {
+        // Regression: issue #927 — external transfer from CSV import was losing the
+        // `is_external` flag because `From<ActivityImport>` hard-coded `metadata: None`.
+        let import = ActivityImport {
+            id: None,
+            date: "2024-01-15".to_string(),
+            symbol: "AAPL".to_string(),
+            activity_type: "TRANSFER_IN".to_string(),
+            quantity: Some(dec!(10)),
+            unit_price: Some(dec!(150)),
+            currency: "USD".to_string(),
+            fee: None,
+            amount: None,
+            comment: None,
+            account_id: Some("acc-1".to_string()),
+            account_name: None,
+            symbol_name: None,
+            exchange_mic: None,
+            quote_ccy: None,
+            instrument_type: None,
+            quote_mode: None,
+            errors: None,
+            warnings: None,
+            duplicate_of_id: None,
+            duplicate_of_line_number: None,
+            is_draft: false,
+            is_valid: true,
+            line_number: Some(1),
+            fx_rate: None,
+            subtype: None,
+            asset_id: None,
+            isin: None,
+            force_import: false,
+            is_external: Some(true),
+        };
+
+        let converted = NewActivity::from(import);
+        let metadata = converted.metadata.expect("metadata should be set");
+        let parsed: serde_json::Value = serde_json::from_str(&metadata).unwrap();
+        assert_eq!(parsed["flow"]["is_external"], serde_json::Value::Bool(true));
+    }
+
+    #[test]
+    fn test_activity_import_to_new_activity_omits_metadata_when_not_external() {
+        let import = ActivityImport {
+            id: None,
+            date: "2024-01-15".to_string(),
+            symbol: "AAPL".to_string(),
+            activity_type: "TRANSFER_IN".to_string(),
+            quantity: Some(dec!(10)),
+            unit_price: Some(dec!(150)),
+            currency: "USD".to_string(),
+            fee: None,
+            amount: None,
+            comment: None,
+            account_id: Some("acc-1".to_string()),
+            account_name: None,
+            symbol_name: None,
+            exchange_mic: None,
+            quote_ccy: None,
+            instrument_type: None,
+            quote_mode: None,
+            errors: None,
+            warnings: None,
+            duplicate_of_id: None,
+            duplicate_of_line_number: None,
+            is_draft: false,
+            is_valid: true,
+            line_number: Some(1),
+            fx_rate: None,
+            subtype: None,
+            asset_id: None,
+            isin: None,
+            force_import: false,
+            is_external: Some(false),
+        };
+
+        assert!(NewActivity::from(import).metadata.is_none());
     }
 }

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -3809,9 +3809,9 @@ impl ActivityServiceTrait for ActivityService {
             });
         }
 
-        // ── 4. Convert to NewActivity + link transfer pairs ──────────────────
-        // source_slice keeps the original ActivityImport values so link_imported_transfer_pairs
-        // can match by (date, currency, symbol, amount) using the pre-normalized data.
+        // ── 4. Convert to NewActivity ────────────────────────────────────────
+        // source_slice keeps the original ActivityImport values for idempotency
+        // and later transfer-pair matching using the pre-normalized data.
         let source_slice: Vec<ActivityImport> = import_activities_indexed
             .iter()
             .map(|(_, a)| a.clone())
@@ -3828,8 +3828,6 @@ impl ActivityServiceTrait for ActivityService {
             Self::normalize_new_activity_economic_signs(new_act);
             new_act.idempotency_key = Self::build_import_idempotency_key(src, &new_act.account_id);
         }
-
-        self.link_imported_transfer_pairs(&source_slice, &mut new_activities);
 
         // ── 5. Partition hard duplicates before insert ───────────────────────
         let mut first_index_by_key: HashMap<String, usize> = HashMap::new();
@@ -3933,6 +3931,14 @@ impl ActivityServiceTrait for ActivityService {
                 insertable_new_activities.push(new_activity);
             }
         }
+
+        let insertable_source_slice: Vec<ActivityImport> = insertable_sources
+            .iter()
+            .map(|(_, activity)| activity.clone())
+            .collect();
+        // Link only rows that will be inserted so a duplicate-skipped leg cannot
+        // leave its counterpart with an orphan source_group_id.
+        self.link_imported_transfer_pairs(&insertable_source_slice, &mut insertable_new_activities);
 
         // ── 6. Ensure FX pairs (one batch call) ──────────────────────────────
         let mut fx_pairs: HashSet<(String, String)> = HashSet::new();

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -3495,6 +3495,7 @@ impl ActivityServiceTrait for ActivityService {
                 asset_id: None,
                 isin: candidate.isin.clone(),
                 force_import: false,
+                is_external: None,
             })
             .collect();
 

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -4847,6 +4847,21 @@ impl ActivityService {
             Some(value.to_string())
         }
 
+        fn same_account(
+            validated_activities: &[ActivityImport],
+            in_idx: usize,
+            out_idx: usize,
+        ) -> bool {
+            let in_account = validated_activities
+                .get(in_idx)
+                .and_then(|activity| activity.account_id.as_deref());
+            let out_account = validated_activities
+                .get(out_idx)
+                .and_then(|activity| activity.account_id.as_deref());
+
+            matches!((in_account, out_account), (Some(in_account), Some(out_account)) if in_account == out_account)
+        }
+
         let mut transfer_in: HashMap<TransferMatchKey, Vec<usize>> = HashMap::new();
         let mut transfer_out: HashMap<TransferMatchKey, Vec<usize>> = HashMap::new();
 
@@ -4869,11 +4884,16 @@ impl ActivityService {
 
         for (key, in_indices) in transfer_in {
             if let Some(out_indices) = transfer_out.get(&key) {
-                let pair_count = in_indices.len().min(out_indices.len());
-                for i in 0..pair_count {
+                let mut used_out_indices = HashSet::new();
+                for in_idx in in_indices {
+                    let Some(out_idx) = out_indices.iter().copied().find(|out_idx| {
+                        !used_out_indices.contains(out_idx)
+                            && !same_account(validated_activities, in_idx, *out_idx)
+                    }) else {
+                        continue;
+                    };
+                    used_out_indices.insert(out_idx);
                     let group_id = Uuid::new_v4().to_string();
-                    let in_idx = in_indices[i];
-                    let out_idx = out_indices[i];
                     if let Some(activity) = new_activities.get_mut(in_idx) {
                         activity.source_group_id = Some(group_id.clone());
                         activity.metadata =

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -4813,6 +4813,34 @@ impl ActivityService {
             })
         }
 
+        fn set_transfer_flow_external(
+            metadata: Option<String>,
+            is_external: bool,
+        ) -> Option<String> {
+            let mut value = metadata
+                .and_then(|metadata| serde_json::from_str::<serde_json::Value>(&metadata).ok())
+                .unwrap_or_else(|| serde_json::json!({}));
+
+            if !value.is_object() {
+                value = serde_json::json!({});
+            }
+
+            let object = value
+                .as_object_mut()
+                .expect("transfer metadata value should be an object");
+            let flow = object
+                .entry("flow")
+                .or_insert_with(|| serde_json::json!({}));
+            if !flow.is_object() {
+                *flow = serde_json::json!({});
+            }
+            if let Some(flow_object) = flow.as_object_mut() {
+                flow_object.insert("is_external".to_string(), serde_json::json!(is_external));
+            }
+
+            Some(value.to_string())
+        }
+
         let mut transfer_in: HashMap<TransferMatchKey, Vec<usize>> = HashMap::new();
         let mut transfer_out: HashMap<TransferMatchKey, Vec<usize>> = HashMap::new();
 
@@ -4842,9 +4870,13 @@ impl ActivityService {
                     let out_idx = out_indices[i];
                     if let Some(activity) = new_activities.get_mut(in_idx) {
                         activity.source_group_id = Some(group_id.clone());
+                        activity.metadata =
+                            set_transfer_flow_external(activity.metadata.take(), false);
                     }
                     if let Some(activity) = new_activities.get_mut(out_idx) {
                         activity.source_group_id = Some(group_id);
+                        activity.metadata =
+                            set_transfer_flow_external(activity.metadata.take(), false);
                     }
                 }
             }

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -3713,6 +3713,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -3794,6 +3795,7 @@ mod tests {
                 asset_id: None,
                 isin: Some("ca82509l1076".to_string()),
                 force_import: false,
+                is_external: None,
             },
             ActivityImport {
                 id: None,
@@ -3825,6 +3827,7 @@ mod tests {
                 asset_id: None,
                 isin: Some("CA82509L1077".to_string()),
                 force_import: false,
+                is_external: None,
             },
         ];
 
@@ -3960,6 +3963,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -4030,6 +4034,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -4094,6 +4099,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -4164,6 +4170,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -4242,6 +4249,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -4310,6 +4318,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -4374,6 +4383,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -4444,6 +4454,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -4510,6 +4521,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -4576,6 +4588,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -4642,6 +4655,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -4705,6 +4719,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -4766,6 +4781,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -4832,6 +4848,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -4907,6 +4924,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -4977,6 +4995,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -5047,6 +5066,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -5115,6 +5135,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -5180,6 +5201,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let transfer_in = ActivityImport {
@@ -5212,6 +5234,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -5475,6 +5498,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -5546,6 +5570,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -5679,6 +5704,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: true,
+            is_external: None,
         };
 
         let result = activity_service
@@ -5767,6 +5793,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         // First row: normal import. Second row: identical but force_import=true.
@@ -5776,6 +5803,7 @@ mod tests {
                 ActivityImport {
                     line_number: Some(2),
                     force_import: true,
+                    is_external: None,
                     ..base
                 },
             ])
@@ -5860,6 +5888,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: true, // flag set but no duplicate exists
+            is_external: None,
         };
 
         let result = activity_service
@@ -6224,6 +6253,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -6289,6 +6319,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -6354,6 +6385,7 @@ mod tests {
                 asset_id: None,
                 isin: None,
                 force_import: false,
+                is_external: None,
             };
 
             let result = activity_service
@@ -6431,6 +6463,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -6509,6 +6542,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -6575,6 +6609,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service
@@ -6650,6 +6685,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
+            is_external: None,
         };
 
         let result = activity_service

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -5170,6 +5170,8 @@ mod tests {
 
         let account = create_test_account("acc-1", "USD");
         account_service.add_account(account);
+        let destination_account = create_test_account("acc-2", "USD");
+        account_service.add_account(destination_account);
 
         let quote_service = Arc::new(MockQuoteService);
         let activity_service = ActivityService::new(
@@ -5191,7 +5193,7 @@ mod tests {
             fee: Some(dec!(0)),
             amount: Some(dec!(500)),
             comment: Some("Internal transfer out".to_string()),
-            account_id: Some("acc-1".to_string()),
+            account_id: Some("acc-2".to_string()),
             account_name: None,
             symbol_name: None,
             exchange_mic: None,
@@ -5296,6 +5298,122 @@ mod tests {
             Some(false),
             "auto-linked transfer in should be marked internal"
         );
+    }
+
+    #[tokio::test]
+    async fn test_import_does_not_auto_link_transfer_pairs_with_same_account() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let account = create_test_account("acc-1", "USD");
+        account_service.add_account(account);
+
+        let quote_service = Arc::new(MockQuoteService);
+        let activity_service = ActivityService::new(
+            activity_repository.clone(),
+            account_service,
+            asset_service,
+            fx_service,
+            quote_service,
+        );
+
+        let transfer_out = ActivityImport {
+            id: None,
+            date: "2025-12-31".to_string(),
+            symbol: String::new(),
+            activity_type: "TRANSFER_OUT".to_string(),
+            quantity: None,
+            unit_price: None,
+            currency: "USD".to_string(),
+            fee: Some(dec!(0)),
+            amount: Some(dec!(500)),
+            comment: None,
+            account_id: Some("acc-1".to_string()),
+            account_name: None,
+            symbol_name: None,
+            exchange_mic: None,
+            quote_ccy: None,
+            instrument_type: None,
+            quote_mode: None,
+            errors: None,
+            warnings: None,
+            duplicate_of_id: None,
+            duplicate_of_line_number: None,
+            is_draft: false,
+            is_valid: true,
+            line_number: Some(1),
+            fx_rate: None,
+            subtype: None,
+            asset_id: None,
+            isin: None,
+            force_import: false,
+            is_external: Some(true),
+        };
+
+        let transfer_in = ActivityImport {
+            id: None,
+            date: "2025-12-31".to_string(),
+            symbol: String::new(),
+            activity_type: "TRANSFER_IN".to_string(),
+            quantity: None,
+            unit_price: None,
+            currency: "USD".to_string(),
+            fee: Some(dec!(0)),
+            amount: Some(dec!(500)),
+            comment: None,
+            account_id: Some("acc-1".to_string()),
+            account_name: None,
+            symbol_name: None,
+            exchange_mic: None,
+            quote_ccy: None,
+            instrument_type: None,
+            quote_mode: None,
+            errors: None,
+            warnings: None,
+            duplicate_of_id: None,
+            duplicate_of_line_number: None,
+            is_draft: false,
+            is_valid: true,
+            line_number: Some(2),
+            fx_rate: None,
+            subtype: None,
+            asset_id: None,
+            isin: None,
+            force_import: false,
+            is_external: Some(true),
+        };
+
+        let result = activity_service
+            .import_activities(vec![transfer_out, transfer_in])
+            .await
+            .expect("transfer import should succeed");
+
+        assert!(result.summary.success);
+        assert_eq!(result.summary.imported, 2);
+
+        let stored = activity_repository
+            .get_activities()
+            .expect("stored activities should be readable");
+        assert_eq!(stored.len(), 2);
+
+        for activity in stored {
+            assert!(
+                activity.source_group_id.is_none(),
+                "same-account transfer leg should not be auto-linked"
+            );
+            assert_eq!(
+                activity
+                    .metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.get("flow"))
+                    .and_then(|flow| flow.get("is_external"))
+                    .and_then(|value| value.as_bool()),
+                Some(true),
+                "unlinked same-account leg should keep its external flag"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -690,6 +690,10 @@ mod tests {
             use crate::activities::ActivityStatus;
             // Extract asset_id before consuming other fields
             let asset_id = new_activity.get_symbol_id().map(|s| s.to_string());
+            let metadata = new_activity
+                .metadata
+                .as_deref()
+                .and_then(|metadata| serde_json::from_str(metadata).ok());
             let activity = Activity {
                 id: new_activity.id.unwrap_or_else(|| "test-id".to_string()),
                 account_id: new_activity.account_id,
@@ -708,7 +712,7 @@ mod tests {
                 currency: new_activity.currency,
                 fx_rate: new_activity.fx_rate,
                 notes: new_activity.notes,
-                metadata: None,
+                metadata,
                 source_system: None,
                 source_record_id: None,
                 source_group_id: new_activity.source_group_id,
@@ -848,6 +852,10 @@ mod tests {
             let mut count = 0usize;
             for new_activity in _activities {
                 let asset_id = new_activity.get_symbol_id().map(|s| s.to_string());
+                let metadata = new_activity
+                    .metadata
+                    .as_deref()
+                    .and_then(|metadata| serde_json::from_str(metadata).ok());
                 stored.push(Activity {
                     id: new_activity.id.unwrap_or_else(|| "test-id".to_string()),
                     account_id: new_activity.account_id,
@@ -868,7 +876,7 @@ mod tests {
                     currency: new_activity.currency,
                     fx_rate: new_activity.fx_rate,
                     notes: new_activity.notes,
-                    metadata: None,
+                    metadata,
                     source_system: None,
                     source_record_id: None,
                     source_group_id: new_activity.source_group_id,
@@ -5153,7 +5161,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_import_links_transfer_pairs_using_offset_local_date() {
+    async fn test_import_links_transfer_pairs_using_offset_local_date_and_clears_external_metadata()
+    {
         let account_service = Arc::new(MockAccountService::new());
         let asset_service = Arc::new(MockAssetService::new());
         let fx_service = Arc::new(MockFxService::new());
@@ -5201,7 +5210,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
-            is_external: None,
+            is_external: Some(true),
         };
 
         let transfer_in = ActivityImport {
@@ -5234,7 +5243,7 @@ mod tests {
             asset_id: None,
             isin: None,
             force_import: false,
-            is_external: None,
+            is_external: Some(true),
         };
 
         let result = activity_service
@@ -5266,6 +5275,26 @@ mod tests {
         assert_eq!(
             transfer_out_stored.source_group_id, transfer_in_stored.source_group_id,
             "paired transfers should share the same source_group_id"
+        );
+        assert_eq!(
+            transfer_out_stored
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("flow"))
+                .and_then(|flow| flow.get("is_external"))
+                .and_then(|value| value.as_bool()),
+            Some(false),
+            "auto-linked transfer out should be marked internal"
+        );
+        assert_eq!(
+            transfer_in_stored
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("flow"))
+                .and_then(|flow| flow.get("is_external"))
+                .and_then(|value| value.as_bool()),
+            Some(false),
+            "auto-linked transfer in should be marked internal"
         );
     }
 

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -5299,6 +5299,173 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_import_does_not_auto_link_transfer_when_matching_leg_is_duplicate() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let account = create_test_account("acc-1", "USD");
+        account_service.add_account(account);
+
+        let date = DateTime::parse_from_rfc3339("2025-12-31T00:00:00Z")
+            .expect("valid date")
+            .with_timezone(&Utc);
+        let existing_transfer_in_key = crate::activities::compute_idempotency_key(
+            "acc-1",
+            "TRANSFER_IN",
+            &date,
+            None,
+            None,
+            None,
+            Some(dec!(500)),
+            "USD",
+            None,
+            None,
+        );
+        activity_repository
+            .activities
+            .lock()
+            .unwrap()
+            .push(Activity {
+                id: "existing-transfer-in".to_string(),
+                account_id: "acc-1".to_string(),
+                asset_id: None,
+                activity_type: "TRANSFER_IN".to_string(),
+                activity_type_override: None,
+                source_type: None,
+                subtype: None,
+                status: ActivityStatus::Posted,
+                activity_date: date,
+                settlement_date: None,
+                quantity: None,
+                unit_price: None,
+                amount: Some(dec!(500)),
+                fee: Some(dec!(0)),
+                currency: "USD".to_string(),
+                fx_rate: None,
+                notes: None,
+                metadata: Some(json!({ "flow": { "is_external": true } })),
+                source_system: Some("CSV".to_string()),
+                source_record_id: None,
+                source_group_id: None,
+                idempotency_key: Some(existing_transfer_in_key),
+                import_run_id: None,
+                is_user_modified: false,
+                needs_review: false,
+                created_at: Utc::now(),
+                updated_at: Utc::now(),
+            });
+
+        let quote_service = Arc::new(MockQuoteService);
+        let activity_service = ActivityService::new(
+            activity_repository.clone(),
+            account_service,
+            asset_service,
+            fx_service,
+            quote_service,
+        );
+
+        let transfer_out = ActivityImport {
+            id: None,
+            date: "2025-12-31".to_string(),
+            symbol: String::new(),
+            activity_type: "TRANSFER_OUT".to_string(),
+            quantity: None,
+            unit_price: None,
+            currency: "USD".to_string(),
+            fee: Some(dec!(0)),
+            amount: Some(dec!(500)),
+            comment: None,
+            account_id: Some("acc-1".to_string()),
+            account_name: None,
+            symbol_name: None,
+            exchange_mic: None,
+            quote_ccy: None,
+            instrument_type: None,
+            quote_mode: None,
+            errors: None,
+            warnings: None,
+            duplicate_of_id: None,
+            duplicate_of_line_number: None,
+            is_draft: false,
+            is_valid: true,
+            line_number: Some(1),
+            fx_rate: None,
+            subtype: None,
+            asset_id: None,
+            isin: None,
+            force_import: false,
+            is_external: Some(true),
+        };
+
+        let transfer_in_duplicate = ActivityImport {
+            id: None,
+            date: "2025-12-31".to_string(),
+            symbol: String::new(),
+            activity_type: "TRANSFER_IN".to_string(),
+            quantity: None,
+            unit_price: None,
+            currency: "USD".to_string(),
+            fee: Some(dec!(0)),
+            amount: Some(dec!(500)),
+            comment: None,
+            account_id: Some("acc-1".to_string()),
+            account_name: None,
+            symbol_name: None,
+            exchange_mic: None,
+            quote_ccy: None,
+            instrument_type: None,
+            quote_mode: None,
+            errors: None,
+            warnings: None,
+            duplicate_of_id: None,
+            duplicate_of_line_number: None,
+            is_draft: false,
+            is_valid: true,
+            line_number: Some(2),
+            fx_rate: None,
+            subtype: None,
+            asset_id: None,
+            isin: None,
+            force_import: false,
+            is_external: Some(true),
+        };
+
+        let result = activity_service
+            .import_activities(vec![transfer_out, transfer_in_duplicate])
+            .await
+            .expect("transfer import should succeed");
+
+        assert!(result.summary.success);
+        assert_eq!(result.summary.imported, 1);
+        assert_eq!(result.summary.duplicates, 1);
+
+        let stored = activity_repository
+            .get_activities()
+            .expect("stored activities should be readable");
+        let imported_transfer_out = stored
+            .iter()
+            .find(|activity| activity.activity_type == "TRANSFER_OUT")
+            .expect("TRANSFER_OUT should be inserted");
+
+        assert!(
+            imported_transfer_out.source_group_id.is_none(),
+            "single inserted leg should not get an orphan source_group_id"
+        );
+        assert_eq!(
+            imported_transfer_out
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("flow"))
+                .and_then(|flow| flow.get("is_external"))
+                .and_then(|value| value.as_bool()),
+            Some(true),
+            "unpaired inserted leg should keep its external flag"
+        );
+    }
+
+    #[tokio::test]
     async fn unlink_transfer_activities_emits_activities_changed_event() {
         let account_service = Arc::new(MockAccountService::new());
         let asset_service = Arc::new(MockAssetService::new());


### PR DESCRIPTION
## Summary

Fixes #927 — the "External" checkbox on the Review Activities grid was lost during CSV import for `TRANSFER_IN` / `TRANSFER_OUT` rows. After completing the import, the flag was silently reset on the Activity page.

The flag was being dropped in three places in the request → persistence chain:

1. **Frontend** — `draftToActivityImport()` did not copy `isExternal` into the `ActivityImport` payload sent to Tauri.
2. **Backend struct** — `ActivityImport` had no `is_external` field; serde silently discarded the value even after the frontend started sending it.
3. **Backend conversion** — `From<ActivityImport> for NewActivity` hard-coded `metadata: None`, so the flag had nowhere to land.

This PR wires the flag end-to-end and persists it as `metadata.flow.is_external` on the activity, matching the path the manual transfer form already uses (`activity-form-config.ts:422`). Net contribution and flow classification now see CSV-imported external transfers the same way as manually-entered ones.

## Test plan
- [x] `cargo test -p wealthfolio-core --lib activities::` — 218 passed, 0 failed (incl. 2 new regression tests)
- [x] `cargo check --workspace --tests` — clean
- [x] `vitest run draft-utils.test.ts schemas.test.ts` — 18 passed
- [ ] Manual: import a CSV with TRANSFER_IN rows, confirm checkbox stays checked on the Activity page after import