### PR TITLE
Add quote unit currency handling

### DIFF
--- a/apps/frontend/src/lib/utils.currency.test.ts
+++ b/apps/frontend/src/lib/utils.currency.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { formatAmount, normalizeCurrency } from "./utils";
+
+describe("currency utilities", () => {
+  it("does not treat GBP as the GBp quote unit", () => {
+    expect(normalizeCurrency("GBP")).toBe("GBP");
+    expect(normalizeCurrency("gbp")).toBe("GBP");
+    expect(formatAmount(12.34, "GBP")).toBe("£12.34");
+  });
+
+  it("normalizes and formats quote units", () => {
+    expect(normalizeCurrency("GBp")).toBe("GBP");
+    expect(normalizeCurrency("gbx")).toBe("GBP");
+    expect(normalizeCurrency("ILA")).toBe("ILS");
+    expect(normalizeCurrency("USX")).toBe("USD");
+    expect(normalizeCurrency("ZAC")).toBe("ZAR");
+
+    expect(formatAmount(12.34, "GBp")).toBe("12.34p");
+    expect(formatAmount(12.34, "ILA")).toBe("12.34ag");
+  });
+});

--- a/apps/frontend/src/lib/utils.ts
+++ b/apps/frontend/src/lib/utils.ts
@@ -2,6 +2,7 @@ import { logger } from "@/adapters";
 import { type ClassValue, clsx } from "clsx";
 import { format, isValid, parse, parseISO } from "date-fns";
 import { twMerge } from "tailwind-merge";
+import { getQuoteUnitCurrency } from "@wealthfolio/ui/lib/currencies";
 import { DECIMAL_PRECISION, DISPLAY_DECIMAL_PRECISION } from "./constants";
 import { AccountValuation } from "./types";
 
