### PR TITLE
Fix release CI dependency failures

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,8 +51,6 @@ jobs:
 
       - name: pnpm Setup
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.33.4
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
@@ -139,8 +137,6 @@ jobs:
 
       - name: pnpm setup
         uses: pnpm/action-setup@v4
-        with:
-          version: 10.33.4
 
       - name: Sync node version and setup cache
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,9 @@ jobs:
         run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
       - name: pnpm Setup
-        run: npm install -g pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.4
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
@@ -136,7 +138,9 @@ jobs:
           key: prebuild-server-linux-amd64
 
       - name: pnpm setup
-        run: npm install -g pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.4
 
       - name: Sync node version and setup cache
         uses: actions/setup-node@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1127,7 +1127,7 @@ dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.10.1",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "libc",
 ]
 
@@ -2042,21 +2042,12 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -2069,12 +2060,6 @@ dependencies = [
  "quote",
  "syn 2.0.114",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2921,22 +2906,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3768,23 +3737,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe 0.1.6",
- "openssl-sys",
- "schannel",
- "security-framework 2.11.1",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4236,53 +4188,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.115"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -5395,13 +5304,11 @@ dependencies = [
  "http-body-util",
  "hyper 1.8.1",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -5412,7 +5319,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower 0.5.3",
@@ -5734,7 +5640,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe 0.2.1",
+ "openssl-probe",
  "rustls-pki-types",
  "schannel",
  "security-framework 3.5.1",
@@ -7358,16 +7264,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -59,5 +59,5 @@ connect-sync = []
 device-sync = []
 
 [dev-dependencies]
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { workspace = true }
 tempfile = "3"

--- a/crates/ai/Cargo.toml
+++ b/crates/ai/Cargo.toml
@@ -26,7 +26,7 @@ reqwest = { workspace = true }
 sha2 = { workspace = true }
 
 # LLM orchestration (rig-core crate exports as "rig")
-rig = { package = "rig-core", version = "0.30" }
+rig = { package = "rig-core", version = "0.30", default-features = false, features = ["reqwest-rustls"] }
 
 # Lazy static initialization
 once_cell = "1"

--- a/crates/market-data/Cargo.toml
+++ b/crates/market-data/Cargo.toml
@@ -8,7 +8,7 @@ async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 log = "0.4"
 num-traits = "0.2"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { workspace = true }
 rust_decimal = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "wealthfolio-app",
   "private": true,
   "version": "3.4.0",
+  "packageManager": "pnpm@10.33.4",
   "type": "module",
   "workspaces": [
     "apps/frontend",


### PR DESCRIPTION
## Summary
- pin pnpm in the release workflow to avoid lockfile mismatch failures from pnpm 11 drift
- record the pnpm package manager version in the root manifest
- switch server dependency graph to rustls-only reqwest paths so the Linux server binary no longer dynamically links OpenSSL

## Root cause
Release jobs installed floating pnpm with npm install -g pnpm, allowing pnpm 11 behavior to reject the existing pnpm 10 lockfile override metadata. The server prebuild also pulled reqwest default-tls through rig-core and a local market-data reqwest declaration, which introduced native-tls/OpenSSL into the runtime dependency graph.

## Verification
- pnpm install --frozen-lockfile
- npx -y -p pnpm@10.33.4 pnpm install --frozen-lockfile --lockfile-only
- cargo check -p wealthfolio-server
- cargo tree -p wealthfolio-server --edges normal,build --target x86_64-unknown-linux-gnu | rg "openssl|native-tls|hyper-tls|tokio-native-tls" returned no matches
- git diff --check