### PR TITLE
feat(portfolio-filters): wire AccountFilter into Holdings, Income, Allocations, Activity

### DIFF
--- a/apps/frontend/src/adapters/adapter-command-parity.test.ts
+++ b/apps/frontend/src/adapters/adapter-command-parity.test.ts
@@ -97,12 +97,218 @@ describe("adapter command parity", () => {
     });
 
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe("/api/v1/allocations/holdings");
+    expect(url).toBe("/api/v1/allocations/holdings/query");
     expect(init.method).toBe("POST");
     expect(JSON.parse(init.body as string)).toEqual({
       filter: { type: "all" },
       taxonomyId: "asset_classes",
       categoryId: "EQUITY",
+    });
+  });
+});
+
+// ─── Scope routing coverage ───────────────────────────────────────────────────
+
+function stubFetch(body: unknown = []) {
+  const res = new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+  const mock = vi.fn<typeof fetch>().mockResolvedValue(res);
+  vi.stubGlobal("fetch", mock);
+  return mock;
+}
+
+function lastCall(mock: ReturnType<typeof stubFetch>) {
+  const [url, init] = mock.mock.calls[0] as [string, RequestInit];
+  return { url, method: (init as RequestInit & { method: string }).method, body: init.body };
+}
+
+describe("scope-based routing — get_holdings", () => {
+  it("all → POST /holdings/query", async () => {
+    const mock = stubFetch();
+    await invoke("get_holdings", { filter: { type: "all" } });
+    const { url, method, body } = lastCall(mock);
+    expect(url).toBe("/api/v1/holdings/query");
+    expect(method).toBe("POST");
+    expect(JSON.parse(body as string)).toEqual({ filter: { type: "all" } });
+  });
+
+  it("account → GET /holdings?accountId=...", async () => {
+    const mock = stubFetch();
+    await invoke("get_holdings", { filter: { type: "account", accountId: "acc_1" } });
+    const { url, method } = lastCall(mock);
+    expect(url).toBe("/api/v1/holdings?accountId=acc_1");
+    expect(method).toBe("GET");
+  });
+
+  it("portfolio → POST /holdings/query", async () => {
+    const mock = stubFetch();
+    await invoke("get_holdings", { filter: { type: "portfolio", portfolioId: "pf_1" } });
+    const { url, method, body } = lastCall(mock);
+    expect(url).toBe("/api/v1/holdings/query");
+    expect(method).toBe("POST");
+    expect(JSON.parse(body as string)).toEqual({
+      filter: { type: "portfolio", portfolioId: "pf_1" },
+    });
+  });
+
+  it("accounts → POST /holdings/query", async () => {
+    const mock = stubFetch();
+    await invoke("get_holdings", {
+      filter: { type: "accounts", accountIds: ["acc_1", "acc_2"] },
+    });
+    const { url, method, body } = lastCall(mock);
+    expect(url).toBe("/api/v1/holdings/query");
+    expect(method).toBe("POST");
+    expect(JSON.parse(body as string)).toEqual({
+      filter: { type: "accounts", accountIds: ["acc_1", "acc_2"] },
+    });
+  });
+});
+
+describe("scope-based routing — get_portfolio_allocations", () => {
+  it("all → POST /allocations/query", async () => {
+    const mock = stubFetch();
+    await invoke("get_portfolio_allocations", { filter: { type: "all" } });
+    const { url, method, body } = lastCall(mock);
+    expect(url).toBe("/api/v1/allocations/query");
+    expect(method).toBe("POST");
+    expect(JSON.parse(body as string)).toEqual({ filter: { type: "all" } });
+  });
+
+  it("account → GET /allocations?accountId=...", async () => {
+    const mock = stubFetch();
+    await invoke("get_portfolio_allocations", {
+      filter: { type: "account", accountId: "acc_1" },
+    });
+    const { url, method } = lastCall(mock);
+    expect(url).toBe("/api/v1/allocations?accountId=acc_1");
+    expect(method).toBe("GET");
+  });
+
+  it("portfolio → POST /allocations/query", async () => {
+    const mock = stubFetch();
+    await invoke("get_portfolio_allocations", {
+      filter: { type: "portfolio", portfolioId: "pf_1" },
+    });
+    const { url, method, body } = lastCall(mock);
+    expect(url).toBe("/api/v1/allocations/query");
+    expect(method).toBe("POST");
+    expect(JSON.parse(body as string)).toEqual({
+      filter: { type: "portfolio", portfolioId: "pf_1" },
+    });
+  });
+
+  it("accounts → POST /allocations/query", async () => {
+    const mock = stubFetch();
+    await invoke("get_portfolio_allocations", {
+      filter: { type: "accounts", accountIds: ["acc_1", "acc_2"] },
+    });
+    const { url, method, body } = lastCall(mock);
+    expect(url).toBe("/api/v1/allocations/query");
+    expect(method).toBe("POST");
+    expect(JSON.parse(body as string)).toEqual({
+      filter: { type: "accounts", accountIds: ["acc_1", "acc_2"] },
+    });
+  });
+});
+
+describe("scope-based routing — get_holdings_by_allocation", () => {
+  const drilldown = { taxonomyId: "asset_classes", categoryId: "EQUITY" };
+
+  it("all → POST /allocations/holdings/query", async () => {
+    const mock = stubFetch();
+    await invoke("get_holdings_by_allocation", { filter: { type: "all" }, ...drilldown });
+    const { url, method, body } = lastCall(mock);
+    expect(url).toBe("/api/v1/allocations/holdings/query");
+    expect(method).toBe("POST");
+    expect(JSON.parse(body as string)).toEqual({ filter: { type: "all" }, ...drilldown });
+  });
+
+  it("account → GET /allocations/holdings?...", async () => {
+    const mock = stubFetch();
+    await invoke("get_holdings_by_allocation", {
+      filter: { type: "account", accountId: "acc_1" },
+      ...drilldown,
+    });
+    const { url, method } = lastCall(mock);
+    expect(url).toBe(
+      "/api/v1/allocations/holdings?accountId=acc_1&taxonomyId=asset_classes&categoryId=EQUITY",
+    );
+    expect(method).toBe("GET");
+  });
+
+  it("portfolio → POST /allocations/holdings/query", async () => {
+    const mock = stubFetch();
+    await invoke("get_holdings_by_allocation", {
+      filter: { type: "portfolio", portfolioId: "pf_1" },
+      ...drilldown,
+    });
+    const { url, method, body } = lastCall(mock);
+    expect(url).toBe("/api/v1/allocations/holdings/query");
+    expect(method).toBe("POST");
+    expect(JSON.parse(body as string)).toEqual({
+      filter: { type: "portfolio", portfolioId: "pf_1" },
+      ...drilldown,
+    });
+  });
+
+  it("accounts → POST /allocations/holdings/query", async () => {
+    const mock = stubFetch();
+    await invoke("get_holdings_by_allocation", {
+      filter: { type: "accounts", accountIds: ["acc_1", "acc_2"] },
+      ...drilldown,
+    });
+    const { url, method, body } = lastCall(mock);
+    expect(url).toBe("/api/v1/allocations/holdings/query");
+    expect(method).toBe("POST");
+    expect(JSON.parse(body as string)).toEqual({
+      filter: { type: "accounts", accountIds: ["acc_1", "acc_2"] },
+      ...drilldown,
+    });
+  });
+});
+
+describe("scope-based routing — get_income_summary", () => {
+  it("all → POST /income/summary/query", async () => {
+    const mock = stubFetch();
+    await invoke("get_income_summary", { filter: { type: "all" } });
+    const { url, method, body } = lastCall(mock);
+    expect(url).toBe("/api/v1/income/summary/query");
+    expect(method).toBe("POST");
+    expect(JSON.parse(body as string)).toEqual({ filter: { type: "all" } });
+  });
+
+  it("account → GET /income/summary?accountId=...", async () => {
+    const mock = stubFetch();
+    await invoke("get_income_summary", { filter: { type: "account", accountId: "acc_1" } });
+    const { url, method } = lastCall(mock);
+    expect(url).toBe("/api/v1/income/summary?accountId=acc_1");
+    expect(method).toBe("GET");
+  });
+
+  it("portfolio → POST /income/summary/query", async () => {
+    const mock = stubFetch();
+    await invoke("get_income_summary", { filter: { type: "portfolio", portfolioId: "pf_1" } });
+    const { url, method, body } = lastCall(mock);
+    expect(url).toBe("/api/v1/income/summary/query");
+    expect(method).toBe("POST");
+    expect(JSON.parse(body as string)).toEqual({
+      filter: { type: "portfolio", portfolioId: "pf_1" },
+    });
+  });
+
+  it("accounts → POST /income/summary/query", async () => {
+    const mock = stubFetch();
+    await invoke("get_income_summary", {
+      filter: { type: "accounts", accountIds: ["acc_1", "acc_2"] },
+    });
+    const { url, method, body } = lastCall(mock);
+    expect(url).toBe("/api/v1/income/summary/query");
+    expect(method).toBe("POST");
+    expect(JSON.parse(body as string)).toEqual({
+      filter: { type: "accounts", accountIds: ["acc_1", "acc_2"] },
     });
   });
 });

--- a/apps/frontend/src/adapters/adapter-command-parity.test.ts
+++ b/apps/frontend/src/adapters/adapter-command-parity.test.ts
@@ -91,15 +91,18 @@ describe("adapter command parity", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     await invoke("get_holdings_by_allocation", {
-      accountId: "PORTFOLIO",
+      filter: { type: "all" },
       taxonomyId: "asset_classes",
       categoryId: "EQUITY",
     });
 
     const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
-    expect(url).toBe(
-      "/api/v1/allocations/holdings?accountId=PORTFOLIO&taxonomyId=asset_classes&categoryId=EQUITY",
-    );
-    expect(init.method).toBe("GET");
+    expect(url).toBe("/api/v1/allocations/holdings");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      filter: { type: "all" },
+      taxonomyId: "asset_classes",
+      categoryId: "EQUITY",
+    });
   });
 });

