### PR TITLE
Trigger broker sync on mobile startup

### DIFF
--- a/.claude/skills/run-e2e-tests/SKILL.md
+++ b/.claude/skills/run-e2e-tests/SKILL.md
@@ -5,10 +5,11 @@ description: >
   about to run, execute, or trigger Playwright E2E tests — including running a
   single spec file, the full test suite, or checking whether E2E tests pass.
   Also use it when setting up the environment for E2E tests or troubleshooting
-  E2E test failures. Do NOT skip this skill just because the task seems simple
-  — the environment setup is mandatory and skipping it leads to silent failures.
+  E2E test failures. Do NOT skip this skill just because the task seems simple —
+  the environment setup is mandatory and skipping it leads to silent failures.
 ---
 
 # Running Wealthfolio E2E Tests
 
-Read `e2e/README.md` and follow its instructions **exactly and in order** before running any E2E test command. Do not skip any step.
+Read `e2e/README.md` and follow its instructions **exactly and in order** before
+running any E2E test command. Do not skip any step.

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,8 +1,12 @@
 # Claude worktrees
-.claude/
+.claude/worktrees/
 
 # Local hidden directories
-.*
+.agents/
+.codex/
+.conductor/
+.kiro/
+.ralph-tui/
 
 # Build outputs
 dist/

--- a/apps/tauri/src/lib.rs
+++ b/apps/tauri/src/lib.rs
@@ -203,6 +203,14 @@ mod mobile {
                     // The frontend will trigger the initial portfolio update after it's mounted
                     emit_app_ready(&handle);
 
+                    // Trigger startup broker sync (async, non-blocking).
+                    // After this, user manually triggers sync via button.
+                    let startup_handle = handle.clone();
+                    let startup_context = Arc::clone(&context);
+                    tauri::async_runtime::spawn(async move {
+                        scheduler::run_startup_sync(&startup_handle, &startup_context).await;
+                    });
+
                     // Start background device sync while the mobile app is active.
                     // The loop self-skips when identity is not configured, and frontend lifecycle
                     // triggers still cover resume/online cases after iOS suspends the process.


### PR DESCRIPTION
## Summary
- start broker startup sync from mobile setup after the service context is ready
- keep existing startup entitlement/token skip behavior
- narrow Prettier ignores to Claude worktrees and known local agent directories

## Verification
- cargo fmt --check -p wealthfolio-app
- cargo check -p wealthfolio-app
- git diff --cached --check