### PR TITLE
fix(alt-assets): liability with future-dated payoff no longer shows as fully paid

### DIFF
--- a/crates/ai/src/env.rs
+++ b/crates/ai/src/env.rs
@@ -889,6 +889,14 @@ pub mod test_env {
             Ok(HashMap::new())
         }
 
+        fn get_latest_quotes_as_of(
+            &self,
+            _symbols: &[String],
+            _as_of: chrono::NaiveDate,
+        ) -> CoreResult<HashMap<String, Quote>> {
+            Ok(HashMap::new())
+        }
+
         fn get_latest_quotes_snapshot(
             &self,
             asset_ids: &[String],

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -616,6 +616,14 @@ mod tests {
             unimplemented!()
         }
 
+        fn get_latest_quotes_as_of(
+            &self,
+            _symbols: &[String],
+            _as_of: chrono::NaiveDate,
+        ) -> Result<HashMap<String, Quote>> {
+            Ok(HashMap::new())
+        }
+
         fn get_latest_quotes_snapshot(
             &self,
             asset_ids: &[String],

--- a/crates/core/src/assets/alternative_assets_service.rs
+++ b/crates/core/src/assets/alternative_assets_service.rs
@@ -828,7 +828,11 @@ mod tests {
             unimplemented!("not used in this test")
         }
 
-        async fn sync(&self, _mode: SyncMode, _asset_ids: Option<Vec<String>>) -> Result<SyncResult> {
+        async fn sync(
+            &self,
+            _mode: SyncMode,
+            _asset_ids: Option<Vec<String>>,
+        ) -> Result<SyncResult> {
             unimplemented!("not used in this test")
         }
 
@@ -844,7 +848,11 @@ mod tests {
             unimplemented!("not used in this test")
         }
 
-        async fn handle_activity_created(&self, _symbol: &str, _activity_date: NaiveDate) -> Result<()> {
+        async fn handle_activity_created(
+            &self,
+            _symbol: &str,
+            _activity_date: NaiveDate,
+        ) -> Result<()> {
             Ok(())
         }
 
@@ -962,9 +970,7 @@ mod tests {
                 .iter()
                 .find(|a| a.id == asset_id)
                 .cloned()
-                .ok_or_else(|| {
-                    Error::Database(DatabaseError::NotFound(asset_id.to_string()))
-                })
+                .ok_or_else(|| Error::Database(DatabaseError::NotFound(asset_id.to_string())))
         }
 
         fn list(&self) -> Result<Vec<crate::assets::assets_model::Asset>> {
@@ -987,7 +993,10 @@ mod tests {
             unimplemented!("not used in this test")
         }
 
-        fn search_by_symbol(&self, _query: &str) -> Result<Vec<crate::assets::assets_model::Asset>> {
+        fn search_by_symbol(
+            &self,
+            _query: &str,
+        ) -> Result<Vec<crate::assets::assets_model::Asset>> {
             unimplemented!("not used in this test")
         }
 

--- a/crates/core/src/assets/alternative_assets_service.rs
+++ b/crates/core/src/assets/alternative_assets_service.rs
@@ -584,14 +584,28 @@ impl AlternativeAssetServiceTrait for AlternativeAssetService {
         // Get asset IDs for quote lookup
         let asset_ids: Vec<String> = alternative_assets.iter().map(|a| a.id.clone()).collect();
 
-        // Fetch latest quotes for all alternative assets
-        let quotes = self.quote_service.get_latest_quotes(&asset_ids)?;
+        // Fetch latest quotes for all alternative assets, restricted to rows
+        // with day <= today so future-dated payoff rows (e.g. a mortgage's
+        // planned 2041 zero) do not zero out the balance today.
+        let as_of = chrono::Local::now().date_naive();
+        let quotes = self
+            .quote_service
+            .get_latest_quotes_as_of(&asset_ids, as_of)?;
 
         // Build AlternativeHolding for each asset
         let holdings: Vec<AlternativeHolding> = alternative_assets
             .into_iter()
             .filter_map(|asset| {
-                let quote = quotes.get(&asset.id)?;
+                let quote = match quotes.get(&asset.id) {
+                    Some(q) => q,
+                    None => {
+                        debug!(
+                            "Skipping alternative asset {} from holdings: no quote with day <= {}",
+                            asset.id, as_of
+                        );
+                        return None;
+                    }
+                };
 
                 // Extract purchase_price from metadata
                 let purchase_price = asset
@@ -660,6 +674,406 @@ impl AlternativeAssetServiceTrait for AlternativeAssetService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::assets::alternative_assets_traits::AlternativeAssetRepositoryTrait;
+    use crate::errors::{DatabaseError, Error, Result};
+    use crate::quotes::{
+        LatestQuotePair, LatestQuoteSnapshot, ProviderInfo, Quote, QuoteImport, QuoteServiceTrait,
+        QuoteSyncState, SymbolSearchResult, SymbolSyncPlan, SyncMode, SyncResult,
+    };
+    use chrono::NaiveDate;
+    use std::collections::{HashMap, HashSet};
+
+    // ---------------------------------------------------------------------------
+    // Minimal mock: QuoteService
+    // Only the two methods called by get_alternative_holdings are meaningful;
+    // everything else panics so accidental calls are caught immediately.
+    //
+    // Crucially, get_latest_quotes returns the "bad" future-zero quote for the
+    // asset. If the implementation accidentally calls the old method instead of
+    // get_latest_quotes_as_of, the returned market_value will be 0 and the
+    // assert_eq!(…, Decimal::new(180_000, 0)) will fail.
+    // ---------------------------------------------------------------------------
+    struct MockQuoteService {
+        /// Quotes returned by get_latest_quotes_as_of (correct, today-bounded path).
+        as_of_quotes: HashMap<String, Quote>,
+        /// Quotes returned by get_latest_quotes (old, unbounded path — should NOT be called).
+        latest_quotes: HashMap<String, Quote>,
+    }
+
+    #[async_trait]
+    impl QuoteServiceTrait for MockQuoteService {
+        fn get_latest_quote(&self, _symbol: &str) -> Result<Quote> {
+            unimplemented!("not used in this test")
+        }
+
+        fn get_latest_quotes(&self, symbols: &[String]) -> Result<HashMap<String, Quote>> {
+            // Intentionally returns "bad" future-zero quotes — fail the test if called.
+            Ok(symbols
+                .iter()
+                .filter_map(|s| self.latest_quotes.get(s).cloned().map(|q| (s.clone(), q)))
+                .collect())
+        }
+
+        fn get_latest_quotes_as_of(
+            &self,
+            symbols: &[String],
+            _as_of: NaiveDate,
+        ) -> Result<HashMap<String, Quote>> {
+            Ok(symbols
+                .iter()
+                .filter_map(|s| self.as_of_quotes.get(s).cloned().map(|q| (s.clone(), q)))
+                .collect())
+        }
+
+        fn get_latest_quotes_snapshot(
+            &self,
+            _asset_ids: &[String],
+        ) -> Result<HashMap<String, LatestQuoteSnapshot>> {
+            unimplemented!("not used in this test")
+        }
+
+        fn get_latest_quotes_pair(
+            &self,
+            _symbols: &[String],
+        ) -> Result<HashMap<String, LatestQuotePair>> {
+            unimplemented!("not used in this test")
+        }
+
+        fn get_historical_quotes(&self, _symbol: &str) -> Result<Vec<Quote>> {
+            unimplemented!("not used in this test")
+        }
+
+        fn get_all_historical_quotes(&self) -> Result<HashMap<String, Vec<(NaiveDate, Quote)>>> {
+            unimplemented!("not used in this test")
+        }
+
+        fn get_quotes_in_range(
+            &self,
+            _symbols: &HashSet<String>,
+            _start: NaiveDate,
+            _end: NaiveDate,
+        ) -> Result<Vec<Quote>> {
+            unimplemented!("not used in this test")
+        }
+
+        fn get_quotes_in_range_filled(
+            &self,
+            _symbols: &HashSet<String>,
+            _start: NaiveDate,
+            _end: NaiveDate,
+        ) -> Result<Vec<Quote>> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn get_daily_quotes(
+            &self,
+            _asset_ids: &HashSet<String>,
+            _start: NaiveDate,
+            _end: NaiveDate,
+        ) -> Result<HashMap<NaiveDate, HashMap<String, Quote>>> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn add_quote(&self, _quote: &Quote) -> Result<Quote> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn update_quote(&self, _quote: Quote) -> Result<Quote> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn delete_quote(&self, _quote_id: &str) -> Result<()> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn bulk_upsert_quotes(&self, _quotes: Vec<Quote>) -> Result<usize> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn search_symbol(&self, _query: &str) -> Result<Vec<SymbolSearchResult>> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn search_symbol_with_currency(
+            &self,
+            _query: &str,
+            _account_currency: Option<&str>,
+        ) -> Result<Vec<SymbolSearchResult>> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn get_asset_profile(
+            &self,
+            _asset: &crate::assets::assets_model::Asset,
+        ) -> Result<crate::assets::assets_model::ProviderProfile> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn fetch_quotes_from_provider(
+            &self,
+            _asset_id: &str,
+            _start: NaiveDate,
+            _end: NaiveDate,
+        ) -> Result<Vec<Quote>> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn fetch_quotes_for_symbol(
+            &self,
+            _symbol: &str,
+            _currency: &str,
+            _start: NaiveDate,
+            _end: NaiveDate,
+        ) -> Result<Vec<Quote>> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn sync(&self, _mode: SyncMode, _asset_ids: Option<Vec<String>>) -> Result<SyncResult> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn resync(&self, _asset_ids: Option<Vec<String>>) -> Result<SyncResult> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn refresh_sync_state(&self) -> Result<()> {
+            unimplemented!("not used in this test")
+        }
+
+        fn get_sync_plan(&self) -> Result<Vec<SymbolSyncPlan>> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn handle_activity_created(&self, _symbol: &str, _activity_date: NaiveDate) -> Result<()> {
+            Ok(())
+        }
+
+        async fn handle_activity_deleted(&self, _symbol: &str) -> Result<()> {
+            Ok(())
+        }
+
+        async fn delete_sync_state(&self, _symbol: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn get_symbols_needing_sync(&self) -> Result<Vec<QuoteSyncState>> {
+            Ok(Vec::new())
+        }
+
+        fn get_sync_state(&self, _symbol: &str) -> Result<Option<QuoteSyncState>> {
+            Ok(None)
+        }
+
+        async fn mark_profile_enriched(&self, _symbol: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn get_assets_needing_profile_enrichment(&self) -> Result<Vec<QuoteSyncState>> {
+            Ok(Vec::new())
+        }
+
+        fn get_sync_states_with_errors(&self) -> Result<Vec<QuoteSyncState>> {
+            Ok(Vec::new())
+        }
+
+        async fn reset_sync_errors(&self, _asset_ids: &[String]) -> Result<()> {
+            Ok(())
+        }
+
+        async fn reset_sync_state_for_profile_change(&self, _asset_id: &str) -> Result<()> {
+            Ok(())
+        }
+
+        async fn update_position_status_from_holdings(
+            &self,
+            _current_holdings: &HashMap<String, rust_decimal::Decimal>,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn get_providers_info(&self) -> Result<Vec<ProviderInfo>> {
+            Ok(Vec::new())
+        }
+
+        async fn update_provider_settings(
+            &self,
+            _provider_id: &str,
+            _priority: i32,
+            _enabled: bool,
+        ) -> Result<()> {
+            Ok(())
+        }
+
+        async fn check_quotes_import(
+            &self,
+            _content: &[u8],
+            _has_header_row: bool,
+        ) -> Result<Vec<QuoteImport>> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn import_quotes(
+            &self,
+            _quotes: Vec<QuoteImport>,
+            _overwrite: bool,
+        ) -> Result<Vec<QuoteImport>> {
+            unimplemented!("not used in this test")
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Minimal mock: AssetRepository — returns a fixed list of assets.
+    // ---------------------------------------------------------------------------
+    struct MockAssetRepository {
+        assets: Vec<crate::assets::assets_model::Asset>,
+    }
+
+    #[async_trait]
+    impl AssetRepositoryTrait for MockAssetRepository {
+        async fn create(&self, _new_asset: NewAsset) -> Result<crate::assets::assets_model::Asset> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn create_batch(
+            &self,
+            _new_assets: Vec<NewAsset>,
+        ) -> Result<Vec<crate::assets::assets_model::Asset>> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn update_profile(
+            &self,
+            _asset_id: &str,
+            _payload: crate::assets::UpdateAssetProfile,
+        ) -> Result<crate::assets::assets_model::Asset> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn update_quote_mode(
+            &self,
+            _asset_id: &str,
+            _quote_mode: &str,
+        ) -> Result<crate::assets::assets_model::Asset> {
+            unimplemented!("not used in this test")
+        }
+
+        fn get_by_id(&self, asset_id: &str) -> Result<crate::assets::assets_model::Asset> {
+            self.assets
+                .iter()
+                .find(|a| a.id == asset_id)
+                .cloned()
+                .ok_or_else(|| {
+                    Error::Database(DatabaseError::NotFound(asset_id.to_string()))
+                })
+        }
+
+        fn list(&self) -> Result<Vec<crate::assets::assets_model::Asset>> {
+            Ok(self.assets.clone())
+        }
+
+        fn list_by_asset_ids(
+            &self,
+            asset_ids: &[String],
+        ) -> Result<Vec<crate::assets::assets_model::Asset>> {
+            Ok(self
+                .assets
+                .iter()
+                .filter(|a| asset_ids.contains(&a.id))
+                .cloned()
+                .collect())
+        }
+
+        async fn delete(&self, _asset_id: &str) -> Result<()> {
+            unimplemented!("not used in this test")
+        }
+
+        fn search_by_symbol(&self, _query: &str) -> Result<Vec<crate::assets::assets_model::Asset>> {
+            unimplemented!("not used in this test")
+        }
+
+        fn find_by_instrument_key(
+            &self,
+            _instrument_key: &str,
+        ) -> Result<Option<crate::assets::assets_model::Asset>> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn cleanup_legacy_metadata(&self, _asset_id: &str) -> Result<()> {
+            Ok(())
+        }
+
+        async fn deactivate(&self, _asset_id: &str) -> Result<()> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn reactivate(&self, _asset_id: &str) -> Result<()> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn copy_user_metadata(&self, _source_id: &str, _target_id: &str) -> Result<()> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn deactivate_orphaned_investments(&self) -> Result<Vec<String>> {
+            Ok(Vec::new())
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Minimal mock: AlternativeAssetRepository — not called by get_alternative_holdings
+    // ---------------------------------------------------------------------------
+    struct NoOpAltAssetRepository;
+
+    #[async_trait]
+    impl AlternativeAssetRepositoryTrait for NoOpAltAssetRepository {
+        async fn delete_alternative_asset(&self, _asset_id: &str) -> Result<()> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn update_asset_metadata(
+            &self,
+            _asset_id: &str,
+            _metadata: Option<serde_json::Value>,
+        ) -> Result<()> {
+            unimplemented!("not used in this test")
+        }
+
+        fn find_liabilities_linked_to(&self, _linked_asset_id: &str) -> Result<Vec<String>> {
+            unimplemented!("not used in this test")
+        }
+
+        async fn update_asset_details(
+            &self,
+            _asset_id: &str,
+            _name: Option<&str>,
+            _display_code: Option<&str>,
+            _metadata: Option<serde_json::Value>,
+            _notes: Option<&str>,
+        ) -> Result<()> {
+            unimplemented!("not used in this test")
+        }
+    }
+
+    // Helper: build a minimal Quote for a given asset + close value + date.
+    fn make_quote(asset_id: &str, close: Decimal, day: NaiveDate) -> Quote {
+        use chrono::{TimeZone, Utc};
+        let ts = Utc.from_utc_datetime(&day.and_hms_opt(12, 0, 0).unwrap());
+        Quote {
+            id: uuid::Uuid::new_v4().to_string(),
+            asset_id: asset_id.to_string(),
+            timestamp: ts,
+            open: close,
+            high: close,
+            low: close,
+            close,
+            adjclose: close,
+            volume: Decimal::ZERO,
+            currency: "EUR".to_string(),
+            data_source: "MANUAL".to_string(),
+            created_at: Utc::now(),
+            notes: None,
+        }
+    }
 
     #[test]
     fn test_validate_alternative_asset_kind() {
@@ -728,5 +1142,67 @@ mod tests {
 
         let removed = AlternativeAssetService::remove_linked_asset_id(Some(metadata));
         assert!(removed.is_none()); // Only had linked_asset_id, so should be None when removed
+    }
+
+    /// Regression test for: liability with a future-dated 0 quote must NOT appear
+    /// as "fully paid" in today's holdings.
+    ///
+    /// The mock's `get_latest_quotes` returns a zero quote dated 2041-01-01 (the
+    /// planned payoff date). The mock's `get_latest_quotes_as_of` returns the
+    /// correct today-bounded quote with close = 180_000. If the implementation
+    /// accidentally calls the old method the assertion will fail with 0 ≠ 180_000.
+    #[test]
+    fn get_alternative_holdings_uses_past_quote_for_liability_with_future_zero() {
+        const ASSET_ID: &str = "mortgage-001";
+
+        let past_day = NaiveDate::from_ymd_opt(2025, 11, 1).unwrap();
+        let future_day = NaiveDate::from_ymd_opt(2041, 1, 1).unwrap();
+
+        let past_quote = make_quote(ASSET_ID, Decimal::new(180_000, 0), past_day);
+        let future_zero_quote = make_quote(ASSET_ID, Decimal::ZERO, future_day);
+
+        let quote_svc = MockQuoteService {
+            as_of_quotes: [(ASSET_ID.to_string(), past_quote)].into_iter().collect(),
+            latest_quotes: [(ASSET_ID.to_string(), future_zero_quote)]
+                .into_iter()
+                .collect(),
+        };
+
+        let liability = crate::assets::assets_model::Asset {
+            id: ASSET_ID.to_string(),
+            kind: AssetKind::Liability,
+            name: Some("Home Mortgage".to_string()),
+            display_code: Some("Mortgage".to_string()),
+            quote_ccy: "EUR".to_string(),
+            is_active: true,
+            quote_mode: QuoteMode::Manual,
+            metadata: Some(json!({
+                "original_amount": "200000",
+                "purchase_price": "200000",
+            })),
+            ..Default::default()
+        };
+
+        let asset_repo = MockAssetRepository {
+            assets: vec![liability],
+        };
+        let alt_repo = NoOpAltAssetRepository;
+
+        let service = AlternativeAssetService::new(
+            Arc::new(alt_repo),
+            Arc::new(asset_repo),
+            Arc::new(quote_svc),
+        );
+
+        let holdings = service
+            .get_alternative_holdings()
+            .expect("get_alternative_holdings should succeed");
+
+        assert_eq!(holdings.len(), 1, "expected exactly one holding");
+        assert_eq!(
+            holdings[0].market_value,
+            Decimal::new(180_000, 0),
+            "market_value must reflect the past-dated quote, not the future 0 payoff row"
+        );
     }
 }

--- a/crates/core/src/assets/assets_service.rs
+++ b/crates/core/src/assets/assets_service.rs
@@ -2766,6 +2766,14 @@ mod tests {
             unimplemented!()
         }
 
+        fn get_latest_quotes_as_of(
+            &self,
+            _symbols: &[String],
+            _as_of: chrono::NaiveDate,
+        ) -> Result<HashMap<String, Quote>> {
+            Ok(HashMap::new())
+        }
+
         fn get_latest_quotes_snapshot(
             &self,
             _asset_ids: &[String],

--- a/crates/core/src/portfolio/holdings/holdings_valuation_service_tests.rs
+++ b/crates/core/src/portfolio/holdings/holdings_valuation_service_tests.rs
@@ -176,6 +176,14 @@ mod tests {
             unimplemented!()
         }
 
+        fn get_latest_quotes_as_of(
+            &self,
+            _symbols: &[String],
+            _as_of: chrono::NaiveDate,
+        ) -> Result<HashMap<String, Quote>> {
+            Ok(HashMap::new())
+        }
+
         fn get_latest_quotes_snapshot(
             &self,
             asset_ids: &[String],

--- a/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
+++ b/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
@@ -1895,3 +1895,66 @@ async fn test_newly_created_account_has_default_archive_values_net_worth() {
         "Test helper should create active accounts"
     );
 }
+
+// ============================================================================
+// Regression Tests
+// ============================================================================
+
+/// Regression: a liability that has a future-dated $0 quote (e.g. a mortgage planned
+/// payoff date) must NOT appear as fully paid-off when computing net worth today.
+/// The `get_latest_quote_as_of` logic filters quotes to those on or before the
+/// requested date, so the future $0 row should be ignored and the most-recent
+/// past balance ($180,000) should be used instead.
+#[tokio::test]
+async fn test_liability_with_future_zero_quote_is_included_at_past_balance() {
+    let valuation_date = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
+
+    // A mortgage LIABILITY account and asset
+    let liab_account = create_test_account("liab-mortgage", "LIABILITY", "USD");
+    let liab_asset = create_test_asset("LIAB-mortgage-reg", AssetKind::Liability, "USD");
+
+    // The position records the outstanding balance as quantity=1, cost-basis=180_000
+    let liab_position = create_test_position(
+        "liab-mortgage",
+        "LIAB-mortgage-reg",
+        dec!(1),
+        dec!(180000),
+        "USD",
+    );
+    let liab_snapshot =
+        create_test_snapshot("liab-mortgage", vec![liab_position], HashMap::new());
+
+    // Two quotes for the same liability:
+    //   • 2024-01-10: current outstanding balance = $180,000
+    //   • 2041-01-01: planned payoff date recorded as $0 (future-dated)
+    let past_quote = create_test_quote(
+        "LIAB-mortgage-reg",
+        dec!(180000),
+        NaiveDate::from_ymd_opt(2024, 1, 10).unwrap(),
+        "USD",
+    );
+    let future_zero_quote = create_test_quote(
+        "LIAB-mortgage-reg",
+        dec!(0),
+        NaiveDate::from_ymd_opt(2041, 1, 1).unwrap(),
+        "USD",
+    );
+
+    let service = create_net_worth_service(
+        vec![liab_account],
+        vec![liab_asset],
+        vec![liab_snapshot],
+        vec![past_quote, future_zero_quote],
+    );
+
+    let result = service.get_net_worth(valuation_date).await.unwrap();
+
+    // The future $0 quote must be excluded; the liability must appear at $180,000.
+    assert_eq!(
+        result.liabilities.total,
+        dec!(180000),
+        "liability with a future-dated $0 quote should be valued at the most-recent past quote"
+    );
+    // Net worth = assets (0) - liabilities (180_000) = -180_000
+    assert_eq!(result.net_worth, dec!(-180000));
+}

--- a/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
+++ b/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
@@ -1921,8 +1921,7 @@ async fn test_liability_with_future_zero_quote_is_included_at_past_balance() {
         dec!(180000),
         "USD",
     );
-    let liab_snapshot =
-        create_test_snapshot("liab-mortgage", vec![liab_position], HashMap::new());
+    let liab_snapshot = create_test_snapshot("liab-mortgage", vec![liab_position], HashMap::new());
 
     // Two quotes for the same liability:
     //   • 2024-01-10: current outstanding balance = $180,000

--- a/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
+++ b/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
@@ -352,6 +352,14 @@ impl QuoteServiceTrait for MockMarketDataRepository {
         Ok(result)
     }
 
+    fn get_latest_quotes_as_of(
+        &self,
+        _symbols: &[String],
+        _as_of: chrono::NaiveDate,
+    ) -> Result<HashMap<String, Quote>> {
+        Ok(HashMap::new())
+    }
+
     fn get_latest_quotes_snapshot(
         &self,
         asset_ids: &[String],

--- a/crates/core/src/quotes/service.rs
+++ b/crates/core/src/quotes/service.rs
@@ -294,6 +294,13 @@ pub trait QuoteServiceTrait: Send + Sync {
     /// Get the latest quotes for multiple symbols.
     fn get_latest_quotes(&self, symbols: &[String]) -> Result<HashMap<String, Quote>>;
 
+    /// Get the latest quotes for multiple symbols, restricted to rows with `day <= as_of`.
+    fn get_latest_quotes_as_of(
+        &self,
+        symbols: &[String],
+        as_of: chrono::NaiveDate,
+    ) -> Result<HashMap<String, Quote>>;
+
     /// Get latest quotes with backend-computed staleness metadata.
     fn get_latest_quotes_snapshot(
         &self,
@@ -904,6 +911,27 @@ where
 
     fn get_latest_quotes(&self, symbols: &[String]) -> Result<HashMap<String, Quote>> {
         let mut quotes = self.quote_store.get_latest_quotes(symbols)?;
+        let assets = self.asset_repo.list_by_asset_ids(symbols)?;
+        let assets_by_id: HashMap<String, Asset> = assets
+            .into_iter()
+            .map(|asset| (asset.id.clone(), asset))
+            .collect();
+
+        for (asset_id, quote) in quotes.iter_mut() {
+            if let Some(asset) = assets_by_id.get(asset_id) {
+                reconcile_quote_currency(quote, asset);
+            }
+        }
+
+        Ok(quotes)
+    }
+
+    fn get_latest_quotes_as_of(
+        &self,
+        symbols: &[String],
+        as_of: chrono::NaiveDate,
+    ) -> Result<HashMap<String, Quote>> {
+        let mut quotes = self.quote_store.get_latest_quotes_as_of(symbols, as_of)?;
         let assets = self.asset_repo.list_by_asset_ids(symbols)?;
         let assets_by_id: HashMap<String, Asset> = assets
             .into_iter()
@@ -2631,6 +2659,14 @@ mod tests {
             unimplemented!("unused in this test")
         }
 
+        fn get_latest_quotes_as_of(
+            &self,
+            _symbols: &[String],
+            _as_of: chrono::NaiveDate,
+        ) -> Result<HashMap<String, Quote>> {
+            Ok(HashMap::new())
+        }
+
         fn get_latest_quotes_pair(
             &self,
             _symbols: &[String],
@@ -2747,6 +2783,14 @@ mod tests {
                         .map(|quote| (symbol.clone(), quote))
                 })
                 .collect())
+        }
+
+        fn get_latest_quotes_as_of(
+            &self,
+            _symbols: &[String],
+            _as_of: chrono::NaiveDate,
+        ) -> Result<HashMap<String, Quote>> {
+            Ok(HashMap::new())
         }
 
         fn get_latest_quotes_pair(

--- a/crates/core/src/quotes/service_tests.rs
+++ b/crates/core/src/quotes/service_tests.rs
@@ -209,6 +209,14 @@ mod tests {
                 .collect())
         }
 
+        fn get_latest_quotes_as_of(
+            &self,
+            _symbols: &[String],
+            _as_of: chrono::NaiveDate,
+        ) -> Result<HashMap<String, Quote>> {
+            Ok(HashMap::new())
+        }
+
         fn get_latest_quotes_pair(
             &self,
             symbols: &[String],

--- a/crates/core/src/quotes/store.rs
+++ b/crates/core/src/quotes/store.rs
@@ -243,6 +243,25 @@ pub trait QuoteStore: Send + Sync {
     /// A map from symbol to its latest quote. Symbols without quotes are omitted.
     fn get_latest_quotes(&self, symbols: &[String]) -> Result<HashMap<String, Quote>>;
 
+    /// Gets the most recent quote per symbol whose `day` is on or before `as_of`.
+    ///
+    /// Future-dated quotes (e.g. scheduled liability payoff balances) are
+    /// excluded. A symbol with no qualifying row is omitted from the result.
+    ///
+    /// # Arguments
+    ///
+    /// * `symbols` - The ticker symbols to query
+    /// * `as_of` - Inclusive upper bound on the quote's `day`
+    ///
+    /// # Returns
+    ///
+    /// A map from symbol to its latest qualifying quote.
+    fn get_latest_quotes_as_of(
+        &self,
+        symbols: &[String],
+        as_of: NaiveDate,
+    ) -> Result<HashMap<String, Quote>>;
+
     /// Gets the latest and previous quotes for multiple symbols.
     ///
     /// # Deprecated

--- a/crates/storage-sqlite/src/market_data/repository.rs
+++ b/crates/storage-sqlite/src/market_data/repository.rs
@@ -535,6 +535,54 @@ impl QuoteStore for MarketDataRepository {
         Ok(result)
     }
 
+    fn get_latest_quotes_as_of(
+        &self,
+        symbols: &[String],
+        as_of: chrono::NaiveDate,
+    ) -> Result<HashMap<String, Quote>> {
+        if symbols.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let mut conn = get_connection(&self.pool)?;
+        let mut result: HashMap<String, Quote> = HashMap::new();
+        let as_of_str = as_of.format("%Y-%m-%d").to_string();
+
+        for chunk in chunk_for_sqlite(symbols) {
+            let placeholders = chunk.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+
+            let sql = format!(
+                "WITH RankedQuotes AS ( \
+                    SELECT \
+                        q.*, \
+                        ROW_NUMBER() OVER (PARTITION BY q.asset_id ORDER BY q.day DESC, {priority} ASC) as rn \
+                    FROM quotes q \
+                    WHERE q.asset_id IN ({placeholders}) AND q.day <= ? \
+                ) \
+                SELECT * FROM RankedQuotes WHERE rn = 1 \
+                ORDER BY asset_id",
+                priority = SOURCE_PRIORITY_CASE_Q,
+                placeholders = placeholders
+            );
+
+            let mut query_builder = Box::new(sql_query(sql)).into_boxed::<Sqlite>();
+
+            for symbol_val in chunk {
+                query_builder = query_builder.bind::<Text, _>(symbol_val);
+            }
+            query_builder = query_builder.bind::<Text, _>(as_of_str.clone());
+
+            let ranked_quotes_db: Vec<QuoteDB> =
+                query_builder.load::<QuoteDB>(&mut conn).into_core()?;
+
+            for quote_db in ranked_quotes_db {
+                result.insert(quote_db.asset_id.clone(), quote_db.into());
+            }
+        }
+
+        Ok(result)
+    }
+
     fn get_latest_quotes_pair(
         &self,
         symbols: &[String],
@@ -1000,5 +1048,43 @@ mod tests {
             .expect("get_latest_quote should succeed");
         assert_eq!(latest.data_source, "YAHOO");
         assert_eq!(latest.close, Decimal::from(180));
+    }
+
+    /// `get_latest_quotes_as_of` must exclude quotes whose `day` is after the
+    /// supplied cutoff, and omit the asset entirely when no qualifying row exists.
+    #[tokio::test]
+    async fn get_latest_quotes_as_of_excludes_future_rows() {
+        let (repo, _temp) = create_test_repository().await;
+        let asset_id = "MORGAGE";
+        insert_test_asset(&repo, asset_id);
+
+        let past = NaiveDate::from_ymd_opt(2020, 1, 1).unwrap();
+        let present = NaiveDate::from_ymd_opt(2024, 6, 1).unwrap();
+        let future = NaiveDate::from_ymd_opt(2041, 12, 31).unwrap();
+
+        repo.save_quote(&quote_with_source(asset_id, past, "MANUAL", Decimal::from(100_000)))
+            .await
+            .expect("save past");
+        repo.save_quote(&quote_with_source(asset_id, present, "MANUAL", Decimal::from(80_000)))
+            .await
+            .expect("save present");
+        repo.save_quote(&quote_with_source(asset_id, future, "MANUAL", Decimal::ZERO))
+            .await
+            .expect("save future");
+
+        // as_of = present: should return the present row (not the future row)
+        let result = repo
+            .get_latest_quotes_as_of(&[asset_id.to_string()], present)
+            .expect("get_latest_quotes_as_of should succeed");
+        assert_eq!(result.len(), 1, "should have one entry");
+        let quote = result.get(asset_id).expect("asset should be present");
+        assert_eq!(quote.close, Decimal::from(80_000), "should return present row, not future");
+
+        // as_of = before all rows: asset should be absent
+        let before_all = NaiveDate::from_ymd_opt(2019, 12, 31).unwrap();
+        let empty = repo
+            .get_latest_quotes_as_of(&[asset_id.to_string()], before_all)
+            .expect("get_latest_quotes_as_of should succeed with empty result");
+        assert!(empty.is_empty(), "no quotes before all rows");
     }
 }

--- a/crates/storage-sqlite/src/market_data/repository.rs
+++ b/crates/storage-sqlite/src/market_data/repository.rs
@@ -1062,15 +1062,30 @@ mod tests {
         let present = NaiveDate::from_ymd_opt(2024, 6, 1).unwrap();
         let future = NaiveDate::from_ymd_opt(2041, 12, 31).unwrap();
 
-        repo.save_quote(&quote_with_source(asset_id, past, "MANUAL", Decimal::from(100_000)))
-            .await
-            .expect("save past");
-        repo.save_quote(&quote_with_source(asset_id, present, "MANUAL", Decimal::from(80_000)))
-            .await
-            .expect("save present");
-        repo.save_quote(&quote_with_source(asset_id, future, "MANUAL", Decimal::ZERO))
-            .await
-            .expect("save future");
+        repo.save_quote(&quote_with_source(
+            asset_id,
+            past,
+            "MANUAL",
+            Decimal::from(100_000),
+        ))
+        .await
+        .expect("save past");
+        repo.save_quote(&quote_with_source(
+            asset_id,
+            present,
+            "MANUAL",
+            Decimal::from(80_000),
+        ))
+        .await
+        .expect("save present");
+        repo.save_quote(&quote_with_source(
+            asset_id,
+            future,
+            "MANUAL",
+            Decimal::ZERO,
+        ))
+        .await
+        .expect("save future");
 
         // as_of = present: should return the present row (not the future row)
         let result = repo
@@ -1078,7 +1093,11 @@ mod tests {
             .expect("get_latest_quotes_as_of should succeed");
         assert_eq!(result.len(), 1, "should have one entry");
         let quote = result.get(asset_id).expect("asset should be present");
-        assert_eq!(quote.close, Decimal::from(80_000), "should return present row, not future");
+        assert_eq!(
+            quote.close,
+            Decimal::from(80_000),
+            "should return present row, not future"
+        );
 
         // as_of = before all rows: asset should be absent
         let before_all = NaiveDate::from_ymd_opt(2019, 12, 31).unwrap();


### PR DESCRIPTION
## Summary
- `AlternativeAssetService::get_alternative_holdings` now selects the latest quote with `day <= today` instead of the absolute latest row. A liability with a future-dated `0` value-history entry (e.g. a mortgage's planned payoff in 2041) previously made the asset appear fully paid in the asset-detail UI and silently dropped its outstanding balance from holdings widgets. It is now valued at the most recent past balance.
- New trait method `get_latest_quotes_as_of(symbols, as_of)` on `QuoteStore` / `QuoteServiceTrait`, with a SQLite impl that adds `AND q.day <= ?` to the existing CTE. All other callers of `get_latest_quotes` are unchanged.
- A `debug!` log line is emitted when an alternative asset is skipped because it has no value-history row with `day <= today` (e.g. a liability whose only entries are future-dated).

## Test plan
- [x] `cargo test -p wealthfolio-storage-sqlite get_latest_quotes_as_of_excludes_future_rows` — verifies the new SQL filter (past row returned, asset omitted when `as_of` precedes all rows).
- [x] `cargo test -p wealthfolio-core get_alternative_holdings_uses_past_quote_for_liability_with_future_zero` — service-layer regression test.
- [x] `cargo test -p wealthfolio-core test_liability_with_future_zero_quote_is_included_at_past_balance` — net-worth regression test.
- [x] Manual: liability with a future-dated `0` row now reports correct balance in the asset detail view and is included in Net Worth at the most recent past balance. Verified against a self-hosted web build.