### PR TITLE
Add cloud request correlation IDs

### DIFF
--- a/apps/frontend/src/features/wealthfolio-connect/components/subscription-plans.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/components/subscription-plans.tsx
@@ -20,6 +20,7 @@ import { WEALTHFOLIO_CONNECT_PORTAL_URL } from "@/lib/constants";
 import { QueryKeys } from "@/lib/query-keys";
 import { useQuery } from "@tanstack/react-query";
 import { useState } from "react";
+import { getDisplayablePlans } from "../lib/plan-visibility";
 
 // Helper to detect if error is an auth/token issue
 function isAuthError(error: Error | null): boolean {
@@ -184,6 +185,7 @@ export function SubscriptionPlans({
   const [billingPeriod, setBillingPeriod] = useState<BillingPeriod>("monthly");
   const { data, isLoading, error } = useSubscriptionPlans(enabled);
   const { signOut, isLoading: isSigningOut } = useWealthfolioConnect();
+  const plans = getDisplayablePlans(data?.plans);
 
   // Handle auth errors - session expired or token sync issue
   if (error && isAuthError(error)) {
@@ -345,7 +347,7 @@ export function SubscriptionPlans({
           </div>
         ) : (
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-            {data?.plans.map((plan) => (
+            {plans.map((plan) => (
               <PlanCard
                 key={plan.id}
                 plan={plan}

--- a/apps/frontend/src/features/wealthfolio-connect/lib/plan-visibility.test.ts
+++ b/apps/frontend/src/features/wealthfolio-connect/lib/plan-visibility.test.ts
@@ -32,7 +32,10 @@ describe("getDisplayablePlans", () => {
   });
 
   it("does not add Plus when the API omits it", () => {
-    const plans = getDisplayablePlans([plan("basic", true, false), plan("essentials", true, false)]);
+    const plans = getDisplayablePlans([
+      plan("basic", true, false),
+      plan("essentials", true, false),
+    ]);
 
     expect(plans.map((item) => item.id)).toEqual(["basic", "essentials"]);
   });

--- a/apps/frontend/src/features/wealthfolio-connect/lib/plan-visibility.test.ts
+++ b/apps/frontend/src/features/wealthfolio-connect/lib/plan-visibility.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import type { SubscriptionPlan } from "../types";
+import { getDisplayablePlans } from "./plan-visibility";
+
+function plan(
+  id: SubscriptionPlan["id"],
+  isAvailable: boolean,
+  isComingSoon: boolean,
+): SubscriptionPlan {
+  return {
+    id,
+    name: id,
+    description: id,
+    pricing: { monthly: 0, yearly: 0 },
+    limits: { householdSize: 1, institutionConnections: 1, devices: 1 },
+    features: [],
+    isAvailable,
+    isComingSoon,
+  };
+}
+
+describe("getDisplayablePlans", () => {
+  it("uses only API-returned plans and hides unavailable non-coming-soon plans", () => {
+    const plans = getDisplayablePlans([
+      plan("basic", true, false),
+      plan("essentials", true, false),
+      plan("duo", false, true),
+      plan("plus", false, false),
+    ]);
+
+    expect(plans.map((item) => item.id)).toEqual(["basic", "essentials", "duo"]);
+  });
+
+  it("does not add Plus when the API omits it", () => {
+    const plans = getDisplayablePlans([plan("basic", true, false), plan("essentials", true, false)]);
+
+    expect(plans.map((item) => item.id)).toEqual(["basic", "essentials"]);
+  });
+});

--- a/apps/frontend/src/features/wealthfolio-connect/lib/plan-visibility.ts
+++ b/apps/frontend/src/features/wealthfolio-connect/lib/plan-visibility.ts
@@ -1,0 +1,5 @@
+import type { SubscriptionPlan } from "../types";
+
+export function getDisplayablePlans(plans: SubscriptionPlan[] | undefined): SubscriptionPlan[] {
+  return (plans ?? []).filter((plan) => plan.isAvailable || plan.isComingSoon);
+}

--- a/crates/connect/src/client.rs
+++ b/crates/connect/src/client.rs
@@ -14,6 +14,10 @@ use crate::broker::{
     BrokerAccount, BrokerBrokerage, BrokerConnection, BrokerConnectionBrokerage,
     BrokerHoldingsResponse, PaginatedUniversalActivity, PlansResponse, UserInfo, UserTeam,
 };
+use crate::request_metadata::{
+    header_value, log_failed_cloud_request, request_metadata_suffix, server_request_id,
+    CloudRequestContext, CLIENT_REQUEST_ID_HEADER,
+};
 use wealthfolio_core::errors::{Error, Result};
 
 use super::broker::BrokerApiClient;
@@ -169,54 +173,94 @@ impl ConnectApiClient {
     }
 
     /// Create default headers for API requests.
-    fn headers(&self) -> HeaderMap {
+    fn headers(&self, client_request_id: &str) -> Result<HeaderMap> {
         let mut headers = HeaderMap::new();
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
         headers.insert(AUTHORIZATION, self.auth_header.clone());
-        headers
+        headers.insert(
+            CLIENT_REQUEST_ID_HEADER,
+            header_value(client_request_id).map_err(Error::Unexpected)?,
+        );
+        Ok(headers)
     }
 
     /// Make a GET request and parse the response.
     async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
+        let context = CloudRequestContext::new("GET", path, None);
         let url = format!("{}{}", self.base_url, path);
 
         let response = self
             .client
             .get(&url)
-            .headers(self.headers())
+            .headers(self.headers(&context.client_request_id)?)
             .send()
             .await
-            .map_err(|e| Error::Unexpected(format!("Request failed: {}", e)))?;
+            .map_err(|e| self.request_transport_error(&context, e))?;
 
-        self.parse_response(response).await
+        self.parse_response(response, &context).await
     }
 
     /// Parse an HTTP response, handling errors appropriately.
-    async fn parse_response<T: DeserializeOwned>(&self, response: reqwest::Response) -> Result<T> {
+    async fn parse_response<T: DeserializeOwned>(
+        &self,
+        response: reqwest::Response,
+        context: &CloudRequestContext,
+    ) -> Result<T> {
         let status = response.status();
-        let body = response
-            .text()
-            .await
-            .map_err(|e| Error::Unexpected(format!("Failed to read response: {}", e)))?;
+        let request_id = server_request_id(response.headers());
+        let body = response.text().await.map_err(|e| {
+            log_failed_cloud_request("ConnectApi", context, Some(status), request_id.as_deref());
+            Error::Unexpected(format!(
+                "Failed to read response: {} ({})",
+                e,
+                request_metadata_suffix(context, request_id.as_deref())
+            ))
+        })?;
 
         if !status.is_success() {
+            log_failed_cloud_request("ConnectApi", context, Some(status), request_id.as_deref());
+
             // Try to parse error response for a better message
             if let Ok(err) = serde_json::from_str::<ApiErrorResponse>(&body) {
                 let msg = err
                     .message
                     .or(err.error)
                     .unwrap_or_else(|| format!("HTTP {}", status));
-                return Err(Error::Unexpected(format!("API error: {}", msg)));
+                return Err(Error::Unexpected(format!(
+                    "API error {}: {} ({})",
+                    status.as_u16(),
+                    msg,
+                    request_metadata_suffix(context, request_id.as_deref())
+                )));
             }
             return Err(Error::Unexpected(format!(
-                "API error {}: {}",
-                status,
-                body.chars().take(200).collect::<String>()
+                "API error {} ({})",
+                status.as_u16(),
+                request_metadata_suffix(context, request_id.as_deref())
             )));
         }
 
-        serde_json::from_str(&body)
-            .map_err(|e| Error::Unexpected(format!("Failed to parse response: {} - {}", e, body)))
+        serde_json::from_str(&body).map_err(|e| {
+            log_failed_cloud_request("ConnectApi", context, Some(status), request_id.as_deref());
+            Error::Unexpected(format!(
+                "Failed to parse response: {} ({})",
+                e,
+                request_metadata_suffix(context, request_id.as_deref())
+            ))
+        })
+    }
+
+    fn request_transport_error(
+        &self,
+        context: &CloudRequestContext,
+        error: reqwest::Error,
+    ) -> Error {
+        log_failed_cloud_request("ConnectApi", context, None, None);
+        Error::Unexpected(format!(
+            "Request failed: {} ({})",
+            error,
+            request_metadata_suffix(context, None)
+        ))
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -240,10 +284,7 @@ impl ConnectApiClient {
         offset: Option<i64>,
         limit: Option<i64>,
     ) -> Result<PaginatedUniversalActivity> {
-        let mut url = format!(
-            "{}/api/v1/sync/brokerage/accounts/{}/activities",
-            self.base_url, account_id
-        );
+        let mut path = format!("/api/v1/sync/brokerage/accounts/{}/activities", account_id);
 
         // Build query parameters
         let mut params = Vec::new();
@@ -260,20 +301,12 @@ impl ConnectApiClient {
             params.push(format!("end_date={}", v));
         }
         if !params.is_empty() {
-            url = format!("{}?{}", url, params.join("&"));
+            path = format!("{}?{}", path, params.join("&"));
         }
 
-        debug!("[ConnectApi] Fetching activities from: {}", url);
+        debug!("[ConnectApi] Fetching activities from: {}", path);
 
-        let response = self
-            .client
-            .get(&url)
-            .headers(self.headers())
-            .send()
-            .await
-            .map_err(|e| Error::Unexpected(format!("Failed to fetch activities: {}", e)))?;
-
-        self.parse_response(response).await
+        self.get(&path).await
     }
 
     /// Fetch current holdings for a broker account.
@@ -282,22 +315,11 @@ impl ConnectApiClient {
     ///
     /// * `account_id` - The broker account ID (provider's ID)
     pub async fn get_account_holdings(&self, account_id: &str) -> Result<BrokerHoldingsResponse> {
-        let url = format!(
-            "{}/api/v1/sync/brokerage/accounts/{}/holdings",
-            self.base_url, account_id
-        );
+        let path = format!("/api/v1/sync/brokerage/accounts/{}/holdings", account_id);
 
-        debug!("[ConnectApi] Fetching holdings from: {}", url);
+        debug!("[ConnectApi] Fetching holdings from: {}", path);
 
-        let response = self
-            .client
-            .get(&url)
-            .headers(self.headers())
-            .send()
-            .await
-            .map_err(|e| Error::Unexpected(format!("Failed to fetch holdings: {}", e)))?;
-
-        self.parse_response(response).await
+        self.get(&path).await
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -393,33 +415,8 @@ impl ConnectApiClient {
 impl BrokerApiClient for ConnectApiClient {
     /// Fetch all broker connections for the user.
     async fn list_connections(&self) -> Result<Vec<BrokerConnection>> {
-        // First, get the raw response to log it
-        let url = format!("{}/api/v1/sync/brokerage/connections", self.base_url);
-        let response = self
-            .client
-            .get(&url)
-            .headers(self.headers())
-            .send()
-            .await
-            .map_err(|e| Error::Unexpected(format!("Request failed: {}", e)))?;
-
-        let status = response.status();
-        let body = response
-            .text()
-            .await
-            .map_err(|e| Error::Unexpected(format!("Failed to read response: {}", e)))?;
-
-        if !status.is_success() {
-            return Err(Error::Unexpected(format!(
-                "API error {}: {}",
-                status,
-                body.chars().take(200).collect::<String>()
-            )));
-        }
-
-        let api_response: ApiConnectionsResponse = serde_json::from_str(&body).map_err(|e| {
-            Error::Unexpected(format!("Failed to parse connections: {} - {}", e, body))
-        })?;
+        let api_response: ApiConnectionsResponse =
+            self.get("/api/v1/sync/brokerage/connections").await?;
 
         let connections: Vec<BrokerConnection> = api_response
             .connections
@@ -473,33 +470,7 @@ impl BrokerApiClient for ConnectApiClient {
         &self,
         _authorization_ids: Option<Vec<String>>,
     ) -> Result<Vec<BrokerAccount>> {
-        // First, get the raw response to log it
-        let url = format!("{}/api/v1/sync/brokerage/accounts", self.base_url);
-        let response = self
-            .client
-            .get(&url)
-            .headers(self.headers())
-            .send()
-            .await
-            .map_err(|e| Error::Unexpected(format!("Request failed: {}", e)))?;
-
-        let status = response.status();
-        let body = response
-            .text()
-            .await
-            .map_err(|e| Error::Unexpected(format!("Failed to read response: {}", e)))?;
-
-        if !status.is_success() {
-            return Err(Error::Unexpected(format!(
-                "API error {}: {}",
-                status,
-                body.chars().take(200).collect::<String>()
-            )));
-        }
-
-        let api_response: ApiAccountsResponse = serde_json::from_str(&body).map_err(|e| {
-            Error::Unexpected(format!("Failed to parse accounts: {} - {}", e, body))
-        })?;
+        let api_response: ApiAccountsResponse = self.get("/api/v1/sync/brokerage/accounts").await?;
 
         Ok(api_response.accounts)
     }
@@ -559,36 +530,67 @@ pub async fn fetch_subscription_plans_public(base_url: &str) -> Result<PlansResp
         .map_err(|e| Error::Unexpected(format!("Failed to initialize HTTP client: {}", e)))?;
 
     let base_url = base_url.trim_end_matches('/');
-    let url = format!("{}/api/v1/subscription/plans", base_url);
+    let path = "/api/v1/subscription/plans";
+    let url = format!("{}{}", base_url, path);
+    let context = CloudRequestContext::new("GET", path, None);
 
     let response = client
         .get(&url)
         .header(CONTENT_TYPE, "application/json")
+        .header(CLIENT_REQUEST_ID_HEADER, context.client_request_id.as_str())
         .send()
         .await
-        .map_err(|e| Error::Unexpected(format!("Request failed: {}", e)))?;
+        .map_err(|e| {
+            log_failed_cloud_request("ConnectApi", &context, None, None);
+            Error::Unexpected(format!(
+                "Request failed: {} ({})",
+                e,
+                request_metadata_suffix(&context, None)
+            ))
+        })?;
 
     let status = response.status();
-    let body = response
-        .text()
-        .await
-        .map_err(|e| Error::Unexpected(format!("Failed to read response: {}", e)))?;
+    let request_id = server_request_id(response.headers());
+    let body = response.text().await.map_err(|e| {
+        log_failed_cloud_request("ConnectApi", &context, Some(status), request_id.as_deref());
+        Error::Unexpected(format!(
+            "Failed to read response: {} ({})",
+            e,
+            request_metadata_suffix(&context, request_id.as_deref())
+        ))
+    })?;
 
     if !status.is_success() {
+        log_failed_cloud_request("ConnectApi", &context, Some(status), request_id.as_deref());
         return Err(Error::Unexpected(format!(
-            "API error {}: {}",
-            status,
-            body.chars().take(200).collect::<String>()
+            "API error {} ({})",
+            status.as_u16(),
+            request_metadata_suffix(&context, request_id.as_deref())
         )));
     }
 
-    serde_json::from_str(&body)
-        .map_err(|e| Error::Unexpected(format!("Failed to parse plans response: {} - {}", e, body)))
+    serde_json::from_str(&body).map_err(|e| {
+        log_failed_cloud_request("ConnectApi", &context, Some(status), request_id.as_deref());
+        Error::Unexpected(format!(
+            "Failed to parse plans response: {} ({})",
+            e,
+            request_metadata_suffix(&context, request_id.as_deref())
+        ))
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::request_metadata::{
+        generate_client_request_id, is_log_safe_request_id, CLIENT_REQUEST_ID_HEADER,
+        SERVER_REQUEST_ID_HEADER,
+    };
+    use std::collections::HashMap;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::{Arc, Mutex};
+    use std::thread;
 
     #[test]
     fn test_client_creation() {
@@ -600,5 +602,127 @@ mod tests {
     fn test_client_url_normalization() {
         let client = ConnectApiClient::new("https://api.wealthfolio.app/", "test-token").unwrap();
         assert_eq!(client.base_url, "https://api.wealthfolio.app");
+    }
+
+    #[test]
+    fn client_request_id_is_log_safe() {
+        let request_id = generate_client_request_id(Some("device_1"));
+        assert!(request_id.starts_with("device_1:"));
+        assert!(is_log_safe_request_id(&request_id));
+        assert!(request_id.len() <= 128);
+
+        let fallback = generate_client_request_id(Some("unsafe/device"));
+        assert!(fallback.starts_with("app:"));
+        assert!(is_log_safe_request_id(&fallback));
+    }
+
+    #[test]
+    fn headers_include_client_request_id_without_x_request_id() {
+        let client = ConnectApiClient::new("https://api.wealthfolio.app", "test-token").unwrap();
+        let headers = client
+            .headers("app:00000000-0000-4000-8000-000000000000")
+            .unwrap();
+
+        assert_eq!(
+            headers
+                .get(CLIENT_REQUEST_ID_HEADER)
+                .and_then(|value| value.to_str().ok()),
+            Some("app:00000000-0000-4000-8000-000000000000")
+        );
+        assert!(!headers.contains_key(SERVER_REQUEST_ID_HEADER));
+    }
+
+    #[tokio::test]
+    async fn request_sends_client_request_id_without_x_request_id() {
+        let (base_url, captured, handle) = start_one_request_server(200, r#"{"plans":[]}"#, None);
+        let client = ConnectApiClient::new(&base_url, "test-token").unwrap();
+
+        let response = client.get_subscription_plans().await.unwrap();
+
+        assert!(response.plans.is_empty());
+        let headers = captured.lock().unwrap().clone().expect("captured request");
+        let client_request_id = headers
+            .get(CLIENT_REQUEST_ID_HEADER)
+            .expect("client request id header");
+        assert!(client_request_id.starts_with("app:"));
+        assert!(is_log_safe_request_id(client_request_id));
+        assert!(!headers.contains_key(SERVER_REQUEST_ID_HEADER));
+        handle.join().expect("server thread");
+    }
+
+    #[tokio::test]
+    async fn failed_request_error_includes_client_and_server_request_ids() {
+        let (base_url, captured, handle) = start_one_request_server(
+            500,
+            r#"{"error":"server_error","message":"temporary failure"}"#,
+            Some("server-req-123"),
+        );
+        let client = ConnectApiClient::new(&base_url, "test-token").unwrap();
+
+        let error = client
+            .get_subscription_plans()
+            .await
+            .expect_err("request should fail")
+            .to_string();
+
+        let headers = captured.lock().unwrap().clone().expect("captured request");
+        let client_request_id = headers
+            .get(CLIENT_REQUEST_ID_HEADER)
+            .expect("client request id header");
+        assert!(error.contains("temporary failure"));
+        assert!(error.contains(&format!("clientRequestId={}", client_request_id)));
+        assert!(error.contains("requestId=server-req-123"));
+        handle.join().expect("server thread");
+    }
+
+    fn start_one_request_server(
+        status: u16,
+        body: &'static str,
+        request_id: Option<&'static str>,
+    ) -> (
+        String,
+        Arc<Mutex<Option<HashMap<String, String>>>>,
+        thread::JoinHandle<()>,
+    ) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test listener");
+        let addr = listener.local_addr().expect("listener addr");
+        let captured = Arc::new(Mutex::new(None));
+        let captured_for_thread = Arc::clone(&captured);
+
+        let handle = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut buffer = [0_u8; 4096];
+            let read = stream.read(&mut buffer).expect("read request");
+            let request = String::from_utf8_lossy(&buffer[..read]);
+            let headers = parse_headers(&request);
+            *captured_for_thread.lock().unwrap() = Some(headers);
+
+            let request_id_header = request_id
+                .map(|value| format!("x-request-id: {}\r\n", value))
+                .unwrap_or_default();
+            let response = format!(
+                "HTTP/1.1 {} OK\r\nContent-Type: application/json\r\n{}Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+                status,
+                request_id_header,
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
+            stream.flush().expect("flush response");
+        });
+
+        (format!("http://{}", addr), captured, handle)
+    }
+
+    fn parse_headers(request: &str) -> HashMap<String, String> {
+        request
+            .lines()
+            .skip(1)
+            .take_while(|line| !line.is_empty())
+            .filter_map(|line| line.split_once(':'))
+            .map(|(name, value)| (name.trim().to_ascii_lowercase(), value.trim().to_string()))
+            .collect()
     }
 }

--- a/crates/connect/src/client.rs
+++ b/crates/connect/src/client.rs
@@ -592,6 +592,9 @@ mod tests {
     use std::sync::{Arc, Mutex};
     use std::thread;
 
+    type CapturedHeaders = Arc<Mutex<Option<HashMap<String, String>>>>;
+    type TestServer = (String, CapturedHeaders, thread::JoinHandle<()>);
+
     #[test]
     fn test_client_creation() {
         let client = ConnectApiClient::new("https://api.wealthfolio.app", "test-token");
@@ -679,11 +682,7 @@ mod tests {
         status: u16,
         body: &'static str,
         request_id: Option<&'static str>,
-    ) -> (
-        String,
-        Arc<Mutex<Option<HashMap<String, String>>>>,
-        thread::JoinHandle<()>,
-    ) {
+    ) -> TestServer {
         let listener = TcpListener::bind("127.0.0.1:0").expect("bind test listener");
         let addr = listener.local_addr().expect("listener addr");
         let captured = Arc::new(Mutex::new(None));

--- a/crates/connect/src/lib.rs
+++ b/crates/connect/src/lib.rs
@@ -8,6 +8,7 @@ pub mod broker;
 pub mod broker_ingest;
 pub mod client;
 pub mod platform;
+mod request_metadata;
 pub mod token_lifecycle;
 
 // Re-export commonly used types

--- a/crates/connect/src/request_metadata.rs
+++ b/crates/connect/src/request_metadata.rs
@@ -1,0 +1,107 @@
+use reqwest::{
+    header::{HeaderMap, HeaderValue},
+    StatusCode,
+};
+use uuid::Uuid;
+
+pub(crate) const CLIENT_REQUEST_ID_HEADER: &str = "x-wf-client-request-id";
+pub(crate) const SERVER_REQUEST_ID_HEADER: &str = "x-request-id";
+
+#[derive(Debug, Clone)]
+pub(crate) struct CloudRequestContext {
+    pub method: &'static str,
+    pub path: String,
+    pub client_request_id: String,
+    pub device_id: Option<String>,
+}
+
+impl CloudRequestContext {
+    pub fn new(method: &'static str, path: impl Into<String>, device_id: Option<&str>) -> Self {
+        Self {
+            method,
+            path: path.into(),
+            client_request_id: generate_client_request_id(device_id),
+            device_id: device_id.map(str::to_string),
+        }
+    }
+}
+
+pub(crate) fn generate_client_request_id(device_id: Option<&str>) -> String {
+    let uuid = Uuid::new_v4();
+    if let Some(device_id) = device_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .filter(|value| is_log_safe_request_id_part(value))
+    {
+        let candidate = format!("{}:{}", device_id, uuid);
+        if is_log_safe_request_id(&candidate) {
+            return candidate;
+        }
+    }
+    format!("app:{}", uuid)
+}
+
+pub(crate) fn is_log_safe_request_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b':' | b'-'))
+}
+
+fn is_log_safe_request_id_part(value: &str) -> bool {
+    is_log_safe_request_id(value)
+}
+
+pub(crate) fn header_value(value: &str) -> Result<HeaderValue, String> {
+    HeaderValue::from_str(value).map_err(|_| "Invalid client request ID format".to_string())
+}
+
+pub(crate) fn server_request_id(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(SERVER_REQUEST_ID_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| is_log_safe_request_id(value))
+        .map(str::to_string)
+}
+
+pub(crate) fn request_metadata_suffix(
+    context: &CloudRequestContext,
+    server_request_id: Option<&str>,
+) -> String {
+    match server_request_id {
+        Some(request_id) => format!(
+            "clientRequestId={}, requestId={}",
+            context.client_request_id, request_id
+        ),
+        None => format!(
+            "clientRequestId={}, requestId=none",
+            context.client_request_id
+        ),
+    }
+}
+
+pub(crate) fn log_failed_cloud_request(
+    target: &str,
+    context: &CloudRequestContext,
+    status: Option<StatusCode>,
+    server_request_id: Option<&str>,
+) {
+    let status = status
+        .map(|status| status.as_u16().to_string())
+        .unwrap_or_else(|| "no_response".to_string());
+    let request_id = server_request_id.unwrap_or("none");
+    let device_id = context.device_id.as_deref().unwrap_or("none");
+
+    log::warn!(
+        "[{}] Cloud request failed method={} path={} status={} clientRequestId={} requestId={} deviceId={}",
+        target,
+        context.method,
+        context.path,
+        status,
+        context.client_request_id,
+        request_id,
+        device_id
+    );
+}

--- a/crates/connect/src/token_lifecycle.rs
+++ b/crates/connect/src/token_lifecycle.rs
@@ -5,6 +5,11 @@ use serde::Deserialize;
 use tokio::sync::{Mutex, RwLock};
 use wealthfolio_core::secrets::SecretStore;
 
+use crate::request_metadata::{
+    log_failed_cloud_request, request_metadata_suffix, server_request_id, CloudRequestContext,
+    CLIENT_REQUEST_ID_HEADER,
+};
+
 pub const CLOUD_REFRESH_TOKEN_KEY: &str = "sync_refresh_token";
 pub const CLOUD_ACCESS_TOKEN_KEY: &str = "sync_access_token";
 
@@ -250,22 +255,43 @@ async fn refresh_access_token(
         })?;
 
     let token_url = format!("{}/auth/v1/token?grant_type=refresh_token", config.auth_url);
+    let context = CloudRequestContext::new("POST", "/auth/v1/token?grant_type=refresh_token", None);
     let response = client
         .post(&token_url)
         .header("apikey", &config.publishable_key)
         .header("Content-Type", "application/json")
+        .header(CLIENT_REQUEST_ID_HEADER, context.client_request_id.as_str())
         .json(&serde_json::json!({ "refresh_token": refresh_token }))
         .send()
         .await
-        .map_err(|e| RefreshRequestError::new(false, format!("Failed to refresh token: {}", e)))?;
+        .map_err(|e| {
+            log_failed_cloud_request("ConnectAuth", &context, None, None);
+            RefreshRequestError::new(
+                false,
+                format!(
+                    "Failed to refresh token: {} ({})",
+                    e,
+                    request_metadata_suffix(&context, None)
+                ),
+            )
+        })?;
 
     let status = response.status();
-    let body = response
-        .text()
-        .await
-        .map_err(|e| RefreshRequestError::new(false, format!("Failed to read response: {}", e)))?;
+    let request_id = server_request_id(response.headers());
+    let body = response.text().await.map_err(|e| {
+        log_failed_cloud_request("ConnectAuth", &context, Some(status), request_id.as_deref());
+        RefreshRequestError::new(
+            false,
+            format!(
+                "Failed to read response: {} ({})",
+                e,
+                request_metadata_suffix(&context, request_id.as_deref())
+            ),
+        )
+    })?;
 
     if !status.is_success() {
+        log_failed_cloud_request("ConnectAuth", &context, Some(status), request_id.as_deref());
         let parsed = serde_json::from_str::<RefreshErrorResponse>(&body).ok();
         let error_code = parsed
             .as_ref()
@@ -274,13 +300,28 @@ async fn refresh_access_token(
         let error_message = parsed
             .as_ref()
             .and_then(|value| value.error_description.clone().or(value.error.clone()))
-            .unwrap_or_else(|| format!("HTTP {}: {}", status, body));
+            .unwrap_or_else(|| format!("HTTP {}", status.as_u16()));
         let invalid = is_session_invalid(status.as_u16(), &error_code, &error_message);
-        return Err(RefreshRequestError::new(invalid, error_message));
+        return Err(RefreshRequestError::new(
+            invalid,
+            format!(
+                "{} ({})",
+                error_message,
+                request_metadata_suffix(&context, request_id.as_deref())
+            ),
+        ));
     }
 
     serde_json::from_str::<RefreshTokenResponse>(&body).map_err(|e| {
-        RefreshRequestError::new(false, format!("Failed to parse token response: {}", e))
+        log_failed_cloud_request("ConnectAuth", &context, Some(status), request_id.as_deref());
+        RefreshRequestError::new(
+            false,
+            format!(
+                "Failed to parse token response: {} ({})",
+                e,
+                request_metadata_suffix(&context, request_id.as_deref())
+            ),
+        )
     })
 }
 

--- a/crates/connect/src/token_lifecycle.rs
+++ b/crates/connect/src/token_lifecycle.rs
@@ -300,7 +300,7 @@ async fn refresh_access_token(
         let error_message = parsed
             .as_ref()
             .and_then(|value| value.error_description.clone().or(value.error.clone()))
-            .unwrap_or_else(|| format!("HTTP {}", status.as_u16()));
+            .unwrap_or_else(|| fallback_refresh_error_message(status.as_u16(), &body));
         let invalid = is_session_invalid(status.as_u16(), &error_code, &error_message);
         return Err(RefreshRequestError::new(
             invalid,
@@ -323,6 +323,15 @@ async fn refresh_access_token(
             ),
         )
     })
+}
+
+fn fallback_refresh_error_message(status: u16, body: &str) -> String {
+    let body = body.trim();
+    if body.is_empty() {
+        format!("HTTP {}", status)
+    } else {
+        body.to_string()
+    }
 }
 
 fn is_session_invalid(status: u16, error_code: &str, message: &str) -> bool {
@@ -409,5 +418,13 @@ mod tests {
             "Invalid refresh token"
         ));
         assert!(is_session_invalid(401, "", "unauthorized"));
+    }
+
+    #[test]
+    fn fallback_refresh_error_preserves_invalid_session_body() {
+        let message =
+            fallback_refresh_error_message(400, "non-json response: invalid refresh token");
+
+        assert!(is_session_invalid(400, "", &message));
     }
 }

--- a/crates/device-sync/src/client.rs
+++ b/crates/device-sync/src/client.rs
@@ -153,6 +153,15 @@ fn with_request_metadata(
     )
 }
 
+fn fallback_api_error_message(body: &str) -> String {
+    let body = body.trim();
+    if body.is_empty() {
+        "Request failed".to_string()
+    } else {
+        format!("Request failed: {}", body)
+    }
+}
+
 fn details_with_request_metadata(
     details: Option<serde_json::Value>,
     context: &CloudRequestContext,
@@ -453,7 +462,11 @@ impl DeviceSyncClient {
             }
             return Err(DeviceSyncError::api(
                 status.as_u16(),
-                with_request_metadata("Request failed", context, request_id.as_deref()),
+                with_request_metadata(
+                    fallback_api_error_message(&body),
+                    context,
+                    request_id.as_deref(),
+                ),
             ));
         }
 
@@ -507,7 +520,11 @@ impl DeviceSyncClient {
 
         Err(DeviceSyncError::api(
             status.as_u16(),
-            with_request_metadata("Request failed", context, request_id.as_deref()),
+            with_request_metadata(
+                fallback_api_error_message(&body),
+                context,
+                request_id.as_deref(),
+            ),
         ))
     }
 
@@ -1143,7 +1160,7 @@ impl DeviceSyncClient {
                             DeviceSyncError::api(
                                 status.as_u16(),
                                 with_request_metadata(
-                                    "Request failed",
+                                    fallback_api_error_message(&body),
                                     &context,
                                     request_id.as_deref(),
                                 ),
@@ -1646,6 +1663,26 @@ mod tests {
             url.as_str(),
             "https://sync.example.com/api/v1/sync/snapshots/snapshot%2Fsegment%20with%20spaces"
         );
+    }
+
+    #[test]
+    fn fallback_error_preserves_snapshot_validation_body_with_metadata() {
+        let context = CloudRequestContext::new(
+            "GET",
+            "/api/v1/sync/snapshots/not-a-uuid",
+            Some("019bb9fe-f707-71e9-a40d-733575f4f246"),
+        );
+        let body = r#"{"path":["snapshotId"],"message":"Invalid UUID"}"#;
+        let err = DeviceSyncError::api(
+            400,
+            with_request_metadata(
+                fallback_api_error_message(body),
+                &context,
+                Some("server-req-1"),
+            ),
+        );
+
+        assert!(err.is_snapshot_id_validation_error());
     }
 
     #[tokio::test]

--- a/crates/device-sync/src/client.rs
+++ b/crates/device-sync/src/client.rs
@@ -5,6 +5,9 @@
 use log::debug;
 use rand::Rng;
 use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE};
+use reqwest::{Method, RequestBuilder, StatusCode};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::OnceLock;
@@ -18,10 +21,11 @@ use crate::types::*;
 
 /// Default timeout for API requests.
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
-const MAX_LOG_BODY_CHARS: usize = 512;
 const SNAPSHOT_UPLOAD_MAX_ATTEMPTS: usize = 5;
 const SNAPSHOT_UPLOAD_BASE_BACKOFF_MS: u64 = 250;
 const SNAPSHOT_UPLOAD_MAX_BACKOFF_MS: u64 = 8_000;
+const CLIENT_REQUEST_ID_HEADER: &str = "x-wf-client-request-id";
+const SERVER_REQUEST_ID_HEADER: &str = "x-request-id";
 
 static SNAPSHOT_UPLOAD_IN_FLIGHT: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
 
@@ -68,6 +72,137 @@ fn snapshot_backoff_with_jitter(attempt: usize) -> Duration {
         .min(SNAPSHOT_UPLOAD_MAX_BACKOFF_MS);
     let jitter = rand::thread_rng().gen_range(0..=(backoff / 5).max(1));
     Duration::from_millis(backoff.saturating_add(jitter))
+}
+
+#[derive(Debug, Clone)]
+struct CloudRequestContext {
+    method: String,
+    path: String,
+    client_request_id: String,
+    device_id: Option<String>,
+}
+
+impl CloudRequestContext {
+    fn new(method: &str, path: impl Into<String>, device_id: Option<&str>) -> Self {
+        Self {
+            method: method.to_string(),
+            path: path.into(),
+            client_request_id: generate_client_request_id(device_id),
+            device_id: device_id.map(str::to_string),
+        }
+    }
+}
+
+fn generate_client_request_id(device_id: Option<&str>) -> String {
+    let uuid = Uuid::new_v4();
+    if let Some(device_id) = device_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .filter(|value| is_log_safe_request_id(value))
+    {
+        let candidate = format!("{}:{}", device_id, uuid);
+        if is_log_safe_request_id(&candidate) {
+            return candidate;
+        }
+    }
+    format!("app:{}", uuid)
+}
+
+fn is_log_safe_request_id(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 128
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b':' | b'-'))
+}
+
+fn server_request_id(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(SERVER_REQUEST_ID_HEADER)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| is_log_safe_request_id(value))
+        .map(str::to_string)
+}
+
+fn request_metadata_suffix(
+    context: &CloudRequestContext,
+    server_request_id: Option<&str>,
+) -> String {
+    match server_request_id {
+        Some(request_id) => format!(
+            "clientRequestId={}, requestId={}",
+            context.client_request_id, request_id
+        ),
+        None => format!(
+            "clientRequestId={}, requestId=none",
+            context.client_request_id
+        ),
+    }
+}
+
+fn with_request_metadata(
+    message: impl Into<String>,
+    context: &CloudRequestContext,
+    server_request_id: Option<&str>,
+) -> String {
+    format!(
+        "{} ({})",
+        message.into(),
+        request_metadata_suffix(context, server_request_id)
+    )
+}
+
+fn details_with_request_metadata(
+    details: Option<serde_json::Value>,
+    context: &CloudRequestContext,
+    server_request_id: Option<&str>,
+) -> Option<serde_json::Value> {
+    let mut metadata = serde_json::Map::new();
+    metadata.insert(
+        "clientRequestId".to_string(),
+        serde_json::Value::String(context.client_request_id.clone()),
+    );
+    if let Some(request_id) = server_request_id {
+        metadata.insert(
+            "requestId".to_string(),
+            serde_json::Value::String(request_id.to_string()),
+        );
+    }
+
+    match details {
+        Some(serde_json::Value::Object(mut object)) => {
+            object.extend(metadata);
+            Some(serde_json::Value::Object(object))
+        }
+        Some(value) => {
+            metadata.insert("apiDetails".to_string(), value);
+            Some(serde_json::Value::Object(metadata))
+        }
+        None => Some(serde_json::Value::Object(metadata)),
+    }
+}
+
+fn log_failed_cloud_request(
+    context: &CloudRequestContext,
+    status: Option<StatusCode>,
+    server_request_id: Option<&str>,
+) {
+    let status = status
+        .map(|status| status.as_u16().to_string())
+        .unwrap_or_else(|| "no_response".to_string());
+    let request_id = server_request_id.unwrap_or("none");
+    let device_id = context.device_id.as_deref().unwrap_or("none");
+
+    log::warn!(
+        "[DeviceSync] Cloud request failed method={} path={} status={} clientRequestId={} requestId={} deviceId={}",
+        context.method,
+        context.path,
+        status,
+        context.client_request_id,
+        request_id,
+        device_id
+    );
 }
 
 /// Client for the Wealthfolio device sync cloud API.
@@ -123,19 +258,6 @@ impl DeviceSyncClient {
             }
         }
         true
-    }
-
-    fn log_response(status: reqwest::StatusCode, body: &str) {
-        if status.is_success() {
-            debug!("API response status: {}", status);
-            return;
-        }
-
-        let mut preview = body.chars().take(MAX_LOG_BODY_CHARS).collect::<String>();
-        if body.chars().count() > MAX_LOG_BODY_CHARS {
-            preview.push_str("...");
-        }
-        debug!("API response error ({}): {}", status, preview);
     }
 
     fn snapshot_from_cursor_latest(value: SyncLatestSnapshotRef) -> SnapshotLatestResponse {
@@ -224,19 +346,24 @@ impl DeviceSyncClient {
         }
     }
 
-    /// Create headers for an API request.
-    fn headers(&self, token: &str) -> Result<HeaderMap> {
-        self.headers_with_device(token, None)
-    }
-
     /// Create headers for an API request with optional device ID.
-    fn headers_with_device(&self, token: &str, device_id: Option<&str>) -> Result<HeaderMap> {
+    fn headers_with_device(
+        &self,
+        token: &str,
+        device_id: Option<&str>,
+        context: &CloudRequestContext,
+    ) -> Result<HeaderMap> {
         let mut headers = HeaderMap::new();
         headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
 
         let auth_value = HeaderValue::from_str(&format!("Bearer {}", token))
             .map_err(|_| DeviceSyncError::auth("Invalid access token format"))?;
         headers.insert(AUTHORIZATION, auth_value);
+        headers.insert(
+            CLIENT_REQUEST_ID_HEADER,
+            HeaderValue::from_str(&context.client_request_id)
+                .map_err(|_| DeviceSyncError::auth("Invalid client request ID format"))?,
+        );
 
         if let Some(device_id) = device_id {
             let device_id_value = HeaderValue::from_str(device_id)
@@ -247,15 +374,70 @@ impl DeviceSyncClient {
         Ok(headers)
     }
 
+    async fn send_json_no_body<T: DeserializeOwned>(
+        &self,
+        method: Method,
+        path: String,
+        token: &str,
+        device_id: Option<&str>,
+    ) -> Result<T> {
+        let context = CloudRequestContext::new(method.as_str(), path.clone(), device_id);
+        let url = format!("{}{}", self.base_url, path);
+        let headers = self.headers_with_device(token, device_id, &context)?;
+        let response = self
+            .send_request(&context, self.client.request(method, &url).headers(headers))
+            .await?;
+        Self::parse_response(response, &context).await
+    }
+
+    async fn send_json_body<T: DeserializeOwned, B: Serialize + ?Sized>(
+        &self,
+        method: Method,
+        path: String,
+        token: &str,
+        device_id: Option<&str>,
+        body: &B,
+    ) -> Result<T> {
+        let context = CloudRequestContext::new(method.as_str(), path.clone(), device_id);
+        let url = format!("{}{}", self.base_url, path);
+        let headers = self.headers_with_device(token, device_id, &context)?;
+        let response = self
+            .send_request(
+                &context,
+                self.client
+                    .request(method, &url)
+                    .headers(headers)
+                    .json(body),
+            )
+            .await?;
+        Self::parse_response(response, &context).await
+    }
+
+    async fn send_request(
+        &self,
+        context: &CloudRequestContext,
+        request: RequestBuilder,
+    ) -> Result<reqwest::Response> {
+        request.send().await.map_err(|err| {
+            log_failed_cloud_request(context, None, None);
+            DeviceSyncError::Http(err)
+        })
+    }
+
     /// Parse a JSON response body.
-    async fn parse_response<T: serde::de::DeserializeOwned>(
+    async fn parse_response<T: DeserializeOwned>(
         response: reqwest::Response,
+        context: &CloudRequestContext,
     ) -> Result<T> {
         let status = response.status();
-        let body = response.text().await?;
-        Self::log_response(status, &body);
+        let request_id = server_request_id(response.headers());
+        let body = response.text().await.map_err(|err| {
+            log_failed_cloud_request(context, Some(status), request_id.as_deref());
+            DeviceSyncError::Http(err)
+        })?;
 
         if !status.is_success() {
+            log_failed_cloud_request(context, Some(status), request_id.as_deref());
             if let Ok(error) = serde_json::from_str::<ApiErrorResponse>(&body) {
                 let code = if error.code.is_empty() {
                     error.error
@@ -265,35 +447,50 @@ impl DeviceSyncClient {
                 return Err(DeviceSyncError::api_structured(
                     status.as_u16(),
                     code,
-                    error.message,
-                    error.details,
+                    with_request_metadata(error.message, context, request_id.as_deref()),
+                    details_with_request_metadata(error.details, context, request_id.as_deref()),
                 ));
             }
             return Err(DeviceSyncError::api(
                 status.as_u16(),
-                format!("Request failed: {}", body),
+                with_request_metadata("Request failed", context, request_id.as_deref()),
             ));
         }
 
         serde_json::from_str(&body).map_err(|e| {
+            log_failed_cloud_request(context, Some(status), request_id.as_deref());
             log::error!(
-                "Failed to deserialize response. Body: {}, Error: {}",
-                body,
-                e
+                "Failed to deserialize cloud response: {} ({})",
+                e,
+                request_metadata_suffix(context, request_id.as_deref())
             );
-            DeviceSyncError::api(status.as_u16(), format!("Failed to parse response: {}", e))
+            DeviceSyncError::api(
+                status.as_u16(),
+                with_request_metadata(
+                    format!("Failed to parse response: {}", e),
+                    context,
+                    request_id.as_deref(),
+                ),
+            )
         })
     }
 
     /// Parse a binary response body while preserving API error handling.
-    async fn parse_binary_response(response: reqwest::Response) -> Result<reqwest::Response> {
+    async fn parse_binary_response(
+        response: reqwest::Response,
+        context: &CloudRequestContext,
+    ) -> Result<reqwest::Response> {
         let status = response.status();
         if status.is_success() {
             return Ok(response);
         }
 
-        let body = response.text().await?;
-        Self::log_response(status, &body);
+        let request_id = server_request_id(response.headers());
+        let body = response.text().await.map_err(|err| {
+            log_failed_cloud_request(context, Some(status), request_id.as_deref());
+            DeviceSyncError::Http(err)
+        })?;
+        log_failed_cloud_request(context, Some(status), request_id.as_deref());
         if let Ok(error) = serde_json::from_str::<ApiErrorResponse>(&body) {
             let code = if error.code.is_empty() {
                 error.error
@@ -303,14 +500,14 @@ impl DeviceSyncClient {
             return Err(DeviceSyncError::api_structured(
                 status.as_u16(),
                 code,
-                error.message,
-                error.details,
+                with_request_metadata(error.message, context, request_id.as_deref()),
+                details_with_request_metadata(error.details, context, request_id.as_deref()),
             ));
         }
 
         Err(DeviceSyncError::api(
             status.as_u16(),
-            format!("Request failed: {}", body),
+            with_request_metadata("Request failed", context, request_id.as_deref()),
         ))
     }
 
@@ -350,55 +547,43 @@ impl DeviceSyncClient {
         token: &str,
         info: RegisterDeviceRequest,
     ) -> Result<EnrollDeviceResponse> {
-        let url = format!("{}/api/v1/sync/team/devices", self.base_url);
         debug!("Enrolling device: {:?}", info);
 
-        let response = self
-            .client
-            .post(&url)
-            .headers(self.headers(token)?)
-            .json(&info)
-            .send()
-            .await?;
-
-        Self::parse_response(response).await
+        self.send_json_body(
+            Method::POST,
+            "/api/v1/sync/team/devices".to_string(),
+            token,
+            None,
+            &info,
+        )
+        .await
     }
 
     /// Get device info by ID.
     ///
     /// GET /api/v1/sync/team/devices/{deviceId}
     pub async fn get_device(&self, token: &str, device_id: &str) -> Result<Device> {
-        let url = format!("{}/api/v1/sync/team/devices/{}", self.base_url, device_id);
-
-        let response = self
-            .client
-            .get(&url)
-            .headers(self.headers(token)?)
-            .send()
-            .await?;
-
-        Self::parse_response(response).await
+        self.send_json_no_body(
+            Method::GET,
+            format!("/api/v1/sync/team/devices/{}", device_id),
+            token,
+            None,
+        )
+        .await
     }
 
     /// List all devices.
     ///
     /// GET /api/v1/sync/team/devices?scope=my|team
     pub async fn list_devices(&self, token: &str, scope: Option<&str>) -> Result<Vec<Device>> {
-        let mut url = format!("{}/api/v1/sync/team/devices", self.base_url);
+        let mut path = "/api/v1/sync/team/devices".to_string();
         if let Some(s) = scope {
-            url = format!("{}?scope={}", url, s);
+            path = format!("{}?scope={}", path, s);
         }
 
-        debug!("[DeviceSync] list_devices URL: {}", url);
+        debug!("[DeviceSync] list_devices path: {}", path);
 
-        let response = self
-            .client
-            .get(&url)
-            .headers(self.headers(token)?)
-            .send()
-            .await?;
-
-        Self::parse_response(response).await
+        self.send_json_no_body(Method::GET, path, token, None).await
     }
 
     /// Update a device (e.g., rename).
@@ -410,52 +595,40 @@ impl DeviceSyncClient {
         device_id: &str,
         update: UpdateDeviceRequest,
     ) -> Result<SuccessResponse> {
-        let url = format!("{}/api/v1/sync/team/devices/{}", self.base_url, device_id);
-
-        let response = self
-            .client
-            .patch(&url)
-            .headers(self.headers(token)?)
-            .json(&update)
-            .send()
-            .await?;
-
-        Self::parse_response(response).await
+        self.send_json_body(
+            Method::PATCH,
+            format!("/api/v1/sync/team/devices/{}", device_id),
+            token,
+            None,
+            &update,
+        )
+        .await
     }
 
     /// Delete a device.
     ///
     /// DELETE /api/v1/sync/team/devices/{deviceId}
     pub async fn delete_device(&self, token: &str, device_id: &str) -> Result<SuccessResponse> {
-        let url = format!("{}/api/v1/sync/team/devices/{}", self.base_url, device_id);
-
-        let response = self
-            .client
-            .delete(&url)
-            .headers(self.headers(token)?)
-            .send()
-            .await?;
-
-        Self::parse_response(response).await
+        self.send_json_no_body(
+            Method::DELETE,
+            format!("/api/v1/sync/team/devices/{}", device_id),
+            token,
+            None,
+        )
+        .await
     }
 
     /// Revoke a device's trust.
     ///
     /// POST /api/v1/sync/team/devices/{deviceId}/revoke
     pub async fn revoke_device(&self, token: &str, device_id: &str) -> Result<SuccessResponse> {
-        let url = format!(
-            "{}/api/v1/sync/team/devices/{}/revoke",
-            self.base_url, device_id
-        );
-
-        let response = self
-            .client
-            .post(&url)
-            .headers(self.headers(token)?)
-            .send()
-            .await?;
-
-        Self::parse_response(response).await
+        self.send_json_no_body(
+            Method::POST,
+            format!("/api/v1/sync/team/devices/{}/revoke", device_id),
+            token,
+            None,
+        )
+        .await
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -475,17 +648,14 @@ impl DeviceSyncClient {
         token: &str,
         device_id: &str,
     ) -> Result<InitializeKeysResult> {
-        let url = format!("{}/api/v1/sync/team/keys/initialize", self.base_url);
-
-        let response = self
-            .client
-            .post(&url)
-            .headers(self.headers_with_device(token, Some(device_id))?)
-            .json(&serde_json::json!({ "device_id": device_id }))
-            .send()
-            .await?;
-
-        Self::parse_response(response).await
+        self.send_json_body(
+            Method::POST,
+            "/api/v1/sync/team/keys/initialize".to_string(),
+            token,
+            Some(device_id),
+            &serde_json::json!({ "device_id": device_id }),
+        )
+        .await
     }
 
     /// Commit team key initialization (Phase 2).
@@ -497,18 +667,16 @@ impl DeviceSyncClient {
         token: &str,
         req: CommitInitializeKeysRequest,
     ) -> Result<CommitInitializeKeysResponse> {
-        let url = format!("{}/api/v1/sync/team/keys/initialize/commit", self.base_url);
         let device_id = req.device_id.clone();
 
-        let response = self
-            .client
-            .post(&url)
-            .headers(self.headers_with_device(token, Some(&device_id))?)
-            .json(&req)
-            .send()
-            .await?;
-
-        Self::parse_response(response).await
+        self.send_json_body(
+            Method::POST,
+            "/api/v1/sync/team/keys/initialize/commit".to_string(),
+            token,
+            Some(&device_id),
+            &req,
+        )
+        .await
     }
 
     /// Start key rotation (Phase 1).
@@ -519,17 +687,14 @@ impl DeviceSyncClient {
         token: &str,
         initiator_device_id: &str,
     ) -> Result<RotateKeysResponse> {
-        let url = format!("{}/api/v1/sync/team/keys/rotate", self.base_url);
-
-        let response = self
-            .client
-            .post(&url)
-            .headers(self.headers_with_device(token, Some(initiator_device_id))?)
-            .json(&serde_json::json!({ "initiator_device_id": initiator_device_id }))
-            .send()
-            .await?;
-
-        Self::parse_response(response).await
+        self.send_json_body(
+            Method::POST,
+            "/api/v1/sync/team/keys/rotate".to_string(),
+            token,
+            Some(initiator_device_id),
+            &serde_json::json!({ "initiator_device_id": initiator_device_id }),
+        )
+        .await
     }
 
     /// Commit key rotation (Phase 2).
@@ -541,17 +706,14 @@ impl DeviceSyncClient {
         device_id: &str,
         req: CommitRotateKeysRequest,
     ) -> Result<CommitRotateKeysResponse> {
-        let url = format!("{}/api/v1/sync/team/keys/rotate/commit", self.base_url);
-
-        let response = self
-            .client
-            .post(&url)
-            .headers(self.headers_with_device(token, Some(device_id))?)
-            .json(&req)
-            .send()
-            .await?;
-
-        Self::parse_response(response).await
+        self.send_json_body(
+            Method::POST,
+            "/api/v1/sync/team/keys/rotate/commit".to_string(),
+            token,
+            Some(device_id),
+            &req,
+        )
+        .await
     }
 
     /// Reset team sync (destructive).
@@ -563,23 +725,20 @@ impl DeviceSyncClient {
         token: &str,
         reason: Option<&str>,
     ) -> Result<ResetTeamSyncResponse> {
-        let url = format!("{}/api/v1/sync/team/keys/reset", self.base_url);
-
         // Build body - only include reason if provided (API rejects null)
         let body = match reason {
             Some(r) => serde_json::json!({ "reason": r }),
             None => serde_json::json!({}),
         };
 
-        let response = self
-            .client
-            .post(&url)
-            .headers(self.headers(token)?)
-            .json(&body)
-            .send()
-            .await?;
-
-        Self::parse_response(response).await
+        self.send_json_body(
+            Method::POST,
+            "/api/v1/sync/team/keys/reset".to_string(),
+            token,
+            None,
+            &body,
+        )
+        .await
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -595,15 +754,14 @@ impl DeviceSyncClient {
         device_id: &str,
         req: SyncPushRequest,
     ) -> Result<SyncPushResponse> {
-        let url = format!("{}/api/v1/sync/events/push", self.base_url);
-        let response = self
-            .client
-            .post(&url)
-            .headers(self.headers_with_device(token, Some(device_id))?)
-            .json(&req)
-            .send()
-            .await?;
-        Self::parse_response(response).await
+        self.send_json_body(
+            Method::POST,
+            "/api/v1/sync/events/push".to_string(),
+            token,
+            Some(device_id),
+            &req,
+        )
+        .await
     }
 
     /// Pull remote events after a cursor.
@@ -616,24 +774,20 @@ impl DeviceSyncClient {
         since: Option<i64>,
         limit: Option<i32>,
     ) -> Result<SyncPullResponse> {
-        let url = format!("{}/api/v1/sync/events/pull", self.base_url);
-        let mut query: Vec<(&str, String)> = Vec::new();
+        let mut path = "/api/v1/sync/events/pull".to_string();
+        let mut query = Vec::new();
         if let Some(value) = since {
-            query.push(("since", value.to_string()));
+            query.push(format!("since={}", value));
         }
         if let Some(value) = limit {
-            query.push(("limit", value.to_string()));
+            query.push(format!("limit={}", value));
+        }
+        if !query.is_empty() {
+            path = format!("{}?{}", path, query.join("&"));
         }
 
-        let mut request = self
-            .client
-            .get(&url)
-            .headers(self.headers_with_device(token, Some(device_id))?);
-        if !query.is_empty() {
-            request = request.query(&query);
-        }
-        let response = request.send().await?;
-        Self::parse_response(response).await
+        self.send_json_no_body(Method::GET, path, token, Some(device_id))
+            .await
     }
 
     /// Get the reconcile-ready-state for this device.
@@ -644,14 +798,13 @@ impl DeviceSyncClient {
         token: &str,
         device_id: &str,
     ) -> Result<ReconcileReadyStateResponse> {
-        let url = format!("{}/api/v1/sync/events/reconcile-ready-state", self.base_url);
-        let response = self
-            .client
-            .get(url)
-            .headers(self.headers_with_device(token, Some(device_id))?)
-            .send()
-            .await?;
-        Self::parse_response(response).await
+        self.send_json_no_body(
+            Method::GET,
+            "/api/v1/sync/events/reconcile-ready-state".to_string(),
+            token,
+            Some(device_id),
+        )
+        .await
     }
 
     /// Get lightweight current server cursor.
@@ -662,14 +815,13 @@ impl DeviceSyncClient {
         token: &str,
         device_id: &str,
     ) -> Result<SyncCursorResponse> {
-        let url = format!("{}/api/v1/sync/events/cursor", self.base_url);
-        let response = self
-            .client
-            .get(url)
-            .headers(self.headers_with_device(token, Some(device_id))?)
-            .send()
-            .await?;
-        Self::parse_response(response).await
+        self.send_json_no_body(
+            Method::GET,
+            "/api/v1/sync/events/cursor".to_string(),
+            token,
+            Some(device_id),
+        )
+        .await
     }
 
     /// Get metadata for the latest available snapshot.
@@ -680,14 +832,13 @@ impl DeviceSyncClient {
         token: &str,
         device_id: &str,
     ) -> Result<SnapshotLatestResponse> {
-        let url = format!("{}/api/v1/sync/snapshots/latest", self.base_url);
-        let response = self
-            .client
-            .get(url)
-            .headers(self.headers_with_device(token, Some(device_id))?)
-            .send()
-            .await?;
-        Self::parse_response(response).await
+        self.send_json_no_body(
+            Method::GET,
+            "/api/v1/sync/snapshots/latest".to_string(),
+            token,
+            Some(device_id),
+        )
+        .await
     }
 
     /// Resolve latest snapshot with server-bug fallback to /events/cursor.latest_snapshot.
@@ -742,13 +893,20 @@ impl DeviceSyncClient {
         snapshot_id: &str,
     ) -> Result<(SnapshotDownloadHeaders, Vec<u8>)> {
         let url = self.snapshot_download_url(snapshot_id)?;
+        let path = url.path().to_string();
+        let context = CloudRequestContext::new("GET", path, Some(device_id));
+        let headers = self.headers_with_device(token, Some(device_id), &context)?;
         let response = self
             .client
             .get(url)
-            .headers(self.headers_with_device(token, Some(device_id))?)
+            .headers(headers)
             .send()
-            .await?;
-        let response = Self::parse_binary_response(response).await?;
+            .await
+            .map_err(|err| {
+                log_failed_cloud_request(&context, None, None);
+                DeviceSyncError::Http(err)
+            })?;
+        let response = Self::parse_binary_response(response, &context).await?;
         let headers = response.headers().clone();
         let body = response.bytes().await?.to_vec();
 
@@ -866,7 +1024,8 @@ impl DeviceSyncClient {
         payload: Vec<u8>,
         cancel_flag: Option<&AtomicBool>,
     ) -> Result<SnapshotUploadResponse> {
-        let url = format!("{}/api/v1/sync/snapshots/upload", self.base_url);
+        let path = "/api/v1/sync/snapshots/upload";
+        let url = format!("{}{}", self.base_url, path);
         let mut attempt = 0usize;
 
         loop {
@@ -880,7 +1039,8 @@ impl DeviceSyncClient {
             }
 
             attempt = attempt.saturating_add(1);
-            let mut headers = self.headers_with_device(token, Some(device_id))?;
+            let context = CloudRequestContext::new("POST", path, Some(device_id));
+            let mut headers = self.headers_with_device(token, Some(device_id), &context)?;
             headers.insert(
                 CONTENT_TYPE,
                 HeaderValue::from_static("application/octet-stream"),
@@ -948,33 +1108,47 @@ impl DeviceSyncClient {
                 Ok(response) => {
                     let status = response.status();
                     if status.is_success() {
-                        return Self::parse_response(response).await;
+                        return Self::parse_response(response, &context).await;
                     }
 
-                    let body = response.text().await?;
-                    Self::log_response(status, &body);
+                    let request_id = server_request_id(response.headers());
+                    let body = response.text().await.map_err(|err| {
+                        log_failed_cloud_request(&context, Some(status), request_id.as_deref());
+                        DeviceSyncError::Http(err)
+                    })?;
+                    log_failed_cloud_request(&context, Some(status), request_id.as_deref());
                     let mut parsed_error_code: Option<String> = None;
                     let mut parsed_error_message: Option<String> = None;
-                    let error = if let Ok(api_error) =
-                        serde_json::from_str::<ApiErrorResponse>(&body)
-                    {
-                        let message = api_error.message;
-                        let code = if api_error.code.is_empty() {
-                            api_error.error
+                    let error =
+                        if let Ok(api_error) = serde_json::from_str::<ApiErrorResponse>(&body) {
+                            let message = api_error.message;
+                            let code = if api_error.code.is_empty() {
+                                api_error.error
+                            } else {
+                                api_error.code
+                            };
+                            parsed_error_code = Some(code.clone());
+                            parsed_error_message = Some(message.clone());
+                            DeviceSyncError::api_structured(
+                                status.as_u16(),
+                                code,
+                                with_request_metadata(message, &context, request_id.as_deref()),
+                                details_with_request_metadata(
+                                    api_error.details,
+                                    &context,
+                                    request_id.as_deref(),
+                                ),
+                            )
                         } else {
-                            api_error.code
+                            DeviceSyncError::api(
+                                status.as_u16(),
+                                with_request_metadata(
+                                    "Request failed",
+                                    &context,
+                                    request_id.as_deref(),
+                                ),
+                            )
                         };
-                        parsed_error_code = Some(code.clone());
-                        parsed_error_message = Some(message.clone());
-                        DeviceSyncError::api_structured(
-                            status.as_u16(),
-                            code,
-                            message,
-                            api_error.details,
-                        )
-                    } else {
-                        DeviceSyncError::api(status.as_u16(), format!("Request failed: {}", body))
-                    };
 
                     if is_retryable_snapshot_error(
                         status.as_u16(),
@@ -997,6 +1171,7 @@ impl DeviceSyncClient {
                     return Err(error);
                 }
                 Err(err) => {
+                    log_failed_cloud_request(&context, None, None);
                     if is_retryable_transport_error(&err) && attempt < SNAPSHOT_UPLOAD_MAX_ATTEMPTS
                     {
                         let backoff = snapshot_backoff_with_jitter(attempt);
@@ -1029,20 +1204,14 @@ impl DeviceSyncClient {
         device_id: &str,
         req: CreatePairingRequest,
     ) -> Result<CreatePairingResponse> {
-        let url = format!(
-            "{}/api/v1/sync/team/devices/{}/pairings",
-            self.base_url, device_id
-        );
-
-        let response = self
-            .client
-            .post(&url)
-            .headers(self.headers_with_device(token, Some(device_id))?)
-            .json(&req)
-            .send()
-            .await?;
-
-        Self::parse_response(response).await
+        self.send_json_body(
+            Method::POST,
+            format!("/api/v1/sync/team/devices/{}/pairings", device_id),
+            token,
+            Some(device_id),
+            &req,
+        )
+        .await
     }
 
     /// Get pairing session details.
@@ -1054,19 +1223,16 @@ impl DeviceSyncClient {
         device_id: &str,
         pairing_id: &str,
     ) -> Result<GetPairingResponse> {
-        let url = format!(
-            "{}/api/v1/sync/team/devices/{}/pairings/{}",
-            self.base_url, device_id, pairing_id
-        );
-
-        let response = self
-            .client
-            .get(&url)
-            .headers(self.headers_with_device(token, Some(device_id))?)
-            .send()
-            .await?;
-
-        Self::parse_response(response).await
+        self.send_json_no_body(
+            Method::GET,
+            format!(
+                "/api/v1/sync/team/devices/{}/pairings/{}",
+                device_id, pairing_id
+            ),
+            token,
+            Some(device_id),
+        )
+        .await
     }
 
     /// Approve a pairing session.
@@ -1078,19 +1244,16 @@ impl DeviceSyncClient {
         device_id: &str,
         pairing_id: &str,
     ) -> Result<SuccessResponse> {
-        let url = format!(
-            "{}/api/v1/sync/team/devices/{}/pairings/{}/approve",
-            self.base_url, device_id, pairing_id
-        );
-
-        let response = self
-            .client
-            .post(&url)
-            .headers(self.headers_with_device(token, Some(device_id))?)
-            .send()
-            .await?;
-
-        Self::parse_response(response).await
+        self.send_json_no_body(
+            Method::POST,
+            format!(
+                "/api/v1/sync/team/devices/{}/pairings/{}/approve",
+                device_id, pairing_id
+            ),
+            token,
+            Some(device_id),
+        )
+        .await
     }
 
     /// Complete a pairing session with key bundle.
@@ -1103,20 +1266,17 @@ impl DeviceSyncClient {
         pairing_id: &str,
         req: CompletePairingRequest,
     ) -> Result<CompletePairingResponse> {
-        let url = format!(
-            "{}/api/v1/sync/team/devices/{}/pairings/{}/complete",
-            self.base_url, device_id, pairing_id
-        );
-
-        let response = self
-            .client
-            .post(&url)
-            .headers(self.headers_with_device(token, Some(device_id))?)
-            .json(&req)
-            .send()
-            .await?;
-
-        Self::parse_response(response).await
+        self.send_json_body(
+            Method::POST,
+            format!(
+                "/api/v1/sync/team/devices/{}/pairings/{}/complete",
+                device_id, pairing_id
+            ),
+            token,
+            Some(device_id),
+            &req,
+        )
+        .await
     }
 
     /// Cancel a pairing session.
@@ -1128,19 +1288,16 @@ impl DeviceSyncClient {
         device_id: &str,
         pairing_id: &str,
     ) -> Result<SuccessResponse> {
-        let url = format!(
-            "{}/api/v1/sync/team/devices/{}/pairings/{}/cancel",
-            self.base_url, device_id, pairing_id
-        );
-
-        let response = self
-            .client
-            .post(&url)
-            .headers(self.headers_with_device(token, Some(device_id))?)
-            .send()
-            .await?;
-
-        Self::parse_response(response).await
+        self.send_json_no_body(
+            Method::POST,
+            format!(
+                "/api/v1/sync/team/devices/{}/pairings/{}/cancel",
+                device_id, pairing_id
+            ),
+            token,
+            Some(device_id),
+        )
+        .await
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -1159,20 +1316,17 @@ impl DeviceSyncClient {
         claimer_device_id: &str,
         req: ClaimPairingRequest,
     ) -> Result<ClaimPairingResponse> {
-        let url = format!(
-            "{}/api/v1/sync/team/devices/{}/pairings/claim",
-            self.base_url, claimer_device_id
-        );
-
-        let response = self
-            .client
-            .post(&url)
-            .headers(self.headers_with_device(token, Some(claimer_device_id))?)
-            .json(&req)
-            .send()
-            .await?;
-
-        Self::parse_response(response).await
+        self.send_json_body(
+            Method::POST,
+            format!(
+                "/api/v1/sync/team/devices/{}/pairings/claim",
+                claimer_device_id
+            ),
+            token,
+            Some(claimer_device_id),
+            &req,
+        )
+        .await
     }
 
     /// Poll for messages/key bundle from the issuer (claimer side).
@@ -1187,19 +1341,16 @@ impl DeviceSyncClient {
         claimer_device_id: &str,
         pairing_id: &str,
     ) -> Result<PairingMessagesResponse> {
-        let url = format!(
-            "{}/api/v1/sync/team/devices/{}/pairings/{}/messages",
-            self.base_url, claimer_device_id, pairing_id
-        );
-
-        let response = self
-            .client
-            .get(&url)
-            .headers(self.headers_with_device(token, Some(claimer_device_id))?)
-            .send()
-            .await?;
-
-        Self::parse_response(response).await
+        self.send_json_no_body(
+            Method::GET,
+            format!(
+                "/api/v1/sync/team/devices/{}/pairings/{}/messages",
+                claimer_device_id, pairing_id
+            ),
+            token,
+            Some(claimer_device_id),
+        )
+        .await
     }
 
     /// Confirm pairing and become trusted (claimer side).
@@ -1216,20 +1367,17 @@ impl DeviceSyncClient {
         pairing_id: &str,
         req: ConfirmPairingRequest,
     ) -> Result<ConfirmPairingResponse> {
-        let url = format!(
-            "{}/api/v1/sync/team/devices/{}/pairings/{}/confirm",
-            self.base_url, claimer_device_id, pairing_id
-        );
-
-        let response = self
-            .client
-            .post(&url)
-            .headers(self.headers_with_device(token, Some(claimer_device_id))?)
-            .json(&req)
-            .send()
-            .await?;
-
-        Self::parse_response(response).await
+        self.send_json_body(
+            Method::POST,
+            format!(
+                "/api/v1/sync/team/devices/{}/pairings/{}/confirm",
+                claimer_device_id, pairing_id
+            ),
+            token,
+            Some(claimer_device_id),
+            &req,
+        )
+        .await
     }
 }
 
@@ -1265,6 +1413,9 @@ mod tests {
     #[derive(Debug, Clone)]
     struct CapturedUploadRequest {
         event_id: Option<String>,
+        client_request_id: Option<String>,
+        request_id: Option<String>,
+        device_id: Option<String>,
         content_length: Option<String>,
         snapshot_size_bytes: Option<String>,
     }
@@ -1414,10 +1565,16 @@ mod tests {
                         return;
                     };
                     let event_id = headers.get("x-snapshot-event-id").cloned();
+                    let client_request_id = headers.get(CLIENT_REQUEST_ID_HEADER).cloned();
+                    let request_id = headers.get(SERVER_REQUEST_ID_HEADER).cloned();
+                    let device_id = headers.get("x-wf-device-id").cloned();
                     let content_length = headers.get("content-length").cloned();
                     let snapshot_size_bytes = headers.get("x-snapshot-size-bytes").cloned();
                     captured_inner.lock().await.push(CapturedUploadRequest {
                         event_id,
+                        client_request_id,
+                        request_id,
+                        device_id,
                         content_length,
                         snapshot_size_bytes,
                     });
@@ -1526,6 +1683,24 @@ mod tests {
         let second_id = requests[1].event_id.clone().expect("second event id");
         assert_eq!(first_id, second_id);
         assert!(Uuid::parse_str(&first_id).is_ok());
+        let first_client_request_id = requests[0]
+            .client_request_id
+            .clone()
+            .expect("first client request id");
+        let second_client_request_id = requests[1]
+            .client_request_id
+            .clone()
+            .expect("second client request id");
+        assert!(first_client_request_id.starts_with("019bb9fe-f707-71e9-a40d-733575f4f246:"));
+        assert!(second_client_request_id.starts_with("019bb9fe-f707-71e9-a40d-733575f4f246:"));
+        assert!(is_log_safe_request_id(&first_client_request_id));
+        assert!(is_log_safe_request_id(&second_client_request_id));
+        assert_ne!(first_client_request_id, second_client_request_id);
+        assert_eq!(
+            requests[0].device_id.as_deref(),
+            Some("019bb9fe-f707-71e9-a40d-733575f4f246")
+        );
+        assert!(requests[0].request_id.is_none());
         assert_eq!(requests[0].content_length, requests[0].snapshot_size_bytes);
         assert_eq!(requests[1].content_length, requests[1].snapshot_size_bytes);
 


### PR DESCRIPTION
## Summary
- send a per-request `x-wf-client-request-id` for Connect, auth refresh, subscription plan, and device sync cloud API calls
- read server `x-request-id` values and include request metadata in failed-request logs/errors without logging sensitive payloads
- filter subscription plan UI to display only API-returned visible plans, so hidden Plus plans are not re-added locally

## Verification
- `cargo test -p wealthfolio-connect -p wealthfolio-device-sync`
- `pnpm --filter frontend test -- plan-visibility`
- `pnpm --filter frontend type-check`
- `pnpm --filter frontend lint` (passes with existing warnings)
- `git diff --check`