### PR TITLE
Fix custom provider source tab state

### DIFF
--- a/apps/frontend/src/pages/settings/market-data/custom-provider-form.test.tsx
+++ b/apps/frontend/src/pages/settings/market-data/custom-provider-form.test.tsx
@@ -1,0 +1,101 @@
+import type { ReactNode } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CustomProviderForm } from "./custom-provider-form";
+import type { NewCustomProvider } from "@/lib/types/custom-provider";
+
+const createProvider = vi.fn();
+const updateProvider = vi.fn();
+
+function setInputValue(input: HTMLElement, value: string) {
+  fireEvent.change(input, { target: { value } });
+}
+
+vi.mock("@wealthfolio/ui", () => ({
+  Dialog: ({ open, children }: { open: boolean; children: ReactNode }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children, ...props }: { children: ReactNode }) => (
+    <p {...props}>{children}</p>
+  ),
+  DialogTitle: ({ children, ...props }: { children: ReactNode }) => <h2 {...props}>{children}</h2>,
+}));
+
+vi.mock("@/adapters", () => ({
+  openUrlInBrowser: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-custom-providers", () => ({
+  useCreateCustomProvider: () => ({
+    mutate: createProvider,
+    isPending: false,
+  }),
+  useUpdateCustomProvider: () => ({
+    mutate: updateProvider,
+    isPending: false,
+  }),
+  useTestCustomProviderSource: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/lib/settings-provider", () => ({
+  useSettingsContext: () => ({
+    settings: { timezone: "UTC" },
+  }),
+}));
+
+describe("CustomProviderForm", () => {
+  beforeEach(() => {
+    createProvider.mockReset();
+    updateProvider.mockReset();
+  });
+
+  it("keeps latest and historical source values separate while switching tabs", async () => {
+    const user = userEvent.setup();
+
+    render(<CustomProviderForm open onOpenChange={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: /both/i }));
+
+    const urlInput = () => screen.getByLabelText(/url template/i);
+    const pricePathInput = () => screen.getByPlaceholderText("$.data.price");
+
+    setInputValue(urlInput(), "https://latest.example.com/price/{SYMBOL}");
+    setInputValue(pricePathInput(), "$.price");
+
+    await user.click(screen.getByRole("button", { name: /historical/i }));
+
+    setInputValue(urlInput(), "https://history.example.com/prices/{SYMBOL}");
+    setInputValue(pricePathInput(), "$[*].adj_close");
+
+    await user.click(screen.getByRole("button", { name: /latest price/i }));
+    expect(urlInput()).toHaveValue("https://latest.example.com/price/{SYMBOL}");
+    expect(pricePathInput()).toHaveValue("$.price");
+
+    await user.click(screen.getByRole("button", { name: /historical/i }));
+    expect(urlInput()).toHaveValue("https://history.example.com/prices/{SYMBOL}");
+    expect(pricePathInput()).toHaveValue("$[*].adj_close");
+
+    await user.click(screen.getByRole("button", { name: /create provider/i }));
+
+    await waitFor(() => expect(createProvider).toHaveBeenCalledTimes(1));
+    const payload = createProvider.mock.calls[0][0] as NewCustomProvider;
+
+    expect(payload.sources).toEqual([
+      expect.objectContaining({
+        kind: "latest",
+        url: "https://latest.example.com/price/{SYMBOL}",
+        pricePath: "$.price",
+      }),
+      expect.objectContaining({
+        kind: "historical",
+        url: "https://history.example.com/prices/{SYMBOL}",
+        pricePath: "$[*].adj_close",
+      }),
+    ]);
+  });
+});

--- a/apps/frontend/src/pages/settings/market-data/custom-provider-form.tsx
+++ b/apps/frontend/src/pages/settings/market-data/custom-provider-form.tsx
@@ -543,6 +543,7 @@ function CustomProviderFormContent({
 
             {/* Step 1 + 2 */}
             <SourceConfigPanel
+              key={activePrefix}
               form={form}
               prefix={activePrefix}
               runtime={activeRuntime}


### PR DESCRIPTION
## Summary
- remount the custom-provider source form when switching between latest and historical source tabs
- add a regression test covering Both mode tab switching and separate source payloads

## Root cause
React Hook Form controllers were reused while their field-name prefix changed between `latestSource.*` and `historicalSource.*`, which could unregister/reset the source that was just edited.

## Verification
- `pnpm --filter frontend exec vitest run src/pages/settings/market-data/custom-provider-form.test.tsx`
- `pnpm --filter frontend type-check`
- `pnpm exec prettier --check apps/frontend/src/pages/settings/market-data/custom-provider-form.tsx apps/frontend/src/pages/settings/market-data/custom-provider-form.test.tsx`
- Playwright MCP with `pnpm dev:web`: verified latest/historical tab switching and intercepted create payload contains distinct latest and historical sources