### PR TITLE
Fix extra scrollbar on dashboard chart views

### DIFF
--- a/apps/frontend/src/pages/dashboard/dashboard-content.tsx
+++ b/apps/frontend/src/pages/dashboard/dashboard-content.tsx
@@ -109,7 +109,7 @@ export function DashboardContent() {
   };
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-full flex-col">
       <div className="px-4 pb-1 pt-2 md:px-6 md:pb-2 lg:px-8">
         <PortfolioUpdateTrigger lastCalculatedAt={currentValuation?.calculatedAt}>
           <div className="flex items-start gap-2">

--- a/apps/frontend/src/pages/net-worth/net-worth-content.tsx
+++ b/apps/frontend/src/pages/net-worth/net-worth-content.tsx
@@ -405,7 +405,7 @@ export function NetWorthContent({ onAddAsset, onAddLiability }: NetWorthContentP
   }
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-full flex-col">
       {/* Top section: Net Worth value */}
       <div className="px-4 pb-1 pt-2 md:px-6 md:pb-2 lg:px-8">
         <div className="flex items-start gap-2">


### PR DESCRIPTION
## Summary
- Use parent-relative minimum height for investment and net worth dashboard chart views
- Avoid forcing 100vh inside nested dashboard scroll containers

Fixes #965

## Verification
- pnpm --filter frontend type-check
- git diff --check HEAD~1..HEAD