### PR TITLE
Improve database backup exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2953,7 +2953,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5051,7 +5051,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5088,7 +5088,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6150,9 +6150,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -6915,13 +6915,15 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-fs"
-version = "2.4.5"
+version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed390cc669f937afeb8b28032ce837bac8ea023d975a2e207375ec05afaf1804"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
 dependencies = [
  "anyhow",
  "dunce",
  "glob",
+ "log",
+ "objc2-foundation",
  "percent-encoding",
  "schemars 0.8.22",
  "serde",
@@ -6931,7 +6933,7 @@ dependencies = [
  "tauri-plugin",
  "tauri-utils",
  "thiserror 2.0.18",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "url",
 ]
 
@@ -7423,11 +7425,26 @@ checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
  "indexmap 2.13.0",
  "serde_core",
- "serde_spanned 1.0.4",
+ "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
  "winnow 0.7.14",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap 2.13.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -7444,6 +7461,15 @@ name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -7486,18 +7512,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247eaa3197818b831697600aadf81514e577e0cba5eab10f7e064e78ae154df1"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 0.7.14",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -9084,6 +9110,12 @@ checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "winreg"

--- a/apps/frontend/src/adapters/tauri/files.ts
+++ b/apps/frontend/src/adapters/tauri/files.ts
@@ -1,6 +1,13 @@
 // File Dialogs
 import { open, save } from "@tauri-apps/plugin-dialog";
-import { writeFile } from "@tauri-apps/plugin-fs";
+import {
+  BaseDirectory,
+  copyFile,
+  remove,
+  startAccessingSecurityScopedResource,
+  stopAccessingSecurityScopedResource,
+  writeFile,
+} from "@tauri-apps/plugin-fs";
 
 const isIOS = (): boolean => {
   if (typeof window === "undefined") {
@@ -21,6 +28,20 @@ const toBase64 = (bytes: Uint8Array): string => {
   }
 
   return btoa(binary);
+};
+
+const describeError = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
 };
 
 const shareFileOnIOS = async (content: Uint8Array, fileName: string): Promise<boolean> => {
@@ -105,6 +126,52 @@ export const openFileSaveDialog = async (
   }
 
   throw lastError;
+};
+
+export const saveAppDataFileViaPicker = async (
+  relativePath: string,
+  fileName: string,
+): Promise<boolean> => {
+  let filePath: string | null = null;
+  try {
+    try {
+      filePath = await save({
+        defaultPath: fileName,
+        filters: [
+          {
+            name: "SQLite Database",
+            extensions: ["db"],
+          },
+        ],
+      });
+    } catch (error) {
+      throw new Error(`save picker failed: ${describeError(error)}`);
+    }
+
+    if (filePath === null) {
+      return false;
+    }
+
+    let didStartScopedAccess = false;
+    try {
+      await startAccessingSecurityScopedResource(filePath);
+      didStartScopedAccess = true;
+      await copyFile(relativePath, filePath, {
+        fromPathBaseDir: BaseDirectory.AppData,
+      });
+    } catch (error) {
+      throw new Error(
+        `copyFile failed from ${relativePath} to ${filePath}: ${describeError(error)}`,
+      );
+    } finally {
+      if (didStartScopedAccess) {
+        await stopAccessingSecurityScopedResource(filePath).catch(() => undefined);
+      }
+    }
+    return true;
+  } finally {
+    await remove(relativePath, { baseDir: BaseDirectory.AppData }).catch(() => undefined);
+  }
 };
 
 // ============================================================================

--- a/apps/frontend/src/adapters/tauri/files.ts
+++ b/apps/frontend/src/adapters/tauri/files.ts
@@ -132,6 +132,10 @@ export const saveAppDataFileViaPicker = async (
   relativePath: string,
   fileName: string,
 ): Promise<boolean> => {
+  if (!/^pending-exports\/[^/\\]+$/.test(relativePath)) {
+    throw new Error("Only pending export files can be saved with the native file picker");
+  }
+
   let filePath: string | null = null;
   try {
     try {

--- a/apps/frontend/src/adapters/tauri/index.ts
+++ b/apps/frontend/src/adapters/tauri/index.ts
@@ -122,13 +122,18 @@ export {
   updateSettings,
   isAutoUpdateCheckEnabled,
   backupDatabase,
+  deleteDatabaseBackup,
+  getDatabaseBackupDownloadUrl,
+  listDatabaseBackups,
   backupDatabaseToPath,
+  backupDatabaseToPendingExport,
   restoreDatabase,
   getAppInfo,
   checkForUpdates,
   installUpdate,
   getPlatform,
 } from "./settings";
+export type { DatabaseBackup } from "./settings";
 
 // Addon Commands (platform-specific)
 export {
@@ -184,6 +189,7 @@ export {
   openFolderDialog,
   openDatabaseFileDialog,
   openFileSaveDialog,
+  saveAppDataFileViaPicker,
   openUrlInBrowser,
 } from "./files";
 

--- a/apps/frontend/src/adapters/tauri/settings.ts
+++ b/apps/frontend/src/adapters/tauri/settings.ts
@@ -2,7 +2,7 @@
 import type { Settings, UpdateInfo } from "@/lib/types";
 import type { AppInfo, PlatformInfo } from "../types";
 
-import { invoke, logger, tauriInvoke } from "./core";
+import { invoke, logger } from "./core";
 
 export const getSettings = async (): Promise<Settings> => {
   try {
@@ -31,16 +31,30 @@ export const isAutoUpdateCheckEnabled = async (): Promise<boolean> => {
   }
 };
 
-export const backupDatabase = async (): Promise<{ filename: string; data: Uint8Array }> => {
+export const backupDatabase = async (): Promise<{ filename: string }> => {
   try {
-    // Desktop (Tauri) returns a tuple [filename, data[]], transform internally to object
-    const result = await tauriInvoke<[string, number[]]>("backup_database");
-    const [filename, data] = result;
-    return { filename, data: new Uint8Array(data) };
+    const filename = await invoke<string>("backup_database");
+    return { filename };
   } catch (error) {
     logger.error("Error backing up database.");
     throw error;
   }
+};
+
+export interface DatabaseBackup {
+  filename: string;
+  sizeBytes: number;
+  modifiedAt: string;
+}
+
+export const listDatabaseBackups = (): Promise<DatabaseBackup[]> =>
+  Promise.reject(new Error("Server backup listing is only supported in web mode"));
+
+export const deleteDatabaseBackup = (_filename: string): Promise<void> =>
+  Promise.reject(new Error("Server backup deletion is only supported in web mode"));
+
+export const getDatabaseBackupDownloadUrl = (_filename: string): string => {
+  throw new Error("Server backup downloads are only supported in web mode");
 };
 
 export const backupDatabaseToPath = async (backupDir: string): Promise<string> => {
@@ -48,6 +62,20 @@ export const backupDatabaseToPath = async (backupDir: string): Promise<string> =
     return await invoke<string>("backup_database_to_path", { backupDir });
   } catch (error) {
     logger.error("Error backing up database to path.");
+    throw error;
+  }
+};
+
+export interface BackupExport {
+  relativePath: string;
+  filename: string;
+}
+
+export const backupDatabaseToPendingExport = async (): Promise<BackupExport> => {
+  try {
+    return await invoke<BackupExport>("backup_database_to_pending_export");
+  } catch (error) {
+    logger.error("Error backing up database to pending export.");
     throw error;
   }
 };

--- a/apps/frontend/src/adapters/web/core.ts
+++ b/apps/frontend/src/adapters/web/core.ts
@@ -37,7 +37,8 @@ export const COMMANDS: CommandMap = {
   get_app_info: { method: "GET", path: "/app/info" },
   check_update: { method: "GET", path: "/app/check-update" },
   backup_database: { method: "POST", path: "/utilities/database/backup" },
-  backup_database_to_path: { method: "POST", path: "/utilities/database/backup-to-path" },
+  list_database_backups: { method: "GET", path: "/utilities/database/backups" },
+  delete_database_backup: { method: "DELETE", path: "/utilities/database/backups" },
   restore_database: { method: "POST", path: "/utilities/database/restore" },
   get_holdings: { method: "GET", path: "/holdings" },
   get_holding: { method: "GET", path: "/holdings/item" },
@@ -350,18 +351,6 @@ export function toBase64(data: Uint8Array | number[]): string {
 }
 
 /**
- * Convert base64 string to Uint8Array
- */
-export function fromBase64(value: string): Uint8Array {
-  const binary = atob(value);
-  const bytes = new Uint8Array(binary.length);
-  for (let i = 0; i < binary.length; i++) {
-    bytes[i] = binary.charCodeAt(i);
-  }
-  return bytes;
-}
-
-/**
  * Invoke a command via REST API (internal - use typed adapter functions instead)
  */
 export const invoke = async <T>(command: string, payload?: Record<string, unknown>): Promise<T> => {
@@ -387,9 +376,9 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
       body = JSON.stringify(data.account);
       break;
     }
-    case "backup_database_to_path": {
-      const { backupDir } = payload as { backupDir: string };
-      body = JSON.stringify({ backupDir });
+    case "delete_database_backup": {
+      const { filename } = payload as { filename: string };
+      url += `/${encodeURIComponent(filename)}`;
       break;
     }
     case "restore_database": {
@@ -1490,17 +1479,6 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
     }
     console.error(`[Invoke] Command "${command}" failed: ${msg}`);
     throw new Error(msg);
-  }
-  if (command === "backup_database") {
-    const parsed = (await res.json()) as { filename: string; dataB64: string };
-    return {
-      filename: parsed.filename,
-      data: fromBase64(parsed.dataB64),
-    } as T;
-  }
-  if (command === "backup_database_to_path") {
-    const parsed = (await res.json()) as { path: string };
-    return parsed.path as T;
   }
   // Handle responses with no body (204 No Content, 202 Accepted, or empty 200)
   if (res.status === 204 || res.status === 202) {

--- a/apps/frontend/src/adapters/web/core.ts
+++ b/apps/frontend/src/adapters/web/core.ts
@@ -39,7 +39,6 @@ export const COMMANDS: CommandMap = {
   backup_database: { method: "POST", path: "/utilities/database/backup" },
   list_database_backups: { method: "GET", path: "/utilities/database/backups" },
   delete_database_backup: { method: "DELETE", path: "/utilities/database/backups" },
-  restore_database: { method: "POST", path: "/utilities/database/restore" },
   get_holdings: { method: "GET", path: "/holdings" },
   get_holding: { method: "GET", path: "/holdings/item" },
   get_asset_holdings: { method: "GET", path: "/holdings/by-asset" },
@@ -379,11 +378,6 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
     case "delete_database_backup": {
       const { filename } = payload as { filename: string };
       url += `/${encodeURIComponent(filename)}`;
-      break;
-    }
-    case "restore_database": {
-      const { backupFilePath } = payload as { backupFilePath: string };
-      body = JSON.stringify({ backupFilePath });
       break;
     }
     case "update_settings": {

--- a/apps/frontend/src/adapters/web/files.ts
+++ b/apps/frontend/src/adapters/web/files.ts
@@ -60,6 +60,15 @@ export const openFileSaveDialog = (
   }
 };
 
+export const saveAppDataFileViaPicker = (
+  _relativePath: string,
+  _fileName: string,
+): Promise<boolean> => {
+  return Promise.reject(
+    new Error("App data file picker export is only supported in the Tauri app"),
+  );
+};
+
 // ============================================================================
 // Shell & Browser
 // ============================================================================

--- a/apps/frontend/src/adapters/web/index.ts
+++ b/apps/frontend/src/adapters/web/index.ts
@@ -341,22 +341,28 @@ export {
   openDatabaseFileDialog,
   openFileSaveDialog,
   openFolderDialog,
+  saveAppDataFileViaPicker,
   openUrlInBrowser,
 } from "./files";
 
 // Settings Commands (web-specific API for backups and updates)
 export {
   backupDatabase,
+  backupDatabaseToPendingExport,
   backupDatabaseToPath,
   checkForUpdates,
+  deleteDatabaseBackup,
   getAppInfo,
+  getDatabaseBackupDownloadUrl,
   getPlatform,
   getSettings,
   installUpdate,
   isAutoUpdateCheckEnabled,
+  listDatabaseBackups,
   restoreDatabase,
   updateSettings,
 } from "./settings";
+export type { DatabaseBackup } from "./settings";
 
 // Addon Commands (web-specific implementations)
 export {

--- a/apps/frontend/src/adapters/web/settings.ts
+++ b/apps/frontend/src/adapters/web/settings.ts
@@ -1,6 +1,6 @@
 // Web adapter - Settings, App Info, Updater Commands
 
-import { invoke, logger } from "./core";
+import { API_PREFIX, invoke, logger } from "./core";
 import type { Settings, UpdateInfo } from "@/lib/types";
 import type { AppInfo, PlatformInfo } from "../types";
 
@@ -35,24 +35,52 @@ export const isAutoUpdateCheckEnabled = async (): Promise<boolean> => {
   }
 };
 
-export const backupDatabase = async (): Promise<{ filename: string; data: Uint8Array }> => {
+export interface DatabaseBackup {
+  filename: string;
+  sizeBytes: number;
+  modifiedAt: string;
+}
+
+export const backupDatabase = async (): Promise<{ filename: string }> => {
   try {
-    // Web backend returns { filename, data } object directly (transformed in invoke)
-    return await invoke<{ filename: string; data: Uint8Array }>("backup_database");
+    return await invoke<{ filename: string }>("backup_database");
   } catch (error) {
     logger.error("Error backing up database.");
     throw error;
   }
 };
 
-export const backupDatabaseToPath = async (backupDir: string): Promise<string> => {
+export const listDatabaseBackups = async (): Promise<DatabaseBackup[]> => {
   try {
-    return await invoke<string>("backup_database_to_path", { backupDir });
+    return await invoke<DatabaseBackup[]>("list_database_backups");
   } catch (error) {
-    logger.error("Error backing up database to path.");
+    logger.error("Error listing database backups.");
     throw error;
   }
 };
+
+export const deleteDatabaseBackup = async (filename: string): Promise<void> => {
+  try {
+    await invoke<void>("delete_database_backup", { filename });
+  } catch (error) {
+    logger.error("Error deleting database backup.");
+    throw error;
+  }
+};
+
+export const getDatabaseBackupDownloadUrl = (filename: string): string =>
+  `${API_PREFIX}/utilities/database/backups/${encodeURIComponent(filename)}/download`;
+
+export const backupDatabaseToPath = (_backupDir: string): Promise<string> =>
+  Promise.reject(new Error("Backing up to a local path is only supported in the Tauri app"));
+
+export interface BackupExport {
+  relativePath: string;
+  filename: string;
+}
+
+export const backupDatabaseToPendingExport = (): Promise<BackupExport> =>
+  Promise.reject(new Error("Pending backup exports are only supported in the Tauri app"));
 
 export const restoreDatabase = async (backupFilePath: string): Promise<void> => {
   try {

--- a/apps/frontend/src/adapters/web/settings.ts
+++ b/apps/frontend/src/adapters/web/settings.ts
@@ -82,14 +82,10 @@ export interface BackupExport {
 export const backupDatabaseToPendingExport = (): Promise<BackupExport> =>
   Promise.reject(new Error("Pending backup exports are only supported in the Tauri app"));
 
-export const restoreDatabase = async (backupFilePath: string): Promise<void> => {
-  try {
-    await invoke<void>("restore_database", { backupFilePath });
-  } catch (error) {
-    logger.error("Error restoring database.");
-    throw error;
-  }
-};
+export const restoreDatabase = (_backupFilePath: string): Promise<void> =>
+  Promise.reject(
+    new Error("Restore in web mode requires stopping Wealthfolio and replacing app.db"),
+  );
 
 // ============================================================================
 // App Commands

--- a/apps/frontend/src/addons/type-bridge.ts
+++ b/apps/frontend/src/addons/type-bridge.ts
@@ -121,7 +121,7 @@ export interface InternalHostAPI {
   // Settings
   getSettings(): Promise<Settings>;
   updateSettings(settingsUpdate: Partial<Settings>): Promise<Settings>;
-  backupDatabase(): Promise<{ filename: string; data: Uint8Array }>;
+  backupDatabase(): Promise<{ filename: string }>;
 
   // Account management
   createAccount(account: unknown): Promise<Account>;

--- a/apps/frontend/src/features/devices-sync/components/device-sync-section.tsx
+++ b/apps/frontend/src/features/devices-sync/components/device-sync-section.tsx
@@ -3,7 +3,15 @@
 // State Machine: FRESH → REGISTERED → READY (+ STALE, RECOVERY)
 // ==================================================================
 
-import { backupDatabase, openFileSaveDialog } from "@/adapters";
+import {
+  backupDatabase,
+  backupDatabaseToPath,
+  backupDatabaseToPendingExport,
+  isWeb,
+  openFolderDialog,
+  saveAppDataFileViaPicker,
+} from "@/adapters";
+import { getPlatform as getRuntimePlatform } from "@/hooks/use-platform";
 import { useQueryClient } from "@tanstack/react-query";
 import { Icons, Skeleton } from "@wealthfolio/ui";
 import {
@@ -144,13 +152,36 @@ export function DeviceSyncSection() {
   const handleBackupBeforeBootstrap = useCallback(async (): Promise<boolean> => {
     setIsBackingUpBeforeBootstrap(true);
     try {
-      const { filename, data } = await backupDatabase();
-      const saved = await openFileSaveDialog(data, filename);
-      if (!saved) {
-        return false;
+      let backupLocation: string;
+
+      if (isWeb) {
+        const { filename } = await backupDatabase();
+        backupLocation = filename;
+      } else {
+        const runtimePlatform = await getRuntimePlatform();
+        if (runtimePlatform.is_desktop) {
+          const selectedDir = await openFolderDialog();
+          if (!selectedDir) {
+            return false;
+          }
+          backupLocation = await backupDatabaseToPath(selectedDir);
+        } else {
+          if (runtimePlatform.os !== "ios") {
+            throw new Error(
+              "Backup before device sync is currently supported on desktop, web, and iOS only",
+            );
+          }
+          const { relativePath, filename } = await backupDatabaseToPendingExport();
+          const saved = await saveAppDataFileViaPicker(relativePath, filename);
+          if (!saved) {
+            return false;
+          }
+          backupLocation = filename;
+        }
       }
+
       toast.success("Backup saved", {
-        description: `A local backup was saved as ${filename}.`,
+        description: `A backup was saved as ${backupLocation}.`,
       });
       return true;
     } catch (err) {

--- a/apps/frontend/src/features/devices-sync/components/pairing-flow/index.tsx
+++ b/apps/frontend/src/features/devices-sync/components/pairing-flow/index.tsx
@@ -2,7 +2,16 @@
 // Main component that orchestrates the pairing flow (issuer and claimer)
 // =====================================================================
 
-import { backupDatabase, logger, openFileSaveDialog } from "@/adapters";
+import {
+  backupDatabase,
+  backupDatabaseToPath,
+  backupDatabaseToPendingExport,
+  isWeb,
+  logger,
+  openFolderDialog,
+  saveAppDataFileViaPicker,
+} from "@/adapters";
+import { getPlatform as getRuntimePlatform } from "@/hooks/use-platform";
 import { Icons } from "@wealthfolio/ui";
 import { Button } from "@wealthfolio/ui/components/ui/button";
 import { useEffect, useRef, useCallback, useState } from "react";
@@ -194,9 +203,25 @@ function ClaimerFlow({ onComplete, onCancel, title, description }: PairingFlowPr
     setIsBackingUp(true);
     setBackupError(null);
     try {
-      const { filename, data } = await backupDatabase();
-      const saved = await openFileSaveDialog(data, filename);
-      if (!saved) return;
+      if (isWeb) {
+        await backupDatabase();
+      } else {
+        const runtimePlatform = await getRuntimePlatform();
+        if (runtimePlatform.is_desktop) {
+          const selectedDir = await openFolderDialog();
+          if (!selectedDir) return;
+          await backupDatabaseToPath(selectedDir);
+        } else {
+          if (runtimePlatform.os !== "ios") {
+            throw new Error(
+              "Backup before device sync is currently supported on desktop, web, and iOS only",
+            );
+          }
+          const { relativePath, filename } = await backupDatabaseToPendingExport();
+          const saved = await saveAppDataFileViaPicker(relativePath, filename);
+          if (!saved) return;
+        }
+      }
       await approveOverwrite();
     } catch (err) {
       setBackupError(err instanceof Error ? err.message : "Backup failed");

--- a/apps/frontend/src/lib/query-keys.ts
+++ b/apps/frontend/src/lib/query-keys.ts
@@ -33,6 +33,7 @@ export const QueryKeys = {
 
   // Settings related keys
   SETTINGS: "settings",
+  DATABASE_BACKUPS: "databaseBackups",
   EXCHANGE_RATES: "exchangeRates",
 
   // New keys for exchange rates

--- a/apps/frontend/src/pages/settings/exports/backup-restore-form.tsx
+++ b/apps/frontend/src/pages/settings/exports/backup-restore-form.tsx
@@ -42,6 +42,7 @@ export const BackupRestoreForm = () => {
     isRestoring,
     isDeletingWebBackup,
     isLoadingWebBackups,
+    webBackupsError,
     canBackup,
     canRestore,
     webBackups,
@@ -71,6 +72,7 @@ export const BackupRestoreForm = () => {
       backups={webBackups}
       isLoadingBackups={isLoadingWebBackups}
       isDeletingBackup={isDeletingWebBackup}
+      backupListError={webBackupsError}
       onDeleteBackup={deleteWebBackup}
       getDownloadUrl={getWebBackupDownloadUrl}
     />
@@ -149,6 +151,7 @@ interface WebPanelProps {
   backups: DatabaseBackup[];
   isLoadingBackups: boolean;
   isDeletingBackup: boolean;
+  backupListError: string | null;
   onDeleteBackup: (filename: string) => Promise<void>;
   getDownloadUrl: (filename: string) => string;
 }
@@ -188,6 +191,7 @@ const WebBackupPanel = ({
   backups,
   isLoadingBackups,
   isDeletingBackup,
+  backupListError,
   onDeleteBackup,
   getDownloadUrl,
 }: WebPanelProps) => {
@@ -230,6 +234,14 @@ const WebBackupPanel = ({
             <div className="text-muted-foreground flex items-center gap-2 rounded-md border border-dashed p-4 text-sm">
               <Icons.Spinner className="h-4 w-4 animate-spin" />
               Loading backups...
+            </div>
+          ) : backupListError ? (
+            <div className="border-destructive/30 bg-destructive/5 text-destructive flex items-start gap-2 rounded-md border p-4 text-sm">
+              <Icons.AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+              <div>
+                <p className="font-medium">Could not load backups</p>
+                <p className="mt-1">{backupListError}</p>
+              </div>
             </div>
           ) : backups.length === 0 ? (
             <div className="rounded-md border border-dashed p-6 text-center">

--- a/apps/frontend/src/pages/settings/exports/backup-restore-form.tsx
+++ b/apps/frontend/src/pages/settings/exports/backup-restore-form.tsx
@@ -6,33 +6,47 @@ import {
   CardHeader,
   CardTitle,
 } from "@wealthfolio/ui/components/ui/card";
+import { DeleteConfirm } from "@wealthfolio/ui/components/common";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@wealthfolio/ui/components/ui/tooltip";
 import { useBackupRestore } from "./use-backup-restore";
 
 const desktopNotes = [
-  "Backup includes WAL and SHM files for complete data integrity.",
+  "Backups are self-contained SQLite database files.",
   "Restore will replace ALL current data with backup data.",
   "A pre-restore backup is automatically created before restoration.",
   "You will be prompted to restart the application after restoration.",
 ] as const;
 
 const webNotes = [
-  "Backups include WAL and SHM files and are stored in the server data directory.",
-  "Download or copy backup files directly from the host environment when needed.",
-  "Restores are only available in the desktop application.",
+  "Backups are SQLite .db files saved in Wealthfolio's data directory.",
+  "Downloaded backups can be restored in the desktop or iOS app.",
+  "To restore in web mode, stop Wealthfolio, replace app.db with a backup file, then restart.",
   "Create backups regularly, especially before bulk imports or migrations.",
 ] as const;
 
 const mobileNotes = [
-  "Backups include WAL and SHM files for complete data integrity.",
-  "When you tap backup, the native share sheet opens so you can Save to Files.",
+  "Backups are self-contained SQLite database files.",
+  "When you tap backup, the native file picker opens so you can Save to Files.",
   "Restore is available on iOS and desktop.",
   "Create backups regularly, especially before bulk imports or migrations.",
 ] as const;
 
 export const BackupRestoreForm = () => {
-  const { performBackup, performRestore, isBackingUp, isRestoring, canRestore, platformMode } =
-    useBackupRestore();
+  const {
+    performBackup,
+    performRestore,
+    deleteWebBackup,
+    getWebBackupDownloadUrl,
+    isBackingUp,
+    isRestoring,
+    isDeletingWebBackup,
+    isLoadingWebBackups,
+    canBackup,
+    canRestore,
+    webBackups,
+    platformMode,
+  } = useBackupRestore();
 
   return platformMode === "desktop" ? (
     <DesktopBackupPanel
@@ -47,10 +61,19 @@ export const BackupRestoreForm = () => {
       performRestore={performRestore}
       isBackingUp={isBackingUp}
       isRestoring={isRestoring}
+      canBackup={canBackup}
       canRestore={canRestore}
     />
   ) : (
-    <WebBackupPanel performBackup={performBackup} isBackingUp={isBackingUp} />
+    <WebBackupPanel
+      performBackup={performBackup}
+      isBackingUp={isBackingUp}
+      backups={webBackups}
+      isLoadingBackups={isLoadingWebBackups}
+      isDeletingBackup={isDeletingWebBackup}
+      onDeleteBackup={deleteWebBackup}
+      getDownloadUrl={getWebBackupDownloadUrl}
+    />
   );
 };
 
@@ -74,7 +97,7 @@ const DesktopBackupPanel = ({
       <div className="grid gap-4 md:grid-cols-2">
         <BackupCard
           title="Create Backup"
-          description="Create a complete backup of your database, including WAL and SHM files, and save it to any folder you choose."
+          description="Create a self-contained backup of your database and save it to any folder you choose."
           isLoading={isBackingUp}
           disabled={isBackingUp || isRestoring}
           actionLabel="Backup Database"
@@ -123,30 +146,165 @@ const DesktopBackupPanel = ({
 interface WebPanelProps {
   performBackup: () => Promise<void>;
   isBackingUp: boolean;
+  backups: DatabaseBackup[];
+  isLoadingBackups: boolean;
+  isDeletingBackup: boolean;
+  onDeleteBackup: (filename: string) => Promise<void>;
+  getDownloadUrl: (filename: string) => string;
 }
 
-const WebBackupPanel = ({ performBackup, isBackingUp }: WebPanelProps) => {
+interface DatabaseBackup {
+  filename: string;
+  sizeBytes: number;
+  modifiedAt: string;
+}
+
+const formatBackupSize = (sizeBytes: number): string => {
+  if (!Number.isFinite(sizeBytes) || sizeBytes <= 0) {
+    return "0 B";
+  }
+
+  const units = ["B", "KB", "MB", "GB"] as const;
+  const exponent = Math.min(Math.floor(Math.log(sizeBytes) / Math.log(1024)), units.length - 1);
+  const value = sizeBytes / 1024 ** exponent;
+  return `${value.toFixed(value >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+};
+
+const formatBackupDate = (modifiedAt: string): string => {
+  const date = new Date(modifiedAt);
+  if (Number.isNaN(date.getTime())) {
+    return "Unknown date";
+  }
+
+  return date.toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+};
+
+const WebBackupPanel = ({
+  performBackup,
+  isBackingUp,
+  backups,
+  isLoadingBackups,
+  isDeletingBackup,
+  onDeleteBackup,
+  getDownloadUrl,
+}: WebPanelProps) => {
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <PanelIntro />
 
-      <BackupCard
-        title="Create Backup"
-        description="Create a complete backup with WAL and SHM files stored automatically in the server data directory for safekeeping."
-        isLoading={isBackingUp}
-        disabled={isBackingUp}
-        actionLabel="Backup Database"
-        onAction={performBackup}
-      />
+      <Card>
+        <CardHeader className="gap-4 space-y-0 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-1.5">
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <Icons.DatabaseBackup className="h-5 w-5" />
+              Database Backups
+            </CardTitle>
+            <CardDescription>
+              SQLite .db files saved in Wealthfolio's data directory.
+            </CardDescription>
+          </div>
+          <Button
+            onClick={performBackup}
+            disabled={isBackingUp}
+            size="sm"
+            className="w-full sm:w-auto"
+          >
+            {isBackingUp ? (
+              <>
+                <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />
+                Creating...
+              </>
+            ) : (
+              <>
+                <Icons.Download className="mr-2 h-4 w-4" />
+                Create Backup
+              </>
+            )}
+          </Button>
+        </CardHeader>
+        <CardContent>
+          {isLoadingBackups ? (
+            <div className="text-muted-foreground flex items-center gap-2 rounded-md border border-dashed p-4 text-sm">
+              <Icons.Spinner className="h-4 w-4 animate-spin" />
+              Loading backups...
+            </div>
+          ) : backups.length === 0 ? (
+            <div className="rounded-md border border-dashed p-6 text-center">
+              <Icons.DatabaseBackup className="text-muted-foreground mx-auto h-6 w-6" />
+              <p className="mt-3 text-sm font-medium">No backups yet</p>
+              <p className="text-muted-foreground mt-1 text-sm">
+                Create a backup to keep a restorable database snapshot.
+              </p>
+            </div>
+          ) : (
+            <div className="divide-border divide-y rounded-md border">
+              {backups.map((backup) => (
+                <div
+                  key={backup.filename}
+                  className="grid gap-3 px-4 py-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium leading-5">{backup.filename}</p>
+                    <p className="text-muted-foreground text-xs">
+                      {formatBackupSize(backup.sizeBytes)} - {formatBackupDate(backup.modifiedAt)}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button asChild size="icon" variant="ghost" className="h-8 w-8">
+                          <a href={getDownloadUrl(backup.filename)} download={backup.filename}>
+                            <Icons.Download className="h-4 w-4" />
+                            <span className="sr-only">Download {backup.filename}</span>
+                          </a>
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>Download</TooltipContent>
+                    </Tooltip>
+                    <DeleteConfirm
+                      deleteConfirmTitle="Delete Backup"
+                      deleteConfirmMessage={
+                        <>
+                          Delete <span className="break-all font-medium">{backup.filename}</span>?
+                          This action cannot be undone.
+                        </>
+                      }
+                      handleDeleteConfirm={() => void onDeleteBackup(backup.filename)}
+                      isPending={isDeletingBackup}
+                      button={
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          disabled={isDeletingBackup}
+                          className="text-muted-foreground hover:text-destructive h-8 w-8"
+                        >
+                          <Icons.Trash className="h-4 w-4" />
+                          <span className="sr-only">Delete {backup.filename}</span>
+                        </Button>
+                      }
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
 
       <ImportantNotes notes={webNotes} />
     </div>
   );
 };
 
-interface MobilePanelProps extends WebPanelProps {
+interface MobilePanelProps {
+  performBackup: () => Promise<void>;
   performRestore: () => Promise<void>;
+  isBackingUp: boolean;
   isRestoring: boolean;
+  canBackup: boolean;
   canRestore: boolean;
 }
 
@@ -155,6 +313,7 @@ const MobileBackupPanel = ({
   performRestore,
   isBackingUp,
   isRestoring,
+  canBackup,
   canRestore,
 }: MobilePanelProps) => {
   return (
@@ -164,9 +323,13 @@ const MobileBackupPanel = ({
       <div className="grid gap-4 md:grid-cols-2">
         <BackupCard
           title="Create Backup"
-          description="Create a complete backup and choose destination via the native share sheet."
+          description={
+            canBackup
+              ? "Create a self-contained backup and choose a destination in the native file picker."
+              : "Backup export is currently available on iOS and desktop only."
+          }
           isLoading={isBackingUp}
-          disabled={isBackingUp}
+          disabled={!canBackup || isBackingUp}
           actionLabel="Backup Database"
           onAction={performBackup}
         />
@@ -264,19 +427,17 @@ const BackupCard = ({
 );
 
 const ImportantNotes = ({ notes }: { notes: readonly string[] }) => (
-  <Card className="border-orange-200 bg-orange-50 dark:border-orange-800 dark:bg-orange-950">
-    <CardContent className="pt-6">
-      <div className="flex items-start gap-3">
-        <Icons.AlertTriangle className="mt-0.5 h-5 w-5 text-orange-600" />
-        <div className="text-sm">
-          <p className="font-medium text-orange-800 dark:text-orange-200">Important Notes:</p>
-          <ul className="mt-2 list-inside list-disc space-y-1 text-orange-700 dark:text-orange-300">
-            {notes.map((note) => (
-              <li key={note}>{note}</li>
-            ))}
-          </ul>
-        </div>
+  <div className="bg-muted/30 rounded-md border p-4">
+    <div className="flex items-start gap-3">
+      <Icons.Info className="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />
+      <div className="min-w-0 text-sm">
+        <p className="font-medium">Backup notes</p>
+        <ul className="text-muted-foreground mt-2 list-inside list-disc space-y-1">
+          {notes.map((note) => (
+            <li key={note}>{note}</li>
+          ))}
+        </ul>
       </div>
-    </CardContent>
-  </Card>
+    </div>
+  </div>
 );

--- a/apps/frontend/src/pages/settings/exports/backup-restore-form.tsx
+++ b/apps/frontend/src/pages/settings/exports/backup-restore-form.tsx
@@ -9,6 +9,7 @@ import {
 import { DeleteConfirm } from "@wealthfolio/ui/components/common";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@wealthfolio/ui/components/ui/tooltip";
+import type { DatabaseBackup } from "@/adapters";
 import { useBackupRestore } from "./use-backup-restore";
 
 const desktopNotes = [
@@ -154,12 +155,6 @@ interface WebPanelProps {
   backupListError: string | null;
   onDeleteBackup: (filename: string) => Promise<void>;
   getDownloadUrl: (filename: string) => string;
-}
-
-interface DatabaseBackup {
-  filename: string;
-  sizeBytes: number;
-  modifiedAt: string;
 }
 
 const formatBackupSize = (sizeBytes: number): string => {

--- a/apps/frontend/src/pages/settings/exports/use-backup-restore.ts
+++ b/apps/frontend/src/pages/settings/exports/use-backup-restore.ts
@@ -1,24 +1,40 @@
 import {
   backupDatabase,
   backupDatabaseToPath,
+  backupDatabaseToPendingExport,
+  deleteDatabaseBackup,
+  getDatabaseBackupDownloadUrl,
   isWeb,
+  listDatabaseBackups,
   logger,
   openDatabaseFileDialog,
-  openFileSaveDialog,
   openFolderDialog,
   restoreDatabase,
+  saveAppDataFileViaPicker,
 } from "@/adapters";
 import { getPlatform as getRuntimePlatform, usePlatform } from "@/hooks/use-platform";
-import { useMutation } from "@tanstack/react-query";
+import { QueryKeys } from "@/lib/query-keys";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "@wealthfolio/ui/components/ui/use-toast";
 
 export function useBackupRestore() {
   const { platform } = usePlatform();
+  const queryClient = useQueryClient();
   const platformMode: "desktop" | "mobile" | "web" = isWeb
     ? "web"
     : platform?.is_mobile
       ? "mobile"
       : "desktop";
+
+  const {
+    data: webBackups = [],
+    isLoading: isLoadingWebBackups,
+    isFetching: isFetchingWebBackups,
+  } = useQuery({
+    queryKey: [QueryKeys.DATABASE_BACKUPS],
+    queryFn: listDatabaseBackups,
+    enabled: isWeb,
+  });
 
   const { mutateAsync: backupWithDirectorySelection, isPending: isBackingUp } = useMutation<{
     location: "local" | "server";
@@ -45,9 +61,13 @@ export function useBackupRestore() {
         return { location: "local" as const, value: backupPath };
       }
 
-      // Mobile: create backup and let user choose file destination.
-      const { filename, data } = await backupDatabase();
-      const saved = await openFileSaveDialog(data, filename);
+      if (runtimePlatform.os !== "ios") {
+        throw new Error("Backup export is currently supported on desktop, web, and iOS only");
+      }
+
+      // iOS: create backup and let user choose file destination.
+      const { relativePath, filename } = await backupDatabaseToPendingExport();
+      const saved = await saveAppDataFileViaPicker(relativePath, filename);
       if (!saved) {
         return null;
       }
@@ -69,11 +89,34 @@ export function useBackupRestore() {
         description,
         variant: "success",
       });
+
+      if (result.location === "server") {
+        queryClient.invalidateQueries({ queryKey: [QueryKeys.DATABASE_BACKUPS] });
+      }
     },
     onError: (error) => {
       logger.error(`Error during backup: ${String(error)}`);
       toast({
         title: "Backup failed",
+        description: error instanceof Error ? error.message : "An unknown error occurred",
+        variant: "destructive",
+      });
+    },
+  });
+
+  const { mutateAsync: deleteWebBackup, isPending: isDeletingWebBackup } = useMutation({
+    mutationFn: deleteDatabaseBackup,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.DATABASE_BACKUPS] });
+      toast({
+        title: "Backup deleted",
+        variant: "success",
+      });
+    },
+    onError: (error) => {
+      logger.error(`Error deleting backup: ${String(error)}`);
+      toast({
+        title: "Delete failed",
         description: error instanceof Error ? error.message : "An unknown error occurred",
         variant: "destructive",
       });
@@ -147,12 +190,20 @@ export function useBackupRestore() {
   return {
     performBackup,
     performRestore,
+    deleteWebBackup,
+    getWebBackupDownloadUrl: getDatabaseBackupDownloadUrl,
     isBackingUp,
     isRestoring,
+    isDeletingWebBackup,
+    isLoadingWebBackups,
+    isFetchingWebBackups,
+    canBackup: platformMode !== "mobile" || platform?.os === "ios",
     canRestore: platformMode === "desktop" || platform?.os === "ios",
+    isIOS: platform?.os === "ios",
     isDesktop: platformMode === "desktop",
     isMobile: platformMode === "mobile",
     isWeb,
+    webBackups,
     platformMode,
   };
 }

--- a/apps/frontend/src/pages/settings/exports/use-backup-restore.ts
+++ b/apps/frontend/src/pages/settings/exports/use-backup-restore.ts
@@ -30,6 +30,8 @@ export function useBackupRestore() {
     data: webBackups = [],
     isLoading: isLoadingWebBackups,
     isFetching: isFetchingWebBackups,
+    isError: hasWebBackupsError,
+    error: webBackupsError,
   } = useQuery({
     queryKey: [QueryKeys.DATABASE_BACKUPS],
     queryFn: listDatabaseBackups,
@@ -197,6 +199,11 @@ export function useBackupRestore() {
     isDeletingWebBackup,
     isLoadingWebBackups,
     isFetchingWebBackups,
+    webBackupsError: hasWebBackupsError
+      ? webBackupsError instanceof Error
+        ? webBackupsError.message
+        : "Unable to load database backups"
+      : null,
     canBackup: platformMode !== "mobile" || platform?.os === "ios",
     canRestore: platformMode === "desktop" || platform?.os === "ios",
     isIOS: platform?.os === "ios",

--- a/apps/frontend/src/pages/settings/exports/use-export-data.ts
+++ b/apps/frontend/src/pages/settings/exports/use-export-data.ts
@@ -1,6 +1,7 @@
 import {
   backupDatabase,
   backupDatabaseToPath,
+  backupDatabaseToPendingExport,
   getAccounts,
   getActivities,
   getGoals,
@@ -9,6 +10,7 @@ import {
   logger,
   openFileSaveDialog,
   openFolderDialog,
+  saveAppDataFileViaPicker,
 } from "@/adapters";
 import { getPlatform as getRuntimePlatform } from "@/hooks/use-platform";
 import { formatData } from "@/lib/export-utils";
@@ -87,9 +89,13 @@ export function useExportData() {
           return { mode: "sqlite", target: "local" as const, value: backupPath };
         }
 
-        // Mobile: create backup and let user pick destination file.
-        const { filename, data } = await backupDatabase();
-        const saved = await openFileSaveDialog(data, filename);
+        if (runtimePlatform.os !== "ios") {
+          throw new Error("SQLite export is currently supported on desktop, web, and iOS only");
+        }
+
+        // iOS: create backup and let user pick destination file.
+        const { relativePath, filename } = await backupDatabaseToPendingExport();
+        const saved = await saveAppDataFileViaPicker(relativePath, filename);
         if (!saved) {
           return null;
         }

--- a/apps/server/src/api.rs
+++ b/apps/server/src/api.rs
@@ -28,6 +28,7 @@ mod assets;
 #[cfg(any(feature = "connect-sync", feature = "device-sync"))]
 pub mod connect;
 mod custom_providers;
+mod database_backups;
 #[cfg(feature = "device-sync")]
 mod device_sync;
 #[cfg(feature = "device-sync")]
@@ -89,6 +90,7 @@ pub fn app_router(state: Arc<AppState>, config: &Config) -> Router {
     let mut protected_api = Router::new()
         .merge(accounts::router())
         .merge(settings::router())
+        .merge(database_backups::router())
         .merge(portfolio::router())
         .merge(holdings::router())
         .merge(performance::router())

--- a/apps/server/src/api/database_backups.rs
+++ b/apps/server/src/api/database_backups.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use crate::{
-    api::shared::normalize_file_path,
     error::{ApiError, ApiResult},
     main_lib::AppState,
 };
@@ -15,12 +14,12 @@ use axum::{
     extract::{Path, State},
     http::{header, StatusCode},
     response::Response,
-    routing::{get, post},
+    routing::{delete, get, post},
     Json, Router,
 };
 use futures::stream;
 use tokio::{fs, io::AsyncReadExt, task};
-use wealthfolio_storage_sqlite::db;
+use wealthfolio_storage_sqlite::{db, is_valid_backup_filename};
 
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -59,41 +58,11 @@ struct BackupFileResponse {
     modified_at: String,
 }
 
-struct ResolvedBackupPath {
-    requested: PathBuf,
-    canonical: PathBuf,
-}
-
 fn backups_dir(data_root: &str) -> PathBuf {
     StdPath::new(data_root).join("backups")
 }
 
-fn is_valid_backup_filename(filename: &str) -> bool {
-    const PREFIX: &str = "wealthfolio_backup_";
-    const SUFFIX: &str = ".db";
-    const EXPECTED_LEN: usize = PREFIX.len() + "YYYYMMDD_HHMMSS".len() + SUFFIX.len();
-
-    if filename.len() != EXPECTED_LEN
-        || !filename.starts_with(PREFIX)
-        || !filename.ends_with(SUFFIX)
-    {
-        return false;
-    }
-
-    let timestamp = &filename[PREFIX.len()..filename.len() - SUFFIX.len()];
-    if timestamp.as_bytes().get(8) != Some(&b'_') {
-        return false;
-    }
-
-    let compact = timestamp.replace('_', "");
-    if compact.len() != 14 || !compact.bytes().all(|b| b.is_ascii_digit()) {
-        return false;
-    }
-
-    chrono::NaiveDateTime::parse_from_str(timestamp, "%Y%m%d_%H%M%S").is_ok()
-}
-
-async fn resolve_backup_path(data_root: &str, filename: &str) -> ApiResult<ResolvedBackupPath> {
+async fn resolve_backup_path(data_root: &str, filename: &str) -> ApiResult<PathBuf> {
     if !is_valid_backup_filename(filename) {
         return Err(ApiError::BadRequest("Invalid backup filename".to_string()));
     }
@@ -125,10 +94,7 @@ async fn resolve_backup_path(data_root: &str, filename: &str) -> ApiResult<Resol
         return Err(ApiError::BadRequest("Invalid backup filename".to_string()));
     }
 
-    Ok(ResolvedBackupPath {
-        requested,
-        canonical,
-    })
+    Ok(canonical)
 }
 
 async fn list_backup_files_route(
@@ -187,7 +153,7 @@ async fn download_backup_file_route(
     Path(filename): Path<String>,
 ) -> ApiResult<Response> {
     let backup_path = resolve_backup_path(&state.data_root, &filename).await?;
-    let file = fs::File::open(&backup_path.canonical)
+    let file = fs::File::open(&backup_path)
         .await
         .with_context(|| format!("Failed to open backup file {}", filename))?;
     let body = stream_file(file);
@@ -224,32 +190,9 @@ async fn delete_backup_file_route(
     Path(filename): Path<String>,
 ) -> ApiResult<StatusCode> {
     let backup_path = resolve_backup_path(&state.data_root, &filename).await?;
-    fs::remove_file(&backup_path.requested)
+    fs::remove_file(&backup_path)
         .await
         .with_context(|| format!("Failed to delete backup file {}", filename))?;
-
-    Ok(StatusCode::NO_CONTENT)
-}
-
-#[derive(serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct RestoreBody {
-    #[serde(rename = "backupFilePath")]
-    backup_file_path: String,
-}
-
-async fn restore_database_route(
-    State(state): State<Arc<AppState>>,
-    Json(body): Json<RestoreBody>,
-) -> ApiResult<StatusCode> {
-    let data_root = state.data_root.clone();
-    task::spawn_blocking(move || {
-        let normalized_path = normalize_file_path(&body.backup_file_path);
-        db::restore_database_safe(&data_root, &normalized_path)
-            .with_context(|| format!("Failed to restore database from {}", normalized_path))
-    })
-    .await
-    .map_err(|e| anyhow::anyhow!("Failed to execute restore task: {}", e))??;
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -264,7 +207,69 @@ pub fn router() -> Router<Arc<AppState>> {
         )
         .route(
             "/utilities/database/backups/{filename}",
-            axum::routing::delete(delete_backup_file_route),
+            delete(delete_backup_file_route),
         )
-        .route("/utilities/database/restore", post(restore_database_route))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn resolve_backup_path_rejects_invalid_filename() {
+        let data_root = tempdir().unwrap();
+
+        let result = resolve_backup_path(
+            data_root.path().to_str().unwrap(),
+            "../wealthfolio_backup_20260514_150409.db",
+        )
+        .await;
+
+        assert!(matches!(result, Err(ApiError::BadRequest(_))));
+    }
+
+    #[tokio::test]
+    async fn resolve_backup_path_accepts_valid_backup_inside_backup_dir() {
+        let data_root = tempdir().unwrap();
+        let backup_dir = data_root.path().join("backups");
+        std::fs::create_dir_all(&backup_dir).unwrap();
+        let backup_file = backup_dir.join("wealthfolio_backup_20260514_150409.db");
+        std::fs::write(&backup_file, b"backup").unwrap();
+
+        let resolved = resolve_backup_path(
+            data_root.path().to_str().unwrap(),
+            "wealthfolio_backup_20260514_150409.db",
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(resolved, std::fs::canonicalize(backup_file).unwrap());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn resolve_backup_path_rejects_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let data_root = tempdir().unwrap();
+        let outside_dir = tempdir().unwrap();
+        let backup_dir = data_root.path().join("backups");
+        std::fs::create_dir_all(&backup_dir).unwrap();
+        let outside_file = outside_dir.path().join("outside.db");
+        std::fs::write(&outside_file, b"not a backup").unwrap();
+        symlink(
+            &outside_file,
+            backup_dir.join("wealthfolio_backup_20260514_150409.db"),
+        )
+        .unwrap();
+
+        let result = resolve_backup_path(
+            data_root.path().to_str().unwrap(),
+            "wealthfolio_backup_20260514_150409.db",
+        )
+        .await;
+
+        assert!(matches!(result, Err(ApiError::BadRequest(_))));
+    }
 }

--- a/apps/server/src/api/database_backups.rs
+++ b/apps/server/src/api/database_backups.rs
@@ -1,0 +1,270 @@
+use std::{
+    io::ErrorKind,
+    path::{Path as StdPath, PathBuf},
+    sync::Arc,
+};
+
+use crate::{
+    api::shared::normalize_file_path,
+    error::{ApiError, ApiResult},
+    main_lib::AppState,
+};
+use anyhow::Context;
+use axum::{
+    body::{Body, Bytes},
+    extract::{Path, State},
+    http::{header, StatusCode},
+    response::Response,
+    routing::{get, post},
+    Json, Router,
+};
+use futures::stream;
+use tokio::{fs, io::AsyncReadExt, task};
+use wealthfolio_storage_sqlite::db;
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BackupDatabaseResponse {
+    filename: String,
+}
+
+async fn backup_database_route(
+    State(state): State<Arc<AppState>>,
+) -> ApiResult<Json<BackupDatabaseResponse>> {
+    let data_root = state.data_root.clone();
+    let backup_path = task::spawn_blocking(move || db::backup_database(&data_root))
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to execute backup task: {}", e))??;
+
+    let filename = StdPath::new(&backup_path)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .ok_or_else(|| anyhow::anyhow!("Invalid backup filename"))?
+        .to_string();
+
+    if !is_valid_backup_filename(&filename) {
+        return Err(ApiError::Internal(
+            "Backup service returned an invalid filename".to_string(),
+        ));
+    }
+
+    Ok(Json(BackupDatabaseResponse { filename }))
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BackupFileResponse {
+    filename: String,
+    size_bytes: u64,
+    modified_at: String,
+}
+
+struct ResolvedBackupPath {
+    requested: PathBuf,
+    canonical: PathBuf,
+}
+
+fn backups_dir(data_root: &str) -> PathBuf {
+    StdPath::new(data_root).join("backups")
+}
+
+fn is_valid_backup_filename(filename: &str) -> bool {
+    const PREFIX: &str = "wealthfolio_backup_";
+    const SUFFIX: &str = ".db";
+    const EXPECTED_LEN: usize = PREFIX.len() + "YYYYMMDD_HHMMSS".len() + SUFFIX.len();
+
+    if filename.len() != EXPECTED_LEN
+        || !filename.starts_with(PREFIX)
+        || !filename.ends_with(SUFFIX)
+    {
+        return false;
+    }
+
+    let timestamp = &filename[PREFIX.len()..filename.len() - SUFFIX.len()];
+    if timestamp.as_bytes().get(8) != Some(&b'_') {
+        return false;
+    }
+
+    let compact = timestamp.replace('_', "");
+    if compact.len() != 14 || !compact.bytes().all(|b| b.is_ascii_digit()) {
+        return false;
+    }
+
+    chrono::NaiveDateTime::parse_from_str(timestamp, "%Y%m%d_%H%M%S").is_ok()
+}
+
+async fn resolve_backup_path(data_root: &str, filename: &str) -> ApiResult<ResolvedBackupPath> {
+    if !is_valid_backup_filename(filename) {
+        return Err(ApiError::BadRequest("Invalid backup filename".to_string()));
+    }
+
+    let backup_dir = backups_dir(data_root);
+    let canonical_dir = match fs::canonicalize(&backup_dir).await {
+        Ok(path) => path,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Err(ApiError::NotFound),
+        Err(err) => {
+            return Err(anyhow::anyhow!(
+                "Failed to access backup directory {}: {}",
+                backup_dir.display(),
+                err
+            )
+            .into())
+        }
+    };
+
+    let requested = backup_dir.join(filename);
+    let canonical = match fs::canonicalize(&requested).await {
+        Ok(path) => path,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Err(ApiError::NotFound),
+        Err(err) => {
+            return Err(anyhow::anyhow!("Backup file not found: {}: {}", filename, err).into())
+        }
+    };
+
+    if !canonical.starts_with(&canonical_dir) {
+        return Err(ApiError::BadRequest("Invalid backup filename".to_string()));
+    }
+
+    Ok(ResolvedBackupPath {
+        requested,
+        canonical,
+    })
+}
+
+async fn list_backup_files_route(
+    State(state): State<Arc<AppState>>,
+) -> ApiResult<Json<Vec<BackupFileResponse>>> {
+    let backup_dir = backups_dir(&state.data_root);
+    let mut entries = match fs::read_dir(&backup_dir).await {
+        Ok(entries) => entries,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(Json(Vec::new())),
+        Err(err) => {
+            return Err(anyhow::anyhow!(
+                "Failed to read backup directory {}: {}",
+                backup_dir.display(),
+                err
+            )
+            .into())
+        }
+    };
+
+    let mut backups = Vec::new();
+    while let Some(entry) = entries
+        .next_entry()
+        .await
+        .context("Failed to read backup directory entry")?
+    {
+        let filename = match entry.file_name().to_str() {
+            Some(filename) if is_valid_backup_filename(filename) => filename.to_string(),
+            _ => continue,
+        };
+
+        let metadata = entry
+            .metadata()
+            .await
+            .with_context(|| format!("Failed to read backup metadata for {}", filename))?;
+        if !metadata.is_file() {
+            continue;
+        }
+
+        let modified_at = metadata
+            .modified()
+            .with_context(|| format!("Failed to read backup modified time for {}", filename))
+            .map(chrono::DateTime::<chrono::Utc>::from)?;
+        backups.push(BackupFileResponse {
+            filename,
+            size_bytes: metadata.len(),
+            modified_at: modified_at.to_rfc3339(),
+        });
+    }
+
+    backups.sort_by(|a, b| b.filename.cmp(&a.filename));
+    Ok(Json(backups))
+}
+
+async fn download_backup_file_route(
+    State(state): State<Arc<AppState>>,
+    Path(filename): Path<String>,
+) -> ApiResult<Response> {
+    let backup_path = resolve_backup_path(&state.data_root, &filename).await?;
+    let file = fs::File::open(&backup_path.canonical)
+        .await
+        .with_context(|| format!("Failed to open backup file {}", filename))?;
+    let body = stream_file(file);
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/octet-stream")
+        .header(
+            header::CONTENT_DISPOSITION,
+            format!("attachment; filename=\"{}\"", filename),
+        )
+        .body(body)
+        .map_err(|e| anyhow::anyhow!("Failed to build backup download response: {}", e).into())
+}
+
+fn stream_file(file: fs::File) -> Body {
+    let stream = stream::unfold(file, |mut file| async move {
+        let mut buffer = vec![0; 64 * 1024];
+        match file.read(&mut buffer).await {
+            Ok(0) => None,
+            Ok(bytes_read) => {
+                buffer.truncate(bytes_read);
+                Some((Ok::<Bytes, std::io::Error>(Bytes::from(buffer)), file))
+            }
+            Err(err) => Some((Err(err), file)),
+        }
+    });
+
+    Body::from_stream(stream)
+}
+
+async fn delete_backup_file_route(
+    State(state): State<Arc<AppState>>,
+    Path(filename): Path<String>,
+) -> ApiResult<StatusCode> {
+    let backup_path = resolve_backup_path(&state.data_root, &filename).await?;
+    fs::remove_file(&backup_path.requested)
+        .await
+        .with_context(|| format!("Failed to delete backup file {}", filename))?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RestoreBody {
+    #[serde(rename = "backupFilePath")]
+    backup_file_path: String,
+}
+
+async fn restore_database_route(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<RestoreBody>,
+) -> ApiResult<StatusCode> {
+    let data_root = state.data_root.clone();
+    task::spawn_blocking(move || {
+        let normalized_path = normalize_file_path(&body.backup_file_path);
+        db::restore_database_safe(&data_root, &normalized_path)
+            .with_context(|| format!("Failed to restore database from {}", normalized_path))
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("Failed to execute restore task: {}", e))??;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/utilities/database/backup", post(backup_database_route))
+        .route("/utilities/database/backups", get(list_backup_files_route))
+        .route(
+            "/utilities/database/backups/{filename}/download",
+            get(download_backup_file_route),
+        )
+        .route(
+            "/utilities/database/backups/{filename}",
+            axum::routing::delete(delete_backup_file_route),
+        )
+        .route("/utilities/database/restore", post(restore_database_route))
+}

--- a/apps/server/src/api/settings.rs
+++ b/apps/server/src/api/settings.rs
@@ -7,28 +7,19 @@ use std::{
 use tokio::sync::Mutex;
 
 use crate::{
-    api::shared::{normalize_file_path, process_portfolio_job, PortfolioJobConfig},
+    api::shared::{process_portfolio_job, PortfolioJobConfig},
     error::ApiResult,
     main_lib::AppState,
 };
-use anyhow::Context;
-use axum::{
-    extract::State,
-    http::StatusCode,
-    routing::{get, post},
-    Json, Router,
-};
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use axum::{extract::State, routing::get, Json, Router};
 use reqwest::StatusCode as HttpStatusCode;
 use semver::Version;
 use serde::Deserialize;
-use tokio::{fs, task};
 use wealthfolio_core::{
     portfolio::{snapshot::SnapshotRecalcMode, valuation::ValuationRecalcMode},
     quotes::MarketSyncMode,
     settings::{Settings, SettingsServiceTrait, SettingsUpdate},
 };
-use wealthfolio_storage_sqlite::db;
 
 async fn get_settings(State(state): State<Arc<AppState>>) -> ApiResult<Json<Settings>> {
     let s = state.settings_service.get_settings()?;
@@ -275,101 +266,6 @@ async fn check_update(
     Ok(Json(result))
 }
 
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct BackupDatabaseResponse {
-    filename: String,
-    data_b64: String,
-}
-
-async fn backup_database_route(
-    State(state): State<Arc<AppState>>,
-) -> ApiResult<Json<BackupDatabaseResponse>> {
-    let data_root = state.data_root.clone();
-    let backup_path = task::spawn_blocking(move || db::backup_database(&data_root))
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to execute backup task: {}", e))??;
-
-    let filename = StdPath::new(&backup_path)
-        .file_name()
-        .and_then(|f| f.to_str())
-        .ok_or_else(|| anyhow::anyhow!("Invalid backup filename"))?
-        .to_string();
-
-    let bytes = fs::read(&backup_path)
-        .await
-        .with_context(|| format!("Failed to read backup file {}", backup_path))?;
-
-    let data_b64 = BASE64.encode(&bytes);
-    Ok(Json(BackupDatabaseResponse { filename, data_b64 }))
-}
-
-#[derive(serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct BackupToPathBody {
-    #[serde(rename = "backupDir")]
-    backup_dir: String,
-}
-
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
-struct BackupToPathResponse {
-    path: String,
-}
-
-async fn backup_database_to_path_route(
-    State(state): State<Arc<AppState>>,
-    Json(body): Json<BackupToPathBody>,
-) -> ApiResult<Json<BackupToPathResponse>> {
-    let data_root = state.data_root.clone();
-    let target_dir = body.backup_dir.clone();
-
-    let backup_path = task::spawn_blocking(move || -> anyhow::Result<String> {
-        let normalized_backup_dir = normalize_file_path(&target_dir);
-
-        let timestamp = chrono::Local::now().format("%Y%m%d_%H%M%S");
-        let backup_filename = format!("wealthfolio_backup_{}.db", timestamp);
-        let backup_path = StdPath::new(&normalized_backup_dir).join(&backup_filename);
-
-        let backup_path_str = backup_path
-            .to_str()
-            .ok_or_else(|| anyhow::anyhow!("Invalid backup path"))?
-            .to_string();
-
-        db::backup_database_to_file(&data_root, &backup_path_str)
-            .with_context(|| format!("Failed to create backup file {}", backup_path_str))?;
-
-        Ok(backup_path_str)
-    })
-    .await
-    .map_err(|e| anyhow::anyhow!("Failed to execute backup-to-path task: {}", e))??;
-
-    Ok(Json(BackupToPathResponse { path: backup_path }))
-}
-
-#[derive(serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct RestoreBody {
-    #[serde(rename = "backupFilePath")]
-    backup_file_path: String,
-}
-
-async fn restore_database_route(
-    State(state): State<Arc<AppState>>,
-    Json(body): Json<RestoreBody>,
-) -> ApiResult<StatusCode> {
-    let data_root = state.data_root.clone();
-    task::spawn_blocking(move || {
-        let normalized_path = normalize_file_path(&body.backup_file_path);
-        db::restore_database_safe(&data_root, &normalized_path)
-            .with_context(|| format!("Failed to restore database from {}", normalized_path))
-    })
-    .await
-    .map_err(|e| anyhow::anyhow!("Failed to execute restore task: {}", e))??;
-
-    Ok(StatusCode::NO_CONTENT)
-}
-
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
         .route("/settings", get(get_settings).put(update_settings))
@@ -379,10 +275,4 @@ pub fn router() -> Router<Arc<AppState>> {
         )
         .route("/app/info", get(get_app_info))
         .route("/app/check-update", get(check_update))
-        .route("/utilities/database/backup", post(backup_database_route))
-        .route(
-            "/utilities/database/backup-to-path",
-            post(backup_database_to_path_route),
-        )
-        .route("/utilities/database/restore", post(restore_database_route))
 }

--- a/apps/server/src/api/shared.rs
+++ b/apps/server/src/api/shared.rs
@@ -39,11 +39,6 @@ pub fn parse_date_optional(
     date_str.map(|s| parse_date(&s, field_name)).transpose()
 }
 
-/// Normalize file paths by stripping file:// prefix
-pub fn normalize_file_path(path: &str) -> String {
-    path.strip_prefix("file://").unwrap_or(path).to_string()
-}
-
 #[derive(Debug, Default, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PortfolioRequestBody {

--- a/apps/tauri/Cargo.toml
+++ b/apps/tauri/Cargo.toml
@@ -21,7 +21,7 @@ wealthfolio-ai = { workspace = true }
 
 # Tauri
 tauri = { version = "2.10", features = [] }
-tauri-plugin-fs = "2"
+tauri-plugin-fs = "2.5"
 tauri-plugin-dialog = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-log = "2"

--- a/apps/tauri/capabilities/mobile.json
+++ b/apps/tauri/capabilities/mobile.json
@@ -15,6 +15,8 @@
     "fs:allow-write-file",
     "fs:allow-read-dir",
     "fs:allow-copy-file",
+    "fs:allow-start-accessing-security-scoped-resource",
+    "fs:allow-stop-accessing-security-scoped-resource",
     "fs:allow-mkdir",
     "fs:allow-remove",
     "fs:allow-rename",

--- a/apps/tauri/src/commands/utilities.rs
+++ b/apps/tauri/src/commands/utilities.rs
@@ -10,6 +10,8 @@ use crate::context::ServiceContext;
 #[cfg(desktop)]
 use crate::updater::{check_for_update, install_update};
 
+const PENDING_EXPORTS_DIR: &str = "pending-exports";
+
 /// Normalize file path by removing file:// URI prefix if present (iOS/Android compatibility)
 fn normalize_file_path(path: &str) -> String {
     if path.starts_with("file://") {
@@ -129,7 +131,11 @@ pub async fn backup_database_to_pending_export(
         "wealthfolio_backup_{}.db",
         chrono::Local::now().format("%Y%m%d_%H%M%S_%3f")
     );
-    let export_dir = app_data_dir_path.join("pending-exports");
+    let export_dir = app_data_dir_path.join(PENDING_EXPORTS_DIR);
+    if export_dir.exists() {
+        fs::remove_dir_all(&export_dir)
+            .map_err(|e| format!("Failed to clean pending export directory: {}", e))?;
+    }
     fs::create_dir_all(&export_dir)
         .map_err(|e| format!("Failed to create pending export directory: {}", e))?;
 
@@ -143,7 +149,7 @@ pub async fn backup_database_to_pending_export(
         .map_err(|e| format!("Failed to create backup export: {}", e))?;
 
     Ok(BackupExport {
-        relative_path: format!("pending-exports/{}", filename),
+        relative_path: format!("{}/{}", PENDING_EXPORTS_DIR, filename),
         filename,
     })
 }

--- a/apps/tauri/src/commands/utilities.rs
+++ b/apps/tauri/src/commands/utilities.rs
@@ -1,7 +1,6 @@
 use chrono;
 use serde::Serialize;
-use std::fs::File;
-use std::io::Read;
+use std::fs;
 use std::path::Path;
 use tauri::Manager;
 use tauri::{AppHandle, Emitter};
@@ -26,6 +25,13 @@ pub struct AppInfo {
     version: String,
     db_path: String,
     logs_dir: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BackupExport {
+    relative_path: String,
+    filename: String,
 }
 
 #[tauri::command]
@@ -87,7 +93,7 @@ pub async fn install_app_update(app_handle: AppHandle) -> Result<(), String> {
 }
 
 #[tauri::command]
-pub async fn backup_database(app_handle: AppHandle) -> Result<(String, Vec<u8>), String> {
+pub async fn backup_database(app_handle: AppHandle) -> Result<String, String> {
     let app_data_dir = app_handle
         .path()
         .app_data_dir()
@@ -98,21 +104,48 @@ pub async fn backup_database(app_handle: AppHandle) -> Result<(String, Vec<u8>),
 
     let backup_path = db::backup_database(&app_data_dir).map_err(|e| e.to_string())?;
 
-    // Read the backup file
-    let mut file =
-        File::open(&backup_path).map_err(|e| format!("Failed to open backup file: {}", e))?;
-    let mut buffer = Vec::new();
-    file.read_to_end(&mut buffer)
-        .map_err(|e| format!("Failed to read backup file: {}", e))?;
-
-    // Get the filename
-    let filename = Path::new(&backup_path)
+    Ok(Path::new(&backup_path)
         .file_name()
         .and_then(|name| name.to_str())
         .ok_or_else(|| "Failed to get backup filename".to_string())?
+        .to_string())
+}
+
+#[tauri::command]
+pub async fn backup_database_to_pending_export(
+    app_handle: AppHandle,
+) -> Result<BackupExport, String> {
+    let app_data_dir_path = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {}", e))?;
+
+    let app_data_dir = app_data_dir_path
+        .to_str()
+        .ok_or_else(|| "Failed to convert app data dir to string".to_string())?
         .to_string();
 
-    Ok((filename, buffer))
+    let filename = format!(
+        "wealthfolio_backup_{}.db",
+        chrono::Local::now().format("%Y%m%d_%H%M%S_%3f")
+    );
+    let export_dir = app_data_dir_path.join("pending-exports");
+    fs::create_dir_all(&export_dir)
+        .map_err(|e| format!("Failed to create pending export directory: {}", e))?;
+
+    let backup_path = export_dir.join(&filename);
+    let backup_path_str = backup_path
+        .to_str()
+        .ok_or_else(|| "Failed to convert backup export path to string".to_string())?
+        .to_string();
+
+    db::backup_database_to_file(&app_data_dir, &backup_path_str)
+        .map_err(|e| format!("Failed to create backup export: {}", e))?;
+
+    Ok(BackupExport {
+        relative_path: format!("pending-exports/{}", filename),
+        filename,
+    })
 }
 
 #[tauri::command]

--- a/apps/tauri/src/lib.rs
+++ b/apps/tauri/src/lib.rs
@@ -416,6 +416,7 @@ pub fn run() {
             commands::utilities::check_for_updates,
             commands::utilities::install_app_update,
             commands::utilities::backup_database,
+            commands::utilities::backup_database_to_pending_export,
             commands::utilities::backup_database_to_path,
             commands::utilities::restore_database,
             // Asset commands

--- a/crates/storage-sqlite/src/db/mod.rs
+++ b/crates/storage-sqlite/src/db/mod.rs
@@ -19,6 +19,9 @@ use crate::errors::StorageError;
 
 // Keep this invocation in sync with the on-disk migrations directory.
 const MIGRATIONS: EmbeddedMigrations = embed_migrations!();
+const BACKUP_FILENAME_PREFIX: &str = "wealthfolio_backup_";
+const BACKUP_FILENAME_SUFFIX: &str = ".db";
+const BACKUP_FILENAME_TIMESTAMP_FORMAT: &str = "%Y%m%d_%H%M%S";
 
 pub type DbPool = r2d2::Pool<ConnectionManager<SqliteConnection>>;
 pub type DbConnection = PooledConnection<ConnectionManager<SqliteConnection>>;
@@ -153,6 +156,40 @@ pub fn get_db_path(input: &str) -> String {
     }
 }
 
+fn create_backup_filename(timestamp: chrono::DateTime<Local>) -> String {
+    format!(
+        "{}{}{}",
+        BACKUP_FILENAME_PREFIX,
+        timestamp.format(BACKUP_FILENAME_TIMESTAMP_FORMAT),
+        BACKUP_FILENAME_SUFFIX
+    )
+}
+
+pub fn is_valid_backup_filename(filename: &str) -> bool {
+    const EXPECTED_LEN: usize =
+        BACKUP_FILENAME_PREFIX.len() + "YYYYMMDD_HHMMSS".len() + BACKUP_FILENAME_SUFFIX.len();
+
+    if filename.len() != EXPECTED_LEN
+        || !filename.starts_with(BACKUP_FILENAME_PREFIX)
+        || !filename.ends_with(BACKUP_FILENAME_SUFFIX)
+    {
+        return false;
+    }
+
+    let timestamp =
+        &filename[BACKUP_FILENAME_PREFIX.len()..filename.len() - BACKUP_FILENAME_SUFFIX.len()];
+    if timestamp.as_bytes().get(8) != Some(&b'_') {
+        return false;
+    }
+
+    let compact = timestamp.replace('_', "");
+    if compact.len() != 14 || !compact.bytes().all(|b| b.is_ascii_digit()) {
+        return false;
+    }
+
+    chrono::NaiveDateTime::parse_from_str(timestamp, BACKUP_FILENAME_TIMESTAMP_FORMAT).is_ok()
+}
+
 pub fn create_backup_path(app_data_dir: &str) -> Result<String> {
     let backup_dir = Path::new(app_data_dir).join("backups");
     fs::create_dir_all(&backup_dir).map_err(|e| {
@@ -160,8 +197,7 @@ pub fn create_backup_path(app_data_dir: &str) -> Result<String> {
         Error::Database(DatabaseError::BackupFailed(e.to_string()))
     })?;
 
-    let timestamp = Local::now().format("%Y%m%d_%H%M%S");
-    let backup_file = format!("wealthfolio_backup_{}.db", timestamp);
+    let backup_file = create_backup_filename(Local::now());
     let backup_path = backup_dir.join(backup_file);
 
     Ok(backup_path.to_str().unwrap().to_string())
@@ -506,5 +542,61 @@ impl DbTransactionExecutor for Arc<DbPool> {
         E: Into<Error>,
     {
         (**self).execute(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use tempfile::tempdir;
+
+    #[test]
+    fn validates_backup_filename_contract() {
+        assert!(is_valid_backup_filename(
+            "wealthfolio_backup_20260514_150409.db"
+        ));
+
+        for filename in [
+            "../wealthfolio_backup_20260514_150409.db",
+            "wealthfolio_backup_20260514_150409.db\0",
+            "wealthfolio_backup_20260514_150409.sqlite",
+            "wealthfolio_backup_20260514_150409_123.db",
+            "wealthfolio_backup_20260514150409.db",
+            "wealthfolio_backup_20260514_15040x.db",
+            "wealthfolio_backup_20260231_150409.db",
+            "other_backup_20260514_150409.db",
+        ] {
+            assert!(
+                !is_valid_backup_filename(filename),
+                "expected {filename} to be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn generated_backup_filename_matches_validator() {
+        let timestamp = Local
+            .with_ymd_and_hms(2026, 5, 14, 15, 4, 9)
+            .single()
+            .unwrap();
+
+        assert_eq!(
+            create_backup_filename(timestamp),
+            "wealthfolio_backup_20260514_150409.db"
+        );
+        assert!(is_valid_backup_filename(&create_backup_filename(timestamp)));
+    }
+
+    #[test]
+    fn create_backup_path_uses_valid_backup_filename() {
+        let app_data = tempdir().unwrap();
+        let backup_path = create_backup_path(app_data.path().to_str().unwrap()).unwrap();
+        let filename = Path::new(&backup_path)
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap();
+
+        assert!(is_valid_backup_filename(filename));
     }
 }

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -47,9 +47,9 @@ pub mod taxonomies;
 
 // Re-export database utilities
 pub use db::{
-    backup_database, create_pool, get_connection, get_db_path, init, restore_database,
-    restore_database_safe, run_migrations, DbConnection, DbPool, DbTransactionExecutor,
-    WriteHandle,
+    backup_database, create_pool, get_connection, get_db_path, init, is_valid_backup_filename,
+    restore_database, restore_database_safe, run_migrations, DbConnection, DbPool,
+    DbTransactionExecutor, WriteHandle,
 };
 
 // Re-export storage errors and conversion helpers

--- a/packages/addon-sdk/src/host-api.ts
+++ b/packages/addon-sdk/src/host-api.ts
@@ -478,7 +478,7 @@ export interface SettingsAPI {
    * Create database backup
    * @returns Promise resolving to backup file information
    */
-  backupDatabase(): Promise<{ filename: string; data: Uint8Array }>;
+  backupDatabase(): Promise<{ filename: string }>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- move web database backup routes into a dedicated API module and add managed list, streamed download, and delete endpoints
- remove the web backup-to-arbitrary-path endpoint while keeping desktop folder backup support
- replace large DB byte roundtrips with filename-only web backups and iOS pending-export file picker flow
- update settings export, SQLite export, and device-sync backup flows across web, desktop, and iOS
- clean up the web backup UI with a compact backup list, download/delete actions, and app-native delete confirmation
- update addon SDK backupDatabase() to return filename-only metadata

## Validation
- cargo check -p wealthfolio-server
- cargo check -p wealthfolio-app
- cargo test -p wealthfolio-server --lib
- pnpm --filter frontend type-check
- pnpm --filter frontend test --run src/features/devices-sync/components/device-sync-section.test.tsx src/features/devices-sync/components/pairing-flow/index.test.tsx
- git diff --check

## Notes
- Android backup export remains gated out until the native picker/copy path is smoke-tested there.
- Web restore is documented as a manual stop/replace app.db/restart workflow.