### PR TITLE
Add Australia CGT planning addon

### DIFF
--- a/addons/australia-cgt-addon/.prettierignore
+++ b/addons/australia-cgt-addon/.prettierignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+*.tsbuildinfo

--- a/addons/australia-cgt-addon/CHANGELOG.md
+++ b/addons/australia-cgt-addon/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+- Initial Australia CGT planning addon.
+- Adds AUD FIFO lot matching, income-year summaries, simple AMMA/AMIT
+  adjustments, CPI cache, 30 June 2027 transition snapshot inputs, franking
+  metadata display, CSV export, and review warnings for unsupported data.

--- a/addons/australia-cgt-addon/README.md
+++ b/addons/australia-cgt-addon/README.md
@@ -1,0 +1,81 @@
+# Australia CGT Planner Addon
+
+Australia CGT Planner is a Wealthfolio addon for Australian capital gains tax
+planning and reconciliation. It is not tax advice and it is not a complete tax
+return engine.
+
+The addon is designed for simple AUD activity review first: it helps users see
+matched parcels, income-year summaries, local AMMA/AMIT adjustments, and records
+that need manual review before an accountant or tax lodgement workflow.
+
+## Current Scope
+
+- AUD BUY/SELL activity matching.
+- FIFO parcel matching by symbol and account ID, with account name as fallback.
+- Australian income-year summaries.
+- Capital losses applied before discount, including losses carried forward from
+  earlier report years.
+- Current-law 50 percent CGT discount eligibility using the ATO 12-month timing
+  rule that excludes both acquisition day and CGT event day.
+- Simple AMMA/AMIT cost-base increases and decreases per parcel and income year.
+- Dividend franking percentage from the `australiaCgt.frankingPercentage`
+  activity metadata field, shown for review only.
+- 30 June 2027 market-value snapshots for transition planning.
+- ABS quarterly CPI fetch and local cache for planning inputs.
+- Warnings for unmatched sells, non-AUD BUY/SELL activity, and unmodelled
+  activity types.
+
+## Limitations
+
+- Not tax advice.
+- Uses FIFO only. It does not yet support taxpayer-selected parcel
+  identification or optimisation.
+- Does not convert foreign-currency CGT amounts. Non-AUD BUY/SELL activity is
+  excluded and surfaced for review.
+- Does not model corporate actions such as splits, consolidations, DRPs, bonus
+  shares, buy-backs, demergers, takeovers, returns of capital, rights issues, or
+  liquidations.
+- AMMA/AMIT support is limited to simple net cost-base movements. It does not
+  implement every AMMA/SDS field or every edge case.
+- Franking data is display-only. The addon does not calculate dividend tax,
+  franking credit gross-up, or tax offsets.
+- Budget 2026-27 transition support is provisional. The addon stores CPI and
+  30 June 2027 snapshot inputs and reports pre-transition parcels, but it does
+  not yet calculate post-2027 indexed disposals end to end.
+- ESS, crypto, foreign-resident CGT rules, and non-CGT income-tax outcomes are
+  outside the current scope.
+- Opening capital losses from years before the imported Wealthfolio history are
+  not yet a separate input.
+
+## Privacy and Storage
+
+Addon tax data is stored locally by the addon in browser local storage. This
+includes AMMA records, CPI observations, transition snapshots, and manual
+acquisition-date overrides.
+
+Refreshing CPI fetches public ABS quarterly CPI data from the ABS API. No
+portfolio data is sent to ABS by this addon.
+
+## Example Workflow
+
+1. Import AUD activity history into Wealthfolio.
+2. Open Australia CGT Planner from the sidebar.
+3. Review unmatched sells, unsupported non-AUD activity, and ignored activity
+   warnings.
+4. Add AMMA/AMIT parcel adjustments from annual statements where relevant.
+5. Add 30 June 2027 parcel market values for transition planning.
+6. Export the matched-lot CSV for accountant review or reconciliation.
+
+## Development
+
+```bash
+pnpm --filter australia-cgt-addon test
+pnpm --filter australia-cgt-addon type-check
+pnpm --filter australia-cgt-addon build
+```
+
+Full app acceptance should use the dedicated Wealthfolio E2E harness:
+
+```bash
+pnpm test:e2e:australia-cgt-addon
+```

--- a/addons/australia-cgt-addon/README.md
+++ b/addons/australia-cgt-addon/README.md
@@ -1,8 +1,8 @@
 # Australia CGT Planner Addon
 
-Australia CGT Planner is a Wealthfolio addon for Australian capital gains tax
-planning and reconciliation. It is not tax advice and it is not a complete tax
-return engine.
+Australia CGT Planner is a community Wealthfolio addon for Australian capital
+gains tax planning and reconciliation. It is not tax advice and it is not a
+complete tax return engine.
 
 The addon is designed for simple AUD activity review first: it helps users see
 matched parcels, income-year summaries, local AMMA/AMIT adjustments, and records
@@ -39,9 +39,9 @@ that need manual review before an accountant or tax lodgement workflow.
   implement every AMMA/SDS field or every edge case.
 - Franking data is display-only. The addon does not calculate dividend tax,
   franking credit gross-up, or tax offsets.
-- Budget 2026-27 transition support is provisional. The addon stores CPI and
-  30 June 2027 snapshot inputs and reports pre-transition parcels, but it does
-  not yet calculate post-2027 indexed disposals end to end.
+- Budget 2026-27 transition support is provisional. The addon stores CPI and 30
+  June 2027 snapshot inputs and reports pre-transition parcels, but it does not
+  yet calculate post-2027 indexed disposals end to end.
 - ESS, crypto, foreign-resident CGT rules, and non-CGT income-tax outcomes are
   outside the current scope.
 - Opening capital losses from years before the imported Wealthfolio history are

--- a/addons/australia-cgt-addon/manifest.json
+++ b/addons/australia-cgt-addon/manifest.json
@@ -2,7 +2,7 @@
   "id": "australia-cgt-addon",
   "name": "Australia CGT Planner",
   "version": "0.1.0",
-  "description": "Planning and reconciliation estimates for simple Australian CGT workflows",
+  "description": "Community planning and reconciliation estimates for simple Australian CGT workflows",
   "author": "Massimo Raso",
   "main": "dist/addon.js",
   "sdkVersion": "3.4.0",

--- a/addons/australia-cgt-addon/manifest.json
+++ b/addons/australia-cgt-addon/manifest.json
@@ -1,0 +1,32 @@
+{
+  "id": "australia-cgt-addon",
+  "name": "Australia CGT Planner",
+  "version": "0.1.0",
+  "description": "Planning and reconciliation estimates for simple Australian CGT workflows",
+  "author": "Massimo Raso",
+  "main": "dist/addon.js",
+  "sdkVersion": "3.4.0",
+  "enabled": true,
+  "permissions": [
+    {
+      "category": "activities",
+      "functions": ["getAll"],
+      "purpose": "Read activity history to match acquisition and disposal lots"
+    },
+    {
+      "category": "accounts",
+      "functions": ["getAll"],
+      "purpose": "Read account names and currencies for tax-report grouping"
+    },
+    {
+      "category": "portfolio",
+      "functions": ["getHoldings"],
+      "purpose": "Read current holdings for unrealized capital gains preview"
+    },
+    {
+      "category": "ui",
+      "functions": ["sidebar.addItem", "router.add"],
+      "purpose": "Add the Australia CGT Planner navigation item and report page"
+    }
+  ]
+}

--- a/addons/australia-cgt-addon/package.json
+++ b/addons/australia-cgt-addon/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "australia-cgt-addon",
+  "version": "0.1.0",
+  "description": "Australian CGT planning and reconciliation addon for Wealthfolio",
+  "type": "module",
+  "main": "dist/addon.js",
+  "author": "Massimo Raso",
+  "license": "MIT",
+  "homepage": "https://github.com/Mrassimo/wealthfolio",
+  "keywords": [
+    "wealthfolio",
+    "addon",
+    "australia",
+    "cgt",
+    "tax"
+  ],
+  "scripts": {
+    "build": "vite build",
+    "dev": "vite build --watch",
+    "dev:server": "wealthfolio dev",
+    "clean": "rm -rf dist",
+    "package": "mkdir -p dist && zip -r dist/$npm_package_name-$npm_package_version.zip manifest.json dist/ README.md CHANGELOG.md",
+    "bundle": "pnpm clean && pnpm build && pnpm package",
+    "lint": "tsc --noEmit",
+    "test": "node test-runner.mjs",
+    "type-check": "tsc --noEmit",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
+  },
+  "dependencies": {
+    "@tanstack/react-query": "^5.90.20",
+    "@wealthfolio/addon-sdk": "workspace:*",
+    "@wealthfolio/ui": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.1.18",
+    "@types/node": "^20.19.33",
+    "@types/react": "^19.2.13",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.4",
+    "@wealthfolio/addon-dev-tools": "workspace:*",
+    "rollup-plugin-external-globals": "^0.13.0",
+    "tailwindcss": "^4.1.18",
+    "typescript": "^5.9.3",
+    "vite": "^7.3.2"
+  },
+  "files": [
+    "dist/",
+    "manifest.json",
+    "README.md",
+    "CHANGELOG.md"
+  ]
+}

--- a/addons/australia-cgt-addon/package.json
+++ b/addons/australia-cgt-addon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "australia-cgt-addon",
   "version": "0.1.0",
-  "description": "Australian CGT planning and reconciliation addon for Wealthfolio",
+  "description": "Community Australian CGT planning and reconciliation addon for Wealthfolio",
   "type": "module",
   "main": "dist/addon.js",
   "author": "Massimo Raso",

--- a/addons/australia-cgt-addon/src/addon.tsx
+++ b/addons/australia-cgt-addon/src/addon.tsx
@@ -1,0 +1,50 @@
+import { QueryClientProvider, type QueryClient } from "@tanstack/react-query";
+import type { AddonEnableFunction } from "@wealthfolio/addon-sdk";
+import { Icons } from "@wealthfolio/ui";
+import React from "react";
+import { AustraliaCgtPage } from "./pages/australia-cgt-page";
+
+const enable: AddonEnableFunction = (ctx) => {
+  ctx.api.logger.info("Australia CGT Planner addon is being enabled");
+
+  const cleanupTasks: Array<() => void> = [];
+
+  try {
+    const sidebarItem = ctx.sidebar.addItem({
+      id: "australia-cgt-addon",
+      label: "Australia CGT Planner",
+      icon: <Icons.Percent className="h-5 w-5" />,
+      route: "/addons/australia-cgt",
+      order: 210,
+    });
+    cleanupTasks.push(() => sidebarItem.remove());
+
+    const AustraliaCgtWrapper = () => {
+      const sharedQueryClient = ctx.api.query.getClient() as QueryClient;
+      return (
+        <QueryClientProvider client={sharedQueryClient}>
+          <AustraliaCgtPage ctx={ctx} />
+        </QueryClientProvider>
+      );
+    };
+
+    ctx.router.add({
+      path: "/addons/australia-cgt",
+      component: React.lazy(() =>
+        Promise.resolve({
+          default: AustraliaCgtWrapper,
+        }),
+      ),
+    });
+  } catch (error) {
+    [...cleanupTasks].reverse().forEach((cleanup) => cleanup());
+    throw error;
+  }
+
+  ctx.onDisable(() => {
+    [...cleanupTasks].reverse().forEach((cleanup) => cleanup());
+    ctx.api.logger.info("Australia CGT Planner addon disabled");
+  });
+};
+
+export default enable;

--- a/addons/australia-cgt-addon/src/addon.tsx
+++ b/addons/australia-cgt-addon/src/addon.tsx
@@ -1,13 +1,29 @@
 import { QueryClientProvider, type QueryClient } from "@tanstack/react-query";
-import type { AddonEnableFunction } from "@wealthfolio/addon-sdk";
+import type { AddonContext, AddonEnableFunction } from "@wealthfolio/addon-sdk";
 import { Icons } from "@wealthfolio/ui";
 import React from "react";
 import { AustraliaCgtPage } from "./pages/australia-cgt-page";
 
+type CleanupTask = () => void;
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function runCleanupTasks(ctx: AddonContext, cleanupTasks: CleanupTask[]) {
+  for (const cleanup of [...cleanupTasks].reverse()) {
+    try {
+      cleanup();
+    } catch (error) {
+      ctx.api.logger.error("Error cleaning up Australia CGT Planner addon: " + errorMessage(error));
+    }
+  }
+}
+
 const enable: AddonEnableFunction = (ctx) => {
   ctx.api.logger.info("Australia CGT Planner addon is being enabled");
 
-  const cleanupTasks: Array<() => void> = [];
+  const cleanupTasks: CleanupTask[] = [];
 
   try {
     const sidebarItem = ctx.sidebar.addItem({
@@ -37,12 +53,13 @@ const enable: AddonEnableFunction = (ctx) => {
       ),
     });
   } catch (error) {
-    [...cleanupTasks].reverse().forEach((cleanup) => cleanup());
+    ctx.api.logger.error("Failed to initialize Australia CGT Planner addon: " + errorMessage(error));
+    runCleanupTasks(ctx, cleanupTasks);
     throw error;
   }
 
   ctx.onDisable(() => {
-    [...cleanupTasks].reverse().forEach((cleanup) => cleanup());
+    runCleanupTasks(ctx, cleanupTasks);
     ctx.api.logger.info("Australia CGT Planner addon disabled");
   });
 };

--- a/addons/australia-cgt-addon/src/components/acquisition-override-form.tsx
+++ b/addons/australia-cgt-addon/src/components/acquisition-override-form.tsx
@@ -1,0 +1,71 @@
+import { Button } from "@wealthfolio/ui";
+
+interface AcquisitionOverrideFormProps {
+  parcelId: string;
+  symbol: string;
+  account: string;
+  acquisitionDate: string;
+  canSave: boolean;
+  onParcelIdChange(value: string): void;
+  onSymbolChange(value: string): void;
+  onAccountChange(value: string): void;
+  onAcquisitionDateChange(value: string): void;
+  onSave(): void;
+}
+
+export function AcquisitionOverrideForm({
+  parcelId,
+  symbol,
+  account,
+  acquisitionDate,
+  canSave,
+  onParcelIdChange,
+  onSymbolChange,
+  onAccountChange,
+  onAcquisitionDateChange,
+  onSave,
+}: AcquisitionOverrideFormProps) {
+  return (
+    <div className="rounded-md bg-slate-50 p-3 text-sm dark:bg-slate-900">
+      <h3 className="font-medium">Aggregated Holding Acquisition</h3>
+      <p className="text-muted-foreground mt-1 text-xs">
+        Use this when Wealthfolio has a holding but not the original parcel acquisition date. A
+        selected parcel fills the matching symbol and account.
+      </p>
+      <div className="mt-3 grid gap-2 sm:grid-cols-2">
+        <input
+          aria-label="Override parcel ID"
+          className="rounded-md border bg-transparent px-3 py-2"
+          list="australia-cgt-open-parcels"
+          placeholder="Parcel ID"
+          value={parcelId}
+          onChange={(event) => onParcelIdChange(event.target.value)}
+        />
+        <input
+          aria-label="Override symbol"
+          className="rounded-md border bg-transparent px-3 py-2"
+          placeholder="Symbol"
+          value={symbol}
+          onChange={(event) => onSymbolChange(event.target.value)}
+        />
+        <input
+          aria-label="Override account"
+          className="rounded-md border bg-transparent px-3 py-2"
+          placeholder="Account"
+          value={account}
+          onChange={(event) => onAccountChange(event.target.value)}
+        />
+        <input
+          aria-label="Override acquisition date"
+          className="rounded-md border bg-transparent px-3 py-2"
+          type="date"
+          value={acquisitionDate}
+          onChange={(event) => onAcquisitionDateChange(event.target.value)}
+        />
+      </div>
+      <Button className="mt-3" disabled={!canSave} onClick={onSave} variant="outline">
+        Save acquisition date
+      </Button>
+    </div>
+  );
+}

--- a/addons/australia-cgt-addon/src/components/amma-form.tsx
+++ b/addons/australia-cgt-addon/src/components/amma-form.tsx
@@ -1,0 +1,108 @@
+import { Button } from "@wealthfolio/ui";
+
+interface AmmaFormProps {
+  parcelId: string;
+  incomeYear: string;
+  taxableIncome: number;
+  cashDistribution: number;
+  frankingCredits: number;
+  increase: number;
+  decrease: number;
+  canSave: boolean;
+  onParcelIdChange(value: string): void;
+  onIncomeYearChange(value: string): void;
+  onTaxableIncomeChange(value: number): void;
+  onCashDistributionChange(value: number): void;
+  onFrankingCreditsChange(value: number): void;
+  onIncreaseChange(value: number): void;
+  onDecreaseChange(value: number): void;
+  onSave(): void;
+}
+
+export function AmmaForm({
+  parcelId,
+  incomeYear,
+  taxableIncome,
+  cashDistribution,
+  frankingCredits,
+  increase,
+  decrease,
+  canSave,
+  onParcelIdChange,
+  onIncomeYearChange,
+  onTaxableIncomeChange,
+  onCashDistributionChange,
+  onFrankingCreditsChange,
+  onIncreaseChange,
+  onDecreaseChange,
+  onSave,
+}: AmmaFormProps) {
+  return (
+    <div className="rounded-md bg-slate-50 p-3 text-sm dark:bg-slate-900">
+      <h3 className="font-medium">AMMA / AMIT</h3>
+      <p className="text-muted-foreground mt-1 text-xs">
+        Choose a parcel from the matched lots or holding parcels below, then enter the AMIT
+        cost-base movement from the AMMA statement.
+      </p>
+      <div className="mt-3 grid gap-2 sm:grid-cols-2">
+        <input
+          aria-label="AMMA parcel ID"
+          className="rounded-md border bg-transparent px-3 py-2"
+          list="australia-cgt-all-parcels"
+          placeholder="Parcel ID"
+          value={parcelId}
+          onChange={(event) => onParcelIdChange(event.target.value)}
+        />
+        <input
+          aria-label="AMMA income year"
+          className="rounded-md border bg-transparent px-3 py-2"
+          value={incomeYear}
+          onChange={(event) => onIncomeYearChange(event.target.value)}
+        />
+        <input
+          aria-label="AMMA taxable income"
+          className="rounded-md border bg-transparent px-3 py-2"
+          inputMode="decimal"
+          type="number"
+          value={taxableIncome}
+          onChange={(event) => onTaxableIncomeChange(Number(event.target.value))}
+        />
+        <input
+          aria-label="AMMA cash distribution"
+          className="rounded-md border bg-transparent px-3 py-2"
+          inputMode="decimal"
+          type="number"
+          value={cashDistribution}
+          onChange={(event) => onCashDistributionChange(Number(event.target.value))}
+        />
+        <input
+          aria-label="AMMA franking credits"
+          className="rounded-md border bg-transparent px-3 py-2"
+          inputMode="decimal"
+          type="number"
+          value={frankingCredits}
+          onChange={(event) => onFrankingCreditsChange(Number(event.target.value))}
+        />
+        <input
+          aria-label="AMIT cost base increase"
+          className="rounded-md border bg-transparent px-3 py-2"
+          inputMode="decimal"
+          type="number"
+          value={increase}
+          onChange={(event) => onIncreaseChange(Number(event.target.value))}
+        />
+        <input
+          aria-label="AMIT cost base decrease"
+          className="rounded-md border bg-transparent px-3 py-2"
+          inputMode="decimal"
+          type="number"
+          value={decrease}
+          onChange={(event) => onDecreaseChange(Number(event.target.value))}
+        />
+      </div>
+      <Button className="mt-3" disabled={!canSave} onClick={onSave} variant="outline">
+        Save AMMA statement
+      </Button>
+    </div>
+  );
+}

--- a/addons/australia-cgt-addon/src/components/cpi-cache-panel.tsx
+++ b/addons/australia-cgt-addon/src/components/cpi-cache-panel.tsx
@@ -1,0 +1,35 @@
+import { Button } from "@wealthfolio/ui";
+import type { CpiObservation } from "../lib/tax-data";
+
+interface CpiCachePanelProps {
+  cpiSeries: CpiObservation[];
+  refreshError: string | null;
+  onRefresh(): void;
+  onSaveSample(): void;
+}
+
+export function CpiCachePanel({
+  cpiSeries,
+  refreshError,
+  onRefresh,
+  onSaveSample,
+}: CpiCachePanelProps) {
+  return (
+    <div className="rounded-md bg-slate-50 p-3 text-sm dark:bg-slate-900">
+      <h3 className="font-medium">CPI Cache</h3>
+      <p className="text-muted-foreground mt-2">Cached observations: {cpiSeries.length}</p>
+      <div className="mt-3 flex flex-wrap gap-2">
+        <Button onClick={onRefresh} variant="outline">
+          Refresh ABS CPI
+        </Button>
+        <Button onClick={onSaveSample} variant="ghost">
+          Insert demo CPI row
+        </Button>
+      </div>
+      <p className="text-muted-foreground mt-2 text-xs">
+        Demo CPI is synthetic test data. Use Refresh ABS CPI for real cache values.
+      </p>
+      {refreshError ? <p className="text-destructive mt-2">{refreshError}</p> : null}
+    </div>
+  );
+}