@@ -278,26 +279,14 @@ const getCurrencyFormatter = (currency: string) => {
 };
 
 /**
- * Minor currency normalization rules.
- * Maps minor currency codes to their major equivalents.
- */
-const MINOR_CURRENCY_MAP: Record<string, string> = {
-  GBp: "GBP", // British pence
-  GBX: "GBP", // British pence (alternative code)
-  ZAc: "ZAR", // South African cents
-  ZAC: "ZAR", // South African cents (uppercase)
-  ILA: "ILS", // Israeli agorot
-  KWF: "KWD", // Kuwaiti fils
-};
-
-/**
  * Normalizes a minor currency code to its major equivalent.
  * E.g., "GBp" -> "GBP", "ZAc" -> "ZAR"
- * If no normalization rule exists, returns the input unchanged.
+ * If no normalization rule exists, returns the uppercased input.
  */
 export function normalizeCurrency(currency: string | undefined): string | undefined {
   if (!currency) return currency;
-  return MINOR_CURRENCY_MAP[currency] ?? currency;
+  const trimmed = currency.trim();
+  return getQuoteUnitCurrency(trimmed)?.major ?? trimmed.toUpperCase();
 }
 
 export function formatAmount(
@@ -310,11 +299,11 @@ export function formatAmount(
   if (!Number.isFinite(numericAmount)) return "-";
   const displayAmount = Math.abs(numericAmount) < 0.005 ? 0 : numericAmount;
   const rawCurrency = currency ?? "USD";
-  const isPenceCurrency = rawCurrency === "GBp" || rawCurrency === "GBX";
+  const quoteUnit = getQuoteUnitCurrency(rawCurrency);
 
-  if (isPenceCurrency) {
+  if (quoteUnit) {
     const formattedNumber = decimalFormatter.format(displayAmount);
-    return displayCurrency ? `${formattedNumber}p` : formattedNumber;
+    return displayCurrency ? `${formattedNumber}${quoteUnit.symbol}` : formattedNumber;
   }
 
   if (!displayCurrency) {

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid.tsx
@@ -45,22 +45,11 @@ interface ActivityDataGridProps {
   onPageSizeChange: (pageSize: number) => void;
 }
 
-function shouldApplyResolvedQuoteCurrency(result: SymbolSearchResult): boolean {
+function canUseResolvedCurrency(result: SymbolSearchResult): boolean {
   if (result.isExisting || isManualSearchResult(result)) {
     return false;
   }
-  return (
-    !result.currency?.trim() ||
-    result.currencySource === "exchange_inferred" ||
-    !result.currencySource
-  );
-}
-
-function shouldApplyResolvedActivityCurrency(result: SymbolSearchResult): boolean {
-  if (result.isExisting || isManualSearchResult(result)) {
-    return false;
-  }
-  return !result.currency?.trim() || result.currencySource === "exchange_inferred";
+  return true;
 }
 
 const ACTIVITY_GRID_COLUMN_VISIBILITY_KEY = "activity-datagrid-column-visibility";
@@ -242,8 +231,7 @@ export function ActivityDataGrid({
 
       // Resolve quote to confirm currency and get latest price
       if (result.dataSource !== "MANUAL") {
-        const shouldUseResolvedQuoteCurrency = shouldApplyResolvedQuoteCurrency(result);
-        const shouldUseResolvedActivityCurrency = shouldApplyResolvedActivityCurrency(result);
+        const shouldUseResolvedCurrency = canUseResolvedCurrency(result);
         resolveSymbolQuote(
           canonicalSymbol,
           canonicalExchangeMic,
@@ -264,13 +252,10 @@ export function ActivityDataGrid({
 
             const changes: Partial<LocalTransaction> = {};
 
-            // Update currency from resolved quote to correct exchange-inferred values
-            // (e.g., search returns "GBp" inferred, resolve confirms "GBP")
-            // Only overwrite if user hasn't manually changed it since selection
-            if (resolved.currency && shouldUseResolvedQuoteCurrency) {
+            // Update currency from resolved quote only if the user has not edited it since selection.
+            if (resolved.currency && shouldUseResolvedCurrency) {
               const confirmedCurrency = resolved.currency.trim();
               if (
-                shouldUseResolvedActivityCurrency &&
                 confirmedCurrency &&
                 row.currency !== confirmedCurrency &&
                 row.currency === (provisionalCurrency ?? row.accountCurrency ?? fallbackCurrency)

--- a/apps/frontend/src/pages/activity/components/forms/fields/__tests__/symbol-search.test.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/fields/__tests__/symbol-search.test.tsx
@@ -148,6 +148,7 @@ function TestForm() {
         <input type="hidden" {...methods.register("assetMetadata.name")} />
         <div data-testid="asset-id">{methods.watch("assetId") ?? ""}</div>
         <div data-testid="exchange-mic">{methods.watch("exchangeMic") ?? ""}</div>
+        <div data-testid="currency">{methods.watch("currency") ?? ""}</div>
         <div data-testid="quote-ccy">{methods.watch("symbolQuoteCcy") ?? ""}</div>
         <div data-testid="asset-name">{methods.watch("assetMetadata.name") ?? ""}</div>
         <div data-testid="quote-mode">{methods.watch("quoteMode") ?? ""}</div>
@@ -233,6 +234,23 @@ describe("SymbolSearch", () => {
     expect(screen.getByTestId("provider-ref")).toHaveTextContent(
       JSON.stringify({ providerId: "YAHOO", providerSymbol: "SHOP.TO" }),
     );
+  });
+
+  it("uses resolved currency over provider search currency for new assets", async () => {
+    resolveSymbolQuoteMock.mockResolvedValue({
+      currency: "USD",
+      price: 140,
+    });
+
+    const user = userEvent.setup();
+    render(<TestForm />);
+
+    await user.click(screen.getByTestId("select-provider-ref"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("quote-ccy")).toHaveTextContent("USD");
+      expect(screen.getByTestId("currency")).toHaveTextContent("USD");
+    });
   });
 
   it("uses explicit quote mode instead of data source for existing assets", async () => {

--- a/apps/frontend/src/pages/activity/components/forms/fields/symbol-search.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/fields/symbol-search.tsx
@@ -12,24 +12,11 @@ import { useRef, useState } from "react";
 import { useFormContext, type FieldPath, type FieldValues } from "react-hook-form";
 import { resolveSymbolQuote } from "@/adapters";
 
-function shouldApplyResolvedQuoteCurrency(searchResult: SymbolSearchResult | undefined): boolean {
+function canUseResolvedCurrency(searchResult: SymbolSearchResult | undefined): boolean {
   if (!searchResult || searchResult.isExisting || isManualSearchResult(searchResult)) {
     return false;
   }
-  return (
-    !searchResult.currency?.trim() ||
-    searchResult.currencySource === "exchange_inferred" ||
-    !searchResult.currencySource
-  );
-}
-
-function shouldApplyResolvedActivityCurrency(
-  searchResult: SymbolSearchResult | undefined,
-): boolean {
-  if (!searchResult || searchResult.isExisting || isManualSearchResult(searchResult)) {
-    return false;
-  }
-  return !searchResult.currency?.trim() || searchResult.currencySource === "exchange_inferred";
+  return true;
 }
 
 interface SymbolSearchProps<TFieldValues extends FieldValues = FieldValues> {
@@ -88,6 +75,9 @@ export function SymbolSearch<TFieldValues extends FieldValues = FieldValues>({
     const requestId = latestResolveRequestId.current;
     const selectedQuoteMode = quoteModeFromSearchResult(searchResult);
     const isManualAsset = selectedQuoteMode === QuoteMode.MANUAL;
+    const previousCurrency = currencyName
+      ? ((getValues(currencyName) as string | undefined)?.trim() ?? undefined)
+      : undefined;
 
     if (quoteModeName) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -148,14 +138,10 @@ export function SymbolSearch<TFieldValues extends FieldValues = FieldValues>({
       setValue(quoteCcyName, (searchResult?.currency ?? undefined) as any);
     }
 
-    // Background quote resolution: confirm inferred currency and show display quote
-    // For existing assets, currency is already established — never override it
-    // Update activity currency when:
-    // - currency was exchange-inferred (needs provider confirmation)
-    // - search result had no currency at all (e.g., OpenFIGI bonds)
-    const shouldUseResolvedQuoteCurrency = shouldApplyResolvedQuoteCurrency(searchResult);
-    const needsCurrencyConfirmation =
-      currencyName && shouldApplyResolvedActivityCurrency(searchResult);
+    // Background quote resolution confirms selected symbol currency and shows display quote.
+    // Existing assets keep their stored currency.
+    const shouldUseResolvedCurrency = canUseResolvedCurrency(searchResult);
+    const needsCurrencyConfirmation = Boolean(currencyName && shouldUseResolvedCurrency);
 
     if (searchResult) {
       setQuoteDisplay({ price: null, isLoading: true });
@@ -172,19 +158,19 @@ export function SymbolSearch<TFieldValues extends FieldValues = FieldValues>({
           setQuoteDisplay({ price: resolved?.price ?? null, isLoading: false });
 
           const confirmedCurrency = resolved?.currency?.trim();
-          if (confirmedCurrency && quoteCcyName && shouldUseResolvedQuoteCurrency) {
-            // Only replace provisional hints; existing assets and selected pairs already
-            // carry stronger quote-currency identity.
+          if (confirmedCurrency && quoteCcyName && shouldUseResolvedCurrency) {
+            // Resolver output is the source of truth for newly selected market assets.
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             setValue(quoteCcyName, confirmedCurrency as any);
           }
 
-          // Update activity currency when:
-          // - provisional (inferred) currency exists and user hasn't changed it
-          // - no currency was known at selection time (e.g., OpenFIGI bonds)
+          // Keep user edits if the activity currency changed after selection.
           if (needsCurrencyConfirmation && confirmedCurrency) {
             const current = getValues(currencyName!);
-            const shouldUpdate = provisionalCurrency ? current === provisionalCurrency : true;
+            const expectedCurrentCurrency = provisionalCurrency || previousCurrency;
+            const shouldUpdate = expectedCurrentCurrency
+              ? current === expectedCurrentCurrency
+              : true;
             if (shouldUpdate) {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any
               setValue(currencyName!, confirmedCurrency as any, {

--- a/apps/frontend/src/pages/activity/import/components/import-toolbar.tsx
+++ b/apps/frontend/src/pages/activity/import/components/import-toolbar.tsx
@@ -10,6 +10,8 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   Icons,
+  quoteCurrencies,
+  quoteUnitCurrencies,
   worldCurrencies,
 } from "@wealthfolio/ui";
 import { useAccounts } from "@/hooks/use-accounts";
@@ -54,7 +56,7 @@ export function ImportToolbar({
 
   // Filter currencies based on search
   const filteredCurrencies = currencySearch
-    ? worldCurrencies.filter(
+    ? quoteCurrencies.filter(
         (c) =>
           c.value.toLowerCase().includes(currencySearch.toLowerCase()) ||
           c.label.toLowerCase().includes(currencySearch.toLowerCase()),
@@ -160,6 +162,24 @@ export function ImportToolbar({
                     }}
                   >
                     <span className="font-mono">{code}</span>
+                  </DropdownMenuItem>
+                ))}
+                <DropdownMenuSeparator />
+                <div className="text-muted-foreground px-2 py-1 text-xs font-medium">
+                  Quote Units
+                </div>
+                {quoteUnitCurrencies.map((currency) => (
+                  <DropdownMenuItem
+                    key={currency.value}
+                    onSelect={() => {
+                      onSetCurrency(currency.value);
+                      setCurrencySearch("");
+                    }}
+                  >
+                    <span className="font-mono">{currency.value}</span>
+                    <span className="text-muted-foreground ml-2 truncate text-xs">
+                      {currency.label.replace(` (${currency.value})`, "")}
+                    </span>
                   </DropdownMenuItem>
                 ))}
                 <DropdownMenuSeparator />

--- a/apps/frontend/src/pages/activity/import/steps/asset-review-step.tsx
+++ b/apps/frontend/src/pages/activity/import/steps/asset-review-step.tsx
@@ -4,6 +4,7 @@ import { TickerAvatar } from "@/components/ticker-avatar";
 import { CreateSecurityDialog } from "@/pages/asset/create-security-dialog";
 import type { ImportAssetPreviewItem, NewAsset, SymbolSearchResult } from "@/lib/types";
 import { getExchangeDisplayName } from "@/lib/constants";
+import { normalizeCurrency } from "@/lib/utils";
 import { Button } from "@wealthfolio/ui/components/ui/button";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
 import { ProgressIndicator } from "@wealthfolio/ui/components/ui/progress-indicator";
@@ -156,14 +157,6 @@ function NeedsFixingRow({
 }
 
 // ─── Auto-Resolved Row ────────────────────────────────────────────────────────
-
-/** Collapse pence/cent variants to their parent currency for mismatch detection. */
-function normalizeCurrency(c: string): string {
-  const u = c.toUpperCase();
-  if (u === "GBX" || u === "GBP" || u === "GBP") return "GBP";
-  if (u === "ZAC") return "ZAR";
-  return u;
-}
 
 interface AutoResolvedRowProps {
   item: ImportAssetPreviewItem;

--- a/apps/frontend/src/pages/asset/create-security-dialog.tsx
+++ b/apps/frontend/src/pages/asset/create-security-dialog.tsx
@@ -1,4 +1,4 @@
-import { getExchanges } from "@/adapters";
+import { getExchanges, resolveSymbolQuote } from "@/adapters";
 import TickerSearchInput from "@/components/ticker-search";
 import { quoteModeFromSearchResult } from "@/lib/asset-utils";
 import { useSettingsContext } from "@/lib/settings-provider";
@@ -33,7 +33,7 @@ import {
   SelectValue,
 } from "@wealthfolio/ui/components/ui/select";
 import { Textarea } from "@wealthfolio/ui/components/ui/textarea";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -115,6 +115,10 @@ export function CreateSecurityDialog({
   const { settings } = useSettingsContext();
   const defaultCurrency = settings?.baseCurrency || "USD";
   const [selectedResult, setSelectedResult] = useState<SymbolSearchResult | undefined>();
+  const [isResolvingSubmit, setIsResolvingSubmit] = useState(false);
+  const resolveRequestSeq = useRef(0);
+  const selectedCurrencyBaselineRef = useRef<string | undefined>(undefined);
+  const quoteCcyUserEditedAfterSelectionRef = useRef(false);
 
   const { data: exchanges = [] } = useQuery({
     queryKey: ["exchanges"],
@@ -150,6 +154,9 @@ export function CreateSecurityDialog({
   });
 
   useEffect(() => {
+    resolveRequestSeq.current += 1;
+    selectedCurrencyBaselineRef.current = undefined;
+    quoteCcyUserEditedAfterSelectionRef.current = false;
     if (open) {
       setSelectedResult(undefined);
       form.reset(defaultValues);
@@ -160,10 +167,16 @@ export function CreateSecurityDialog({
     (_symbol: string, result?: SymbolSearchResult) => {
       if (!result) return;
 
+      const requestId = ++resolveRequestSeq.current;
+      const previousCurrency = form.getValues("quoteCcy")?.trim();
       const canonicalSymbol = result.canonicalSymbol || result.symbol;
       const canonicalExchangeMic = result.canonicalExchangeMic || result.exchangeMic;
+      const provisionalCurrency = result.currency?.trim();
+      const expectedCurrency = provisionalCurrency || previousCurrency;
 
       setSelectedResult(result);
+      selectedCurrencyBaselineRef.current = expectedCurrency;
+      quoteCcyUserEditedAfterSelectionRef.current = false;
       form.setValue("symbol", canonicalSymbol.toUpperCase(), { shouldValidate: true });
       form.setValue("name", result.longName || result.shortName || "", { shouldValidate: true });
 
@@ -172,25 +185,62 @@ export function CreateSecurityDialog({
       if (mappedType) {
         form.setValue("instrumentType", mappedType);
       }
-      if (result.currency) {
-        form.setValue("quoteCcy", result.currency, { shouldValidate: true });
+      if (provisionalCurrency) {
+        form.setValue("quoteCcy", provisionalCurrency, { shouldValidate: true });
       }
       if (canonicalExchangeMic) {
         form.setValue("instrumentExchangeMic", normalizeMic(canonicalExchangeMic));
       }
 
+      const selectedQuoteMode = mappedType ? quoteModeFromSearchResult(result) : "MANUAL";
+
       // If the type is unrecognized, fall back to manual mode.
       // Otherwise auto-sync unless the result is from MANUAL source.
-      if (!mappedType) {
-        form.setValue("quoteMode", "MANUAL");
-      } else {
-        form.setValue("quoteMode", quoteModeFromSearchResult(result));
+      form.setValue("quoteMode", selectedQuoteMode);
+
+      if (selectedQuoteMode !== "MARKET") {
+        return;
       }
+
+      resolveSymbolQuote(
+        canonicalSymbol,
+        canonicalExchangeMic,
+        result.quoteType,
+        result.providerId,
+        provisionalCurrency,
+      )
+        .then((resolved) => {
+          if (requestId !== resolveRequestSeq.current) return;
+
+          const currentSymbol = form.getValues("symbol")?.trim().toUpperCase();
+          const currentMic = normalizeMic(form.getValues("instrumentExchangeMic"));
+          if (
+            currentSymbol !== canonicalSymbol.toUpperCase() ||
+            currentMic !== normalizeMic(canonicalExchangeMic) ||
+            (mappedType && form.getValues("instrumentType") !== mappedType)
+          ) {
+            return;
+          }
+
+          const confirmedCurrency = resolved?.currency?.trim();
+          if (!confirmedCurrency) return;
+
+          const currentCurrency = form.getValues("quoteCcy")?.trim();
+          if (
+            !quoteCcyUserEditedAfterSelectionRef.current &&
+            (!currentCurrency || currentCurrency === expectedCurrency)
+          ) {
+            form.setValue("quoteCcy", confirmedCurrency, { shouldValidate: true });
+          }
+        })
+        .catch(() => {
+          // Search selection remains usable even if quote confirmation fails.
+        });
     },
     [form],
   );
 
-  const handleSubmit = (values: CreateSecurityFormValues) => {
+  const handleSubmit = async (values: CreateSecurityFormValues) => {
     const kind = values.instrumentType === "FX" ? "FX" : "INVESTMENT";
     const selectedCanonicalSymbol = selectedResult?.canonicalSymbol || selectedResult?.symbol;
     const selectedCanonicalMic = normalizeMic(
@@ -222,6 +272,29 @@ export function CreateSecurityDialog({
       (!initialInstrumentType || initialInstrumentType === values.instrumentType)
         ? initialAsset.providerConfig
         : undefined;
+    let resolvedQuoteCcy = values.quoteCcy;
+
+    if (selectedResult && selectedProviderRef && values.quoteMode === "MARKET") {
+      setIsResolvingSubmit(true);
+      try {
+        const resolved = await resolveSymbolQuote(
+          values.symbol,
+          normalizeMic(values.instrumentExchangeMic) || undefined,
+          selectedResult.quoteType,
+          selectedResult.providerId,
+          values.quoteCcy,
+        );
+        const confirmedCurrency = resolved?.currency?.trim();
+        if (confirmedCurrency && !quoteCcyUserEditedAfterSelectionRef.current) {
+          resolvedQuoteCcy = confirmedCurrency;
+          form.setValue("quoteCcy", confirmedCurrency, { shouldValidate: true });
+        }
+      } catch {
+        // Continue with the selected/provided currency when confirmation is unavailable.
+      } finally {
+        setIsResolvingSubmit(false);
+      }
+    }
 
     const payload: NewAsset = {
       kind,
@@ -229,7 +302,7 @@ export function CreateSecurityDialog({
       displayCode: values.symbol,
       isActive: true,
       quoteMode: values.quoteMode,
-      quoteCcy: values.quoteCcy,
+      quoteCcy: resolvedQuoteCcy,
       instrumentType: values.instrumentType,
       instrumentSymbol: values.symbol,
       instrumentExchangeMic: values.instrumentExchangeMic || undefined,
@@ -243,6 +316,7 @@ export function CreateSecurityDialog({
 
   const handleDialogKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key !== "Enter") return;
+    if (isPending || isResolvingSubmit) return;
     if ((e.target as HTMLElement).tagName === "TEXTAREA") return;
     // Don't submit when interacting with the ticker search popover
     const inPopover = (e.target as HTMLElement).closest("[data-radix-popper-content-wrapper]");
@@ -294,6 +368,9 @@ export function CreateSecurityDialog({
                             selectedResult &&
                             next.trim() !== selectedCanonicalSymbol?.toUpperCase()
                           ) {
+                            resolveRequestSeq.current += 1;
+                            selectedCurrencyBaselineRef.current = undefined;
+                            quoteCcyUserEditedAfterSelectionRef.current = false;
                             setSelectedResult(undefined);
                           }
                           field.onChange(next);
@@ -356,7 +433,12 @@ export function CreateSecurityDialog({
                     <FormControl>
                       <CurrencyInput
                         value={field.value}
-                        onChange={field.onChange}
+                        onChange={(nextCurrency) => {
+                          if (selectedResult) {
+                            quoteCcyUserEditedAfterSelectionRef.current = true;
+                          }
+                          field.onChange(nextCurrency);
+                        }}
                         placeholder="Select currency"
                         valueDisplay="code"
                         allowCustom
@@ -436,16 +518,16 @@ export function CreateSecurityDialog({
                 type="button"
                 variant="outline"
                 onClick={() => onOpenChange(false)}
-                disabled={isPending}
+                disabled={isPending || isResolvingSubmit}
               >
                 Cancel
               </Button>
               <Button
                 type="button"
                 onClick={() => void form.handleSubmit(handleSubmit)()}
-                disabled={isPending}
+                disabled={isPending || isResolvingSubmit}
               >
-                {isPending ? (
+                {isPending || isResolvingSubmit ? (
                   <span className="flex items-center gap-2">
                     <Icons.Spinner className="h-4 w-4 animate-spin" /> Creating...
                   </span>

--- a/crates/core/src/assets/assets_model_tests.rs
+++ b/crates/core/src/assets/assets_model_tests.rs
@@ -357,6 +357,20 @@ mod tests {
     }
 
     #[test]
+    fn test_canonicalize_market_identity_uses_tase_minor_unit_as_fallback() {
+        let canonical = canonicalize_market_identity(
+            Some(InstrumentType::Equity),
+            Some("1159029"),
+            Some("XTAE"),
+            None,
+        );
+
+        assert_eq!(canonical.instrument_symbol.as_deref(), Some("1159029"));
+        assert_eq!(canonical.instrument_exchange_mic.as_deref(), Some("XTAE"));
+        assert_eq!(canonical.quote_ccy.as_deref(), Some("ILA"));
+    }
+
+    #[test]
     fn test_resolve_quote_ccy_precedence_prefers_explicit_quote_ccy() {
         let resolved = resolve_quote_ccy_precedence(
             Some("GBp"),

--- a/crates/core/src/fx/currency.rs
+++ b/crates/core/src/fx/currency.rs
@@ -37,8 +37,8 @@ fn get_rules() -> &'static HashMap<&'static str, CurrencyNormalizationRule> {
             "KWF",
             CurrencyNormalizationRule {
                 major_code: "KWD",
-                factor: dec!(0.01),
-                label: "SA Cents",
+                factor: dec!(0.001),
+                label: "Kuwaiti Fils",
             },
         );
         map.insert(
@@ -65,6 +65,15 @@ fn get_rules() -> &'static HashMap<&'static str, CurrencyNormalizationRule> {
                 major_code: "ILS",
                 factor: dec!(0.01),
                 label: "Agorot",
+            },
+        );
+
+        map.insert(
+            "USX",
+            CurrencyNormalizationRule {
+                major_code: "USD",
+                factor: dec!(0.01),
+                label: "US Cents",
             },
         );
 
@@ -114,4 +123,39 @@ pub fn resolve_currency(candidates: &[&str]) -> String {
         .find(|c| !c.trim().is_empty())
         .map(|c| c.to_string())
         .unwrap_or_else(|| "USD".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_ila_to_ils() {
+        let (amount, currency) = normalize_amount(dec!(12345), "ILA");
+
+        assert_eq!(amount, dec!(123.45));
+        assert_eq!(currency, "ILS");
+        assert_eq!(normalize_currency_code("ILA"), "ILS");
+        assert_eq!(denormalization_multiplier("ILA"), dec!(100));
+    }
+
+    #[test]
+    fn normalizes_kwf_to_kwd() {
+        let (amount, currency) = normalize_amount(dec!(987), "KWF");
+
+        assert_eq!(amount, dec!(0.987));
+        assert_eq!(currency, "KWD");
+        assert_eq!(normalize_currency_code("KWF"), "KWD");
+        assert_eq!(denormalization_multiplier("KWF"), dec!(1000));
+    }
+
+    #[test]
+    fn normalizes_usx_to_usd() {
+        let (amount, currency) = normalize_amount(dec!(9876), "USX");
+
+        assert_eq!(amount, dec!(98.76));
+        assert_eq!(currency, "USD");
+        assert_eq!(normalize_currency_code("USX"), "USD");
+        assert_eq!(denormalization_multiplier("USX"), dec!(100));
+    }
 }

--- a/crates/market-data/src/resolver/exchange_metadata.rs
+++ b/crates/market-data/src/resolver/exchange_metadata.rs
@@ -58,6 +58,7 @@ mod tests {
         assert_eq!(mic_to_currency("XTSE"), Some("CAD"));
         assert_eq!(mic_to_currency("XLON"), Some("GBp")); // LSE quotes in pence
         assert_eq!(mic_to_currency("CXE"), Some("GBP"));
+        assert_eq!(mic_to_currency("XTAE"), Some("ILA"));
         assert_eq!(mic_to_currency("XETR"), Some("EUR"));
         assert_eq!(mic_to_currency("XTKS"), Some("JPY"));
         assert_eq!(mic_to_currency("UNKNOWN"), None);
@@ -75,5 +76,8 @@ mod tests {
 
         let unknown = exchanges_for_currency("XYZ");
         assert!(unknown.is_empty());
+
+        let ila_exchanges = exchanges_for_currency("ILA");
+        assert!(ila_exchanges.contains(&"XTAE"));
     }
 }

--- a/crates/market-data/src/resolver/exchange_suffixes.rs
+++ b/crates/market-data/src/resolver/exchange_suffixes.rs
@@ -300,6 +300,11 @@ mod tests {
             Some("GBp")
         );
 
+        assert_eq!(
+            map.get_currency(&Cow::Borrowed("XTAE"), &Cow::Borrowed("YAHOO")),
+            Some("ILA")
+        );
+
         // Cboe UK (Yahoo .XC) - provider reports GBP for this venue
         assert_eq!(
             map.get_suffix(&Cow::Borrowed("CXE"), &Cow::Borrowed("YAHOO")),

--- a/crates/market-data/src/resolver/exchanges.json
+++ b/crates/market-data/src/resolver/exchanges.json
@@ -645,7 +645,7 @@
       "mic": "XTAE",
       "name": "TASE",
       "long_name": "Tel Aviv Stock Exchange",
-      "currency": "ILS",
+      "currency": "ILA",
       "timezone": "Asia/Jerusalem",
       "close": [17, 25],
       "yahoo": { "suffix": ".TA", "codes": ["TLV"] }
@@ -728,6 +728,7 @@
     "NOK": ["XOSL"],
     "PLN": ["XWAR"],
     "ILS": ["XTAE"],
+    "ILA": ["XTAE"],
     "ZAR": ["XJSE"],
     "TWD": ["XTAI", "XTAI_OTC"]
   }

--- a/crates/market-data/src/resolver/rules_resolver.rs
+++ b/crates/market-data/src/resolver/rules_resolver.rs
@@ -587,6 +587,10 @@ mod tests {
         let currency = resolver.get_equity_currency(&Some("XLON".into()), &"YAHOO".into());
         assert_eq!(currency.as_deref(), Some("GBp"));
 
+        // Tel Aviv fallback quote unit for listed securities.
+        let currency = resolver.get_equity_currency(&Some("XTAE".into()), &"YAHOO".into());
+        assert_eq!(currency.as_deref(), Some("ILA"));
+
         // No MIC
         let currency = resolver.get_equity_currency(&None, &"YAHOO".into());
         assert!(currency.is_none());

--- a/packages/ui/src/components/data-grid/data-grid-cell-variants.tsx
+++ b/packages/ui/src/components/data-grid/data-grid-cell-variants.tsx
@@ -22,7 +22,7 @@ import * as React from "react";
 import { toast } from "sonner";
 import { useBadgeOverflow } from "../../hooks/use-badge-overflow";
 import { useDebouncedCallback } from "../../hooks/use-debounced-callback";
-import { worldCurrencies } from "../../lib/currencies";
+import { quoteCurrencies } from "../../lib/currencies";
 import { generateId } from "../../lib/id";
 import { cn } from "../../lib/utils";
 import { DataGridCellWrapper } from "./data-grid-cell-wrapper";
@@ -2822,10 +2822,10 @@ export function CurrencyCell<TData>({
 
   const filteredCurrencies = React.useMemo(() => {
     if (!searchQuery.trim()) {
-      return worldCurrencies;
+      return quoteCurrencies;
     }
     const query = searchQuery.toLowerCase();
-    return worldCurrencies.filter(
+    return quoteCurrencies.filter(
       (currency) => currency.value.toLowerCase().includes(query) || currency.label.toLowerCase().includes(query),
     );
   }, [searchQuery]);

--- a/packages/ui/src/components/financial/currency-input.tsx
+++ b/packages/ui/src/components/financial/currency-input.tsx
@@ -86,6 +86,13 @@ export const CurrencyInput = forwardRef<HTMLButtonElement, CurrencyInputProps>(
       setDesktopSearchQuery("");
     };
 
+    const getCustomCurrencyValue = (query: string) => {
+      const trimmed = query.trim();
+      if (!allowCustom || !trimmed) return undefined;
+      if (worldCurrencies.some((currency) => currency.value === trimmed)) return undefined;
+      return trimmed;
+    };
+
     const handleOpenAutoFocus = useCallback(
       (e: Event) => {
         if (!autoFocusSearch) return;
@@ -105,6 +112,7 @@ export const CurrencyInput = forwardRef<HTMLButtonElement, CurrencyInputProps>(
           curr.value.toLowerCase().includes(searchQuery.toLowerCase()) ||
           curr.label.toLowerCase().includes(searchQuery.toLowerCase()),
       );
+      const customCurrencyValue = getCustomCurrencyValue(searchQuery);
       const mobileDisplayText = selectedCurrency
         ? valueDisplay === "code"
           ? selectedCurrency.value
@@ -216,17 +224,25 @@ export const CurrencyInput = forwardRef<HTMLButtonElement, CurrencyInputProps>(
                           {value === curr.value && <Icons.Check className="text-primary h-5 w-5 flex-shrink-0" />}
                         </button>
                       ))}
+                      {customCurrencyValue && (
+                        <button
+                          onClick={() => handleSelect(customCurrencyValue)}
+                          className="text-primary w-full py-2 text-center text-sm font-medium hover:underline"
+                        >
+                          Use &quot;{customCurrencyValue}&quot; as custom currency
+                        </button>
+                      )}
                     </div>
                   ) : (
                     <div className="text-muted-foreground flex h-full flex-col items-center justify-center gap-2 text-center text-sm">
                       <Icons.Search className="h-12 w-12 opacity-20" />
                       <span>No currencies found for &quot;{searchQuery}&quot;.</span>
-                      {allowCustom && searchQuery.trim() && (
+                      {customCurrencyValue && (
                         <button
-                          onClick={() => handleSelect(searchQuery.trim())}
+                          onClick={() => handleSelect(customCurrencyValue)}
                           className="text-primary mt-2 text-sm font-medium hover:underline"
                         >
-                          Use &quot;{searchQuery.trim()}&quot; as custom currency
+                          Use &quot;{customCurrencyValue}&quot; as custom currency
                         </button>
                       )}
                     </div>
@@ -238,6 +254,8 @@ export const CurrencyInput = forwardRef<HTMLButtonElement, CurrencyInputProps>(
         </>
       );
     }
+
+    const desktopCustomCurrencyValue = getCustomCurrencyValue(desktopSearchQuery);
 
     return (
       <Popover open={open} onOpenChange={setOpen} modal={true}>
@@ -270,12 +288,12 @@ export const CurrencyInput = forwardRef<HTMLButtonElement, CurrencyInputProps>(
             />
             <CommandList>
               <CommandEmpty>
-                {allowCustom && desktopSearchQuery.trim() ? (
+                {desktopCustomCurrencyValue ? (
                   <button
                     className="text-primary w-full py-1 text-sm font-medium hover:underline"
-                    onClick={() => handleSelect(desktopSearchQuery.trim())}
+                    onClick={() => handleSelect(desktopCustomCurrencyValue)}
                   >
-                    Use &quot;{desktopSearchQuery.trim()}&quot; as custom currency
+                    Use &quot;{desktopCustomCurrencyValue}&quot; as custom currency
                   </button>
                 ) : (
                   "No currency found."
@@ -283,6 +301,14 @@ export const CurrencyInput = forwardRef<HTMLButtonElement, CurrencyInputProps>(
               </CommandEmpty>
               <CommandGroup>
                 <ScrollArea className="max-h-96 overflow-y-auto">
+                  {desktopCustomCurrencyValue && (
+                    <CommandItem
+                      value={desktopCustomCurrencyValue}
+                      onSelect={() => handleSelect(desktopCustomCurrencyValue)}
+                    >
+                      Use &quot;{desktopCustomCurrencyValue}&quot; as custom currency
+                    </CommandItem>
+                  )}
                   {worldCurrencies.map((currency) => (
                     <CommandItem
                       value={currency.label}

--- a/packages/ui/src/lib/currencies.ts
+++ b/packages/ui/src/lib/currencies.ts
@@ -161,3 +161,39 @@ export const worldCurrencies = [
   { label: "Zambian kwacha (ZMK)", value: "ZMK" },
   { label: "Zimbabwean dollar (ZWR)", value: "ZWR" },
 ];
+
+export const quoteUnitCurrencies = [
+  { label: "British pence (GBp)", value: "GBp", major: "GBP", symbol: "p" },
+  { label: "British pence (GBX)", value: "GBX", major: "GBP", symbol: "p" },
+  { label: "Israeli agorot (ILA)", value: "ILA", major: "ILS", symbol: "ag" },
+  { label: "US cents (USX)", value: "USX", major: "USD", symbol: "c" },
+  {
+    label: "South African cents (ZAc)",
+    value: "ZAc",
+    major: "ZAR",
+    symbol: "c",
+    aliases: ["ZAC"],
+  },
+  { label: "Kuwaiti fils (KWF)", value: "KWF", major: "KWD", symbol: "fils" },
+] as const;
+
+export const quoteCurrencies = [...worldCurrencies, ...quoteUnitCurrencies];
+
+export function getQuoteUnitCurrency(currency: string | null | undefined) {
+  const trimmed = currency?.trim();
+  if (!trimmed) return undefined;
+
+  const normalized = trimmed.toUpperCase();
+
+  return quoteUnitCurrencies.find((quoteUnit) => {
+    if (quoteUnit.value === trimmed) return true;
+    if (
+      "aliases" in quoteUnit &&
+      quoteUnit.aliases.some((alias) => alias.toUpperCase() === normalized)
+    ) {
+      return true;
+    }
+    if (quoteUnit.value !== quoteUnit.value.toUpperCase()) return false;
+    return quoteUnit.value === normalized;
+  });
+}

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,14 +1,13 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 import { DECIMAL_PRECISION, DISPLAY_DECIMAL_PRECISION } from "./constants";
+import { getQuoteUnitCurrency } from "./currencies";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
-/**
- * Format amount with currency support, including special handling for pence (GBp/GBX)
- */
+/** Format amount with currency support, including quote units such as GBp and ILA. */
 const DECIMAL_FORMAT_OPTIONS: Intl.NumberFormatOptions = {
   minimumFractionDigits: DISPLAY_DECIMAL_PRECISION,
   maximumFractionDigits: DISPLAY_DECIMAL_PRECISION,
@@ -68,9 +67,10 @@ const getCompactCurrencyFormatter = (currency: string, maximumFractionDigits: nu
 
 export function formatCurrencySymbol(currency: string | null | undefined) {
   const rawCurrency = currency || "USD";
+  const quoteUnit = getQuoteUnitCurrency(rawCurrency);
 
-  if (rawCurrency === "GBp" || rawCurrency === "GBX") {
-    return "p";
+  if (quoteUnit) {
+    return quoteUnit.symbol;
   }
 
   const normalizedCurrency = rawCurrency.toUpperCase();
@@ -109,11 +109,11 @@ export function formatAmount(
   if (!Number.isFinite(numericAmount)) return "-";
   const displayAmount = Math.abs(numericAmount) < 0.005 ? 0 : numericAmount;
   const rawCurrency = currency ?? "USD";
-  const isPenceCurrency = rawCurrency === "GBp" || rawCurrency === "GBX";
+  const quoteUnit = getQuoteUnitCurrency(rawCurrency);
 
-  if (isPenceCurrency) {
+  if (quoteUnit) {
     const formattedNumber = decimalFormatter.format(displayAmount);
-    return displayCurrency ? `${formattedNumber}p` : formattedNumber;
+    return displayCurrency ? `${formattedNumber}${quoteUnit.symbol}` : formattedNumber;
   }
 
   if (!displayCurrency) {
@@ -134,12 +134,21 @@ export function formatCompactAmount(
   const rawCurrency = currency ?? "USD";
   const abs = Math.abs(numericAmount);
   const maximumFractionDigits = abs >= 1_000_000 ? 2 : abs >= 100_000 ? 0 : abs >= 1_000 ? 1 : 0;
+  const quoteUnit = getQuoteUnitCurrency(rawCurrency);
 
   if (!displayCurrency) {
     return new Intl.NumberFormat("en-US", {
       notation: "compact",
       maximumFractionDigits,
     }).format(numericAmount);
+  }
+
+  if (quoteUnit) {
+    const formattedNumber = new Intl.NumberFormat("en-US", {
+      notation: "compact",
+      maximumFractionDigits,
+    }).format(numericAmount);
+    return `${formattedNumber}${quoteUnit.symbol}`;
   }
 
   return getCompactCurrencyFormatter(rawCurrency, maximumFractionDigits).format(numericAmount);


### PR DESCRIPTION
## Summary
- add shared quote-unit currency metadata for GBp/GBX, ILA, USX, ZAc, and KWF
- use resolved quote currency as the source of truth for new market symbol selections while preserving existing/manual assets and explicit user edits
- add TASE ILA fallback metadata and fix KWF/USX currency normalization
- expose quote-unit choices in non-custom currency pickers and keep custom entry available in CurrencyInput

## Validation
- cargo fmt --check
- cargo test -p wealthfolio-core normalizes_
- cargo test -p wealthfolio-core test_canonicalize_market_identity_uses_tase_minor_unit_as_fallback
- cargo test -p wealthfolio-market-data test_get_equity_currency
- cargo test -p wealthfolio-market-data test_mic_to_currency
- cargo test -p wealthfolio-market-data test_exchange_map_europe
- cargo test -p wealthfolio-market-data test_parse_raw_search_payload_preserves_currency
- pnpm --filter frontend type-check
- pnpm --filter frontend test -- symbol-search utils.currency
- pnpm --filter @wealthfolio/ui type-check
- pnpm --filter @wealthfolio/ui build:types
- git diff --check