### PR TITLE
Fix portfolio reporting scope UI regressions

### DIFF
--- a/apps/frontend/src/pages/holdings/holdings-page.tsx
+++ b/apps/frontend/src/pages/holdings/holdings-page.tsx
@@ -122,7 +122,7 @@ export const HoldingsPage = () => {
   );
   const updatePortfolioMutation = useUpdatePortfolioMutation();
 
-  const handleAccountSelect = (account: Account) => {
+  const handleAccountSelect = useCallback((account: Account) => {
     setSelectedAccount(account);
     setIsEditMode(false);
     // Sync AccountFilter when mobile filter sheet selects an account.
@@ -131,7 +131,20 @@ export const HoldingsPage = () => {
     } else {
       setAccountFilter({ type: "account", accountId: account.id });
     }
-  };
+  }, []);
+
+  const handleAccountFilterChange = useCallback(
+    (filter: AccountFilter) => {
+      setAccountFilter(filter);
+      setIsEditMode(false);
+      setSelectedAccount(
+        filter.type === "account"
+          ? (accounts.find((account) => account.id === filter.accountId) ?? null)
+          : null,
+      );
+    },
+    [accounts],
+  );
 
   // Check if the selected account supports manual holdings editing
   const canEditHoldings = useMemo(() => {
@@ -581,7 +594,7 @@ export const HoldingsPage = () => {
             <Icons.ListFilter className="h-4 w-4" />
           </Button>
         ) : (
-          <AccountFilterSelector value={accountFilter} onChange={setAccountFilter} />
+          <AccountFilterSelector value={accountFilter} onChange={handleAccountFilterChange} />
         )}
         {/* Show Update button for HOLDINGS-mode manual accounts (only on investments tab) */}
         {canEditHoldings && !isEditMode && currentTab === "investments" && (
@@ -600,8 +613,8 @@ export const HoldingsPage = () => {
     [
       isMobileViewport,
       setIsFilterSheetOpen,
-      selectedAccount,
-      handleAccountSelect,
+      accountFilter,
+      handleAccountFilterChange,
       canEditHoldings,
       isEditMode,
       currentTab,

--- a/apps/frontend/src/pages/income/income-mobile-filter-sheet.tsx
+++ b/apps/frontend/src/pages/income/income-mobile-filter-sheet.tsx
@@ -67,22 +67,18 @@ export const IncomeMobileFilterSheet = ({
               </div>
 
               {portfolios.map((p) => {
-                const isSelected =
-                  accountFilter.type === "portfolio" && accountFilter.portfolioId === p.id;
                 return (
                   <div
                     key={p.id}
                     className={cn(
-                      "flex cursor-pointer items-center justify-between border-t p-3 text-sm transition-colors",
-                      isSelected ? "bg-accent/50 font-medium" : "hover:bg-muted/50",
+                      "text-muted-foreground flex cursor-not-allowed items-center justify-between border-t p-3 text-sm opacity-75",
                     )}
-                    onClick={() => select({ type: "portfolio", portfolioId: p.id })}
                   >
                     <span className="flex items-center gap-2">
                       <Icons.Folder className="text-muted-foreground h-4 w-4" />
                       {p.name}
                     </span>
-                    {isSelected && <Icons.Check className="text-primary h-4 w-4" />}
+                    <span className="text-xs">Coming soon</span>
                   </div>
                 );
               })}

--- a/apps/frontend/src/pages/settings/portfolios/portfolios-page.tsx
+++ b/apps/frontend/src/pages/settings/portfolios/portfolios-page.tsx
@@ -2,6 +2,16 @@ import { useState } from "react";
 import { useAccounts } from "@/hooks/use-accounts";
 import { usePortfolioMutations, usePortfolios } from "@/hooks/use-portfolios";
 import type { NewPortfolio, PortfolioWithAccounts } from "@/lib/types";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@wealthfolio/ui/components/ui/alert-dialog";
 import { Button } from "@wealthfolio/ui/components/ui/button";
 import { Checkbox } from "@wealthfolio/ui/components/ui/checkbox";
 import {
@@ -24,6 +34,7 @@ export default function PortfoliosPage() {
 
   const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState<PortfolioWithAccounts | null>(null);
+  const [deleting, setDeleting] = useState<PortfolioWithAccounts | null>(null);
 
   const openCreate = () => {
     setEditing(null);
@@ -35,8 +46,9 @@ export default function PortfoliosPage() {
     setOpen(true);
   };
 
-  const handleDelete = (id: string) => {
-    deleteMutation.mutate(id);
+  const handleDelete = () => {
+    if (!deleting) return;
+    deleteMutation.mutate(deleting.id, { onSuccess: () => setDeleting(null) });
   };
 
   return (
@@ -70,7 +82,7 @@ export default function PortfoliosPage() {
                 <Button
                   variant="ghost"
                   size="icon"
-                  onClick={() => handleDelete(p.id)}
+                  onClick={() => setDeleting(p)}
                   disabled={deleteMutation.isPending}
                 >
                   <Icons.Trash className="h-4 w-4" />
@@ -97,6 +109,29 @@ export default function PortfoliosPage() {
         }}
         isSaving={createMutation.isPending || updateMutation.isPending}
       />
+
+      <AlertDialog open={deleting !== null} onOpenChange={(value) => !value && setDeleting(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete portfolio?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This removes {deleting ? `"${deleting.name}"` : "this portfolio"} and its account
+              memberships. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleteMutation.isPending}>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              disabled={deleteMutation.isPending}
+              onClick={handleDelete}
+            >
+              <Icons.Trash className="mr-2 h-4 w-4" />
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- disable portfolio choices in the mobile Income filter until portfolio aggregation ships
- keep Holdings desktop account filter state in sync with the selected account so manual holdings updates remain available
- add a confirmation dialog before deleting portfolio reporting scopes

## Context
Follow-up to merged PR #964 from @Jonjon-prog. These are the small UI fixes from the post-merge review so the new portfolio reporting scope UI does not expose deferred behavior or one-click destructive deletes.

## Verification
- pnpm --filter frontend type-check
- pnpm --filter frontend lint
- git diff --check