--- a/addons/australia-cgt-addon/src/components/cpi-cache-panel.tsx
+++ b/addons/australia-cgt-addon/src/components/cpi-cache-panel.tsx
@@ -5,14 +5,12 @@ interface CpiCachePanelProps {
   cpiSeries: CpiObservation[];
   refreshError: string | null;
   onRefresh(): void;
-  onSaveSample(): void;
 }
 
 export function CpiCachePanel({
   cpiSeries,
   refreshError,
   onRefresh,
-  onSaveSample,
 }: CpiCachePanelProps) {
   return (
     <div className="rounded-md bg-slate-50 p-3 text-sm dark:bg-slate-900">
@@ -22,13 +20,7 @@ export function CpiCachePanel({
         <Button onClick={onRefresh} variant="outline">
           Refresh ABS CPI
         </Button>
-        <Button onClick={onSaveSample} variant="ghost">
-          Insert demo CPI row
-        </Button>
       </div>
-      <p className="text-muted-foreground mt-2 text-xs">
-        Demo CPI is synthetic test data. Use Refresh ABS CPI for real cache values.
-      </p>
       {refreshError ? <p className="text-destructive mt-2">{refreshError}</p> : null}
     </div>
   );

--- a/addons/australia-cgt-addon/src/components/dividend-franking-table.tsx
+++ b/addons/australia-cgt-addon/src/components/dividend-franking-table.tsx
@@ -1,0 +1,49 @@
+import type { CgtReport } from "../lib/cgt-engine";
+import { formatAud } from "../lib/format";
+
+export function DividendFrankingTable({ report }: { report: CgtReport }) {
+  return (
+    <section className="rounded-md border">
+      <div className="border-b p-4">
+        <h2 className="text-base font-semibold">Dividend Franking Metadata</h2>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[640px] text-sm">
+          <thead className="bg-muted/40 text-muted-foreground text-left">
+            <tr>
+              <th className="px-4 py-3 font-medium">Symbol</th>
+              <th className="px-4 py-3 font-medium">Income year</th>
+              <th className="px-4 py-3 text-right font-medium">Amount</th>
+              <th className="px-4 py-3 text-right font-medium">Franking percent</th>
+              <th className="px-4 py-3 text-right font-medium">Franked amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            {report.dividends.map((dividend) => (
+              <tr key={dividend.activityId} className="border-t">
+                <td className="px-4 py-3">{dividend.symbol}</td>
+                <td className="px-4 py-3">{dividend.incomeYear}</td>
+                <td className="px-4 py-3 text-right">{formatAud(dividend.amount)}</td>
+                <td className="px-4 py-3 text-right">
+                  {dividend.frankingPercentage === null
+                    ? "Missing"
+                    : `${dividend.frankingPercentage}%`}
+                </td>
+                <td className="px-4 py-3 text-right">
+                  {dividend.frankedAmount === null ? "Missing" : formatAud(dividend.frankedAmount)}
+                </td>
+              </tr>
+            ))}
+            {report.dividends.length === 0 ? (
+              <tr>
+                <td className="text-muted-foreground px-4 py-8 text-center" colSpan={5}>
+                  No dividend activities with franking metadata found.
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/addons/australia-cgt-addon/src/components/holding-parcels-table.tsx
+++ b/addons/australia-cgt-addon/src/components/holding-parcels-table.tsx
@@ -1,0 +1,48 @@
+import type { HoldingParcel } from "../lib/cgt-engine";
+import { formatAud } from "../lib/format";
+
+interface HoldingParcelsTableProps {
+  holdingParcels: HoldingParcel[];
+  isLoading: boolean;
+}
+
+export function HoldingParcelsTable({ holdingParcels, isLoading }: HoldingParcelsTableProps) {
+  return (
+    <section className="rounded-md border">
+      <div className="border-b p-4">
+        <h2 className="text-base font-semibold">Holding Parcels</h2>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[640px] text-sm">
+          <thead className="bg-muted/40 text-muted-foreground text-left">
+            <tr>
+              <th className="px-4 py-3 font-medium">Parcel</th>
+              <th className="px-4 py-3 font-medium">Symbol</th>
+              <th className="px-4 py-3 font-medium">Acquired</th>
+              <th className="px-4 py-3 text-right font-medium">Quantity</th>
+              <th className="px-4 py-3 text-right font-medium">Cost base</th>
+            </tr>
+          </thead>
+          <tbody>
+            {holdingParcels.map((parcel) => (
+              <tr key={parcel.parcelId} className="border-t">
+                <td className="px-4 py-3">{parcel.parcelId}</td>
+                <td className="px-4 py-3">{parcel.symbol}</td>
+                <td className="px-4 py-3">{parcel.acquisitionDate}</td>
+                <td className="px-4 py-3 text-right">{parcel.quantity}</td>
+                <td className="px-4 py-3 text-right">{formatAud(parcel.costBase)}</td>
+              </tr>
+            ))}
+            {holdingParcels.length === 0 ? (
+              <tr>
+                <td className="text-muted-foreground px-4 py-8 text-center" colSpan={5}>
+                  {isLoading ? "Loading holding parcels..." : "No holdings found."}
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/addons/australia-cgt-addon/src/components/income-year-summary-table.tsx
+++ b/addons/australia-cgt-addon/src/components/income-year-summary-table.tsx
@@ -1,0 +1,53 @@
+import type { CgtReport } from "../lib/cgt-engine";
+import { formatAud } from "../lib/format";
+
+export function IncomeYearSummaryTable({ report }: { report: CgtReport }) {
+  return (
+    <section className="rounded-md border">
+      <div className="border-b p-4">
+        <h2 className="text-base font-semibold">Income Year Summary</h2>
+        <p className="text-muted-foreground mt-1 text-xs">
+          Final taxable gains are calculated here after same-year and carried-forward capital
+          losses.
+        </p>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[760px] text-sm">
+          <thead className="bg-muted/40 text-muted-foreground text-left">
+            <tr>
+              <th className="px-4 py-3 font-medium">Income year</th>
+              <th className="px-4 py-3 text-right font-medium">Proceeds</th>
+              <th className="px-4 py-3 text-right font-medium">Cost base</th>
+              <th className="px-4 py-3 text-right font-medium">Gross gain</th>
+              <th className="px-4 py-3 text-right font-medium">Losses applied</th>
+              <th className="px-4 py-3 text-right font-medium">Loss carry-forward</th>
+              <th className="px-4 py-3 text-right font-medium">Discount</th>
+              <th className="px-4 py-3 text-right font-medium">Taxable gain</th>
+            </tr>
+          </thead>
+          <tbody>
+            {report.incomeYears.map((year) => (
+              <tr key={year.incomeYear} className="border-t">
+                <td className="px-4 py-3 font-medium">{year.incomeYear}</td>
+                <td className="px-4 py-3 text-right">{formatAud(year.proceeds)}</td>
+                <td className="px-4 py-3 text-right">{formatAud(year.costBase)}</td>
+                <td className="px-4 py-3 text-right">{formatAud(year.grossGain)}</td>
+                <td className="px-4 py-3 text-right">{formatAud(year.capitalLossesApplied)}</td>
+                <td className="px-4 py-3 text-right">{formatAud(year.capitalLossCarryForward)}</td>
+                <td className="px-4 py-3 text-right">{formatAud(year.discountApplied)}</td>
+                <td className="px-4 py-3 text-right">{formatAud(year.taxableGain)}</td>
+              </tr>
+            ))}
+            {report.incomeYears.length === 0 ? (
+              <tr>
+                <td className="text-muted-foreground px-4 py-8 text-center" colSpan={8}>
+                  No matched BUY/SELL lots found yet.
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/addons/australia-cgt-addon/src/components/matched-lots-table.tsx
+++ b/addons/australia-cgt-addon/src/components/matched-lots-table.tsx
@@ -1,0 +1,55 @@
+import type { CgtReport } from "../lib/cgt-engine";
+import { formatAud } from "../lib/format";
+
+export function MatchedLotsTable({ report }: { report: CgtReport }) {
+  return (
+    <section className="rounded-md border">
+      <div className="border-b p-4">
+        <h2 className="text-base font-semibold">Matched Lots</h2>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[920px] text-sm">
+          <thead className="bg-muted/40 text-muted-foreground text-left">
+            <tr>
+              <th className="px-4 py-3 font-medium">Symbol</th>
+              <th className="px-4 py-3 font-medium">Account</th>
+              <th className="px-4 py-3 text-right font-medium">Quantity</th>
+              <th className="px-4 py-3 font-medium">Acquired</th>
+              <th className="px-4 py-3 font-medium">Disposed</th>
+              <th className="px-4 py-3 text-right font-medium">AMIT adj.</th>
+              <th className="px-4 py-3 text-right font-medium">Gain</th>
+              <th className="px-4 py-3 text-right font-medium">Pre-loss discount</th>
+              <th className="px-4 py-3 text-right font-medium">Pre-loss taxable</th>
+            </tr>
+          </thead>
+          <tbody>
+            {report.closedLots.map((lot, index) => (
+              <tr
+                key={`${lot.symbol}-${lot.acquisitionDate}-${lot.disposalDate}-${index}`}
+                className="border-t"
+              >
+                <td className="px-4 py-3 font-medium">{lot.symbol}</td>
+                <td className="px-4 py-3">{lot.account}</td>
+                <td className="px-4 py-3 text-right">{lot.quantity}</td>
+                <td className="px-4 py-3">{lot.acquisitionDate}</td>
+                <td className="px-4 py-3">{lot.disposalDate}</td>
+                <td className="px-4 py-3 text-right">{formatAud(lot.amitCostBaseAdjustment)}</td>
+                <td
+                  className={
+                    lot.grossGain < 0 ? "px-4 py-3 text-right text-red-600" : "px-4 py-3 text-right"
+                  }
+                >
+                  {formatAud(lot.grossGain)}
+                </td>
+                <td className="px-4 py-3 text-right">{formatAud(lot.preLossDiscountEstimate)}</td>
+                <td className="px-4 py-3 text-right">
+                  {formatAud(lot.preLossTaxableGainEstimate)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/addons/australia-cgt-addon/src/components/review-warnings.tsx
+++ b/addons/australia-cgt-addon/src/components/review-warnings.tsx
@@ -1,0 +1,57 @@
+import { Icons } from "@wealthfolio/ui";
+import type { CgtReport } from "../lib/cgt-engine";
+
+export function ReviewWarnings({ report }: { report: CgtReport }) {
+  return (
+    <>
+      {report.unmatchedSells.length > 0 ? (
+        <section className="rounded-md border border-amber-300 bg-amber-50 p-4 text-sm text-amber-950 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-100">
+          <div className="flex items-start gap-3">
+            <Icons.AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
+            <div>
+              <h2 className="font-semibold">Unmatched sells need review</h2>
+              <p className="mt-1">
+                {report.unmatchedSells.length} disposal
+                {report.unmatchedSells.length === 1 ? "" : "s"} could not be fully matched to
+                earlier buy lots. Totals exclude the unmatched quantity until the missing
+                acquisition history is added.
+              </p>
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      {report.unsupportedActivities.length > 0 ? (
+        <section className="rounded-md border border-red-300 bg-red-50 p-4 text-sm text-red-950 dark:border-red-700 dark:bg-red-950 dark:text-red-100">
+          <div className="flex items-start gap-3">
+            <Icons.AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
+            <div>
+              <h2 className="font-semibold">Non-AUD activities excluded</h2>
+              <p className="mt-1">
+                {report.unsupportedActivities.length} BUY/SELL activit
+                {report.unsupportedActivities.length === 1 ? "y was" : "ies were"} excluded because
+                this addon does not convert foreign-currency CGT amounts to AUD yet.
+              </p>
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      {report.ignoredActivities.length > 0 ? (
+        <section className="rounded-md border border-slate-300 bg-slate-50 p-4 text-sm text-slate-950 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100">
+          <div className="flex items-start gap-3">
+            <Icons.AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
+            <div>
+              <h2 className="font-semibold">Some activity types are not modelled</h2>
+              <p className="mt-1">
+                {report.ignoredActivities.length} non-BUY/SELL activit
+                {report.ignoredActivities.length === 1 ? "y is" : "ies are"} not included in CGT lot
+                matching. Review transfers, splits, and corporate actions manually.
+              </p>
+            </div>
+          </div>
+        </section>
+      ) : null}
+    </>
+  );
+}

--- a/addons/australia-cgt-addon/src/components/stored-tax-data-panel.tsx
+++ b/addons/australia-cgt-addon/src/components/stored-tax-data-panel.tsx
@@ -1,0 +1,149 @@
+import { Button } from "@wealthfolio/ui";
+import { formatAud } from "../lib/format";
+import type { AustraliaCgtAddonData } from "../lib/tax-data";
+
+interface StoredTaxDataPanelProps {
+  taxData: AustraliaCgtAddonData;
+  onClear(): void;
+  onDeleteAmma(statementId: string): void;
+  onDeleteCpi(quarter: string): void;
+  onDeleteSnapshot(parcelId: string): void;
+  onDeleteAcquisitionOverride(parcelId: string): void;
+}
+
+export function StoredTaxDataPanel({
+  taxData,
+  onClear,
+  onDeleteAmma,
+  onDeleteCpi,
+  onDeleteSnapshot,
+  onDeleteAcquisitionOverride,
+}: StoredTaxDataPanelProps) {
+  return (
+    <>
+      <div className="mt-4 flex flex-wrap gap-3 text-sm">
+        <span>AMMA statements: {taxData.ammaStatements.length}</span>
+        <span>AMIT adjustments: {taxData.amitAdjustments.length}</span>
+        <span>2027 snapshots: {taxData.transitionSnapshots.length}</span>
+        <span>Acquisition overrides: {taxData.acquisitionOverrides.length}</span>
+        <Button onClick={onClear} size="sm" variant="ghost">
+          Clear local tax data
+        </Button>
+      </div>
+      <div className="mt-4 grid gap-3 lg:grid-cols-2">
+        <div className="bg-background rounded-md border p-3">
+          <h3 className="text-sm font-medium">Stored AMMA statements</h3>
+          <div className="mt-2 divide-y text-sm">
+            {taxData.ammaStatements.map((statement) => (
+              <div key={statement.id} className="flex items-center justify-between gap-3 py-2">
+                <div>
+                  <p className="font-medium">
+                    {statement.parcelId ?? statement.holdingKey} · {statement.incomeYear}
+                  </p>
+                  <p className="text-muted-foreground text-xs">
+                    Taxable {formatAud(statement.taxableIncome)} · Cash{" "}
+                    {formatAud(statement.cashDistribution)} · Franking{" "}
+                    {formatAud(statement.frankingCredits)} · AMIT{" "}
+                    {formatAud(statement.amitCostBaseIncrease - statement.amitCostBaseDecrease)}
+                  </p>
+                </div>
+                <Button
+                  aria-label={`Delete AMMA ${statement.id}`}
+                  onClick={() => onDeleteAmma(statement.id)}
+                  size="sm"
+                  variant="ghost"
+                >
+                  Delete
+                </Button>
+              </div>
+            ))}
+            {taxData.ammaStatements.length === 0 ? (
+              <p className="text-muted-foreground py-2 text-xs">No AMMA statements saved.</p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="bg-background rounded-md border p-3">
+          <h3 className="text-sm font-medium">Stored CPI observations</h3>
+          <div className="mt-2 divide-y text-sm">
+            {taxData.cpiSeries.map((observation) => (
+              <div
+                key={observation.quarter}
+                className="flex items-center justify-between gap-3 py-2"
+              >
+                <p>
+                  {observation.quarter} · {observation.value} · {observation.source}
+                </p>
+                <Button
+                  aria-label={`Delete CPI ${observation.quarter}`}
+                  onClick={() => onDeleteCpi(observation.quarter)}
+                  size="sm"
+                  variant="ghost"
+                >
+                  Delete
+                </Button>
+              </div>
+            ))}
+            {taxData.cpiSeries.length === 0 ? (
+              <p className="text-muted-foreground py-2 text-xs">No CPI observations saved.</p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="bg-background rounded-md border p-3">
+          <h3 className="text-sm font-medium">Stored 2027 snapshots</h3>
+          <div className="mt-2 divide-y text-sm">
+            {taxData.transitionSnapshots.map((snapshot) => (
+              <div key={snapshot.parcelId} className="flex items-center justify-between gap-3 py-2">
+                <div>
+                  <p className="font-medium">{snapshot.parcelId}</p>
+                  <p className="text-muted-foreground text-xs">
+                    {snapshot.symbol} · {snapshot.account} · {formatAud(snapshot.marketValueAt2027)}
+                  </p>
+                </div>
+                <Button
+                  aria-label={`Delete snapshot ${snapshot.parcelId}`}
+                  onClick={() => onDeleteSnapshot(snapshot.parcelId)}
+                  size="sm"
+                  variant="ghost"
+                >
+                  Delete
+                </Button>
+              </div>
+            ))}
+            {taxData.transitionSnapshots.length === 0 ? (
+              <p className="text-muted-foreground py-2 text-xs">No snapshots saved.</p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="bg-background rounded-md border p-3">
+          <h3 className="text-sm font-medium">Stored acquisition overrides</h3>
+          <div className="mt-2 divide-y text-sm">
+            {taxData.acquisitionOverrides.map((override) => (
+              <div key={override.parcelId} className="flex items-center justify-between gap-3 py-2">
+                <div>
+                  <p className="font-medium">{override.parcelId}</p>
+                  <p className="text-muted-foreground text-xs">
+                    {override.symbol} · {override.account} · {override.acquisitionDate}
+                  </p>
+                </div>
+                <Button
+                  aria-label={`Delete acquisition override ${override.parcelId}`}
+                  onClick={() => onDeleteAcquisitionOverride(override.parcelId)}
+                  size="sm"
+                  variant="ghost"
+                >
+                  Delete
+                </Button>
+              </div>
+            ))}
+            {taxData.acquisitionOverrides.length === 0 ? (
+              <p className="text-muted-foreground py-2 text-xs">No acquisition overrides saved.</p>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/addons/australia-cgt-addon/src/components/stored-tax-data-panel.tsx
+++ b/addons/australia-cgt-addon/src/components/stored-tax-data-panel.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@wealthfolio/ui";
+import { useState } from "react";
 import { formatAud } from "../lib/format";
 import type { AustraliaCgtAddonData } from "../lib/tax-data";
 
@@ -19,6 +20,13 @@ export function StoredTaxDataPanel({
   onDeleteSnapshot,
   onDeleteAcquisitionOverride,
 }: StoredTaxDataPanelProps) {
+  const [confirmingClear, setConfirmingClear] = useState(false);
+
+  const confirmClear = () => {
+    onClear();
+    setConfirmingClear(false);
+  };
+
   return (
     <>
       <div className="mt-4 flex flex-wrap gap-3 text-sm">
@@ -26,9 +34,20 @@ export function StoredTaxDataPanel({
         <span>AMIT adjustments: {taxData.amitAdjustments.length}</span>
         <span>2027 snapshots: {taxData.transitionSnapshots.length}</span>
         <span>Acquisition overrides: {taxData.acquisitionOverrides.length}</span>
-        <Button onClick={onClear} size="sm" variant="ghost">
-          Clear local tax data
-        </Button>
+        {confirmingClear ? (
+          <>
+            <Button onClick={confirmClear} size="sm" variant="destructive">
+              Confirm clear local tax data
+            </Button>
+            <Button onClick={() => setConfirmingClear(false)} size="sm" variant="outline">
+              Cancel
+            </Button>
+          </>
+        ) : (
+          <Button onClick={() => setConfirmingClear(true)} size="sm" variant="outline">
+            Clear local tax data
+          </Button>
+        )}
       </div>
       <div className="mt-4 grid gap-3 lg:grid-cols-2">
         <div className="bg-background rounded-md border p-3">

--- a/addons/australia-cgt-addon/src/components/summary-cards.tsx
+++ b/addons/australia-cgt-addon/src/components/summary-cards.tsx
@@ -1,0 +1,37 @@
+import type { CgtReport } from "../lib/cgt-engine";
+import { formatAud } from "../lib/format";
+
+export function SummaryCards({ report }: { report: CgtReport }) {
+  return (
+    <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+      <div className="rounded-md border p-4">
+        <p className="text-muted-foreground text-xs font-medium uppercase">Closed lots</p>
+        <p className="mt-2 text-2xl font-semibold">{report.closedLots.length}</p>
+      </div>
+      <div className="rounded-md border p-4">
+        <p className="text-muted-foreground text-xs font-medium uppercase">Proceeds</p>
+        <p className="mt-2 text-2xl font-semibold">
+          {formatAud(report.incomeYears.reduce((sum, year) => sum + year.proceeds, 0))}
+        </p>
+      </div>
+      <div className="rounded-md border p-4">
+        <p className="text-muted-foreground text-xs font-medium uppercase">Gross gains</p>
+        <p className="mt-2 text-2xl font-semibold">
+          {formatAud(report.incomeYears.reduce((sum, year) => sum + year.grossGain, 0))}
+        </p>
+      </div>
+      <div className="rounded-md border p-4">
+        <p className="text-muted-foreground text-xs font-medium uppercase">Losses applied</p>
+        <p className="mt-2 text-2xl font-semibold">
+          {formatAud(report.incomeYears.reduce((sum, year) => sum + year.capitalLossesApplied, 0))}
+        </p>
+      </div>
+      <div className="rounded-md border p-4">
+        <p className="text-muted-foreground text-xs font-medium uppercase">Taxable gains</p>
+        <p className="mt-2 text-2xl font-semibold">
+          {formatAud(report.incomeYears.reduce((sum, year) => sum + year.taxableGain, 0))}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/addons/australia-cgt-addon/src/components/transition-parcels-table.tsx
+++ b/addons/australia-cgt-addon/src/components/transition-parcels-table.tsx
@@ -1,0 +1,47 @@
+import type { CgtReport } from "../lib/cgt-engine";
+import { formatAud } from "../lib/format";
+
+export function TransitionParcelsTable({ report }: { report: CgtReport }) {
+  return (
+    <section className="rounded-md border">
+      <div className="border-b p-4">
+        <h2 className="text-base font-semibold">2027 Transition Parcels</h2>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[720px] text-sm">
+          <thead className="bg-muted/40 text-muted-foreground text-left">
+            <tr>
+              <th className="px-4 py-3 font-medium">Parcel</th>
+              <th className="px-4 py-3 font-medium">Symbol</th>
+              <th className="px-4 py-3 text-right font-medium">Quantity</th>
+              <th className="px-4 py-3 text-right font-medium">Cost base</th>
+              <th className="px-4 py-3 text-right font-medium">2027 value</th>
+              <th className="px-4 py-3 text-right font-medium">Pre-2027 taxable</th>
+            </tr>
+          </thead>
+          <tbody>
+            {report.transitionLots.map((lot) => (
+              <tr key={lot.parcelId} className="border-t">
+                <td className="px-4 py-3">{lot.parcelId}</td>
+                <td className="px-4 py-3">{lot.symbol}</td>
+                <td className="px-4 py-3 text-right">{lot.quantity}</td>
+                <td className="px-4 py-3 text-right">{formatAud(lot.costBase)}</td>
+                <td className="px-4 py-3 text-right">{formatAud(lot.marketValueAt2027)}</td>
+                <td className="px-4 py-3 text-right">
+                  {formatAud(lot.preCommencementTaxableGain)}
+                </td>
+              </tr>
+            ))}
+            {report.transitionLots.length === 0 ? (
+              <tr>
+                <td className="text-muted-foreground px-4 py-8 text-center" colSpan={6}>
+                  No 2027 parcel snapshots saved yet.
+                </td>
+              </tr>
+            ) : null}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/addons/australia-cgt-addon/src/components/transition-snapshot-form.tsx
+++ b/addons/australia-cgt-addon/src/components/transition-snapshot-form.tsx
@@ -1,0 +1,95 @@
+import { Button } from "@wealthfolio/ui";
+
+interface TransitionSnapshotFormProps {
+  parcelId: string;
+  symbol: string;
+  account: string;
+  acquisitionDate: string;
+  quantity: number;
+  marketValue: number;
+  canSave: boolean;
+  onParcelIdChange(value: string): void;
+  onSymbolChange(value: string): void;
+  onAccountChange(value: string): void;
+  onAcquisitionDateChange(value: string): void;
+  onQuantityChange(value: number): void;
+  onMarketValueChange(value: number): void;
+  onSave(): void;
+}
+
+export function TransitionSnapshotForm({
+  parcelId,
+  symbol,
+  account,
+  acquisitionDate,
+  quantity,
+  marketValue,
+  canSave,
+  onParcelIdChange,
+  onSymbolChange,
+  onAccountChange,
+  onAcquisitionDateChange,
+  onQuantityChange,
+  onMarketValueChange,
+  onSave,
+}: TransitionSnapshotFormProps) {
+  return (
+    <div className="rounded-md bg-slate-50 p-3 text-sm dark:bg-slate-900">
+      <h3 className="font-medium">30 June 2027 Parcel Value</h3>
+      <p className="text-muted-foreground mt-1 text-xs">
+        Selecting a known parcel fills symbol, account, acquired date, and quantity; edit them only
+        when the parcel was aggregated outside Wealthfolio.
+      </p>
+      <div className="mt-3 grid gap-2 sm:grid-cols-2">
+        <input
+          aria-label="Snapshot parcel ID"
+          className="rounded-md border bg-transparent px-3 py-2"
+          list="australia-cgt-open-parcels"
+          placeholder="Parcel ID"
+          value={parcelId}
+          onChange={(event) => onParcelIdChange(event.target.value)}
+        />
+        <input
+          aria-label="Snapshot symbol"
+          className="rounded-md border bg-transparent px-3 py-2"
+          placeholder="Symbol"
+          value={symbol}
+          onChange={(event) => onSymbolChange(event.target.value)}
+        />
+        <input
+          aria-label="Snapshot account"
+          className="rounded-md border bg-transparent px-3 py-2"
+          placeholder="Account"
+          value={account}
+          onChange={(event) => onAccountChange(event.target.value)}
+        />
+        <input
+          aria-label="Snapshot acquisition date"
+          className="rounded-md border bg-transparent px-3 py-2"
+          type="date"
+          value={acquisitionDate}
+          onChange={(event) => onAcquisitionDateChange(event.target.value)}
+        />
+        <input
+          aria-label="Snapshot quantity"
+          className="rounded-md border bg-transparent px-3 py-2"
+          inputMode="decimal"
+          type="number"
+          value={quantity}
+          onChange={(event) => onQuantityChange(Number(event.target.value))}
+        />
+        <input
+          aria-label="Snapshot market value"
+          className="rounded-md border bg-transparent px-3 py-2"
+          inputMode="decimal"
+          type="number"
+          value={marketValue}
+          onChange={(event) => onMarketValueChange(Number(event.target.value))}
+        />
+      </div>
+      <Button className="mt-3" disabled={!canSave} onClick={onSave} variant="outline">
+        Save 2027 snapshot
+      </Button>
+    </div>
+  );
+}

--- a/addons/australia-cgt-addon/src/hooks/use-australia-cgt-report.ts
+++ b/addons/australia-cgt-addon/src/hooks/use-australia-cgt-report.ts
@@ -1,0 +1,71 @@
+import { useQuery } from "@tanstack/react-query";
+import type { Account, ActivityDetails, AddonContext, Holding } from "@wealthfolio/addon-sdk";
+import { useMemo } from "react";
+import { buildCgtReport, buildHoldingParcels } from "../lib/cgt-engine";
+import { buildAllParcelOptions, buildOpenParcelOptions } from "../lib/parcel-options";
+import type { AustraliaCgtAddonData } from "../lib/tax-data";
+
+export function useAustraliaCgtReport(ctx: AddonContext, taxData: AustraliaCgtAddonData) {
+  const activitiesQuery = useQuery<ActivityDetails[]>({
+    queryKey: ["australia-cgt", "activities"],
+    queryFn: () => ctx.api.activities.getAll(),
+    staleTime: 60_000,
+  });
+
+  const accountsQuery = useQuery<Account[]>({
+    queryKey: ["australia-cgt", "accounts"],
+    queryFn: () => ctx.api.accounts.getAll(),
+    staleTime: 60_000,
+  });
+
+  const holdingsQuery = useQuery<Holding[]>({
+    queryKey: ["australia-cgt", "holdings", accountsQuery.data?.map((account) => account.id)],
+    enabled: Boolean(accountsQuery.data),
+    queryFn: async () => {
+      const accounts = accountsQuery.data ?? [];
+      const holdings = await Promise.all(
+        accounts.map((account) => ctx.api.portfolio.getHoldings(account.id)),
+      );
+      return holdings.flat();
+    },
+    staleTime: 60_000,
+  });
+
+  const holdingParcels = useMemo(
+    () =>
+      buildHoldingParcels((holdingsQuery.data ?? []) as Holding[], taxData.acquisitionOverrides),
+    [holdingsQuery.data, taxData.acquisitionOverrides],
+  );
+
+  const report = useMemo(
+    () =>
+      buildCgtReport((activitiesQuery.data ?? []) as Parameters<typeof buildCgtReport>[0], {
+        amitAdjustments: taxData.amitAdjustments,
+        transitionSnapshots: taxData.transitionSnapshots,
+        acquisitionOverrides: taxData.acquisitionOverrides,
+        holdingParcels,
+      }),
+    [
+      activitiesQuery.data,
+      holdingParcels,
+      taxData.acquisitionOverrides,
+      taxData.amitAdjustments,
+      taxData.transitionSnapshots,
+    ],
+  );
+
+  const allParcelOptions = useMemo(
+    () => buildAllParcelOptions(holdingParcels, report),
+    [holdingParcels, report],
+  );
+  const openParcelOptions = useMemo(() => buildOpenParcelOptions(holdingParcels), [holdingParcels]);
+
+  return {
+    activitiesQuery,
+    holdingsQuery,
+    report,
+    holdingParcels,
+    allParcelOptions,
+    openParcelOptions,
+  };
+}

--- a/addons/australia-cgt-addon/src/hooks/use-australia-cgt-tax-data.ts
+++ b/addons/australia-cgt-addon/src/hooks/use-australia-cgt-tax-data.ts
@@ -1,0 +1,28 @@
+import { useState } from "react";
+import {
+  createAustraliaCgtAddonStore,
+  emptyAustraliaCgtAddonData,
+  type AustraliaCgtAddonData,
+} from "../lib/tax-data";
+
+export function useAustraliaCgtTaxData() {
+  const [taxDataStore] = useState(() => createAustraliaCgtAddonStore());
+  const [taxData, setTaxData] = useState<AustraliaCgtAddonData>(() => taxDataStore.load());
+
+  const saveTaxData = (nextData: AustraliaCgtAddonData) => {
+    setTaxData(nextData);
+    taxDataStore.save(nextData);
+  };
+
+  const clearTaxData = () => {
+    const nextData = emptyAustraliaCgtAddonData();
+    taxDataStore.clear();
+    setTaxData(nextData);
+  };
+
+  return {
+    taxData,
+    saveTaxData,
+    clearTaxData,
+  };
+}

--- a/addons/australia-cgt-addon/src/lib/cgt-engine.ts
+++ b/addons/australia-cgt-addon/src/lib/cgt-engine.ts
@@ -227,8 +227,14 @@ export interface HoldingParcel {
 }
 
 function toDate(value: string | Date): Date {
-  if (value instanceof Date) return value;
-  return new Date(`${value.slice(0, 10)}T00:00:00`);
+  if (value instanceof Date) {
+    return new Date(Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate()));
+  }
+  const [year, month, day] = value
+    .slice(0, 10)
+    .split("-")
+    .map((part) => Number.parseInt(part, 10));
+  return new Date(Date.UTC(year, month - 1, day));
 }
 
 function roundCurrency(value: number): number {
@@ -308,16 +314,16 @@ function buildAmitAdjustmentsByParcel(
 
 function isoDate(value: string | Date): string {
   if (typeof value === "string") return value.slice(0, 10);
-  const year = value.getFullYear();
-  const month = String(value.getMonth() + 1).padStart(2, "0");
-  const day = String(value.getDate()).padStart(2, "0");
+  const year = value.getUTCFullYear();
+  const month = String(value.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(value.getUTCDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
 }
 
 function getAustralianIncomeYear(date: string | Date): string {
   const parsed = toDate(date);
-  const year = parsed.getFullYear();
-  const month = parsed.getMonth() + 1;
+  const year = parsed.getUTCFullYear();
+  const month = parsed.getUTCMonth() + 1;
   const startYear = month >= 7 ? year : year - 1;
   const endYearShort = String(startYear + 1).slice(-2);
   return `${startYear}-${endYearShort}`;
@@ -329,7 +335,7 @@ function isHeldAtLeastTwelveMonths(acquisitionDate: string | Date, disposalDate:
   const acquisition = toDate(acquisitionDate);
   const disposal = toDate(disposalDate);
   const threshold = new Date(acquisition);
-  threshold.setMonth(threshold.getMonth() + 12);
+  threshold.setUTCMonth(threshold.getUTCMonth() + 12);
   return disposal.getTime() > threshold.getTime();
 }
 
@@ -406,7 +412,7 @@ export function extractDividendTaxDetails(
   activities: WealthfolioCgtActivity[],
 ): DividendTaxDetail[] {
   return activities
-    .filter((activity) => activity.activityType === "DIVIDEND")
+    .filter((activity) => activity.activityType === "DIVIDEND" && isAudCurrency(activity.currency))
     .map((activity) => {
       const amount = positive(numberValue(activity.amount));
       const frankingPercentage = getFrankingPercentage(activity.metadata);
@@ -435,11 +441,13 @@ export function buildTransitionLots(
   const transitionLots = openLots.flatMap((lot) => {
     const snapshot = snapshotsByParcel.get(lot.parcelId);
     if (!snapshot) return [];
-    const remainingCostBase = roundCurrency(lot.remainingQuantity * lot.unitCostBase);
+    const transitionQuantity = Math.min(positive(snapshot.quantity), lot.remainingQuantity);
+    if (transitionQuantity <= 0) return [];
+    const remainingCostBase = roundCurrency(transitionQuantity * lot.unitCostBase);
     const adjustment = sumAmitAdjustment(
       lot.parcelId,
       PRE_TRANSITION_INCOME_YEAR,
-      lot.remainingQuantity,
+      transitionQuantity,
       lot.originalQuantity,
       lot.disposals,
       adjustmentsByParcel,
@@ -459,7 +467,7 @@ export function buildTransitionLots(
         symbol: lot.symbol,
         account: lot.account,
         acquisitionDate: lot.acquisitionDate,
-        quantity: lot.remainingQuantity,
+        quantity: transitionQuantity,
         costBase: adjustedCostBase,
         marketValueAt2027: snapshot.marketValueAt2027,
         preCommencementTaxableGain: preCommencement.taxableGain,
@@ -473,15 +481,19 @@ export function buildTransitionLots(
     if (coveredParcelIds.has(parcel.parcelId) || parcel.quantity <= 0) return [];
     const snapshot = snapshotsByParcel.get(parcel.parcelId);
     if (!snapshot) return [];
+    const transitionQuantity = Math.min(positive(snapshot.quantity), parcel.quantity);
+    if (transitionQuantity <= 0) return [];
+    const unitCostBase = parcel.quantity > 0 ? parcel.costBase / parcel.quantity : 0;
+    const transitionCostBase = roundCurrency(transitionQuantity * unitCostBase);
     const adjustment = sumAmitAdjustment(
       parcel.parcelId,
       PRE_TRANSITION_INCOME_YEAR,
-      parcel.quantity,
+      transitionQuantity,
       parcel.quantity,
       [],
       adjustmentsByParcel,
     );
-    const adjustedCostBase = roundCurrency(parcel.costBase + adjustment);
+    const adjustedCostBase = roundCurrency(transitionCostBase + adjustment);
     const preCommencement = calculateCurrentLawTaxableGain({
       grossGain: snapshot.marketValueAt2027 - adjustedCostBase,
       capitalLosses: 0,
@@ -496,7 +508,7 @@ export function buildTransitionLots(
         symbol: parcel.symbol,
         account: parcel.account,
         acquisitionDate: parcel.acquisitionDate,
-        quantity: parcel.quantity,
+        quantity: transitionQuantity,
         costBase: adjustedCostBase,
         marketValueAt2027: snapshot.marketValueAt2027,
         preCommencementTaxableGain: preCommencement.taxableGain,
@@ -562,16 +574,29 @@ export function buildCgtReport(
   const ignoredActivities: IgnoredActivity[] = [];
 
   for (const activity of sortedActivities) {
-    if (activity.activityType !== "BUY" && activity.activityType !== "SELL") {
-      if (activity.activityType !== "DIVIDEND") {
-        ignoredActivities.push({
+    if (activity.activityType === "DIVIDEND") {
+      if (!isAudCurrency(activity.currency)) {
+        unsupportedActivities.push({
           activityId: activity.id,
           activityType: activity.activityType,
           symbol: activity.assetSymbol,
           account: activity.accountName,
           date: isoDate(activity.date),
+          currency: activity.currency,
+          reason: "NON_AUD_CURRENCY",
         });
       }
+      continue;
+    }
+
+    if (activity.activityType !== "BUY" && activity.activityType !== "SELL") {
+      ignoredActivities.push({
+        activityId: activity.id,
+        activityType: activity.activityType,
+        symbol: activity.assetSymbol,
+        account: activity.accountName,
+        date: isoDate(activity.date),
+      });
       continue;
     }
 

--- a/addons/australia-cgt-addon/src/lib/cgt-engine.ts
+++ b/addons/australia-cgt-addon/src/lib/cgt-engine.ts
@@ -1,0 +1,814 @@
+import {
+  type AmitCostBaseAdjustment,
+  type ParcelAcquisitionOverride,
+  type TransitionMarketValueSnapshot,
+  getFrankingPercentage,
+} from "./tax-data";
+
+export interface CurrentLawGainInput {
+  grossGain: number;
+  capitalLosses: number;
+  acquisitionDate: string | Date;
+  disposalDate: string | Date;
+  eligibleForDiscount: boolean;
+}
+
+export interface CurrentLawGainResult {
+  grossGain: number;
+  capitalLossesApplied: number;
+  netGainBeforeDiscount: number;
+  discountEligible: boolean;
+  discountApplied: number;
+  taxableGain: number;
+}
+
+export interface IndexedGainInput {
+  costBase: number;
+  proceeds: number;
+  indexationFactor: number;
+}
+
+export interface IndexedGainResult {
+  costBase: number;
+  proceeds: number;
+  indexationFactor: number;
+  indexedCostBase: number;
+  realCapitalGain: number;
+}
+
+export interface TransitionGainInput {
+  originalCostBase: number;
+  transitionValueAt2027: number;
+  proceeds: number;
+  acquisitionDate: string | Date;
+  disposalDate: string | Date;
+  post2027IndexationFactor: number;
+}
+
+export interface TransitionGainResult {
+  preCommencement: CurrentLawGainResult;
+  postCommencement: IndexedGainResult;
+  totalTaxableGain: number;
+}
+
+export interface MinimumTaxInput {
+  realCapitalGain: number;
+  taxOnGainBeforeTopUp: number;
+  receivesIncomeSupport: boolean;
+}
+
+export interface MinimumTaxResult {
+  minimumTaxRequired: number;
+  topUpTax: number;
+  exempt: boolean;
+}
+
+export interface WealthfolioCgtActivity {
+  id: string;
+  activityType: string;
+  date: string | Date;
+  quantity: string | number | null;
+  unitPrice: string | number | null;
+  amount: string | number | null;
+  fee: string | number | null;
+  currency: string;
+  assetSymbol: string;
+  assetName?: string;
+  accountId?: string;
+  accountName: string;
+  fxRate?: string | number | null;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ClosedLot {
+  parcelId: string;
+  symbol: string;
+  assetName?: string;
+  account: string;
+  incomeYear: string;
+  acquisitionDate: string;
+  disposalDate: string;
+  quantity: number;
+  proceeds: number;
+  costBase: number;
+  amitCostBaseAdjustment: number;
+  grossGain: number;
+  taxableGain: number;
+  discountApplied: number;
+  discountEligible: boolean;
+  method: "FIFO";
+}
+
+export interface IncomeYearSummary {
+  incomeYear: string;
+  proceeds: number;
+  costBase: number;
+  amitCostBaseAdjustment: number;
+  grossGain: number;
+  grossCapitalGains: number;
+  capitalLossesApplied: number;
+  capitalLossCarryForward: number;
+  discountApplied: number;
+  taxableGain: number;
+}
+
+export interface CgtReport {
+  closedLots: ClosedLot[];
+  incomeYears: IncomeYearSummary[];
+  unmatchedSells: UnmatchedSell[];
+  unsupportedActivities: UnsupportedActivity[];
+  ignoredActivities: IgnoredActivity[];
+  dividends: DividendTaxDetail[];
+  transitionLots: TransitionLot[];
+}
+
+export interface UnmatchedSell {
+  symbol: string;
+  account: string;
+  date: string;
+  quantity: number;
+  proceeds: number;
+}
+
+export interface UnsupportedActivity {
+  activityId: string;
+  activityType: string;
+  symbol: string;
+  account: string;
+  date: string;
+  currency: string;
+  reason: "NON_AUD_CURRENCY";
+}
+
+export interface IgnoredActivity {
+  activityId: string;
+  activityType: string;
+  symbol: string;
+  account: string;
+  date: string;
+}
+
+interface OpenLot {
+  parcelId: string;
+  symbol: string;
+  assetName?: string;
+  account: string;
+  acquisitionDate: string;
+  remainingQuantity: number;
+  unitCostBase: number;
+  originalQuantity: number;
+  disposals: Array<{ incomeYear: string; quantity: number }>;
+}
+
+interface IncomeYearAccumulator extends IncomeYearSummary {
+  capitalLosses: number;
+  nonDiscountGains: number;
+  discountEligibleGains: number;
+}
+
+export interface CgtReportOptions {
+  amitAdjustments?: AmitCostBaseAdjustment[];
+  transitionSnapshots?: TransitionMarketValueSnapshot[];
+  acquisitionOverrides?: ParcelAcquisitionOverride[];
+  holdingParcels?: HoldingParcel[];
+}
+
+export interface DividendTaxDetail {
+  activityId: string;
+  symbol: string;
+  account: string;
+  incomeYear: string;
+  amount: number;
+  frankingPercentage: number | null;
+  frankedAmount: number | null;
+}
+
+export interface TransitionLot {
+  parcelId: string;
+  symbol: string;
+  account: string;
+  acquisitionDate: string;
+  quantity: number;
+  costBase: number;
+  marketValueAt2027: number;
+  preCommencementTaxableGain: number;
+  valuationMethod: TransitionMarketValueSnapshot["valuationMethod"];
+}
+
+export interface HoldingLike {
+  id: string;
+  quantity: number;
+  openDate?: string | Date | null;
+  lots?: Array<{
+    id: string;
+    acquisitionDate: string;
+    quantity: number;
+    costBasis: number;
+  }> | null;
+  accountId?: string;
+  accountName?: string;
+  instrument?: {
+    symbol?: string | null;
+    name?: string | null;
+  } | null;
+  costBasis?: {
+    local: number;
+    base: number;
+  } | null;
+}
+
+export interface HoldingParcel {
+  parcelId: string;
+  symbol: string;
+  account: string;
+  acquisitionDate: string;
+  quantity: number;
+  costBase: number;
+}
+
+function toDate(value: string | Date): Date {
+  if (value instanceof Date) return value;
+  return new Date(`${value.slice(0, 10)}T00:00:00`);
+}
+
+function roundCurrency(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+function positive(value: number): number {
+  return Math.max(0, value);
+}
+
+function numberValue(value: string | number | null | undefined): number {
+  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function sumAmitAdjustment(
+  parcelId: string,
+  disposalIncomeYear: string,
+  quantity: number,
+  originalQuantity: number,
+  priorDisposals: Array<{ incomeYear: string; quantity: number }>,
+  adjustmentsByParcel: Map<string, AmitCostBaseAdjustment[]>,
+): number {
+  if (originalQuantity === 0) return 0;
+  return roundCurrency(
+    (adjustmentsByParcel.get(parcelId) ?? [])
+      .filter(
+        (adjustment) =>
+          incomeYearSortKey(adjustment.incomeYear) <= incomeYearSortKey(disposalIncomeYear),
+      )
+      .reduce((sum, adjustment) => {
+        const disposedBeforeAdjustment = priorDisposals
+          .filter(
+            (disposal) =>
+              incomeYearSortKey(disposal.incomeYear) < incomeYearSortKey(adjustment.incomeYear),
+          )
+          .reduce((disposed, disposal) => disposed + disposal.quantity, 0);
+        const adjustmentQuantity = originalQuantity - disposedBeforeAdjustment;
+        if (adjustmentQuantity <= 0) return sum;
+        return sum + adjustment.amount * (quantity / adjustmentQuantity);
+      }, 0),
+  );
+}
+
+function lotPoolKey(symbol: string, accountIdOrName: string): string {
+  return `${symbol}\u0000${accountIdOrName}`;
+}
+
+function activityAccountKey(activity: WealthfolioCgtActivity): string {
+  return activity.accountId ?? activity.accountName;
+}
+
+function incomeYearSortKey(incomeYear: string): number {
+  const startYear = Number.parseInt(incomeYear.slice(0, 4), 10);
+  return Number.isFinite(startYear) ? startYear : 0;
+}
+
+function isAudCurrency(currency: string): boolean {
+  return currency.trim().toUpperCase() === "AUD";
+}
+
+function buildAmitAdjustmentsByParcel(
+  adjustments: AmitCostBaseAdjustment[] | undefined,
+): Map<string, AmitCostBaseAdjustment[]> {
+  const byParcel = new Map<string, AmitCostBaseAdjustment[]>();
+  for (const adjustment of adjustments ?? []) {
+    const parcelAdjustments = byParcel.get(adjustment.parcelId) ?? [];
+    parcelAdjustments.push(adjustment);
+    byParcel.set(adjustment.parcelId, parcelAdjustments);
+  }
+  return byParcel;
+}
+
+function isoDate(value: string | Date): string {
+  if (typeof value === "string") return value.slice(0, 10);
+  const year = value.getFullYear();
+  const month = String(value.getMonth() + 1).padStart(2, "0");
+  const day = String(value.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+function getAustralianIncomeYear(date: string | Date): string {
+  const parsed = toDate(date);
+  const year = parsed.getFullYear();
+  const month = parsed.getMonth() + 1;
+  const startYear = month >= 7 ? year : year - 1;
+  const endYearShort = String(startYear + 1).slice(-2);
+  return `${startYear}-${endYearShort}`;
+}
+
+const PRE_TRANSITION_INCOME_YEAR = "2026-27";
+
+function isHeldAtLeastTwelveMonths(acquisitionDate: string | Date, disposalDate: string | Date) {
+  const acquisition = toDate(acquisitionDate);
+  const disposal = toDate(disposalDate);
+  const threshold = new Date(acquisition);
+  threshold.setMonth(threshold.getMonth() + 12);
+  return disposal.getTime() > threshold.getTime();
+}
+
+export function calculateCurrentLawTaxableGain(input: CurrentLawGainInput): CurrentLawGainResult {
+  const grossGain = positive(input.grossGain);
+  const lossesApplied = Math.min(grossGain, positive(input.capitalLosses));
+  const netGainBeforeDiscount = roundCurrency(grossGain - lossesApplied);
+  const discountEligible =
+    input.eligibleForDiscount &&
+    netGainBeforeDiscount > 0 &&
+    isHeldAtLeastTwelveMonths(input.acquisitionDate, input.disposalDate);
+  const discountApplied = discountEligible ? roundCurrency(netGainBeforeDiscount * 0.5) : 0;
+  const taxableGain = roundCurrency(netGainBeforeDiscount - discountApplied);
+
+  return {
+    grossGain,
+    capitalLossesApplied: lossesApplied,
+    netGainBeforeDiscount,
+    discountEligible,
+    discountApplied,
+    taxableGain,
+  };
+}
+
+export function calculateIndexedGain(input: IndexedGainInput): IndexedGainResult {
+  const indexedCostBase = roundCurrency(input.costBase * input.indexationFactor);
+  const realCapitalGain = roundCurrency(positive(input.proceeds - indexedCostBase));
+
+  return {
+    costBase: input.costBase,
+    proceeds: input.proceeds,
+    indexationFactor: input.indexationFactor,
+    indexedCostBase,
+    realCapitalGain,
+  };
+}
+
+export function calculateTransitionGain(input: TransitionGainInput): TransitionGainResult {
+  const preCommencement = calculateCurrentLawTaxableGain({
+    grossGain: input.transitionValueAt2027 - input.originalCostBase,
+    capitalLosses: 0,
+    acquisitionDate: input.acquisitionDate,
+    disposalDate: "2027-07-01",
+    eligibleForDiscount: true,
+  });
+  const postCommencement = calculateIndexedGain({
+    costBase: input.transitionValueAt2027,
+    proceeds: input.proceeds,
+    indexationFactor: input.post2027IndexationFactor,
+  });
+
+  return {
+    preCommencement,
+    postCommencement,
+    totalTaxableGain: roundCurrency(preCommencement.taxableGain + postCommencement.realCapitalGain),
+  };
+}
+
+export function calculateMinimumTaxTopUp(input: MinimumTaxInput): MinimumTaxResult {
+  const minimumTaxRequired = roundCurrency(positive(input.realCapitalGain) * 0.3);
+  const exempt = input.receivesIncomeSupport || minimumTaxRequired === 0;
+  const topUpTax = exempt
+    ? 0
+    : roundCurrency(positive(minimumTaxRequired - positive(input.taxOnGainBeforeTopUp)));
+
+  return {
+    minimumTaxRequired,
+    topUpTax,
+    exempt,
+  };
+}
+
+export function extractDividendTaxDetails(
+  activities: WealthfolioCgtActivity[],
+): DividendTaxDetail[] {
+  return activities
+    .filter((activity) => activity.activityType === "DIVIDEND")
+    .map((activity) => {
+      const amount = positive(numberValue(activity.amount));
+      const frankingPercentage = getFrankingPercentage(activity.metadata);
+      return {
+        activityId: activity.id,
+        symbol: activity.assetSymbol,
+        account: activity.accountName,
+        incomeYear: getAustralianIncomeYear(activity.date),
+        amount,
+        frankingPercentage,
+        frankedAmount:
+          frankingPercentage === null ? null : roundCurrency(amount * (frankingPercentage / 100)),
+      };
+    });
+}
+
+export function buildTransitionLots(
+  openLots: OpenLot[],
+  options: CgtReportOptions,
+): TransitionLot[] {
+  const snapshotsByParcel = new Map(
+    (options.transitionSnapshots ?? []).map((snapshot) => [snapshot.parcelId, snapshot]),
+  );
+  const adjustmentsByParcel = buildAmitAdjustmentsByParcel(options.amitAdjustments);
+
+  const transitionLots = openLots.flatMap((lot) => {
+    const snapshot = snapshotsByParcel.get(lot.parcelId);
+    if (!snapshot) return [];
+    const remainingCostBase = roundCurrency(lot.remainingQuantity * lot.unitCostBase);
+    const adjustment = sumAmitAdjustment(
+      lot.parcelId,
+      PRE_TRANSITION_INCOME_YEAR,
+      lot.remainingQuantity,
+      lot.originalQuantity,
+      lot.disposals,
+      adjustmentsByParcel,
+    );
+    const adjustedCostBase = roundCurrency(remainingCostBase + adjustment);
+    const preCommencement = calculateCurrentLawTaxableGain({
+      grossGain: snapshot.marketValueAt2027 - adjustedCostBase,
+      capitalLosses: 0,
+      acquisitionDate: lot.acquisitionDate,
+      disposalDate: "2027-07-01",
+      eligibleForDiscount: true,
+    });
+
+    return [
+      {
+        parcelId: lot.parcelId,
+        symbol: lot.symbol,
+        account: lot.account,
+        acquisitionDate: lot.acquisitionDate,
+        quantity: lot.remainingQuantity,
+        costBase: adjustedCostBase,
+        marketValueAt2027: snapshot.marketValueAt2027,
+        preCommencementTaxableGain: preCommencement.taxableGain,
+        valuationMethod: snapshot.valuationMethod,
+      },
+    ];
+  });
+
+  const coveredParcelIds = new Set(transitionLots.map((lot) => lot.parcelId));
+  const holdingTransitionLots = (options.holdingParcels ?? []).flatMap((parcel) => {
+    if (coveredParcelIds.has(parcel.parcelId) || parcel.quantity <= 0) return [];
+    const snapshot = snapshotsByParcel.get(parcel.parcelId);
+    if (!snapshot) return [];
+    const adjustment = sumAmitAdjustment(
+      parcel.parcelId,
+      PRE_TRANSITION_INCOME_YEAR,
+      parcel.quantity,
+      parcel.quantity,
+      [],
+      adjustmentsByParcel,
+    );
+    const adjustedCostBase = roundCurrency(parcel.costBase + adjustment);
+    const preCommencement = calculateCurrentLawTaxableGain({
+      grossGain: snapshot.marketValueAt2027 - adjustedCostBase,
+      capitalLosses: 0,
+      acquisitionDate: parcel.acquisitionDate,
+      disposalDate: "2027-07-01",
+      eligibleForDiscount: true,
+    });
+
+    return [
+      {
+        parcelId: parcel.parcelId,
+        symbol: parcel.symbol,
+        account: parcel.account,
+        acquisitionDate: parcel.acquisitionDate,
+        quantity: parcel.quantity,
+        costBase: adjustedCostBase,
+        marketValueAt2027: snapshot.marketValueAt2027,
+        preCommencementTaxableGain: preCommencement.taxableGain,
+        valuationMethod: snapshot.valuationMethod,
+      },
+    ];
+  });
+
+  return [...transitionLots, ...holdingTransitionLots];
+}
+
+export function buildHoldingParcels(
+  holdings: HoldingLike[],
+  acquisitionOverrides: ParcelAcquisitionOverride[] = [],
+): HoldingParcel[] {
+  const overridesByParcel = new Map(
+    acquisitionOverrides.map((override) => [override.parcelId, override]),
+  );
+
+  return holdings.flatMap((holding) => {
+    const symbol = holding.instrument?.symbol ?? holding.id;
+    const account = holding.accountName ?? holding.accountId ?? "Unknown account";
+    const lots = holding.lots ?? [];
+    if (lots.length > 0) {
+      return lots.map((lot) => ({
+        parcelId: lot.id,
+        symbol,
+        account,
+        acquisitionDate: lot.acquisitionDate,
+        quantity: lot.quantity,
+        costBase: lot.costBasis,
+      }));
+    }
+
+    const override = overridesByParcel.get(holding.id);
+    const acquisitionDate = override?.acquisitionDate ?? isoDate(holding.openDate ?? new Date());
+    return [
+      {
+        parcelId: holding.id,
+        symbol,
+        account,
+        acquisitionDate,
+        quantity: holding.quantity,
+        costBase: override?.costBase ?? holding.costBasis?.local ?? 0,
+      },
+    ];
+  });
+}
+
+export function buildCgtReport(
+  activities: WealthfolioCgtActivity[],
+  options: CgtReportOptions = {},
+): CgtReport {
+  const sortedActivities = [...activities].sort(
+    (a, b) => toDate(a.date).getTime() - toDate(b.date).getTime(),
+  );
+  const lotsByAccountSymbol = new Map<string, OpenLot[]>();
+  const buyCountsBySymbolAccount = new Map<string, number>();
+  const adjustmentsByParcel = buildAmitAdjustmentsByParcel(options.amitAdjustments);
+  const closedLots: ClosedLot[] = [];
+  const unmatchedSells: UnmatchedSell[] = [];
+  const unsupportedActivities: UnsupportedActivity[] = [];
+  const ignoredActivities: IgnoredActivity[] = [];
+
+  for (const activity of sortedActivities) {
+    if (activity.activityType !== "BUY" && activity.activityType !== "SELL") {
+      if (activity.activityType !== "DIVIDEND") {
+        ignoredActivities.push({
+          activityId: activity.id,
+          activityType: activity.activityType,
+          symbol: activity.assetSymbol,
+          account: activity.accountName,
+          date: isoDate(activity.date),
+        });
+      }
+      continue;
+    }
+
+    if (!isAudCurrency(activity.currency)) {
+      unsupportedActivities.push({
+        activityId: activity.id,
+        activityType: activity.activityType,
+        symbol: activity.assetSymbol,
+        account: activity.accountName,
+        date: isoDate(activity.date),
+        currency: activity.currency,
+        reason: "NON_AUD_CURRENCY",
+      });
+      continue;
+    }
+
+    const symbol = activity.assetSymbol;
+    const quantity = positive(numberValue(activity.quantity));
+    if (!symbol || quantity === 0) continue;
+
+    const fee = positive(numberValue(activity.fee));
+    const unitPrice = positive(numberValue(activity.unitPrice));
+    const totalAmount = positive(numberValue(activity.amount)) || unitPrice * quantity;
+    const poolKey = lotPoolKey(symbol, activityAccountKey(activity));
+    const accountSymbolLots = lotsByAccountSymbol.get(poolKey) ?? [];
+
+    if (activity.activityType === "BUY") {
+      const buyIndex = buyCountsBySymbolAccount.get(poolKey) ?? 0;
+      accountSymbolLots.push({
+        parcelId: activity.id,
+        symbol,
+        assetName: activity.assetName,
+        account: activity.accountName,
+        acquisitionDate: isoDate(activity.date),
+        remainingQuantity: quantity,
+        unitCostBase: (totalAmount + fee) / quantity,
+        originalQuantity: quantity,
+        disposals: [],
+      });
+      buyCountsBySymbolAccount.set(poolKey, buyIndex + 1);
+      lotsByAccountSymbol.set(poolKey, accountSymbolLots);
+      continue;
+    }
+
+    let quantityToSell = quantity;
+    const unitProceeds = (totalAmount - fee) / quantity;
+
+    while (quantityToSell > 0 && accountSymbolLots.length > 0) {
+      const lot = accountSymbolLots[0];
+      const matchedQuantity = Math.min(quantityToSell, lot.remainingQuantity);
+      const proceeds = roundCurrency(matchedQuantity * unitProceeds);
+      const costBase = roundCurrency(matchedQuantity * lot.unitCostBase);
+      const amitCostBaseAdjustment = sumAmitAdjustment(
+        lot.parcelId,
+        getAustralianIncomeYear(activity.date),
+        matchedQuantity,
+        lot.originalQuantity,
+        lot.disposals,
+        adjustmentsByParcel,
+      );
+      const adjustedCostBase = roundCurrency(costBase + amitCostBaseAdjustment);
+      const grossGain = roundCurrency(proceeds - adjustedCostBase);
+      const currentLawGain = calculateCurrentLawTaxableGain({
+        grossGain,
+        capitalLosses: 0,
+        acquisitionDate: lot.acquisitionDate,
+        disposalDate: activity.date,
+        eligibleForDiscount: true,
+      });
+
+      closedLots.push({
+        parcelId: lot.parcelId,
+        symbol,
+        assetName: lot.assetName ?? activity.assetName,
+        account: lot.account,
+        incomeYear: getAustralianIncomeYear(activity.date),
+        acquisitionDate: lot.acquisitionDate,
+        disposalDate: isoDate(activity.date),
+        quantity: roundCurrency(matchedQuantity),
+        proceeds,
+        costBase: adjustedCostBase,
+        amitCostBaseAdjustment,
+        grossGain,
+        taxableGain: currentLawGain.taxableGain,
+        discountApplied: currentLawGain.discountApplied,
+        discountEligible: currentLawGain.discountEligible,
+        method: "FIFO",
+      });
+
+      lot.remainingQuantity = roundCurrency(lot.remainingQuantity - matchedQuantity);
+      lot.disposals.push({
+        incomeYear: getAustralianIncomeYear(activity.date),
+        quantity: matchedQuantity,
+      });
+      quantityToSell = roundCurrency(quantityToSell - matchedQuantity);
+      if (lot.remainingQuantity === 0) {
+        accountSymbolLots.shift();
+      }
+    }
+
+    if (quantityToSell > 0) {
+      unmatchedSells.push({
+        symbol,
+        account: activity.accountName,
+        date: isoDate(activity.date),
+        quantity: roundCurrency(quantityToSell),
+        proceeds: roundCurrency(quantityToSell * unitProceeds),
+      });
+    }
+  }
+
+  const summaries = new Map<string, IncomeYearAccumulator>();
+  for (const lot of closedLots) {
+    const summary = summaries.get(lot.incomeYear) ?? {
+      incomeYear: lot.incomeYear,
+      proceeds: 0,
+      costBase: 0,
+      amitCostBaseAdjustment: 0,
+      grossGain: 0,
+      grossCapitalGains: 0,
+      capitalLossesApplied: 0,
+      capitalLossCarryForward: 0,
+      discountApplied: 0,
+      taxableGain: 0,
+      capitalLosses: 0,
+      nonDiscountGains: 0,
+      discountEligibleGains: 0,
+    };
+    summary.proceeds = roundCurrency(summary.proceeds + lot.proceeds);
+    summary.costBase = roundCurrency(summary.costBase + lot.costBase);
+    summary.amitCostBaseAdjustment = roundCurrency(
+      summary.amitCostBaseAdjustment + lot.amitCostBaseAdjustment,
+    );
+    summary.grossGain = roundCurrency(summary.grossGain + lot.grossGain);
+
+    if (lot.grossGain < 0) {
+      summary.capitalLosses += Math.abs(lot.grossGain);
+    } else if (lot.discountEligible) {
+      summary.discountEligibleGains += lot.grossGain;
+    } else {
+      summary.nonDiscountGains += lot.grossGain;
+    }
+
+    summaries.set(lot.incomeYear, summary);
+  }
+
+  let carriedForwardLosses = 0;
+  const sortedSummaries = [...summaries.values()].sort((a, b) =>
+    a.incomeYear.localeCompare(b.incomeYear),
+  );
+
+  for (const summary of sortedSummaries) {
+    const capitalLosses = positive(summary.capitalLosses);
+    const nonDiscountGains = positive(summary.nonDiscountGains);
+    const discountEligibleGains = positive(summary.discountEligibleGains);
+    const availableLosses = roundCurrency(carriedForwardLosses + capitalLosses);
+    const lossesAppliedToNonDiscountGains = Math.min(nonDiscountGains, availableLosses);
+    const remainingLosses = availableLosses - lossesAppliedToNonDiscountGains;
+    const lossesAppliedToDiscountGains = Math.min(discountEligibleGains, remainingLosses);
+    const remainingNonDiscountGains = nonDiscountGains - lossesAppliedToNonDiscountGains;
+    const remainingDiscountGains = discountEligibleGains - lossesAppliedToDiscountGains;
+
+    summary.grossCapitalGains = roundCurrency(nonDiscountGains + discountEligibleGains);
+    summary.capitalLossesApplied = roundCurrency(
+      lossesAppliedToNonDiscountGains + lossesAppliedToDiscountGains,
+    );
+    summary.capitalLossCarryForward = roundCurrency(remainingLosses - lossesAppliedToDiscountGains);
+    summary.discountApplied = roundCurrency(remainingDiscountGains * 0.5);
+    summary.taxableGain = roundCurrency(remainingNonDiscountGains + remainingDiscountGains * 0.5);
+    carriedForwardLosses = summary.capitalLossCarryForward;
+  }
+
+  const incomeYears = sortedSummaries
+    .map(
+      ({
+        capitalLosses: _capitalLosses,
+        nonDiscountGains: _nonDiscountGains,
+        discountEligibleGains: _discountEligibleGains,
+        ...summary
+      }) => summary,
+    )
+    .sort((a, b) => a.incomeYear.localeCompare(b.incomeYear));
+  const sortedClosedLots = [...closedLots].sort(
+    (a, b) =>
+      a.disposalDate.localeCompare(b.disposalDate) ||
+      a.symbol.localeCompare(b.symbol) ||
+      a.account.localeCompare(b.account),
+  );
+
+  return {
+    closedLots: sortedClosedLots,
+    incomeYears,
+    unmatchedSells,
+    unsupportedActivities,
+    ignoredActivities,
+    dividends: extractDividendTaxDetails(activities),
+    transitionLots: buildTransitionLots([...lotsByAccountSymbol.values()].flat(), options),
+  };
+}
+
+export function exportReportCsv(report: CgtReport): string {
+  const header = [
+    "incomeYear",
+    "symbol",
+    "account",
+    "quantity",
+    "acquisitionDate",
+    "disposalDate",
+    "proceeds",
+    "costBase",
+    "amitCostBaseAdjustment",
+    "grossGain",
+    "lotCapitalLoss",
+    "discountApplied",
+    "taxableGain",
+    "method",
+  ];
+  const rows = report.closedLots.map((lot) =>
+    [
+      lot.incomeYear,
+      lot.symbol,
+      lot.account,
+      lot.quantity,
+      lot.acquisitionDate,
+      lot.disposalDate,
+      lot.proceeds,
+      lot.costBase,
+      lot.amitCostBaseAdjustment,
+      lot.grossGain,
+      lot.grossGain < 0 ? Math.abs(lot.grossGain) : 0,
+      lot.discountApplied,
+      lot.taxableGain,
+      lot.method,
+    ]
+      .map((value) => `"${String(value).replaceAll('"', '""')}"`)
+      .join(","),
+  );
+
+  return [header.join(","), ...rows].join("\n");
+}

--- a/addons/australia-cgt-addon/src/lib/cgt-engine.ts
+++ b/addons/australia-cgt-addon/src/lib/cgt-engine.ts
@@ -93,8 +93,8 @@ export interface ClosedLot {
   costBase: number;
   amitCostBaseAdjustment: number;
   grossGain: number;
-  taxableGain: number;
-  discountApplied: number;
+  preLossTaxableGainEstimate: number;
+  preLossDiscountEstimate: number;
   discountEligible: boolean;
   method: "FIFO";
 }
@@ -655,8 +655,8 @@ export function buildCgtReport(
         costBase: adjustedCostBase,
         amitCostBaseAdjustment,
         grossGain,
-        taxableGain: currentLawGain.taxableGain,
-        discountApplied: currentLawGain.discountApplied,
+        preLossTaxableGainEstimate: currentLawGain.taxableGain,
+        preLossDiscountEstimate: currentLawGain.discountApplied,
         discountEligible: currentLawGain.discountEligible,
         method: "FIFO",
       });
@@ -785,8 +785,8 @@ export function exportReportCsv(report: CgtReport): string {
     "amitCostBaseAdjustment",
     "grossGain",
     "lotCapitalLoss",
-    "discountApplied",
-    "taxableGain",
+    "preLossDiscountEstimate",
+    "preLossTaxableGainEstimate",
     "method",
   ];
   const rows = report.closedLots.map((lot) =>
@@ -802,8 +802,8 @@ export function exportReportCsv(report: CgtReport): string {
       lot.amitCostBaseAdjustment,
       lot.grossGain,
       lot.grossGain < 0 ? Math.abs(lot.grossGain) : 0,
-      lot.discountApplied,
-      lot.taxableGain,
+      lot.preLossDiscountEstimate,
+      lot.preLossTaxableGainEstimate,
       lot.method,
     ]
       .map((value) => `"${String(value).replaceAll('"', '""')}"`)

--- a/addons/australia-cgt-addon/src/lib/export-csv.ts
+++ b/addons/australia-cgt-addon/src/lib/export-csv.ts
@@ -1,0 +1,14 @@
+import { exportReportCsv, type CgtReport } from "./cgt-engine";
+
+export function downloadCsv(report: CgtReport) {
+  const csv = exportReportCsv(report);
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = "wealthfolio-australia-cgt-report.csv";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}

--- a/addons/australia-cgt-addon/src/lib/format.ts
+++ b/addons/australia-cgt-addon/src/lib/format.ts
@@ -1,0 +1,7 @@
+export function formatAud(value: number) {
+  return new Intl.NumberFormat("en-AU", {
+    style: "currency",
+    currency: "AUD",
+    maximumFractionDigits: 0,
+  }).format(value);
+}

--- a/addons/australia-cgt-addon/src/lib/parcel-options.ts
+++ b/addons/australia-cgt-addon/src/lib/parcel-options.ts
@@ -1,0 +1,55 @@
+import type { CgtReport, HoldingParcel } from "./cgt-engine";
+
+export function holdingKeyForParcel(parcel: Pick<HoldingParcel, "symbol" | "account"> | undefined) {
+  return parcel ? `${parcel.symbol}:${parcel.account}` : "";
+}
+
+export function findParcelContext(
+  parcelId: string,
+  parcels: HoldingParcel[],
+  report: CgtReport,
+) {
+  return (
+    parcels.find((parcel) => parcel.parcelId === parcelId) ??
+    report.closedLots.find((lot) => lot.parcelId === parcelId)
+  );
+}
+
+export function findOpenParcelContext(parcelId: string, parcels: HoldingParcel[]) {
+  return parcels.find((parcel) => parcel.parcelId === parcelId && parcel.quantity > 0);
+}
+
+function sortParcelOptions(parcels: HoldingParcel[]): HoldingParcel[] {
+  return [...parcels].sort((a, b) =>
+    `${a.symbol}:${a.account}:${a.parcelId}`.localeCompare(
+      `${b.symbol}:${b.account}:${b.parcelId}`,
+    ),
+  );
+}
+
+export function buildAllParcelOptions(
+  parcels: HoldingParcel[],
+  report: CgtReport,
+): HoldingParcel[] {
+  const byId = new Map<string, HoldingParcel>();
+  for (const parcel of parcels) {
+    byId.set(parcel.parcelId, parcel);
+  }
+  for (const lot of report.closedLots) {
+    if (!byId.has(lot.parcelId)) {
+      byId.set(lot.parcelId, {
+        parcelId: lot.parcelId,
+        symbol: lot.symbol,
+        account: lot.account,
+        acquisitionDate: lot.acquisitionDate,
+        quantity: lot.quantity,
+        costBase: lot.costBase,
+      });
+    }
+  }
+  return sortParcelOptions([...byId.values()]);
+}
+
+export function buildOpenParcelOptions(parcels: HoldingParcel[]): HoldingParcel[] {
+  return sortParcelOptions(parcels.filter((parcel) => parcel.quantity > 0));
+}

--- a/addons/australia-cgt-addon/src/lib/tax-data.ts
+++ b/addons/australia-cgt-addon/src/lib/tax-data.ts
@@ -1,0 +1,260 @@
+export interface AmmaStatement {
+  id: string;
+  holdingKey: string;
+  parcelId?: string;
+  incomeYear: string;
+  taxableIncome: number;
+  cashDistribution: number;
+  frankingCredits: number;
+  amitCostBaseIncrease: number;
+  amitCostBaseDecrease: number;
+  notes?: string;
+}
+
+export interface CpiObservation {
+  quarter: string;
+  value: number;
+  source: "ABS" | "MANUAL";
+  fetchedAt: string;
+}
+
+export interface TransitionMarketValueSnapshot {
+  parcelId: string;
+  symbol: string;
+  account: string;
+  acquisitionDate: string;
+  quantity: number;
+  marketValueAt2027: number;
+  valuationMethod: "quoted-market" | "manual" | "apportionment";
+  notes?: string;
+}
+
+export interface AmitCostBaseAdjustment {
+  parcelId: string;
+  incomeYear: string;
+  amount: number;
+  sourceStatementId?: string;
+}
+
+export interface ParcelAcquisitionOverride {
+  parcelId: string;
+  symbol: string;
+  account: string;
+  acquisitionDate: string;
+  quantity?: number;
+  costBase?: number;
+  source: "holding-lot" | "manual";
+}
+
+export interface AustraliaCgtAddonData {
+  ammaStatements: AmmaStatement[];
+  cpiSeries: CpiObservation[];
+  transitionSnapshots: TransitionMarketValueSnapshot[];
+  amitAdjustments: AmitCostBaseAdjustment[];
+  acquisitionOverrides: ParcelAcquisitionOverride[];
+}
+
+interface StoredAustraliaCgtAddonData {
+  version: number;
+  payload: Partial<AustraliaCgtAddonData>;
+}
+
+export interface AddonTaxDataStore {
+  load(): AustraliaCgtAddonData;
+  save(data: AustraliaCgtAddonData): void;
+  clear(): void;
+}
+
+export interface KeyValueStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+export const FRANKING_PERCENTAGE_METADATA_KEY = "australiaCgt.frankingPercentage";
+export const DEFAULT_ABS_QUARTERLY_CPI_URL =
+  "https://data.api.abs.gov.au/rest/data/ABS,CPI_Q/1.999901.20.50.Q?lastNObservations=80&format=csv";
+
+const STORAGE_VERSION = 1;
+
+export function emptyAustraliaCgtAddonData(): AustraliaCgtAddonData {
+  return {
+    ammaStatements: [],
+    cpiSeries: [],
+    transitionSnapshots: [],
+    amitAdjustments: [],
+    acquisitionOverrides: [],
+  };
+}
+
+export function createMemoryStorage(initial: Record<string, string> = {}): KeyValueStorage {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => {
+      values.set(key, value);
+    },
+    removeItem: (key) => {
+      values.delete(key);
+    },
+  };
+}
+
+export function createAustraliaCgtAddonStore(
+  storage: KeyValueStorage | undefined = globalThis.localStorage,
+  namespace = "australia-cgt-addon",
+): AddonTaxDataStore {
+  const storageKey = `${namespace}:tax-data:v${STORAGE_VERSION}`;
+
+  return {
+    load() {
+      if (!storage) return emptyAustraliaCgtAddonData();
+      const raw = storage.getItem(storageKey);
+      if (!raw) return emptyAustraliaCgtAddonData();
+
+      try {
+        const parsed = JSON.parse(raw) as
+          | Partial<AustraliaCgtAddonData>
+          | StoredAustraliaCgtAddonData;
+        const payload =
+          "payload" in parsed && typeof parsed.version === "number" ? parsed.payload : parsed;
+        return {
+          ...emptyAustraliaCgtAddonData(),
+          ...payload,
+        };
+      } catch {
+        return emptyAustraliaCgtAddonData();
+      }
+    },
+    save(data) {
+      storage?.setItem(storageKey, JSON.stringify({ version: STORAGE_VERSION, payload: data }));
+    },
+    clear() {
+      storage?.removeItem(storageKey);
+    },
+  };
+}
+
+export function upsertById<T extends { id: string }>(items: T[], item: T): T[] {
+  const existingIndex = items.findIndex((candidate) => candidate.id === item.id);
+  if (existingIndex === -1) return [...items, item];
+  return items.map((candidate, index) => (index === existingIndex ? item : candidate));
+}
+
+export function buildAmitAdjustmentsFromAmma(
+  statements: AmmaStatement[],
+): AmitCostBaseAdjustment[] {
+  return statements
+    .map((statement) => ({
+      parcelId: statement.parcelId ?? statement.holdingKey,
+      incomeYear: statement.incomeYear,
+      amount: statement.amitCostBaseIncrease - statement.amitCostBaseDecrease,
+      sourceStatementId: statement.id,
+    }))
+    .filter((adjustment) => adjustment.amount !== 0);
+}
+
+export function getFrankingPercentage(
+  metadata: Record<string, unknown> | undefined,
+): number | null {
+  const value = metadata?.[FRANKING_PERCENTAGE_METADATA_KEY];
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+export function withFrankingPercentageMetadata(
+  metadata: Record<string, unknown> | undefined,
+  frankingPercentage: number,
+): Record<string, unknown> {
+  return {
+    ...(metadata ?? {}),
+    [FRANKING_PERCENTAGE_METADATA_KEY]: frankingPercentage,
+  };
+}
+
+function cpiQuarterSortKey(quarter: string): number {
+  const match = /(\d{4})-Q([1-4])/.exec(quarter);
+  if (!match) return 0;
+  return Number(match[1]) * 10 + Number(match[2]);
+}
+
+export function calculateCpiIndexationFactor(
+  series: CpiObservation[],
+  startQuarter: string,
+  endQuarter: string,
+): number {
+  const byQuarter = new Map(series.map((entry) => [entry.quarter, entry.value]));
+  const startValue = byQuarter.get(startQuarter);
+  const endValue = byQuarter.get(endQuarter);
+  if (!startValue || !endValue || startValue <= 0) {
+    throw new Error(`Missing CPI values for ${startQuarter} to ${endQuarter}`);
+  }
+  return endValue / startValue;
+}
+
+export function mergeCpiSeries(
+  existing: CpiObservation[],
+  incoming: CpiObservation[],
+): CpiObservation[] {
+  const byQuarter = new Map(existing.map((entry) => [entry.quarter, entry]));
+  for (const entry of incoming) {
+    byQuarter.set(entry.quarter, entry);
+  }
+  return [...byQuarter.values()].sort(
+    (a, b) => cpiQuarterSortKey(a.quarter) - cpiQuarterSortKey(b.quarter),
+  );
+}
+
+export function parseAbsCpiCsv(csv: string, fetchedAt: string): CpiObservation[] {
+  const [headerLine, ...lines] = csv.trim().split(/\r?\n/);
+  if (!headerLine) return [];
+  const headers = headerLine.split(",").map((header) => header.trim().toLowerCase());
+  const quarterIndex = headers.findIndex((header) =>
+    ["quarter", "period", "time_period"].includes(header),
+  );
+  const valueIndex = ["obs_value", "value", "cpi", "index"]
+    .map((candidate) => headers.indexOf(candidate))
+    .find((index) => index !== -1);
+  if (quarterIndex === -1 || valueIndex === undefined) return [];
+
+  return lines
+    .map((line) => line.split(",").map((value) => value.trim().replace(/^"|"$/g, "")))
+    .map((columns) => ({
+      quarter: columns[quarterIndex],
+      value: Number.parseFloat(columns[valueIndex]),
+      source: "ABS" as const,
+      fetchedAt,
+    }))
+    .filter((entry) => entry.quarter && Number.isFinite(entry.value));
+}
+
+export async function fetchAbsCpiSeries(
+  url = DEFAULT_ABS_QUARTERLY_CPI_URL,
+  fetcher: typeof fetch = fetch,
+  now = () => new Date().toISOString(),
+): Promise<CpiObservation[]> {
+  const response = await fetcher(url, {
+    headers: {
+      Accept: "text/csv, application/vnd.sdmx.data+csv",
+    },
+  });
+  if (!response.ok) {
+    throw new Error(`ABS CPI fetch failed with status ${response.status}`);
+  }
+  return parseAbsCpiCsv(await response.text(), now());
+}
+
+export async function refreshCachedAbsCpiSeries(
+  data: AustraliaCgtAddonData,
+  fetcher: typeof fetch = fetch,
+): Promise<AustraliaCgtAddonData> {
+  const incoming = await fetchAbsCpiSeries(DEFAULT_ABS_QUARTERLY_CPI_URL, fetcher);
+  return {
+    ...data,
+    cpiSeries: mergeCpiSeries(data.cpiSeries, incoming),
+  };
+}

--- a/addons/australia-cgt-addon/src/pages/australia-cgt-page.tsx
+++ b/addons/australia-cgt-addon/src/pages/australia-cgt-page.tsx
@@ -25,7 +25,6 @@ import {
 } from "../lib/parcel-options";
 import {
   buildAmitAdjustmentsFromAmma,
-  mergeCpiSeries,
   refreshCachedAbsCpiSeries,
 } from "../lib/tax-data";
 
@@ -148,20 +147,6 @@ export function AustraliaCgtPage({ ctx }: { ctx: AddonContext }) {
     saveTaxData({
       ...taxData,
       cpiSeries: taxData.cpiSeries.filter((observation) => observation.quarter !== quarter),
-    });
-  };
-
-  const saveCpiSample = () => {
-    saveTaxData({
-      ...taxData,
-      cpiSeries: mergeCpiSeries(taxData.cpiSeries, [
-        {
-          quarter: "2027-Q3",
-          value: 120,
-          source: "MANUAL",
-          fetchedAt: new Date().toISOString(),
-        },
-      ]),
     });
   };
 
@@ -390,7 +375,6 @@ export function AustraliaCgtPage({ ctx }: { ctx: AddonContext }) {
                 cpiSeries={taxData.cpiSeries}
                 refreshError={cpiRefreshError}
                 onRefresh={refreshAbsCpi}
-                onSaveSample={saveCpiSample}
               />
               <TransitionSnapshotForm
                 account={snapshotAccount}

--- a/addons/australia-cgt-addon/src/pages/australia-cgt-page.tsx
+++ b/addons/australia-cgt-addon/src/pages/australia-cgt-page.tsx
@@ -1,6 +1,18 @@
 import type { AddonContext } from "@wealthfolio/addon-sdk";
 import { Button, Icons, Page, PageContent, PageHeader } from "@wealthfolio/ui";
 import { useState } from "react";
+import { AcquisitionOverrideForm } from "../components/acquisition-override-form";
+import { AmmaForm } from "../components/amma-form";
+import { CpiCachePanel } from "../components/cpi-cache-panel";
+import { DividendFrankingTable } from "../components/dividend-franking-table";
+import { HoldingParcelsTable } from "../components/holding-parcels-table";
+import { IncomeYearSummaryTable } from "../components/income-year-summary-table";
+import { MatchedLotsTable } from "../components/matched-lots-table";
+import { ReviewWarnings } from "../components/review-warnings";
+import { StoredTaxDataPanel } from "../components/stored-tax-data-panel";
+import { SummaryCards } from "../components/summary-cards";
+import { TransitionParcelsTable } from "../components/transition-parcels-table";
+import { TransitionSnapshotForm } from "../components/transition-snapshot-form";
 import { useAustraliaCgtReport } from "../hooks/use-australia-cgt-report";
 import { useAustraliaCgtTaxData } from "../hooks/use-australia-cgt-tax-data";
 import { calculateMinimumTaxTopUp } from "../lib/cgt-engine";
@@ -48,24 +60,21 @@ export function AustraliaCgtPage({ ctx }: { ctx: AddonContext }) {
     allParcelOptions,
     openParcelOptions,
   } = useAustraliaCgtReport(ctx, taxData);
+
+  const openSnapshotParcel = findOpenParcelContext(snapshotParcelId.trim(), holdingParcels);
+  const openOverrideParcel = findOpenParcelContext(overrideParcelId.trim(), holdingParcels);
   const canSaveAmma = ammaParcelId.trim().length > 0 && (ammaIncrease !== 0 || ammaDecrease !== 0);
   const canSaveSnapshot =
     snapshotParcelId.trim().length > 0 &&
-    (snapshotSymbol.trim().length > 0 ||
-      Boolean(findOpenParcelContext(snapshotParcelId.trim(), holdingParcels)?.symbol)) &&
-    (snapshotAccount.trim().length > 0 ||
-      Boolean(findOpenParcelContext(snapshotParcelId.trim(), holdingParcels)?.account)) &&
-    (snapshotAcquisitionDate.length > 0 ||
-      Boolean(findOpenParcelContext(snapshotParcelId.trim(), holdingParcels)?.acquisitionDate)) &&
-    (snapshotQuantity > 0 ||
-      (findOpenParcelContext(snapshotParcelId.trim(), holdingParcels)?.quantity ?? 0) > 0) &&
+    (snapshotSymbol.trim().length > 0 || Boolean(openSnapshotParcel?.symbol)) &&
+    (snapshotAccount.trim().length > 0 || Boolean(openSnapshotParcel?.account)) &&
+    (snapshotAcquisitionDate.length > 0 || Boolean(openSnapshotParcel?.acquisitionDate)) &&
+    (snapshotQuantity > 0 || (openSnapshotParcel?.quantity ?? 0) > 0) &&
     snapshotValue > 0;
   const canSaveOverride =
     overrideParcelId.trim().length > 0 &&
-    (overrideSymbol.trim().length > 0 ||
-      Boolean(findOpenParcelContext(overrideParcelId.trim(), holdingParcels)?.symbol)) &&
-    (overrideAccount.trim().length > 0 ||
-      Boolean(findOpenParcelContext(overrideParcelId.trim(), holdingParcels)?.account)) &&
+    (overrideSymbol.trim().length > 0 || Boolean(openOverrideParcel?.symbol)) &&
+    (overrideAccount.trim().length > 0 || Boolean(openOverrideParcel?.account)) &&
     overrideDate.length > 0;
 
   const fillSnapshotParcel = (parcelId: string) => {
@@ -292,87 +301,8 @@ export function AustraliaCgtPage({ ctx }: { ctx: AddonContext }) {
       {header}
       <PageContent>
         <div className="flex flex-col gap-6">
-          <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
-            <div className="rounded-md border p-4">
-              <p className="text-muted-foreground text-xs font-medium uppercase">Closed lots</p>
-              <p className="mt-2 text-2xl font-semibold">{report.closedLots.length}</p>
-            </div>
-            <div className="rounded-md border p-4">
-              <p className="text-muted-foreground text-xs font-medium uppercase">Proceeds</p>
-              <p className="mt-2 text-2xl font-semibold">
-                {formatAud(report.incomeYears.reduce((sum, year) => sum + year.proceeds, 0))}
-              </p>
-            </div>
-            <div className="rounded-md border p-4">
-              <p className="text-muted-foreground text-xs font-medium uppercase">Gross gains</p>
-              <p className="mt-2 text-2xl font-semibold">
-                {formatAud(report.incomeYears.reduce((sum, year) => sum + year.grossGain, 0))}
-              </p>
-            </div>
-            <div className="rounded-md border p-4">
-              <p className="text-muted-foreground text-xs font-medium uppercase">Losses applied</p>
-              <p className="mt-2 text-2xl font-semibold">
-                {formatAud(
-                  report.incomeYears.reduce((sum, year) => sum + year.capitalLossesApplied, 0),
-                )}
-              </p>
-            </div>
-            <div className="rounded-md border p-4">
-              <p className="text-muted-foreground text-xs font-medium uppercase">Taxable gains</p>
-              <p className="mt-2 text-2xl font-semibold">
-                {formatAud(report.incomeYears.reduce((sum, year) => sum + year.taxableGain, 0))}
-              </p>
-            </div>
-          </section>
-
-          {report.unmatchedSells.length > 0 ? (
-            <section className="rounded-md border border-amber-300 bg-amber-50 p-4 text-sm text-amber-950 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-100">
-              <div className="flex items-start gap-3">
-                <Icons.AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
-                <div>
-                  <h2 className="font-semibold">Unmatched sells need review</h2>
-                  <p className="mt-1">
-                    {report.unmatchedSells.length} disposal
-                    {report.unmatchedSells.length === 1 ? "" : "s"} could not be fully matched to
-                    earlier buy lots. Totals exclude the unmatched quantity until the missing
-                    acquisition history is added.
-                  </p>
-                </div>
-              </div>
-            </section>
-          ) : null}
-
-          {report.unsupportedActivities.length > 0 ? (
-            <section className="rounded-md border border-red-300 bg-red-50 p-4 text-sm text-red-950 dark:border-red-700 dark:bg-red-950 dark:text-red-100">
-              <div className="flex items-start gap-3">
-                <Icons.AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
-                <div>
-                  <h2 className="font-semibold">Non-AUD activities excluded</h2>
-                  <p className="mt-1">
-                    {report.unsupportedActivities.length} BUY/SELL activit
-                    {report.unsupportedActivities.length === 1 ? "y was" : "ies were"} excluded
-                    because this addon does not convert foreign-currency CGT amounts to AUD yet.
-                  </p>
-                </div>
-              </div>
-            </section>
-          ) : null}
-
-          {report.ignoredActivities.length > 0 ? (
-            <section className="rounded-md border border-slate-300 bg-slate-50 p-4 text-sm text-slate-950 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100">
-              <div className="flex items-start gap-3">
-                <Icons.AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
-                <div>
-                  <h2 className="font-semibold">Some activity types are not modelled</h2>
-                  <p className="mt-1">
-                    {report.ignoredActivities.length} non-BUY/SELL activit
-                    {report.ignoredActivities.length === 1 ? "y is" : "ies are"} not included in CGT
-                    lot matching. Review transfers, splits, and corporate actions manually.
-                  </p>
-                </div>
-              </div>
-            </section>
-          ) : null}
+          <SummaryCards report={report} />
+          <ReviewWarnings report={report} />
 
           <section className="rounded-md border p-4">
             <div className="mb-4 flex flex-col gap-1">
@@ -438,570 +368,77 @@ export function AustraliaCgtPage({ ctx }: { ctx: AddonContext }) {
               ))}
             </datalist>
             <div className="grid gap-4 lg:grid-cols-2">
-              <div className="rounded-md bg-slate-50 p-3 text-sm dark:bg-slate-900">
-                <h3 className="font-medium">AMMA / AMIT</h3>
-                <p className="text-muted-foreground mt-1 text-xs">
-                  Choose a parcel from the matched lots or holding parcels below, then enter the
-                  AMIT cost-base movement from the AMMA statement.
-                </p>
-                <div className="mt-3 grid gap-2 sm:grid-cols-2">
-                  <input
-                    aria-label="AMMA parcel ID"
-                    className="rounded-md border bg-transparent px-3 py-2"
-                    list="australia-cgt-all-parcels"
-                    placeholder="Parcel ID"
-                    value={ammaParcelId}
-                    onChange={(event) => setAmmaParcelId(event.target.value)}
-                  />
-                  <input
-                    aria-label="AMMA income year"
-                    className="rounded-md border bg-transparent px-3 py-2"
-                    value={ammaIncomeYear}
-                    onChange={(event) => setAmmaIncomeYear(event.target.value)}
-                  />
-                  <input
-                    aria-label="AMMA taxable income"
-                    className="rounded-md border bg-transparent px-3 py-2"
-                    inputMode="decimal"
-                    type="number"
-                    value={ammaTaxableIncome}
-                    onChange={(event) => setAmmaTaxableIncome(Number(event.target.value))}
-                  />
-                  <input
-                    aria-label="AMMA cash distribution"
-                    className="rounded-md border bg-transparent px-3 py-2"
-                    inputMode="decimal"
-                    type="number"
-                    value={ammaCashDistribution}
-                    onChange={(event) => setAmmaCashDistribution(Number(event.target.value))}
-                  />
-                  <input
-                    aria-label="AMMA franking credits"
-                    className="rounded-md border bg-transparent px-3 py-2"
-                    inputMode="decimal"
-                    type="number"
-                    value={ammaFrankingCredits}
-                    onChange={(event) => setAmmaFrankingCredits(Number(event.target.value))}
-                  />
-                  <input
-                    aria-label="AMIT cost base increase"
-                    className="rounded-md border bg-transparent px-3 py-2"
-                    inputMode="decimal"
-                    type="number"
-                    value={ammaIncrease}
-                    onChange={(event) => setAmmaIncrease(Number(event.target.value))}
-                  />
-                  <input
-                    aria-label="AMIT cost base decrease"
-                    className="rounded-md border bg-transparent px-3 py-2"
-                    inputMode="decimal"
-                    type="number"
-                    value={ammaDecrease}
-                    onChange={(event) => setAmmaDecrease(Number(event.target.value))}
-                  />
-                </div>
-                <Button
-                  className="mt-3"
-                  disabled={!canSaveAmma}
-                  onClick={saveAmmaStatement}
-                  variant="outline"
-                >
-                  Save AMMA statement
-                </Button>
-              </div>
-
-              <div className="rounded-md bg-slate-50 p-3 text-sm dark:bg-slate-900">
-                <h3 className="font-medium">CPI Cache</h3>
-                <p className="text-muted-foreground mt-2">
-                  Cached observations: {taxData.cpiSeries.length}
-                </p>
-                <div className="mt-3 flex flex-wrap gap-2">
-                  <Button onClick={refreshAbsCpi} variant="outline">
-                    Refresh ABS CPI
-                  </Button>
-                  <Button onClick={saveCpiSample} variant="ghost">
-                    Insert demo CPI row
-                  </Button>
-                </div>
-                <p className="text-muted-foreground mt-2 text-xs">
-                  Demo CPI is synthetic test data. Use Refresh ABS CPI for real cache values.
-                </p>
-                {cpiRefreshError ? (
-                  <p className="text-destructive mt-2">{cpiRefreshError}</p>
-                ) : null}
-              </div>
-
-              <div className="rounded-md bg-slate-50 p-3 text-sm dark:bg-slate-900">
-                <h3 className="font-medium">30 June 2027 Parcel Value</h3>
-                <p className="text-muted-foreground mt-1 text-xs">
-                  Selecting a known parcel fills symbol, account, acquired date, and quantity; edit
-                  them only when the parcel was aggregated outside Wealthfolio.
-                </p>
-                <div className="mt-3 grid gap-2 sm:grid-cols-2">
-                  <input
-                    aria-label="Snapshot parcel ID"
-                    className="rounded-md border bg-transparent px-3 py-2"
-                    list="australia-cgt-open-parcels"
-                    placeholder="Parcel ID"
-                    value={snapshotParcelId}
-                    onChange={(event) => fillSnapshotParcel(event.target.value)}
-                  />
-                  <input
-                    aria-label="Snapshot symbol"
-                    className="rounded-md border bg-transparent px-3 py-2"
-                    placeholder="Symbol"
-                    value={snapshotSymbol}
-                    onChange={(event) => setSnapshotSymbol(event.target.value)}
-                  />
-                  <input
-                    aria-label="Snapshot account"
-                    className="rounded-md border bg-transparent px-3 py-2"
-                    placeholder="Account"
-                    value={snapshotAccount}
-                    onChange={(event) => setSnapshotAccount(event.target.value)}
-                  />
-                  <input
-                    aria-label="Snapshot acquisition date"
-                    className="rounded-md border bg-transparent px-3 py-2"
-                    type="date"
-                    value={snapshotAcquisitionDate}
-                    onChange={(event) => setSnapshotAcquisitionDate(event.target.value)}
-                  />
-                  <input
-                    aria-label="Snapshot quantity"
-                    className="rounded-md border bg-transparent px-3 py-2"
-                    inputMode="decimal"
-                    type="number"
-                    value={snapshotQuantity}
-                    onChange={(event) => setSnapshotQuantity(Number(event.target.value))}
-                  />
-                  <input
-                    aria-label="Snapshot market value"
-                    className="rounded-md border bg-transparent px-3 py-2"
-                    inputMode="decimal"
-                    type="number"
-                    value={snapshotValue}
-                    onChange={(event) => setSnapshotValue(Number(event.target.value))}
-                  />
-                </div>
-                <Button
-                  className="mt-3"
-                  disabled={!canSaveSnapshot}
-                  onClick={saveTransitionSnapshot}
-                  variant="outline"
-                >
-                  Save 2027 snapshot
-                </Button>
-              </div>
-
-              <div className="rounded-md bg-slate-50 p-3 text-sm dark:bg-slate-900">
-                <h3 className="font-medium">Aggregated Holding Acquisition</h3>
-                <p className="text-muted-foreground mt-1 text-xs">
-                  Use this when Wealthfolio has a holding but not the original parcel acquisition
-                  date. A selected parcel fills the matching symbol and account.
-                </p>
-                <div className="mt-3 grid gap-2 sm:grid-cols-2">
-                  <input
-                    aria-label="Override parcel ID"
-                    className="rounded-md border bg-transparent px-3 py-2"
-                    list="australia-cgt-open-parcels"
-                    placeholder="Parcel ID"
-                    value={overrideParcelId}
-                    onChange={(event) => fillOverrideParcel(event.target.value)}
-                  />
-                  <input
-                    aria-label="Override symbol"
-                    className="rounded-md border bg-transparent px-3 py-2"
-                    placeholder="Symbol"
-                    value={overrideSymbol}
-                    onChange={(event) => setOverrideSymbol(event.target.value)}
-                  />
-                  <input
-                    aria-label="Override account"
-                    className="rounded-md border bg-transparent px-3 py-2"
-                    placeholder="Account"
-                    value={overrideAccount}
-                    onChange={(event) => setOverrideAccount(event.target.value)}
-                  />
-                  <input
-                    aria-label="Override acquisition date"
-                    className="rounded-md border bg-transparent px-3 py-2"
-                    type="date"
-                    value={overrideDate}
-                    onChange={(event) => setOverrideDate(event.target.value)}
-                  />
-                </div>
-                <Button
-                  className="mt-3"
-                  disabled={!canSaveOverride}
-                  onClick={saveAcquisitionOverride}
-                  variant="outline"
-                >
-                  Save acquisition date
-                </Button>
-              </div>
+              <AmmaForm
+                canSave={canSaveAmma}
+                cashDistribution={ammaCashDistribution}
+                decrease={ammaDecrease}
+                frankingCredits={ammaFrankingCredits}
+                incomeYear={ammaIncomeYear}
+                increase={ammaIncrease}
+                parcelId={ammaParcelId}
+                taxableIncome={ammaTaxableIncome}
+                onCashDistributionChange={setAmmaCashDistribution}
+                onDecreaseChange={setAmmaDecrease}
+                onFrankingCreditsChange={setAmmaFrankingCredits}
+                onIncomeYearChange={setAmmaIncomeYear}
+                onIncreaseChange={setAmmaIncrease}
+                onParcelIdChange={setAmmaParcelId}
+                onSave={saveAmmaStatement}
+                onTaxableIncomeChange={setAmmaTaxableIncome}
+              />
+              <CpiCachePanel
+                cpiSeries={taxData.cpiSeries}
+                refreshError={cpiRefreshError}
+                onRefresh={refreshAbsCpi}
+                onSaveSample={saveCpiSample}
+              />
+              <TransitionSnapshotForm
+                account={snapshotAccount}
+                acquisitionDate={snapshotAcquisitionDate}
+                canSave={canSaveSnapshot}
+                marketValue={snapshotValue}
+                parcelId={snapshotParcelId}
+                quantity={snapshotQuantity}
+                symbol={snapshotSymbol}
+                onAccountChange={setSnapshotAccount}
+                onAcquisitionDateChange={setSnapshotAcquisitionDate}
+                onMarketValueChange={setSnapshotValue}
+                onParcelIdChange={fillSnapshotParcel}
+                onQuantityChange={setSnapshotQuantity}
+                onSave={saveTransitionSnapshot}
+                onSymbolChange={setSnapshotSymbol}
+              />
+              <AcquisitionOverrideForm
+                account={overrideAccount}
+                acquisitionDate={overrideDate}
+                canSave={canSaveOverride}
+                parcelId={overrideParcelId}
+                symbol={overrideSymbol}
+                onAccountChange={setOverrideAccount}
+                onAcquisitionDateChange={setOverrideDate}
+                onParcelIdChange={fillOverrideParcel}
+                onSave={saveAcquisitionOverride}
+                onSymbolChange={setOverrideSymbol}
+              />
             </div>
-            <div className="mt-4 flex flex-wrap gap-3 text-sm">
-              <span>AMMA statements: {taxData.ammaStatements.length}</span>
-              <span>AMIT adjustments: {taxData.amitAdjustments.length}</span>
-              <span>2027 snapshots: {taxData.transitionSnapshots.length}</span>
-              <span>Acquisition overrides: {taxData.acquisitionOverrides.length}</span>
-              <Button onClick={clearTaxData} size="sm" variant="ghost">
-                Clear local tax data
-              </Button>
-            </div>
-            <div className="mt-4 grid gap-3 lg:grid-cols-2">
-              <div className="bg-background rounded-md border p-3">
-                <h3 className="text-sm font-medium">Stored AMMA statements</h3>
-                <div className="mt-2 divide-y text-sm">
-                  {taxData.ammaStatements.map((statement) => (
-                    <div
-                      key={statement.id}
-                      className="flex items-center justify-between gap-3 py-2"
-                    >
-                      <div>
-                        <p className="font-medium">
-                          {statement.parcelId ?? statement.holdingKey} · {statement.incomeYear}
-                        </p>
-                        <p className="text-muted-foreground text-xs">
-                          Taxable {formatAud(statement.taxableIncome)} · Cash{" "}
-                          {formatAud(statement.cashDistribution)} · Franking{" "}
-                          {formatAud(statement.frankingCredits)} · AMIT{" "}
-                          {formatAud(
-                            statement.amitCostBaseIncrease - statement.amitCostBaseDecrease,
-                          )}
-                        </p>
-                      </div>
-                      <Button
-                        aria-label={`Delete AMMA ${statement.id}`}
-                        onClick={() => deleteAmmaStatement(statement.id)}
-                        size="sm"
-                        variant="ghost"
-                      >
-                        Delete
-                      </Button>
-                    </div>
-                  ))}
-                  {taxData.ammaStatements.length === 0 ? (
-                    <p className="text-muted-foreground py-2 text-xs">No AMMA statements saved.</p>
-                  ) : null}
-                </div>
-              </div>
-
-              <div className="bg-background rounded-md border p-3">
-                <h3 className="text-sm font-medium">Stored CPI observations</h3>
-                <div className="mt-2 divide-y text-sm">
-                  {taxData.cpiSeries.map((observation) => (
-                    <div
-                      key={observation.quarter}
-                      className="flex items-center justify-between gap-3 py-2"
-                    >
-                      <p>
-                        {observation.quarter} · {observation.value} · {observation.source}
-                      </p>
-                      <Button
-                        aria-label={`Delete CPI ${observation.quarter}`}
-                        onClick={() => deleteCpiObservation(observation.quarter)}
-                        size="sm"
-                        variant="ghost"
-                      >
-                        Delete
-                      </Button>
-                    </div>
-                  ))}
-                  {taxData.cpiSeries.length === 0 ? (
-                    <p className="text-muted-foreground py-2 text-xs">No CPI observations saved.</p>
-                  ) : null}
-                </div>
-              </div>
-
-              <div className="bg-background rounded-md border p-3">
-                <h3 className="text-sm font-medium">Stored 2027 snapshots</h3>
-                <div className="mt-2 divide-y text-sm">
-                  {taxData.transitionSnapshots.map((snapshot) => (
-                    <div
-                      key={snapshot.parcelId}
-                      className="flex items-center justify-between gap-3 py-2"
-                    >
-                      <div>
-                        <p className="font-medium">{snapshot.parcelId}</p>
-                        <p className="text-muted-foreground text-xs">
-                          {snapshot.symbol} · {snapshot.account} ·{" "}
-                          {formatAud(snapshot.marketValueAt2027)}
-                        </p>
-                      </div>
-                      <Button
-                        aria-label={`Delete snapshot ${snapshot.parcelId}`}
-                        onClick={() => deleteTransitionSnapshot(snapshot.parcelId)}
-                        size="sm"
-                        variant="ghost"
-                      >
-                        Delete
-                      </Button>
-                    </div>
-                  ))}
-                  {taxData.transitionSnapshots.length === 0 ? (
-                    <p className="text-muted-foreground py-2 text-xs">No snapshots saved.</p>
-                  ) : null}
-                </div>
-              </div>
-
-              <div className="bg-background rounded-md border p-3">
-                <h3 className="text-sm font-medium">Stored acquisition overrides</h3>
-                <div className="mt-2 divide-y text-sm">
-                  {taxData.acquisitionOverrides.map((override) => (
-                    <div
-                      key={override.parcelId}
-                      className="flex items-center justify-between gap-3 py-2"
-                    >
-                      <div>
-                        <p className="font-medium">{override.parcelId}</p>
-                        <p className="text-muted-foreground text-xs">
-                          {override.symbol} · {override.account} · {override.acquisitionDate}
-                        </p>
-                      </div>
-                      <Button
-                        aria-label={`Delete acquisition override ${override.parcelId}`}
-                        onClick={() => deleteAcquisitionOverride(override.parcelId)}
-                        size="sm"
-                        variant="ghost"
-                      >
-                        Delete
-                      </Button>
-                    </div>
-                  ))}
-                  {taxData.acquisitionOverrides.length === 0 ? (
-                    <p className="text-muted-foreground py-2 text-xs">
-                      No acquisition overrides saved.
-                    </p>
-                  ) : null}
-                </div>
-              </div>
-            </div>
+            <StoredTaxDataPanel
+              taxData={taxData}
+              onClear={clearTaxData}
+              onDeleteAcquisitionOverride={deleteAcquisitionOverride}
+              onDeleteAmma={deleteAmmaStatement}
+              onDeleteCpi={deleteCpiObservation}
+              onDeleteSnapshot={deleteTransitionSnapshot}
+            />
           </section>
 
-          <section className="rounded-md border">
-            <div className="border-b p-4">
-              <h2 className="text-base font-semibold">Income Year Summary</h2>
-            </div>
-            <div className="overflow-x-auto">
-              <table className="w-full min-w-[760px] text-sm">
-                <thead className="bg-muted/40 text-muted-foreground text-left">
-                  <tr>
-                    <th className="px-4 py-3 font-medium">Income year</th>
-                    <th className="px-4 py-3 text-right font-medium">Proceeds</th>
-                    <th className="px-4 py-3 text-right font-medium">Cost base</th>
-                    <th className="px-4 py-3 text-right font-medium">Gross gain</th>
-                    <th className="px-4 py-3 text-right font-medium">Losses applied</th>
-                    <th className="px-4 py-3 text-right font-medium">Loss carry-forward</th>
-                    <th className="px-4 py-3 text-right font-medium">Discount</th>
-                    <th className="px-4 py-3 text-right font-medium">Taxable gain</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {report.incomeYears.map((year) => (
-                    <tr key={year.incomeYear} className="border-t">
-                      <td className="px-4 py-3 font-medium">{year.incomeYear}</td>
-                      <td className="px-4 py-3 text-right">{formatAud(year.proceeds)}</td>
-                      <td className="px-4 py-3 text-right">{formatAud(year.costBase)}</td>
-                      <td className="px-4 py-3 text-right">{formatAud(year.grossGain)}</td>
-                      <td className="px-4 py-3 text-right">
-                        {formatAud(year.capitalLossesApplied)}
-                      </td>
-                      <td className="px-4 py-3 text-right">
-                        {formatAud(year.capitalLossCarryForward)}
-                      </td>
-                      <td className="px-4 py-3 text-right">{formatAud(year.discountApplied)}</td>
-                      <td className="px-4 py-3 text-right">{formatAud(year.taxableGain)}</td>
-                    </tr>
-                  ))}
-                  {report.incomeYears.length === 0 ? (
-                    <tr>
-                      <td className="text-muted-foreground px-4 py-8 text-center" colSpan={8}>
-                        No matched BUY/SELL lots found yet.
-                      </td>
-                    </tr>
-                  ) : null}
-                </tbody>
-              </table>
-            </div>
-          </section>
-
-          <section className="rounded-md border">
-            <div className="border-b p-4">
-              <h2 className="text-base font-semibold">2027 Transition Parcels</h2>
-            </div>
-            <div className="overflow-x-auto">
-              <table className="w-full min-w-[720px] text-sm">
-                <thead className="bg-muted/40 text-muted-foreground text-left">
-                  <tr>
-                    <th className="px-4 py-3 font-medium">Parcel</th>
-                    <th className="px-4 py-3 font-medium">Symbol</th>
-                    <th className="px-4 py-3 text-right font-medium">Quantity</th>
-                    <th className="px-4 py-3 text-right font-medium">Cost base</th>
-                    <th className="px-4 py-3 text-right font-medium">2027 value</th>
-                    <th className="px-4 py-3 text-right font-medium">Pre-2027 taxable</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {report.transitionLots.map((lot) => (
-                    <tr key={lot.parcelId} className="border-t">
-                      <td className="px-4 py-3">{lot.parcelId}</td>
-                      <td className="px-4 py-3">{lot.symbol}</td>
-                      <td className="px-4 py-3 text-right">{lot.quantity}</td>
-                      <td className="px-4 py-3 text-right">{formatAud(lot.costBase)}</td>
-                      <td className="px-4 py-3 text-right">{formatAud(lot.marketValueAt2027)}</td>
-                      <td className="px-4 py-3 text-right">
-                        {formatAud(lot.preCommencementTaxableGain)}
-                      </td>
-                    </tr>
-                  ))}
-                  {report.transitionLots.length === 0 ? (
-                    <tr>
-                      <td className="text-muted-foreground px-4 py-8 text-center" colSpan={6}>
-                        No 2027 parcel snapshots saved yet.
-                      </td>
-                    </tr>
-                  ) : null}
-                </tbody>
-              </table>
-            </div>
-          </section>
-
-          <section className="rounded-md border">
-            <div className="border-b p-4">
-              <h2 className="text-base font-semibold">Dividend Franking Metadata</h2>
-            </div>
-            <div className="overflow-x-auto">
-              <table className="w-full min-w-[640px] text-sm">
-                <thead className="bg-muted/40 text-muted-foreground text-left">
-                  <tr>
-                    <th className="px-4 py-3 font-medium">Symbol</th>
-                    <th className="px-4 py-3 font-medium">Income year</th>
-                    <th className="px-4 py-3 text-right font-medium">Amount</th>
-                    <th className="px-4 py-3 text-right font-medium">Franking percent</th>
-                    <th className="px-4 py-3 text-right font-medium">Franked amount</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {report.dividends.map((dividend) => (
-                    <tr key={dividend.activityId} className="border-t">
-                      <td className="px-4 py-3">{dividend.symbol}</td>
-                      <td className="px-4 py-3">{dividend.incomeYear}</td>
-                      <td className="px-4 py-3 text-right">{formatAud(dividend.amount)}</td>
-                      <td className="px-4 py-3 text-right">
-                        {dividend.frankingPercentage === null
-                          ? "Missing"
-                          : `${dividend.frankingPercentage}%`}
-                      </td>
-                      <td className="px-4 py-3 text-right">
-                        {dividend.frankedAmount === null
-                          ? "Missing"
-                          : formatAud(dividend.frankedAmount)}
-                      </td>
-                    </tr>
-                  ))}
-                  {report.dividends.length === 0 ? (
-                    <tr>
-                      <td className="text-muted-foreground px-4 py-8 text-center" colSpan={5}>
-                        No dividend activities with franking metadata found.
-                      </td>
-                    </tr>
-                  ) : null}
-                </tbody>
-              </table>
-            </div>
-          </section>
-
-          <section className="rounded-md border">
-            <div className="border-b p-4">
-              <h2 className="text-base font-semibold">Holding Parcels</h2>
-            </div>
-            <div className="overflow-x-auto">
-              <table className="w-full min-w-[640px] text-sm">
-                <thead className="bg-muted/40 text-muted-foreground text-left">
-                  <tr>
-                    <th className="px-4 py-3 font-medium">Parcel</th>
-                    <th className="px-4 py-3 font-medium">Symbol</th>
-                    <th className="px-4 py-3 font-medium">Acquired</th>
-                    <th className="px-4 py-3 text-right font-medium">Quantity</th>
-                    <th className="px-4 py-3 text-right font-medium">Cost base</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {holdingParcels.map((parcel) => (
-                    <tr key={parcel.parcelId} className="border-t">
-                      <td className="px-4 py-3">{parcel.parcelId}</td>
-                      <td className="px-4 py-3">{parcel.symbol}</td>
-                      <td className="px-4 py-3">{parcel.acquisitionDate}</td>
-                      <td className="px-4 py-3 text-right">{parcel.quantity}</td>
-                      <td className="px-4 py-3 text-right">{formatAud(parcel.costBase)}</td>
-                    </tr>
-                  ))}
-                  {holdingParcels.length === 0 ? (
-                    <tr>
-                      <td className="text-muted-foreground px-4 py-8 text-center" colSpan={5}>
-                        {holdingsQuery.isLoading
-                          ? "Loading holding parcels..."
-                          : "No holdings found."}
-                      </td>
-                    </tr>
-                  ) : null}
-                </tbody>
-              </table>
-            </div>
-          </section>
-
-          <section className="rounded-md border">
-            <div className="border-b p-4">
-              <h2 className="text-base font-semibold">Matched Lots</h2>
-            </div>
-            <div className="overflow-x-auto">
-              <table className="w-full min-w-[920px] text-sm">
-                <thead className="bg-muted/40 text-muted-foreground text-left">
-                  <tr>
-                    <th className="px-4 py-3 font-medium">Symbol</th>
-                    <th className="px-4 py-3 font-medium">Account</th>
-                    <th className="px-4 py-3 text-right font-medium">Quantity</th>
-                    <th className="px-4 py-3 font-medium">Acquired</th>
-                    <th className="px-4 py-3 font-medium">Disposed</th>
-                    <th className="px-4 py-3 text-right font-medium">AMIT adj.</th>
-                    <th className="px-4 py-3 text-right font-medium">Gain</th>
-                    <th className="px-4 py-3 text-right font-medium">Discount</th>
-                    <th className="px-4 py-3 text-right font-medium">Taxable</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {report.closedLots.map((lot, index) => (
-                    <tr
-                      key={`${lot.symbol}-${lot.acquisitionDate}-${lot.disposalDate}-${index}`}
-                      className="border-t"
-                    >
-                      <td className="px-4 py-3 font-medium">{lot.symbol}</td>
-                      <td className="px-4 py-3">{lot.account}</td>
-                      <td className="px-4 py-3 text-right">{lot.quantity}</td>
-                      <td className="px-4 py-3">{lot.acquisitionDate}</td>
-                      <td className="px-4 py-3">{lot.disposalDate}</td>
-                      <td className="px-4 py-3 text-right">
-                        {formatAud(lot.amitCostBaseAdjustment)}
-                      </td>
-                      <td
-                        className={
-                          lot.grossGain < 0
-                            ? "px-4 py-3 text-right text-red-600"
-                            : "px-4 py-3 text-right"
-                        }
-                      >
-                        {formatAud(lot.grossGain)}
-                      </td>
-                      <td className="px-4 py-3 text-right">{formatAud(lot.discountApplied)}</td>
-                      <td className="px-4 py-3 text-right">{formatAud(lot.taxableGain)}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </section>
+          <IncomeYearSummaryTable report={report} />
+          <TransitionParcelsTable report={report} />
+          <DividendFrankingTable report={report} />
+          <HoldingParcelsTable
+            holdingParcels={holdingParcels}
+            isLoading={holdingsQuery.isLoading}
+          />
+          <MatchedLotsTable report={report} />
         </div>
       </PageContent>
     </Page>

--- a/addons/australia-cgt-addon/src/pages/australia-cgt-page.tsx
+++ b/addons/australia-cgt-addon/src/pages/australia-cgt-page.tsx
@@ -1,0 +1,1009 @@
+import type { AddonContext } from "@wealthfolio/addon-sdk";
+import { Button, Icons, Page, PageContent, PageHeader } from "@wealthfolio/ui";
+import { useState } from "react";
+import { useAustraliaCgtReport } from "../hooks/use-australia-cgt-report";
+import { useAustraliaCgtTaxData } from "../hooks/use-australia-cgt-tax-data";
+import { calculateMinimumTaxTopUp } from "../lib/cgt-engine";
+import { downloadCsv } from "../lib/export-csv";
+import { formatAud } from "../lib/format";
+import {
+  findOpenParcelContext,
+  findParcelContext,
+  holdingKeyForParcel,
+} from "../lib/parcel-options";
+import {
+  buildAmitAdjustmentsFromAmma,
+  mergeCpiSeries,
+  refreshCachedAbsCpiSeries,
+} from "../lib/tax-data";
+
+export function AustraliaCgtPage({ ctx }: { ctx: AddonContext }) {
+  const [ordinaryIncomeTaxOnGain, setOrdinaryIncomeTaxOnGain] = useState(1400);
+  const [minimumTaxExempt, setMinimumTaxExempt] = useState(false);
+  const { taxData, saveTaxData, clearTaxData } = useAustraliaCgtTaxData();
+  const [ammaParcelId, setAmmaParcelId] = useState("");
+  const [ammaIncomeYear, setAmmaIncomeYear] = useState("2026-27");
+  const [ammaTaxableIncome, setAmmaTaxableIncome] = useState(0);
+  const [ammaCashDistribution, setAmmaCashDistribution] = useState(0);
+  const [ammaFrankingCredits, setAmmaFrankingCredits] = useState(0);
+  const [ammaIncrease, setAmmaIncrease] = useState(0);
+  const [ammaDecrease, setAmmaDecrease] = useState(0);
+  const [snapshotParcelId, setSnapshotParcelId] = useState("");
+  const [snapshotSymbol, setSnapshotSymbol] = useState("");
+  const [snapshotAccount, setSnapshotAccount] = useState("");
+  const [snapshotAcquisitionDate, setSnapshotAcquisitionDate] = useState("");
+  const [snapshotQuantity, setSnapshotQuantity] = useState(0);
+  const [snapshotValue, setSnapshotValue] = useState(0);
+  const [overrideParcelId, setOverrideParcelId] = useState("");
+  const [overrideSymbol, setOverrideSymbol] = useState("");
+  const [overrideAccount, setOverrideAccount] = useState("");
+  const [overrideDate, setOverrideDate] = useState("2024-07-01");
+  const [cpiRefreshError, setCpiRefreshError] = useState<string | null>(null);
+
+  const {
+    activitiesQuery,
+    holdingsQuery,
+    report,
+    holdingParcels,
+    allParcelOptions,
+    openParcelOptions,
+  } = useAustraliaCgtReport(ctx, taxData);
+  const canSaveAmma = ammaParcelId.trim().length > 0 && (ammaIncrease !== 0 || ammaDecrease !== 0);
+  const canSaveSnapshot =
+    snapshotParcelId.trim().length > 0 &&
+    (snapshotSymbol.trim().length > 0 ||
+      Boolean(findOpenParcelContext(snapshotParcelId.trim(), holdingParcels)?.symbol)) &&
+    (snapshotAccount.trim().length > 0 ||
+      Boolean(findOpenParcelContext(snapshotParcelId.trim(), holdingParcels)?.account)) &&
+    (snapshotAcquisitionDate.length > 0 ||
+      Boolean(findOpenParcelContext(snapshotParcelId.trim(), holdingParcels)?.acquisitionDate)) &&
+    (snapshotQuantity > 0 ||
+      (findOpenParcelContext(snapshotParcelId.trim(), holdingParcels)?.quantity ?? 0) > 0) &&
+    snapshotValue > 0;
+  const canSaveOverride =
+    overrideParcelId.trim().length > 0 &&
+    (overrideSymbol.trim().length > 0 ||
+      Boolean(findOpenParcelContext(overrideParcelId.trim(), holdingParcels)?.symbol)) &&
+    (overrideAccount.trim().length > 0 ||
+      Boolean(findOpenParcelContext(overrideParcelId.trim(), holdingParcels)?.account)) &&
+    overrideDate.length > 0;
+
+  const fillSnapshotParcel = (parcelId: string) => {
+    setSnapshotParcelId(parcelId);
+    const parcel = findOpenParcelContext(parcelId.trim(), holdingParcels);
+    if (!parcel) {
+      setSnapshotSymbol("");
+      setSnapshotAccount("");
+      setSnapshotAcquisitionDate("");
+      setSnapshotQuantity(0);
+      return;
+    }
+    setSnapshotSymbol(parcel.symbol);
+    setSnapshotAccount(parcel.account);
+    setSnapshotAcquisitionDate(parcel.acquisitionDate);
+    setSnapshotQuantity(parcel.quantity);
+  };
+
+  const fillOverrideParcel = (parcelId: string) => {
+    setOverrideParcelId(parcelId);
+    const parcel = findOpenParcelContext(parcelId.trim(), holdingParcels);
+    if (!parcel) {
+      setOverrideSymbol("");
+      setOverrideAccount("");
+      return;
+    }
+    setOverrideSymbol(parcel.symbol);
+    setOverrideAccount(parcel.account);
+    setOverrideDate(parcel.acquisitionDate);
+  };
+
+  const saveAmmaStatement = () => {
+    const parcelId = ammaParcelId.trim();
+    if (!parcelId) return;
+    const parcel = findParcelContext(parcelId, holdingParcels, report);
+    const holdingKey = holdingKeyForParcel(parcel) || parcelId;
+    const statement = {
+      id: `${parcelId}:${ammaIncomeYear}`,
+      holdingKey,
+      parcelId,
+      incomeYear: ammaIncomeYear,
+      taxableIncome: ammaTaxableIncome,
+      cashDistribution: ammaCashDistribution,
+      frankingCredits: ammaFrankingCredits,
+      amitCostBaseIncrease: ammaIncrease,
+      amitCostBaseDecrease: ammaDecrease,
+    };
+    const ammaStatements = [
+      ...taxData.ammaStatements.filter((candidate) => candidate.id !== statement.id),
+      statement,
+    ];
+    saveTaxData({
+      ...taxData,
+      ammaStatements,
+      amitAdjustments: buildAmitAdjustmentsFromAmma(ammaStatements),
+    });
+  };
+
+  const deleteAmmaStatement = (statementId: string) => {
+    const ammaStatements = taxData.ammaStatements.filter(
+      (statement) => statement.id !== statementId,
+    );
+    saveTaxData({
+      ...taxData,
+      ammaStatements,
+      amitAdjustments: buildAmitAdjustmentsFromAmma(ammaStatements),
+    });
+  };
+
+  const deleteCpiObservation = (quarter: string) => {
+    saveTaxData({
+      ...taxData,
+      cpiSeries: taxData.cpiSeries.filter((observation) => observation.quarter !== quarter),
+    });
+  };
+
+  const saveCpiSample = () => {
+    saveTaxData({
+      ...taxData,
+      cpiSeries: mergeCpiSeries(taxData.cpiSeries, [
+        {
+          quarter: "2027-Q3",
+          value: 120,
+          source: "MANUAL",
+          fetchedAt: new Date().toISOString(),
+        },
+      ]),
+    });
+  };
+
+  const refreshAbsCpi = async () => {
+    setCpiRefreshError(null);
+    try {
+      saveTaxData(await refreshCachedAbsCpiSeries(taxData));
+    } catch (error) {
+      setCpiRefreshError(error instanceof Error ? error.message : "ABS CPI refresh failed");
+    }
+  };
+
+  const saveTransitionSnapshot = () => {
+    const parcelId = snapshotParcelId.trim();
+    if (!parcelId) return;
+    const parcel = findOpenParcelContext(parcelId, holdingParcels);
+    const snapshot = {
+      parcelId,
+      symbol: snapshotSymbol.trim() || parcel?.symbol || "",
+      account: snapshotAccount.trim() || parcel?.account || "",
+      acquisitionDate: snapshotAcquisitionDate || parcel?.acquisitionDate || "",
+      quantity: snapshotQuantity || parcel?.quantity || 0,
+      marketValueAt2027: snapshotValue,
+      valuationMethod: "manual" as const,
+    };
+    saveTaxData({
+      ...taxData,
+      transitionSnapshots: [
+        ...taxData.transitionSnapshots.filter(
+          (candidate) => candidate.parcelId !== snapshot.parcelId,
+        ),
+        snapshot,
+      ],
+    });
+  };
+
+  const deleteTransitionSnapshot = (parcelId: string) => {
+    saveTaxData({
+      ...taxData,
+      transitionSnapshots: taxData.transitionSnapshots.filter(
+        (snapshot) => snapshot.parcelId !== parcelId,
+      ),
+    });
+  };
+
+  const saveAcquisitionOverride = () => {
+    const parcelId = overrideParcelId.trim();
+    if (!parcelId) return;
+    const parcel = findOpenParcelContext(parcelId, holdingParcels);
+    const override = {
+      parcelId,
+      symbol: overrideSymbol.trim() || parcel?.symbol || "",
+      account: overrideAccount.trim() || parcel?.account || "",
+      acquisitionDate: overrideDate,
+      source: "manual" as const,
+    };
+    saveTaxData({
+      ...taxData,
+      acquisitionOverrides: [
+        ...taxData.acquisitionOverrides.filter(
+          (candidate) => candidate.parcelId !== override.parcelId,
+        ),
+        override,
+      ],
+    });
+  };
+
+  const deleteAcquisitionOverride = (parcelId: string) => {
+    saveTaxData({
+      ...taxData,
+      acquisitionOverrides: taxData.acquisitionOverrides.filter(
+        (override) => override.parcelId !== parcelId,
+      ),
+    });
+  };
+
+  const latestIncomeYear = report.incomeYears.at(-1);
+  const minimumTax = calculateMinimumTaxTopUp({
+    realCapitalGain: latestIncomeYear?.taxableGain ?? 0,
+    taxOnGainBeforeTopUp: ordinaryIncomeTaxOnGain,
+    receivesIncomeSupport: minimumTaxExempt,
+  });
+
+  const header = (
+    <PageHeader
+      actions={
+        <Button
+          disabled={report.closedLots.length === 0}
+          onClick={() => downloadCsv(report)}
+          variant="outline"
+        >
+          <Icons.Download className="mr-2 h-4 w-4" />
+          Export CSV
+        </Button>
+      }
+    >
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <Icons.Percent className="text-primary h-5 w-5" />
+          <h1 className="text-xl font-semibold">Australia CGT Planner</h1>
+        </div>
+        <p className="text-muted-foreground text-sm">
+          Planning estimates for simple AUD activity, with limitations surfaced for review.
+        </p>
+      </div>
+    </PageHeader>
+  );
+
+  if (activitiesQuery.isLoading) {
+    return (
+      <Page>
+        {header}
+        <PageContent>
+          <div className="flex min-h-[40vh] items-center justify-center">
+            <Icons.Loader className="text-primary h-8 w-8 animate-spin" />
+          </div>
+        </PageContent>
+      </Page>
+    );
+  }
+
+  if (activitiesQuery.error) {
+    return (
+      <Page>
+        {header}
+        <PageContent>
+          <div className="border-destructive/30 bg-destructive/10 text-destructive rounded-md border p-4 text-sm">
+            Failed to load Wealthfolio activities: {(activitiesQuery.error as Error).message}
+          </div>
+        </PageContent>
+      </Page>
+    );
+  }
+
+  return (
+    <Page>
+      {header}
+      <PageContent>
+        <div className="flex flex-col gap-6">
+          <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+            <div className="rounded-md border p-4">
+              <p className="text-muted-foreground text-xs font-medium uppercase">Closed lots</p>
+              <p className="mt-2 text-2xl font-semibold">{report.closedLots.length}</p>
+            </div>
+            <div className="rounded-md border p-4">
+              <p className="text-muted-foreground text-xs font-medium uppercase">Proceeds</p>
+              <p className="mt-2 text-2xl font-semibold">
+                {formatAud(report.incomeYears.reduce((sum, year) => sum + year.proceeds, 0))}
+              </p>
+            </div>
+            <div className="rounded-md border p-4">
+              <p className="text-muted-foreground text-xs font-medium uppercase">Gross gains</p>
+              <p className="mt-2 text-2xl font-semibold">
+                {formatAud(report.incomeYears.reduce((sum, year) => sum + year.grossGain, 0))}
+              </p>
+            </div>
+            <div className="rounded-md border p-4">
+              <p className="text-muted-foreground text-xs font-medium uppercase">Losses applied</p>
+              <p className="mt-2 text-2xl font-semibold">
+                {formatAud(
+                  report.incomeYears.reduce((sum, year) => sum + year.capitalLossesApplied, 0),
+                )}
+              </p>
+            </div>
+            <div className="rounded-md border p-4">
+              <p className="text-muted-foreground text-xs font-medium uppercase">Taxable gains</p>
+              <p className="mt-2 text-2xl font-semibold">
+                {formatAud(report.incomeYears.reduce((sum, year) => sum + year.taxableGain, 0))}
+              </p>
+            </div>
+          </section>
+
+          {report.unmatchedSells.length > 0 ? (
+            <section className="rounded-md border border-amber-300 bg-amber-50 p-4 text-sm text-amber-950 dark:border-amber-700 dark:bg-amber-950 dark:text-amber-100">
+              <div className="flex items-start gap-3">
+                <Icons.AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
+                <div>
+                  <h2 className="font-semibold">Unmatched sells need review</h2>
+                  <p className="mt-1">
+                    {report.unmatchedSells.length} disposal
+                    {report.unmatchedSells.length === 1 ? "" : "s"} could not be fully matched to
+                    earlier buy lots. Totals exclude the unmatched quantity until the missing
+                    acquisition history is added.
+                  </p>
+                </div>
+              </div>
+            </section>
+          ) : null}
+
+          {report.unsupportedActivities.length > 0 ? (
+            <section className="rounded-md border border-red-300 bg-red-50 p-4 text-sm text-red-950 dark:border-red-700 dark:bg-red-950 dark:text-red-100">
+              <div className="flex items-start gap-3">
+                <Icons.AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
+                <div>
+                  <h2 className="font-semibold">Non-AUD activities excluded</h2>
+                  <p className="mt-1">
+                    {report.unsupportedActivities.length} BUY/SELL activit
+                    {report.unsupportedActivities.length === 1 ? "y was" : "ies were"} excluded
+                    because this addon does not convert foreign-currency CGT amounts to AUD yet.
+                  </p>
+                </div>
+              </div>
+            </section>
+          ) : null}
+
+          {report.ignoredActivities.length > 0 ? (
+            <section className="rounded-md border border-slate-300 bg-slate-50 p-4 text-sm text-slate-950 dark:border-slate-700 dark:bg-slate-900 dark:text-slate-100">
+              <div className="flex items-start gap-3">
+                <Icons.AlertTriangle className="mt-0.5 h-5 w-5 shrink-0" />
+                <div>
+                  <h2 className="font-semibold">Some activity types are not modelled</h2>
+                  <p className="mt-1">
+                    {report.ignoredActivities.length} non-BUY/SELL activit
+                    {report.ignoredActivities.length === 1 ? "y is" : "ies are"} not included in CGT
+                    lot matching. Review transfers, splits, and corporate actions manually.
+                  </p>
+                </div>
+              </div>
+            </section>
+          ) : null}
+
+          <section className="rounded-md border p-4">
+            <div className="mb-4 flex flex-col gap-1">
+              <h2 className="text-base font-semibold">Budget 2026-27 Scenario Inputs</h2>
+              <p className="text-muted-foreground text-sm">
+                Provisional planning inputs for announced settings from 1 July 2027. The main report
+                remains a current-law estimate and does not yet calculate post-2027 indexed
+                disposals end to end.
+              </p>
+            </div>
+            <div className="grid gap-4 md:grid-cols-3">
+              <label className="flex flex-col gap-2 text-sm">
+                Tax on gain before minimum-tax top-up
+                <input
+                  className="rounded-md border bg-transparent px-3 py-2"
+                  inputMode="decimal"
+                  type="number"
+                  value={ordinaryIncomeTaxOnGain}
+                  onChange={(event) => setOrdinaryIncomeTaxOnGain(Number(event.target.value))}
+                />
+              </label>
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  checked={minimumTaxExempt}
+                  type="checkbox"
+                  onChange={(event) => setMinimumTaxExempt(event.target.checked)}
+                />
+                Income-support minimum-tax exemption
+              </label>
+              <div className="rounded-md bg-slate-50 p-3 text-sm dark:bg-slate-900">
+                <p className="text-muted-foreground">
+                  Illustrative minimum-tax top-up on latest taxable gain
+                </p>
+                <p className="mt-1 text-lg font-semibold">{formatAud(minimumTax.topUpTax)}</p>
+              </div>
+            </div>
+          </section>
+
+          <section className="rounded-md border p-4">
+            <div className="mb-4 flex flex-col gap-1">
+              <h2 className="text-base font-semibold">Addon Tax Data</h2>
+              <p className="text-muted-foreground text-sm">
+                Local addon-only records for AMMA, CPI, 2027 parcel values, AMIT adjustments, and
+                aggregated-holding acquisition dates.
+              </p>
+            </div>
+            <datalist id="australia-cgt-all-parcels">
+              {allParcelOptions.map((parcel) => (
+                <option
+                  key={parcel.parcelId}
+                  label={`${parcel.symbol} · ${parcel.account} · ${parcel.acquisitionDate}`}
+                  value={parcel.parcelId}
+                />
+              ))}
+            </datalist>
+            <datalist id="australia-cgt-open-parcels">
+              {openParcelOptions.map((parcel) => (
+                <option
+                  key={parcel.parcelId}
+                  label={`${parcel.symbol} · ${parcel.account} · ${parcel.acquisitionDate}`}
+                  value={parcel.parcelId}
+                />
+              ))}
+            </datalist>
+            <div className="grid gap-4 lg:grid-cols-2">
+              <div className="rounded-md bg-slate-50 p-3 text-sm dark:bg-slate-900">
+                <h3 className="font-medium">AMMA / AMIT</h3>
+                <p className="text-muted-foreground mt-1 text-xs">
+                  Choose a parcel from the matched lots or holding parcels below, then enter the
+                  AMIT cost-base movement from the AMMA statement.
+                </p>
+                <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                  <input
+                    aria-label="AMMA parcel ID"
+                    className="rounded-md border bg-transparent px-3 py-2"
+                    list="australia-cgt-all-parcels"
+                    placeholder="Parcel ID"
+                    value={ammaParcelId}
+                    onChange={(event) => setAmmaParcelId(event.target.value)}
+                  />
+                  <input
+                    aria-label="AMMA income year"
+                    className="rounded-md border bg-transparent px-3 py-2"
+                    value={ammaIncomeYear}
+                    onChange={(event) => setAmmaIncomeYear(event.target.value)}
+                  />
+                  <input
+                    aria-label="AMMA taxable income"
+                    className="rounded-md border bg-transparent px-3 py-2"
+                    inputMode="decimal"
+                    type="number"
+                    value={ammaTaxableIncome}
+                    onChange={(event) => setAmmaTaxableIncome(Number(event.target.value))}
+                  />
+                  <input
+                    aria-label="AMMA cash distribution"
+                    className="rounded-md border bg-transparent px-3 py-2"
+                    inputMode="decimal"
+                    type="number"
+                    value={ammaCashDistribution}
+                    onChange={(event) => setAmmaCashDistribution(Number(event.target.value))}
+                  />
+                  <input
+                    aria-label="AMMA franking credits"
+                    className="rounded-md border bg-transparent px-3 py-2"
+                    inputMode="decimal"
+                    type="number"
+                    value={ammaFrankingCredits}
+                    onChange={(event) => setAmmaFrankingCredits(Number(event.target.value))}
+                  />
+                  <input
+                    aria-label="AMIT cost base increase"
+                    className="rounded-md border bg-transparent px-3 py-2"
+                    inputMode="decimal"
+                    type="number"
+                    value={ammaIncrease}
+                    onChange={(event) => setAmmaIncrease(Number(event.target.value))}
+                  />
+                  <input
+                    aria-label="AMIT cost base decrease"
+                    className="rounded-md border bg-transparent px-3 py-2"
+                    inputMode="decimal"
+                    type="number"
+                    value={ammaDecrease}
+                    onChange={(event) => setAmmaDecrease(Number(event.target.value))}
+                  />
+                </div>
+                <Button
+                  className="mt-3"
+                  disabled={!canSaveAmma}
+                  onClick={saveAmmaStatement}
+                  variant="outline"
+                >
+                  Save AMMA statement
+                </Button>
+              </div>
+
+              <div className="rounded-md bg-slate-50 p-3 text-sm dark:bg-slate-900">
+                <h3 className="font-medium">CPI Cache</h3>
+                <p className="text-muted-foreground mt-2">
+                  Cached observations: {taxData.cpiSeries.length}
+                </p>
+                <div className="mt-3 flex flex-wrap gap-2">
+                  <Button onClick={refreshAbsCpi} variant="outline">
+                    Refresh ABS CPI
+                  </Button>
+                  <Button onClick={saveCpiSample} variant="ghost">
+                    Insert demo CPI row
+                  </Button>
+                </div>
+                <p className="text-muted-foreground mt-2 text-xs">
+                  Demo CPI is synthetic test data. Use Refresh ABS CPI for real cache values.
+                </p>
+                {cpiRefreshError ? (
+                  <p className="text-destructive mt-2">{cpiRefreshError}</p>
+                ) : null}
+              </div>
+
+              <div className="rounded-md bg-slate-50 p-3 text-sm dark:bg-slate-900">
+                <h3 className="font-medium">30 June 2027 Parcel Value</h3>
+                <p className="text-muted-foreground mt-1 text-xs">
+                  Selecting a known parcel fills symbol, account, acquired date, and quantity; edit
+                  them only when the parcel was aggregated outside Wealthfolio.
+                </p>
+                <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                  <input
+                    aria-label="Snapshot parcel ID"
+                    className="rounded-md border bg-transparent px-3 py-2"
+                    list="australia-cgt-open-parcels"
+                    placeholder="Parcel ID"
+                    value={snapshotParcelId}
+                    onChange={(event) => fillSnapshotParcel(event.target.value)}
+                  />
+                  <input
+                    aria-label="Snapshot symbol"
+                    className="rounded-md border bg-transparent px-3 py-2"
+                    placeholder="Symbol"
+                    value={snapshotSymbol}
+                    onChange={(event) => setSnapshotSymbol(event.target.value)}
+                  />
+                  <input
+                    aria-label="Snapshot account"
+                    className="rounded-md border bg-transparent px-3 py-2"
+                    placeholder="Account"
+                    value={snapshotAccount}
+                    onChange={(event) => setSnapshotAccount(event.target.value)}
+                  />
+                  <input
+                    aria-label="Snapshot acquisition date"
+                    className="rounded-md border bg-transparent px-3 py-2"
+                    type="date"
+                    value={snapshotAcquisitionDate}
+                    onChange={(event) => setSnapshotAcquisitionDate(event.target.value)}
+                  />
+                  <input
+                    aria-label="Snapshot quantity"
+                    className="rounded-md border bg-transparent px-3 py-2"
+                    inputMode="decimal"
+                    type="number"
+                    value={snapshotQuantity}
+                    onChange={(event) => setSnapshotQuantity(Number(event.target.value))}
+                  />
+                  <input
+                    aria-label="Snapshot market value"
+                    className="rounded-md border bg-transparent px-3 py-2"
+                    inputMode="decimal"
+                    type="number"
+                    value={snapshotValue}
+                    onChange={(event) => setSnapshotValue(Number(event.target.value))}
+                  />
+                </div>
+                <Button
+                  className="mt-3"
+                  disabled={!canSaveSnapshot}
+                  onClick={saveTransitionSnapshot}
+                  variant="outline"
+                >
+                  Save 2027 snapshot
+                </Button>
+              </div>
+
+              <div className="rounded-md bg-slate-50 p-3 text-sm dark:bg-slate-900">
+                <h3 className="font-medium">Aggregated Holding Acquisition</h3>
+                <p className="text-muted-foreground mt-1 text-xs">
+                  Use this when Wealthfolio has a holding but not the original parcel acquisition
+                  date. A selected parcel fills the matching symbol and account.
+                </p>
+                <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                  <input
+                    aria-label="Override parcel ID"
+                    className="rounded-md border bg-transparent px-3 py-2"
+                    list="australia-cgt-open-parcels"
+                    placeholder="Parcel ID"
+                    value={overrideParcelId}
+                    onChange={(event) => fillOverrideParcel(event.target.value)}
+                  />
+                  <input
+                    aria-label="Override symbol"
+                    className="rounded-md border bg-transparent px-3 py-2"
+                    placeholder="Symbol"
+                    value={overrideSymbol}
+                    onChange={(event) => setOverrideSymbol(event.target.value)}
+                  />
+                  <input
+                    aria-label="Override account"
+                    className="rounded-md border bg-transparent px-3 py-2"
+                    placeholder="Account"
+                    value={overrideAccount}
+                    onChange={(event) => setOverrideAccount(event.target.value)}
+                  />
+                  <input
+                    aria-label="Override acquisition date"
+                    className="rounded-md border bg-transparent px-3 py-2"
+                    type="date"
+                    value={overrideDate}
+                    onChange={(event) => setOverrideDate(event.target.value)}
+                  />
+                </div>
+                <Button
+                  className="mt-3"
+                  disabled={!canSaveOverride}
+                  onClick={saveAcquisitionOverride}
+                  variant="outline"
+                >
+                  Save acquisition date
+                </Button>
+              </div>
+            </div>
+            <div className="mt-4 flex flex-wrap gap-3 text-sm">
+              <span>AMMA statements: {taxData.ammaStatements.length}</span>
+              <span>AMIT adjustments: {taxData.amitAdjustments.length}</span>
+              <span>2027 snapshots: {taxData.transitionSnapshots.length}</span>
+              <span>Acquisition overrides: {taxData.acquisitionOverrides.length}</span>
+              <Button onClick={clearTaxData} size="sm" variant="ghost">
+                Clear local tax data
+              </Button>
+            </div>
+            <div className="mt-4 grid gap-3 lg:grid-cols-2">
+              <div className="bg-background rounded-md border p-3">
+                <h3 className="text-sm font-medium">Stored AMMA statements</h3>
+                <div className="mt-2 divide-y text-sm">
+                  {taxData.ammaStatements.map((statement) => (
+                    <div
+                      key={statement.id}
+                      className="flex items-center justify-between gap-3 py-2"
+                    >
+                      <div>
+                        <p className="font-medium">
+                          {statement.parcelId ?? statement.holdingKey} · {statement.incomeYear}
+                        </p>
+                        <p className="text-muted-foreground text-xs">
+                          Taxable {formatAud(statement.taxableIncome)} · Cash{" "}
+                          {formatAud(statement.cashDistribution)} · Franking{" "}
+                          {formatAud(statement.frankingCredits)} · AMIT{" "}
+                          {formatAud(
+                            statement.amitCostBaseIncrease - statement.amitCostBaseDecrease,
+                          )}
+                        </p>
+                      </div>
+                      <Button
+                        aria-label={`Delete AMMA ${statement.id}`}
+                        onClick={() => deleteAmmaStatement(statement.id)}
+                        size="sm"
+                        variant="ghost"
+                      >
+                        Delete
+                      </Button>
+                    </div>
+                  ))}
+                  {taxData.ammaStatements.length === 0 ? (
+                    <p className="text-muted-foreground py-2 text-xs">No AMMA statements saved.</p>
+                  ) : null}
+                </div>
+              </div>
+
+              <div className="bg-background rounded-md border p-3">
+                <h3 className="text-sm font-medium">Stored CPI observations</h3>
+                <div className="mt-2 divide-y text-sm">
+                  {taxData.cpiSeries.map((observation) => (
+                    <div
+                      key={observation.quarter}
+                      className="flex items-center justify-between gap-3 py-2"
+                    >
+                      <p>
+                        {observation.quarter} · {observation.value} · {observation.source}
+                      </p>
+                      <Button
+                        aria-label={`Delete CPI ${observation.quarter}`}
+                        onClick={() => deleteCpiObservation(observation.quarter)}
+                        size="sm"
+                        variant="ghost"
+                      >
+                        Delete
+                      </Button>
+                    </div>
+                  ))}
+                  {taxData.cpiSeries.length === 0 ? (
+                    <p className="text-muted-foreground py-2 text-xs">No CPI observations saved.</p>
+                  ) : null}
+                </div>
+              </div>
+
+              <div className="bg-background rounded-md border p-3">
+                <h3 className="text-sm font-medium">Stored 2027 snapshots</h3>
+                <div className="mt-2 divide-y text-sm">
+                  {taxData.transitionSnapshots.map((snapshot) => (
+                    <div
+                      key={snapshot.parcelId}
+                      className="flex items-center justify-between gap-3 py-2"
+                    >
+                      <div>
+                        <p className="font-medium">{snapshot.parcelId}</p>
+                        <p className="text-muted-foreground text-xs">
+                          {snapshot.symbol} · {snapshot.account} ·{" "}
+                          {formatAud(snapshot.marketValueAt2027)}
+                        </p>
+                      </div>
+                      <Button
+                        aria-label={`Delete snapshot ${snapshot.parcelId}`}
+                        onClick={() => deleteTransitionSnapshot(snapshot.parcelId)}
+                        size="sm"
+                        variant="ghost"
+                      >
+                        Delete
+                      </Button>
+                    </div>
+                  ))}
+                  {taxData.transitionSnapshots.length === 0 ? (
+                    <p className="text-muted-foreground py-2 text-xs">No snapshots saved.</p>
+                  ) : null}
+                </div>
+              </div>
+
+              <div className="bg-background rounded-md border p-3">
+                <h3 className="text-sm font-medium">Stored acquisition overrides</h3>
+                <div className="mt-2 divide-y text-sm">
+                  {taxData.acquisitionOverrides.map((override) => (
+                    <div
+                      key={override.parcelId}
+                      className="flex items-center justify-between gap-3 py-2"
+                    >
+                      <div>
+                        <p className="font-medium">{override.parcelId}</p>
+                        <p className="text-muted-foreground text-xs">
+                          {override.symbol} · {override.account} · {override.acquisitionDate}
+                        </p>
+                      </div>
+                      <Button
+                        aria-label={`Delete acquisition override ${override.parcelId}`}
+                        onClick={() => deleteAcquisitionOverride(override.parcelId)}
+                        size="sm"
+                        variant="ghost"
+                      >
+                        Delete
+                      </Button>
+                    </div>
+                  ))}
+                  {taxData.acquisitionOverrides.length === 0 ? (
+                    <p className="text-muted-foreground py-2 text-xs">
+                      No acquisition overrides saved.
+                    </p>
+                  ) : null}
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="rounded-md border">
+            <div className="border-b p-4">
+              <h2 className="text-base font-semibold">Income Year Summary</h2>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[760px] text-sm">
+                <thead className="bg-muted/40 text-muted-foreground text-left">
+                  <tr>
+                    <th className="px-4 py-3 font-medium">Income year</th>
+                    <th className="px-4 py-3 text-right font-medium">Proceeds</th>
+                    <th className="px-4 py-3 text-right font-medium">Cost base</th>
+                    <th className="px-4 py-3 text-right font-medium">Gross gain</th>
+                    <th className="px-4 py-3 text-right font-medium">Losses applied</th>
+                    <th className="px-4 py-3 text-right font-medium">Loss carry-forward</th>
+                    <th className="px-4 py-3 text-right font-medium">Discount</th>
+                    <th className="px-4 py-3 text-right font-medium">Taxable gain</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {report.incomeYears.map((year) => (
+                    <tr key={year.incomeYear} className="border-t">
+                      <td className="px-4 py-3 font-medium">{year.incomeYear}</td>
+                      <td className="px-4 py-3 text-right">{formatAud(year.proceeds)}</td>
+                      <td className="px-4 py-3 text-right">{formatAud(year.costBase)}</td>
+                      <td className="px-4 py-3 text-right">{formatAud(year.grossGain)}</td>
+                      <td className="px-4 py-3 text-right">
+                        {formatAud(year.capitalLossesApplied)}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        {formatAud(year.capitalLossCarryForward)}
+                      </td>
+                      <td className="px-4 py-3 text-right">{formatAud(year.discountApplied)}</td>
+                      <td className="px-4 py-3 text-right">{formatAud(year.taxableGain)}</td>
+                    </tr>
+                  ))}
+                  {report.incomeYears.length === 0 ? (
+                    <tr>
+                      <td className="text-muted-foreground px-4 py-8 text-center" colSpan={8}>
+                        No matched BUY/SELL lots found yet.
+                      </td>
+                    </tr>
+                  ) : null}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="rounded-md border">
+            <div className="border-b p-4">
+              <h2 className="text-base font-semibold">2027 Transition Parcels</h2>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[720px] text-sm">
+                <thead className="bg-muted/40 text-muted-foreground text-left">
+                  <tr>
+                    <th className="px-4 py-3 font-medium">Parcel</th>
+                    <th className="px-4 py-3 font-medium">Symbol</th>
+                    <th className="px-4 py-3 text-right font-medium">Quantity</th>
+                    <th className="px-4 py-3 text-right font-medium">Cost base</th>
+                    <th className="px-4 py-3 text-right font-medium">2027 value</th>
+                    <th className="px-4 py-3 text-right font-medium">Pre-2027 taxable</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {report.transitionLots.map((lot) => (
+                    <tr key={lot.parcelId} className="border-t">
+                      <td className="px-4 py-3">{lot.parcelId}</td>
+                      <td className="px-4 py-3">{lot.symbol}</td>
+                      <td className="px-4 py-3 text-right">{lot.quantity}</td>
+                      <td className="px-4 py-3 text-right">{formatAud(lot.costBase)}</td>
+                      <td className="px-4 py-3 text-right">{formatAud(lot.marketValueAt2027)}</td>
+                      <td className="px-4 py-3 text-right">
+                        {formatAud(lot.preCommencementTaxableGain)}
+                      </td>
+                    </tr>
+                  ))}
+                  {report.transitionLots.length === 0 ? (
+                    <tr>
+                      <td className="text-muted-foreground px-4 py-8 text-center" colSpan={6}>
+                        No 2027 parcel snapshots saved yet.
+                      </td>
+                    </tr>
+                  ) : null}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="rounded-md border">
+            <div className="border-b p-4">
+              <h2 className="text-base font-semibold">Dividend Franking Metadata</h2>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[640px] text-sm">
+                <thead className="bg-muted/40 text-muted-foreground text-left">
+                  <tr>
+                    <th className="px-4 py-3 font-medium">Symbol</th>
+                    <th className="px-4 py-3 font-medium">Income year</th>
+                    <th className="px-4 py-3 text-right font-medium">Amount</th>
+                    <th className="px-4 py-3 text-right font-medium">Franking percent</th>
+                    <th className="px-4 py-3 text-right font-medium">Franked amount</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {report.dividends.map((dividend) => (
+                    <tr key={dividend.activityId} className="border-t">
+                      <td className="px-4 py-3">{dividend.symbol}</td>
+                      <td className="px-4 py-3">{dividend.incomeYear}</td>
+                      <td className="px-4 py-3 text-right">{formatAud(dividend.amount)}</td>
+                      <td className="px-4 py-3 text-right">
+                        {dividend.frankingPercentage === null
+                          ? "Missing"
+                          : `${dividend.frankingPercentage}%`}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        {dividend.frankedAmount === null
+                          ? "Missing"
+                          : formatAud(dividend.frankedAmount)}
+                      </td>
+                    </tr>
+                  ))}
+                  {report.dividends.length === 0 ? (
+                    <tr>
+                      <td className="text-muted-foreground px-4 py-8 text-center" colSpan={5}>
+                        No dividend activities with franking metadata found.
+                      </td>
+                    </tr>
+                  ) : null}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="rounded-md border">
+            <div className="border-b p-4">
+              <h2 className="text-base font-semibold">Holding Parcels</h2>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[640px] text-sm">
+                <thead className="bg-muted/40 text-muted-foreground text-left">
+                  <tr>
+                    <th className="px-4 py-3 font-medium">Parcel</th>
+                    <th className="px-4 py-3 font-medium">Symbol</th>
+                    <th className="px-4 py-3 font-medium">Acquired</th>
+                    <th className="px-4 py-3 text-right font-medium">Quantity</th>
+                    <th className="px-4 py-3 text-right font-medium">Cost base</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {holdingParcels.map((parcel) => (
+                    <tr key={parcel.parcelId} className="border-t">
+                      <td className="px-4 py-3">{parcel.parcelId}</td>
+                      <td className="px-4 py-3">{parcel.symbol}</td>
+                      <td className="px-4 py-3">{parcel.acquisitionDate}</td>
+                      <td className="px-4 py-3 text-right">{parcel.quantity}</td>
+                      <td className="px-4 py-3 text-right">{formatAud(parcel.costBase)}</td>
+                    </tr>
+                  ))}
+                  {holdingParcels.length === 0 ? (
+                    <tr>
+                      <td className="text-muted-foreground px-4 py-8 text-center" colSpan={5}>
+                        {holdingsQuery.isLoading
+                          ? "Loading holding parcels..."
+                          : "No holdings found."}
+                      </td>
+                    </tr>
+                  ) : null}
+                </tbody>
+              </table>
+            </div>
+          </section>
+
+          <section className="rounded-md border">
+            <div className="border-b p-4">
+              <h2 className="text-base font-semibold">Matched Lots</h2>
+            </div>
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[920px] text-sm">
+                <thead className="bg-muted/40 text-muted-foreground text-left">
+                  <tr>
+                    <th className="px-4 py-3 font-medium">Symbol</th>
+                    <th className="px-4 py-3 font-medium">Account</th>
+                    <th className="px-4 py-3 text-right font-medium">Quantity</th>
+                    <th className="px-4 py-3 font-medium">Acquired</th>
+                    <th className="px-4 py-3 font-medium">Disposed</th>
+                    <th className="px-4 py-3 text-right font-medium">AMIT adj.</th>
+                    <th className="px-4 py-3 text-right font-medium">Gain</th>
+                    <th className="px-4 py-3 text-right font-medium">Discount</th>
+                    <th className="px-4 py-3 text-right font-medium">Taxable</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {report.closedLots.map((lot, index) => (
+                    <tr
+                      key={`${lot.symbol}-${lot.acquisitionDate}-${lot.disposalDate}-${index}`}
+                      className="border-t"
+                    >
+                      <td className="px-4 py-3 font-medium">{lot.symbol}</td>
+                      <td className="px-4 py-3">{lot.account}</td>
+                      <td className="px-4 py-3 text-right">{lot.quantity}</td>
+                      <td className="px-4 py-3">{lot.acquisitionDate}</td>
+                      <td className="px-4 py-3">{lot.disposalDate}</td>
+                      <td className="px-4 py-3 text-right">
+                        {formatAud(lot.amitCostBaseAdjustment)}
+                      </td>
+                      <td
+                        className={
+                          lot.grossGain < 0
+                            ? "px-4 py-3 text-right text-red-600"
+                            : "px-4 py-3 text-right"
+                        }
+                      >
+                        {formatAud(lot.grossGain)}
+                      </td>
+                      <td className="px-4 py-3 text-right">{formatAud(lot.discountApplied)}</td>
+                      <td className="px-4 py-3 text-right">{formatAud(lot.taxableGain)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        </div>
+      </PageContent>
+    </Page>
+  );
+}

--- a/addons/australia-cgt-addon/test-runner.mjs
+++ b/addons/australia-cgt-addon/test-runner.mjs
@@ -1,7 +1,9 @@
 import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { promisify } from "node:util";
 import ts from "typescript";
 
 const addonRoot = new URL(".", import.meta.url);
@@ -10,6 +12,7 @@ const taxDataUrl = new URL("src/lib/tax-data.ts", addonRoot);
 const tempDir = await mkdtemp(path.join(tmpdir(), "australia-cgt-addon-"));
 const compiledEnginePath = path.join(tempDir, "cgt-engine.mjs");
 const compiledTaxDataPath = path.join(tempDir, "tax-data.mjs");
+const execFileAsync = promisify(execFile);
 
 async function importEngine() {
   const { readFile } = await import("node:fs/promises");
@@ -592,6 +595,43 @@ test("transition snapshots produce parcel-level 2027 transition rows", () => {
   assert.equal(report.transitionLots[0].preCommencementTaxableGain, 300);
 });
 
+test("transition snapshots use saved quantity for corrected parcel apportionment", () => {
+  const report = buildCgtReport(
+    [
+      {
+        id: "buy-1",
+        activityType: "BUY",
+        date: "2024-07-01",
+        quantity: "10",
+        unitPrice: "100",
+        fee: "0",
+        amount: "1000",
+        currency: "AUD",
+        assetSymbol: "VAS.AX",
+        accountName: "Australian Taxable",
+      },
+    ],
+    {
+      transitionSnapshots: [
+        {
+          parcelId: "buy-1",
+          symbol: "VAS.AX",
+          account: "Australian Taxable",
+          acquisitionDate: "2024-07-01",
+          quantity: 5,
+          marketValueAt2027: 800,
+          valuationMethod: "manual",
+        },
+      ],
+    },
+  );
+
+  assert.equal(report.transitionLots.length, 1);
+  assert.equal(report.transitionLots[0].quantity, 5);
+  assert.equal(report.transitionLots[0].costBase, 500);
+  assert.equal(report.transitionLots[0].preCommencementTaxableGain, 150);
+});
+
 test("transition snapshots include aggregated open holding parcels", () => {
   const holdingParcels = buildHoldingParcels(
     [
@@ -741,6 +781,29 @@ test("franking metadata displays fully and partly franked dividend examples", ()
   assert.equal(dividends[1].frankedAmount, 300);
 });
 
+test("report excludes non-AUD dividend rows from AUD franking review", () => {
+  const report = buildCgtReport([
+    {
+      id: "usd-dividend",
+      activityType: "DIVIDEND",
+      date: "2026-09-01",
+      quantity: null,
+      unitPrice: null,
+      amount: "100",
+      fee: null,
+      currency: "USD",
+      assetSymbol: "AAPL",
+      accountName: "Australian Taxable",
+      metadata: withFrankingPercentageMetadata(undefined, 100),
+    },
+  ]);
+
+  assert.equal(report.dividends.length, 0);
+  assert.equal(report.unsupportedActivities.length, 1);
+  assert.equal(report.unsupportedActivities[0].activityId, "usd-dividend");
+  assert.equal(report.unsupportedActivities[0].reason, "NON_AUD_CURRENCY");
+});
+
 test("parcel acquisition overrides cover aggregated holdings without lots", () => {
   const parcels = buildHoldingParcels(
     [
@@ -801,6 +864,55 @@ test("report accepts API timestamp date strings", () => {
   assert.equal(report.closedLots[0].acquisitionDate, "2024-07-01");
   assert.equal(report.closedLots[0].disposalDate, "2026-05-01");
   assert.equal(report.closedLots[0].preLossTaxableGainEstimate, 30);
+});
+
+test("report keeps timestamp ledger dates stable across client timezones", async () => {
+  const script = `
+    import { buildCgtReport } from ${JSON.stringify(`file://${compiledEnginePath}`)};
+    const report = buildCgtReport([
+      {
+        id: "buy-boundary",
+        activityType: "BUY",
+        date: new Date("2024-07-01T00:00:00.000Z"),
+        quantity: "1",
+        unitPrice: "100",
+        fee: "0",
+        amount: "100",
+        currency: "AUD",
+        assetSymbol: "TZ.AX",
+        accountName: "Australian Taxable",
+      },
+      {
+        id: "sell-boundary",
+        activityType: "SELL",
+        date: new Date("2025-07-01T00:00:00.000Z"),
+        quantity: "1",
+        unitPrice: "160",
+        fee: "0",
+        amount: "160",
+        currency: "AUD",
+        assetSymbol: "TZ.AX",
+        accountName: "Australian Taxable",
+      },
+    ]);
+    console.log(JSON.stringify({
+      incomeYear: report.incomeYears[0]?.incomeYear,
+      acquisitionDate: report.closedLots[0]?.acquisitionDate,
+      disposalDate: report.closedLots[0]?.disposalDate
+    }));
+  `;
+  const { stdout } = await execFileAsync(process.execPath, ["--input-type=module", "-e", script], {
+    env: {
+      ...process.env,
+      TZ: "America/Los_Angeles",
+    },
+  });
+
+  assert.deepEqual(JSON.parse(stdout), {
+    incomeYear: "2025-26",
+    acquisitionDate: "2024-07-01",
+    disposalDate: "2025-07-01",
+  });
 });
 
 test("report matches FIFO lots within the selling account only", () => {

--- a/addons/australia-cgt-addon/test-runner.mjs
+++ b/addons/australia-cgt-addon/test-runner.mjs
@@ -1,0 +1,1265 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import ts from "typescript";
+
+const addonRoot = new URL(".", import.meta.url);
+const engineUrl = new URL("src/lib/cgt-engine.ts", addonRoot);
+const taxDataUrl = new URL("src/lib/tax-data.ts", addonRoot);
+const tempDir = await mkdtemp(path.join(tmpdir(), "australia-cgt-addon-"));
+const compiledEnginePath = path.join(tempDir, "cgt-engine.mjs");
+const compiledTaxDataPath = path.join(tempDir, "tax-data.mjs");
+
+async function importEngine() {
+  const { readFile } = await import("node:fs/promises");
+  const taxDataSource = await readFile(taxDataUrl, "utf8");
+  const compiledTaxData = ts.transpileModule(taxDataSource, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      jsx: ts.JsxEmit.ReactJSX,
+    },
+  });
+  await writeFile(compiledTaxDataPath, compiledTaxData.outputText, "utf8");
+
+  const source = (await readFile(engineUrl, "utf8")).replace(
+    'from "./tax-data"',
+    'from "./tax-data.mjs"',
+  );
+  const compiled = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      jsx: ts.JsxEmit.ReactJSX,
+    },
+  });
+  await writeFile(compiledEnginePath, compiled.outputText, "utf8");
+  return import(`file://${compiledEnginePath}`);
+}
+
+const {
+  buildHoldingParcels,
+  buildCgtReport,
+  calculateCurrentLawTaxableGain,
+  calculateIndexedGain,
+  calculateMinimumTaxTopUp,
+  calculateTransitionGain,
+  extractDividendTaxDetails,
+  exportReportCsv,
+} = await importEngine();
+const {
+  DEFAULT_ABS_QUARTERLY_CPI_URL,
+  FRANKING_PERCENTAGE_METADATA_KEY,
+  buildAmitAdjustmentsFromAmma,
+  calculateCpiIndexationFactor,
+  createAustraliaCgtAddonStore,
+  createMemoryStorage,
+  emptyAustraliaCgtAddonData,
+  fetchAbsCpiSeries,
+  mergeCpiSeries,
+  parseAbsCpiCsv,
+  refreshCachedAbsCpiSeries,
+  withFrankingPercentageMetadata,
+} = await import(`file://${compiledTaxDataPath}`);
+
+const tests = [];
+
+function test(name, fn) {
+  tests.push({ name, fn });
+}
+
+test("current law halves an eligible long-held gain after losses", () => {
+  const result = calculateCurrentLawTaxableGain({
+    grossGain: 60,
+    capitalLosses: 0,
+    acquisitionDate: "2024-07-01",
+    disposalDate: "2026-07-02",
+    eligibleForDiscount: true,
+  });
+
+  assert.equal(result.taxableGain, 30);
+  assert.equal(result.discountApplied, 30);
+});
+
+test("current law does not discount a short-held gain", () => {
+  const result = calculateCurrentLawTaxableGain({
+    grossGain: 60,
+    capitalLosses: 0,
+    acquisitionDate: "2026-01-01",
+    disposalDate: "2026-06-30",
+    eligibleForDiscount: true,
+  });
+
+  assert.equal(result.taxableGain, 60);
+  assert.equal(result.discountApplied, 0);
+});
+
+test("current law applies capital losses before the discount", () => {
+  const result = calculateCurrentLawTaxableGain({
+    grossGain: 100,
+    capitalLosses: 40,
+    acquisitionDate: "2024-07-01",
+    disposalDate: "2026-07-02",
+    eligibleForDiscount: true,
+  });
+
+  assert.equal(result.netGainBeforeDiscount, 60);
+  assert.equal(result.taxableGain, 30);
+});
+
+test("current law uses calendar months for the twelve-month discount", () => {
+  const result = calculateCurrentLawTaxableGain({
+    grossGain: 60,
+    capitalLosses: 0,
+    acquisitionDate: "2024-02-29",
+    disposalDate: "2025-02-28",
+    eligibleForDiscount: true,
+  });
+
+  assert.equal(result.discountEligible, false);
+  assert.equal(result.taxableGain, 60);
+});
+
+test("current law excludes exact-anniversary disposals from the twelve-month discount", () => {
+  const exactAnniversary = calculateCurrentLawTaxableGain({
+    grossGain: 60,
+    capitalLosses: 0,
+    acquisitionDate: "2024-07-01",
+    disposalDate: "2025-07-01",
+    eligibleForDiscount: true,
+  });
+  const nextDay = calculateCurrentLawTaxableGain({
+    grossGain: 60,
+    capitalLosses: 0,
+    acquisitionDate: "2024-07-01",
+    disposalDate: "2025-07-02",
+    eligibleForDiscount: true,
+  });
+
+  assert.equal(exactAnniversary.discountEligible, false);
+  assert.equal(exactAnniversary.taxableGain, 60);
+  assert.equal(nextDay.discountEligible, true);
+  assert.equal(nextDay.taxableGain, 30);
+});
+
+test("indexation taxes the real gain after CPI uplift", () => {
+  const result = calculateIndexedGain({
+    costBase: 100,
+    proceeds: 125,
+    indexationFactor: 1.13,
+  });
+
+  assert.equal(result.indexedCostBase, 113);
+  assert.equal(result.realCapitalGain, 12);
+});
+
+test("transition assets split pre-2027 discount and post-2027 indexation components", () => {
+  const result = calculateTransitionGain({
+    originalCostBase: 800000,
+    transitionValueAt2027: 1131371,
+    proceeds: 1600000,
+    acquisitionDate: "2022-07-01",
+    disposalDate: "2032-07-01",
+    post2027IndexationFactor: 1.131407822898059,
+  });
+
+  assert.equal(result.preCommencement.taxableGain, 165685.5);
+  assert.equal(Math.round(result.postCommencement.realCapitalGain), 319958);
+  assert.equal(Math.round(result.totalTaxableGain), 485644);
+});
+
+test("minimum tax tops low-rate capital gain tax up to 30 percent unless exempt", () => {
+  const result = calculateMinimumTaxTopUp({
+    realCapitalGain: 10000,
+    taxOnGainBeforeTopUp: 1400,
+    receivesIncomeSupport: false,
+  });
+
+  assert.equal(result.minimumTaxRequired, 3000);
+  assert.equal(result.topUpTax, 1600);
+
+  const exempt = calculateMinimumTaxTopUp({
+    realCapitalGain: 10000,
+    taxOnGainBeforeTopUp: 1400,
+    receivesIncomeSupport: true,
+  });
+
+  assert.equal(exempt.topUpTax, 0);
+});
+
+test("report matches FIFO lots, includes fees, groups by Australian income year, and exports CSV", () => {
+  const activities = [
+    {
+      id: "buy-1",
+      activityType: "BUY",
+      date: new Date("2024-07-01T10:00:00Z"),
+      quantity: "10",
+      unitPrice: "100",
+      fee: "10",
+      amount: "1000",
+      currency: "AUD",
+      assetSymbol: "VAS.AX",
+      assetName: "Vanguard Australian Shares",
+      accountName: "Australian Taxable",
+    },
+    {
+      id: "buy-2",
+      activityType: "BUY",
+      date: new Date("2026-03-01T10:00:00Z"),
+      quantity: "10",
+      unitPrice: "120",
+      fee: "10",
+      amount: "1200",
+      currency: "AUD",
+      assetSymbol: "VAS.AX",
+      assetName: "Vanguard Australian Shares",
+      accountName: "Australian Taxable",
+    },
+    {
+      id: "sell-1",
+      activityType: "SELL",
+      date: new Date("2026-08-01T10:00:00Z"),
+      quantity: "12",
+      unitPrice: "150",
+      fee: "12",
+      amount: "1800",
+      currency: "AUD",
+      assetSymbol: "VAS.AX",
+      assetName: "Vanguard Australian Shares",
+      accountName: "Australian Taxable",
+    },
+  ];
+
+  const report = buildCgtReport(activities);
+
+  assert.equal(report.closedLots.length, 2);
+  assert.equal(report.closedLots[0].quantity, 10);
+  assert.equal(report.closedLots[0].taxableGain, 240);
+  assert.equal(report.closedLots[1].quantity, 2);
+  assert.equal(report.closedLots[1].taxableGain, 56);
+  assert.equal(report.incomeYears[0].incomeYear, "2026-27");
+  assert.equal(report.incomeYears[0].taxableGain, 296);
+
+  const csv = exportReportCsv(report);
+  assert.match(csv, /incomeYear,symbol,account,quantity,acquisitionDate,disposalDate/);
+  assert.match(csv, /"2026-27","VAS\.AX","Australian Taxable","10"/);
+});
+
+test("AMMA statements persist locally and derive AMIT cost base adjustments", () => {
+  const storage = createMemoryStorage();
+  const store = createAustraliaCgtAddonStore(storage, "test-addon");
+  const ammaStatements = [
+    {
+      id: "VAS.AX:2026-27",
+      holdingKey: "buy-1",
+      incomeYear: "2026-27",
+      taxableIncome: 300,
+      cashDistribution: 280,
+      frankingCredits: 20,
+      amitCostBaseIncrease: 45,
+      amitCostBaseDecrease: 15,
+    },
+  ];
+  const data = {
+    ammaStatements,
+    cpiSeries: [],
+    transitionSnapshots: [],
+    amitAdjustments: buildAmitAdjustmentsFromAmma(ammaStatements),
+    acquisitionOverrides: [],
+  };
+
+  store.save(data);
+
+  assert.deepEqual(store.load().amitAdjustments, [
+    {
+      parcelId: "buy-1",
+      incomeYear: "2026-27",
+      amount: 30,
+      sourceStatementId: "VAS.AX:2026-27",
+    },
+  ]);
+});
+
+test("tax data store writes a versioned envelope and reads legacy payloads", () => {
+  const legacyKey = "test-addon:tax-data:v1";
+  const legacyData = {
+    ammaStatements: [
+      {
+        id: "legacy:2026-27",
+        holdingKey: "legacy",
+        parcelId: "legacy",
+        incomeYear: "2026-27",
+        taxableIncome: 12,
+        cashDistribution: 10,
+        frankingCredits: 2,
+        amitCostBaseIncrease: 3,
+        amitCostBaseDecrease: 1,
+      },
+    ],
+  };
+  const storage = createMemoryStorage({
+    [legacyKey]: JSON.stringify(legacyData),
+  });
+  const store = createAustraliaCgtAddonStore(storage, "test-addon");
+
+  assert.equal(store.load().ammaStatements[0].taxableIncome, 12);
+
+  const nextData = emptyAustraliaCgtAddonData();
+  store.save(nextData);
+  assert.deepEqual(JSON.parse(storage.getItem(legacyKey)), {
+    version: 1,
+    payload: nextData,
+  });
+});
+
+test("AMMA statements map explicit parcel IDs into AMIT adjustments", () => {
+  const adjustments = buildAmitAdjustmentsFromAmma([
+    {
+      id: "VAS.AX:Australian Taxable:2026-27",
+      holdingKey: "VAS.AX:Australian Taxable",
+      parcelId: "buy-1",
+      incomeYear: "2026-27",
+      taxableIncome: 0,
+      cashDistribution: 0,
+      frankingCredits: 0,
+      amitCostBaseIncrease: 45,
+      amitCostBaseDecrease: 15,
+    },
+  ]);
+
+  assert.deepEqual(adjustments, [
+    {
+      parcelId: "buy-1",
+      incomeYear: "2026-27",
+      amount: 30,
+      sourceStatementId: "VAS.AX:Australian Taxable:2026-27",
+    },
+  ]);
+});
+
+test("AMMA-derived AMIT adjustments change disposal cost base and taxable gain", () => {
+  const ammaStatements = [
+    {
+      id: "buy-1:2025-26",
+      holdingKey: "VAS.AX:Australian Taxable",
+      parcelId: "buy-1",
+      incomeYear: "2025-26",
+      taxableIncome: 300,
+      cashDistribution: 280,
+      frankingCredits: 20,
+      amitCostBaseIncrease: 30,
+      amitCostBaseDecrease: 0,
+    },
+  ];
+  const report = buildCgtReport(
+    [
+      {
+        id: "buy-1",
+        activityType: "BUY",
+        date: "2024-07-01",
+        quantity: "10",
+        unitPrice: "100",
+        fee: "0",
+        amount: "1000",
+        currency: "AUD",
+        assetSymbol: "VAS.AX",
+        accountName: "Australian Taxable",
+      },
+      {
+        id: "sell-1",
+        activityType: "SELL",
+        date: "2026-05-01",
+        quantity: "10",
+        unitPrice: "150",
+        fee: "0",
+        amount: "1500",
+        currency: "AUD",
+        assetSymbol: "VAS.AX",
+        accountName: "Australian Taxable",
+      },
+    ],
+    {
+      amitAdjustments: buildAmitAdjustmentsFromAmma(ammaStatements),
+    },
+  );
+
+  assert.equal(report.closedLots[0].amitCostBaseAdjustment, 30);
+  assert.equal(report.closedLots[0].costBase, 1030);
+  assert.equal(report.closedLots[0].taxableGain, 235);
+});
+
+test("ABS CPI series parses, merges, caches, and produces indexation factor", async () => {
+  const parsed = parseAbsCpiCsv("quarter,value\n2027-Q3,120\n2032-Q3,135.6\n", "now");
+  assert.equal(parsed.length, 2);
+  assert.equal(calculateCpiIndexationFactor(parsed, "2027-Q3", "2032-Q3"), 1.13);
+  assert.match(DEFAULT_ABS_QUARTERLY_CPI_URL, /ABS,CPI_Q/);
+
+  const merged = mergeCpiSeries(parsed.slice(0, 1), [
+    { quarter: "2032-Q3", value: 136, source: "MANUAL", fetchedAt: "later" },
+  ]);
+  assert.equal(merged[1].value, 136);
+
+  const fetched = await fetchAbsCpiSeries(
+    "https://example.test/cpi.csv",
+    async () =>
+      new Response("TIME_PERIOD,INDEX,OBS_VALUE\n2027-Q3,999901,120\n", {
+        status: 200,
+      }),
+    () => "fetched",
+  );
+  assert.deepEqual(fetched, [
+    { quarter: "2027-Q3", value: 120, source: "ABS", fetchedAt: "fetched" },
+  ]);
+
+  const refreshed = await refreshCachedAbsCpiSeries(
+    {
+      ammaStatements: [],
+      cpiSeries: parsed.slice(0, 1),
+      transitionSnapshots: [],
+      amitAdjustments: [],
+      acquisitionOverrides: [],
+    },
+    async () =>
+      new Response("TIME_PERIOD,OBS_VALUE\n2032-Q3,135.6\n", {
+        status: 200,
+      }),
+  );
+  assert.equal(refreshed.cpiSeries.length, 2);
+});
+
+test("AMIT adjustments alter parcel-level cost base before gain calculation", () => {
+  const report = buildCgtReport(
+    [
+      {
+        id: "buy-1",
+        activityType: "BUY",
+        date: "2024-07-01",
+        quantity: "10",
+        unitPrice: "100",
+        fee: "0",
+        amount: "1000",
+        currency: "AUD",
+        assetSymbol: "VAS.AX",
+        accountName: "Australian Taxable",
+      },
+      {
+        id: "sell-1",
+        activityType: "SELL",
+        date: "2026-08-01",
+        quantity: "10",
+        unitPrice: "150",
+        fee: "0",
+        amount: "1500",
+        currency: "AUD",
+        assetSymbol: "VAS.AX",
+        accountName: "Australian Taxable",
+      },
+    ],
+    {
+      amitAdjustments: [{ parcelId: "buy-1", incomeYear: "2025-26", amount: 30 }],
+    },
+  );
+
+  assert.equal(report.closedLots[0].costBase, 1030);
+  assert.equal(report.closedLots[0].amitCostBaseAdjustment, 30);
+  assert.equal(report.closedLots[0].taxableGain, 235);
+  assert.equal(report.incomeYears[0].amitCostBaseAdjustment, 30);
+});
+
+test("AMIT adjustments after disposal year do not alter past disposals", () => {
+  const report = buildCgtReport(
+    [
+      {
+        id: "buy-1",
+        activityType: "BUY",
+        date: "2024-07-01",
+        quantity: "10",
+        unitPrice: "100",
+        fee: "0",
+        amount: "1000",
+        currency: "AUD",
+        assetSymbol: "VAS.AX",
+        accountName: "Australian Taxable",
+      },
+      {
+        id: "sell-1",
+        activityType: "SELL",
+        date: "2026-08-01",
+        quantity: "10",
+        unitPrice: "150",
+        fee: "0",
+        amount: "1500",
+        currency: "AUD",
+        assetSymbol: "VAS.AX",
+        accountName: "Australian Taxable",
+      },
+    ],
+    {
+      amitAdjustments: [{ parcelId: "buy-1", incomeYear: "2027-28", amount: 30 }],
+    },
+  );
+
+  assert.equal(report.closedLots[0].costBase, 1000);
+  assert.equal(report.closedLots[0].amitCostBaseAdjustment, 0);
+  assert.equal(report.closedLots[0].taxableGain, 250);
+});
+
+test("AMIT adjustments after a partial disposal apply to the surviving holding quantity", () => {
+  const report = buildCgtReport(
+    [
+      {
+        id: "buy-1",
+        activityType: "BUY",
+        date: "2024-07-01",
+        quantity: "100",
+        unitPrice: "10",
+        fee: "0",
+        amount: "1000",
+        currency: "AUD",
+        assetSymbol: "VAS.AX",
+        accountName: "Australian Taxable",
+      },
+      {
+        id: "sell-1",
+        activityType: "SELL",
+        date: "2026-05-01",
+        quantity: "50",
+        unitPrice: "15",
+        fee: "0",
+        amount: "750",
+        currency: "AUD",
+        assetSymbol: "VAS.AX",
+        accountName: "Australian Taxable",
+      },
+      {
+        id: "sell-2",
+        activityType: "SELL",
+        date: "2027-08-01",
+        quantity: "50",
+        unitPrice: "16",
+        fee: "0",
+        amount: "800",
+        currency: "AUD",
+        assetSymbol: "VAS.AX",
+        accountName: "Australian Taxable",
+      },
+    ],
+    {
+      amitAdjustments: [{ parcelId: "buy-1", incomeYear: "2026-27", amount: 100 }],
+    },
+  );
+
+  assert.equal(report.closedLots[0].amitCostBaseAdjustment, 0);
+  assert.equal(report.closedLots[1].amitCostBaseAdjustment, 100);
+  assert.equal(report.closedLots[1].costBase, 600);
+  assert.equal(report.closedLots[1].taxableGain, 100);
+});
+
+test("transition snapshots produce parcel-level 2027 transition rows", () => {
+  const report = buildCgtReport(
+    [
+      {
+        id: "buy-1",
+        activityType: "BUY",
+        date: "2024-07-01",
+        quantity: "10",
+        unitPrice: "100",
+        fee: "0",
+        amount: "1000",
+        currency: "AUD",
+        assetSymbol: "VAS.AX",
+        accountName: "Australian Taxable",
+      },
+    ],
+    {
+      transitionSnapshots: [
+        {
+          parcelId: "buy-1",
+          symbol: "VAS.AX",
+          account: "Australian Taxable",
+          acquisitionDate: "2024-07-01",
+          quantity: 10,
+          marketValueAt2027: 1600,
+          valuationMethod: "manual",
+        },
+      ],
+    },
+  );
+
+  assert.equal(report.transitionLots.length, 1);
+  assert.equal(report.transitionLots[0].marketValueAt2027, 1600);
+  assert.equal(report.transitionLots[0].preCommencementTaxableGain, 300);
+});
+
+test("transition snapshots include aggregated open holding parcels", () => {
+  const holdingParcels = buildHoldingParcels(
+    [
+      {
+        id: "aggregated-VAS",
+        quantity: 10,
+        openDate: null,
+        lots: null,
+        accountName: "Australian Taxable",
+        instrument: { symbol: "VAS.AX" },
+        costBasis: { local: 1000, base: 1000 },
+      },
+    ],
+    [
+      {
+        parcelId: "aggregated-VAS",
+        symbol: "VAS.AX",
+        account: "Australian Taxable",
+        acquisitionDate: "2024-07-01",
+        source: "manual",
+      },
+    ],
+  );
+  const report = buildCgtReport([], {
+    holdingParcels,
+    transitionSnapshots: [
+      {
+        parcelId: "aggregated-VAS",
+        symbol: "VAS.AX",
+        account: "Australian Taxable",
+        acquisitionDate: "2024-07-01",
+        quantity: 10,
+        marketValueAt2027: 1600,
+        valuationMethod: "manual",
+      },
+    ],
+  });
+
+  assert.equal(report.transitionLots.length, 1);
+  assert.equal(report.transitionLots[0].parcelId, "aggregated-VAS");
+  assert.equal(report.transitionLots[0].costBase, 1000);
+  assert.equal(report.transitionLots[0].preCommencementTaxableGain, 300);
+});
+
+test("transition snapshots exclude post-transition AMIT adjustments", () => {
+  const report = buildCgtReport(
+    [
+      {
+        id: "buy-1",
+        activityType: "BUY",
+        date: "2024-07-01",
+        quantity: "10",
+        unitPrice: "100",
+        fee: "0",
+        amount: "1000",
+        currency: "AUD",
+        assetSymbol: "VAS.AX",
+        accountName: "Australian Taxable",
+      },
+    ],
+    {
+      amitAdjustments: [
+        {
+          parcelId: "buy-1",
+          incomeYear: "2027-28",
+          amount: 200,
+        },
+      ],
+      transitionSnapshots: [
+        {
+          parcelId: "buy-1",
+          symbol: "VAS.AX",
+          account: "Australian Taxable",
+          acquisitionDate: "2024-07-01",
+          quantity: 10,
+          marketValueAt2027: 1600,
+          valuationMethod: "manual",
+        },
+      ],
+    },
+  );
+
+  assert.equal(report.transitionLots.length, 1);
+  assert.equal(report.transitionLots[0].costBase, 1000);
+  assert.equal(report.transitionLots[0].preCommencementTaxableGain, 300);
+});
+
+test("franking percentage is read from dividend activity metadata", () => {
+  const metadata = withFrankingPercentageMetadata(undefined, 70);
+  assert.equal(metadata[FRANKING_PERCENTAGE_METADATA_KEY], 70);
+
+  const dividends = extractDividendTaxDetails([
+    {
+      id: "dividend-1",
+      activityType: "DIVIDEND",
+      date: "2026-09-01",
+      quantity: null,
+      unitPrice: null,
+      amount: "100",
+      fee: null,
+      currency: "AUD",
+      assetSymbol: "VAS.AX",
+      accountName: "Australian Taxable",
+      metadata,
+    },
+  ]);
+
+  assert.equal(dividends[0].frankingPercentage, 70);
+  assert.equal(dividends[0].frankedAmount, 70);
+});
+
+test("franking metadata displays fully and partly franked dividend examples", () => {
+  const dividends = extractDividendTaxDetails([
+    {
+      id: "cba-dividend",
+      activityType: "DIVIDEND",
+      date: "2026-09-01",
+      quantity: null,
+      unitPrice: null,
+      amount: "700",
+      fee: null,
+      currency: "AUD",
+      assetSymbol: "CBA.AX",
+      accountName: "Australian Taxable",
+      metadata: withFrankingPercentageMetadata(undefined, 100),
+    },
+    {
+      id: "wes-dividend",
+      activityType: "DIVIDEND",
+      date: "2026-10-01",
+      quantity: null,
+      unitPrice: null,
+      amount: "500",
+      fee: null,
+      currency: "AUD",
+      assetSymbol: "WES.AX",
+      accountName: "Australian Taxable",
+      metadata: withFrankingPercentageMetadata(undefined, 60),
+    },
+  ]);
+
+  assert.equal(dividends[0].symbol, "CBA.AX");
+  assert.equal(dividends[0].frankingPercentage, 100);
+  assert.equal(dividends[0].frankedAmount, 700);
+  assert.equal(dividends[1].symbol, "WES.AX");
+  assert.equal(dividends[1].frankingPercentage, 60);
+  assert.equal(dividends[1].frankedAmount, 300);
+});
+
+test("parcel acquisition overrides cover aggregated holdings without lots", () => {
+  const parcels = buildHoldingParcels(
+    [
+      {
+        id: "aggregated-VAS",
+        quantity: 25,
+        openDate: null,
+        lots: null,
+        accountName: "Australian Taxable",
+        instrument: { symbol: "VAS.AX" },
+        costBasis: { local: 2500, base: 2500 },
+      },
+    ],
+    [
+      {
+        parcelId: "aggregated-VAS",
+        symbol: "VAS.AX",
+        account: "Australian Taxable",
+        acquisitionDate: "2021-07-01",
+        source: "manual",
+      },
+    ],
+  );
+
+  assert.equal(parcels[0].acquisitionDate, "2021-07-01");
+  assert.equal(parcels[0].costBase, 2500);
+});
+
+test("report accepts API timestamp date strings", () => {
+  const report = buildCgtReport([
+    {
+      id: "buy-api",
+      activityType: "BUY",
+      date: "2024-07-01T10:00:00.000Z",
+      quantity: "1",
+      unitPrice: "100",
+      fee: "0",
+      amount: "100",
+      currency: "AUD",
+      assetSymbol: "API.AX",
+      accountName: "Australian Taxable",
+    },
+    {
+      id: "sell-api",
+      activityType: "SELL",
+      date: "2026-05-01T10:00:00.000Z",
+      quantity: "1",
+      unitPrice: "160",
+      fee: "0",
+      amount: "160",
+      currency: "AUD",
+      assetSymbol: "API.AX",
+      accountName: "Australian Taxable",
+    },
+  ]);
+
+  assert.equal(report.incomeYears[0].incomeYear, "2025-26");
+  assert.equal(report.closedLots[0].acquisitionDate, "2024-07-01");
+  assert.equal(report.closedLots[0].disposalDate, "2026-05-01");
+  assert.equal(report.closedLots[0].taxableGain, 30);
+});
+
+test("report matches FIFO lots within the selling account only", () => {
+  const report = buildCgtReport([
+    {
+      id: "taxable-buy",
+      activityType: "BUY",
+      date: "2024-07-01",
+      quantity: "1",
+      unitPrice: "100",
+      fee: "0",
+      amount: "100",
+      currency: "AUD",
+      assetSymbol: "VAS.AX",
+      accountName: "Australian Taxable",
+    },
+    {
+      id: "super-buy",
+      activityType: "BUY",
+      date: "2024-07-02",
+      quantity: "1",
+      unitPrice: "200",
+      fee: "0",
+      amount: "200",
+      currency: "AUD",
+      assetSymbol: "VAS.AX",
+      accountName: "Super",
+    },
+    {
+      id: "super-sell",
+      activityType: "SELL",
+      date: "2026-05-01",
+      quantity: "1",
+      unitPrice: "260",
+      fee: "0",
+      amount: "260",
+      currency: "AUD",
+      assetSymbol: "VAS.AX",
+      accountName: "Super",
+    },
+  ]);
+
+  assert.equal(report.closedLots.length, 1);
+  assert.equal(report.closedLots[0].parcelId, "super-buy");
+  assert.equal(report.closedLots[0].account, "Super");
+  assert.equal(report.closedLots[0].costBase, 200);
+  assert.equal(report.closedLots[0].taxableGain, 30);
+  assert.equal(report.transitionLots.length, 0);
+});
+
+test("acquisition overrides do not rename imported BUY activity lots", () => {
+  const report = buildCgtReport(
+    [
+      {
+        id: "buy-1",
+        activityType: "BUY",
+        date: "2024-07-01",
+        quantity: "1",
+        unitPrice: "100",
+        fee: "0",
+        amount: "100",
+        currency: "AUD",
+        assetSymbol: "VAS.AX",
+        accountName: "Australian Taxable",
+      },
+      {
+        id: "sell-1",
+        activityType: "SELL",
+        date: "2026-08-01",
+        quantity: "1",
+        unitPrice: "160",
+        fee: "0",
+        amount: "160",
+        currency: "AUD",
+        assetSymbol: "VAS.AX",
+        accountName: "Australian Taxable",
+      },
+    ],
+    {
+      acquisitionOverrides: [
+        {
+          parcelId: "aggregated-VAS",
+          symbol: "VAS.AX",
+          account: "Australian Taxable",
+          acquisitionDate: "2021-07-01",
+          source: "manual",
+        },
+      ],
+    },
+  );
+
+  assert.equal(report.closedLots[0].parcelId, "buy-1");
+  assert.equal(report.closedLots[0].acquisitionDate, "2024-07-01");
+});
+
+test("report excludes non-AUD CGT lots and surfaces them for review", () => {
+  const report = buildCgtReport([
+    {
+      id: "usd-buy",
+      activityType: "BUY",
+      date: "2024-07-01",
+      quantity: "1",
+      unitPrice: "100",
+      fee: "0",
+      amount: "100",
+      currency: "USD",
+      assetSymbol: "AAPL",
+      accountName: "Australian Taxable",
+      fxRate: "1.5",
+    },
+    {
+      id: "usd-sell",
+      activityType: "SELL",
+      date: "2026-08-01",
+      quantity: "1",
+      unitPrice: "160",
+      fee: "0",
+      amount: "160",
+      currency: "USD",
+      assetSymbol: "AAPL",
+      accountName: "Australian Taxable",
+      fxRate: "1.5",
+    },
+  ]);
+
+  assert.equal(report.closedLots.length, 0);
+  assert.equal(report.incomeYears.length, 0);
+  assert.equal(report.unsupportedActivities.length, 2);
+  assert.equal(report.unsupportedActivities[0].reason, "NON_AUD_CURRENCY");
+});
+
+test("report surfaces ignored activity types for review", () => {
+  const report = buildCgtReport([
+    {
+      id: "split-1",
+      activityType: "SPLIT",
+      date: "2025-01-01",
+      quantity: "2",
+      unitPrice: null,
+      fee: null,
+      amount: null,
+      currency: "AUD",
+      assetSymbol: "VAS.AX",
+      accountName: "Australian Taxable",
+    },
+  ]);
+
+  assert.equal(report.ignoredActivities.length, 1);
+  assert.equal(report.ignoredActivities[0].activityType, "SPLIT");
+});
+
+test("closed lots are sorted by disposal date, symbol, and account", () => {
+  const report = buildCgtReport([
+    {
+      id: "z-buy",
+      activityType: "BUY",
+      date: "2024-07-01",
+      quantity: "1",
+      unitPrice: "100",
+      fee: "0",
+      amount: "100",
+      currency: "AUD",
+      assetSymbol: "ZZZ.AX",
+      accountName: "Australian Taxable",
+    },
+    {
+      id: "a-buy",
+      activityType: "BUY",
+      date: "2024-07-01",
+      quantity: "1",
+      unitPrice: "100",
+      fee: "0",
+      amount: "100",
+      currency: "AUD",
+      assetSymbol: "AAA.AX",
+      accountName: "Australian Taxable",
+    },
+    {
+      id: "z-sell",
+      activityType: "SELL",
+      date: "2026-08-02",
+      quantity: "1",
+      unitPrice: "160",
+      fee: "0",
+      amount: "160",
+      currency: "AUD",
+      assetSymbol: "ZZZ.AX",
+      accountName: "Australian Taxable",
+    },
+    {
+      id: "a-sell",
+      activityType: "SELL",
+      date: "2026-08-01",
+      quantity: "1",
+      unitPrice: "160",
+      fee: "0",
+      amount: "160",
+      currency: "AUD",
+      assetSymbol: "AAA.AX",
+      accountName: "Australian Taxable",
+    },
+  ]);
+
+  assert.deepEqual(
+    report.closedLots.map((lot) => lot.symbol),
+    ["AAA.AX", "ZZZ.AX"],
+  );
+});
+
+test("income year summary applies capital losses before discount", () => {
+  const report = buildCgtReport([
+    {
+      id: "gain-buy",
+      activityType: "BUY",
+      date: "2024-07-01",
+      quantity: "1",
+      unitPrice: "100",
+      fee: "0",
+      amount: "100",
+      currency: "AUD",
+      assetSymbol: "GAIN.AX",
+      accountName: "Australian Taxable",
+    },
+    {
+      id: "loss-buy",
+      activityType: "BUY",
+      date: "2024-07-01",
+      quantity: "1",
+      unitPrice: "100",
+      fee: "0",
+      amount: "100",
+      currency: "AUD",
+      assetSymbol: "LOSS.AX",
+      accountName: "Australian Taxable",
+    },
+    {
+      id: "gain-sell",
+      activityType: "SELL",
+      date: "2026-05-01",
+      quantity: "1",
+      unitPrice: "200",
+      fee: "0",
+      amount: "200",
+      currency: "AUD",
+      assetSymbol: "GAIN.AX",
+      accountName: "Australian Taxable",
+    },
+    {
+      id: "loss-sell",
+      activityType: "SELL",
+      date: "2026-05-01",
+      quantity: "1",
+      unitPrice: "60",
+      fee: "0",
+      amount: "60",
+      currency: "AUD",
+      assetSymbol: "LOSS.AX",
+      accountName: "Australian Taxable",
+    },
+  ]);
+
+  assert.equal(report.incomeYears[0].grossGain, 60);
+  assert.equal(report.incomeYears[0].capitalLossesApplied, 40);
+  assert.equal(report.incomeYears[0].discountApplied, 30);
+  assert.equal(report.incomeYears[0].taxableGain, 30);
+});
+
+test("income year summary carries unapplied capital losses forward", () => {
+  const report = buildCgtReport([
+    {
+      id: "loss-buy",
+      activityType: "BUY",
+      date: "2023-07-01",
+      quantity: "1",
+      unitPrice: "200",
+      fee: "0",
+      amount: "200",
+      currency: "AUD",
+      assetSymbol: "AAA.AX",
+      accountName: "Australian Taxable",
+    },
+    {
+      id: "loss-sell",
+      activityType: "SELL",
+      date: "2024-08-01",
+      quantity: "1",
+      unitPrice: "120",
+      fee: "0",
+      amount: "120",
+      currency: "AUD",
+      assetSymbol: "AAA.AX",
+      accountName: "Australian Taxable",
+    },
+    {
+      id: "gain-buy",
+      activityType: "BUY",
+      date: "2024-07-01",
+      quantity: "1",
+      unitPrice: "100",
+      fee: "0",
+      amount: "100",
+      currency: "AUD",
+      assetSymbol: "BBB.AX",
+      accountName: "Australian Taxable",
+    },
+    {
+      id: "gain-sell",
+      activityType: "SELL",
+      date: "2025-08-01",
+      quantity: "1",
+      unitPrice: "200",
+      fee: "0",
+      amount: "200",
+      currency: "AUD",
+      assetSymbol: "BBB.AX",
+      accountName: "Australian Taxable",
+    },
+  ]);
+
+  assert.equal(report.incomeYears[0].incomeYear, "2024-25");
+  assert.equal(report.incomeYears[0].capitalLossCarryForward, 80);
+  assert.equal(report.incomeYears[0].taxableGain, 0);
+  assert.equal(report.incomeYears[1].incomeYear, "2025-26");
+  assert.equal(report.incomeYears[1].capitalLossesApplied, 80);
+  assert.equal(report.incomeYears[1].capitalLossCarryForward, 0);
+  assert.equal(report.incomeYears[1].taxableGain, 10);
+});
+
+test("report matches lots by account id when account names duplicate", () => {
+  const report = buildCgtReport([
+    {
+      id: "account-a-buy",
+      activityType: "BUY",
+      date: "2024-07-01",
+      quantity: "1",
+      unitPrice: "100",
+      fee: "0",
+      amount: "100",
+      currency: "AUD",
+      assetSymbol: "VAS.AX",
+      accountName: "Brokerage",
+      accountId: "account-a",
+    },
+    {
+      id: "account-b-buy",
+      activityType: "BUY",
+      date: "2024-07-01",
+      quantity: "1",
+      unitPrice: "200",
+      fee: "0",
+      amount: "200",
+      currency: "AUD",
+      assetSymbol: "VAS.AX",
+      accountName: "Brokerage",
+      accountId: "account-b",
+    },
+    {
+      id: "account-b-sell",
+      activityType: "SELL",
+      date: "2026-08-01",
+      quantity: "1",
+      unitPrice: "260",
+      fee: "0",
+      amount: "260",
+      currency: "AUD",
+      assetSymbol: "VAS.AX",
+      accountName: "Brokerage",
+      accountId: "account-b",
+    },
+  ]);
+
+  assert.equal(report.closedLots.length, 1);
+  assert.equal(report.closedLots[0].parcelId, "account-b-buy");
+  assert.equal(report.closedLots[0].costBase, 200);
+  assert.equal(report.closedLots[0].taxableGain, 30);
+});
+
+test("report surfaces unmatched sell quantities for review", () => {
+  const report = buildCgtReport([
+    {
+      id: "buy-one",
+      activityType: "BUY",
+      date: "2025-01-01",
+      quantity: "1",
+      unitPrice: "100",
+      fee: "0",
+      amount: "100",
+      currency: "AUD",
+      assetSymbol: "SHORT.AX",
+      accountName: "Australian Taxable",
+    },
+    {
+      id: "sell-two",
+      activityType: "SELL",
+      date: "2026-05-01",
+      quantity: "2",
+      unitPrice: "150",
+      fee: "0",
+      amount: "300",
+      currency: "AUD",
+      assetSymbol: "SHORT.AX",
+      accountName: "Australian Taxable",
+    },
+  ]);
+
+  assert.equal(report.closedLots.length, 1);
+  assert.equal(report.unmatchedSells.length, 1);
+  assert.equal(report.unmatchedSells[0].symbol, "SHORT.AX");
+  assert.equal(report.unmatchedSells[0].quantity, 1);
+});
+
+test("CSV export labels per-lot losses as lotCapitalLoss", () => {
+  const csv = exportReportCsv({
+    closedLots: [
+      {
+        parcelId: "loss-buy",
+        symbol: "LOSS.AX",
+        account: "Australian Taxable",
+        incomeYear: "2025-26",
+        acquisitionDate: "2024-07-01",
+        disposalDate: "2026-05-01",
+        quantity: 1,
+        proceeds: 60,
+        costBase: 100,
+        amitCostBaseAdjustment: 0,
+        grossGain: -40,
+        taxableGain: 0,
+        discountApplied: 0,
+        discountEligible: false,
+        method: "FIFO",
+      },
+    ],
+    incomeYears: [],
+    unmatchedSells: [],
+    dividends: [],
+    transitionLots: [],
+    unsupportedActivities: [],
+    ignoredActivities: [],
+  });
+
+  assert.match(csv.split("\n")[0], /lotCapitalLoss/);
+  assert.doesNotMatch(csv.split("\n")[0], /capitalLossesApplied/);
+});
+
+let failures = 0;
+
+for (const { name, fn } of tests) {
+  try {
+    await fn();
+    console.log(`ok - ${name}`);
+  } catch (error) {
+    failures += 1;
+    console.error(`not ok - ${name}`);
+    console.error(error);
+  }
+}
+
+await rm(tempDir, { recursive: true, force: true });
+
+if (failures > 0) {
+  process.exitCode = 1;
+}

--- a/addons/australia-cgt-addon/test-runner.mjs
+++ b/addons/australia-cgt-addon/test-runner.mjs
@@ -235,9 +235,9 @@ test("report matches FIFO lots, includes fees, groups by Australian income year,
 
   assert.equal(report.closedLots.length, 2);
   assert.equal(report.closedLots[0].quantity, 10);
-  assert.equal(report.closedLots[0].taxableGain, 240);
+  assert.equal(report.closedLots[0].preLossTaxableGainEstimate, 240);
   assert.equal(report.closedLots[1].quantity, 2);
-  assert.equal(report.closedLots[1].taxableGain, 56);
+  assert.equal(report.closedLots[1].preLossTaxableGainEstimate, 56);
   assert.equal(report.incomeYears[0].incomeYear, "2026-27");
   assert.equal(report.incomeYears[0].taxableGain, 296);
 
@@ -386,7 +386,7 @@ test("AMMA-derived AMIT adjustments change disposal cost base and taxable gain",
 
   assert.equal(report.closedLots[0].amitCostBaseAdjustment, 30);
   assert.equal(report.closedLots[0].costBase, 1030);
-  assert.equal(report.closedLots[0].taxableGain, 235);
+  assert.equal(report.closedLots[0].preLossTaxableGainEstimate, 235);
 });
 
 test("ABS CPI series parses, merges, caches, and produces indexation factor", async () => {
@@ -463,7 +463,7 @@ test("AMIT adjustments alter parcel-level cost base before gain calculation", ()
 
   assert.equal(report.closedLots[0].costBase, 1030);
   assert.equal(report.closedLots[0].amitCostBaseAdjustment, 30);
-  assert.equal(report.closedLots[0].taxableGain, 235);
+  assert.equal(report.closedLots[0].preLossTaxableGainEstimate, 235);
   assert.equal(report.incomeYears[0].amitCostBaseAdjustment, 30);
 });
 
@@ -502,7 +502,7 @@ test("AMIT adjustments after disposal year do not alter past disposals", () => {
 
   assert.equal(report.closedLots[0].costBase, 1000);
   assert.equal(report.closedLots[0].amitCostBaseAdjustment, 0);
-  assert.equal(report.closedLots[0].taxableGain, 250);
+  assert.equal(report.closedLots[0].preLossTaxableGainEstimate, 250);
 });
 
 test("AMIT adjustments after a partial disposal apply to the surviving holding quantity", () => {
@@ -553,7 +553,7 @@ test("AMIT adjustments after a partial disposal apply to the surviving holding q
   assert.equal(report.closedLots[0].amitCostBaseAdjustment, 0);
   assert.equal(report.closedLots[1].amitCostBaseAdjustment, 100);
   assert.equal(report.closedLots[1].costBase, 600);
-  assert.equal(report.closedLots[1].taxableGain, 100);
+  assert.equal(report.closedLots[1].preLossTaxableGainEstimate, 100);
 });
 
 test("transition snapshots produce parcel-level 2027 transition rows", () => {
@@ -800,7 +800,7 @@ test("report accepts API timestamp date strings", () => {
   assert.equal(report.incomeYears[0].incomeYear, "2025-26");
   assert.equal(report.closedLots[0].acquisitionDate, "2024-07-01");
   assert.equal(report.closedLots[0].disposalDate, "2026-05-01");
-  assert.equal(report.closedLots[0].taxableGain, 30);
+  assert.equal(report.closedLots[0].preLossTaxableGainEstimate, 30);
 });
 
 test("report matches FIFO lots within the selling account only", () => {
@@ -847,7 +847,7 @@ test("report matches FIFO lots within the selling account only", () => {
   assert.equal(report.closedLots[0].parcelId, "super-buy");
   assert.equal(report.closedLots[0].account, "Super");
   assert.equal(report.closedLots[0].costBase, 200);
-  assert.equal(report.closedLots[0].taxableGain, 30);
+  assert.equal(report.closedLots[0].preLossTaxableGainEstimate, 30);
   assert.equal(report.transitionLots.length, 0);
 });
 
@@ -1175,7 +1175,7 @@ test("report matches lots by account id when account names duplicate", () => {
   assert.equal(report.closedLots.length, 1);
   assert.equal(report.closedLots[0].parcelId, "account-b-buy");
   assert.equal(report.closedLots[0].costBase, 200);
-  assert.equal(report.closedLots[0].taxableGain, 30);
+  assert.equal(report.closedLots[0].preLossTaxableGainEstimate, 30);
 });
 
 test("report surfaces unmatched sell quantities for review", () => {
@@ -1227,8 +1227,8 @@ test("CSV export labels per-lot losses as lotCapitalLoss", () => {
         costBase: 100,
         amitCostBaseAdjustment: 0,
         grossGain: -40,
-        taxableGain: 0,
-        discountApplied: 0,
+        preLossTaxableGainEstimate: 0,
+        preLossDiscountEstimate: 0,
         discountEligible: false,
         method: "FIFO",
       },
@@ -1243,6 +1243,72 @@ test("CSV export labels per-lot losses as lotCapitalLoss", () => {
 
   assert.match(csv.split("\n")[0], /lotCapitalLoss/);
   assert.doesNotMatch(csv.split("\n")[0], /capitalLossesApplied/);
+});
+
+test("CSV export labels matched-lot taxable values as pre-loss estimates", () => {
+  const csv = exportReportCsv({
+    closedLots: [
+      {
+        parcelId: "gain-buy",
+        symbol: "GAIN.AX",
+        account: "Australian Taxable",
+        incomeYear: "2025-26",
+        acquisitionDate: "2024-07-01",
+        disposalDate: "2026-05-01",
+        quantity: 1,
+        proceeds: 200,
+        costBase: 100,
+        amitCostBaseAdjustment: 0,
+        grossGain: 100,
+        preLossTaxableGainEstimate: 50,
+        preLossDiscountEstimate: 50,
+        discountEligible: true,
+        method: "FIFO",
+      },
+      {
+        parcelId: "loss-buy",
+        symbol: "LOSS.AX",
+        account: "Australian Taxable",
+        incomeYear: "2025-26",
+        acquisitionDate: "2024-07-01",
+        disposalDate: "2026-05-01",
+        quantity: 1,
+        proceeds: 60,
+        costBase: 100,
+        amitCostBaseAdjustment: 0,
+        grossGain: -40,
+        preLossTaxableGainEstimate: 0,
+        preLossDiscountEstimate: 0,
+        discountEligible: false,
+        method: "FIFO",
+      },
+    ],
+    incomeYears: [
+      {
+        incomeYear: "2025-26",
+        proceeds: 260,
+        costBase: 200,
+        amitCostBaseAdjustment: 0,
+        grossGain: 60,
+        grossCapitalGains: 100,
+        capitalLossesApplied: 40,
+        capitalLossCarryForward: 0,
+        discountApplied: 30,
+        taxableGain: 30,
+      },
+    ],
+    unmatchedSells: [],
+    dividends: [],
+    transitionLots: [],
+    unsupportedActivities: [],
+    ignoredActivities: [],
+  });
+
+  const header = csv.split("\n")[0];
+  assert.match(header, /preLossDiscountEstimate/);
+  assert.match(header, /preLossTaxableGainEstimate/);
+  assert.doesNotMatch(header, /(?<!preLoss)discountApplied/);
+  assert.doesNotMatch(header, /(?<!preLoss)taxableGain/);
 });
 
 let failures = 0;

--- a/addons/australia-cgt-addon/tsconfig.json
+++ b/addons/australia-cgt-addon/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@wealthfolio/addon-sdk": ["../../packages/addon-sdk/src"],
+      "@wealthfolio/ui": ["../../packages/ui/src"],
+      "@wealthfolio/ui/*": ["../../packages/ui/src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [
+    { "path": "./tsconfig.node.json" },
+    { "path": "../../packages/ui" },
+    { "path": "../../packages/addon-sdk" }
+  ]
+}

--- a/addons/australia-cgt-addon/tsconfig.node.json
+++ b/addons/australia-cgt-addon/tsconfig.node.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/addons/australia-cgt-addon/vite.config.ts
+++ b/addons/australia-cgt-addon/vite.config.ts
@@ -1,0 +1,37 @@
+import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
+import { defineConfig } from "vite";
+import externalGlobals from "rollup-plugin-external-globals";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  define: {
+    "process.env.NODE_ENV": JSON.stringify("production"),
+  },
+  build: {
+    lib: {
+      entry: "src/addon.tsx",
+      fileName: () => "addon.js",
+      formats: ["es"],
+    },
+    rollupOptions: {
+      external: ["react", "react-dom"],
+      plugins: [
+        externalGlobals({
+          react: "React",
+          "react-dom": "ReactDOM",
+        }),
+      ],
+      output: {
+        globals: {
+          react: "React",
+          "react-dom": "ReactDOM",
+        },
+      },
+    },
+    outDir: "dist",
+    emptyOutDir: true,
+    minify: false,
+    sourcemap: true,
+  },
+});

--- a/apps/frontend/src/addons/addons-dev-mode.ts
+++ b/apps/frontend/src/addons/addons-dev-mode.ts
@@ -1,6 +1,6 @@
 import { logger } from "@/adapters";
 import { reloadAllAddons } from "@/addons/addons-core";
-import { createAddonContext } from "./addons-runtime-context";
+import { createAddonContext } from "@/addons/addons-runtime-context";
 
 interface DevModeConfig {
   enabled: boolean;
@@ -309,7 +309,7 @@ class AddonDevManager {
         logger.info(`✅ Successfully hot-reloaded ${addonId}`);
 
         // Trigger navigation update to refresh the UI
-        const { triggerNavigationUpdate } = await import("./addons-runtime-context");
+        const { triggerNavigationUpdate } = await import("@/addons/addons-runtime-context");
         if (triggerNavigationUpdate) {
           triggerNavigationUpdate();
         }

--- a/e2e/14-australia-cgt-addon.spec.ts
+++ b/e2e/14-australia-cgt-addon.spec.ts
@@ -1,4 +1,5 @@
 import { expect, Page, test } from "@playwright/test";
+import { readFile } from "node:fs/promises";
 import path from "path";
 import { fileURLToPath } from "url";
 import { BASE_URL, createAccount, loginIfNeeded } from "./helpers";
@@ -111,6 +112,9 @@ test.describe("Australia CGT addon", () => {
     const browserErrors: string[] = [];
     page.on("console", (message) => {
       if (message.type() === "error") {
+        if (/^Failed to load resource: .* 404 \(Not Found\)$/.test(message.text())) {
+          return;
+        }
         browserErrors.push(message.text());
       }
     });
@@ -135,9 +139,17 @@ test.describe("Australia CGT addon", () => {
     }
     await expect(cgtHeading).toBeVisible();
 
-    await expect(page.getByText("2025-26")).toBeVisible();
+    const incomeYearSummary = page.locator("section").filter({
+      has: page.getByRole("heading", { name: "Income Year Summary" }),
+    });
+    const matchedLots = page.locator("section").filter({
+      has: page.getByRole("heading", { name: "Matched Lots" }),
+    });
+
+    await expect(incomeYearSummary.getByRole("row", { name: /2025-26/ })).toBeVisible();
     await expect(page.getByText("VAS").first()).toBeVisible();
-    await expect(page.getByText("$296").first()).toBeVisible();
+    await expect(incomeYearSummary.getByRole("row", { name: /2025-26.*\$296/ })).toBeVisible();
+    await expect(matchedLots.getByRole("columnheader", { name: "Pre-loss taxable" })).toBeVisible();
 
     await page.getByRole("button", { name: "Clear local tax data" }).click();
     await expect(page.getByText("AMMA statements: 0")).toBeVisible();
@@ -158,7 +170,7 @@ test.describe("Australia CGT addon", () => {
     await page.getByRole("button", { name: "Save AMMA statement" }).click();
     await expect(page.getByText("AMMA statements: 1")).toBeVisible();
     await expect(page.getByText("AMIT adjustments: 1")).toBeVisible();
-    await expect(page.getByText("$281").first()).toBeVisible();
+    await expect(incomeYearSummary.getByRole("row", { name: /2025-26.*\$281/ })).toBeVisible();
     await expect(page.getByText(/Taxable \$300 · Cash \$280 · Franking \$20/)).toBeVisible();
     await expect(page.getByRole("button", { name: /Delete AMMA .*:2025-26/ })).toBeVisible();
 
@@ -194,12 +206,23 @@ test.describe("Australia CGT addon", () => {
     await page.reload({ waitUntil: "domcontentloaded" });
     await expect(cgtHeading).toBeVisible({ timeout: 30000 });
     await expect(page.getByText("AMMA statements: 1")).toBeVisible();
-    await expect(page.getByText("$281").first()).toBeVisible();
+    await expect(incomeYearSummary.getByRole("row", { name: /2025-26.*\$281/ })).toBeVisible();
     await expect(page.getByText("Cached observations: 1")).toBeVisible();
     await expect(page.getByText("2027 snapshots: 1")).toBeVisible();
     await expect(page.getByText("Acquisition overrides: 1")).toBeVisible();
 
     const exportButton = page.getByRole("button", { name: /Export CSV/i });
     await expect(exportButton).toBeEnabled();
+    const downloadPromise = page.waitForEvent("download");
+    await exportButton.click();
+    const download = await downloadPromise;
+    const downloadPath = await download.path();
+    expect(downloadPath).toBeTruthy();
+    const csv = await readFile(downloadPath!, "utf8");
+    expect(csv).toContain("preLossDiscountEstimate,preLossTaxableGainEstimate");
+    expect(csv).toContain('"2025-26","VAS"');
+    expect(csv).toContain('"FIFO"');
+
+    expect(browserErrors).toEqual([]);
   });
 });

--- a/e2e/14-australia-cgt-addon.spec.ts
+++ b/e2e/14-australia-cgt-addon.spec.ts
@@ -13,6 +13,10 @@ test.skip(
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURE = path.join(__dirname, "fixtures", "australia-cgt-addon.csv");
 const ACCOUNT_NAME = "Australian Taxable";
+const EXPECTED_404_URLS = new Set([
+  "http://localhost:3001/addon-updates",
+  `${BASE_URL}/.well-known/appspecific/com.chrome.devtools.json`,
+]);
 
 async function completeAudOnboardingIfNeeded(page: Page) {
   await page.goto(BASE_URL, { waitUntil: "domcontentloaded" });
@@ -110,12 +114,22 @@ test.describe("Australia CGT addon", () => {
   test("loads from addon dev mode and reports imported AUD CGT lots", async () => {
     test.setTimeout(240000);
     const browserErrors: string[] = [];
+    const notFoundResponses: string[] = [];
     page.on("console", (message) => {
       if (message.type() === "error") {
-        if (/^Failed to load resource: .* 404 \(Not Found\)$/.test(message.text())) {
+        const text = message.text();
+        if (
+          text ===
+          "Failed to load resource: the server responded with a status of 404 (Not Found)"
+        ) {
           return;
         }
-        browserErrors.push(message.text());
+        browserErrors.push(text);
+      }
+    });
+    page.on("response", (response) => {
+      if (response.status() === 404) {
+        notFoundResponses.push(response.url());
       }
     });
     page.on("pageerror", (error) => {
@@ -155,8 +169,12 @@ test.describe("Australia CGT addon", () => {
     await expect(page.getByText("AMMA statements: 0")).toBeVisible();
     await expect(page.getByText("Cached observations: 0")).toBeVisible();
 
+    // Imported CSV dates are normalized by the web E2E import path before the addon sees them.
+    // Keep this selector deliberate by matching the parcel's symbol, account, and displayed date.
     const firstDisposedParcelId = await page
-      .locator('datalist#australia-cgt-all-parcels option[label*="2024-06-30"]')
+      .locator(
+        'datalist#australia-cgt-all-parcels option[label*="VAS"][label*="Australian Taxable"][label*="2024-06-30"]',
+      )
       .first()
       .getAttribute("value");
     expect(firstDisposedParcelId).toBeTruthy();
@@ -223,6 +241,8 @@ test.describe("Australia CGT addon", () => {
     expect(csv).toContain('"2025-26","VAS"');
     expect(csv).toContain('"FIFO"');
 
+    const expectedNotFoundUrls = notFoundResponses.filter((url) => EXPECTED_404_URLS.has(url));
+    expect(notFoundResponses).toEqual(expectedNotFoundUrls);
     expect(browserErrors).toEqual([]);
   });
 });

--- a/e2e/14-australia-cgt-addon.spec.ts
+++ b/e2e/14-australia-cgt-addon.spec.ts
@@ -166,11 +166,14 @@ test.describe("Australia CGT addon", () => {
     await expect(matchedLots.getByRole("columnheader", { name: "Pre-loss taxable" })).toBeVisible();
 
     await page.getByRole("button", { name: "Clear local tax data" }).click();
+    await expect(page.getByRole("button", { name: "Confirm clear local tax data" })).toBeVisible();
+    await page.getByRole("button", { name: "Confirm clear local tax data" }).click();
     await expect(page.getByText("AMMA statements: 0")).toBeVisible();
     await expect(page.getByText("Cached observations: 0")).toBeVisible();
+    await expect(page.getByRole("button", { name: "Insert demo CPI row" })).toHaveCount(0);
 
-    // Imported CSV dates are normalized by the web E2E import path before the addon sees them.
-    // Keep this selector deliberate by matching the parcel's symbol, account, and displayed date.
+    // The Wealthfolio web import fixture reaches the addon with this displayed acquisition date.
+    // Keep this selector deliberate by matching symbol, account, and displayed date.
     const firstDisposedParcelId = await page
       .locator(
         'datalist#australia-cgt-all-parcels option[label*="VAS"][label*="Australian Taxable"][label*="2024-06-30"]',
@@ -191,10 +194,6 @@ test.describe("Australia CGT addon", () => {
     await expect(incomeYearSummary.getByRole("row", { name: /2025-26.*\$281/ })).toBeVisible();
     await expect(page.getByText(/Taxable \$300 · Cash \$280 · Franking \$20/)).toBeVisible();
     await expect(page.getByRole("button", { name: /Delete AMMA .*:2025-26/ })).toBeVisible();
-
-    await page.getByRole("button", { name: "Insert demo CPI row" }).click();
-    await expect(page.getByText("Cached observations: 1")).toBeVisible();
-    await expect(page.getByRole("button", { name: /Delete CPI 2027-Q3/ })).toBeVisible();
 
     const openParcelId = await page
       .locator('datalist#australia-cgt-open-parcels option[label*="VAS"]')
@@ -225,7 +224,7 @@ test.describe("Australia CGT addon", () => {
     await expect(cgtHeading).toBeVisible({ timeout: 30000 });
     await expect(page.getByText("AMMA statements: 1")).toBeVisible();
     await expect(incomeYearSummary.getByRole("row", { name: /2025-26.*\$281/ })).toBeVisible();
-    await expect(page.getByText("Cached observations: 1")).toBeVisible();
+    await expect(page.getByText("Cached observations: 0")).toBeVisible();
     await expect(page.getByText("2027 snapshots: 1")).toBeVisible();
     await expect(page.getByText("Acquisition overrides: 1")).toBeVisible();
 

--- a/e2e/14-australia-cgt-addon.spec.ts
+++ b/e2e/14-australia-cgt-addon.spec.ts
@@ -1,0 +1,205 @@
+import { expect, Page, test } from "@playwright/test";
+import path from "path";
+import { fileURLToPath } from "url";
+import { BASE_URL, createAccount, loginIfNeeded } from "./helpers";
+
+test.describe.configure({ mode: "serial" });
+test.skip(
+  process.env.WF_E2E_ENABLE_AUSTRALIA_CGT_ADDON !== "true",
+  "Australia CGT addon E2E requires the addon dev server; run pnpm test:e2e:australia-cgt-addon.",
+);
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.join(__dirname, "fixtures", "australia-cgt-addon.csv");
+const ACCOUNT_NAME = "Australian Taxable";
+
+async function completeAudOnboardingIfNeeded(page: Page) {
+  await page.goto(BASE_URL, { waitUntil: "domcontentloaded" });
+
+  const continueButton = page.getByRole("button", { name: "Continue" });
+  const loginInput = page.getByPlaceholder("Enter your password");
+  const dashboardHeading = page.getByRole("heading", { name: "Dashboard" });
+  const accountsHeading = page.getByRole("heading", { name: "Accounts" });
+
+  await expect(continueButton.or(loginInput).or(dashboardHeading).or(accountsHeading)).toBeVisible({
+    timeout: 120000,
+  });
+
+  if (await loginInput.isVisible()) {
+    await loginIfNeeded(page);
+    return;
+  }
+
+  if (!(await continueButton.isVisible())) return;
+
+  await continueButton.click();
+  await expect(page.getByTestId("currency-aud-button")).toBeVisible({ timeout: 5000 });
+  await page.getByTestId("currency-aud-button").click();
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await expect(page.getByTestId("theme-light-button")).toBeVisible({ timeout: 5000 });
+  await page.getByTestId("theme-light-button").click();
+  await page.getByRole("button", { name: "Continue" }).click();
+
+  await expect(page.getByTestId("onboarding-finish-button")).toBeVisible({ timeout: 15000 });
+  await page.getByTestId("onboarding-finish-button").click();
+
+  await page.waitForURL(new RegExp(`${BASE_URL}/settings/accounts`), { timeout: 15000 });
+}
+
+async function selectImportAccount(page: Page, accountName: string) {
+  const selectorTrigger = page.getByRole("combobox", { name: /Select an account/i });
+  await expect(selectorTrigger).toBeVisible({ timeout: 5000 });
+  await selectorTrigger.click();
+
+  const searchInput = page.getByPlaceholder("Search accounts...");
+  await searchInput.fill(accountName);
+
+  const accountOption = page.getByRole("option", { name: new RegExp(accountName, "i") }).first();
+  await expect(accountOption).toBeVisible({ timeout: 5000 });
+  await accountOption.click();
+}
+
+async function importCgtFixture(page: Page) {
+  await page.goto(`${BASE_URL}/import`, { waitUntil: "domcontentloaded" });
+  await expect(page.getByRole("heading", { name: /Import Activities/i })).toBeVisible({
+    timeout: 10000,
+  });
+
+  await selectImportAccount(page, ACCOUNT_NAME);
+
+  await page.locator('input[type="file"]').setInputFiles(FIXTURE);
+  await expect(page.getByText("CSV Preview")).toBeVisible({ timeout: 10000 });
+  await expect(page.getByText(/3 row/i)).toBeVisible({ timeout: 5000 });
+
+  await page.getByRole("button", { name: /Configure Mapping/i }).click();
+  await expect(page.getByRole("button", { name: /Review Assets/i })).toBeEnabled({
+    timeout: 10000,
+  });
+  await page.getByRole("button", { name: /Review Assets/i }).click();
+
+  await expect(page.getByRole("button", { name: /Review Activities/i })).toBeEnabled({
+    timeout: 30000,
+  });
+  await page.getByRole("button", { name: /Review Activities/i }).click();
+
+  await expect(page.getByRole("button", { name: /Continue to Import/i })).toBeEnabled({
+    timeout: 30000,
+  });
+  await page.getByRole("button", { name: /Continue to Import/i }).click();
+
+  const importButton = page.getByRole("button", { name: /Import \d+ Activit/i });
+  await expect(importButton).toBeEnabled({ timeout: 10000 });
+  await importButton.click();
+
+  await expect(page.getByText("Import Complete")).toBeVisible({ timeout: 60000 });
+}
+
+test.describe("Australia CGT addon", () => {
+  let page: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test("loads from addon dev mode and reports imported AUD CGT lots", async () => {
+    test.setTimeout(240000);
+    const browserErrors: string[] = [];
+    page.on("console", (message) => {
+      if (message.type() === "error") {
+        browserErrors.push(message.text());
+      }
+    });
+    page.on("pageerror", (error) => {
+      browserErrors.push(error.message);
+    });
+
+    await completeAudOnboardingIfNeeded(page);
+    await createAccount(page, ACCOUNT_NAME, "AUD", "Transactions");
+    await importCgtFixture(page);
+
+    await page.goto(`${BASE_URL}/addons/australia-cgt`, { waitUntil: "domcontentloaded" });
+    const cgtHeading = page.getByRole("heading", { name: "Australia CGT Planner" });
+    const errorHeading = page.getByRole("heading", { name: "Something went wrong" });
+    await expect(cgtHeading.or(errorHeading)).toBeVisible({ timeout: 30000 });
+    if (await errorHeading.isVisible().catch(() => false)) {
+      await page.getByRole("button", { name: "Show error details" }).click();
+      const bodyText = await page.locator("body").innerText();
+      throw new Error(
+        `Australia CGT route rendered app error.\n\n${bodyText}\n\nBrowser errors:\n${browserErrors.join("\n")}`,
+      );
+    }
+    await expect(cgtHeading).toBeVisible();
+
+    await expect(page.getByText("2025-26")).toBeVisible();
+    await expect(page.getByText("VAS").first()).toBeVisible();
+    await expect(page.getByText("$296").first()).toBeVisible();
+
+    await page.getByRole("button", { name: "Clear local tax data" }).click();
+    await expect(page.getByText("AMMA statements: 0")).toBeVisible();
+    await expect(page.getByText("Cached observations: 0")).toBeVisible();
+
+    const firstDisposedParcelId = await page
+      .locator('datalist#australia-cgt-all-parcels option[label*="2024-06-30"]')
+      .first()
+      .getAttribute("value");
+    expect(firstDisposedParcelId).toBeTruthy();
+
+    await page.getByLabel("AMMA parcel ID").fill(firstDisposedParcelId!);
+    await page.getByLabel("AMMA income year").fill("2025-26");
+    await page.getByLabel("AMMA taxable income").fill("300");
+    await page.getByLabel("AMMA cash distribution").fill("280");
+    await page.getByLabel("AMMA franking credits").fill("20");
+    await page.getByLabel("AMIT cost base increase").fill("30");
+    await page.getByRole("button", { name: "Save AMMA statement" }).click();
+    await expect(page.getByText("AMMA statements: 1")).toBeVisible();
+    await expect(page.getByText("AMIT adjustments: 1")).toBeVisible();
+    await expect(page.getByText("$281").first()).toBeVisible();
+    await expect(page.getByText(/Taxable \$300 · Cash \$280 · Franking \$20/)).toBeVisible();
+    await expect(page.getByRole("button", { name: /Delete AMMA .*:2025-26/ })).toBeVisible();
+
+    await page.getByRole("button", { name: "Insert demo CPI row" }).click();
+    await expect(page.getByText("Cached observations: 1")).toBeVisible();
+    await expect(page.getByRole("button", { name: /Delete CPI 2027-Q3/ })).toBeVisible();
+
+    const openParcelId = await page
+      .locator('datalist#australia-cgt-open-parcels option[label*="VAS"]')
+      .first()
+      .getAttribute("value");
+    expect(openParcelId).toBeTruthy();
+
+    await page.getByLabel("Snapshot parcel ID").fill(openParcelId!);
+    await page.getByLabel("Snapshot market value").fill("1600");
+    await page.getByRole("button", { name: "Save 2027 snapshot" }).click();
+    await expect(page.getByText("2027 snapshots: 1")).toBeVisible();
+    await expect(page.getByRole("button", { name: /Delete snapshot/ })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "2027 Transition Parcels" })).toBeVisible();
+    await expect(page.getByRole("cell", { name: openParcelId! }).first()).toBeVisible();
+    await expect(page.getByText("$1,600").first()).toBeVisible();
+
+    await page.getByLabel("Override parcel ID").fill("aggregated-VAS");
+    await page.getByLabel("Override symbol").fill("VAS.AX");
+    await page.getByLabel("Override account").fill(ACCOUNT_NAME);
+    await page.getByLabel("Override acquisition date").fill("2021-07-01");
+    await page.getByRole("button", { name: "Save acquisition date" }).click();
+    await expect(page.getByText("Acquisition overrides: 1")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /Delete acquisition override aggregated-VAS/ }),
+    ).toBeVisible();
+
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expect(cgtHeading).toBeVisible({ timeout: 30000 });
+    await expect(page.getByText("AMMA statements: 1")).toBeVisible();
+    await expect(page.getByText("$281").first()).toBeVisible();
+    await expect(page.getByText("Cached observations: 1")).toBeVisible();
+    await expect(page.getByText("2027 snapshots: 1")).toBeVisible();
+    await expect(page.getByText("Acquisition overrides: 1")).toBeVisible();
+
+    const exportButton = page.getByRole("button", { name: /Export CSV/i });
+    await expect(exportButton).toBeEnabled();
+  });
+});

--- a/e2e/fixtures/australia-cgt-addon.csv
+++ b/e2e/fixtures/australia-cgt-addon.csv
@@ -1,0 +1,4 @@
+date,symbol,instrumentType,quantity,activityType,unitPrice,currency,fee,amount,fxRate,subtype
+2024-07-01,VAS.AX,EQUITY,10,BUY,100,AUD,10,,,
+2026-03-01,VAS.AX,EQUITY,10,BUY,120,AUD,10,,,
+2026-05-01,VAS.AX,EQUITY,12,SELL,150,AUD,12,,,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test:ui": "pnpm --filter frontend test:ui",
     "test:coverage": "pnpm --filter frontend test:coverage",
     "test:e2e": "node scripts/run-e2e.mjs",
+    "test:e2e:australia-cgt-addon": "node scripts/run-australia-cgt-addon-e2e.mjs",
     "test:e2e:ui": "node scripts/run-e2e.mjs --ui",
     "lint": "pnpm --filter frontend lint && pnpm -r lint",
     "lint:fix": "pnpm --filter frontend lint:fix && pnpm -r lint:fix",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,55 @@ importers:
         specifier: ^8.55.0
         version: 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
 
+  addons/australia-cgt-addon:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.90.20
+        version: 5.90.21(react@19.2.4)
+      '@wealthfolio/addon-sdk':
+        specifier: workspace:*
+        version: link:../../packages/addon-sdk
+      '@wealthfolio/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.1.18
+        version: 4.2.1(vite@7.3.2(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1))
+      '@types/node':
+        specifier: ^20.19.33
+        version: 20.19.35
+      '@types/react':
+        specifier: ^19.2.13
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^5.1.4
+        version: 5.1.4(vite@7.3.2(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1))
+      '@wealthfolio/addon-dev-tools':
+        specifier: workspace:*
+        version: link:../../packages/addon-dev-tools
+      rollup-plugin-external-globals:
+        specifier: ^0.13.0
+        version: 0.13.0(rollup@4.60.3)
+      tailwindcss:
+        specifier: ^4.1.18
+        version: 4.2.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.2
+        version: 7.3.2(@types/node@20.19.35)(jiti@2.6.1)(lightningcss@1.31.1)
+
   addons/goal-progress-tracker:
     dependencies:
       '@tanstack/react-query':
@@ -3154,6 +3203,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}

--- a/scripts/run-australia-cgt-addon-e2e.mjs
+++ b/scripts/run-australia-cgt-addon-e2e.mjs
@@ -1,20 +1,48 @@
 import { spawn, spawnSync } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { once } from "node:events";
-import { copyFile, access } from "node:fs/promises";
+import { copyFile, access, readFile } from "node:fs/promises";
 import { setTimeout } from "node:timers/promises";
 import { prepE2eEnv } from "./prep-e2e.mjs";
 
 const FRONTEND_URL = "http://localhost:1420";
 const BACKEND_URL = "http://localhost:8088";
 const ADDON_URL = "http://localhost:3001";
-const TEST_SERVER_ENV = {
+const SHUTDOWN_TIMEOUT_MS = 5_000;
+
+const parseEnvFile = (content) =>
+  Object.fromEntries(
+    content
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line && !line.startsWith("#"))
+      .map((line) => {
+        const separator = line.indexOf("=");
+        if (separator === -1) return [line, ""];
+        return [line.slice(0, separator), line.slice(separator + 1).replace(/^["']|["']$/g, "")];
+      }),
+  );
+
+const getFreshDbPath = async () => {
+  const env = parseEnvFile(await readFile(".env.web", "utf8"));
+  const dbPath = env.WF_DB_PATH;
+  if (!dbPath?.includes("app-testing-")) {
+    throw new Error(
+      `Australia CGT E2E must run against a fresh app-testing DB; got ${dbPath || "missing WF_DB_PATH"}`,
+    );
+  }
+  console.log(`Australia CGT E2E database path: ${dbPath}`);
+  return dbPath;
+};
+
+const createTestServerEnv = (dbPath) => ({
   WF_LISTEN_ADDR: "127.0.0.1:8088",
   WF_CORS_ALLOW_ORIGINS: FRONTEND_URL,
   WF_SECRET_KEY: randomBytes(32).toString("base64"),
   WF_AUTH_REQUIRED: "false",
+  WF_DB_PATH: dbPath,
   VITE_API_TARGET: BACKEND_URL,
-};
+});
 
 const ensureEnvFile = async () => {
   try {
@@ -83,19 +111,52 @@ const spawnTestProcess = (command, args, env = {}) =>
     env: { ...process.env, ...env },
   });
 
+const waitForExitOrTimeout = async (child, timeoutMs) => {
+  if (child.exitCode !== null || child.signalCode !== null) return true;
+
+  let timeout;
+  try {
+    await Promise.race([
+      once(child, "exit").then(() => true),
+      new Promise((resolve) => {
+        timeout = globalThis.setTimeout(() => resolve(false), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) globalThis.clearTimeout(timeout);
+  }
+
+  return child.exitCode !== null || child.signalCode !== null;
+};
+
+const stopChild = async (child) => {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+
+  child.kill("SIGINT");
+  if (await waitForExitOrTimeout(child, SHUTDOWN_TIMEOUT_MS)) return;
+
+  child.kill("SIGTERM");
+  if (await waitForExitOrTimeout(child, SHUTDOWN_TIMEOUT_MS)) return;
+
+  child.kill("SIGKILL");
+  await waitForExitOrTimeout(child, SHUTDOWN_TIMEOUT_MS);
+};
+
 const run = async () => {
   requireCommand("cargo", ["--version"]);
   await ensureEnvFile();
   await prepE2eEnv();
+  const dbPath = await getFreshDbPath();
+  const testServerEnv = createTestServerEnv(dbPath);
 
   const addonServer = spawnChecked("pnpm", ["--filter", "australia-cgt-addon", "dev:server"]);
   const backendServer = spawnChecked(
     "cargo",
     ["run", "--manifest-path", "apps/server/Cargo.toml"],
-    TEST_SERVER_ENV,
+    testServerEnv,
   );
   const frontendServer = spawnChecked("pnpm", ["--filter", "frontend", "dev"], {
-    ...TEST_SERVER_ENV,
+    ...testServerEnv,
     BUILD_TARGET: "web",
     WF_ENABLE_VITE_PROXY: "true",
     VITE_ENABLE_ADDON_DEV_MODE: "true",
@@ -103,12 +164,7 @@ const run = async () => {
   const children = [addonServer, backendServer, frontendServer];
 
   const cleanup = async () => {
-    for (const child of children) {
-      if (child.exitCode === null && !child.killed) {
-        child.kill("SIGINT");
-      }
-    }
-    await Promise.all(children.map((child) => once(child, "exit").catch(() => {})));
+    await Promise.all(children.map((child) => stopChild(child).catch(() => {})));
   };
 
   process.once("SIGINT", () => cleanup().catch(() => {}));

--- a/scripts/run-australia-cgt-addon-e2e.mjs
+++ b/scripts/run-australia-cgt-addon-e2e.mjs
@@ -1,0 +1,145 @@
+import { spawn, spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { once } from "node:events";
+import { copyFile, access } from "node:fs/promises";
+import { setTimeout } from "node:timers/promises";
+import { prepE2eEnv } from "./prep-e2e.mjs";
+
+const FRONTEND_URL = "http://localhost:1420";
+const BACKEND_URL = "http://localhost:8088";
+const ADDON_URL = "http://localhost:3001";
+const TEST_SERVER_ENV = {
+  WF_LISTEN_ADDR: "127.0.0.1:8088",
+  WF_CORS_ALLOW_ORIGINS: FRONTEND_URL,
+  WF_SECRET_KEY: randomBytes(32).toString("base64"),
+  WF_AUTH_REQUIRED: "false",
+  VITE_API_TARGET: BACKEND_URL,
+};
+
+const ensureEnvFile = async () => {
+  try {
+    await access(".env.web");
+  } catch (_error) {
+    await copyFile(".env.web.example", ".env.web");
+  }
+};
+
+const requireCommand = (command, args = ["--version"]) => {
+  const result = spawnSync(command, args, { stdio: "ignore" });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(" ")} exited with code ${result.status}`);
+  }
+};
+
+const waitForServer = async (url, processes, { timeout = 120_000, interval = 500 } = {}) => {
+  const deadline = Date.now() + timeout;
+
+  while (Date.now() < deadline) {
+    for (const process of processes) {
+      if (process.startupError) {
+        throw process.startupError;
+      }
+      if (process.exitCode !== null) {
+        throw new Error(`Process exited prematurely with code ${process.exitCode}`);
+      }
+    }
+
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch (_error) {
+      // Wait until service responds.
+    }
+
+    await setTimeout(interval);
+  }
+
+  throw new Error(`Timed out waiting for ${url}`);
+};
+
+const spawnCommand = (command, args, env = {}) =>
+  Object.assign(
+    spawn(command, args, {
+      stdio: "inherit",
+      env: { ...process.env, ...env },
+    }),
+    { startupError: null },
+  );
+
+const spawnChecked = (command, args, env = {}) => {
+  const child = spawnCommand(command, args, env);
+  child.once("error", (error) => {
+    child.startupError = error;
+  });
+  return child;
+};
+
+const spawnTestProcess = (command, args, env = {}) =>
+  spawn(command, args, {
+    stdio: "inherit",
+    env: { ...process.env, ...env },
+  });
+
+const run = async () => {
+  requireCommand("cargo", ["--version"]);
+  await ensureEnvFile();
+  await prepE2eEnv();
+
+  const addonServer = spawnChecked("pnpm", ["--filter", "australia-cgt-addon", "dev:server"]);
+  const backendServer = spawnChecked(
+    "cargo",
+    ["run", "--manifest-path", "apps/server/Cargo.toml"],
+    TEST_SERVER_ENV,
+  );
+  const frontendServer = spawnChecked("pnpm", ["--filter", "frontend", "dev"], {
+    ...TEST_SERVER_ENV,
+    BUILD_TARGET: "web",
+    WF_ENABLE_VITE_PROXY: "true",
+    VITE_ENABLE_ADDON_DEV_MODE: "true",
+  });
+  const children = [addonServer, backendServer, frontendServer];
+
+  const cleanup = async () => {
+    for (const child of children) {
+      if (child.exitCode === null && !child.killed) {
+        child.kill("SIGINT");
+      }
+    }
+    await Promise.all(children.map((child) => once(child, "exit").catch(() => {})));
+  };
+
+  process.once("SIGINT", () => cleanup().catch(() => {}));
+  process.once("SIGTERM", () => cleanup().catch(() => {}));
+
+  try {
+    await waitForServer(`${ADDON_URL}/health`, children, { timeout: 90_000 });
+    await waitForServer(FRONTEND_URL, children, { timeout: 120_000 });
+    await waitForServer(`${BACKEND_URL}/api/v1/healthz`, children, {
+      timeout: 180_000,
+      interval: 1000,
+    });
+
+    const tests = spawnTestProcess(
+      "pnpm",
+      ["exec", "playwright", "test", "e2e/14-australia-cgt-addon.spec.ts"],
+      {
+        WF_E2E_ENABLE_AUSTRALIA_CGT_ADDON: "true",
+      },
+    );
+    await once(tests, "exit").then(([code]) => {
+      if (code !== 0) {
+        throw new Error(`Playwright exited with code ${code}`);
+      }
+    });
+  } finally {
+    await cleanup();
+  }
+};
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Adds an Australia CGT planning and reconciliation addon for Wealthfolio.

This is deliberately framed as a community planning MVP for simple AUD activity review, not a comprehensive Australian tax calculator and not tax advice. It keeps tax-specific logic and supplemental tax records inside an addon workspace, with only the minimum dev/test wiring needed to load and verify it through Wealthfolio's addon runtime.

## Current scope

- AUD BUY/SELL activity matching.
- FIFO parcel matching by symbol and account ID, with account name as fallback.
- Australian income-year summaries.
- Same-year capital loss offset before discount, plus unapplied capital losses carried forward across report years.
- Current-law 50% CGT discount eligibility using the ATO 12-month timing rule that excludes both acquisition day and CGT event day.
- Simple AMMA/AMIT cost-base increases and decreases per parcel and income year, including later AMIT adjustments allocated over surviving quantity after prior-year partial disposals.
- Dividend franking percentage from the `australiaCgt.frankingPercentage` activity metadata field, shown for review only.
- Warnings for unmatched sells, non-AUD activity, and unmodelled activity types.
- Local 30 June 2027 market-value snapshot inputs for Budget transition planning.
- ABS CPI cache support for planning inputs.
- CSV export of matched lots for accountant review/reconciliation, with lot-level taxable columns labelled as pre-loss estimates.

## Limitations and non-goals

- Not tax advice.
- FIFO only; no taxpayer-selected parcel identification or optimisation yet.
- No foreign-currency CGT conversion. Non-AUD BUY/SELL activity is excluded and surfaced for review.
- No corporate-action modelling for splits, consolidations, DRPs, bonus shares, buy-backs, demergers, takeovers, returns of capital, rights issues, or liquidations.
- AMMA/AMIT support is limited to simple net cost-base movements, not every AMMA/SDS field or every edge case.
- Franking data is display-only. The addon does not calculate dividend tax, franking credit gross-up, or tax offsets.
- Budget 2026-27 transition support is provisional. The addon stores CPI and 30 June 2027 snapshot inputs and reports pre-transition parcels, but does not yet calculate post-2027 indexed disposals end to end.
- Opening capital losses from years before the imported Wealthfolio history are not yet a separate input.
- ESS, crypto, foreign-resident CGT rules, and non-CGT income-tax outcomes are outside the current scope.

## Project fit

- Uses the existing `addons/*` workspace pattern with `manifest.json`, Vite build, addon SDK, shared QueryClient, sidebar item, and addon route.
- Keeps `src/addon.tsx` as registration glue, puts the page implementation under `src/pages/`, moves UI sections into `src/components/`, moves query/report and tax-data orchestration into `src/hooks/`, and splits formatting/export/parcel helpers into focused `src/lib/` modules.
- Keeps desktop/web core unchanged. No database migration, Tauri command, Axum API, or core repository change is introduced.
- Keeps addon tax data local to the addon in browser local storage.
- Refreshing CPI fetches public ABS CPI data only; portfolio data is not sent to ABS by this addon.
- Uses repo-native validation paths: addon unit tests, addon type-check/build, workspace package builds, and a dedicated Playwright runner with a fresh DB, real web frontend, Rust backend, and addon dev server.
- Avoids committed secrets; the E2E runner generates a random `WF_SECRET_KEY` per run.

## Files outside the addon

- `apps/frontend/src/addons/addons-dev-mode.ts`: fixes addon dev-mode imports to use the project alias consistently.
- `package.json`: adds `test:e2e:australia-cgt-addon`.
- `pnpm-lock.yaml`: records the new addon workspace dependencies.
- `e2e/14-australia-cgt-addon.spec.ts` and fixture: dedicated integration coverage for the addon, including scoped income-year assertions and CSV download verification.
- `scripts/run-australia-cgt-addon-e2e.mjs`: starts the addon dev server, web frontend, Rust backend, fresh DB, and Playwright spec.

## Validation

- `CI=true pnpm install --frozen-lockfile`
- `pnpm --filter @wealthfolio/ui build`
- `pnpm --filter @wealthfolio/addon-sdk build`
- `pnpm run build:types`
- `pnpm --filter australia-cgt-addon test`
- `pnpm --filter australia-cgt-addon type-check`
- `pnpm --filter australia-cgt-addon build`
- `pnpm test:e2e:australia-cgt-addon`
  - Confirmed runner logs `Australia CGT E2E database path: ./db/app-testing-20260514T010444Z.db`.
- `git diff --check upstream/main`

## Review-response changes

- Renamed UI/manifest framing to Australia CGT Planner and clarified community-addon identity.
- Expanded README with scope, limitations, privacy/localStorage, ABS CPI fetch behaviour, examples, and development commands.
- Added `CHANGELOG.md`.
- Fixed discount timing for exact-anniversary disposals.
- Matched lots by account ID when available to avoid duplicate account-name cross-matching.
- Added capital loss carry-forward across report years.
- Renamed matched-lot discount/taxable CSV/UI fields as pre-loss estimates so final taxable values live in income-year summaries.
- Fixed AMIT allocation after prior-year partial disposals.
- Added an AMMA-derived disposal test where the statement changes cost base and taxable gain.
- Added fully and partly franked dividend metadata examples.
- Updated the E2E AMMA flow to assert the saved AMMA adjustment changes the income-year row and persists after reload.
- Updated the E2E runner to pass `WF_DB_PATH` from `.env.web`, fail fast without an `app-testing-*` DB, and avoid cleanup hangs from already-exited child processes.
- Tightened the E2E AMMA parcel selector so the imported-date normalization is deliberate and scoped by symbol/account/date instead of date-only.
- Replaced broad 404 console suppression with exact known 404 response URL checks for the addon dev-server polling endpoint and Chrome devtools probe.
- Added guarded addon cleanup handling with per-task error logging during initialization failure and disable.
- Split registration, page, components, hooks, and helper modules so `addon.tsx` is registration glue and the page is an orchestration layer.
- Removed the unused `date-fns` addon dependency.
- Fixed timezone-sensitive Date handling so timestamp inputs do not drift across Australian income-year boundaries.
- Made 2027 transition rows use saved snapshot quantity with cost-base apportionment.
- Excluded and warned on non-AUD dividend rows instead of displaying them as AUD franking rows.
- Removed the production demo CPI insertion action.
- Added a confirmation step before clearing all local addon tax data.