--- a/apps/frontend/src/adapters/shared/portfolio.ts
+++ b/apps/frontend/src/adapters/shared/portfolio.ts
@@ -1,5 +1,6 @@
 // Portfolio Commands
 import type {
+  AccountFilter,
   Holding,
   AllocationHoldings,
   IncomeSummary,
@@ -23,12 +24,12 @@ export const recalculatePortfolio = async (): Promise<void> => {
   return invoke<void>("recalculate_portfolio");
 };
 
-export const getHoldings = async (accountId: string): Promise<Holding[]> => {
-  return invoke<Holding[]>("get_holdings", { accountId });
+export const getHoldings = async (filter: AccountFilter): Promise<Holding[]> => {
+  return invoke<Holding[]>("get_holdings", { filter });
 };
 
-export const getIncomeSummary = async (accountId?: string): Promise<IncomeSummary[]> => {
-  return invoke<IncomeSummary[]>("get_income_summary", { accountId });
+export const getIncomeSummary = async (filter?: AccountFilter): Promise<IncomeSummary[]> => {
+  return invoke<IncomeSummary[]>("get_income_summary", { filter });
 };
 
 export const getHistoricalValuations = async (
@@ -130,8 +131,10 @@ export const getAssetHoldings = async (assetId: string): Promise<Holding[]> => {
   return invoke<Holding[]>("get_asset_holdings", { assetId });
 };
 
-export const getPortfolioAllocations = async (accountId: string): Promise<PortfolioAllocations> => {
-  return invoke<PortfolioAllocations>("get_portfolio_allocations", { accountId });
+export const getPortfolioAllocations = async (
+  filter: AccountFilter,
+): Promise<PortfolioAllocations> => {
+  return invoke<PortfolioAllocations>("get_portfolio_allocations", { filter });
 };
 
 /**
@@ -140,12 +143,12 @@ export const getPortfolioAllocations = async (accountId: string): Promise<Portfo
  * Returns full category metadata along with the holdings.
  */
 export const getHoldingsByAllocation = async (
-  accountId: string,
+  filter: AccountFilter,
   taxonomyId: string,
   categoryId: string,
 ): Promise<AllocationHoldings> => {
   return invoke<AllocationHoldings>("get_holdings_by_allocation", {
-    accountId,
+    filter,
     taxonomyId,
     categoryId,
   });

--- a/apps/frontend/src/adapters/shared/portfolio.ts
+++ b/apps/frontend/src/adapters/shared/portfolio.ts
@@ -1,6 +1,6 @@
 // Portfolio Commands
 import type {
-  AccountFilter,
+  AccountScope,
   Holding,
   AllocationHoldings,
   IncomeSummary,
@@ -24,11 +24,11 @@ export const recalculatePortfolio = async (): Promise<void> => {
   return invoke<void>("recalculate_portfolio");
 };
 
-export const getHoldings = async (filter: AccountFilter): Promise<Holding[]> => {
+export const getHoldings = async (filter: AccountScope): Promise<Holding[]> => {
   return invoke<Holding[]>("get_holdings", { filter });
 };
 
-export const getIncomeSummary = async (filter?: AccountFilter): Promise<IncomeSummary[]> => {
+export const getIncomeSummary = async (filter?: AccountScope): Promise<IncomeSummary[]> => {
   return invoke<IncomeSummary[]>("get_income_summary", { filter });
 };
 
@@ -132,7 +132,7 @@ export const getAssetHoldings = async (assetId: string): Promise<Holding[]> => {
 };
 
 export const getPortfolioAllocations = async (
-  filter: AccountFilter,
+  filter: AccountScope,
 ): Promise<PortfolioAllocations> => {
   return invoke<PortfolioAllocations>("get_portfolio_allocations", { filter });
 };
@@ -143,7 +143,7 @@ export const getPortfolioAllocations = async (
  * Returns full category metadata along with the holdings.
  */
 export const getHoldingsByAllocation = async (
-  filter: AccountFilter,
+  filter: AccountScope,
   taxonomyId: string,
   categoryId: string,
 ): Promise<AllocationHoldings> => {

--- a/apps/frontend/src/adapters/web/core.ts
+++ b/apps/frontend/src/adapters/web/core.ts
@@ -43,13 +43,13 @@ export const COMMANDS: CommandMap = {
   backup_database: { method: "POST", path: "/utilities/database/backup" },
   list_database_backups: { method: "GET", path: "/utilities/database/backups" },
   delete_database_backup: { method: "DELETE", path: "/utilities/database/backups" },
-  get_holdings: { method: "POST", path: "/holdings" },
+  get_holdings: { method: "POST", path: "/holdings/query" },
   get_holding: { method: "GET", path: "/holdings/item" },
   get_asset_holdings: { method: "GET", path: "/holdings/by-asset" },
   get_historical_valuations: { method: "GET", path: "/valuations/history" },
   get_latest_valuations: { method: "GET", path: "/valuations/latest" },
-  get_portfolio_allocations: { method: "POST", path: "/allocations" },
-  get_holdings_by_allocation: { method: "POST", path: "/allocations/holdings" },
+  get_portfolio_allocations: { method: "POST", path: "/allocations/query" },
+  get_holdings_by_allocation: { method: "POST", path: "/allocations/holdings/query" },
   // Snapshot management
   get_snapshots: { method: "GET", path: "/snapshots" },
   get_snapshot_by_date: { method: "GET", path: "/snapshots/holdings" },
@@ -63,7 +63,7 @@ export const COMMANDS: CommandMap = {
   calculate_accounts_simple_performance: { method: "POST", path: "/performance/accounts/simple" },
   calculate_performance_history: { method: "POST", path: "/performance/history" },
   calculate_performance_summary: { method: "POST", path: "/performance/summary" },
-  get_income_summary: { method: "POST", path: "/income/summary" },
+  get_income_summary: { method: "POST", path: "/income/summary/query" },
   // Goals
   get_goals: { method: "GET", path: "/goals" },
   get_goal: { method: "GET", path: "/goals" },
@@ -360,6 +360,7 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
   const config = COMMANDS[command];
   if (!config) throw new Error(`Unsupported command ${command}`);
   let url = `${API_PREFIX}${config.path}`;
+  let method = config.method;
   let body: BodyInit | undefined;
 
   switch (command) {
@@ -406,8 +407,13 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
       break;
     }
     case "get_holdings": {
-      const p = payload as { filter: unknown };
-      body = JSON.stringify({ filter: p.filter });
+      const p = payload as { filter: { type: string; accountId?: string } };
+      if (p.filter?.type === "account" && p.filter.accountId) {
+        url = `${API_PREFIX}/holdings?accountId=${encodeURIComponent(p.filter.accountId)}`;
+        method = "GET";
+      } else {
+        body = JSON.stringify({ filter: p.filter });
+      }
       break;
     }
     case "get_holding": {
@@ -444,17 +450,35 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
       break;
     }
     case "get_portfolio_allocations": {
-      const p = payload as { filter: unknown };
-      body = JSON.stringify({ filter: p.filter });
+      const p = payload as { filter: { type: string; accountId?: string } };
+      if (p.filter?.type === "account" && p.filter.accountId) {
+        url = `${API_PREFIX}/allocations?accountId=${encodeURIComponent(p.filter.accountId)}`;
+        method = "GET";
+      } else {
+        body = JSON.stringify({ filter: p.filter });
+      }
       break;
     }
     case "get_holdings_by_allocation": {
-      const p = payload as { filter: unknown; taxonomyId: string; categoryId: string };
-      body = JSON.stringify({
-        filter: p.filter,
-        taxonomyId: p.taxonomyId,
-        categoryId: p.categoryId,
-      });
+      const p = payload as {
+        filter: { type: string; accountId?: string };
+        taxonomyId: string;
+        categoryId: string;
+      };
+      if (p.filter?.type === "account" && p.filter.accountId) {
+        const params = new URLSearchParams();
+        params.set("accountId", p.filter.accountId);
+        params.set("taxonomyId", p.taxonomyId);
+        params.set("categoryId", p.categoryId);
+        url = `${API_PREFIX}/allocations/holdings?${params.toString()}`;
+        method = "GET";
+      } else {
+        body = JSON.stringify({
+          filter: p.filter,
+          taxonomyId: p.taxonomyId,
+          categoryId: p.categoryId,
+        });
+      }
       break;
     }
     // Snapshot management
@@ -559,8 +583,13 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
       break;
     }
     case "get_income_summary": {
-      const p = payload as { filter?: unknown };
-      body = JSON.stringify({ filter: p?.filter ?? null });
+      const p = payload as { filter?: { type: string; accountId?: string } };
+      if (p?.filter?.type === "account" && p.filter.accountId) {
+        url = `${API_PREFIX}/income/summary?accountId=${encodeURIComponent(p.filter.accountId)}`;
+        method = "GET";
+      } else {
+        body = JSON.stringify({ filter: p?.filter ?? null });
+      }
       break;
     }
     case "get_goal":
@@ -1463,7 +1492,7 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
   }
 
   const res = await fetch(url, {
-    method: config.method,
+    method,
     headers,
     body,
     credentials: "same-origin",

--- a/apps/frontend/src/adapters/web/core.ts
+++ b/apps/frontend/src/adapters/web/core.ts
@@ -43,13 +43,13 @@ export const COMMANDS: CommandMap = {
   backup_database: { method: "POST", path: "/utilities/database/backup" },
   list_database_backups: { method: "GET", path: "/utilities/database/backups" },
   delete_database_backup: { method: "DELETE", path: "/utilities/database/backups" },
-  get_holdings: { method: "GET", path: "/holdings" },
+  get_holdings: { method: "POST", path: "/holdings" },
   get_holding: { method: "GET", path: "/holdings/item" },
   get_asset_holdings: { method: "GET", path: "/holdings/by-asset" },
   get_historical_valuations: { method: "GET", path: "/valuations/history" },
   get_latest_valuations: { method: "GET", path: "/valuations/latest" },
-  get_portfolio_allocations: { method: "GET", path: "/allocations" },
-  get_holdings_by_allocation: { method: "GET", path: "/allocations/holdings" },
+  get_portfolio_allocations: { method: "POST", path: "/allocations" },
+  get_holdings_by_allocation: { method: "POST", path: "/allocations/holdings" },
   // Snapshot management
   get_snapshots: { method: "GET", path: "/snapshots" },
   get_snapshot_by_date: { method: "GET", path: "/snapshots/holdings" },
@@ -63,7 +63,7 @@ export const COMMANDS: CommandMap = {
   calculate_accounts_simple_performance: { method: "POST", path: "/performance/accounts/simple" },
   calculate_performance_history: { method: "POST", path: "/performance/history" },
   calculate_performance_summary: { method: "POST", path: "/performance/summary" },
-  get_income_summary: { method: "GET", path: "/income/summary" },
+  get_income_summary: { method: "POST", path: "/income/summary" },
   // Goals
   get_goals: { method: "GET", path: "/goals" },
   get_goal: { method: "GET", path: "/goals" },
@@ -406,8 +406,8 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
       break;
     }
     case "get_holdings": {
-      const p = payload as { accountId: string };
-      url += `?accountId=${encodeURIComponent(p.accountId)}`;
+      const p = payload as { filter: unknown };
+      body = JSON.stringify({ filter: p.filter });
       break;
     }
     case "get_holding": {
@@ -444,23 +444,17 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
       break;
     }
     case "get_portfolio_allocations": {
-      const { accountId } = payload as { accountId: string };
-      const params = new URLSearchParams();
-      params.set("accountId", accountId);
-      url += `?${params.toString()}`;
+      const p = payload as { filter: unknown };
+      body = JSON.stringify({ filter: p.filter });
       break;
     }
     case "get_holdings_by_allocation": {
-      const { accountId, taxonomyId, categoryId } = payload as {
-        accountId: string;
-        taxonomyId: string;
-        categoryId: string;
-      };
-      const params = new URLSearchParams();
-      params.set("accountId", accountId);
-      params.set("taxonomyId", taxonomyId);
-      params.set("categoryId", categoryId);
-      url += `?${params.toString()}`;
+      const p = payload as { filter: unknown; taxonomyId: string; categoryId: string };
+      body = JSON.stringify({
+        filter: p.filter,
+        taxonomyId: p.taxonomyId,
+        categoryId: p.categoryId,
+      });
       break;
     }
     // Snapshot management
@@ -565,10 +559,8 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
       break;
     }
     case "get_income_summary": {
-      const { accountId: incomeAccountId } = payload as { accountId?: string };
-      if (incomeAccountId) {
-        url += `?accountId=${encodeURIComponent(incomeAccountId)}`;
-      }
+      const p = payload as { filter?: unknown };
+      body = JSON.stringify({ filter: p?.filter ?? null });
       break;
     }
     case "get_goal":

--- a/apps/frontend/src/addons/addons-runtime-context.ts
+++ b/apps/frontend/src/addons/addons-runtime-context.ts
@@ -218,7 +218,7 @@ export function createAddonContext(addonId: string): AddonContext {
       const baseAPI = createSDKHostAPIBridge(
         {
           // Core data access
-          getHoldings: getHoldings,
+          getHoldings: (accountId: string) => getHoldings({ type: "account", accountId }),
           getActivities: getActivities,
           getAccounts: getAccounts,
 
@@ -255,7 +255,7 @@ export function createAddonContext(addonId: string): AddonContext {
           // Portfolio
           updatePortfolio,
           recalculatePortfolio,
-          getIncomeSummary,
+          getIncomeSummary: () => getIncomeSummary(undefined),
           getHistoricalValuations,
           getLatestValuations,
           calculatePerformanceHistory,

--- a/apps/frontend/src/components/account-filter-selector.tsx
+++ b/apps/frontend/src/components/account-filter-selector.tsx
@@ -13,16 +13,16 @@ import { cn } from "@/lib/utils";
 import { useState } from "react";
 import { useAccounts } from "@/hooks/use-accounts";
 import { usePortfolios } from "@/hooks/use-portfolios";
-import type { AccountFilter } from "@/lib/types";
+import type { AccountScope } from "@/lib/types";
 
-interface AccountFilterSelectorProps {
-  value: AccountFilter;
-  onChange: (filter: AccountFilter) => void;
+interface AccountScopeSelectorProps {
+  value: AccountScope;
+  onChange: (filter: AccountScope) => void;
   className?: string;
 }
 
 function filterLabel(
-  filter: AccountFilter,
+  filter: AccountScope,
   accounts: { id: string; name: string }[],
   portfolios: { id: string; name: string }[],
 ): string {
@@ -36,14 +36,14 @@ function filterLabel(
   return `Custom (${filter.accountIds.length})`;
 }
 
-export function AccountFilterSelector({ value, onChange, className }: AccountFilterSelectorProps) {
+export function AccountScopeSelector({ value, onChange, className }: AccountScopeSelectorProps) {
   const [open, setOpen] = useState(false);
   const { accounts } = useAccounts({ filterActive: false, includeArchived: false });
   const { data: portfolios = [] } = usePortfolios();
 
   const label = filterLabel(value, accounts, portfolios);
 
-  const select = (filter: AccountFilter) => {
+  const select = (filter: AccountScope) => {
     onChange(filter);
     setOpen(false);
   };

--- a/apps/frontend/src/components/account-filter-selector.tsx
+++ b/apps/frontend/src/components/account-filter-selector.tsx
@@ -33,7 +33,13 @@ function filterLabel(
   if (filter.type === "portfolio") {
     return portfolios.find((p) => p.id === filter.portfolioId)?.name ?? "Portfolio";
   }
-  return `Custom (${filter.accountIds.length})`;
+  return `${filter.accountIds.length} Accounts`;
+}
+
+function isAccountChecked(value: AccountScope, accountId: string): boolean {
+  if (value.type === "account") return value.accountId === accountId;
+  if (value.type === "accounts") return value.accountIds.includes(accountId);
+  return false;
 }
 
 export function AccountScopeSelector({ value, onChange, className }: AccountScopeSelectorProps) {
@@ -46,6 +52,26 @@ export function AccountScopeSelector({ value, onChange, className }: AccountScop
   const select = (filter: AccountScope) => {
     onChange(filter);
     setOpen(false);
+  };
+
+  // Toggle a single account in/out of the selection without closing the popover,
+  // collapsing to account/all when the count reaches 1/0.
+  const toggleAccount = (accountId: string) => {
+    if (value.type === "account" && value.accountId === accountId) {
+      onChange({ type: "all" });
+    } else if (value.type === "account") {
+      onChange({ type: "accounts", accountIds: [value.accountId, accountId] });
+    } else if (value.type === "accounts") {
+      const ids = value.accountIds.includes(accountId)
+        ? value.accountIds.filter((id) => id !== accountId)
+        : [...value.accountIds, accountId];
+      if (ids.length === 0) onChange({ type: "all" });
+      else if (ids.length === 1) onChange({ type: "account", accountId: ids[0] });
+      else onChange({ type: "accounts", accountIds: ids });
+    } else {
+      // Currently all/portfolio — start a new single-account selection.
+      onChange({ type: "account", accountId });
+    }
   };
 
   return (
@@ -63,7 +89,7 @@ export function AccountScopeSelector({ value, onChange, className }: AccountScop
         >
           {value.type === "portfolio" ? (
             <Icons.Folder className="h-4 w-4 shrink-0 opacity-70" />
-          ) : value.type === "account" ? (
+          ) : value.type === "account" || value.type === "accounts" ? (
             <Icons.CreditCard className="h-4 w-4 shrink-0 opacity-70" />
           ) : (
             <Icons.Wallet className="h-4 w-4 shrink-0 opacity-70" />
@@ -117,26 +143,24 @@ export function AccountScopeSelector({ value, onChange, className }: AccountScop
 
             {accounts.length > 0 && (
               <CommandGroup heading="Accounts">
-                {accounts.map((a) => (
-                  <CommandItem
-                    key={a.id}
-                    value={a.id}
-                    keywords={[a.name, a.currency]}
-                    onSelect={() => select({ type: "account", accountId: a.id })}
-                  >
-                    <Icons.CreditCard className="mr-2 h-4 w-4" />
-                    {a.name}
-                    <span className="text-muted-foreground ml-1 text-xs">({a.currency})</span>
-                    <Icons.Check
-                      className={cn(
-                        "ml-auto h-4 w-4",
-                        value.type === "account" && value.accountId === a.id
-                          ? "opacity-100"
-                          : "opacity-0",
-                      )}
-                    />
-                  </CommandItem>
-                ))}
+                {accounts.map((a) => {
+                  const checked = isAccountChecked(value, a.id);
+                  return (
+                    <CommandItem
+                      key={a.id}
+                      value={a.id}
+                      keywords={[a.name, a.currency]}
+                      onSelect={() => toggleAccount(a.id)}
+                    >
+                      <Icons.CreditCard className="mr-2 h-4 w-4" />
+                      {a.name}
+                      <span className="text-muted-foreground ml-1 text-xs">({a.currency})</span>
+                      <Icons.Check
+                        className={cn("ml-auto h-4 w-4", checked ? "opacity-100" : "opacity-0")}
+                      />
+                    </CommandItem>
+                  );
+                })}
               </CommandGroup>
             )}
           </CommandList>

--- a/apps/frontend/src/components/account-filter-selector.tsx
+++ b/apps/frontend/src/components/account-filter-selector.tsx
@@ -30,7 +30,10 @@ function filterLabel(
   if (filter.type === "account") {
     return accounts.find((a) => a.id === filter.accountId)?.name ?? "Account";
   }
-  return portfolios.find((p) => p.id === filter.portfolioId)?.name ?? "Portfolio";
+  if (filter.type === "portfolio") {
+    return portfolios.find((p) => p.id === filter.portfolioId)?.name ?? "Portfolio";
+  }
+  return `Custom (${filter.accountIds.length})`;
 }
 
 export function AccountFilterSelector({ value, onChange, className }: AccountFilterSelectorProps) {
@@ -91,10 +94,22 @@ export function AccountFilterSelector({ value, onChange, className }: AccountFil
             {portfolios.length > 0 && (
               <CommandGroup heading="Portfolios">
                 {portfolios.map((p) => (
-                  <CommandItem key={p.id} value={p.id} keywords={[p.name]} disabled>
+                  <CommandItem
+                    key={p.id}
+                    value={p.id}
+                    keywords={[p.name]}
+                    onSelect={() => select({ type: "portfolio", portfolioId: p.id })}
+                  >
                     <Icons.Folder className="mr-2 h-4 w-4" />
                     {p.name}
-                    <span className="text-muted-foreground ml-auto text-xs">Coming soon</span>
+                    <Icons.Check
+                      className={cn(
+                        "ml-auto h-4 w-4",
+                        value.type === "portfolio" && value.portfolioId === p.id
+                          ? "opacity-100"
+                          : "opacity-0",
+                      )}
+                    />
                   </CommandItem>
                 ))}
               </CommandGroup>

--- a/apps/frontend/src/features/goals/retirement-planner/hooks/use-portfolio.ts
+++ b/apps/frontend/src/features/goals/retirement-planner/hooks/use-portfolio.ts
@@ -28,7 +28,9 @@ export function usePortfolioData(accountIds?: string[]) {
     queryKey: [QueryKeys.HOLDINGS, activeAccountIds],
     queryFn: async (): Promise<Holding[]> => {
       if (activeAccountIds.length === 0) return [];
-      const perAccount = await Promise.all(activeAccountIds.map((id) => getHoldings(id)));
+      const perAccount = await Promise.all(
+        activeAccountIds.map((id) => getHoldings({ type: "account", accountId: id })),
+      );
       // Aggregate by symbol so drift analysis sees combined weights across all FIRE accounts.
       const bySymbol = new Map<string, Holding>();
       for (const holdings of perAccount) {

--- a/apps/frontend/src/hooks/use-holdings.ts
+++ b/apps/frontend/src/hooks/use-holdings.ts
@@ -1,10 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
-import { AccountFilter, Holding } from "@/lib/types";
+import { AccountScope, Holding } from "@/lib/types";
 import { getHoldings } from "@/adapters";
 import { QueryKeys } from "@/lib/query-keys";
 
-export function useHoldings(filter: AccountFilter | string) {
-  const accountFilter: AccountFilter =
+export function useHoldings(filter: AccountScope | string) {
+  const accountFilter: AccountScope =
     typeof filter === "string" ? { type: "account", accountId: filter } : filter;
 
   const {

--- a/apps/frontend/src/hooks/use-holdings.ts
+++ b/apps/frontend/src/hooks/use-holdings.ts
@@ -1,18 +1,21 @@
 import { useQuery } from "@tanstack/react-query";
-import { Holding } from "@/lib/types";
+import { AccountFilter, Holding } from "@/lib/types";
 import { getHoldings } from "@/adapters";
 import { QueryKeys } from "@/lib/query-keys";
 
-export function useHoldings(accountId: string) {
+export function useHoldings(filter: AccountFilter | string) {
+  const accountFilter: AccountFilter =
+    typeof filter === "string" ? { type: "account", accountId: filter } : filter;
+
   const {
     data: holdings = [],
     isLoading,
     isError,
     error,
   } = useQuery<Holding[], Error>({
-    queryKey: [QueryKeys.HOLDINGS, accountId],
-    queryFn: () => getHoldings(accountId),
-    enabled: !!accountId,
+    queryKey: [QueryKeys.HOLDINGS, accountFilter],
+    queryFn: () => getHoldings(accountFilter),
+    enabled: typeof filter === "string" ? !!filter : true,
   });
 
   return { holdings, isLoading, isError, error };

--- a/apps/frontend/src/hooks/use-portfolio-allocations.ts
+++ b/apps/frontend/src/hooks/use-portfolio-allocations.ts
@@ -1,18 +1,21 @@
 import { useQuery } from "@tanstack/react-query";
-import { PortfolioAllocations } from "@/lib/types";
+import { AccountFilter, PortfolioAllocations } from "@/lib/types";
 import { getPortfolioAllocations } from "@/adapters";
 import { QueryKeys } from "@/lib/query-keys";
 
-export function usePortfolioAllocations(accountId: string) {
+export function usePortfolioAllocations(filter: AccountFilter | string) {
+  const accountFilter: AccountFilter =
+    typeof filter === "string" ? { type: "account", accountId: filter } : filter;
+
   const {
     data: allocations,
     isLoading,
     isError,
     error,
   } = useQuery<PortfolioAllocations, Error>({
-    queryKey: [QueryKeys.PORTFOLIO_ALLOCATIONS, accountId],
-    queryFn: () => getPortfolioAllocations(accountId),
-    enabled: !!accountId,
+    queryKey: [QueryKeys.PORTFOLIO_ALLOCATIONS, accountFilter],
+    queryFn: () => getPortfolioAllocations(accountFilter),
+    enabled: typeof filter === "string" ? !!filter : true,
   });
 
   return { allocations, isLoading, isError, error };

--- a/apps/frontend/src/hooks/use-portfolio-allocations.ts
+++ b/apps/frontend/src/hooks/use-portfolio-allocations.ts
@@ -1,10 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
-import { AccountFilter, PortfolioAllocations } from "@/lib/types";
+import { AccountScope, PortfolioAllocations } from "@/lib/types";
 import { getPortfolioAllocations } from "@/adapters";
 import { QueryKeys } from "@/lib/query-keys";
 
-export function usePortfolioAllocations(filter: AccountFilter | string) {
-  const accountFilter: AccountFilter =
+export function usePortfolioAllocations(filter: AccountScope | string) {
+  const accountFilter: AccountScope =
     typeof filter === "string" ? { type: "account", accountId: filter } : filter;
 
   const {

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -622,6 +622,8 @@ export interface Holding {
   prevCloseValue?: MonetaryValue | null;
   weight: number;
   asOfDate: string;
+  /** Source account IDs for aggregated holdings (portfolio/multi-account scope). Empty for single-account. */
+  sourceAccountIds?: string[];
 }
 
 /**

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -63,7 +63,8 @@ export interface NewPortfolio {
 export type AccountFilter =
   | { type: "all" }
   | { type: "account"; accountId: string }
-  | { type: "portfolio"; portfolioId: string };
+  | { type: "portfolio"; portfolioId: string }
+  | { type: "adHoc"; accountIds: string[] };
 
 export interface Account {
   id: string;

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -60,11 +60,11 @@ export interface NewPortfolio {
   accountIds: string[];
 }
 
-export type AccountFilter =
+export type AccountScope =
   | { type: "all" }
   | { type: "account"; accountId: string }
   | { type: "portfolio"; portfolioId: string }
-  | { type: "adHoc"; accountIds: string[] };
+  | { type: "accounts"; accountIds: string[] };
 
 export interface Account {
   id: string;

--- a/apps/frontend/src/pages/account/account-holdings.tsx
+++ b/apps/frontend/src/pages/account/account-holdings.tsx
@@ -2,7 +2,7 @@ import { getHoldings } from "@/adapters";
 import { useAccounts } from "@/hooks/use-accounts";
 import { useIsMobileViewport } from "@/hooks/use-platform";
 import { QueryKeys } from "@/lib/query-keys";
-import { Account, Holding, HoldingType } from "@/lib/types";
+import { Holding, HoldingType } from "@/lib/types";
 import { canAddHoldings } from "@/lib/activity-restrictions";
 import { HoldingsTable } from "@/pages/holdings/components/holdings-table";
 import { HoldingsTableMobile } from "@/pages/holdings/components/holdings-table-mobile";

--- a/apps/frontend/src/pages/account/account-holdings.tsx
+++ b/apps/frontend/src/pages/account/account-holdings.tsx
@@ -36,7 +36,7 @@ const AccountHoldings = ({
 
   const { data: holdings, isLoading } = useQuery<Holding[], Error>({
     queryKey: [QueryKeys.HOLDINGS, accountId],
-    queryFn: () => getHoldings(accountId),
+    queryFn: () => getHoldings({ type: "account", accountId }),
   });
 
   const { accounts } = useAccounts();

--- a/apps/frontend/src/pages/account/account-holdings.tsx
+++ b/apps/frontend/src/pages/account/account-holdings.tsx
@@ -56,10 +56,6 @@ const AccountHoldings = ({
     return canAddHoldings(selectedAccount ?? undefined);
   }, [selectedAccount]);
 
-  const dummyAccounts = useMemo(() => {
-    return selectedAccount ? [selectedAccount] : [];
-  }, [selectedAccount]);
-
   const filteredHoldings = holdings?.filter((holding) => holding.holdingType !== HoldingType.CASH);
 
   const typeOptions = useMemo(() => {
@@ -154,10 +150,6 @@ const AccountHoldings = ({
       </div>
     );
   }
-
-  const handleAccountChange = (_account: Account) => {
-    // No-op for account page since we're already on a specific account
-  };
 
   return (
     <div>

--- a/apps/frontend/src/pages/account/account-holdings.tsx
+++ b/apps/frontend/src/pages/account/account-holdings.tsx
@@ -177,10 +177,10 @@ const AccountHoldings = ({
           selectedTypes={selectedTypes}
           setSelectedTypes={setSelectedTypes}
           accountFilter={{ type: "account", accountId: selectedAccount?.id ?? "" }}
-          onAccountFilterChange={() => {}}
+          onAccountScopeChange={() => {}}
           accounts={[]}
           portfolios={[]}
-          showAccountFilter={false}
+          showAccountScope={false}
           typeOptions={typeOptions}
         />
       ) : (

--- a/apps/frontend/src/pages/account/account-holdings.tsx
+++ b/apps/frontend/src/pages/account/account-holdings.tsx
@@ -184,9 +184,10 @@ const AccountHoldings = ({
           isLoading={isLoading}
           selectedTypes={selectedTypes}
           setSelectedTypes={setSelectedTypes}
-          selectedAccount={selectedAccount}
-          accounts={dummyAccounts}
-          onAccountChange={handleAccountChange}
+          accountFilter={{ type: "account", accountId: selectedAccount?.id ?? "" }}
+          onAccountFilterChange={() => {}}
+          accounts={[]}
+          portfolios={[]}
           showAccountFilter={false}
           typeOptions={typeOptions}
         />

--- a/apps/frontend/src/pages/account/account-page.tsx
+++ b/apps/frontend/src/pages/account/account-page.tsx
@@ -144,7 +144,7 @@ const AccountPage = () => {
   // Query holdings to check if account has any assets
   const { data: holdings, isLoading: isHoldingsLoading } = useQuery<Holding[], Error>({
     queryKey: [QueryKeys.HOLDINGS, id],
-    queryFn: () => getHoldings(id),
+    queryFn: () => getHoldings({ type: "account", accountId: id }),
   });
 
   // Check if account has any holdings (including cash)

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -5,7 +5,7 @@ import { useIsMobileViewport } from "@/hooks/use-platform";
 import { debounce } from "@/lib/debounce";
 import { ActivityType } from "@/lib/constants";
 import { QueryKeys } from "@/lib/query-keys";
-import { Account, ActivityDetails } from "@/lib/types";
+import { Account, AccountScope, ActivityDetails } from "@/lib/types";
 import { useQuery } from "@tanstack/react-query";
 import type { SortingState } from "@tanstack/react-table";
 import { Button, Icons, Page, PageContent, PageHeader } from "@wealthfolio/ui";
@@ -37,13 +37,9 @@ const ActivityPage = () => {
   const [showActionPalette, setShowActionPalette] = useState(false);
 
   // Filter and search state
-  const [selectedAccounts, setSelectedAccounts] = usePersistentState<string[]>(
-    "activity-filter-accounts",
-    [],
-  );
-  const [selectedPortfolioId, setSelectedPortfolioId] = usePersistentState<string | null>(
-    "activity-filter-portfolio",
-    null,
+  const [accountScope, setAccountScope] = usePersistentState<AccountScope>(
+    "activity-filter-scope",
+    { type: "all" },
   );
   const { data: portfolios = [] } = usePortfolios();
   const [selectedActivityTypes, setSelectedActivityTypes] = usePersistentState<ActivityType[]>(
@@ -112,14 +108,15 @@ const ActivityPage = () => {
 
   const isDatagridView = viewMode === "datagrid";
 
-  // Resolve account IDs at render time so portfolio membership changes are
-  // picked up immediately without stale persisted state.
+  // Resolve the typed scope to a flat account ID list for the activity search.
   const effectiveAccountIds = useMemo(() => {
-    if (selectedPortfolioId) {
-      return portfolios.find((p) => p.id === selectedPortfolioId)?.accountIds ?? [];
+    if (accountScope.type === "account") return [accountScope.accountId];
+    if (accountScope.type === "accounts") return accountScope.accountIds;
+    if (accountScope.type === "portfolio") {
+      return portfolios.find((p) => p.id === accountScope.portfolioId)?.accountIds ?? [];
     }
-    return selectedAccounts;
-  }, [selectedPortfolioId, portfolios, selectedAccounts]);
+    return []; // "all" → no filter
+  }, [accountScope, portfolios]);
 
   // Infinite scroll search for table view
   const infiniteSearch = useActivitySearch({
@@ -268,37 +265,16 @@ const ActivityPage = () => {
       <PageHeader heading="Activity" actions={headerActions} />
       <PageContent className="pb-2 md:pb-4 lg:pb-5">
         <div className="flex min-h-0 flex-1 flex-col space-y-4 overflow-hidden">
-          {/* Unified Controls */}
-          {portfolios.length > 0 && !isMobileViewport && (
-            <div className="flex items-center gap-2">
-              <span className="text-muted-foreground text-xs">Portfolio:</span>
-              <select
-                className="border-input bg-background rounded-md border px-2 py-1 text-xs"
-                value={selectedPortfolioId ?? ""}
-                onChange={(e) => {
-                  const id = e.target.value || null;
-                  setSelectedPortfolioId(id);
-                  if (!id) setSelectedAccounts([]);
-                }}
-              >
-                <option value="">All</option>
-                {portfolios.map((p) => (
-                  <option key={p.id} value={p.id}>
-                    {p.name}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
           {isMobileViewport ? (
             <ActivityMobileControls
               accounts={accounts}
               searchQuery={searchInput}
               onSearchQueryChange={handleSearchChange}
-              selectedAccountIds={selectedAccounts}
+              selectedAccountIds={effectiveAccountIds}
               onAccountIdsChange={(ids) => {
-                setSelectedAccounts(ids);
-                setSelectedPortfolioId(null);
+                if (ids.length === 0) setAccountScope({ type: "all" });
+                else if (ids.length === 1) setAccountScope({ type: "account", accountId: ids[0] });
+                else setAccountScope({ type: "accounts", accountIds: ids });
               }}
               selectedActivityTypes={selectedActivityTypes}
               onActivityTypesChange={setSelectedActivityTypes}
@@ -307,14 +283,10 @@ const ActivityPage = () => {
             />
           ) : (
             <ActivityViewControls
-              accounts={accounts}
               searchQuery={searchInput}
               onSearchQueryChange={handleSearchChange}
-              selectedAccountIds={selectedAccounts}
-              onAccountIdsChange={(ids) => {
-                setSelectedAccounts(ids);
-                setSelectedPortfolioId(null);
-              }}
+              accountScope={accountScope}
+              onAccountScopeChange={setAccountScope}
               selectedActivityTypes={selectedActivityTypes}
               onActivityTypesChange={setSelectedActivityTypes}
               selectedInstrumentTypes={selectedInstrumentTypes}

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -1,5 +1,6 @@
 import { getAccounts } from "@/adapters";
 import { usePersistentState } from "@/hooks/use-persistent-state";
+import { usePortfolios } from "@/hooks/use-portfolios";
 import { useIsMobileViewport } from "@/hooks/use-platform";
 import { debounce } from "@/lib/debounce";
 import { ActivityType } from "@/lib/constants";
@@ -40,6 +41,11 @@ const ActivityPage = () => {
     "activity-filter-accounts",
     [],
   );
+  const [selectedPortfolioId, setSelectedPortfolioId] = usePersistentState<string | null>(
+    "activity-filter-portfolio",
+    null,
+  );
+  const { data: portfolios = [] } = usePortfolios();
   const [selectedActivityTypes, setSelectedActivityTypes] = usePersistentState<ActivityType[]>(
     "activity-filter-types",
     [],
@@ -254,13 +260,42 @@ const ActivityPage = () => {
       <PageContent className="pb-2 md:pb-4 lg:pb-5">
         <div className="flex min-h-0 flex-1 flex-col space-y-4 overflow-hidden">
           {/* Unified Controls */}
+          {portfolios.length > 0 && !isMobileViewport && (
+            <div className="flex items-center gap-2">
+              <span className="text-muted-foreground text-xs">Portfolio:</span>
+              <select
+                className="border-input bg-background rounded-md border px-2 py-1 text-xs"
+                value={selectedPortfolioId ?? ""}
+                onChange={(e) => {
+                  const id = e.target.value || null;
+                  setSelectedPortfolioId(id);
+                  if (id) {
+                    const p = portfolios.find((p) => p.id === id);
+                    if (p) setSelectedAccounts(p.accountIds);
+                  } else {
+                    setSelectedAccounts([]);
+                  }
+                }}
+              >
+                <option value="">All</option>
+                {portfolios.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
           {isMobileViewport ? (
             <ActivityMobileControls
               accounts={accounts}
               searchQuery={searchInput}
               onSearchQueryChange={handleSearchChange}
               selectedAccountIds={selectedAccounts}
-              onAccountIdsChange={setSelectedAccounts}
+              onAccountIdsChange={(ids) => {
+                setSelectedAccounts(ids);
+                setSelectedPortfolioId(null);
+              }}
               selectedActivityTypes={selectedActivityTypes}
               onActivityTypesChange={setSelectedActivityTypes}
               isCompactView={isCompactView}
@@ -272,7 +307,10 @@ const ActivityPage = () => {
               searchQuery={searchInput}
               onSearchQueryChange={handleSearchChange}
               selectedAccountIds={selectedAccounts}
-              onAccountIdsChange={setSelectedAccounts}
+              onAccountIdsChange={(ids) => {
+                setSelectedAccounts(ids);
+                setSelectedPortfolioId(null);
+              }}
               selectedActivityTypes={selectedActivityTypes}
               onActivityTypesChange={setSelectedActivityTypes}
               selectedInstrumentTypes={selectedInstrumentTypes}

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -112,11 +112,20 @@ const ActivityPage = () => {
 
   const isDatagridView = viewMode === "datagrid";
 
+  // Resolve account IDs at render time so portfolio membership changes are
+  // picked up immediately without stale persisted state.
+  const effectiveAccountIds = useMemo(() => {
+    if (selectedPortfolioId) {
+      return portfolios.find((p) => p.id === selectedPortfolioId)?.accountIds ?? [];
+    }
+    return selectedAccounts;
+  }, [selectedPortfolioId, portfolios, selectedAccounts]);
+
   // Infinite scroll search for table view
   const infiniteSearch = useActivitySearch({
     mode: "infinite",
     filters: {
-      accountIds: selectedAccounts,
+      accountIds: effectiveAccountIds,
       activityTypes: selectedActivityTypes,
       instrumentTypes: selectedInstrumentTypes,
       status: statusFilter,
@@ -129,7 +138,7 @@ const ActivityPage = () => {
   const paginatedSearch = useActivitySearch({
     mode: "paginated",
     filters: {
-      accountIds: selectedAccounts,
+      accountIds: effectiveAccountIds,
       activityTypes: selectedActivityTypes,
       instrumentTypes: selectedInstrumentTypes,
       status: statusFilter,
@@ -147,7 +156,7 @@ const ActivityPage = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    selectedAccounts,
+    effectiveAccountIds,
     selectedActivityTypes,
     selectedInstrumentTypes,
     statusFilter,
@@ -269,12 +278,7 @@ const ActivityPage = () => {
                 onChange={(e) => {
                   const id = e.target.value || null;
                   setSelectedPortfolioId(id);
-                  if (id) {
-                    const p = portfolios.find((p) => p.id === id);
-                    if (p) setSelectedAccounts(p.accountIds);
-                  } else {
-                    setSelectedAccounts([]);
-                  }
+                  if (!id) setSelectedAccounts([]);
                 }}
               >
                 <option value="">All</option>

--- a/apps/frontend/src/pages/activity/components/activity-view-controls.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-view-controls.tsx
@@ -2,7 +2,8 @@ import { useEffect, useMemo, useState } from "react";
 
 import { ActivityType, ActivityTypeNames, INSTRUMENT_TYPE_OPTIONS } from "@/lib/constants";
 import { debounce } from "@/lib/debounce";
-import { Account } from "@/lib/types";
+import type { AccountScope } from "@/lib/types";
+import { AccountScopeSelector } from "@/components/account-filter-selector";
 import {
   AnimatedToggleGroup,
   Button,
@@ -15,11 +16,10 @@ import type { ActivityStatusFilter } from "../hooks/use-activity-search";
 export type ActivityViewMode = "table" | "datagrid";
 
 interface ActivityViewControlsProps {
-  accounts: Account[];
   searchQuery: string;
   onSearchQueryChange: (value: string) => void;
-  selectedAccountIds: string[];
-  onAccountIdsChange: (ids: string[]) => void;
+  accountScope: AccountScope;
+  onAccountScopeChange: (scope: AccountScope) => void;
   selectedActivityTypes: ActivityType[];
   onActivityTypesChange: (types: ActivityType[]) => void;
   selectedInstrumentTypes: string[];
@@ -36,11 +36,10 @@ interface ActivityViewControlsProps {
 }
 
 export function ActivityViewControls({
-  accounts,
   searchQuery,
   onSearchQueryChange,
-  selectedAccountIds,
-  onAccountIdsChange,
+  accountScope,
+  onAccountScopeChange,
   selectedActivityTypes,
   onActivityTypesChange,
   selectedInstrumentTypes,
@@ -73,15 +72,6 @@ export function ActivityViewControls({
     setLocalSearch(searchQuery);
   }, [searchQuery]);
 
-  const accountOptions = useMemo(
-    () =>
-      accounts.map((account) => ({
-        value: account.id,
-        label: `${account.name} (${account.currency})`,
-      })),
-    [accounts],
-  );
-
   const activityOptions = useMemo(
     () =>
       (Object.entries(ActivityTypeNames) as [ActivityType, string][]).map(([value, label]) => ({
@@ -107,7 +97,7 @@ export function ActivityViewControls({
 
   const hasActiveFilters =
     searchQuery.trim().length > 0 ||
-    selectedAccountIds.length > 0 ||
+    accountScope.type !== "all" ||
     selectedActivityTypes.length > 0 ||
     selectedInstrumentTypes.length > 0 ||
     statusFilter !== "all";
@@ -124,12 +114,7 @@ export function ActivityViewControls({
           className="w-[160px] lg:w-[240px]"
         />
 
-        <FacetedFilter
-          title="Account"
-          options={accountOptions}
-          selectedValues={new Set(selectedAccountIds)}
-          onFilterChange={(values: Set<string>) => onAccountIdsChange(Array.from(values))}
-        />
+        <AccountScopeSelector value={accountScope} onChange={onAccountScopeChange} />
 
         <FacetedFilter
           title="Type"
@@ -167,7 +152,7 @@ export function ActivityViewControls({
             onClick={() => {
               setLocalSearch("");
               onSearchQueryChange("");
-              onAccountIdsChange([]);
+              onAccountScopeChange({ type: "all" });
               onActivityTypesChange([]);
               onInstrumentTypesChange([]);
               onStatusFilterChange("all");

--- a/apps/frontend/src/pages/activity/import/steps/review-step.tsx
+++ b/apps/frontend/src/pages/activity/import/steps/review-step.tsx
@@ -95,7 +95,7 @@ export function ReviewStep() {
   const [selectedRows, setSelectedRows] = useState<number[]>([]);
   const [statusFilter, setStatusFilter] = useState<Set<string>>(new Set());
   const [typeFilter, setTypeFilter] = useState<Set<string>>(new Set());
-  const [accountFilter, setAccountFilter] = useState<Set<string>>(new Set());
+  const [accountFilter, setAccountScope] = useState<Set<string>>(new Set());
   const [symbolFilter, setSymbolFilter] = useState<Set<string>>(new Set());
 
   // Calculate filter stats (counts by status)
@@ -177,7 +177,7 @@ export function ReviewStep() {
 
   const clearAllFilters = useCallback(() => {
     setTypeFilter(new Set());
-    setAccountFilter(new Set());
+    setAccountScope(new Set());
     setSymbolFilter(new Set());
     setStatusFilter(new Set());
   }, []);
@@ -426,7 +426,7 @@ export function ReviewStep() {
             title="Account"
             options={facetedOptions.accounts}
             selectedValues={accountFilter}
-            onFilterChange={setAccountFilter}
+            onFilterChange={setAccountScope}
           />
           <FacetedFilter
             title="Status"

--- a/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
+++ b/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
@@ -16,7 +16,7 @@ import { useQuery } from "@tanstack/react-query";
 import { getHoldingsByAllocation } from "@/adapters";
 import { TickerAvatar } from "@/components/ticker-avatar";
 import type {
-  AccountFilter,
+  AccountScope,
   TaxonomyAllocation,
   CategoryAllocation,
   HoldingSummary,
@@ -28,7 +28,7 @@ interface AllocationDetailSheetProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
   allocation?: TaxonomyAllocation;
-  accountFilter: AccountFilter;
+  accountFilter: AccountScope;
   baseCurrency: string;
   initialCategoryId?: string | null;
 }

--- a/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
+++ b/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
@@ -15,7 +15,12 @@ import { useQuery } from "@tanstack/react-query";
 
 import { getHoldingsByAllocation } from "@/adapters";
 import { TickerAvatar } from "@/components/ticker-avatar";
-import type { TaxonomyAllocation, CategoryAllocation, HoldingSummary } from "@/lib/types";
+import type {
+  AccountFilter,
+  TaxonomyAllocation,
+  CategoryAllocation,
+  HoldingSummary,
+} from "@/lib/types";
 import { QueryKeys } from "@/lib/query-keys";
 import { CompactAllocationStrip } from "./compact-allocation-strip";
 
@@ -23,7 +28,7 @@ interface AllocationDetailSheetProps {
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
   allocation?: TaxonomyAllocation;
-  accountId: string;
+  accountFilter: AccountFilter;
   baseCurrency: string;
   initialCategoryId?: string | null;
 }
@@ -32,7 +37,7 @@ export function AllocationDetailSheet({
   isOpen,
   onOpenChange,
   allocation,
-  accountId,
+  accountFilter,
   baseCurrency,
   initialCategoryId,
 }: AllocationDetailSheetProps) {
@@ -91,13 +96,13 @@ export function AllocationDetailSheet({
   } = useQuery({
     queryKey: [
       QueryKeys.HOLDINGS_BY_ALLOCATION,
-      accountId,
+      accountFilter,
       allocation?.taxonomyId,
       selectedCategoryId,
     ],
     queryFn: () =>
       getHoldingsByAllocation(
-        { type: "account", accountId },
+        accountFilter,
         allocation?.taxonomyId ?? "",
         selectedCategoryId ?? "",
       ),

--- a/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
+++ b/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
@@ -96,7 +96,11 @@ export function AllocationDetailSheet({
       selectedCategoryId,
     ],
     queryFn: () =>
-      getHoldingsByAllocation(accountId, allocation?.taxonomyId ?? "", selectedCategoryId ?? ""),
+      getHoldingsByAllocation(
+        { type: "account", accountId },
+        allocation?.taxonomyId ?? "",
+        selectedCategoryId ?? "",
+      ),
     enabled: !!selectedCategoryId && !!allocation?.taxonomyId,
     staleTime: 30000,
   });

--- a/apps/frontend/src/pages/holdings/components/drillable-account-chart.tsx
+++ b/apps/frontend/src/pages/holdings/components/drillable-account-chart.tsx
@@ -19,6 +19,7 @@ import { useMemo, useState } from "react";
 
 interface DrillableAccountChartProps {
   isLoading?: boolean;
+  accountIds?: string[];
   onAccountClick?: (accountId: string, accountName: string) => void;
 }
 
@@ -29,6 +30,7 @@ interface DrillableAccountChartProps {
  */
 export function DrillableAccountChart({
   isLoading: isLoadingProp,
+  accountIds,
   onAccountClick,
 }: DrillableAccountChartProps) {
   const { settings } = useSettingsContext();
@@ -36,10 +38,12 @@ export function DrillableAccountChart({
   const [activeIndex, setActiveIndex] = useState(0);
   const { path, drillDown, navigateTo, isAtRoot } = useDrillDownState();
 
-  const { data: accounts = [], isLoading: isLoadingAccounts } = useQuery<Account[], Error>({
+  const { data: allAccounts = [], isLoading: isLoadingAccounts } = useQuery<Account[], Error>({
     queryKey: [QueryKeys.ACCOUNTS],
     queryFn: () => getAccounts(),
   });
+
+  const accounts = accountIds ? allAccounts.filter((a) => accountIds.includes(a.id)) : allAccounts;
 
   const { data: performanceData, isLoading: isLoadingPerformance } =
     useAccountsSimplePerformance(accounts);

--- a/apps/frontend/src/pages/holdings/components/holdings-mobile-filter-sheet.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-mobile-filter-sheet.tsx
@@ -9,20 +9,20 @@ import {
   SheetTitle,
 } from "@wealthfolio/ui/components/ui/sheet";
 import { HOLDING_CATEGORY_FILTERS } from "@/lib/constants";
-import { Account, AccountFilter, HoldingCategoryFilterId } from "@/lib/types";
+import { Account, AccountScope, HoldingCategoryFilterId } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { AnimatedToggleGroup, ScrollArea, Separator } from "@wealthfolio/ui";
 
 interface HoldingsMobileFilterSheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  accountFilter: AccountFilter;
-  onAccountFilterChange: (filter: AccountFilter) => void;
+  accountFilter: AccountScope;
+  onAccountScopeChange: (filter: AccountScope) => void;
   accounts: Account[];
   portfolios: { id: string; name: string }[];
   selectedTypes: string[];
   setSelectedTypes: (types: string[]) => void;
-  showAccountFilter?: boolean;
+  showAccountScope?: boolean;
   sortBy: "symbol" | "marketValue";
   setSortBy: (value: "symbol" | "marketValue") => void;
   showTotalReturn: boolean;
@@ -36,12 +36,12 @@ export const HoldingsMobileFilterSheet = ({
   open,
   onOpenChange,
   accountFilter,
-  onAccountFilterChange,
+  onAccountScopeChange,
   accounts,
   portfolios,
   selectedTypes,
   setSelectedTypes,
-  showAccountFilter = true,
+  showAccountScope = true,
   sortBy,
   setSortBy,
   showTotalReturn,
@@ -132,7 +132,7 @@ export const HoldingsMobileFilterSheet = ({
             {setCategoryFilter && <Separator />}
 
             {/* Account Filter Section */}
-            {showAccountFilter && (
+            {showAccountScope && (
               <div className="space-y-3">
                 <h4 className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
                   Account
@@ -146,7 +146,7 @@ export const HoldingsMobileFilterSheet = ({
                         : "hover:bg-muted/50",
                     )}
                     onClick={() => {
-                      onAccountFilterChange({ type: "all" });
+                      onAccountScopeChange({ type: "all" });
                       onOpenChange(false);
                     }}
                   >
@@ -169,7 +169,7 @@ export const HoldingsMobileFilterSheet = ({
                           : "hover:bg-muted/50",
                       )}
                       onClick={() => {
-                        onAccountFilterChange({ type: "portfolio", portfolioId: portfolio.id });
+                        onAccountScopeChange({ type: "portfolio", portfolioId: portfolio.id });
                         onOpenChange(false);
                       }}
                     >
@@ -193,7 +193,7 @@ export const HoldingsMobileFilterSheet = ({
                           : "hover:bg-muted/50",
                       )}
                       onClick={() => {
-                        onAccountFilterChange({ type: "account", accountId: account.id });
+                        onAccountScopeChange({ type: "account", accountId: account.id });
                         onOpenChange(false);
                       }}
                     >

--- a/apps/frontend/src/pages/holdings/components/holdings-mobile-filter-sheet.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-mobile-filter-sheet.tsx
@@ -8,18 +8,18 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@wealthfolio/ui/components/ui/sheet";
-import { HOLDING_CATEGORY_FILTERS, PORTFOLIO_ACCOUNT_ID } from "@/lib/constants";
-import { Account, HoldingCategoryFilterId } from "@/lib/types";
+import { HOLDING_CATEGORY_FILTERS } from "@/lib/constants";
+import { Account, AccountFilter, HoldingCategoryFilterId } from "@/lib/types";
 import { cn } from "@/lib/utils";
-import { useSettingsContext } from "@/lib/settings-provider";
 import { AnimatedToggleGroup, ScrollArea, Separator } from "@wealthfolio/ui";
 
 interface HoldingsMobileFilterSheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  selectedAccount: Account | null;
+  accountFilter: AccountFilter;
+  onAccountFilterChange: (filter: AccountFilter) => void;
   accounts: Account[];
-  onAccountChange: (account: Account) => void;
+  portfolios: { id: string; name: string }[];
   selectedTypes: string[];
   setSelectedTypes: (types: string[]) => void;
   showAccountFilter?: boolean;
@@ -35,9 +35,10 @@ interface HoldingsMobileFilterSheetProps {
 export const HoldingsMobileFilterSheet = ({
   open,
   onOpenChange,
-  selectedAccount,
+  accountFilter,
+  onAccountFilterChange,
   accounts,
-  onAccountChange,
+  portfolios,
   selectedTypes,
   setSelectedTypes,
   showAccountFilter = true,
@@ -49,9 +50,6 @@ export const HoldingsMobileFilterSheet = ({
   setCategoryFilter,
   typeOptions,
 }: HoldingsMobileFilterSheetProps) => {
-  const { settings } = useSettingsContext();
-  const baseCurrency = settings?.baseCurrency ?? "USD";
-
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
@@ -143,54 +141,70 @@ export const HoldingsMobileFilterSheet = ({
                   <div
                     className={cn(
                       "flex cursor-pointer items-center justify-between p-3 text-sm transition-colors",
-                      selectedAccount?.id === PORTFOLIO_ACCOUNT_ID
+                      accountFilter.type === "all"
                         ? "bg-accent/50 font-medium"
                         : "hover:bg-muted/50",
                     )}
                     onClick={() => {
-                      onAccountChange({
-                        id: PORTFOLIO_ACCOUNT_ID,
-                        name: "All Portfolio",
-                        accountType: "PORTFOLIO" as unknown as Account["accountType"],
-                        balance: 0,
-                        currency: baseCurrency,
-                        isDefault: false,
-                        isActive: true,
-                        createdAt: new Date(),
-                        updatedAt: new Date(),
-                      } as Account);
+                      onAccountFilterChange({ type: "all" });
                       onOpenChange(false);
                     }}
                   >
                     <span className="flex items-center gap-2">
-                      <Icons.LayoutDashboard className="text-muted-foreground h-4 w-4" />
-                      All Portfolio
+                      <Icons.Wallet className="text-muted-foreground h-4 w-4" />
+                      All Accounts
                     </span>
-                    {selectedAccount?.id === PORTFOLIO_ACCOUNT_ID && (
+                    {accountFilter.type === "all" && (
                       <Icons.Check className="text-primary h-4 w-4" />
                     )}
                   </div>
+                  {portfolios.map((portfolio) => (
+                    <div
+                      key={portfolio.id}
+                      className={cn(
+                        "flex cursor-pointer items-center justify-between border-t p-3 text-sm transition-colors",
+                        accountFilter.type === "portfolio" &&
+                          accountFilter.portfolioId === portfolio.id
+                          ? "bg-accent/50 font-medium"
+                          : "hover:bg-muted/50",
+                      )}
+                      onClick={() => {
+                        onAccountFilterChange({ type: "portfolio", portfolioId: portfolio.id });
+                        onOpenChange(false);
+                      }}
+                    >
+                      <span className="flex items-center gap-2">
+                        <Icons.Folder className="text-muted-foreground h-4 w-4" />
+                        {portfolio.name}
+                      </span>
+                      {accountFilter.type === "portfolio" &&
+                        accountFilter.portfolioId === portfolio.id && (
+                          <Icons.Check className="text-primary h-4 w-4" />
+                        )}
+                    </div>
+                  ))}
                   {accounts.map((account) => (
                     <div
                       key={account.id}
                       className={cn(
                         "flex cursor-pointer items-center justify-between border-t p-3 text-sm transition-colors",
-                        selectedAccount?.id === account.id
+                        accountFilter.type === "account" && accountFilter.accountId === account.id
                           ? "bg-accent/50 font-medium"
                           : "hover:bg-muted/50",
                       )}
                       onClick={() => {
-                        onAccountChange(account);
+                        onAccountFilterChange({ type: "account", accountId: account.id });
                         onOpenChange(false);
                       }}
                     >
                       <span className="flex items-center gap-2">
-                        <Icons.Wallet className="text-muted-foreground h-4 w-4" />
+                        <Icons.CreditCard className="text-muted-foreground h-4 w-4" />
                         {account.name}
                       </span>
-                      {selectedAccount?.id === account.id && (
-                        <Icons.Check className="text-primary h-4 w-4" />
-                      )}
+                      {accountFilter.type === "account" &&
+                        accountFilter.accountId === account.id && (
+                          <Icons.Check className="text-primary h-4 w-4" />
+                        )}
                     </div>
                   ))}
                 </div>

--- a/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
@@ -1,7 +1,7 @@
 import { TickerAvatar } from "@/components/ticker-avatar";
 import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
 import { parseOccSymbol } from "@/lib/occ-symbol";
-import { Account, AccountFilter, Holding } from "@/lib/types";
+import { Account, AccountScope, Holding } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { AmountDisplay, GainPercent, Input, Separator } from "@wealthfolio/ui";
 import { Button } from "@wealthfolio/ui/components/ui/button";
@@ -17,11 +17,11 @@ interface HoldingsTableMobileProps {
   isLoading: boolean;
   selectedTypes: string[];
   setSelectedTypes: (types: string[]) => void;
-  accountFilter: AccountFilter;
-  onAccountFilterChange: (filter: AccountFilter) => void;
+  accountFilter: AccountScope;
+  onAccountScopeChange: (filter: AccountScope) => void;
   accounts: Account[];
   portfolios: { id: string; name: string }[];
-  showAccountFilter?: boolean;
+  showAccountScope?: boolean;
   showSearch?: boolean;
   showFilterButton?: boolean;
   sortBy?: "symbol" | "marketValue";
@@ -37,10 +37,10 @@ export const HoldingsTableMobile = ({
   selectedTypes,
   setSelectedTypes,
   accountFilter,
-  onAccountFilterChange,
+  onAccountScopeChange,
   accounts,
   portfolios,
-  showAccountFilter = true,
+  showAccountScope = true,
   showSearch = true,
   showFilterButton = true,
   sortBy: controlledSortBy,
@@ -64,10 +64,10 @@ export const HoldingsTableMobile = ({
   const setShowTotalReturn = controlledSetShowTotalReturn ?? setInternalShowTotalReturn;
 
   const hasActiveFilters = useMemo(() => {
-    const hasAccountFilter = showAccountFilter && accountFilter.type !== "all";
+    const hasAccountScope = showAccountScope && accountFilter.type !== "all";
     const hasTypeFilter = selectedTypes.length > 0;
-    return hasAccountFilter || hasTypeFilter;
-  }, [accountFilter, selectedTypes, showAccountFilter]);
+    return hasAccountScope || hasTypeFilter;
+  }, [accountFilter, selectedTypes, showAccountScope]);
 
   const filteredHoldings = useMemo(() => {
     let result = [...holdings];
@@ -246,12 +246,12 @@ export const HoldingsTableMobile = ({
         open={isFilterSheetOpen}
         onOpenChange={setIsFilterSheetOpen}
         accountFilter={accountFilter}
-        onAccountFilterChange={onAccountFilterChange}
+        onAccountScopeChange={onAccountScopeChange}
         accounts={accounts}
         portfolios={portfolios}
         selectedTypes={selectedTypes}
         setSelectedTypes={setSelectedTypes}
-        showAccountFilter={showAccountFilter}
+        showAccountScope={showAccountScope}
         sortBy={sortBy}
         setSortBy={setSortBy}
         showTotalReturn={showTotalReturn}

--- a/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
@@ -1,8 +1,7 @@
 import { TickerAvatar } from "@/components/ticker-avatar";
 import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
-import { PORTFOLIO_ACCOUNT_ID } from "@/lib/constants";
 import { parseOccSymbol } from "@/lib/occ-symbol";
-import { Account, Holding } from "@/lib/types";
+import { Account, AccountFilter, Holding } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { AmountDisplay, GainPercent, Input, Separator } from "@wealthfolio/ui";
 import { Button } from "@wealthfolio/ui/components/ui/button";
@@ -18,9 +17,10 @@ interface HoldingsTableMobileProps {
   isLoading: boolean;
   selectedTypes: string[];
   setSelectedTypes: (types: string[]) => void;
-  selectedAccount: Account | null;
+  accountFilter: AccountFilter;
+  onAccountFilterChange: (filter: AccountFilter) => void;
   accounts: Account[];
-  onAccountChange: (account: Account) => void;
+  portfolios: { id: string; name: string }[];
   showAccountFilter?: boolean;
   showSearch?: boolean;
   showFilterButton?: boolean;
@@ -36,9 +36,10 @@ export const HoldingsTableMobile = ({
   isLoading,
   selectedTypes,
   setSelectedTypes,
-  selectedAccount,
+  accountFilter,
+  onAccountFilterChange,
   accounts,
-  onAccountChange,
+  portfolios,
   showAccountFilter = true,
   showSearch = true,
   showFilterButton = true,
@@ -63,10 +64,10 @@ export const HoldingsTableMobile = ({
   const setShowTotalReturn = controlledSetShowTotalReturn ?? setInternalShowTotalReturn;
 
   const hasActiveFilters = useMemo(() => {
-    const hasAccountFilter = showAccountFilter && selectedAccount?.id !== PORTFOLIO_ACCOUNT_ID;
+    const hasAccountFilter = showAccountFilter && accountFilter.type !== "all";
     const hasTypeFilter = selectedTypes.length > 0;
     return hasAccountFilter || hasTypeFilter;
-  }, [selectedAccount, selectedTypes, showAccountFilter]);
+  }, [accountFilter, selectedTypes, showAccountFilter]);
 
   const filteredHoldings = useMemo(() => {
     let result = [...holdings];
@@ -244,9 +245,10 @@ export const HoldingsTableMobile = ({
       <HoldingsMobileFilterSheet
         open={isFilterSheetOpen}
         onOpenChange={setIsFilterSheetOpen}
-        selectedAccount={selectedAccount}
+        accountFilter={accountFilter}
+        onAccountFilterChange={onAccountFilterChange}
         accounts={accounts}
-        onAccountChange={onAccountChange}
+        portfolios={portfolios}
         selectedTypes={selectedTypes}
         setSelectedTypes={setSelectedTypes}
         showAccountFilter={showAccountFilter}

--- a/apps/frontend/src/pages/holdings/holdings-insights-page.tsx
+++ b/apps/frontend/src/pages/holdings/holdings-insights-page.tsx
@@ -7,7 +7,7 @@ import { useHoldings } from "@/hooks/use-holdings";
 import { usePortfolioAllocations } from "@/hooks/use-portfolio-allocations";
 import { PORTFOLIO_ACCOUNT_ID, isAlternativeAssetKind, type AssetKind } from "@/lib/constants";
 import { useSettingsContext } from "@/lib/settings-provider";
-import type { TaxonomyAllocation } from "@/lib/types";
+import type { AccountFilter, TaxonomyAllocation } from "@/lib/types";
 import { useNavigate } from "react-router-dom";
 import { AllocationDetailSheet } from "./components/allocation-detail-sheet";
 import { CashHoldingsWidget } from "./components/cash-holdings-widget";
@@ -21,16 +21,22 @@ import { SegmentedAllocationBar } from "./components/segmented-allocation-bar";
 
 interface HoldingsInsightsPageProps {
   accountId?: string;
+  filter?: AccountFilter;
 }
 
-export const HoldingsInsightsPage = ({ accountId: accountIdProp }: HoldingsInsightsPageProps) => {
+export const HoldingsInsightsPage = ({
+  accountId: accountIdProp,
+  filter: filterProp,
+}: HoldingsInsightsPageProps) => {
   const navigate = useNavigate();
   const { settings } = useSettingsContext();
   const baseCurrency = settings?.baseCurrency ?? "USD";
 
+  const accountFilter: AccountFilter =
+    filterProp ?? (accountIdProp ? { type: "account", accountId: accountIdProp } : { type: "all" });
   const accountId = accountIdProp ?? PORTFOLIO_ACCOUNT_ID;
-  const { holdings, isLoading: holdingsLoading } = useHoldings(accountId);
-  const { allocations, isLoading: allocationsLoading } = usePortfolioAllocations(accountId);
+  const { holdings, isLoading: holdingsLoading } = useHoldings(accountFilter);
+  const { allocations, isLoading: allocationsLoading } = usePortfolioAllocations(accountFilter);
 
   const isLoading = holdingsLoading || allocationsLoading;
 

--- a/apps/frontend/src/pages/holdings/holdings-insights-page.tsx
+++ b/apps/frontend/src/pages/holdings/holdings-insights-page.tsx
@@ -8,7 +8,7 @@ import { usePortfolioAllocations } from "@/hooks/use-portfolio-allocations";
 import { usePortfolios } from "@/hooks/use-portfolios";
 import { PORTFOLIO_ACCOUNT_ID, isAlternativeAssetKind, type AssetKind } from "@/lib/constants";
 import { useSettingsContext } from "@/lib/settings-provider";
-import type { AccountFilter, TaxonomyAllocation } from "@/lib/types";
+import type { AccountScope, TaxonomyAllocation } from "@/lib/types";
 import { useNavigate } from "react-router-dom";
 import { AllocationDetailSheet } from "./components/allocation-detail-sheet";
 import { CashHoldingsWidget } from "./components/cash-holdings-widget";
@@ -22,7 +22,7 @@ import { SegmentedAllocationBar } from "./components/segmented-allocation-bar";
 
 interface HoldingsInsightsPageProps {
   accountId?: string;
-  filter?: AccountFilter;
+  filter?: AccountScope;
 }
 
 export const HoldingsInsightsPage = ({
@@ -33,7 +33,7 @@ export const HoldingsInsightsPage = ({
   const { settings } = useSettingsContext();
   const baseCurrency = settings?.baseCurrency ?? "USD";
 
-  const accountFilter: AccountFilter =
+  const accountFilter: AccountScope =
     filterProp ?? (accountIdProp ? { type: "account", accountId: accountIdProp } : { type: "all" });
   const accountId = accountIdProp ?? PORTFOLIO_ACCOUNT_ID;
   const { holdings, isLoading: holdingsLoading } = useHoldings(accountFilter);

--- a/apps/frontend/src/pages/holdings/holdings-insights-page.tsx
+++ b/apps/frontend/src/pages/holdings/holdings-insights-page.tsx
@@ -309,7 +309,7 @@ export const HoldingsInsightsPage = ({
         isOpen={isSheetOpen}
         onOpenChange={setIsSheetOpen}
         allocation={selectedAllocation}
-        accountId={accountId}
+        accountFilter={accountFilter}
         baseCurrency={baseCurrency}
         initialCategoryId={initialCategoryId}
       />

--- a/apps/frontend/src/pages/holdings/holdings-insights-page.tsx
+++ b/apps/frontend/src/pages/holdings/holdings-insights-page.tsx
@@ -6,7 +6,7 @@ import { useCallback, useMemo, useState } from "react";
 import { useHoldings } from "@/hooks/use-holdings";
 import { usePortfolioAllocations } from "@/hooks/use-portfolio-allocations";
 import { usePortfolios } from "@/hooks/use-portfolios";
-import { PORTFOLIO_ACCOUNT_ID, isAlternativeAssetKind, type AssetKind } from "@/lib/constants";
+import { isAlternativeAssetKind, type AssetKind } from "@/lib/constants";
 import { useSettingsContext } from "@/lib/settings-provider";
 import type { AccountScope, TaxonomyAllocation } from "@/lib/types";
 import { useNavigate } from "react-router-dom";
@@ -35,17 +35,17 @@ export const HoldingsInsightsPage = ({
 
   const accountFilter: AccountScope =
     filterProp ?? (accountIdProp ? { type: "account", accountId: accountIdProp } : { type: "all" });
-  const accountId = accountIdProp ?? PORTFOLIO_ACCOUNT_ID;
   const { holdings, isLoading: holdingsLoading } = useHoldings(accountFilter);
   const { allocations, isLoading: allocationsLoading } = usePortfolioAllocations(accountFilter);
 
   const { data: portfolios = [] } = usePortfolios();
   const filteredAccountIds = useMemo(() => {
     if (accountFilter.type === "account") return [accountFilter.accountId];
+    if (accountFilter.type === "accounts") return accountFilter.accountIds;
     if (accountFilter.type === "portfolio") {
       return portfolios.find((p) => p.id === accountFilter.portfolioId)?.accountIds;
     }
-    return undefined;
+    return undefined; // "all" → DrillableAccountChart shows every account
   }, [accountFilter, portfolios]);
 
   const isLoading = holdingsLoading || allocationsLoading;

--- a/apps/frontend/src/pages/holdings/holdings-insights-page.tsx
+++ b/apps/frontend/src/pages/holdings/holdings-insights-page.tsx
@@ -43,7 +43,7 @@ export const HoldingsInsightsPage = ({
     if (accountFilter.type === "account") return [accountFilter.accountId];
     if (accountFilter.type === "accounts") return accountFilter.accountIds;
     if (accountFilter.type === "portfolio") {
-      return portfolios.find((p) => p.id === accountFilter.portfolioId)?.accountIds;
+      return portfolios.find((p) => p.id === accountFilter.portfolioId)?.accountIds ?? [];
     }
     return undefined; // "all" → DrillableAccountChart shows every account
   }, [accountFilter, portfolios]);

--- a/apps/frontend/src/pages/holdings/holdings-insights-page.tsx
+++ b/apps/frontend/src/pages/holdings/holdings-insights-page.tsx
@@ -5,6 +5,7 @@ import { useCallback, useMemo, useState } from "react";
 
 import { useHoldings } from "@/hooks/use-holdings";
 import { usePortfolioAllocations } from "@/hooks/use-portfolio-allocations";
+import { usePortfolios } from "@/hooks/use-portfolios";
 import { PORTFOLIO_ACCOUNT_ID, isAlternativeAssetKind, type AssetKind } from "@/lib/constants";
 import { useSettingsContext } from "@/lib/settings-provider";
 import type { AccountFilter, TaxonomyAllocation } from "@/lib/types";
@@ -37,6 +38,15 @@ export const HoldingsInsightsPage = ({
   const accountId = accountIdProp ?? PORTFOLIO_ACCOUNT_ID;
   const { holdings, isLoading: holdingsLoading } = useHoldings(accountFilter);
   const { allocations, isLoading: allocationsLoading } = usePortfolioAllocations(accountFilter);
+
+  const { data: portfolios = [] } = usePortfolios();
+  const filteredAccountIds = useMemo(() => {
+    if (accountFilter.type === "account") return [accountFilter.accountId];
+    if (accountFilter.type === "portfolio") {
+      return portfolios.find((p) => p.id === accountFilter.portfolioId)?.accountIds;
+    }
+    return undefined;
+  }, [accountFilter, portfolios]);
 
   const isLoading = holdingsLoading || allocationsLoading;
 
@@ -163,7 +173,7 @@ export const HoldingsInsightsPage = ({
             }
           />
 
-          <DrillableAccountChart isLoading={isLoading} />
+          <DrillableAccountChart isLoading={isLoading} accountIds={filteredAccountIds} />
 
           <DrillableDonutChart
             title="Classes"

--- a/apps/frontend/src/pages/holdings/holdings-page.tsx
+++ b/apps/frontend/src/pages/holdings/holdings-page.tsx
@@ -9,6 +9,7 @@ import { AccountFilterSelector } from "@/components/account-filter-selector";
 import { ActionPalette, type ActionPaletteGroup } from "@/components/action-palette";
 import { useAccounts } from "@/hooks/use-accounts";
 import { useHoldings } from "@/hooks/use-holdings";
+import { usePortfolios } from "@/hooks/use-portfolios";
 import {
   useAlternativeHoldings,
   useDeleteAlternativeAsset,
@@ -67,6 +68,7 @@ export const HoldingsPage = () => {
 
   const { holdings, isLoading } = useHoldings(accountFilter);
   const { accounts, isLoading: isAccountsLoading } = useAccounts();
+  const { data: portfolios = [] } = usePortfolios();
   const { data: alternativeHoldings, isLoading: isAlternativeHoldingsLoading } =
     useAlternativeHoldings();
 
@@ -117,17 +119,6 @@ export const HoldingsPage = () => {
     undefined,
   );
   const updatePortfolioMutation = useUpdatePortfolioMutation();
-
-  const handleAccountSelect = useCallback((account: Account) => {
-    setSelectedAccount(account);
-    setIsEditMode(false);
-    // Sync AccountFilter when mobile filter sheet selects an account.
-    if (account.id === PORTFOLIO_ACCOUNT_ID) {
-      setAccountFilter({ type: "all" });
-    } else {
-      setAccountFilter({ type: "account", accountId: account.id });
-    }
-  }, []);
 
   const handleAccountFilterChange = useCallback(
     (filter: AccountFilter) => {
@@ -431,9 +422,10 @@ export const HoldingsPage = () => {
               isLoading={isDataLoading}
               selectedTypes={selectedTypes}
               setSelectedTypes={setSelectedTypes}
-              selectedAccount={selectedAccount}
+              accountFilter={accountFilter}
+              onAccountFilterChange={handleAccountFilterChange}
               accounts={accounts ?? []}
-              onAccountChange={handleAccountSelect}
+              portfolios={portfolios}
               showSearch={true}
               showFilterButton={false}
               sortBy={sortBy}
@@ -662,9 +654,10 @@ export const HoldingsPage = () => {
       <HoldingsMobileFilterSheet
         open={isFilterSheetOpen}
         onOpenChange={setIsFilterSheetOpen}
-        selectedAccount={selectedAccount}
+        accountFilter={accountFilter}
+        onAccountFilterChange={handleAccountFilterChange}
         accounts={accounts ?? []}
-        onAccountChange={handleAccountSelect}
+        portfolios={portfolios}
         selectedTypes={selectedTypes}
         setSelectedTypes={setSelectedTypes}
         sortBy={sortBy}

--- a/apps/frontend/src/pages/holdings/holdings-page.tsx
+++ b/apps/frontend/src/pages/holdings/holdings-page.tsx
@@ -62,14 +62,10 @@ export const HoldingsPage = () => {
 
   const [accountFilter, setAccountFilter] = useState<AccountFilter>({ type: "all" });
 
-  // Derive accountId for holdings: portfolio filter falls back to TOTAL (follow-up PR adds aggregation).
-  const holdingsAccountId =
-    accountFilter.type === "account" ? accountFilter.accountId : PORTFOLIO_ACCOUNT_ID;
-
   // Keep selectedAccount for edit/add functionality when a specific account is selected.
   const [selectedAccount, setSelectedAccount] = useState<Account | null>(null);
 
-  const { holdings, isLoading } = useHoldings(holdingsAccountId);
+  const { holdings, isLoading } = useHoldings(accountFilter);
   const { accounts, isLoading: isAccountsLoading } = useAccounts();
   const { data: alternativeHoldings, isLoading: isAlternativeHoldingsLoading } =
     useAlternativeHoldings();

--- a/apps/frontend/src/pages/holdings/holdings-page.tsx
+++ b/apps/frontend/src/pages/holdings/holdings-page.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
 import { SwipablePage, SwipablePageView } from "@/components/page";
-import { AccountFilterSelector } from "@/components/account-filter-selector";
+import { AccountScopeSelector } from "@/components/account-filter-selector";
 import { ActionPalette, type ActionPaletteGroup } from "@/components/action-palette";
 import { useAccounts } from "@/hooks/use-accounts";
 import { useHoldings } from "@/hooks/use-holdings";
@@ -24,7 +24,7 @@ import {
 } from "@/lib/constants";
 import {
   Account,
-  AccountFilter,
+  AccountScope,
   HoldingType,
   AlternativeAssetHolding,
   AlternativeAssetKind,
@@ -61,7 +61,7 @@ export const HoldingsPage = () => {
   const { settings } = useSettingsContext();
   const baseCurrency = settings?.baseCurrency ?? "USD";
 
-  const [accountFilter, setAccountFilter] = useState<AccountFilter>({ type: "all" });
+  const [accountFilter, setAccountScope] = useState<AccountScope>({ type: "all" });
 
   // Keep selectedAccount for edit/add functionality when a specific account is selected.
   const [selectedAccount, setSelectedAccount] = useState<Account | null>(null);
@@ -120,9 +120,9 @@ export const HoldingsPage = () => {
   );
   const updatePortfolioMutation = useUpdatePortfolioMutation();
 
-  const handleAccountFilterChange = useCallback(
-    (filter: AccountFilter) => {
-      setAccountFilter(filter);
+  const handleAccountScopeChange = useCallback(
+    (filter: AccountScope) => {
+      setAccountScope(filter);
       setIsEditMode(false);
       setSelectedAccount(
         filter.type === "account"
@@ -423,7 +423,7 @@ export const HoldingsPage = () => {
               selectedTypes={selectedTypes}
               setSelectedTypes={setSelectedTypes}
               accountFilter={accountFilter}
-              onAccountFilterChange={handleAccountFilterChange}
+              onAccountScopeChange={handleAccountScopeChange}
               accounts={accounts ?? []}
               portfolios={portfolios}
               showSearch={true}
@@ -582,7 +582,7 @@ export const HoldingsPage = () => {
             <Icons.ListFilter className="h-4 w-4" />
           </Button>
         ) : (
-          <AccountFilterSelector value={accountFilter} onChange={handleAccountFilterChange} />
+          <AccountScopeSelector value={accountFilter} onChange={handleAccountScopeChange} />
         )}
         {/* Show Update button for HOLDINGS-mode manual accounts (only on investments tab) */}
         {canEditHoldings && !isEditMode && currentTab === "investments" && (
@@ -602,7 +602,7 @@ export const HoldingsPage = () => {
       isMobileViewport,
       setIsFilterSheetOpen,
       accountFilter,
-      handleAccountFilterChange,
+      handleAccountScopeChange,
       canEditHoldings,
       isEditMode,
       currentTab,
@@ -655,7 +655,7 @@ export const HoldingsPage = () => {
         open={isFilterSheetOpen}
         onOpenChange={setIsFilterSheetOpen}
         accountFilter={accountFilter}
-        onAccountFilterChange={handleAccountFilterChange}
+        onAccountScopeChange={handleAccountScopeChange}
         accounts={accounts ?? []}
         portfolios={portfolios}
         selectedTypes={selectedTypes}

--- a/apps/frontend/src/pages/income/income-mobile-filter-sheet.tsx
+++ b/apps/frontend/src/pages/income/income-mobile-filter-sheet.tsx
@@ -8,7 +8,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@wealthfolio/ui/components/ui/sheet";
-import type { AccountFilter } from "@/lib/types";
+import type { AccountScope } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { ScrollArea } from "@wealthfolio/ui";
 import { useAccounts } from "@/hooks/use-accounts";
@@ -17,21 +17,21 @@ import { usePortfolios } from "@/hooks/use-portfolios";
 interface IncomeMobileFilterSheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  accountFilter: AccountFilter;
-  onAccountFilterChange: (filter: AccountFilter) => void;
+  accountFilter: AccountScope;
+  onAccountScopeChange: (filter: AccountScope) => void;
 }
 
 export const IncomeMobileFilterSheet = ({
   open,
   onOpenChange,
   accountFilter,
-  onAccountFilterChange,
+  onAccountScopeChange,
 }: IncomeMobileFilterSheetProps) => {
   const { accounts } = useAccounts();
   const { data: portfolios = [] } = usePortfolios();
 
-  const select = (filter: AccountFilter) => {
-    onAccountFilterChange(filter);
+  const select = (filter: AccountScope) => {
+    onAccountScopeChange(filter);
     onOpenChange(false);
   };
 

--- a/apps/frontend/src/pages/income/income-mobile-filter-sheet.tsx
+++ b/apps/frontend/src/pages/income/income-mobile-filter-sheet.tsx
@@ -67,18 +67,22 @@ export const IncomeMobileFilterSheet = ({
               </div>
 
               {portfolios.map((p) => {
+                const isSelected =
+                  accountFilter.type === "portfolio" && accountFilter.portfolioId === p.id;
                 return (
                   <div
                     key={p.id}
                     className={cn(
-                      "text-muted-foreground flex cursor-not-allowed items-center justify-between border-t p-3 text-sm opacity-75",
+                      "flex cursor-pointer items-center justify-between border-t p-3 text-sm transition-colors",
+                      isSelected ? "bg-accent/50 font-medium" : "hover:bg-muted/50",
                     )}
+                    onClick={() => select({ type: "portfolio", portfolioId: p.id })}
                   >
                     <span className="flex items-center gap-2">
                       <Icons.Folder className="text-muted-foreground h-4 w-4" />
                       {p.name}
                     </span>
-                    <span className="text-xs">Coming soon</span>
+                    {isSelected && <Icons.Check className="text-primary h-4 w-4" />}
                   </div>
                 );
               })}

--- a/apps/frontend/src/pages/income/income-page.tsx
+++ b/apps/frontend/src/pages/income/income-page.tsx
@@ -11,8 +11,8 @@ import { EmptyPlaceholder } from "@wealthfolio/ui/components/ui/empty-placeholde
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
 import { Skeleton } from "@wealthfolio/ui/components/ui/skeleton";
 import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
-import { AccountFilterSelector } from "@/components/account-filter-selector";
-import type { AccountFilter } from "@/lib/types";
+import { AccountScopeSelector } from "@/components/account-filter-selector";
+import type { AccountScope } from "@/lib/types";
 
 import { QueryKeys } from "@/lib/query-keys";
 import type { IncomeSummary } from "@/lib/types";
@@ -66,7 +66,7 @@ export default function IncomePage() {
   const { isBalanceHidden } = useBalancePrivacy();
   const [isFilterSheetOpen, setIsFilterSheetOpen] = useState(false);
 
-  const [accountFilter, setAccountFilter] = useState<AccountFilter>({ type: "all" });
+  const [accountFilter, setAccountScope] = useState<AccountScope>({ type: "all" });
 
   const incomeFilter = accountFilter.type === "all" ? undefined : accountFilter;
 
@@ -94,7 +94,7 @@ export default function IncomePage() {
     return (
       <>
         <div className="pointer-events-auto fixed right-2 top-4 z-20 hidden items-center gap-2 md:flex lg:right-4">
-          <AccountFilterSelector value={accountFilter} onChange={setAccountFilter} />
+          <AccountScopeSelector value={accountFilter} onChange={setAccountScope} />
           <IncomePeriodSelector
             selectedPeriod={selectedPeriod}
             onPeriodSelect={setSelectedPeriod}
@@ -127,7 +127,7 @@ export default function IncomePage() {
           open={isFilterSheetOpen}
           onOpenChange={setIsFilterSheetOpen}
           accountFilter={accountFilter}
-          onAccountFilterChange={setAccountFilter}
+          onAccountScopeChange={setAccountScope}
         />
       </>
     );
@@ -198,7 +198,7 @@ export default function IncomePage() {
     <>
       {/* Desktop: fixed header with account selector + period toggle */}
       <div className="pointer-events-auto fixed right-2 top-4 z-20 hidden items-center gap-2 md:flex lg:right-4">
-        <AccountFilterSelector value={accountFilter} onChange={setAccountFilter} />
+        <AccountScopeSelector value={accountFilter} onChange={setAccountScope} />
         <IncomePeriodSelector selectedPeriod={selectedPeriod} onPeriodSelect={setSelectedPeriod} />
       </div>
 
@@ -489,7 +489,7 @@ export default function IncomePage() {
         open={isFilterSheetOpen}
         onOpenChange={setIsFilterSheetOpen}
         accountFilter={accountFilter}
-        onAccountFilterChange={setAccountFilter}
+        onAccountScopeChange={setAccountScope}
       />
     </>
   );

--- a/apps/frontend/src/pages/income/income-page.tsx
+++ b/apps/frontend/src/pages/income/income-page.tsx
@@ -68,16 +68,15 @@ export default function IncomePage() {
 
   const [accountFilter, setAccountFilter] = useState<AccountFilter>({ type: "all" });
 
-  // Portfolio-level income aggregation is a follow-up; portfolio filter falls back to all accounts.
-  const accountId = accountFilter.type === "account" ? accountFilter.accountId : undefined;
+  const incomeFilter = accountFilter.type === "all" ? undefined : accountFilter;
 
   const {
     data: incomeData,
     isLoading,
     error,
   } = useQuery<IncomeSummary[], Error>({
-    queryKey: [QueryKeys.INCOME_SUMMARY, accountId ?? "ALL"],
-    queryFn: () => getIncomeSummary(accountId),
+    queryKey: [QueryKeys.INCOME_SUMMARY, incomeFilter ?? "ALL"],
+    queryFn: () => getIncomeSummary(incomeFilter),
   });
 
   if (isLoading) {

--- a/apps/frontend/src/pages/insights/portfolio-insights.tsx
+++ b/apps/frontend/src/pages/insights/portfolio-insights.tsx
@@ -1,6 +1,6 @@
 import { AccountFilterSelector } from "@/components/account-filter-selector";
 import { SwipablePage, SwipablePageView } from "@/components/page";
-import { PORTFOLIO_ACCOUNT_ID } from "@/lib/constants";
+
 import type { AccountFilter } from "@/lib/types";
 import IncomePage from "@/pages/income/income-page";
 import PerformancePage from "@/pages/performance/performance-page";
@@ -36,10 +36,6 @@ const DashboardLoader = () => (
 export default function PortfolioInsightsPage() {
   const [accountFilter, setAccountFilter] = useState<AccountFilter>({ type: "all" });
 
-  // Portfolio-level holdings aggregation is a follow-up; portfolio filter uses all accounts.
-  const accountId =
-    accountFilter.type === "account" ? accountFilter.accountId : PORTFOLIO_ACCOUNT_ID;
-
   const holdingsActions = useMemo(
     () => <AccountFilterSelector value={accountFilter} onChange={setAccountFilter} />,
     [accountFilter],
@@ -54,7 +50,7 @@ export default function PortfolioInsightsPage() {
         icon: Icons.PieChart,
         content: (
           <Suspense fallback={<DashboardLoader />}>
-            <HoldingsInsightsPage accountId={accountId} />
+            <HoldingsInsightsPage filter={accountFilter} />
           </Suspense>
         ),
         actions: holdingsActions,
@@ -80,7 +76,7 @@ export default function PortfolioInsightsPage() {
         ),
       },
     ],
-    [accountId, holdingsActions],
+    [accountFilter, holdingsActions],
   );
 
   return <SwipablePage views={views} defaultView="holdings" withPadding={true} />;

--- a/apps/frontend/src/pages/insights/portfolio-insights.tsx
+++ b/apps/frontend/src/pages/insights/portfolio-insights.tsx
@@ -1,7 +1,7 @@
-import { AccountFilterSelector } from "@/components/account-filter-selector";
+import { AccountScopeSelector } from "@/components/account-filter-selector";
 import { SwipablePage, SwipablePageView } from "@/components/page";
 
-import type { AccountFilter } from "@/lib/types";
+import type { AccountScope } from "@/lib/types";
 import IncomePage from "@/pages/income/income-page";
 import PerformancePage from "@/pages/performance/performance-page";
 import { Icons } from "@wealthfolio/ui";
@@ -34,10 +34,10 @@ const DashboardLoader = () => (
 );
 
 export default function PortfolioInsightsPage() {
-  const [accountFilter, setAccountFilter] = useState<AccountFilter>({ type: "all" });
+  const [accountFilter, setAccountScope] = useState<AccountScope>({ type: "all" });
 
   const holdingsActions = useMemo(
-    () => <AccountFilterSelector value={accountFilter} onChange={setAccountFilter} />,
+    () => <AccountScopeSelector value={accountFilter} onChange={setAccountScope} />,
     [accountFilter],
   );
 

--- a/apps/server/src/api/holdings/dto.rs
+++ b/apps/server/src/api/holdings/dto.rs
@@ -1,11 +1,26 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+use wealthfolio_core::portfolios::AccountFilter;
 
 #[derive(Deserialize)]
 pub struct HoldingsQuery {
     #[serde(rename = "accountId")]
     pub account_id: String,
+}
+
+#[derive(Deserialize)]
+pub struct FilterBody {
+    pub filter: AccountFilter,
+}
+
+#[derive(Deserialize)]
+pub struct AllocationFilterBody {
+    pub filter: AccountFilter,
+    #[serde(rename = "taxonomyId")]
+    pub taxonomy_id: String,
+    #[serde(rename = "categoryId")]
+    pub category_id: String,
 }
 
 #[derive(Deserialize)]

--- a/apps/server/src/api/holdings/dto.rs
+++ b/apps/server/src/api/holdings/dto.rs
@@ -4,12 +4,6 @@ use serde::{Deserialize, Serialize};
 use wealthfolio_core::portfolios::AccountFilter;
 
 #[derive(Deserialize)]
-pub struct HoldingsQuery {
-    #[serde(rename = "accountId")]
-    pub account_id: String,
-}
-
-#[derive(Deserialize)]
 pub struct FilterBody {
     pub filter: AccountFilter,
 }
@@ -45,16 +39,6 @@ pub struct HistoryQuery {
     pub start_date: Option<String>,
     #[serde(rename = "endDate")]
     pub end_date: Option<String>,
-}
-
-#[derive(Deserialize)]
-pub struct AllocationHoldingsQuery {
-    #[serde(rename = "accountId")]
-    pub account_id: String,
-    #[serde(rename = "taxonomyId")]
-    pub taxonomy_id: String,
-    #[serde(rename = "categoryId")]
-    pub category_id: String,
 }
 
 #[derive(Deserialize)]

--- a/apps/server/src/api/holdings/dto.rs
+++ b/apps/server/src/api/holdings/dto.rs
@@ -18,6 +18,22 @@ pub struct AllocationFilterBody {
 }
 
 #[derive(Deserialize)]
+pub struct AccountIdQuery {
+    #[serde(rename = "accountId")]
+    pub account_id: String,
+}
+
+#[derive(Deserialize)]
+pub struct AllocationHoldingsQuery {
+    #[serde(rename = "accountId")]
+    pub account_id: String,
+    #[serde(rename = "taxonomyId")]
+    pub taxonomy_id: String,
+    #[serde(rename = "categoryId")]
+    pub category_id: String,
+}
+
+#[derive(Deserialize)]
 pub struct HoldingItemQuery {
     #[serde(rename = "accountId")]
     pub account_id: String,

--- a/apps/server/src/api/holdings/dto.rs
+++ b/apps/server/src/api/holdings/dto.rs
@@ -1,16 +1,16 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
-use wealthfolio_core::portfolios::AccountFilter;
+use wealthfolio_core::portfolios::AccountScope;
 
 #[derive(Deserialize)]
 pub struct FilterBody {
-    pub filter: AccountFilter,
+    pub filter: AccountScope,
 }
 
 #[derive(Deserialize)]
 pub struct AllocationFilterBody {
-    pub filter: AccountFilter,
+    pub filter: AccountScope,
     #[serde(rename = "taxonomyId")]
     pub taxonomy_id: String,
     #[serde(rename = "categoryId")]

--- a/apps/server/src/api/holdings/handlers.rs
+++ b/apps/server/src/api/holdings/handlers.rs
@@ -50,12 +50,8 @@ fn resolve_scope(
     }
 }
 
-fn aggregated_id(filter: &AccountScope) -> String {
-    if let AccountScope::Portfolio { portfolio_id } = filter {
-        portfolio_id.clone()
-    } else {
-        String::new()
-    }
+fn aggregated_id(_filter: &AccountScope) -> String {
+    String::new()
 }
 
 pub async fn get_holdings(

--- a/apps/server/src/api/holdings/handlers.rs
+++ b/apps/server/src/api/holdings/handlers.rs
@@ -23,10 +23,11 @@ use wealthfolio_core::{
 use crate::{error::ApiResult, main_lib::AppState};
 
 use super::dto::{
-    AllocationFilterBody, AssetHoldingsQuery, CheckHoldingsImportRequest,
-    CheckHoldingsImportResult, DeleteSnapshotQuery, FilterBody, HistoryQuery, HoldingItemQuery,
-    HoldingsSnapshotInput, ImportHoldingsCsvRequest, ImportHoldingsCsvResult,
-    SaveManualHoldingsRequest, SnapshotDateQuery, SnapshotInfo, SnapshotsQuery, SymbolCheckResult,
+    AccountIdQuery, AllocationFilterBody, AllocationHoldingsQuery, AssetHoldingsQuery,
+    CheckHoldingsImportRequest, CheckHoldingsImportResult, DeleteSnapshotQuery, FilterBody,
+    HistoryQuery, HoldingItemQuery, HoldingsSnapshotInput, ImportHoldingsCsvRequest,
+    ImportHoldingsCsvResult, SaveManualHoldingsRequest, SnapshotDateQuery, SnapshotInfo,
+    SnapshotsQuery, SymbolCheckResult,
 };
 use super::mappers::{parse_date, parse_date_optional, snapshot_source_to_string};
 
@@ -77,6 +78,45 @@ pub async fn get_holdings(
         }
     };
     Ok(Json(holdings))
+}
+
+/// GET /holdings?accountId=... — simple single-account scope
+pub async fn get_holdings_for_account(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<AccountIdQuery>,
+) -> ApiResult<Json<Vec<Holding>>> {
+    let base = state.base_currency.read().unwrap().clone();
+    let holdings = state
+        .holdings_service
+        .get_holdings(&q.account_id, &base)
+        .await?;
+    Ok(Json(holdings))
+}
+
+/// GET /allocations?accountId=... — simple single-account scope
+pub async fn get_allocations_for_account(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<AccountIdQuery>,
+) -> ApiResult<Json<PortfolioAllocations>> {
+    let base = state.base_currency.read().unwrap().clone();
+    let allocations = state
+        .allocation_service
+        .get_portfolio_allocations(&q.account_id, &base)
+        .await?;
+    Ok(Json(allocations))
+}
+
+/// GET /allocations/holdings?accountId=...&taxonomyId=...&categoryId=... — simple single-account scope
+pub async fn get_holdings_by_allocation_for_account(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<AllocationHoldingsQuery>,
+) -> ApiResult<Json<AllocationHoldings>> {
+    let base = state.base_currency.read().unwrap().clone();
+    let result = state
+        .allocation_service
+        .get_holdings_by_allocation(&q.account_id, &base, &q.taxonomy_id, &q.category_id)
+        .await?;
+    Ok(Json(result))
 }
 
 pub async fn get_holding(

--- a/apps/server/src/api/holdings/handlers.rs
+++ b/apps/server/src/api/holdings/handlers.rs
@@ -6,7 +6,7 @@ use axum::{
 };
 use chrono::{NaiveDate, Utc};
 use rust_decimal::Decimal;
-use wealthfolio_core::portfolios::AccountScope;
+use wealthfolio_core::portfolios::{AccountScope, ResolvedAccountScope};
 use wealthfolio_core::{
     accounts::AccountServiceTrait,
     portfolio::{
@@ -30,17 +30,22 @@ use super::dto::{
 };
 use super::mappers::{parse_date, parse_date_optional, snapshot_source_to_string};
 
-fn resolve_filter(
+fn resolve_scope(
     filter: &AccountScope,
     state: &AppState,
-) -> Result<Vec<String>, crate::error::ApiError> {
+) -> Result<ResolvedAccountScope, crate::error::ApiError> {
     match filter {
-        AccountScope::All => Ok(vec!["TOTAL".to_string()]),
-        AccountScope::Account { account_id } => Ok(vec![account_id.clone()]),
-        AccountScope::Portfolio { .. } | AccountScope::Accounts { .. } => state
-            .portfolio_service
-            .resolve_account_filter(filter)
-            .map_err(Into::into),
+        AccountScope::All => Ok(ResolvedAccountScope::TotalSnapshot),
+        AccountScope::Account { account_id } => {
+            Ok(ResolvedAccountScope::Account(account_id.clone()))
+        }
+        AccountScope::Portfolio { .. } | AccountScope::Accounts { .. } => {
+            let ids = state
+                .portfolio_service
+                .resolve_account_filter(filter)
+                .map_err(crate::error::ApiError::from)?;
+            Ok(ResolvedAccountScope::Accounts(ids))
+        }
     }
 }
 
@@ -57,14 +62,19 @@ pub async fn get_holdings(
     Json(body): Json<FilterBody>,
 ) -> ApiResult<Json<Vec<Holding>>> {
     let base = state.base_currency.read().unwrap().clone();
-    let ids = resolve_filter(&body.filter, &state)?;
-    let holdings = if ids.len() == 1 {
-        state.holdings_service.get_holdings(&ids[0], &base).await?
-    } else {
-        state
-            .holdings_service
-            .get_holdings_for_accounts(&ids, &base, &aggregated_id(&body.filter))
-            .await?
+    let holdings = match resolve_scope(&body.filter, &state)? {
+        ResolvedAccountScope::TotalSnapshot => {
+            state.holdings_service.get_holdings("TOTAL", &base).await?
+        }
+        ResolvedAccountScope::Account(id) => {
+            state.holdings_service.get_holdings(&id, &base).await?
+        }
+        ResolvedAccountScope::Accounts(ids) => {
+            state
+                .holdings_service
+                .get_holdings_for_accounts(&ids, &base, &aggregated_id(&body.filter))
+                .await?
+        }
     };
     Ok(Json(holdings))
 }
@@ -163,17 +173,25 @@ pub async fn get_portfolio_allocations(
     Json(body): Json<FilterBody>,
 ) -> ApiResult<Json<PortfolioAllocations>> {
     let base = state.base_currency.read().unwrap().clone();
-    let ids = resolve_filter(&body.filter, &state)?;
-    let allocations = if ids.len() == 1 {
-        state
-            .allocation_service
-            .get_portfolio_allocations(&ids[0], &base)
-            .await?
-    } else {
-        state
-            .allocation_service
-            .get_portfolio_allocations_for_accounts(&ids, &base, &aggregated_id(&body.filter))
-            .await?
+    let allocations = match resolve_scope(&body.filter, &state)? {
+        ResolvedAccountScope::TotalSnapshot => {
+            state
+                .allocation_service
+                .get_portfolio_allocations("TOTAL", &base)
+                .await?
+        }
+        ResolvedAccountScope::Account(id) => {
+            state
+                .allocation_service
+                .get_portfolio_allocations(&id, &base)
+                .await?
+        }
+        ResolvedAccountScope::Accounts(ids) => {
+            state
+                .allocation_service
+                .get_portfolio_allocations_for_accounts(&ids, &base, &aggregated_id(&body.filter))
+                .await?
+        }
     };
     Ok(Json(allocations))
 }
@@ -183,23 +201,31 @@ pub async fn get_holdings_by_allocation(
     Json(body): Json<AllocationFilterBody>,
 ) -> ApiResult<Json<AllocationHoldings>> {
     let base = state.base_currency.read().unwrap().clone();
-    let ids = resolve_filter(&body.filter, &state)?;
-    let result = if ids.len() == 1 {
-        state
-            .allocation_service
-            .get_holdings_by_allocation(&ids[0], &base, &body.taxonomy_id, &body.category_id)
-            .await?
-    } else {
-        state
-            .allocation_service
-            .get_holdings_by_allocation_for_accounts(
-                &ids,
-                &base,
-                &body.taxonomy_id,
-                &body.category_id,
-                &aggregated_id(&body.filter),
-            )
-            .await?
+    let result = match resolve_scope(&body.filter, &state)? {
+        ResolvedAccountScope::TotalSnapshot => {
+            state
+                .allocation_service
+                .get_holdings_by_allocation("TOTAL", &base, &body.taxonomy_id, &body.category_id)
+                .await?
+        }
+        ResolvedAccountScope::Account(id) => {
+            state
+                .allocation_service
+                .get_holdings_by_allocation(&id, &base, &body.taxonomy_id, &body.category_id)
+                .await?
+        }
+        ResolvedAccountScope::Accounts(ids) => {
+            state
+                .allocation_service
+                .get_holdings_by_allocation_for_accounts(
+                    &ids,
+                    &base,
+                    &body.taxonomy_id,
+                    &body.category_id,
+                    &aggregated_id(&body.filter),
+                )
+                .await?
+        }
     };
     Ok(Json(result))
 }

--- a/apps/server/src/api/holdings/handlers.rs
+++ b/apps/server/src/api/holdings/handlers.rs
@@ -6,7 +6,7 @@ use axum::{
 };
 use chrono::{NaiveDate, Utc};
 use rust_decimal::Decimal;
-use wealthfolio_core::portfolios::AccountFilter;
+use wealthfolio_core::portfolios::AccountScope;
 use wealthfolio_core::{
     accounts::AccountServiceTrait,
     portfolio::{
@@ -31,21 +31,21 @@ use super::dto::{
 use super::mappers::{parse_date, parse_date_optional, snapshot_source_to_string};
 
 fn resolve_filter(
-    filter: &AccountFilter,
+    filter: &AccountScope,
     state: &AppState,
 ) -> Result<Vec<String>, crate::error::ApiError> {
     match filter {
-        AccountFilter::All => Ok(vec!["TOTAL".to_string()]),
-        AccountFilter::Account { account_id } => Ok(vec![account_id.clone()]),
-        AccountFilter::Portfolio { .. } | AccountFilter::AdHoc { .. } => state
+        AccountScope::All => Ok(vec!["TOTAL".to_string()]),
+        AccountScope::Account { account_id } => Ok(vec![account_id.clone()]),
+        AccountScope::Portfolio { .. } | AccountScope::Accounts { .. } => state
             .portfolio_service
             .resolve_account_filter(filter)
             .map_err(Into::into),
     }
 }
 
-fn aggregated_id(filter: &AccountFilter) -> String {
-    if let AccountFilter::Portfolio { portfolio_id } = filter {
+fn aggregated_id(filter: &AccountScope) -> String {
+    if let AccountScope::Portfolio { portfolio_id } = filter {
         portfolio_id.clone()
     } else {
         String::new()

--- a/apps/server/src/api/holdings/handlers.rs
+++ b/apps/server/src/api/holdings/handlers.rs
@@ -6,6 +6,7 @@ use axum::{
 };
 use chrono::{NaiveDate, Utc};
 use rust_decimal::Decimal;
+use wealthfolio_core::portfolios::AccountFilter;
 use wealthfolio_core::{
     accounts::AccountServiceTrait,
     portfolio::{
@@ -22,22 +23,49 @@ use wealthfolio_core::{
 use crate::{error::ApiResult, main_lib::AppState};
 
 use super::dto::{
-    AllocationHoldingsQuery, AssetHoldingsQuery, CheckHoldingsImportRequest,
-    CheckHoldingsImportResult, DeleteSnapshotQuery, HistoryQuery, HoldingItemQuery, HoldingsQuery,
-    HoldingsSnapshotInput, ImportHoldingsCsvRequest, ImportHoldingsCsvResult,
+    AllocationFilterBody, AllocationHoldingsQuery, AssetHoldingsQuery, CheckHoldingsImportRequest,
+    CheckHoldingsImportResult, DeleteSnapshotQuery, FilterBody, HistoryQuery, HoldingItemQuery,
+    HoldingsQuery, HoldingsSnapshotInput, ImportHoldingsCsvRequest, ImportHoldingsCsvResult,
     SaveManualHoldingsRequest, SnapshotDateQuery, SnapshotInfo, SnapshotsQuery, SymbolCheckResult,
 };
 use super::mappers::{parse_date, parse_date_optional, snapshot_source_to_string};
 
+fn resolve_filter(
+    filter: &AccountFilter,
+    state: &AppState,
+) -> Result<Vec<String>, crate::error::ApiError> {
+    match filter {
+        AccountFilter::All => Ok(vec!["TOTAL".to_string()]),
+        AccountFilter::Account { account_id } => Ok(vec![account_id.clone()]),
+        AccountFilter::Portfolio { .. } | AccountFilter::AdHoc { .. } => state
+            .portfolio_service
+            .resolve_account_filter(filter)
+            .map_err(Into::into),
+    }
+}
+
+fn aggregated_id(filter: &AccountFilter) -> String {
+    if let AccountFilter::Portfolio { portfolio_id } = filter {
+        portfolio_id.clone()
+    } else {
+        String::new()
+    }
+}
+
 pub async fn get_holdings(
     State(state): State<Arc<AppState>>,
-    Query(q): Query<HoldingsQuery>,
+    Json(body): Json<FilterBody>,
 ) -> ApiResult<Json<Vec<Holding>>> {
     let base = state.base_currency.read().unwrap().clone();
-    let holdings = state
-        .holdings_service
-        .get_holdings(&q.account_id, &base)
-        .await?;
+    let ids = resolve_filter(&body.filter, &state)?;
+    let holdings = if ids.len() == 1 {
+        state.holdings_service.get_holdings(&ids[0], &base).await?
+    } else {
+        state
+            .holdings_service
+            .get_holdings_for_accounts(&ids, &base, &aggregated_id(&body.filter))
+            .await?
+    };
     Ok(Json(holdings))
 }
 
@@ -132,25 +160,47 @@ pub async fn get_latest_valuations(
 
 pub async fn get_portfolio_allocations(
     State(state): State<Arc<AppState>>,
-    Query(q): Query<HoldingsQuery>,
+    Json(body): Json<FilterBody>,
 ) -> ApiResult<Json<PortfolioAllocations>> {
     let base = state.base_currency.read().unwrap().clone();
-    let allocations = state
-        .allocation_service
-        .get_portfolio_allocations(&q.account_id, &base)
-        .await?;
+    let ids = resolve_filter(&body.filter, &state)?;
+    let allocations = if ids.len() == 1 {
+        state
+            .allocation_service
+            .get_portfolio_allocations(&ids[0], &base)
+            .await?
+    } else {
+        state
+            .allocation_service
+            .get_portfolio_allocations_for_accounts(&ids, &base, &aggregated_id(&body.filter))
+            .await?
+    };
     Ok(Json(allocations))
 }
 
 pub async fn get_holdings_by_allocation(
     State(state): State<Arc<AppState>>,
-    Query(q): Query<AllocationHoldingsQuery>,
+    Json(body): Json<AllocationFilterBody>,
 ) -> ApiResult<Json<AllocationHoldings>> {
     let base = state.base_currency.read().unwrap().clone();
-    let result = state
-        .allocation_service
-        .get_holdings_by_allocation(&q.account_id, &base, &q.taxonomy_id, &q.category_id)
-        .await?;
+    let ids = resolve_filter(&body.filter, &state)?;
+    let result = if ids.len() == 1 {
+        state
+            .allocation_service
+            .get_holdings_by_allocation(&ids[0], &base, &body.taxonomy_id, &body.category_id)
+            .await?
+    } else {
+        state
+            .allocation_service
+            .get_holdings_by_allocation_for_accounts(
+                &ids,
+                &base,
+                &body.taxonomy_id,
+                &body.category_id,
+                &aggregated_id(&body.filter),
+            )
+            .await?
+    };
     Ok(Json(result))
 }
 

--- a/apps/server/src/api/holdings/handlers.rs
+++ b/apps/server/src/api/holdings/handlers.rs
@@ -23,9 +23,9 @@ use wealthfolio_core::{
 use crate::{error::ApiResult, main_lib::AppState};
 
 use super::dto::{
-    AllocationFilterBody, AllocationHoldingsQuery, AssetHoldingsQuery, CheckHoldingsImportRequest,
+    AllocationFilterBody, AssetHoldingsQuery, CheckHoldingsImportRequest,
     CheckHoldingsImportResult, DeleteSnapshotQuery, FilterBody, HistoryQuery, HoldingItemQuery,
-    HoldingsQuery, HoldingsSnapshotInput, ImportHoldingsCsvRequest, ImportHoldingsCsvResult,
+    HoldingsSnapshotInput, ImportHoldingsCsvRequest, ImportHoldingsCsvResult,
     SaveManualHoldingsRequest, SnapshotDateQuery, SnapshotInfo, SnapshotsQuery, SymbolCheckResult,
 };
 use super::mappers::{parse_date, parse_date_optional, snapshot_source_to_string};

--- a/apps/server/src/api/holdings/mod.rs
+++ b/apps/server/src/api/holdings/mod.rs
@@ -13,7 +13,7 @@ use crate::main_lib::AppState;
 
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
-        .route("/holdings", get(handlers::get_holdings))
+        .route("/holdings", post(handlers::get_holdings))
         .route("/holdings/item", get(handlers::get_holding))
         .route("/holdings/by-asset", get(handlers::get_asset_holdings))
         .route(
@@ -21,10 +21,10 @@ pub fn router() -> Router<Arc<AppState>> {
             get(handlers::get_historical_valuations),
         )
         .route("/valuations/latest", get(handlers::get_latest_valuations))
-        .route("/allocations", get(handlers::get_portfolio_allocations))
+        .route("/allocations", post(handlers::get_portfolio_allocations))
         .route(
             "/allocations/holdings",
-            get(handlers::get_holdings_by_allocation),
+            post(handlers::get_holdings_by_allocation),
         )
         .route(
             "/snapshots",

--- a/apps/server/src/api/holdings/mod.rs
+++ b/apps/server/src/api/holdings/mod.rs
@@ -13,7 +13,8 @@ use crate::main_lib::AppState;
 
 pub fn router() -> Router<Arc<AppState>> {
     Router::new()
-        .route("/holdings", post(handlers::get_holdings))
+        .route("/holdings", get(handlers::get_holdings_for_account))
+        .route("/holdings/query", post(handlers::get_holdings))
         .route("/holdings/item", get(handlers::get_holding))
         .route("/holdings/by-asset", get(handlers::get_asset_holdings))
         .route(
@@ -21,9 +22,17 @@ pub fn router() -> Router<Arc<AppState>> {
             get(handlers::get_historical_valuations),
         )
         .route("/valuations/latest", get(handlers::get_latest_valuations))
-        .route("/allocations", post(handlers::get_portfolio_allocations))
+        .route("/allocations", get(handlers::get_allocations_for_account))
+        .route(
+            "/allocations/query",
+            post(handlers::get_portfolio_allocations),
+        )
         .route(
             "/allocations/holdings",
+            get(handlers::get_holdings_by_allocation_for_account),
+        )
+        .route(
+            "/allocations/holdings/query",
             post(handlers::get_holdings_by_allocation),
         )
         .route(

--- a/apps/server/src/api/performance.rs
+++ b/apps/server/src/api/performance.rs
@@ -98,17 +98,18 @@ async fn calculate_performance_summary(
 #[derive(serde::Deserialize)]
 struct IncomeSummaryAccountQuery {
     #[serde(rename = "accountId")]
-    account_id: String,
+    account_id: Option<String>,
 }
 
-/// GET /income/summary?accountId=... — simple single-account scope
+/// GET /income/summary?accountId=... — single-account or all-accounts scope
 async fn get_income_summary_for_account(
     State(state): State<Arc<AppState>>,
     Query(q): Query<IncomeSummaryAccountQuery>,
 ) -> ApiResult<Json<Vec<IncomeSummary>>> {
+    let account_ids: Option<Vec<String>> = q.account_id.map(|id| vec![id]);
     let items = state
         .income_service
-        .get_income_summary(Some(&[q.account_id]))?;
+        .get_income_summary(account_ids.as_deref())?;
     Ok(Json(items))
 }
 

--- a/apps/server/src/api/performance.rs
+++ b/apps/server/src/api/performance.rs
@@ -93,18 +93,18 @@ async fn calculate_performance_summary(
 
 #[derive(serde::Deserialize)]
 struct IncomeSummaryBody {
-    filter: Option<wealthfolio_core::portfolios::AccountFilter>,
+    filter: Option<wealthfolio_core::portfolios::AccountScope>,
 }
 
 async fn get_income_summary(
     State(state): State<Arc<AppState>>,
     Json(body): Json<IncomeSummaryBody>,
 ) -> ApiResult<Json<Vec<IncomeSummary>>> {
-    use wealthfolio_core::portfolios::AccountFilter;
+    use wealthfolio_core::portfolios::AccountScope;
     let account_ids: Option<Vec<String>> = match &body.filter {
-        None | Some(AccountFilter::All) => None,
-        Some(AccountFilter::Account { account_id }) => Some(vec![account_id.clone()]),
-        Some(AccountFilter::Portfolio { .. }) | Some(AccountFilter::AdHoc { .. }) => Some(
+        None | Some(AccountScope::All) => None,
+        Some(AccountScope::Account { account_id }) => Some(vec![account_id.clone()]),
+        Some(AccountScope::Portfolio { .. }) | Some(AccountScope::Accounts { .. }) => Some(
             state
                 .portfolio_service
                 .resolve_account_filter(body.filter.as_ref().unwrap())

--- a/apps/server/src/api/performance.rs
+++ b/apps/server/src/api/performance.rs
@@ -1,11 +1,7 @@
 use std::sync::Arc;
 
 use crate::{error::ApiResult, main_lib::AppState};
-use axum::{
-    extract::{Query, State},
-    routing::post,
-    Json, Router,
-};
+use axum::{extract::State, routing::post, Json, Router};
 use wealthfolio_core::{
     accounts::{AccountServiceTrait, TrackingMode},
     portfolio::{
@@ -112,7 +108,7 @@ async fn get_income_summary(
             state
                 .portfolio_service
                 .resolve_account_filter(body.filter.as_ref().unwrap())
-                .map_err(|e| crate::error::ApiError::from(e))?,
+                .map_err(crate::error::ApiError::from)?,
         ),
     };
     let items = state

--- a/apps/server/src/api/performance.rs
+++ b/apps/server/src/api/performance.rs
@@ -1,7 +1,11 @@
 use std::sync::Arc;
 
 use crate::{error::ApiResult, main_lib::AppState};
-use axum::{extract::State, routing::post, Json, Router};
+use axum::{
+    extract::{Query, State},
+    routing::{get, post},
+    Json, Router,
+};
 use wealthfolio_core::{
     accounts::{AccountServiceTrait, TrackingMode},
     portfolio::{
@@ -92,10 +96,28 @@ async fn calculate_performance_summary(
 }
 
 #[derive(serde::Deserialize)]
+struct IncomeSummaryAccountQuery {
+    #[serde(rename = "accountId")]
+    account_id: String,
+}
+
+/// GET /income/summary?accountId=... — simple single-account scope
+async fn get_income_summary_for_account(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<IncomeSummaryAccountQuery>,
+) -> ApiResult<Json<Vec<IncomeSummary>>> {
+    let items = state
+        .income_service
+        .get_income_summary(Some(&[q.account_id]))?;
+    Ok(Json(items))
+}
+
+#[derive(serde::Deserialize)]
 struct IncomeSummaryBody {
     filter: Option<wealthfolio_core::portfolios::AccountScope>,
 }
 
+/// POST /income/summary/query — typed scope query (all, portfolio, multi-account)
 async fn get_income_summary(
     State(state): State<Arc<AppState>>,
     Json(body): Json<IncomeSummaryBody>,
@@ -125,5 +147,6 @@ pub fn router() -> Router<Arc<AppState>> {
         )
         .route("/performance/history", post(calculate_performance_history))
         .route("/performance/summary", post(calculate_performance_summary))
-        .route("/income/summary", post(get_income_summary))
+        .route("/income/summary", get(get_income_summary_for_account))
+        .route("/income/summary/query", post(get_income_summary))
 }

--- a/apps/server/src/api/performance.rs
+++ b/apps/server/src/api/performance.rs
@@ -96,18 +96,28 @@ async fn calculate_performance_summary(
 }
 
 #[derive(serde::Deserialize)]
-struct IncomeSummaryQuery {
-    #[serde(rename = "accountId")]
-    account_id: Option<String>,
+struct IncomeSummaryBody {
+    filter: Option<wealthfolio_core::portfolios::AccountFilter>,
 }
 
 async fn get_income_summary(
     State(state): State<Arc<AppState>>,
-    Query(query): Query<IncomeSummaryQuery>,
+    Json(body): Json<IncomeSummaryBody>,
 ) -> ApiResult<Json<Vec<IncomeSummary>>> {
+    use wealthfolio_core::portfolios::AccountFilter;
+    let account_ids: Option<Vec<String>> = match &body.filter {
+        None | Some(AccountFilter::All) => None,
+        Some(AccountFilter::Account { account_id }) => Some(vec![account_id.clone()]),
+        Some(AccountFilter::Portfolio { .. }) | Some(AccountFilter::AdHoc { .. }) => Some(
+            state
+                .portfolio_service
+                .resolve_account_filter(body.filter.as_ref().unwrap())
+                .map_err(|e| crate::error::ApiError::from(e))?,
+        ),
+    };
     let items = state
         .income_service
-        .get_income_summary(query.account_id.as_deref())?;
+        .get_income_summary(account_ids.as_deref())?;
     Ok(Json(items))
 }
 
@@ -119,5 +129,5 @@ pub fn router() -> Router<Arc<AppState>> {
         )
         .route("/performance/history", post(calculate_performance_history))
         .route("/performance/summary", post(calculate_performance_summary))
-        .route("/income/summary", axum::routing::get(get_income_summary))
+        .route("/income/summary", post(get_income_summary))
 }

--- a/apps/tauri/src/commands/portfolio.rs
+++ b/apps/tauri/src/commands/portfolio.rs
@@ -29,6 +29,42 @@ use wealthfolio_core::{
 };
 
 // ============================================================================
+// AccountFilter IPC boundary struct
+// ============================================================================
+
+/// Flat struct that mirrors the TypeScript `AccountFilter` discriminated union.
+/// Used only at the Tauri IPC boundary because serde internally-tagged enums
+/// fail deserialization in Tauri v2 (all variant fields are required simultaneously).
+/// The frontend sends `{ type: "account", accountId: "X" }` unchanged — this struct
+/// deserializes that format and converts to the internal `AccountFilter` enum.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountFilterInput {
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub account_id: Option<String>,
+    pub portfolio_id: Option<String>,
+    pub account_ids: Option<Vec<String>>,
+}
+
+impl AccountFilterInput {
+    fn into_account_filter(self) -> AccountFilter {
+        match self.kind.as_str() {
+            "account" => AccountFilter::Account {
+                account_id: self.account_id.unwrap_or_default(),
+            },
+            "portfolio" => AccountFilter::Portfolio {
+                portfolio_id: self.portfolio_id.unwrap_or_default(),
+            },
+            "adHoc" => AccountFilter::AdHoc {
+                account_ids: self.account_ids.unwrap_or_default(),
+            },
+            _ => AccountFilter::All,
+        }
+    }
+}
+
+// ============================================================================
 // Snapshot Info Types
 // ============================================================================
 
@@ -92,10 +128,12 @@ async fn resolve_filter_to_ids(
 #[tauri::command]
 pub async fn get_holdings(
     state: State<'_, Arc<ServiceContext>>,
-    filter: AccountFilter,
+    filter: AccountFilterInput,
 ) -> Result<Vec<Holding>, String> {
     debug!("Get holdings...");
     let base_currency = state.get_base_currency();
+    let aggregated_id = filter.portfolio_id.clone().unwrap_or_default();
+    let filter = filter.into_account_filter();
     let ids = resolve_filter_to_ids(&filter, &state).await?;
     if ids.len() == 1 {
         state
@@ -104,11 +142,6 @@ pub async fn get_holdings(
             .await
             .map_err(|e| e.to_string())
     } else {
-        let aggregated_id = if let AccountFilter::Portfolio { portfolio_id } = &filter {
-            portfolio_id.clone()
-        } else {
-            String::new()
-        };
         state
             .holdings_service()
             .get_holdings_for_accounts(&ids, &base_currency, &aggregated_id)
@@ -163,9 +196,11 @@ pub async fn get_asset_holdings(
 #[tauri::command]
 pub async fn get_portfolio_allocations(
     state: State<'_, Arc<ServiceContext>>,
-    filter: AccountFilter,
+    filter: AccountFilterInput,
 ) -> Result<PortfolioAllocations, String> {
     let base_currency = state.get_base_currency();
+    let aggregated_id = filter.portfolio_id.clone().unwrap_or_default();
+    let filter = filter.into_account_filter();
     let ids = resolve_filter_to_ids(&filter, &state).await?;
     if ids.len() == 1 {
         state
@@ -174,11 +209,6 @@ pub async fn get_portfolio_allocations(
             .await
             .map_err(|e| e.to_string())
     } else {
-        let aggregated_id = if let AccountFilter::Portfolio { portfolio_id } = &filter {
-            portfolio_id.clone()
-        } else {
-            String::new()
-        };
         state
             .allocation_service()
             .get_portfolio_allocations_for_accounts(&ids, &base_currency, &aggregated_id)
@@ -190,11 +220,13 @@ pub async fn get_portfolio_allocations(
 #[tauri::command]
 pub async fn get_holdings_by_allocation(
     state: State<'_, Arc<ServiceContext>>,
-    filter: AccountFilter,
+    filter: AccountFilterInput,
     taxonomy_id: String,
     category_id: String,
 ) -> Result<AllocationHoldings, String> {
     let base_currency = state.get_base_currency();
+    let aggregated_id = filter.portfolio_id.clone().unwrap_or_default();
+    let filter = filter.into_account_filter();
     let ids = resolve_filter_to_ids(&filter, &state).await?;
     if ids.len() == 1 {
         state
@@ -203,11 +235,6 @@ pub async fn get_holdings_by_allocation(
             .await
             .map_err(|e| e.to_string())
     } else {
-        let aggregated_id = if let AccountFilter::Portfolio { portfolio_id } = &filter {
-            portfolio_id.clone()
-        } else {
-            String::new()
-        };
         state
             .allocation_service()
             .get_holdings_by_allocation_for_accounts(
@@ -284,18 +311,23 @@ pub async fn get_latest_valuations(
 #[tauri::command]
 pub async fn get_income_summary(
     state: State<'_, Arc<ServiceContext>>,
-    filter: Option<AccountFilter>,
+    filter: Option<AccountFilterInput>,
 ) -> Result<Vec<IncomeSummary>, String> {
     debug!("Fetching income summary...");
-    let account_ids: Option<Vec<String>> = match &filter {
-        None | Some(AccountFilter::All) => None,
-        Some(AccountFilter::Account { account_id }) => Some(vec![account_id.clone()]),
-        Some(AccountFilter::Portfolio { .. }) | Some(AccountFilter::AdHoc { .. }) => Some(
-            state
-                .portfolio_service()
-                .resolve_account_filter(filter.as_ref().unwrap())
-                .map_err(|e| e.to_string())?,
-        ),
+    let account_ids: Option<Vec<String>> = if let Some(input) = filter {
+        let af = input.into_account_filter();
+        match &af {
+            AccountFilter::All => None,
+            AccountFilter::Account { account_id } => Some(vec![account_id.clone()]),
+            AccountFilter::Portfolio { .. } | AccountFilter::AdHoc { .. } => Some(
+                state
+                    .portfolio_service()
+                    .resolve_account_filter(&af)
+                    .map_err(|e| e.to_string())?,
+            ),
+        }
+    } else {
+        None
     };
     state
         .income_service()

--- a/apps/tauri/src/commands/portfolio.rs
+++ b/apps/tauri/src/commands/portfolio.rs
@@ -48,18 +48,29 @@ pub struct AccountFilterInput {
 }
 
 impl AccountFilterInput {
-    fn into_account_filter(self) -> AccountFilter {
+    fn into_account_filter(self) -> Result<AccountFilter, String> {
         match self.kind.as_str() {
-            "account" => AccountFilter::Account {
-                account_id: self.account_id.unwrap_or_default(),
-            },
-            "portfolio" => AccountFilter::Portfolio {
-                portfolio_id: self.portfolio_id.unwrap_or_default(),
-            },
-            "adHoc" => AccountFilter::AdHoc {
-                account_ids: self.account_ids.unwrap_or_default(),
-            },
-            _ => AccountFilter::All,
+            "all" => Ok(AccountFilter::All),
+            "account" => {
+                let id = self
+                    .account_id
+                    .filter(|s| !s.is_empty())
+                    .ok_or_else(|| "accountId required for filter type 'account'".to_string())?;
+                Ok(AccountFilter::Account { account_id: id })
+            }
+            "portfolio" => {
+                let id = self.portfolio_id.filter(|s| !s.is_empty()).ok_or_else(|| {
+                    "portfolioId required for filter type 'portfolio'".to_string()
+                })?;
+                Ok(AccountFilter::Portfolio { portfolio_id: id })
+            }
+            "adHoc" | "accounts" => {
+                let ids = self.account_ids.filter(|v| !v.is_empty()).ok_or_else(|| {
+                    "accountIds required and must be non-empty for filter type 'adHoc'".to_string()
+                })?;
+                Ok(AccountFilter::AdHoc { account_ids: ids })
+            }
+            other => Err(format!("unknown filter type: '{other}'")),
         }
     }
 }
@@ -133,7 +144,7 @@ pub async fn get_holdings(
     debug!("Get holdings...");
     let base_currency = state.get_base_currency();
     let aggregated_id = filter.portfolio_id.clone().unwrap_or_default();
-    let filter = filter.into_account_filter();
+    let filter = filter.into_account_filter()?;
     let ids = resolve_filter_to_ids(&filter, &state).await?;
     if ids.len() == 1 {
         state
@@ -200,7 +211,7 @@ pub async fn get_portfolio_allocations(
 ) -> Result<PortfolioAllocations, String> {
     let base_currency = state.get_base_currency();
     let aggregated_id = filter.portfolio_id.clone().unwrap_or_default();
-    let filter = filter.into_account_filter();
+    let filter = filter.into_account_filter()?;
     let ids = resolve_filter_to_ids(&filter, &state).await?;
     if ids.len() == 1 {
         state
@@ -226,7 +237,7 @@ pub async fn get_holdings_by_allocation(
 ) -> Result<AllocationHoldings, String> {
     let base_currency = state.get_base_currency();
     let aggregated_id = filter.portfolio_id.clone().unwrap_or_default();
-    let filter = filter.into_account_filter();
+    let filter = filter.into_account_filter()?;
     let ids = resolve_filter_to_ids(&filter, &state).await?;
     if ids.len() == 1 {
         state
@@ -315,7 +326,7 @@ pub async fn get_income_summary(
 ) -> Result<Vec<IncomeSummary>, String> {
     debug!("Fetching income summary...");
     let account_ids: Option<Vec<String>> = if let Some(input) = filter {
-        let af = input.into_account_filter();
+        let af = input.into_account_filter()?;
         match &af {
             AccountFilter::All => None,
             AccountFilter::Account { account_id } => Some(vec![account_id.clone()]),

--- a/apps/tauri/src/commands/portfolio.rs
+++ b/apps/tauri/src/commands/portfolio.rs
@@ -23,23 +23,23 @@ use wealthfolio_core::{
         CashBalanceInput, ManualHoldingInput, ManualSnapshotRequest, ManualSnapshotService,
         SnapshotSource,
     },
-    portfolios::AccountFilter,
+    portfolios::AccountScope,
     quotes::MarketSyncMode,
     valuation::DailyAccountValuation,
 };
 
 // ============================================================================
-// AccountFilter IPC boundary struct
+// AccountScope IPC boundary struct
 // ============================================================================
 
-/// Flat struct that mirrors the TypeScript `AccountFilter` discriminated union.
+/// Flat struct that mirrors the TypeScript `AccountScope` discriminated union.
 /// Used only at the Tauri IPC boundary because serde internally-tagged enums
 /// fail deserialization in Tauri v2 (all variant fields are required simultaneously).
 /// The frontend sends `{ type: "account", accountId: "X" }` unchanged — this struct
-/// deserializes that format and converts to the internal `AccountFilter` enum.
+/// deserializes that format and converts to the internal `AccountScope` enum.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct AccountFilterInput {
+pub struct AccountScopeInput {
     #[serde(rename = "type")]
     pub kind: String,
     pub account_id: Option<String>,
@@ -47,28 +47,28 @@ pub struct AccountFilterInput {
     pub account_ids: Option<Vec<String>>,
 }
 
-impl AccountFilterInput {
-    fn into_account_filter(self) -> Result<AccountFilter, String> {
+impl AccountScopeInput {
+    fn into_account_filter(self) -> Result<AccountScope, String> {
         match self.kind.as_str() {
-            "all" => Ok(AccountFilter::All),
+            "all" => Ok(AccountScope::All),
             "account" => {
                 let id = self
                     .account_id
                     .filter(|s| !s.is_empty())
                     .ok_or_else(|| "accountId required for filter type 'account'".to_string())?;
-                Ok(AccountFilter::Account { account_id: id })
+                Ok(AccountScope::Account { account_id: id })
             }
             "portfolio" => {
                 let id = self.portfolio_id.filter(|s| !s.is_empty()).ok_or_else(|| {
                     "portfolioId required for filter type 'portfolio'".to_string()
                 })?;
-                Ok(AccountFilter::Portfolio { portfolio_id: id })
+                Ok(AccountScope::Portfolio { portfolio_id: id })
             }
             "adHoc" | "accounts" => {
                 let ids = self.account_ids.filter(|v| !v.is_empty()).ok_or_else(|| {
                     "accountIds required and must be non-empty for filter type 'adHoc'".to_string()
                 })?;
-                Ok(AccountFilter::AdHoc { account_ids: ids })
+                Ok(AccountScope::Accounts { account_ids: ids })
             }
             other => Err(format!("unknown filter type: '{other}'")),
         }
@@ -120,16 +120,16 @@ pub async fn update_portfolio(handle: AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-/// Resolves `AccountFilter` to account IDs. `All` returns `["TOTAL"]` to use the fast
-/// pre-computed snapshot; `Portfolio`/`AdHoc` return resolved member IDs for aggregation.
+/// Resolves `AccountScope` to account IDs. `All` returns `["TOTAL"]` to use the fast
+/// pre-computed snapshot; `Portfolio`/`Accounts` return resolved member IDs for aggregation.
 async fn resolve_filter_to_ids(
-    filter: &AccountFilter,
+    filter: &AccountScope,
     state: &ServiceContext,
 ) -> Result<Vec<String>, String> {
     match filter {
-        AccountFilter::All => Ok(vec!["TOTAL".to_string()]),
-        AccountFilter::Account { account_id } => Ok(vec![account_id.clone()]),
-        AccountFilter::Portfolio { .. } | AccountFilter::AdHoc { .. } => state
+        AccountScope::All => Ok(vec!["TOTAL".to_string()]),
+        AccountScope::Account { account_id } => Ok(vec![account_id.clone()]),
+        AccountScope::Portfolio { .. } | AccountScope::Accounts { .. } => state
             .portfolio_service()
             .resolve_account_filter(filter)
             .map_err(|e| e.to_string()),
@@ -139,7 +139,7 @@ async fn resolve_filter_to_ids(
 #[tauri::command]
 pub async fn get_holdings(
     state: State<'_, Arc<ServiceContext>>,
-    filter: AccountFilterInput,
+    filter: AccountScopeInput,
 ) -> Result<Vec<Holding>, String> {
     debug!("Get holdings...");
     let base_currency = state.get_base_currency();
@@ -207,7 +207,7 @@ pub async fn get_asset_holdings(
 #[tauri::command]
 pub async fn get_portfolio_allocations(
     state: State<'_, Arc<ServiceContext>>,
-    filter: AccountFilterInput,
+    filter: AccountScopeInput,
 ) -> Result<PortfolioAllocations, String> {
     let base_currency = state.get_base_currency();
     let aggregated_id = filter.portfolio_id.clone().unwrap_or_default();
@@ -231,7 +231,7 @@ pub async fn get_portfolio_allocations(
 #[tauri::command]
 pub async fn get_holdings_by_allocation(
     state: State<'_, Arc<ServiceContext>>,
-    filter: AccountFilterInput,
+    filter: AccountScopeInput,
     taxonomy_id: String,
     category_id: String,
 ) -> Result<AllocationHoldings, String> {
@@ -322,15 +322,15 @@ pub async fn get_latest_valuations(
 #[tauri::command]
 pub async fn get_income_summary(
     state: State<'_, Arc<ServiceContext>>,
-    filter: Option<AccountFilterInput>,
+    filter: Option<AccountScopeInput>,
 ) -> Result<Vec<IncomeSummary>, String> {
     debug!("Fetching income summary...");
     let account_ids: Option<Vec<String>> = if let Some(input) = filter {
         let af = input.into_account_filter()?;
         match &af {
-            AccountFilter::All => None,
-            AccountFilter::Account { account_id } => Some(vec![account_id.clone()]),
-            AccountFilter::Portfolio { .. } | AccountFilter::AdHoc { .. } => Some(
+            AccountScope::All => None,
+            AccountScope::Account { account_id } => Some(vec![account_id.clone()]),
+            AccountScope::Portfolio { .. } | AccountScope::Accounts { .. } => Some(
                 state
                     .portfolio_service()
                     .resolve_account_filter(&af)

--- a/apps/tauri/src/commands/portfolio.rs
+++ b/apps/tauri/src/commands/portfolio.rs
@@ -66,7 +66,8 @@ impl AccountScopeInput {
             }
             "adHoc" | "accounts" => {
                 let ids = self.account_ids.filter(|v| !v.is_empty()).ok_or_else(|| {
-                    "accountIds required and must be non-empty for filter type 'adHoc'".to_string()
+                    "accountIds required and must be non-empty for filter type 'accounts'"
+                        .to_string()
                 })?;
                 Ok(AccountScope::Accounts { account_ids: ids })
             }
@@ -150,7 +151,6 @@ pub async fn get_holdings(
 ) -> Result<Vec<Holding>, String> {
     debug!("Get holdings...");
     let base_currency = state.get_base_currency();
-    let aggregated_id = filter.portfolio_id.clone().unwrap_or_default();
     let filter = filter.into_account_filter()?;
     match resolve_scope(&filter, &state).await? {
         ResolvedAccountScope::TotalSnapshot => state
@@ -165,7 +165,7 @@ pub async fn get_holdings(
             .map_err(|e| e.to_string()),
         ResolvedAccountScope::Accounts(ids) => state
             .holdings_service()
-            .get_holdings_for_accounts(&ids, &base_currency, &aggregated_id)
+            .get_holdings_for_accounts(&ids, &base_currency, "")
             .await
             .map_err(|e| e.to_string()),
     }
@@ -220,7 +220,6 @@ pub async fn get_portfolio_allocations(
     filter: AccountScopeInput,
 ) -> Result<PortfolioAllocations, String> {
     let base_currency = state.get_base_currency();
-    let aggregated_id = filter.portfolio_id.clone().unwrap_or_default();
     let filter = filter.into_account_filter()?;
     match resolve_scope(&filter, &state).await? {
         ResolvedAccountScope::TotalSnapshot => state
@@ -235,7 +234,7 @@ pub async fn get_portfolio_allocations(
             .map_err(|e| e.to_string()),
         ResolvedAccountScope::Accounts(ids) => state
             .allocation_service()
-            .get_portfolio_allocations_for_accounts(&ids, &base_currency, &aggregated_id)
+            .get_portfolio_allocations_for_accounts(&ids, &base_currency, "")
             .await
             .map_err(|e| e.to_string()),
     }
@@ -249,7 +248,6 @@ pub async fn get_holdings_by_allocation(
     category_id: String,
 ) -> Result<AllocationHoldings, String> {
     let base_currency = state.get_base_currency();
-    let aggregated_id = filter.portfolio_id.clone().unwrap_or_default();
     let filter = filter.into_account_filter()?;
     match resolve_scope(&filter, &state).await? {
         ResolvedAccountScope::TotalSnapshot => state
@@ -269,7 +267,7 @@ pub async fn get_holdings_by_allocation(
                 &base_currency,
                 &taxonomy_id,
                 &category_id,
-                &aggregated_id,
+                "",
             )
             .await
             .map_err(|e| e.to_string()),

--- a/apps/tauri/src/commands/portfolio.rs
+++ b/apps/tauri/src/commands/portfolio.rs
@@ -23,7 +23,7 @@ use wealthfolio_core::{
         CashBalanceInput, ManualHoldingInput, ManualSnapshotRequest, ManualSnapshotService,
         SnapshotSource,
     },
-    portfolios::AccountScope,
+    portfolios::{AccountScope, ResolvedAccountScope},
     quotes::MarketSyncMode,
     valuation::DailyAccountValuation,
 };
@@ -120,19 +120,26 @@ pub async fn update_portfolio(handle: AppHandle) -> Result<(), String> {
     Ok(())
 }
 
-/// Resolves `AccountScope` to account IDs. `All` returns `["TOTAL"]` to use the fast
-/// pre-computed snapshot; `Portfolio`/`Accounts` return resolved member IDs for aggregation.
-async fn resolve_filter_to_ids(
+/// Resolves an `AccountScope` to a `ResolvedAccountScope`.
+/// `All` → `TotalSnapshot` (fast precomputed path, no TOTAL string leak).
+/// `Account` → `Account(id)`.
+/// `Portfolio`/`Accounts` → `Accounts(ids)` via membership resolution.
+async fn resolve_scope(
     filter: &AccountScope,
     state: &ServiceContext,
-) -> Result<Vec<String>, String> {
+) -> Result<ResolvedAccountScope, String> {
     match filter {
-        AccountScope::All => Ok(vec!["TOTAL".to_string()]),
-        AccountScope::Account { account_id } => Ok(vec![account_id.clone()]),
-        AccountScope::Portfolio { .. } | AccountScope::Accounts { .. } => state
-            .portfolio_service()
-            .resolve_account_filter(filter)
-            .map_err(|e| e.to_string()),
+        AccountScope::All => Ok(ResolvedAccountScope::TotalSnapshot),
+        AccountScope::Account { account_id } => {
+            Ok(ResolvedAccountScope::Account(account_id.clone()))
+        }
+        AccountScope::Portfolio { .. } | AccountScope::Accounts { .. } => {
+            let ids = state
+                .portfolio_service()
+                .resolve_account_filter(filter)
+                .map_err(|e| e.to_string())?;
+            Ok(ResolvedAccountScope::Accounts(ids))
+        }
     }
 }
 
@@ -145,19 +152,22 @@ pub async fn get_holdings(
     let base_currency = state.get_base_currency();
     let aggregated_id = filter.portfolio_id.clone().unwrap_or_default();
     let filter = filter.into_account_filter()?;
-    let ids = resolve_filter_to_ids(&filter, &state).await?;
-    if ids.len() == 1 {
-        state
+    match resolve_scope(&filter, &state).await? {
+        ResolvedAccountScope::TotalSnapshot => state
             .holdings_service()
-            .get_holdings(&ids[0], &base_currency)
+            .get_holdings("TOTAL", &base_currency)
             .await
-            .map_err(|e| e.to_string())
-    } else {
-        state
+            .map_err(|e| e.to_string()),
+        ResolvedAccountScope::Account(id) => state
+            .holdings_service()
+            .get_holdings(&id, &base_currency)
+            .await
+            .map_err(|e| e.to_string()),
+        ResolvedAccountScope::Accounts(ids) => state
             .holdings_service()
             .get_holdings_for_accounts(&ids, &base_currency, &aggregated_id)
             .await
-            .map_err(|e| e.to_string())
+            .map_err(|e| e.to_string()),
     }
 }
 
@@ -212,19 +222,22 @@ pub async fn get_portfolio_allocations(
     let base_currency = state.get_base_currency();
     let aggregated_id = filter.portfolio_id.clone().unwrap_or_default();
     let filter = filter.into_account_filter()?;
-    let ids = resolve_filter_to_ids(&filter, &state).await?;
-    if ids.len() == 1 {
-        state
+    match resolve_scope(&filter, &state).await? {
+        ResolvedAccountScope::TotalSnapshot => state
             .allocation_service()
-            .get_portfolio_allocations(&ids[0], &base_currency)
+            .get_portfolio_allocations("TOTAL", &base_currency)
             .await
-            .map_err(|e| e.to_string())
-    } else {
-        state
+            .map_err(|e| e.to_string()),
+        ResolvedAccountScope::Account(id) => state
+            .allocation_service()
+            .get_portfolio_allocations(&id, &base_currency)
+            .await
+            .map_err(|e| e.to_string()),
+        ResolvedAccountScope::Accounts(ids) => state
             .allocation_service()
             .get_portfolio_allocations_for_accounts(&ids, &base_currency, &aggregated_id)
             .await
-            .map_err(|e| e.to_string())
+            .map_err(|e| e.to_string()),
     }
 }
 
@@ -238,15 +251,18 @@ pub async fn get_holdings_by_allocation(
     let base_currency = state.get_base_currency();
     let aggregated_id = filter.portfolio_id.clone().unwrap_or_default();
     let filter = filter.into_account_filter()?;
-    let ids = resolve_filter_to_ids(&filter, &state).await?;
-    if ids.len() == 1 {
-        state
+    match resolve_scope(&filter, &state).await? {
+        ResolvedAccountScope::TotalSnapshot => state
             .allocation_service()
-            .get_holdings_by_allocation(&ids[0], &base_currency, &taxonomy_id, &category_id)
+            .get_holdings_by_allocation("TOTAL", &base_currency, &taxonomy_id, &category_id)
             .await
-            .map_err(|e| e.to_string())
-    } else {
-        state
+            .map_err(|e| e.to_string()),
+        ResolvedAccountScope::Account(id) => state
+            .allocation_service()
+            .get_holdings_by_allocation(&id, &base_currency, &taxonomy_id, &category_id)
+            .await
+            .map_err(|e| e.to_string()),
+        ResolvedAccountScope::Accounts(ids) => state
             .allocation_service()
             .get_holdings_by_allocation_for_accounts(
                 &ids,
@@ -256,7 +272,7 @@ pub async fn get_holdings_by_allocation(
                 &aggregated_id,
             )
             .await
-            .map_err(|e| e.to_string())
+            .map_err(|e| e.to_string()),
     }
 }
 
@@ -327,15 +343,10 @@ pub async fn get_income_summary(
     debug!("Fetching income summary...");
     let account_ids: Option<Vec<String>> = if let Some(input) = filter {
         let af = input.into_account_filter()?;
-        match &af {
-            AccountScope::All => None,
-            AccountScope::Account { account_id } => Some(vec![account_id.clone()]),
-            AccountScope::Portfolio { .. } | AccountScope::Accounts { .. } => Some(
-                state
-                    .portfolio_service()
-                    .resolve_account_filter(&af)
-                    .map_err(|e| e.to_string())?,
-            ),
+        match resolve_scope(&af, &state).await? {
+            ResolvedAccountScope::TotalSnapshot => None,
+            ResolvedAccountScope::Account(id) => Some(vec![id]),
+            ResolvedAccountScope::Accounts(ids) => Some(ids),
         }
     } else {
         None

--- a/apps/tauri/src/commands/portfolio.rs
+++ b/apps/tauri/src/commands/portfolio.rs
@@ -23,6 +23,7 @@ use wealthfolio_core::{
         CashBalanceInput, ManualHoldingInput, ManualSnapshotRequest, ManualSnapshotService,
         SnapshotSource,
     },
+    portfolios::AccountFilter,
     quotes::MarketSyncMode,
     valuation::DailyAccountValuation,
 };
@@ -72,18 +73,48 @@ pub async fn update_portfolio(handle: AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+/// Resolves `AccountFilter` to account IDs. `All` returns `["TOTAL"]` to use the fast
+/// pre-computed snapshot; `Portfolio`/`AdHoc` return resolved member IDs for aggregation.
+async fn resolve_filter_to_ids(
+    filter: &AccountFilter,
+    state: &ServiceContext,
+) -> Result<Vec<String>, String> {
+    match filter {
+        AccountFilter::All => Ok(vec!["TOTAL".to_string()]),
+        AccountFilter::Account { account_id } => Ok(vec![account_id.clone()]),
+        AccountFilter::Portfolio { .. } | AccountFilter::AdHoc { .. } => state
+            .portfolio_service()
+            .resolve_account_filter(filter)
+            .map_err(|e| e.to_string()),
+    }
+}
+
 #[tauri::command]
 pub async fn get_holdings(
     state: State<'_, Arc<ServiceContext>>,
-    account_id: String,
+    filter: AccountFilter,
 ) -> Result<Vec<Holding>, String> {
     debug!("Get holdings...");
     let base_currency = state.get_base_currency();
-    state
-        .holdings_service()
-        .get_holdings(&account_id, &base_currency)
-        .await
-        .map_err(|e| e.to_string())
+    let ids = resolve_filter_to_ids(&filter, &state).await?;
+    if ids.len() == 1 {
+        state
+            .holdings_service()
+            .get_holdings(&ids[0], &base_currency)
+            .await
+            .map_err(|e| e.to_string())
+    } else {
+        let aggregated_id = if let AccountFilter::Portfolio { portfolio_id } = &filter {
+            portfolio_id.clone()
+        } else {
+            String::new()
+        };
+        state
+            .holdings_service()
+            .get_holdings_for_accounts(&ids, &base_currency, &aggregated_id)
+            .await
+            .map_err(|e| e.to_string())
+    }
 }
 
 #[tauri::command]
@@ -132,34 +163,63 @@ pub async fn get_asset_holdings(
 #[tauri::command]
 pub async fn get_portfolio_allocations(
     state: State<'_, Arc<ServiceContext>>,
-    account_id: String,
+    filter: AccountFilter,
 ) -> Result<PortfolioAllocations, String> {
-    debug!("Get portfolio allocations for account: {}", account_id);
     let base_currency = state.get_base_currency();
-    state
-        .allocation_service()
-        .get_portfolio_allocations(&account_id, &base_currency)
-        .await
-        .map_err(|e| e.to_string())
+    let ids = resolve_filter_to_ids(&filter, &state).await?;
+    if ids.len() == 1 {
+        state
+            .allocation_service()
+            .get_portfolio_allocations(&ids[0], &base_currency)
+            .await
+            .map_err(|e| e.to_string())
+    } else {
+        let aggregated_id = if let AccountFilter::Portfolio { portfolio_id } = &filter {
+            portfolio_id.clone()
+        } else {
+            String::new()
+        };
+        state
+            .allocation_service()
+            .get_portfolio_allocations_for_accounts(&ids, &base_currency, &aggregated_id)
+            .await
+            .map_err(|e| e.to_string())
+    }
 }
 
 #[tauri::command]
 pub async fn get_holdings_by_allocation(
     state: State<'_, Arc<ServiceContext>>,
-    account_id: String,
+    filter: AccountFilter,
     taxonomy_id: String,
     category_id: String,
 ) -> Result<AllocationHoldings, String> {
-    debug!(
-        "Get holdings for category {} in taxonomy {} for account {}",
-        category_id, taxonomy_id, account_id
-    );
     let base_currency = state.get_base_currency();
-    state
-        .allocation_service()
-        .get_holdings_by_allocation(&account_id, &base_currency, &taxonomy_id, &category_id)
-        .await
-        .map_err(|e| e.to_string())
+    let ids = resolve_filter_to_ids(&filter, &state).await?;
+    if ids.len() == 1 {
+        state
+            .allocation_service()
+            .get_holdings_by_allocation(&ids[0], &base_currency, &taxonomy_id, &category_id)
+            .await
+            .map_err(|e| e.to_string())
+    } else {
+        let aggregated_id = if let AccountFilter::Portfolio { portfolio_id } = &filter {
+            portfolio_id.clone()
+        } else {
+            String::new()
+        };
+        state
+            .allocation_service()
+            .get_holdings_by_allocation_for_accounts(
+                &ids,
+                &base_currency,
+                &taxonomy_id,
+                &category_id,
+                &aggregated_id,
+            )
+            .await
+            .map_err(|e| e.to_string())
+    }
 }
 
 #[tauri::command]
@@ -224,12 +284,22 @@ pub async fn get_latest_valuations(
 #[tauri::command]
 pub async fn get_income_summary(
     state: State<'_, Arc<ServiceContext>>,
-    account_id: Option<String>,
+    filter: Option<AccountFilter>,
 ) -> Result<Vec<IncomeSummary>, String> {
     debug!("Fetching income summary...");
+    let account_ids: Option<Vec<String>> = match &filter {
+        None | Some(AccountFilter::All) => None,
+        Some(AccountFilter::Account { account_id }) => Some(vec![account_id.clone()]),
+        Some(AccountFilter::Portfolio { .. }) | Some(AccountFilter::AdHoc { .. }) => Some(
+            state
+                .portfolio_service()
+                .resolve_account_filter(filter.as_ref().unwrap())
+                .map_err(|e| e.to_string())?,
+        ),
+    };
     state
         .income_service()
-        .get_income_summary(account_id.as_deref())
+        .get_income_summary(account_ids.as_deref())
         .map_err(|e| e.to_string())
 }
 

--- a/apps/tauri/src/commands/portfolio.rs
+++ b/apps/tauri/src/commands/portfolio.rs
@@ -1201,6 +1201,7 @@ pub async fn get_snapshot_by_date(
             weight: Decimal::ZERO,
             as_of_date: target_date,
             metadata: asset.metadata.clone(),
+            source_account_ids: Vec::new(),
         };
         holdings.push(holding);
     }
@@ -1246,6 +1247,7 @@ pub async fn get_snapshot_by_date(
             weight: Decimal::ZERO,
             as_of_date: target_date,
             metadata: None,
+            source_account_ids: Vec::new(),
         };
         holdings.push(holding);
     }

--- a/crates/ai/src/env.rs
+++ b/crates/ai/src/env.rs
@@ -505,6 +505,15 @@ pub mod test_env {
             Ok(self.holdings.clone())
         }
 
+        async fn get_holdings_for_accounts(
+            &self,
+            _account_ids: &[String],
+            _base_currency: &str,
+            _aggregated_account_id: &str,
+        ) -> CoreResult<Vec<Holding>> {
+            Ok(self.holdings.clone())
+        }
+
         async fn get_holding(
             &self,
             _account_id: &str,
@@ -1123,12 +1132,41 @@ pub mod test_env {
             Ok(PortfolioAllocations::default())
         }
 
+        async fn get_portfolio_allocations_for_accounts(
+            &self,
+            _account_ids: &[String],
+            _base_currency: &str,
+            _aggregated_account_id: &str,
+        ) -> CoreResult<PortfolioAllocations> {
+            Ok(PortfolioAllocations::default())
+        }
+
         async fn get_holdings_by_allocation(
             &self,
             _account_id: &str,
             base_currency: &str,
             taxonomy_id: &str,
             category_id: &str,
+        ) -> CoreResult<AllocationHoldings> {
+            Ok(AllocationHoldings {
+                taxonomy_id: taxonomy_id.to_string(),
+                taxonomy_name: "Mock Taxonomy".to_string(),
+                category_id: category_id.to_string(),
+                category_name: "Mock Category".to_string(),
+                color: "#808080".to_string(),
+                holdings: Vec::new(),
+                total_value: rust_decimal::Decimal::ZERO,
+                currency: base_currency.to_string(),
+            })
+        }
+
+        async fn get_holdings_by_allocation_for_accounts(
+            &self,
+            _account_ids: &[String],
+            base_currency: &str,
+            taxonomy_id: &str,
+            category_id: &str,
+            _aggregated_account_id: &str,
         ) -> CoreResult<AllocationHoldings> {
             Ok(AllocationHoldings {
                 taxonomy_id: taxonomy_id.to_string(),
@@ -1148,7 +1186,10 @@ pub mod test_env {
     pub struct MockIncomeService;
 
     impl IncomeServiceTrait for MockIncomeService {
-        fn get_income_summary(&self, _account_id: Option<&str>) -> CoreResult<Vec<IncomeSummary>> {
+        fn get_income_summary(
+            &self,
+            _account_ids: Option<&[String]>,
+        ) -> CoreResult<Vec<IncomeSummary>> {
             Ok(vec![
                 IncomeSummary::new("TOTAL", "USD".to_string()),
                 IncomeSummary::new("YTD", "USD".to_string()),

--- a/crates/ai/src/tools/cash_balances.rs
+++ b/crates/ai/src/tools/cash_balances.rs
@@ -291,6 +291,7 @@ mod tests {
             prev_close_value: None,
             weight: Decimal::ZERO,
             as_of_date: NaiveDate::from_ymd_opt(2025, 1, 15).unwrap(),
+            source_account_ids: vec![],
             metadata: None,
         }
     }

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -1268,7 +1268,10 @@ mod tests {
             unimplemented!()
         }
 
-        fn get_income_activities_data(&self, _account_ids: Option<&[String]>) -> Result<Vec<IncomeData>> {
+        fn get_income_activities_data(
+            &self,
+            _account_ids: Option<&[String]>,
+        ) -> Result<Vec<IncomeData>> {
             unimplemented!()
         }
 

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -1268,7 +1268,7 @@ mod tests {
             unimplemented!()
         }
 
-        fn get_income_activities_data(&self, _account_id: Option<&str>) -> Result<Vec<IncomeData>> {
+        fn get_income_activities_data(&self, _account_ids: Option<&[String]>) -> Result<Vec<IncomeData>> {
             unimplemented!()
         }
 

--- a/crates/core/src/activities/activities_traits.rs
+++ b/crates/core/src/activities/activities_traits.rs
@@ -96,7 +96,8 @@ pub trait ActivityRepositoryTrait: Send + Sync {
     ) -> Result<()>;
     // Add other repository methods if necessary, e.g., calculate_average_cost, get_deposit_activities
     fn calculate_average_cost(&self, account_id: &str, asset_id: &str) -> Result<Decimal>;
-    fn get_income_activities_data(&self, account_id: Option<&str>) -> Result<Vec<IncomeData>>;
+    fn get_income_activities_data(&self, account_ids: Option<&[String]>)
+        -> Result<Vec<IncomeData>>;
     fn get_first_activity_date_overall(&self) -> Result<DateTime<Utc>>;
 
     /// Gets the first and last activity dates for each asset in the provided list.

--- a/crates/core/src/limits/limits_service.rs
+++ b/crates/core/src/limits/limits_service.rs
@@ -432,7 +432,7 @@ mod tests {
         fn calculate_average_cost(&self, _: &str, _: &str) -> Result<Decimal> {
             unimplemented!()
         }
-        fn get_income_activities_data(&self, _account_id: Option<&str>) -> Result<Vec<IncomeData>> {
+        fn get_income_activities_data(&self, _account_ids: Option<&[String]>) -> Result<Vec<IncomeData>> {
             unimplemented!()
         }
         fn get_first_activity_date_overall(&self) -> Result<DateTime<Utc>> {

--- a/crates/core/src/limits/limits_service.rs
+++ b/crates/core/src/limits/limits_service.rs
@@ -432,7 +432,10 @@ mod tests {
         fn calculate_average_cost(&self, _: &str, _: &str) -> Result<Decimal> {
             unimplemented!()
         }
-        fn get_income_activities_data(&self, _account_ids: Option<&[String]>) -> Result<Vec<IncomeData>> {
+        fn get_income_activities_data(
+            &self,
+            _account_ids: Option<&[String]>,
+        ) -> Result<Vec<IncomeData>> {
             unimplemented!()
         }
         fn get_first_activity_date_overall(&self) -> Result<DateTime<Utc>> {

--- a/crates/core/src/portfolio/allocation/allocation_service.rs
+++ b/crates/core/src/portfolio/allocation/allocation_service.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use log::debug;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 
@@ -364,7 +363,7 @@ impl AllocationService {
                     // Asset classes include cash, use total_with_cash
                     // Cash holdings now have proper instruments with classifications
                     asset_classes_alloc = self.aggregate_by_taxonomy(
-                        &holdings,
+                        holdings,
                         &taxonomy.id,
                         &taxonomy.name,
                         &taxonomy.color,
@@ -376,7 +375,7 @@ impl AllocationService {
                 }
                 "industries_gics" => {
                     sectors_alloc = self.aggregate_by_taxonomy(
-                        &holdings,
+                        holdings,
                         &taxonomy.id,
                         "Sectors", // Use friendly name
                         &taxonomy.color,
@@ -388,7 +387,7 @@ impl AllocationService {
                 }
                 "regions" => {
                     regions_alloc = self.aggregate_by_taxonomy(
-                        &holdings,
+                        holdings,
                         &taxonomy.id,
                         "Regions",
                         &taxonomy.color,
@@ -400,7 +399,7 @@ impl AllocationService {
                 }
                 "risk_category" => {
                     risk_alloc = self.aggregate_by_taxonomy(
-                        &holdings,
+                        holdings,
                         &taxonomy.id,
                         "Risk Category",
                         &taxonomy.color,
@@ -412,7 +411,7 @@ impl AllocationService {
                 }
                 "instrument_type" => {
                     security_types_alloc = self.aggregate_by_taxonomy(
-                        &holdings,
+                        holdings,
                         &taxonomy.id,
                         "Instrument Type",
                         &taxonomy.color,
@@ -425,7 +424,7 @@ impl AllocationService {
                 _ if !taxonomy.is_system => {
                     // User-created custom taxonomies only (skip system placeholder "custom_groups")
                     let custom_alloc = self.aggregate_by_taxonomy(
-                        &holdings,
+                        holdings,
                         &taxonomy.id,
                         &taxonomy.name,
                         &taxonomy.color,

--- a/crates/core/src/portfolio/allocation/allocation_service.rs
+++ b/crates/core/src/portfolio/allocation/allocation_service.rs
@@ -25,6 +25,14 @@ pub trait AllocationServiceTrait: Send + Sync {
         base_currency: &str,
     ) -> Result<PortfolioAllocations>;
 
+    /// Computes portfolio allocations aggregated across multiple accounts (portfolio filter).
+    async fn get_portfolio_allocations_for_accounts(
+        &self,
+        account_ids: &[String],
+        base_currency: &str,
+        aggregated_account_id: &str,
+    ) -> Result<PortfolioAllocations>;
+
     /// Returns holdings filtered by a taxonomy category with full category metadata.
     /// Used for drill-down views when user clicks on an allocation category.
     async fn get_holdings_by_allocation(
@@ -33,6 +41,16 @@ pub trait AllocationServiceTrait: Send + Sync {
         base_currency: &str,
         taxonomy_id: &str,
         category_id: &str,
+    ) -> Result<AllocationHoldings>;
+
+    /// Returns holdings by allocation aggregated across multiple accounts.
+    async fn get_holdings_by_allocation_for_accounts(
+        &self,
+        account_ids: &[String],
+        base_currency: &str,
+        taxonomy_id: &str,
+        category_id: &str,
+        aggregated_account_id: &str,
     ) -> Result<AllocationHoldings>;
 }
 
@@ -285,26 +303,12 @@ impl AllocationService {
             _ => category_id, // No parent - this is the top level
         }
     }
-}
 
-#[async_trait]
-impl AllocationServiceTrait for AllocationService {
-    async fn get_portfolio_allocations(
+    async fn compute_allocations_from_holdings(
         &self,
-        account_id: &str,
-        base_currency: &str,
+        holdings: &[Holding],
+        _base_currency: &str,
     ) -> Result<PortfolioAllocations> {
-        debug!(
-            "Computing portfolio allocations for account {} in {}",
-            account_id, base_currency
-        );
-
-        // 1. Get holdings
-        let holdings = self
-            .holdings_service
-            .get_holdings(account_id, base_currency)
-            .await?;
-
         if holdings.is_empty() {
             return Ok(PortfolioAllocations::default());
         }
@@ -450,23 +454,17 @@ impl AllocationServiceTrait for AllocationService {
         })
     }
 
-    async fn get_holdings_by_allocation(
+    async fn compute_holdings_by_allocation_from_holdings(
         &self,
-        account_id: &str,
+        holdings: &[Holding],
         base_currency: &str,
         taxonomy_id: &str,
         category_id: &str,
     ) -> Result<AllocationHoldings> {
-        debug!(
-            "Getting holdings for category {} in taxonomy {} for account {}",
-            category_id, taxonomy_id, account_id
-        );
-
         // Get taxonomy with categories for hierarchy lookup and metadata
         let taxonomy_with_cats = self.taxonomy_service.get_taxonomy(taxonomy_id)?;
         let empty_categories: Vec<Category> = Vec::new();
 
-        // Extract taxonomy metadata
         let (taxonomy_name, taxonomy_color, categories) = match &taxonomy_with_cats {
             Some(twc) => (
                 twc.taxonomy.name.clone(),
@@ -480,7 +478,6 @@ impl AllocationServiceTrait for AllocationService {
             ),
         };
 
-        // Look up category metadata
         let (category_name, category_color) = if category_id == "__UNKNOWN__" {
             ("Unknown".to_string(), "#878580".to_string())
         } else {
@@ -490,12 +487,6 @@ impl AllocationServiceTrait for AllocationService {
                 .map(|c| (c.name.clone(), c.color.clone()))
                 .unwrap_or_else(|| (category_id.to_string(), taxonomy_color.clone()))
         };
-
-        // Get all holdings for the account
-        let holdings = self
-            .holdings_service
-            .get_holdings(account_id, base_currency)
-            .await?;
 
         if holdings.is_empty() {
             return Ok(AllocationHoldings {
@@ -550,7 +541,7 @@ impl AllocationServiceTrait for AllocationService {
         // Calculate total value of matched holdings for weight calculation
         let mut matched_holdings: Vec<(&Holding, i32)> = Vec::new();
 
-        for holding in &holdings {
+        for holding in holdings {
             let asset_id = match &holding.instrument {
                 Some(instrument) => &instrument.id,
                 None => continue,
@@ -640,5 +631,76 @@ impl AllocationServiceTrait for AllocationService {
             total_value: total_matched_value,
             currency: base_currency.to_string(),
         })
+    }
+}
+
+#[async_trait]
+impl AllocationServiceTrait for AllocationService {
+    async fn get_portfolio_allocations(
+        &self,
+        account_id: &str,
+        base_currency: &str,
+    ) -> Result<PortfolioAllocations> {
+        let holdings = self
+            .holdings_service
+            .get_holdings(account_id, base_currency)
+            .await?;
+        self.compute_allocations_from_holdings(&holdings, base_currency)
+            .await
+    }
+
+    async fn get_portfolio_allocations_for_accounts(
+        &self,
+        account_ids: &[String],
+        base_currency: &str,
+        aggregated_account_id: &str,
+    ) -> Result<PortfolioAllocations> {
+        let holdings = self
+            .holdings_service
+            .get_holdings_for_accounts(account_ids, base_currency, aggregated_account_id)
+            .await?;
+        self.compute_allocations_from_holdings(&holdings, base_currency)
+            .await
+    }
+
+    async fn get_holdings_by_allocation(
+        &self,
+        account_id: &str,
+        base_currency: &str,
+        taxonomy_id: &str,
+        category_id: &str,
+    ) -> Result<AllocationHoldings> {
+        let holdings = self
+            .holdings_service
+            .get_holdings(account_id, base_currency)
+            .await?;
+        self.compute_holdings_by_allocation_from_holdings(
+            &holdings,
+            base_currency,
+            taxonomy_id,
+            category_id,
+        )
+        .await
+    }
+
+    async fn get_holdings_by_allocation_for_accounts(
+        &self,
+        account_ids: &[String],
+        base_currency: &str,
+        taxonomy_id: &str,
+        category_id: &str,
+        aggregated_account_id: &str,
+    ) -> Result<AllocationHoldings> {
+        let holdings = self
+            .holdings_service
+            .get_holdings_for_accounts(account_ids, base_currency, aggregated_account_id)
+            .await?;
+        self.compute_holdings_by_allocation_from_holdings(
+            &holdings,
+            base_currency,
+            taxonomy_id,
+            category_id,
+        )
+        .await
     }
 }

--- a/crates/core/src/portfolio/holdings/holdings_model.rs
+++ b/crates/core/src/portfolio/holdings/holdings_model.rs
@@ -126,4 +126,9 @@ pub struct Holding {
     /// Asset metadata (JSON) for alternative assets.
     /// Contains purchase_price, purchase_date, sub_type, linked_asset_id, etc.
     pub metadata: Option<Value>,
+
+    /// Source account IDs for aggregated holdings (portfolio or multi-account scope).
+    /// Empty for single-account holdings; `account_id` is then the authoritative identity.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub source_account_ids: Vec<String>,
 }

--- a/crates/core/src/portfolio/holdings/holdings_service.rs
+++ b/crates/core/src/portfolio/holdings/holdings_service.rs
@@ -712,6 +712,34 @@ impl HoldingsServiceTrait for HoldingsService {
             a_cash.cmp(&b_cash).then_with(|| a.id.cmp(&b.id))
         });
 
+        // Recompute percentage fields from the summed base values.
+        // The merge loop accumulates monetary values but percentages from the first
+        // account seen are no longer correct for the aggregated position.
+        for h in result.iter_mut() {
+            let cost_base = h
+                .cost_basis
+                .as_ref()
+                .map(|c| c.base)
+                .unwrap_or(Decimal::ZERO);
+            if cost_base > Decimal::ZERO {
+                h.unrealized_gain_pct = h.unrealized_gain.as_ref().map(|v| v.base / cost_base);
+                h.total_gain_pct = h.total_gain.as_ref().map(|v| v.base / cost_base);
+            } else {
+                h.unrealized_gain_pct = None;
+                h.total_gain_pct = None;
+            }
+            let prev_close_base = h
+                .prev_close_value
+                .as_ref()
+                .map(|p| p.base)
+                .unwrap_or(Decimal::ZERO);
+            if prev_close_base > Decimal::ZERO {
+                h.day_change_pct = h.day_change.as_ref().map(|v| v.base / prev_close_base);
+            } else {
+                h.day_change_pct = None;
+            }
+        }
+
         apply_portfolio_weights(aggregated_account_id, &mut result);
         Ok(result)
     }

--- a/crates/core/src/portfolio/holdings/holdings_service.rs
+++ b/crates/core/src/portfolio/holdings/holdings_service.rs
@@ -1510,6 +1510,7 @@ mod tests {
             }),
             weight: dec!(0.1),
             as_of_date: as_of,
+            source_account_ids: vec![],
             metadata: None,
         };
 
@@ -1579,6 +1580,7 @@ mod tests {
             }),
             weight: dec!(1),
             as_of_date: valuation_date_today(),
+            source_account_ids: vec![],
             metadata: None,
         };
 

--- a/crates/core/src/portfolio/holdings/holdings_service.rs
+++ b/crates/core/src/portfolio/holdings/holdings_service.rs
@@ -280,6 +280,7 @@ impl HoldingsService {
                 weight: Decimal::ZERO,
                 as_of_date: today,
                 metadata: asset_info.metadata.clone(),
+                source_account_ids: Vec::new(),
             };
             holdings.push(holding_view);
         }
@@ -339,6 +340,7 @@ impl HoldingsService {
                 weight: Decimal::ZERO,
                 as_of_date: today,
                 metadata: None,
+                source_account_ids: Vec::new(),
             };
             holdings.push(holding_view);
         }
@@ -675,6 +677,9 @@ impl HoldingsServiceTrait for HoldingsService {
             match merged.entry(key.clone()) {
                 std::collections::hash_map::Entry::Occupied(mut occ) => {
                     let acc = occ.get_mut();
+                    if !acc.source_account_ids.contains(&holding.account_id) {
+                        acc.source_account_ids.push(holding.account_id.clone());
+                    }
                     acc.quantity += holding.quantity;
                     add_monetary(&mut acc.market_value, &holding.market_value);
                     add_optional_monetary(&mut acc.cost_basis, &holding.cost_basis);
@@ -696,9 +701,11 @@ impl HoldingsServiceTrait for HoldingsService {
                     }
                 }
                 std::collections::hash_map::Entry::Vacant(vac) => {
+                    let original_account_id = holding.account_id.clone();
                     let mut h = holding;
                     h.id = format!("AGG-{}", key);
                     h.account_id = aggregated_account_id.to_string();
+                    h.source_account_ids = vec![original_account_id];
                     vac.insert(h);
                 }
             }
@@ -946,6 +953,7 @@ impl HoldingsServiceTrait for HoldingsService {
                 weight: Decimal::ZERO,
                 as_of_date: snapshot.snapshot_date,
                 metadata: asset.metadata.clone(),
+                source_account_ids: Vec::new(),
             };
             holdings.push(holding);
         }
@@ -991,6 +999,7 @@ impl HoldingsServiceTrait for HoldingsService {
                 weight: Decimal::ZERO,
                 as_of_date: snapshot.snapshot_date,
                 metadata: None,
+                source_account_ids: Vec::new(),
             };
             holdings.push(holding);
         }

--- a/crates/core/src/portfolio/holdings/holdings_service.rs
+++ b/crates/core/src/portfolio/holdings/holdings_service.rs
@@ -22,6 +22,17 @@ use super::HoldingsValuationServiceTrait;
 pub trait HoldingsServiceTrait: Send + Sync {
     async fn get_holdings(&self, account_id: &str, base_currency: &str) -> Result<Vec<Holding>>;
 
+    /// Aggregates holdings from multiple accounts into a single merged list.
+    /// Holdings with the same asset are merged by summing MonetaryValue fields.
+    /// Lots are concatenated. Weights are recomputed over the full merged set.
+    /// `aggregated_account_id` is stored on each resulting Holding (use `""` for ad-hoc filters).
+    async fn get_holdings_for_accounts(
+        &self,
+        account_ids: &[String],
+        base_currency: &str,
+        aggregated_account_id: &str,
+    ) -> Result<Vec<Holding>>;
+
     /// Retrieves a specific holding for an account, calculates its valuation, and includes lot details.
     async fn get_holding(
         &self,
@@ -357,6 +368,19 @@ impl HoldingsService {
     }
 }
 
+fn add_monetary(acc: &mut MonetaryValue, other: &MonetaryValue) {
+    acc.local += other.local;
+    acc.base += other.base;
+}
+
+fn add_optional_monetary(acc: &mut Option<MonetaryValue>, other: &Option<MonetaryValue>) {
+    match (acc.as_mut(), other) {
+        (Some(a), Some(b)) => add_monetary(a, b),
+        (None, Some(b)) => *acc = Some(b.clone()),
+        _ => {}
+    }
+}
+
 fn apply_factor_to_monetary_value(value: &mut MonetaryValue, factor: Decimal) {
     value.local *= factor;
 }
@@ -617,6 +641,79 @@ impl HoldingsServiceTrait for HoldingsService {
         }
 
         Ok(holdings)
+    }
+
+    async fn get_holdings_for_accounts(
+        &self,
+        account_ids: &[String],
+        base_currency: &str,
+        aggregated_account_id: &str,
+    ) -> Result<Vec<Holding>> {
+        if account_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Collect all holdings from each member account.
+        let mut all_holdings: Vec<Holding> = Vec::new();
+        for account_id in account_ids {
+            let holdings = self.get_holdings(account_id, base_currency).await?;
+            all_holdings.extend(holdings);
+        }
+
+        // Merge by key: securities/alternatives → asset id; cash → local_currency.
+        let mut merged: HashMap<String, Holding> = HashMap::new();
+        for holding in all_holdings {
+            let key = match &holding.holding_type {
+                HoldingType::Cash => format!("CASH-{}", holding.local_currency),
+                _ => holding
+                    .instrument
+                    .as_ref()
+                    .map(|i| i.id.clone())
+                    .unwrap_or_else(|| holding.id.clone()),
+            };
+
+            match merged.entry(key.clone()) {
+                std::collections::hash_map::Entry::Occupied(mut occ) => {
+                    let acc = occ.get_mut();
+                    acc.quantity += holding.quantity;
+                    add_monetary(&mut acc.market_value, &holding.market_value);
+                    add_optional_monetary(&mut acc.cost_basis, &holding.cost_basis);
+                    add_optional_monetary(&mut acc.unrealized_gain, &holding.unrealized_gain);
+                    add_optional_monetary(&mut acc.realized_gain, &holding.realized_gain);
+                    add_optional_monetary(&mut acc.total_gain, &holding.total_gain);
+                    add_optional_monetary(&mut acc.day_change, &holding.day_change);
+                    add_optional_monetary(&mut acc.prev_close_value, &holding.prev_close_value);
+                    if let Some(date) = holding.open_date {
+                        acc.open_date = Some(match acc.open_date {
+                            Some(existing) => existing.min(date),
+                            None => date,
+                        });
+                    }
+                    if let Some(lots) = holding.lots {
+                        acc.lots
+                            .get_or_insert_with(std::collections::VecDeque::new)
+                            .extend(lots);
+                    }
+                }
+                std::collections::hash_map::Entry::Vacant(vac) => {
+                    let mut h = holding;
+                    h.id = format!("AGG-{}", key);
+                    h.account_id = aggregated_account_id.to_string();
+                    vac.insert(h);
+                }
+            }
+        }
+
+        let mut result: Vec<Holding> = merged.into_values().collect();
+        // Sort for deterministic output: cash last, then by id.
+        result.sort_by(|a, b| {
+            let a_cash = matches!(a.holding_type, HoldingType::Cash);
+            let b_cash = matches!(b.holding_type, HoldingType::Cash);
+            a_cash.cmp(&b_cash).then_with(|| a.id.cmp(&b.id))
+        });
+
+        apply_portfolio_weights(aggregated_account_id, &mut result);
+        Ok(result)
     }
 
     async fn get_holding(

--- a/crates/core/src/portfolio/holdings/holdings_valuation_service_tests.rs
+++ b/crates/core/src/portfolio/holdings/holdings_valuation_service_tests.rs
@@ -506,6 +506,7 @@ mod tests {
             realized_gain_pct: None,   // To be calculated
             total_gain: None,          // To be calculated
             total_gain_pct: None,      // To be calculated
+            source_account_ids: vec![],
             metadata: None,
         }
     }

--- a/crates/core/src/portfolio/income/income_service.rs
+++ b/crates/core/src/portfolio/income/income_service.rs
@@ -14,7 +14,7 @@ use rust_decimal::Decimal;
 use std::sync::{Arc, RwLock};
 // Define the trait for the income service
 pub trait IncomeServiceTrait: Send + Sync {
-    fn get_income_summary(&self, account_id: Option<&str>) -> Result<Vec<IncomeSummary>>;
+    fn get_income_summary(&self, account_ids: Option<&[String]>) -> Result<Vec<IncomeSummary>>;
 }
 
 pub struct IncomeService {
@@ -68,12 +68,12 @@ impl IncomeService {
 
 // Implement the trait for IncomeService
 impl IncomeServiceTrait for IncomeService {
-    fn get_income_summary(&self, account_id: Option<&str>) -> Result<Vec<IncomeSummary>> {
+    fn get_income_summary(&self, account_ids: Option<&[String]>) -> Result<Vec<IncomeSummary>> {
         debug!("Getting income summary...");
 
         let activities = match self
             .activity_repository
-            .get_income_activities_data(account_id)
+            .get_income_activities_data(account_ids)
         {
             Ok(activity) => activity,
             Err(e) => {
@@ -93,15 +93,14 @@ impl IncomeServiceTrait for IncomeService {
         let two_years_ago = current_year - 2;
         let current_month = current_date.month();
 
-        // Scope the baseline date to the filtered account so monthly-average
-        // denominators are correct.  Falls back to portfolio-wide when no filter.
-        let oldest_date = if let Some(id) = account_id {
-            let ids = vec![id.to_string()];
-            match self.activity_repository.get_first_activity_date(Some(&ids)) {
+        // Scope baseline date to member accounts so monthly-average denominators are correct.
+        // Falls back to portfolio-wide when no filter.
+        let oldest_date = if let Some(ids) = account_ids.filter(|ids| !ids.is_empty()) {
+            match self.activity_repository.get_first_activity_date(Some(ids)) {
                 Ok(Some(date)) => date,
                 Ok(None) => return Ok(Vec::new()),
                 Err(e) => {
-                    error!("Error getting first activity date for account: {:?}", e);
+                    error!("Error getting first activity date for accounts: {:?}", e);
                     return Err(e);
                 }
             }

--- a/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
+++ b/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
@@ -481,7 +481,8 @@ mod tests {
         }
         fn get_income_activities_data(
             &self,
-            _account_id: Option<&str>,
+            
+            _account_ids: Option<&[String]>,
         ) -> AppResult<Vec<ActivityIncomeData>> {
             unimplemented!()
         }
@@ -710,7 +711,8 @@ mod tests {
         }
         fn get_income_activities_data(
             &self,
-            _account_id: Option<&str>,
+            
+            _account_ids: Option<&[String]>,
         ) -> AppResult<Vec<ActivityIncomeData>> {
             unimplemented!()
         }

--- a/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
+++ b/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
@@ -481,7 +481,7 @@ mod tests {
         }
         fn get_income_activities_data(
             &self,
-            
+
             _account_ids: Option<&[String]>,
         ) -> AppResult<Vec<ActivityIncomeData>> {
             unimplemented!()
@@ -711,7 +711,7 @@ mod tests {
         }
         fn get_income_activities_data(
             &self,
-            
+
             _account_ids: Option<&[String]>,
         ) -> AppResult<Vec<ActivityIncomeData>> {
             unimplemented!()

--- a/crates/core/src/portfolios/mod.rs
+++ b/crates/core/src/portfolios/mod.rs
@@ -5,6 +5,7 @@ pub mod portfolios_traits;
 
 pub use portfolios_model::{
     AccountScope, NewPortfolio, Portfolio, PortfolioUpdate, PortfolioWithAccounts,
+    ResolvedAccountScope,
 };
 pub use portfolios_service::PortfolioService;
 pub use portfolios_traits::{PortfolioRepositoryTrait, PortfolioServiceTrait};

--- a/crates/core/src/portfolios/mod.rs
+++ b/crates/core/src/portfolios/mod.rs
@@ -4,7 +4,7 @@ pub mod portfolios_service_tests;
 pub mod portfolios_traits;
 
 pub use portfolios_model::{
-    AccountFilter, NewPortfolio, Portfolio, PortfolioUpdate, PortfolioWithAccounts,
+    AccountScope, NewPortfolio, Portfolio, PortfolioUpdate, PortfolioWithAccounts,
 };
 pub use portfolios_service::PortfolioService;
 pub use portfolios_traits::{PortfolioRepositoryTrait, PortfolioServiceTrait};

--- a/crates/core/src/portfolios/portfolios_model.rs
+++ b/crates/core/src/portfolios/portfolios_model.rs
@@ -128,9 +128,12 @@ pub enum AccountScope {
     /// All active, non-archived accounts.
     All,
     /// A single specific account.
+    #[serde(rename_all = "camelCase")]
     Account { account_id: String },
     /// A saved portfolio — resolved to its member account IDs.
+    #[serde(rename_all = "camelCase")]
     Portfolio { portfolio_id: String },
     /// Ad-hoc list of account IDs (e.g. activity page multi-select).
+    #[serde(rename_all = "camelCase")]
     Accounts { account_ids: Vec<String> },
 }

--- a/crates/core/src/portfolios/portfolios_model.rs
+++ b/crates/core/src/portfolios/portfolios_model.rs
@@ -111,7 +111,7 @@ impl PortfolioUpdate {
 /// encoded strings like `MULTI:id,id` or `PORTFOLIO`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
-pub enum AccountFilter {
+pub enum AccountScope {
     /// All active, non-archived accounts.
     All,
     /// A single specific account.
@@ -119,5 +119,5 @@ pub enum AccountFilter {
     /// A saved portfolio — resolved to its member account IDs.
     Portfolio { portfolio_id: String },
     /// Ad-hoc list of account IDs (e.g. activity page multi-select).
-    AdHoc { account_ids: Vec<String> },
+    Accounts { account_ids: Vec<String> },
 }

--- a/crates/core/src/portfolios/portfolios_model.rs
+++ b/crates/core/src/portfolios/portfolios_model.rs
@@ -118,4 +118,6 @@ pub enum AccountFilter {
     Account { account_id: String },
     /// A saved portfolio — resolved to its member account IDs.
     Portfolio { portfolio_id: String },
+    /// Ad-hoc list of account IDs (e.g. activity page multi-select).
+    AdHoc { account_ids: Vec<String> },
 }

--- a/crates/core/src/portfolios/portfolios_model.rs
+++ b/crates/core/src/portfolios/portfolios_model.rs
@@ -105,6 +105,19 @@ impl PortfolioUpdate {
     }
 }
 
+/// The resolved form of an `AccountScope` after service-layer resolution.
+/// Makes the "use precomputed TOTAL snapshot" path explicit instead of
+/// leaking the fake account ID `"TOTAL"` through downstream code.
+#[derive(Debug, Clone)]
+pub enum ResolvedAccountScope {
+    /// Use the precomputed all-accounts snapshot (fast path).
+    TotalSnapshot,
+    /// A single real account.
+    Account(String),
+    /// Multiple accounts — requires on-read aggregation.
+    Accounts(Vec<String>),
+}
+
 /// Typed account scope filter — resolved once at the service boundary.
 ///
 /// Repositories receive `&[String]` account IDs and must not parse

--- a/crates/core/src/portfolios/portfolios_service.rs
+++ b/crates/core/src/portfolios/portfolios_service.rs
@@ -1,8 +1,6 @@
 use std::sync::Arc;
 
-use super::portfolios_model::{
-    AccountFilter, NewPortfolio, PortfolioUpdate, PortfolioWithAccounts,
-};
+use super::portfolios_model::{AccountScope, NewPortfolio, PortfolioUpdate, PortfolioWithAccounts};
 use super::portfolios_traits::{PortfolioRepositoryTrait, PortfolioServiceTrait};
 use crate::accounts::AccountRepositoryTrait;
 use crate::errors::{DatabaseError, Result, ValidationError};
@@ -84,7 +82,7 @@ impl PortfolioServiceTrait for PortfolioService {
         self.repository.list()
     }
 
-    fn resolve_account_filter(&self, filter: &AccountFilter) -> Result<Vec<String>> {
+    fn resolve_account_filter(&self, filter: &AccountScope) -> Result<Vec<String>> {
         self.repository.resolve_account_ids(filter)
     }
 }

--- a/crates/core/src/portfolios/portfolios_service_tests.rs
+++ b/crates/core/src/portfolios/portfolios_service_tests.rs
@@ -7,7 +7,7 @@ mod tests {
     use crate::accounts::{Account, AccountRepositoryTrait, AccountUpdate, NewAccount};
     use crate::errors::{DatabaseError, Error, Result};
     use crate::portfolios::{
-        AccountFilter, NewPortfolio, PortfolioRepositoryTrait, PortfolioService,
+        AccountScope, NewPortfolio, PortfolioRepositoryTrait, PortfolioService,
         PortfolioServiceTrait, PortfolioUpdate, PortfolioWithAccounts,
     };
 
@@ -85,14 +85,14 @@ mod tests {
             Ok(self.portfolios.lock().unwrap().clone())
         }
 
-        fn resolve_account_ids(&self, filter: &AccountFilter) -> Result<Vec<String>> {
+        fn resolve_account_ids(&self, filter: &AccountScope) -> Result<Vec<String>> {
             match filter {
-                AccountFilter::All => Ok(vec!["a1".to_string(), "a2".to_string()]),
-                AccountFilter::Account { account_id } => Ok(vec![account_id.clone()]),
-                AccountFilter::Portfolio { portfolio_id: _ } => {
+                AccountScope::All => Ok(vec!["a1".to_string(), "a2".to_string()]),
+                AccountScope::Account { account_id } => Ok(vec![account_id.clone()]),
+                AccountScope::Portfolio { portfolio_id: _ } => {
                     Ok(vec!["a1".to_string(), "a2".to_string()])
                 }
-                AccountFilter::AdHoc { account_ids } => Ok(account_ids.clone()),
+                AccountScope::Accounts { account_ids } => Ok(account_ids.clone()),
             }
         }
     }
@@ -266,7 +266,7 @@ mod tests {
     #[tokio::test]
     async fn resolve_account_filter_all() {
         let svc = make_service_with(MockPortfolioRepo::default(), &[]);
-        let ids = svc.resolve_account_filter(&AccountFilter::All).unwrap();
+        let ids = svc.resolve_account_filter(&AccountScope::All).unwrap();
         assert_eq!(ids, vec!["a1", "a2"]);
     }
 
@@ -274,7 +274,7 @@ mod tests {
     async fn resolve_account_filter_single_account() {
         let svc = make_service_with(MockPortfolioRepo::default(), &[]);
         let ids = svc
-            .resolve_account_filter(&AccountFilter::Account {
+            .resolve_account_filter(&AccountScope::Account {
                 account_id: "a1".to_string(),
             })
             .unwrap();

--- a/crates/core/src/portfolios/portfolios_service_tests.rs
+++ b/crates/core/src/portfolios/portfolios_service_tests.rs
@@ -92,6 +92,7 @@ mod tests {
                 AccountFilter::Portfolio { portfolio_id: _ } => {
                     Ok(vec!["a1".to_string(), "a2".to_string()])
                 }
+                AccountFilter::AdHoc { account_ids } => Ok(account_ids.clone()),
             }
         }
     }

--- a/crates/core/src/portfolios/portfolios_traits.rs
+++ b/crates/core/src/portfolios/portfolios_traits.rs
@@ -1,8 +1,6 @@
 use async_trait::async_trait;
 
-use super::portfolios_model::{
-    AccountFilter, NewPortfolio, PortfolioUpdate, PortfolioWithAccounts,
-};
+use super::portfolios_model::{AccountScope, NewPortfolio, PortfolioUpdate, PortfolioWithAccounts};
 use crate::errors::Result;
 
 #[async_trait]
@@ -12,8 +10,8 @@ pub trait PortfolioRepositoryTrait: Send + Sync {
     async fn delete(&self, id: &str) -> Result<usize>;
     fn get_by_id(&self, id: &str) -> Result<PortfolioWithAccounts>;
     fn list(&self) -> Result<Vec<PortfolioWithAccounts>>;
-    /// Resolve an AccountFilter to the concrete list of account IDs.
-    fn resolve_account_ids(&self, filter: &AccountFilter) -> Result<Vec<String>>;
+    /// Resolve an AccountScope to the concrete list of account IDs.
+    fn resolve_account_ids(&self, filter: &AccountScope) -> Result<Vec<String>>;
 }
 
 #[async_trait]
@@ -23,6 +21,6 @@ pub trait PortfolioServiceTrait: Send + Sync {
     async fn delete_portfolio(&self, id: &str) -> Result<()>;
     fn get_portfolio(&self, id: &str) -> Result<PortfolioWithAccounts>;
     fn list_portfolios(&self) -> Result<Vec<PortfolioWithAccounts>>;
-    /// Resolve an AccountFilter to validated, ordered account IDs.
-    fn resolve_account_filter(&self, filter: &AccountFilter) -> Result<Vec<String>>;
+    /// Resolve an AccountScope to validated, ordered account IDs.
+    fn resolve_account_filter(&self, filter: &AccountScope) -> Result<Vec<String>>;
 }

--- a/crates/core/src/quotes/service.rs
+++ b/crates/core/src/quotes/service.rs
@@ -3235,7 +3235,7 @@ mod tests {
             unimplemented!("unused in this test")
         }
 
-        fn get_income_activities_data(&self, _account_id: Option<&str>) -> Result<Vec<IncomeData>> {
+        fn get_income_activities_data(&self, _account_ids: Option<&[String]>) -> Result<Vec<IncomeData>> {
             unimplemented!("unused in this test")
         }
 

--- a/crates/core/src/quotes/service.rs
+++ b/crates/core/src/quotes/service.rs
@@ -3235,7 +3235,10 @@ mod tests {
             unimplemented!("unused in this test")
         }
 
-        fn get_income_activities_data(&self, _account_ids: Option<&[String]>) -> Result<Vec<IncomeData>> {
+        fn get_income_activities_data(
+            &self,
+            _account_ids: Option<&[String]>,
+        ) -> Result<Vec<IncomeData>> {
             unimplemented!("unused in this test")
         }
 

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -1326,7 +1326,10 @@ impl ActivityRepositoryTrait for ActivityRepository {
         Ok(activities)
     }
 
-    fn get_income_activities_data(&self, account_id: Option<&str>) -> Result<Vec<IncomeData>> {
+    fn get_income_activities_data(
+        &self,
+        account_ids: Option<&[String]>,
+    ) -> Result<Vec<IncomeData>> {
         let mut conn = get_connection(&self.pool)?;
 
         // For income reporting, we need to handle different subtypes:
@@ -1334,9 +1337,17 @@ impl ActivityRepositoryTrait for ActivityRepository {
         // - Valid asset-backed income pairs: if amount is 0, calculate from:
         //   1. quantity * unit_price (if unit_price is available)
         //   2. quantity * market_price from quotes table (fallback)
-        let account_filter = match account_id {
-            Some(_) => "AND a.account_id = ?",
-            None => "",
+        // IDs are internal UUIDs — safe to interpolate directly; escape single quotes defensively.
+        let account_filter = match account_ids {
+            Some(ids) if !ids.is_empty() => {
+                let escaped = ids
+                    .iter()
+                    .map(|id| format!("'{}'", id.replace('\'', "''")))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("AND a.account_id IN ({escaped})")
+            }
+            _ => String::new(),
         };
 
         let query = format!(
@@ -1400,16 +1411,9 @@ impl ActivityRepositoryTrait for ActivityRepository {
             pub amount: String,
         }
 
-        let raw_results = if let Some(id) = account_id {
-            diesel::sql_query(&query)
-                .bind::<diesel::sql_types::Text, _>(id)
-                .load::<RawIncomeData>(&mut conn)
-                .map_err(ActivityError::from)?
-        } else {
-            diesel::sql_query(&query)
-                .load::<RawIncomeData>(&mut conn)
-                .map_err(ActivityError::from)?
-        };
+        let raw_results = diesel::sql_query(&query)
+            .load::<RawIncomeData>(&mut conn)
+            .map_err(ActivityError::from)?;
 
         // Transform raw results into IncomeData
         let results = raw_results
@@ -2304,7 +2308,7 @@ mod tests {
         .expect("zero income amounts");
 
         let rows = repo
-            .get_income_activities_data(Some("acc-income"))
+            .get_income_activities_data(Some(&[String::from("acc-income")]))
             .expect("income data");
         let staking_amount = rows
             .iter()

--- a/crates/storage-sqlite/src/portfolios/repository.rs
+++ b/crates/storage-sqlite/src/portfolios/repository.rs
@@ -14,7 +14,7 @@ use wealthfolio_core::errors::Error;
 use super::model::{build_portfolio_with_accounts, PortfolioAccountDB, PortfolioDB};
 use wealthfolio_core::errors::Result;
 use wealthfolio_core::portfolios::{
-    AccountFilter, NewPortfolio, PortfolioRepositoryTrait, PortfolioUpdate, PortfolioWithAccounts,
+    AccountScope, NewPortfolio, PortfolioRepositoryTrait, PortfolioUpdate, PortfolioWithAccounts,
 };
 
 pub struct PortfolioRepository {
@@ -223,11 +223,11 @@ impl PortfolioRepositoryTrait for PortfolioRepository {
         Ok(result)
     }
 
-    fn resolve_account_ids(&self, filter: &AccountFilter) -> Result<Vec<String>> {
+    fn resolve_account_ids(&self, filter: &AccountScope) -> Result<Vec<String>> {
         let mut conn = get_connection(&self.pool)?;
 
         match filter {
-            AccountFilter::All => {
+            AccountScope::All => {
                 use crate::schema::accounts::dsl::*;
                 let ids = accounts
                     .filter(is_active.eq(true))
@@ -238,8 +238,8 @@ impl PortfolioRepositoryTrait for PortfolioRepository {
                     .map_err(StorageError::from)?;
                 Ok(ids)
             }
-            AccountFilter::Account { account_id } => Ok(vec![account_id.clone()]),
-            AccountFilter::Portfolio { portfolio_id: pfid } => {
+            AccountScope::Account { account_id } => Ok(vec![account_id.clone()]),
+            AccountScope::Portfolio { portfolio_id: pfid } => {
                 use crate::schema::portfolio_accounts::dsl::*;
                 let ids = portfolio_accounts
                     .filter(portfolio_id.eq(pfid))
@@ -249,7 +249,7 @@ impl PortfolioRepositoryTrait for PortfolioRepository {
                     .map_err(StorageError::from)?;
                 Ok(ids)
             }
-            AccountFilter::AdHoc { account_ids } => Ok(account_ids.clone()),
+            AccountScope::Accounts { account_ids } => Ok(account_ids.clone()),
         }
     }
 }

--- a/crates/storage-sqlite/src/portfolios/repository.rs
+++ b/crates/storage-sqlite/src/portfolios/repository.rs
@@ -249,6 +249,7 @@ impl PortfolioRepositoryTrait for PortfolioRepository {
                     .map_err(StorageError::from)?;
                 Ok(ids)
             }
+            AccountFilter::AdHoc { account_ids } => Ok(account_ids.clone()),
         }
     }
 }


### PR DESCRIPTION
## Summary

Hey @afadil , 

Here is the PR for the step 14 of portfolio view design. 

It wires the typed `AccountFilter` discriminant union into all relevant pages so users can filter by saved portfolio, individual account, or all accounts.

- **Holdings / Allocations**: replace `accountId: string` state with `AccountFilter`; use `AccountFilterSelector` component; backend resolves portfolio → account IDs and aggregates holdings in base currency
- **Income**: replace `accountId` filter with `AccountFilter`; backend resolves portfolio members before querying
- **Activity**: add portfolio preset dropdown (sets `selectedAccounts` from portfolio members — agreed design, full `AccountFilter` replacement deferred per Q6)
- **Mobile filter sheet**: add portfolios section, fix "All Portfolio" label → "All Accounts"
- **`DrillableAccountChart`**: now respects current filter (account/portfolio) instead of always showing all accounts
- **Rust IPC fix**: serde internally-tagged enums fail deserialization in Tauri v2 IPC; replaced `AccountFilter` enum as command parameter with `AccountFilterInput` flat struct at the IPC boundary only — internal logic still uses `AccountFilter` enum

## Backend changes

- `get_holdings`, `get_portfolio_allocations`, `get_holdings_by_allocation`, `get_income_summary` — now accept `AccountFilterInput` (Tauri) / `Json<FilterBody>` (Axum); resolve filter → account IDs via `portfolio_service.resolve_account_filter`
- `get_holdings_for_accounts` — new aggregation path: merges holdings by asset across accounts, sums `MonetaryValue { local, base }`, sets `account_id = ""`
- `get_portfolio_allocations_for_accounts`, `get_holdings_by_allocation_for_accounts` — same aggregation pattern for allocations

## Known issues / open questions for Afadil

1. `account_id` on aggregated holdings**

When Holdings are fetched for a portfolio (multi-account), the results are merged by `asset_id` across member accounts. Each merged holding needs an `account_id` but no single account owns it. Currently set to `""` (empty string). Two options:
- **Option A (current):** `account_id = ""` — neutral, signals "aggregated"
- **Option B:** `account_id = portfolio_id` — makes the source traceable in the UI

Keeping Option A for now. 
Would like your recommendation before changing, since this touches how the frontend displays or routes holdings.

**2. GET → POST on existing Axum routes**

To carry `AccountFilter` in the request body, four routes changed from GET to POST:
- `GET /holdings` → `POST /holdings`
- `GET /allocations` → `POST /allocations`
- `GET /allocations/holdings` → `POST /allocations/holdings`
- `GET /income/summary` → `POST /income/summary`

This is a breaking change for any existing web mode client. Flagging in case a cleaner approach (e.g. a separate `/account-filters/resolve` endpoint as mentioned in the design doc, or query params) is preferred.

**3. Regions allocation widget — values can exceed portfolio total**

Pre-existing bug, not introduced by this PR. When a holding is a global fund (e.g. World ETF), its value is distributed across multiple regions based on underlying exposure weights. The sum of all region values can therefore exceed the total portfolio value. Root cause is in the taxonomy allocation calculation, not in the AccountFilter wiring. 
Flagging for visibility.

## Test plan

- [x] `cargo test` — 1054 passed
- [x] `pnpm type-check` — no new errors
- [x] `pnpm test` — 624 passed (updated adapter parity test for POST)
- [x] Manual: Holdings All accounts ✓, individual account ✓, portfolio ✓
- [x] Manual: Income with portfolio filter ✓
- [x] Manual: Mobile filter sheet shows portfolios ✓
- [x] Manual: `DrillableAccountChart` respects filter ✓
- [x] Dashboard unchanged ✓
- [ ] Web mode (Axum) — not testable locally without `WF_SECRET_KEY` config


## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).