### PR TITLE
feat(ai): generic AI tools for taxonomy assignments (list, get, set)

### DIFF
--- a/apps/server/src/ai_environment.rs
+++ b/apps/server/src/ai_environment.rs
@@ -11,7 +11,8 @@ use wealthfolio_core::{
     allocation::AllocationServiceTrait, goals::GoalServiceTrait, health::HealthServiceTrait,
     holdings::HoldingsServiceTrait, income::IncomeServiceTrait,
     performance::PerformanceServiceTrait, quotes::QuoteServiceTrait, secrets::SecretStore,
-    settings::SettingsServiceTrait, valuation::ValuationServiceTrait,
+    settings::SettingsServiceTrait, taxonomies::TaxonomyServiceTrait,
+    valuation::ValuationServiceTrait,
 };
 
 /// Server-side implementation of AiEnvironment.
@@ -33,6 +34,7 @@ pub struct ServerAiEnvironment {
     performance_service: Arc<dyn PerformanceServiceTrait + Send + Sync>,
     income_service: Arc<dyn IncomeServiceTrait + Send + Sync>,
     health_service: Arc<dyn HealthServiceTrait + Send + Sync>,
+    taxonomy_service: Arc<dyn TaxonomyServiceTrait + Send + Sync>,
 }
 
 impl ServerAiEnvironment {
@@ -53,6 +55,7 @@ impl ServerAiEnvironment {
         performance_service: Arc<dyn PerformanceServiceTrait + Send + Sync>,
         income_service: Arc<dyn IncomeServiceTrait + Send + Sync>,
         health_service: Arc<dyn HealthServiceTrait + Send + Sync>,
+        taxonomy_service: Arc<dyn TaxonomyServiceTrait + Send + Sync>,
     ) -> Self {
         Self {
             base_currency,
@@ -69,6 +72,7 @@ impl ServerAiEnvironment {
             performance_service,
             income_service,
             health_service,
+            taxonomy_service,
         }
     }
 }
@@ -128,5 +132,9 @@ impl AiEnvironment for ServerAiEnvironment {
 
     fn health_service(&self) -> Arc<dyn HealthServiceTrait> {
         self.health_service.clone()
+    }
+
+    fn taxonomy_service(&self) -> Arc<dyn TaxonomyServiceTrait> {
+        self.taxonomy_service.clone()
     }
 }

--- a/apps/server/src/ai_environment.rs
+++ b/apps/server/src/ai_environment.rs
@@ -8,8 +8,8 @@ use std::sync::{Arc, RwLock};
 use wealthfolio_ai::{AiEnvironment, ChatRepositoryTrait};
 use wealthfolio_core::{
     accounts::AccountServiceTrait, activities::ActivityServiceTrait,
-    allocation::AllocationServiceTrait, goals::GoalServiceTrait, health::HealthServiceTrait,
-    holdings::HoldingsServiceTrait, income::IncomeServiceTrait,
+    allocation::AllocationServiceTrait, assets::AssetServiceTrait, goals::GoalServiceTrait,
+    health::HealthServiceTrait, holdings::HoldingsServiceTrait, income::IncomeServiceTrait,
     performance::PerformanceServiceTrait, quotes::QuoteServiceTrait, secrets::SecretStore,
     settings::SettingsServiceTrait, taxonomies::TaxonomyServiceTrait,
     valuation::ValuationServiceTrait,
@@ -35,6 +35,7 @@ pub struct ServerAiEnvironment {
     income_service: Arc<dyn IncomeServiceTrait + Send + Sync>,
     health_service: Arc<dyn HealthServiceTrait + Send + Sync>,
     taxonomy_service: Arc<dyn TaxonomyServiceTrait + Send + Sync>,
+    assets_service: Arc<dyn AssetServiceTrait + Send + Sync>,
 }
 
 impl ServerAiEnvironment {
@@ -56,6 +57,7 @@ impl ServerAiEnvironment {
         income_service: Arc<dyn IncomeServiceTrait + Send + Sync>,
         health_service: Arc<dyn HealthServiceTrait + Send + Sync>,
         taxonomy_service: Arc<dyn TaxonomyServiceTrait + Send + Sync>,
+        assets_service: Arc<dyn AssetServiceTrait + Send + Sync>,
     ) -> Self {
         Self {
             base_currency,
@@ -73,6 +75,7 @@ impl ServerAiEnvironment {
             income_service,
             health_service,
             taxonomy_service,
+            assets_service,
         }
     }
 }
@@ -136,5 +139,9 @@ impl AiEnvironment for ServerAiEnvironment {
 
     fn taxonomy_service(&self) -> Arc<dyn TaxonomyServiceTrait> {
         self.taxonomy_service.clone()
+    }
+
+    fn assets_service(&self) -> Arc<dyn AssetServiceTrait> {
+        self.assets_service.clone()
     }
 }

--- a/apps/server/src/main_lib.rs
+++ b/apps/server/src/main_lib.rs
@@ -444,6 +444,7 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
         performance_service.clone(),
         income_service.clone(),
         health_service.clone(),
+        taxonomy_service.clone(),
     ));
     let ai_chat_service = Arc::new(ChatService::new(ai_environment, ChatConfig::default()));
 

--- a/apps/server/src/main_lib.rs
+++ b/apps/server/src/main_lib.rs
@@ -445,6 +445,7 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
         income_service.clone(),
         health_service.clone(),
         taxonomy_service.clone(),
+        asset_service.clone(),
     ));
     let ai_chat_service = Arc::new(ChatService::new(ai_environment, ChatConfig::default()));
 

--- a/apps/tauri/src/context/ai_environment.rs
+++ b/apps/tauri/src/context/ai_environment.rs
@@ -8,8 +8,8 @@ use std::sync::{Arc, RwLock};
 use wealthfolio_ai::{AiEnvironment, ChatRepositoryTrait};
 use wealthfolio_core::{
     accounts::AccountServiceTrait, activities::ActivityServiceTrait,
-    allocation::AllocationServiceTrait, goals::GoalServiceTrait, health::HealthServiceTrait,
-    holdings::HoldingsServiceTrait, income::IncomeServiceTrait,
+    allocation::AllocationServiceTrait, assets::AssetServiceTrait, goals::GoalServiceTrait,
+    health::HealthServiceTrait, holdings::HoldingsServiceTrait, income::IncomeServiceTrait,
     performance::PerformanceServiceTrait, quotes::QuoteServiceTrait, secrets::SecretStore,
     settings::SettingsServiceTrait, taxonomies::TaxonomyServiceTrait,
     valuation::ValuationServiceTrait,
@@ -35,6 +35,7 @@ pub struct TauriAiEnvironment {
     income_service: Arc<dyn IncomeServiceTrait + Send + Sync>,
     health_service: Arc<dyn HealthServiceTrait + Send + Sync>,
     taxonomy_service: Arc<dyn TaxonomyServiceTrait + Send + Sync>,
+    assets_service: Arc<dyn AssetServiceTrait + Send + Sync>,
 }
 
 impl TauriAiEnvironment {
@@ -56,6 +57,7 @@ impl TauriAiEnvironment {
         income_service: Arc<dyn IncomeServiceTrait + Send + Sync>,
         health_service: Arc<dyn HealthServiceTrait + Send + Sync>,
         taxonomy_service: Arc<dyn TaxonomyServiceTrait + Send + Sync>,
+        assets_service: Arc<dyn AssetServiceTrait + Send + Sync>,
     ) -> Self {
         Self {
             base_currency,
@@ -73,6 +75,7 @@ impl TauriAiEnvironment {
             income_service,
             health_service,
             taxonomy_service,
+            assets_service,
         }
     }
 }
@@ -136,5 +139,9 @@ impl AiEnvironment for TauriAiEnvironment {
 
     fn taxonomy_service(&self) -> Arc<dyn TaxonomyServiceTrait> {
         self.taxonomy_service.clone()
+    }
+
+    fn assets_service(&self) -> Arc<dyn AssetServiceTrait> {
+        self.assets_service.clone()
     }
 }

--- a/apps/tauri/src/context/ai_environment.rs
+++ b/apps/tauri/src/context/ai_environment.rs
@@ -11,7 +11,8 @@ use wealthfolio_core::{
     allocation::AllocationServiceTrait, goals::GoalServiceTrait, health::HealthServiceTrait,
     holdings::HoldingsServiceTrait, income::IncomeServiceTrait,
     performance::PerformanceServiceTrait, quotes::QuoteServiceTrait, secrets::SecretStore,
-    settings::SettingsServiceTrait, valuation::ValuationServiceTrait,
+    settings::SettingsServiceTrait, taxonomies::TaxonomyServiceTrait,
+    valuation::ValuationServiceTrait,
 };
 
 /// Tauri-side implementation of AiEnvironment.
@@ -33,6 +34,7 @@ pub struct TauriAiEnvironment {
     performance_service: Arc<dyn PerformanceServiceTrait + Send + Sync>,
     income_service: Arc<dyn IncomeServiceTrait + Send + Sync>,
     health_service: Arc<dyn HealthServiceTrait + Send + Sync>,
+    taxonomy_service: Arc<dyn TaxonomyServiceTrait + Send + Sync>,
 }
 
 impl TauriAiEnvironment {
@@ -53,6 +55,7 @@ impl TauriAiEnvironment {
         performance_service: Arc<dyn PerformanceServiceTrait + Send + Sync>,
         income_service: Arc<dyn IncomeServiceTrait + Send + Sync>,
         health_service: Arc<dyn HealthServiceTrait + Send + Sync>,
+        taxonomy_service: Arc<dyn TaxonomyServiceTrait + Send + Sync>,
     ) -> Self {
         Self {
             base_currency,
@@ -69,6 +72,7 @@ impl TauriAiEnvironment {
             performance_service,
             income_service,
             health_service,
+            taxonomy_service,
         }
     }
 }
@@ -128,5 +132,9 @@ impl AiEnvironment for TauriAiEnvironment {
 
     fn health_service(&self) -> Arc<dyn HealthServiceTrait> {
         self.health_service.clone()
+    }
+
+    fn taxonomy_service(&self) -> Arc<dyn TaxonomyServiceTrait> {
+        self.taxonomy_service.clone()
     }
 }

--- a/apps/tauri/src/context/providers.rs
+++ b/apps/tauri/src/context/providers.rs
@@ -339,6 +339,7 @@ pub async fn initialize_context(
         income_service.clone(),
         health_service.clone(),
         taxonomy_service.clone(),
+        asset_service.clone(),
     ));
     let ai_chat_service = Arc::new(ChatService::new(ai_environment, ChatConfig::default()));
 

--- a/apps/tauri/src/context/providers.rs
+++ b/apps/tauri/src/context/providers.rs
@@ -338,6 +338,7 @@ pub async fn initialize_context(
         performance_service.clone(),
         income_service.clone(),
         health_service.clone(),
+        taxonomy_service.clone(),
     ));
     let ai_chat_service = Arc::new(ChatService::new(ai_environment, ChatConfig::default()));
 

--- a/crates/ai/src/chat.rs
+++ b/crates/ai/src/chat.rs
@@ -1346,6 +1346,9 @@ async fn spawn_chat_stream<E: AiEnvironment + 'static>(
             if is_allowed("get_asset_taxonomy_assignments") {
                 allowed_tools.push(Box::new(tool_set.get_asset_taxonomy_assignments));
             }
+            if is_allowed("set_asset_taxonomy_assignments") {
+                allowed_tools.push(Box::new(tool_set.set_asset_taxonomy_assignments));
+            }
 
             let mut builder = $client
                 .agent(&model_id)

--- a/crates/ai/src/chat.rs
+++ b/crates/ai/src/chat.rs
@@ -1340,6 +1340,12 @@ async fn spawn_chat_stream<E: AiEnvironment + 'static>(
             if is_allowed("get_health_status") {
                 allowed_tools.push(Box::new(tool_set.health_status));
             }
+            if is_allowed("list_taxonomies") {
+                allowed_tools.push(Box::new(tool_set.list_taxonomies));
+            }
+            if is_allowed("get_asset_taxonomy_assignments") {
+                allowed_tools.push(Box::new(tool_set.get_asset_taxonomy_assignments));
+            }
 
             let mut builder = $client
                 .agent(&model_id)

--- a/crates/ai/src/env.rs
+++ b/crates/ai/src/env.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use wealthfolio_core::{
     accounts::AccountServiceTrait,
     activities::ActivityServiceTrait,
+    assets::AssetServiceTrait,
     goals::GoalServiceTrait,
     health::HealthServiceTrait,
     portfolio::{
@@ -78,6 +79,9 @@ pub trait AiEnvironment: Send + Sync {
 
     /// Get the taxonomy service for listing taxonomies and categories.
     fn taxonomy_service(&self) -> Arc<dyn TaxonomyServiceTrait>;
+
+    /// Get the asset service for looking up assets by symbol.
+    fn assets_service(&self) -> Arc<dyn AssetServiceTrait>;
 }
 
 #[cfg(test)]
@@ -1341,6 +1345,110 @@ pub mod test_env {
         }
     }
 
+    /// Mock assets service for testing (symbol-based lookup).
+    #[derive(Default)]
+    pub struct MockAssetsService {
+        pub assets: Vec<Asset>,
+    }
+
+    #[async_trait]
+    impl AssetServiceTrait for MockAssetsService {
+        fn get_assets(&self) -> CoreResult<Vec<Asset>> {
+            Ok(self.assets.clone())
+        }
+
+        fn get_asset_by_id(&self, asset_id: &str) -> CoreResult<Asset> {
+            self.assets
+                .iter()
+                .find(|a| a.id == asset_id)
+                .cloned()
+                .ok_or_else(|| {
+                    CoreError::Database(DatabaseError::NotFound(format!("Asset {}", asset_id)))
+                })
+        }
+
+        async fn delete_asset(&self, _asset_id: &str) -> CoreResult<()> {
+            unimplemented!("MockAssetsService::delete_asset")
+        }
+
+        async fn update_asset_profile(
+            &self,
+            _asset_id: &str,
+            _payload: wealthfolio_core::assets::UpdateAssetProfile,
+        ) -> CoreResult<Asset> {
+            unimplemented!("MockAssetsService::update_asset_profile")
+        }
+
+        async fn create_asset(
+            &self,
+            _new_asset: wealthfolio_core::assets::NewAsset,
+        ) -> CoreResult<Asset> {
+            unimplemented!("MockAssetsService::create_asset")
+        }
+
+        async fn get_or_create_minimal_asset(
+            &self,
+            _asset_id: &str,
+            _context_currency: Option<String>,
+            _metadata: Option<wealthfolio_core::assets::AssetMetadata>,
+            _quote_mode: Option<String>,
+        ) -> CoreResult<Asset> {
+            unimplemented!("MockAssetsService::get_or_create_minimal_asset")
+        }
+
+        async fn update_quote_mode(&self, _asset_id: &str, _quote_mode: &str) -> CoreResult<Asset> {
+            unimplemented!("MockAssetsService::update_quote_mode")
+        }
+
+        async fn get_assets_by_asset_ids(&self, asset_ids: &[String]) -> CoreResult<Vec<Asset>> {
+            Ok(self
+                .assets
+                .iter()
+                .filter(|a| asset_ids.contains(&a.id))
+                .cloned()
+                .collect())
+        }
+
+        async fn enrich_asset_profile(&self, _asset_id: &str) -> CoreResult<Asset> {
+            unimplemented!("MockAssetsService::enrich_asset_profile")
+        }
+
+        async fn enrich_assets(
+            &self,
+            _asset_ids: Vec<String>,
+        ) -> CoreResult<(usize, usize, usize)> {
+            unimplemented!("MockAssetsService::enrich_assets")
+        }
+
+        async fn cleanup_legacy_metadata(&self, _asset_id: &str) -> CoreResult<()> {
+            unimplemented!("MockAssetsService::cleanup_legacy_metadata")
+        }
+
+        async fn merge_unknown_asset(
+            &self,
+            _resolved_asset_id: &str,
+            _unknown_asset_id: &str,
+            _activity_repository: &dyn wealthfolio_core::activities::ActivityRepositoryTrait,
+        ) -> CoreResult<u32> {
+            unimplemented!("MockAssetsService::merge_unknown_asset")
+        }
+
+        async fn ensure_assets(
+            &self,
+            _specs: Vec<wealthfolio_core::assets::AssetSpec>,
+            _activity_repository: &dyn wealthfolio_core::activities::ActivityRepositoryTrait,
+        ) -> CoreResult<wealthfolio_core::assets::EnsureAssetsResult> {
+            unimplemented!("MockAssetsService::ensure_assets")
+        }
+
+        async fn resolve_import_asset_inputs(
+            &self,
+            _inputs: Vec<wealthfolio_core::assets::AssetResolutionInput>,
+        ) -> CoreResult<Vec<wealthfolio_core::assets::AssetResolutionOutput>> {
+            unimplemented!("MockAssetsService::resolve_import_asset_inputs")
+        }
+    }
+
     /// Mock environment for testing.
     pub struct MockEnvironment {
         pub base_currency: String,
@@ -1358,6 +1466,7 @@ pub mod test_env {
         pub income_service: Arc<dyn IncomeServiceTrait>,
         pub health_service: Arc<dyn HealthServiceTrait>,
         pub taxonomy_service: Arc<dyn TaxonomyServiceTrait>,
+        pub assets_service: Arc<dyn AssetServiceTrait>,
     }
 
     impl Default for MockEnvironment {
@@ -1384,6 +1493,7 @@ pub mod test_env {
                 income_service: Arc::new(MockIncomeService),
                 health_service: Arc::new(MockHealthService::default()),
                 taxonomy_service: Arc::new(MockTaxonomyService::default()),
+                assets_service: Arc::new(MockAssetsService::default()),
             }
         }
 
@@ -1453,6 +1563,10 @@ pub mod test_env {
 
         fn taxonomy_service(&self) -> Arc<dyn TaxonomyServiceTrait> {
             self.taxonomy_service.clone()
+        }
+
+        fn assets_service(&self) -> Arc<dyn AssetServiceTrait> {
+            self.assets_service.clone()
         }
     }
 

--- a/crates/ai/src/env.rs
+++ b/crates/ai/src/env.rs
@@ -1343,6 +1343,15 @@ pub mod test_env {
         async fn remove_asset_assignment(&self, _id: &str) -> CoreResult<usize> {
             unimplemented!("MockTaxonomyService::remove_asset_assignment")
         }
+
+        async fn replace_asset_assignments(
+            &self,
+            _asset_id: &str,
+            _taxonomy_id: &str,
+            _assignments: Vec<NewAssetTaxonomyAssignment>,
+        ) -> CoreResult<Vec<AssetTaxonomyAssignment>> {
+            unimplemented!("MockTaxonomyService::replace_asset_assignments")
+        }
     }
 
     /// Mock assets service for testing (symbol-based lookup).

--- a/crates/ai/src/env.rs
+++ b/crates/ai/src/env.rs
@@ -19,6 +19,7 @@ use wealthfolio_core::{
     quotes::QuoteServiceTrait,
     secrets::SecretStore,
     settings::SettingsServiceTrait,
+    taxonomies::TaxonomyServiceTrait,
 };
 
 use crate::types::ChatRepositoryTrait;
@@ -74,6 +75,9 @@ pub trait AiEnvironment: Send + Sync {
 
     /// Get the health service for portfolio health diagnostics.
     fn health_service(&self) -> Arc<dyn HealthServiceTrait>;
+
+    /// Get the taxonomy service for listing taxonomies and categories.
+    fn taxonomy_service(&self) -> Arc<dyn TaxonomyServiceTrait>;
 }
 
 #[cfg(test)]
@@ -118,7 +122,10 @@ pub mod test_env {
         },
         secrets::SecretStore,
         settings::{Settings, SettingsServiceTrait, SettingsUpdate},
-        taxonomies::TaxonomyServiceTrait,
+        taxonomies::{
+            AssetTaxonomyAssignment, Category, NewAssetTaxonomyAssignment, NewCategory,
+            NewTaxonomy, Taxonomy, TaxonomyServiceTrait, TaxonomyWithCategories,
+        },
         valuation::{
             DailyAccountValuation, NegativeBalanceInfo, ValuationRecalcMode, ValuationServiceTrait,
         },
@@ -1237,6 +1244,103 @@ pub mod test_env {
         }
     }
 
+    /// Mock taxonomy service for testing.
+    #[derive(Default)]
+    pub struct MockTaxonomyService {
+        pub taxonomies: Vec<TaxonomyWithCategories>,
+    }
+
+    #[async_trait]
+    impl TaxonomyServiceTrait for MockTaxonomyService {
+        fn get_taxonomies(&self) -> CoreResult<Vec<Taxonomy>> {
+            Ok(self.taxonomies.iter().map(|t| t.taxonomy.clone()).collect())
+        }
+
+        fn get_taxonomy(&self, id: &str) -> CoreResult<Option<TaxonomyWithCategories>> {
+            Ok(self
+                .taxonomies
+                .iter()
+                .find(|t| t.taxonomy.id == id)
+                .cloned())
+        }
+
+        fn get_taxonomies_with_categories(&self) -> CoreResult<Vec<TaxonomyWithCategories>> {
+            Ok(self.taxonomies.clone())
+        }
+
+        async fn create_taxonomy(&self, _taxonomy: NewTaxonomy) -> CoreResult<Taxonomy> {
+            unimplemented!("MockTaxonomyService::create_taxonomy")
+        }
+
+        async fn update_taxonomy(&self, _taxonomy: Taxonomy) -> CoreResult<Taxonomy> {
+            unimplemented!("MockTaxonomyService::update_taxonomy")
+        }
+
+        async fn delete_taxonomy(&self, _id: &str) -> CoreResult<usize> {
+            unimplemented!("MockTaxonomyService::delete_taxonomy")
+        }
+
+        async fn create_category(&self, _category: NewCategory) -> CoreResult<Category> {
+            unimplemented!("MockTaxonomyService::create_category")
+        }
+
+        async fn update_category(&self, _category: Category) -> CoreResult<Category> {
+            unimplemented!("MockTaxonomyService::update_category")
+        }
+
+        async fn delete_category(
+            &self,
+            _taxonomy_id: &str,
+            _category_id: &str,
+        ) -> CoreResult<usize> {
+            unimplemented!("MockTaxonomyService::delete_category")
+        }
+
+        async fn move_category(
+            &self,
+            _taxonomy_id: &str,
+            _category_id: &str,
+            _new_parent_id: Option<String>,
+            _position: i32,
+        ) -> CoreResult<Category> {
+            unimplemented!("MockTaxonomyService::move_category")
+        }
+
+        async fn import_taxonomy_json(&self, _json_str: &str) -> CoreResult<Taxonomy> {
+            unimplemented!("MockTaxonomyService::import_taxonomy_json")
+        }
+
+        fn export_taxonomy_json(&self, _id: &str) -> CoreResult<String> {
+            unimplemented!("MockTaxonomyService::export_taxonomy_json")
+        }
+
+        fn get_asset_assignments(
+            &self,
+            _asset_id: &str,
+        ) -> CoreResult<Vec<AssetTaxonomyAssignment>> {
+            Ok(Vec::new())
+        }
+
+        fn get_category_assignments(
+            &self,
+            _taxonomy_id: &str,
+            _category_id: &str,
+        ) -> CoreResult<Vec<AssetTaxonomyAssignment>> {
+            Ok(Vec::new())
+        }
+
+        async fn assign_asset_to_category(
+            &self,
+            _assignment: NewAssetTaxonomyAssignment,
+        ) -> CoreResult<AssetTaxonomyAssignment> {
+            unimplemented!("MockTaxonomyService::assign_asset_to_category")
+        }
+
+        async fn remove_asset_assignment(&self, _id: &str) -> CoreResult<usize> {
+            unimplemented!("MockTaxonomyService::remove_asset_assignment")
+        }
+    }
+
     /// Mock environment for testing.
     pub struct MockEnvironment {
         pub base_currency: String,
@@ -1253,6 +1357,7 @@ pub mod test_env {
         pub performance_service: Arc<dyn PerformanceServiceTrait>,
         pub income_service: Arc<dyn IncomeServiceTrait>,
         pub health_service: Arc<dyn HealthServiceTrait>,
+        pub taxonomy_service: Arc<dyn TaxonomyServiceTrait>,
     }
 
     impl Default for MockEnvironment {
@@ -1278,6 +1383,7 @@ pub mod test_env {
                 performance_service: Arc::new(MockPerformanceService),
                 income_service: Arc::new(MockIncomeService),
                 health_service: Arc::new(MockHealthService::default()),
+                taxonomy_service: Arc::new(MockTaxonomyService::default()),
             }
         }
 
@@ -1343,6 +1449,10 @@ pub mod test_env {
 
         fn health_service(&self) -> Arc<dyn HealthServiceTrait> {
             self.health_service.clone()
+        }
+
+        fn taxonomy_service(&self) -> Arc<dyn TaxonomyServiceTrait> {
+            self.taxonomy_service.clone()
         }
     }
 

--- a/crates/ai/src/tools/asset_taxonomy_assignments.rs
+++ b/crates/ai/src/tools/asset_taxonomy_assignments.rs
@@ -510,5 +510,16 @@ mod tests {
         ) -> wealthfolio_core::errors::Result<usize> {
             unimplemented!()
         }
+
+        async fn replace_asset_assignments(
+            &self,
+            _asset_id: &str,
+            _taxonomy_id: &str,
+            _assignments: Vec<wealthfolio_core::taxonomies::NewAssetTaxonomyAssignment>,
+        ) -> wealthfolio_core::errors::Result<
+            Vec<wealthfolio_core::taxonomies::AssetTaxonomyAssignment>,
+        > {
+            unimplemented!()
+        }
     }
 }

--- a/crates/ai/src/tools/asset_taxonomy_assignments.rs
+++ b/crates/ai/src/tools/asset_taxonomy_assignments.rs
@@ -1,0 +1,514 @@
+//! Get asset taxonomy assignments tool.
+//!
+//! Resolves a user-facing symbol to an asset_id, then returns all
+//! taxonomy assignments for that asset (optionally filtered by taxonomy_id).
+
+use rig::{completion::ToolDefinition, tool::Tool};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::env::AiEnvironment;
+use crate::error::AiError;
+
+// ============================================================================
+// Symbol Resolver
+// ============================================================================
+
+/// Resolves a user-visible symbol (e.g. "VWRL" or "VWRL.MI") to an opaque
+/// `asset_id` using exact, case-insensitive `instrument_symbol` matching.
+///
+/// Tie-break rules:
+/// - 0 matches → Err("Asset not found for symbol '{symbol}'")
+/// - 1 match   → Ok(asset_id)
+/// - 2+ matches → Err("Ambiguous symbol '{symbol}', please specify with exchange suffix (e.g. 'VWRL.MI')")
+pub fn resolve_symbol(
+    assets_service: &Arc<dyn wealthfolio_core::assets::AssetServiceTrait>,
+    symbol: &str,
+) -> Result<String, AiError> {
+    let matches = assets_service
+        .search_by_symbol(symbol)
+        .map_err(|e| AiError::ToolExecutionFailed(e.to_string()))?;
+
+    match matches.len() {
+        0 => Err(AiError::ToolExecutionFailed(format!(
+            "Asset not found for symbol '{symbol}'"
+        ))),
+        1 => Ok(matches.into_iter().next().unwrap().id),
+        _ => Err(AiError::ToolExecutionFailed(format!(
+            "Ambiguous symbol '{symbol}', please specify with exchange suffix (e.g. 'VWRL.MI')"
+        ))),
+    }
+}
+
+// ============================================================================
+// Tool Arguments and Output
+// ============================================================================
+
+/// Arguments for the get_asset_taxonomy_assignments tool.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetAssetTaxonomyAssignmentsArgs {
+    /// Ticker symbol for the asset (e.g. "AAPL", "VWRL.MI").
+    pub symbol: String,
+
+    /// Optional taxonomy ID filter. If omitted, returns all taxonomies.
+    pub taxonomy_id: Option<String>,
+}
+
+/// DTO for a single taxonomy assignment row.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaxonomyAssignmentDto {
+    pub taxonomy_id: String,
+    pub taxonomy_name: String,
+    pub category_id: String,
+    pub category_name: String,
+    /// Weight in basis points (10 000 = 100%).
+    pub weight_basis_points: i32,
+    pub source: String,
+}
+
+/// Output envelope for the get_asset_taxonomy_assignments tool.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetAssetTaxonomyAssignmentsOutput {
+    pub symbol: String,
+    pub asset_id: String,
+    pub assignments: Vec<TaxonomyAssignmentDto>,
+}
+
+// ============================================================================
+// Tool Implementation
+// ============================================================================
+
+/// Tool to get taxonomy assignments for an asset identified by symbol.
+pub struct GetAssetTaxonomyAssignmentsTool<E: AiEnvironment> {
+    env: Arc<E>,
+}
+
+impl<E: AiEnvironment> GetAssetTaxonomyAssignmentsTool<E> {
+    pub fn new(env: Arc<E>) -> Self {
+        Self { env }
+    }
+}
+
+impl<E: AiEnvironment> Clone for GetAssetTaxonomyAssignmentsTool<E> {
+    fn clone(&self) -> Self {
+        Self {
+            env: self.env.clone(),
+        }
+    }
+}
+
+impl<E: AiEnvironment + 'static> Tool for GetAssetTaxonomyAssignmentsTool<E> {
+    const NAME: &'static str = "get_asset_taxonomy_assignments";
+
+    type Error = AiError;
+    type Args = GetAssetTaxonomyAssignmentsArgs;
+    type Output = GetAssetTaxonomyAssignmentsOutput;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Get taxonomy assignments for an asset. Returns how the asset is classified across taxonomies (regions, sectors, asset classes, etc.). Optionally filter to a single taxonomy.".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "symbol": {
+                        "type": "string",
+                        "description": "Ticker symbol for the asset (e.g. 'AAPL', 'VWRL.MI')"
+                    },
+                    "taxonomyId": {
+                        "type": "string",
+                        "description": "Optional: taxonomy ID to filter results (use list_taxonomies to discover IDs)"
+                    }
+                },
+                "required": ["symbol"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        // Resolve symbol → asset_id
+        let asset_id = resolve_symbol(&self.env.assets_service(), &args.symbol)?;
+
+        // Fetch raw assignments
+        let raw_assignments = self
+            .env
+            .taxonomy_service()
+            .get_asset_assignments(&asset_id)
+            .map_err(|e| AiError::ToolExecutionFailed(e.to_string()))?;
+
+        // Optionally filter by taxonomy_id
+        let raw_assignments: Vec<_> = if let Some(ref tid) = args.taxonomy_id {
+            raw_assignments
+                .into_iter()
+                .filter(|a| &a.taxonomy_id == tid)
+                .collect()
+        } else {
+            raw_assignments
+        };
+
+        // Enrich with names by loading all taxonomies once
+        let taxonomies = self
+            .env
+            .taxonomy_service()
+            .get_taxonomies_with_categories()
+            .map_err(|e| AiError::ToolExecutionFailed(e.to_string()))?;
+
+        // Build lookup: taxonomy_id → (taxonomy_name, category_id → category_name)
+        let lookup: std::collections::HashMap<
+            String,
+            (String, std::collections::HashMap<String, String>),
+        > = taxonomies
+            .into_iter()
+            .map(|twc| {
+                let cat_map: std::collections::HashMap<String, String> =
+                    twc.categories.into_iter().map(|c| (c.id, c.name)).collect();
+                (twc.taxonomy.id, (twc.taxonomy.name, cat_map))
+            })
+            .collect();
+
+        let assignments = raw_assignments
+            .into_iter()
+            .map(|a| {
+                let taxonomy_name = lookup
+                    .get(&a.taxonomy_id)
+                    .map(|(tn, _)| tn.clone())
+                    .unwrap_or_else(|| a.taxonomy_id.clone());
+                let category_name = lookup
+                    .get(&a.taxonomy_id)
+                    .and_then(|(_, cm)| cm.get(&a.category_id))
+                    .cloned()
+                    .unwrap_or_else(|| a.category_id.clone());
+                TaxonomyAssignmentDto {
+                    taxonomy_id: a.taxonomy_id,
+                    taxonomy_name,
+                    category_id: a.category_id,
+                    category_name,
+                    weight_basis_points: a.weight,
+                    source: a.source,
+                }
+            })
+            .collect();
+
+        Ok(GetAssetTaxonomyAssignmentsOutput {
+            symbol: args.symbol,
+            asset_id,
+            assignments,
+        })
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::env::test_env::{MockAssetsService, MockEnvironment, MockTaxonomyService};
+    use chrono::NaiveDateTime;
+    use wealthfolio_core::{
+        assets::Asset,
+        taxonomies::{AssetTaxonomyAssignment, Category, Taxonomy, TaxonomyWithCategories},
+    };
+
+    fn make_asset(id: &str, symbol: &str) -> Asset {
+        Asset {
+            id: id.to_string(),
+            kind: wealthfolio_core::assets::AssetKind::Investment,
+            name: Some(id.to_string()),
+            display_code: None,
+            notes: None,
+            metadata: None,
+            is_active: true,
+            quote_mode: wealthfolio_core::assets::QuoteMode::Market,
+            quote_ccy: "USD".to_string(),
+            instrument_type: None,
+            instrument_symbol: Some(symbol.to_string()),
+            instrument_exchange_mic: None,
+            instrument_key: None,
+            provider_config: None,
+            exchange_name: None,
+            created_at: NaiveDateTime::default(),
+            updated_at: NaiveDateTime::default(),
+        }
+    }
+
+    fn make_taxonomy(id: &str, name: &str) -> Taxonomy {
+        let now = NaiveDateTime::default();
+        Taxonomy {
+            id: id.to_string(),
+            name: name.to_string(),
+            color: "#ffffff".to_string(),
+            description: None,
+            is_system: false,
+            is_single_select: true,
+            sort_order: 0,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn make_category(id: &str, taxonomy_id: &str, name: &str) -> Category {
+        let now = NaiveDateTime::default();
+        Category {
+            id: id.to_string(),
+            taxonomy_id: taxonomy_id.to_string(),
+            parent_id: None,
+            name: name.to_string(),
+            key: id.to_string(),
+            color: "#808080".to_string(),
+            description: None,
+            sort_order: 0,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn make_assignment(
+        asset_id: &str,
+        taxonomy_id: &str,
+        category_id: &str,
+        weight: i32,
+    ) -> AssetTaxonomyAssignment {
+        AssetTaxonomyAssignment {
+            id: format!("{}-{}-{}", asset_id, taxonomy_id, category_id),
+            asset_id: asset_id.to_string(),
+            taxonomy_id: taxonomy_id.to_string(),
+            category_id: category_id.to_string(),
+            weight,
+            source: "manual".to_string(),
+            created_at: NaiveDateTime::default(),
+            updated_at: NaiveDateTime::default(),
+        }
+    }
+
+    // --- SymbolResolver tests ---
+
+    // Test 1 (RED→GREEN): 0 matches → error
+    #[test]
+    fn symbol_resolver_no_match_returns_error() {
+        let svc = Arc::new(MockAssetsService { assets: vec![] });
+        let result = resolve_symbol(
+            &(svc as Arc<dyn wealthfolio_core::assets::AssetServiceTrait>),
+            "UNKNOWN",
+        );
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("Asset not found for symbol 'UNKNOWN'"),
+            "got: {msg}"
+        );
+    }
+
+    // Test 2 (RED→GREEN): 1 match → Ok with correct asset_id
+    #[test]
+    fn symbol_resolver_single_match_returns_asset_id() {
+        let asset = make_asset("AAPL", "AAPL");
+        let svc = Arc::new(MockAssetsService {
+            assets: vec![asset],
+        });
+        let result = resolve_symbol(
+            &(svc as Arc<dyn wealthfolio_core::assets::AssetServiceTrait>),
+            "AAPL",
+        );
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "AAPL");
+    }
+
+    // Test 3 (RED→GREEN): 2+ matches → ambiguous error
+    #[test]
+    fn symbol_resolver_multiple_matches_returns_ambiguous_error() {
+        let a1 = make_asset("VWRL", "VWRL");
+        let a2 = make_asset("VWRL.MI", "VWRL");
+        let svc = Arc::new(MockAssetsService {
+            assets: vec![a1, a2],
+        });
+        let result = resolve_symbol(
+            &(svc as Arc<dyn wealthfolio_core::assets::AssetServiceTrait>),
+            "VWRL",
+        );
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Ambiguous symbol 'VWRL'"), "got: {msg}");
+        assert!(msg.contains("exchange suffix"), "got: {msg}");
+    }
+
+    // --- Tool smoke test ---
+
+    // Test 4 (RED→GREEN): tool returns enriched DTO with all fields populated
+    #[tokio::test]
+    async fn tool_returns_enriched_assignments() {
+        let asset = make_asset("VWRL.MI", "VWRL.MI");
+        let taxonomy = make_taxonomy("regions", "Regions");
+        let category = make_category("EUROPE", "regions", "Europe");
+        let assignment = make_assignment("VWRL.MI", "regions", "EUROPE", 10000);
+
+        let mut taxonomy_svc = MockTaxonomyService::default();
+        // Override get_asset_assignments to return our assignment
+        taxonomy_svc.taxonomies = vec![TaxonomyWithCategories {
+            taxonomy,
+            categories: vec![category],
+        }];
+
+        let mut env = MockEnvironment::new();
+        env.assets_service = Arc::new(MockAssetsService {
+            assets: vec![asset],
+        });
+        env.taxonomy_service = Arc::new(MockTaxonomyServiceWithAssignments {
+            inner: taxonomy_svc,
+            assignments: vec![assignment],
+        });
+
+        let tool = GetAssetTaxonomyAssignmentsTool::new(Arc::new(env));
+        let result = tool
+            .call(GetAssetTaxonomyAssignmentsArgs {
+                symbol: "VWRL.MI".to_string(),
+                taxonomy_id: None,
+            })
+            .await;
+
+        assert!(result.is_ok(), "tool call failed: {:?}", result.err());
+        let output = result.unwrap();
+        assert_eq!(output.symbol, "VWRL.MI");
+        assert_eq!(output.asset_id, "VWRL.MI");
+        assert_eq!(output.assignments.len(), 1);
+
+        let a = &output.assignments[0];
+        assert_eq!(a.taxonomy_id, "regions");
+        assert_eq!(a.taxonomy_name, "Regions");
+        assert_eq!(a.category_id, "EUROPE");
+        assert_eq!(a.category_name, "Europe");
+        assert_eq!(a.weight_basis_points, 10000);
+        assert_eq!(a.source, "manual");
+    }
+
+    /// Extended mock taxonomy service that also serves assignments.
+    struct MockTaxonomyServiceWithAssignments {
+        inner: MockTaxonomyService,
+        assignments: Vec<AssetTaxonomyAssignment>,
+    }
+
+    #[async_trait::async_trait]
+    impl wealthfolio_core::taxonomies::TaxonomyServiceTrait for MockTaxonomyServiceWithAssignments {
+        fn get_taxonomies(
+            &self,
+        ) -> wealthfolio_core::errors::Result<Vec<wealthfolio_core::taxonomies::Taxonomy>> {
+            self.inner.get_taxonomies()
+        }
+
+        fn get_taxonomy(
+            &self,
+            id: &str,
+        ) -> wealthfolio_core::errors::Result<
+            Option<wealthfolio_core::taxonomies::TaxonomyWithCategories>,
+        > {
+            self.inner.get_taxonomy(id)
+        }
+
+        fn get_taxonomies_with_categories(
+            &self,
+        ) -> wealthfolio_core::errors::Result<
+            Vec<wealthfolio_core::taxonomies::TaxonomyWithCategories>,
+        > {
+            self.inner.get_taxonomies_with_categories()
+        }
+
+        async fn create_taxonomy(
+            &self,
+            _taxonomy: wealthfolio_core::taxonomies::NewTaxonomy,
+        ) -> wealthfolio_core::errors::Result<wealthfolio_core::taxonomies::Taxonomy> {
+            unimplemented!()
+        }
+
+        async fn update_taxonomy(
+            &self,
+            _taxonomy: wealthfolio_core::taxonomies::Taxonomy,
+        ) -> wealthfolio_core::errors::Result<wealthfolio_core::taxonomies::Taxonomy> {
+            unimplemented!()
+        }
+
+        async fn delete_taxonomy(&self, _id: &str) -> wealthfolio_core::errors::Result<usize> {
+            unimplemented!()
+        }
+
+        async fn create_category(
+            &self,
+            _category: wealthfolio_core::taxonomies::NewCategory,
+        ) -> wealthfolio_core::errors::Result<wealthfolio_core::taxonomies::Category> {
+            unimplemented!()
+        }
+
+        async fn update_category(
+            &self,
+            _category: wealthfolio_core::taxonomies::Category,
+        ) -> wealthfolio_core::errors::Result<wealthfolio_core::taxonomies::Category> {
+            unimplemented!()
+        }
+
+        async fn delete_category(
+            &self,
+            _taxonomy_id: &str,
+            _category_id: &str,
+        ) -> wealthfolio_core::errors::Result<usize> {
+            unimplemented!()
+        }
+
+        async fn move_category(
+            &self,
+            _taxonomy_id: &str,
+            _category_id: &str,
+            _new_parent_id: Option<String>,
+            _position: i32,
+        ) -> wealthfolio_core::errors::Result<wealthfolio_core::taxonomies::Category> {
+            unimplemented!()
+        }
+
+        async fn import_taxonomy_json(
+            &self,
+            _json_str: &str,
+        ) -> wealthfolio_core::errors::Result<wealthfolio_core::taxonomies::Taxonomy> {
+            unimplemented!()
+        }
+
+        fn export_taxonomy_json(&self, _id: &str) -> wealthfolio_core::errors::Result<String> {
+            unimplemented!()
+        }
+
+        fn get_asset_assignments(
+            &self,
+            _asset_id: &str,
+        ) -> wealthfolio_core::errors::Result<
+            Vec<wealthfolio_core::taxonomies::AssetTaxonomyAssignment>,
+        > {
+            Ok(self.assignments.clone())
+        }
+
+        fn get_category_assignments(
+            &self,
+            _taxonomy_id: &str,
+            _category_id: &str,
+        ) -> wealthfolio_core::errors::Result<
+            Vec<wealthfolio_core::taxonomies::AssetTaxonomyAssignment>,
+        > {
+            Ok(vec![])
+        }
+
+        async fn assign_asset_to_category(
+            &self,
+            _assignment: wealthfolio_core::taxonomies::NewAssetTaxonomyAssignment,
+        ) -> wealthfolio_core::errors::Result<wealthfolio_core::taxonomies::AssetTaxonomyAssignment>
+        {
+            unimplemented!()
+        }
+
+        async fn remove_asset_assignment(
+            &self,
+            _id: &str,
+        ) -> wealthfolio_core::errors::Result<usize> {
+            unimplemented!()
+        }
+    }
+}

--- a/crates/ai/src/tools/asset_taxonomy_assignments.rs
+++ b/crates/ai/src/tools/asset_taxonomy_assignments.rs
@@ -351,7 +351,6 @@ mod tests {
                 taxonomy,
                 categories: vec![category],
             }],
-            ..Default::default()
         };
 
         let mut env = MockEnvironment::new();

--- a/crates/ai/src/tools/asset_taxonomy_assignments.rs
+++ b/crates/ai/src/tools/asset_taxonomy_assignments.rs
@@ -346,12 +346,13 @@ mod tests {
         let category = make_category("EUROPE", "regions", "Europe");
         let assignment = make_assignment("VWRL.MI", "regions", "EUROPE", 10000);
 
-        let mut taxonomy_svc = MockTaxonomyService::default();
-        // Override get_asset_assignments to return our assignment
-        taxonomy_svc.taxonomies = vec![TaxonomyWithCategories {
-            taxonomy,
-            categories: vec![category],
-        }];
+        let taxonomy_svc = MockTaxonomyService {
+            taxonomies: vec![TaxonomyWithCategories {
+                taxonomy,
+                categories: vec![category],
+            }],
+            ..Default::default()
+        };
 
         let mut env = MockEnvironment::new();
         env.assets_service = Arc::new(MockAssetsService {

--- a/crates/ai/src/tools/mod.rs
+++ b/crates/ai/src/tools/mod.rs
@@ -27,6 +27,7 @@ pub mod income;
 pub mod performance;
 pub mod record_activities;
 pub mod record_activity;
+pub mod taxonomies;
 pub mod valuation;
 
 // Re-export constants
@@ -45,6 +46,7 @@ pub use income::GetIncomeTool;
 pub use performance::GetPerformanceTool;
 pub use record_activities::RecordActivitiesTool;
 pub use record_activity::RecordActivityTool;
+pub use taxonomies::ListTaxonomiesTool;
 pub use valuation::GetValuationHistoryTool;
 
 use std::sync::Arc;
@@ -66,6 +68,7 @@ pub struct ToolSet<E: AiEnvironment> {
     pub record_activities: RecordActivitiesTool<E>,
     pub import_csv: ImportCsvTool<E>,
     pub health_status: GetHealthStatusTool<E>,
+    pub list_taxonomies: ListTaxonomiesTool<E>,
 }
 
 impl<E: AiEnvironment> ToolSet<E> {
@@ -84,7 +87,8 @@ impl<E: AiEnvironment> ToolSet<E> {
             record_activity: RecordActivityTool::new(env.clone()),
             record_activities: RecordActivitiesTool::new(env.clone()),
             import_csv: ImportCsvTool::new(env.clone(), base_currency),
-            health_status: GetHealthStatusTool::new(env),
+            health_status: GetHealthStatusTool::new(env.clone()),
+            list_taxonomies: ListTaxonomiesTool::new(env),
         }
     }
 }

--- a/crates/ai/src/tools/mod.rs
+++ b/crates/ai/src/tools/mod.rs
@@ -28,6 +28,7 @@ pub mod income;
 pub mod performance;
 pub mod record_activities;
 pub mod record_activity;
+pub mod set_asset_taxonomy_assignments;
 pub mod taxonomies;
 pub mod valuation;
 
@@ -48,6 +49,7 @@ pub use income::GetIncomeTool;
 pub use performance::GetPerformanceTool;
 pub use record_activities::RecordActivitiesTool;
 pub use record_activity::RecordActivityTool;
+pub use set_asset_taxonomy_assignments::SetAssetTaxonomyAssignmentsTool;
 pub use taxonomies::ListTaxonomiesTool;
 pub use valuation::GetValuationHistoryTool;
 
@@ -72,6 +74,7 @@ pub struct ToolSet<E: AiEnvironment> {
     pub health_status: GetHealthStatusTool<E>,
     pub list_taxonomies: ListTaxonomiesTool<E>,
     pub get_asset_taxonomy_assignments: GetAssetTaxonomyAssignmentsTool<E>,
+    pub set_asset_taxonomy_assignments: SetAssetTaxonomyAssignmentsTool<E>,
 }
 
 impl<E: AiEnvironment> ToolSet<E> {
@@ -92,7 +95,8 @@ impl<E: AiEnvironment> ToolSet<E> {
             import_csv: ImportCsvTool::new(env.clone(), base_currency),
             health_status: GetHealthStatusTool::new(env.clone()),
             list_taxonomies: ListTaxonomiesTool::new(env.clone()),
-            get_asset_taxonomy_assignments: GetAssetTaxonomyAssignmentsTool::new(env),
+            get_asset_taxonomy_assignments: GetAssetTaxonomyAssignmentsTool::new(env.clone()),
+            set_asset_taxonomy_assignments: SetAssetTaxonomyAssignmentsTool::new(env),
         }
     }
 }

--- a/crates/ai/src/tools/mod.rs
+++ b/crates/ai/src/tools/mod.rs
@@ -17,6 +17,7 @@
 pub mod accounts;
 pub mod activities;
 pub mod allocation;
+pub mod asset_taxonomy_assignments;
 pub mod cash_balances;
 pub mod constants;
 pub mod goals;
@@ -37,6 +38,7 @@ pub use constants::*;
 pub use accounts::GetAccountsTool;
 pub use activities::SearchActivitiesTool;
 pub use allocation::GetAssetAllocationTool;
+pub use asset_taxonomy_assignments::GetAssetTaxonomyAssignmentsTool;
 pub use cash_balances::GetCashBalancesTool;
 pub use goals::GetGoalsTool;
 pub use health::GetHealthStatusTool;
@@ -69,6 +71,7 @@ pub struct ToolSet<E: AiEnvironment> {
     pub import_csv: ImportCsvTool<E>,
     pub health_status: GetHealthStatusTool<E>,
     pub list_taxonomies: ListTaxonomiesTool<E>,
+    pub get_asset_taxonomy_assignments: GetAssetTaxonomyAssignmentsTool<E>,
 }
 
 impl<E: AiEnvironment> ToolSet<E> {
@@ -88,7 +91,8 @@ impl<E: AiEnvironment> ToolSet<E> {
             record_activities: RecordActivitiesTool::new(env.clone()),
             import_csv: ImportCsvTool::new(env.clone(), base_currency),
             health_status: GetHealthStatusTool::new(env.clone()),
-            list_taxonomies: ListTaxonomiesTool::new(env),
+            list_taxonomies: ListTaxonomiesTool::new(env.clone()),
+            get_asset_taxonomy_assignments: GetAssetTaxonomyAssignmentsTool::new(env),
         }
     }
 }

--- a/crates/ai/src/tools/set_asset_taxonomy_assignments.rs
+++ b/crates/ai/src/tools/set_asset_taxonomy_assignments.rs
@@ -1,0 +1,566 @@
+//! Set asset taxonomy assignments tool.
+//!
+//! Atomically replaces all taxonomy assignments for (asset_id, taxonomy_id).
+//! Validates weights before any DB writes, then calls the service layer.
+
+use rig::{completion::ToolDefinition, tool::Tool};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use wealthfolio_core::taxonomies::NewAssetTaxonomyAssignment;
+
+use crate::env::AiEnvironment;
+use crate::error::AiError;
+use crate::tools::asset_taxonomy_assignments::resolve_symbol;
+
+// ============================================================================
+// Tool Arguments and Output
+// ============================================================================
+
+/// A single assignment row in the tool input.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssignmentInput {
+    pub category_id: String,
+    /// Weight in basis points (0–10000, where 10000 = 100%).
+    pub weight_basis_points: i32,
+}
+
+/// Arguments for the set_asset_taxonomy_assignments tool.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetAssetTaxonomyAssignmentsArgs {
+    /// Ticker symbol for the asset (e.g. "AAPL", "VWRL.MI").
+    pub symbol: String,
+    /// Taxonomy ID to replace assignments for.
+    pub taxonomy_id: String,
+    /// New assignment rows. Empty list clears all assignments.
+    pub assignments: Vec<AssignmentInput>,
+}
+
+/// A single assignment row in the tool output.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AssignmentOutput {
+    pub category_id: String,
+    pub category_name: String,
+    pub weight_basis_points: i32,
+    pub source: String,
+}
+
+/// Output for the set_asset_taxonomy_assignments tool.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SetAssetTaxonomyAssignmentsOutput {
+    pub assignments: Vec<AssignmentOutput>,
+    /// Remaining unallocated basis points (10000 - sum). 0 when fully allocated.
+    pub unallocated_basis_points: i32,
+}
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+/// Validate assignment weights before any DB writes.
+/// Returns the total sum if valid, or an AiError describing the violation.
+fn validate_weights(assignments: &[AssignmentInput]) -> Result<i32, AiError> {
+    for a in assignments {
+        if a.weight_basis_points < 0 {
+            return Err(AiError::ToolExecutionFailed(format!(
+                "weight_basis_points must be >= 0, got {} for category '{}'",
+                a.weight_basis_points, a.category_id
+            )));
+        }
+        if a.weight_basis_points > 10000 {
+            return Err(AiError::ToolExecutionFailed(format!(
+                "weight_basis_points must be <= 10000, got {} for category '{}'",
+                a.weight_basis_points, a.category_id
+            )));
+        }
+    }
+
+    let total: i32 = assignments.iter().map(|a| a.weight_basis_points).sum();
+    if total > 10000 {
+        return Err(AiError::ToolExecutionFailed(format!(
+            "Total weight_basis_points ({total}) exceeds 10000 (100%)"
+        )));
+    }
+
+    Ok(total)
+}
+
+// ============================================================================
+// Tool Implementation
+// ============================================================================
+
+/// Tool to atomically replace taxonomy assignments for an asset.
+pub struct SetAssetTaxonomyAssignmentsTool<E: AiEnvironment> {
+    env: Arc<E>,
+}
+
+impl<E: AiEnvironment> SetAssetTaxonomyAssignmentsTool<E> {
+    pub fn new(env: Arc<E>) -> Self {
+        Self { env }
+    }
+}
+
+impl<E: AiEnvironment> Clone for SetAssetTaxonomyAssignmentsTool<E> {
+    fn clone(&self) -> Self {
+        Self {
+            env: self.env.clone(),
+        }
+    }
+}
+
+impl<E: AiEnvironment + 'static> Tool for SetAssetTaxonomyAssignmentsTool<E> {
+    const NAME: &'static str = "set_asset_taxonomy_assignments";
+
+    type Error = AiError;
+    type Args = SetAssetTaxonomyAssignmentsArgs;
+    type Output = SetAssetTaxonomyAssignmentsOutput;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "Atomically replace all taxonomy assignments for an asset within a given taxonomy. \
+                Weights are in basis points (10000 = 100%). Partial allocation is allowed; the response \
+                includes unallocated_basis_points. Pass an empty assignments list to clear all assignments. \
+                Example: [{\"categoryId\": \"US\", \"weightBasisPoints\": 6000}, {\"categoryId\": \"EU\", \"weightBasisPoints\": 4000}]"
+                .to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "symbol": {
+                        "type": "string",
+                        "description": "Ticker symbol for the asset (e.g. 'AAPL', 'VWRL.MI')"
+                    },
+                    "taxonomyId": {
+                        "type": "string",
+                        "description": "Taxonomy ID to replace assignments for (use list_taxonomies to discover IDs)"
+                    },
+                    "assignments": {
+                        "type": "array",
+                        "description": "New assignment rows. Empty array clears all assignments.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "categoryId": {
+                                    "type": "string",
+                                    "description": "Category ID within the taxonomy"
+                                },
+                                "weightBasisPoints": {
+                                    "type": "integer",
+                                    "description": "Weight in basis points (0–10000, where 10000 = 100%)"
+                                }
+                            },
+                            "required": ["categoryId", "weightBasisPoints"]
+                        }
+                    }
+                },
+                "required": ["symbol", "taxonomyId", "assignments"]
+            }),
+        }
+    }
+
+    async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
+        // 1. Validate weights before any DB writes
+        let total = validate_weights(&args.assignments)?;
+
+        // 2. Resolve symbol → asset_id
+        let asset_id = resolve_symbol(&self.env.assets_service(), &args.symbol)?;
+
+        // 3. Build NewAssetTaxonomyAssignment list with source = "ai"
+        let new_assignments: Vec<NewAssetTaxonomyAssignment> = args
+            .assignments
+            .iter()
+            .map(|a| NewAssetTaxonomyAssignment {
+                id: None,
+                asset_id: asset_id.clone(),
+                taxonomy_id: args.taxonomy_id.clone(),
+                category_id: a.category_id.clone(),
+                weight: a.weight_basis_points,
+                source: "ai".to_string(),
+            })
+            .collect();
+
+        // 4. Atomic replace via service
+        let persisted = self
+            .env
+            .taxonomy_service()
+            .replace_asset_assignments(&asset_id, &args.taxonomy_id, new_assignments)
+            .await
+            .map_err(|e| AiError::ToolExecutionFailed(e.to_string()))?;
+
+        // 5. Enrich with category names by loading taxonomies
+        let taxonomies = self
+            .env
+            .taxonomy_service()
+            .get_taxonomies_with_categories()
+            .map_err(|e| AiError::ToolExecutionFailed(e.to_string()))?;
+
+        let cat_name_lookup: std::collections::HashMap<String, String> = taxonomies
+            .into_iter()
+            .flat_map(|twc| twc.categories.into_iter().map(|c| (c.id, c.name)))
+            .collect();
+
+        let assignments = persisted
+            .into_iter()
+            .map(|a| {
+                let category_name = cat_name_lookup
+                    .get(&a.category_id)
+                    .cloned()
+                    .unwrap_or_else(|| a.category_id.clone());
+                AssignmentOutput {
+                    category_id: a.category_id,
+                    category_name,
+                    weight_basis_points: a.weight,
+                    source: a.source,
+                }
+            })
+            .collect();
+
+        Ok(SetAssetTaxonomyAssignmentsOutput {
+            assignments,
+            unallocated_basis_points: 10000 - total,
+        })
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::env::test_env::{MockAssetsService, MockEnvironment};
+    use chrono::NaiveDateTime;
+    use std::sync::Mutex;
+    use wealthfolio_core::{
+        assets::Asset,
+        taxonomies::{
+            AssetTaxonomyAssignment, NewAssetTaxonomyAssignment, NewCategory, NewTaxonomy,
+            TaxonomyServiceTrait, TaxonomyWithCategories,
+        },
+    };
+
+    fn make_asset(id: &str, symbol: &str) -> Asset {
+        Asset {
+            id: id.to_string(),
+            kind: wealthfolio_core::assets::AssetKind::Investment,
+            name: Some(id.to_string()),
+            display_code: None,
+            notes: None,
+            metadata: None,
+            is_active: true,
+            quote_mode: wealthfolio_core::assets::QuoteMode::Market,
+            quote_ccy: "USD".to_string(),
+            instrument_type: None,
+            instrument_symbol: Some(symbol.to_string()),
+            instrument_exchange_mic: None,
+            instrument_key: None,
+            provider_config: None,
+            exchange_name: None,
+            created_at: NaiveDateTime::default(),
+            updated_at: NaiveDateTime::default(),
+        }
+    }
+
+    fn input(cat: &str, weight: i32) -> AssignmentInput {
+        AssignmentInput {
+            category_id: cat.to_string(),
+            weight_basis_points: weight,
+        }
+    }
+
+    fn args(
+        symbol: &str,
+        taxonomy_id: &str,
+        assignments: Vec<AssignmentInput>,
+    ) -> SetAssetTaxonomyAssignmentsArgs {
+        SetAssetTaxonomyAssignmentsArgs {
+            symbol: symbol.to_string(),
+            taxonomy_id: taxonomy_id.to_string(),
+            assignments,
+        }
+    }
+
+    // ---- Validation-only tests (no env needed) ----
+
+    // Test 1 (RED→GREEN): negative weight rejected
+    #[test]
+    fn validation_rejects_negative_weight() {
+        let err = validate_weights(&[input("US", -1)]).unwrap_err();
+        assert!(
+            err.to_string().contains("weight_basis_points must be >= 0"),
+            "got: {err}"
+        );
+    }
+
+    // Test 2 (RED→GREEN): weight > 10000 rejected
+    #[test]
+    fn validation_rejects_weight_above_10000() {
+        let err = validate_weights(&[input("US", 10001)]).unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("weight_basis_points must be <= 10000"),
+            "got: {err}"
+        );
+    }
+
+    // Test 3 (RED→GREEN): sum > 10000 rejected
+    #[test]
+    fn validation_rejects_sum_above_10000() {
+        let err = validate_weights(&[input("US", 6000), input("EU", 5000)]).unwrap_err();
+        assert!(err.to_string().contains("exceeds 10000"), "got: {err}");
+    }
+
+    // Test 4 (RED→GREEN): sum < 10000 accepted, returns correct total
+    #[test]
+    fn validation_accepts_partial_allocation() {
+        let total = validate_weights(&[input("US", 6000), input("EU", 3000)]).unwrap();
+        assert_eq!(total, 9000);
+    }
+
+    // Test 5 (RED→GREEN): sum = 10000 accepted
+    #[test]
+    fn validation_accepts_full_allocation() {
+        let total = validate_weights(&[input("US", 6000), input("EU", 4000)]).unwrap();
+        assert_eq!(total, 10000);
+    }
+
+    // Test 6 (RED→GREEN): empty list accepted
+    #[test]
+    fn validation_accepts_empty_list() {
+        let total = validate_weights(&[]).unwrap();
+        assert_eq!(total, 0);
+    }
+
+    // ---- Tool integration tests (with mock env) ----
+
+    /// Mock taxonomy service that captures calls to replace_asset_assignments.
+    struct MockSetTaxonomyService {
+        assignments: Mutex<Vec<AssetTaxonomyAssignment>>,
+    }
+
+    impl MockSetTaxonomyService {
+        fn new() -> Self {
+            Self {
+                assignments: Mutex::new(vec![]),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl TaxonomyServiceTrait for MockSetTaxonomyService {
+        fn get_taxonomies(
+            &self,
+        ) -> wealthfolio_core::errors::Result<Vec<wealthfolio_core::taxonomies::Taxonomy>> {
+            Ok(vec![])
+        }
+
+        fn get_taxonomy(
+            &self,
+            _id: &str,
+        ) -> wealthfolio_core::errors::Result<Option<TaxonomyWithCategories>> {
+            Ok(None)
+        }
+
+        fn get_taxonomies_with_categories(
+            &self,
+        ) -> wealthfolio_core::errors::Result<Vec<TaxonomyWithCategories>> {
+            Ok(vec![])
+        }
+
+        async fn create_taxonomy(
+            &self,
+            _taxonomy: NewTaxonomy,
+        ) -> wealthfolio_core::errors::Result<wealthfolio_core::taxonomies::Taxonomy> {
+            unimplemented!()
+        }
+
+        async fn update_taxonomy(
+            &self,
+            _taxonomy: wealthfolio_core::taxonomies::Taxonomy,
+        ) -> wealthfolio_core::errors::Result<wealthfolio_core::taxonomies::Taxonomy> {
+            unimplemented!()
+        }
+
+        async fn delete_taxonomy(&self, _id: &str) -> wealthfolio_core::errors::Result<usize> {
+            unimplemented!()
+        }
+
+        async fn create_category(
+            &self,
+            _category: NewCategory,
+        ) -> wealthfolio_core::errors::Result<wealthfolio_core::taxonomies::Category> {
+            unimplemented!()
+        }
+
+        async fn update_category(
+            &self,
+            _category: wealthfolio_core::taxonomies::Category,
+        ) -> wealthfolio_core::errors::Result<wealthfolio_core::taxonomies::Category> {
+            unimplemented!()
+        }
+
+        async fn delete_category(
+            &self,
+            _taxonomy_id: &str,
+            _category_id: &str,
+        ) -> wealthfolio_core::errors::Result<usize> {
+            unimplemented!()
+        }
+
+        async fn move_category(
+            &self,
+            _taxonomy_id: &str,
+            _category_id: &str,
+            _new_parent_id: Option<String>,
+            _position: i32,
+        ) -> wealthfolio_core::errors::Result<wealthfolio_core::taxonomies::Category> {
+            unimplemented!()
+        }
+
+        async fn import_taxonomy_json(
+            &self,
+            _json_str: &str,
+        ) -> wealthfolio_core::errors::Result<wealthfolio_core::taxonomies::Taxonomy> {
+            unimplemented!()
+        }
+
+        fn export_taxonomy_json(&self, _id: &str) -> wealthfolio_core::errors::Result<String> {
+            unimplemented!()
+        }
+
+        fn get_asset_assignments(
+            &self,
+            _asset_id: &str,
+        ) -> wealthfolio_core::errors::Result<Vec<AssetTaxonomyAssignment>> {
+            Ok(vec![])
+        }
+
+        fn get_category_assignments(
+            &self,
+            _taxonomy_id: &str,
+            _category_id: &str,
+        ) -> wealthfolio_core::errors::Result<Vec<AssetTaxonomyAssignment>> {
+            Ok(vec![])
+        }
+
+        async fn assign_asset_to_category(
+            &self,
+            _assignment: NewAssetTaxonomyAssignment,
+        ) -> wealthfolio_core::errors::Result<AssetTaxonomyAssignment> {
+            unimplemented!()
+        }
+
+        async fn remove_asset_assignment(
+            &self,
+            _id: &str,
+        ) -> wealthfolio_core::errors::Result<usize> {
+            unimplemented!()
+        }
+
+        async fn replace_asset_assignments(
+            &self,
+            asset_id: &str,
+            taxonomy_id: &str,
+            assignments: Vec<NewAssetTaxonomyAssignment>,
+        ) -> wealthfolio_core::errors::Result<Vec<AssetTaxonomyAssignment>> {
+            let persisted: Vec<AssetTaxonomyAssignment> = assignments
+                .into_iter()
+                .map(|a| AssetTaxonomyAssignment {
+                    id: uuid::Uuid::new_v4().to_string(),
+                    asset_id: asset_id.to_string(),
+                    taxonomy_id: taxonomy_id.to_string(),
+                    category_id: a.category_id,
+                    weight: a.weight,
+                    source: a.source,
+                    created_at: NaiveDateTime::default(),
+                    updated_at: NaiveDateTime::default(),
+                })
+                .collect();
+            *self.assignments.lock().unwrap() = persisted.clone();
+            Ok(persisted)
+        }
+    }
+
+    fn make_env_with_asset(asset: Asset) -> (MockEnvironment, Arc<MockSetTaxonomyService>) {
+        let taxonomy_svc = Arc::new(MockSetTaxonomyService::new());
+        let mut env = MockEnvironment::new();
+        env.assets_service = Arc::new(MockAssetsService {
+            assets: vec![asset],
+        });
+        env.taxonomy_service = taxonomy_svc.clone();
+        (env, taxonomy_svc)
+    }
+
+    // Test 7 (RED→GREEN): unknown symbol propagates resolver error
+    #[tokio::test]
+    async fn tool_unknown_symbol_returns_error() {
+        let (env, _) = make_env_with_asset(make_asset("AAPL", "AAPL"));
+        let tool = SetAssetTaxonomyAssignmentsTool::new(Arc::new(env));
+        let result = tool
+            .call(args("UNKNOWN", "regions", vec![input("US", 5000)]))
+            .await;
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("Asset not found"),
+            "expected 'Asset not found'"
+        );
+    }
+
+    // Test 8 (RED→GREEN): validation runs before symbol resolution (negative weight → error before DB)
+    #[tokio::test]
+    async fn tool_rejects_invalid_weights_before_db() {
+        let (env, svc) = make_env_with_asset(make_asset("AAPL", "AAPL"));
+        let tool = SetAssetTaxonomyAssignmentsTool::new(Arc::new(env));
+        let result = tool
+            .call(args("AAPL", "regions", vec![input("US", -1)]))
+            .await;
+        assert!(result.is_err());
+        // DB was not called (replace_asset_assignments not invoked)
+        assert!(svc.assignments.lock().unwrap().is_empty());
+    }
+
+    // Test 9 (RED→GREEN): successful path → rows have source = "ai"
+    #[tokio::test]
+    async fn tool_successful_path_rows_have_source_ai() {
+        let (env, _) = make_env_with_asset(make_asset("AAPL", "AAPL"));
+        let tool = SetAssetTaxonomyAssignmentsTool::new(Arc::new(env));
+        let result = tool
+            .call(args(
+                "AAPL",
+                "regions",
+                vec![input("US", 6000), input("EU", 4000)],
+            ))
+            .await
+            .unwrap();
+        assert_eq!(result.assignments.len(), 2);
+        assert!(result.assignments.iter().all(|a| a.source == "ai"));
+        assert_eq!(result.unallocated_basis_points, 0);
+    }
+
+    // Test 10 (RED→GREEN): partial allocation → correct unallocated_basis_points
+    #[tokio::test]
+    async fn tool_partial_allocation_reports_unallocated() {
+        let (env, _) = make_env_with_asset(make_asset("AAPL", "AAPL"));
+        let tool = SetAssetTaxonomyAssignmentsTool::new(Arc::new(env));
+        let result = tool
+            .call(args("AAPL", "regions", vec![input("US", 7000)]))
+            .await
+            .unwrap();
+        assert_eq!(result.unallocated_basis_points, 3000);
+    }
+
+    // Test 11 (RED→GREEN): empty assignments → clears, unallocated = 10000
+    #[tokio::test]
+    async fn tool_empty_assignments_clears_and_reports_fully_unallocated() {
+        let (env, _) = make_env_with_asset(make_asset("AAPL", "AAPL"));
+        let tool = SetAssetTaxonomyAssignmentsTool::new(Arc::new(env));
+        let result = tool.call(args("AAPL", "regions", vec![])).await.unwrap();
+        assert!(result.assignments.is_empty());
+        assert_eq!(result.unallocated_basis_points, 10000);
+    }
+}

--- a/crates/ai/src/tools/set_asset_taxonomy_assignments.rs
+++ b/crates/ai/src/tools/set_asset_taxonomy_assignments.rs
@@ -164,12 +164,34 @@ impl<E: AiEnvironment + 'static> Tool for SetAssetTaxonomyAssignmentsTool<E> {
 
     async fn call(&self, args: Self::Args) -> Result<Self::Output, Self::Error> {
         // 1. Validate weights before any DB writes
-        let total = validate_weights(&args.assignments)?;
+        validate_weights(&args.assignments)?;
 
         // 2. Resolve symbol → asset_id
         let asset_id = resolve_symbol(&self.env.assets_service(), &args.symbol)?;
 
-        // 3. Build NewAssetTaxonomyAssignment list with source = "ai"
+        // 3. Validate category_ids against the taxonomy
+        let taxonomy = self
+            .env
+            .taxonomy_service()
+            .get_taxonomy(&args.taxonomy_id)
+            .map_err(|e| AiError::ToolExecutionFailed(e.to_string()))?
+            .ok_or_else(|| {
+                AiError::ToolExecutionFailed(format!("Taxonomy '{}' not found", args.taxonomy_id))
+            })?;
+
+        let valid_category_ids: std::collections::HashSet<&str> =
+            taxonomy.categories.iter().map(|c| c.id.as_str()).collect();
+
+        for a in &args.assignments {
+            if !valid_category_ids.contains(a.category_id.as_str()) {
+                return Err(AiError::ToolExecutionFailed(format!(
+                    "Unknown category_id '{}' for taxonomy '{}'",
+                    a.category_id, args.taxonomy_id
+                )));
+            }
+        }
+
+        // 4. Build NewAssetTaxonomyAssignment list with source = "ai"
         let new_assignments: Vec<NewAssetTaxonomyAssignment> = args
             .assignments
             .iter()
@@ -183,7 +205,7 @@ impl<E: AiEnvironment + 'static> Tool for SetAssetTaxonomyAssignmentsTool<E> {
             })
             .collect();
 
-        // 4. Atomic replace via service
+        // 5. Atomic replace via service
         let persisted = self
             .env
             .taxonomy_service()
@@ -191,17 +213,15 @@ impl<E: AiEnvironment + 'static> Tool for SetAssetTaxonomyAssignmentsTool<E> {
             .await
             .map_err(|e| AiError::ToolExecutionFailed(e.to_string()))?;
 
-        // 5. Enrich with category names by loading taxonomies
-        let taxonomies = self
-            .env
-            .taxonomy_service()
-            .get_taxonomies_with_categories()
-            .map_err(|e| AiError::ToolExecutionFailed(e.to_string()))?;
-
-        let cat_name_lookup: std::collections::HashMap<String, String> = taxonomies
+        // 6. Enrich with category names (reuse taxonomy already loaded in step 3)
+        let cat_name_lookup: std::collections::HashMap<String, String> = taxonomy
+            .categories
             .into_iter()
-            .flat_map(|twc| twc.categories.into_iter().map(|c| (c.id, c.name)))
+            .map(|c| (c.id, c.name))
             .collect();
+
+        // 7. Compute unallocated from persisted rows (handles dedup by the DB)
+        let persisted_total: i32 = persisted.iter().map(|a| a.weight).sum();
 
         let assignments = persisted
             .into_iter()
@@ -221,7 +241,7 @@ impl<E: AiEnvironment + 'static> Tool for SetAssetTaxonomyAssignmentsTool<E> {
 
         Ok(SetAssetTaxonomyAssignmentsOutput {
             assignments,
-            unallocated_basis_points: 10000 - total,
+            unallocated_basis_points: 10000 - persisted_total,
         })
     }
 }
@@ -239,8 +259,8 @@ mod tests {
     use wealthfolio_core::{
         assets::Asset,
         taxonomies::{
-            AssetTaxonomyAssignment, NewAssetTaxonomyAssignment, NewCategory, NewTaxonomy,
-            TaxonomyServiceTrait, TaxonomyWithCategories,
+            AssetTaxonomyAssignment, Category, NewAssetTaxonomyAssignment, NewCategory,
+            NewTaxonomy, Taxonomy, TaxonomyServiceTrait, TaxonomyWithCategories,
         },
     };
 
@@ -340,14 +360,50 @@ mod tests {
 
     /// Mock taxonomy service that captures calls to replace_asset_assignments.
     struct MockSetTaxonomyService {
+        taxonomy: TaxonomyWithCategories,
         assignments: Mutex<Vec<AssetTaxonomyAssignment>>,
     }
 
     impl MockSetTaxonomyService {
-        fn new() -> Self {
+        fn new(taxonomy: TaxonomyWithCategories) -> Self {
             Self {
+                taxonomy,
                 assignments: Mutex::new(vec![]),
             }
+        }
+    }
+
+    fn make_taxonomy(id: &str, category_ids: &[&str]) -> TaxonomyWithCategories {
+        let now = NaiveDateTime::default();
+        let taxonomy = Taxonomy {
+            id: id.to_string(),
+            name: id.to_string(),
+            color: "#ffffff".to_string(),
+            description: None,
+            is_system: false,
+            is_single_select: false,
+            sort_order: 0,
+            created_at: now,
+            updated_at: now,
+        };
+        let categories = category_ids
+            .iter()
+            .map(|&cat_id| Category {
+                id: cat_id.to_string(),
+                taxonomy_id: id.to_string(),
+                parent_id: None,
+                name: cat_id.to_string(),
+                key: cat_id.to_string(),
+                color: "#808080".to_string(),
+                description: None,
+                sort_order: 0,
+                created_at: now,
+                updated_at: now,
+            })
+            .collect();
+        TaxonomyWithCategories {
+            taxonomy,
+            categories,
         }
     }
 
@@ -361,9 +417,13 @@ mod tests {
 
         fn get_taxonomy(
             &self,
-            _id: &str,
+            id: &str,
         ) -> wealthfolio_core::errors::Result<Option<TaxonomyWithCategories>> {
-            Ok(None)
+            if self.taxonomy.taxonomy.id == id {
+                Ok(Some(self.taxonomy.clone()))
+            } else {
+                Ok(None)
+            }
         }
 
         fn get_taxonomies_with_categories(
@@ -487,7 +547,10 @@ mod tests {
     }
 
     fn make_env_with_asset(asset: Asset) -> (MockEnvironment, Arc<MockSetTaxonomyService>) {
-        let taxonomy_svc = Arc::new(MockSetTaxonomyService::new());
+        let taxonomy_svc = Arc::new(MockSetTaxonomyService::new(make_taxonomy(
+            "regions",
+            &["US", "EU"],
+        )));
         let mut env = MockEnvironment::new();
         env.assets_service = Arc::new(MockAssetsService {
             assets: vec![asset],

--- a/crates/ai/src/tools/taxonomies.rs
+++ b/crates/ai/src/tools/taxonomies.rs
@@ -1,0 +1,250 @@
+//! List taxonomies tool — lets the AI agent discover all taxonomies and their categories.
+
+use rig::{completion::ToolDefinition, tool::Tool};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use crate::env::AiEnvironment;
+use crate::error::AiError;
+
+// ============================================================================
+// Tool Arguments and Output
+// ============================================================================
+
+/// Arguments for the list_taxonomies tool (no parameters needed).
+#[derive(Debug, Deserialize)]
+pub struct ListTaxonomiesArgs {}
+
+/// DTO for a single category within a taxonomy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CategoryDto {
+    pub category_id: String,
+    pub category_name: String,
+    pub parent_id: Option<String>,
+    pub sort_order: i32,
+}
+
+/// DTO for a single taxonomy with its categories.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaxonomyDto {
+    pub taxonomy_id: String,
+    pub taxonomy_name: String,
+    pub is_single_select: bool,
+    pub categories: Vec<CategoryDto>,
+}
+
+/// Output envelope for the list_taxonomies tool.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListTaxonomiesOutput {
+    pub taxonomies: Vec<TaxonomyDto>,
+}
+
+// ============================================================================
+// Tool Implementation
+// ============================================================================
+
+/// Tool to list all taxonomies and their categories.
+pub struct ListTaxonomiesTool<E: AiEnvironment> {
+    env: Arc<E>,
+}
+
+impl<E: AiEnvironment> ListTaxonomiesTool<E> {
+    pub fn new(env: Arc<E>) -> Self {
+        Self { env }
+    }
+}
+
+impl<E: AiEnvironment> Clone for ListTaxonomiesTool<E> {
+    fn clone(&self) -> Self {
+        Self {
+            env: self.env.clone(),
+        }
+    }
+}
+
+impl<E: AiEnvironment + 'static> Tool for ListTaxonomiesTool<E> {
+    const NAME: &'static str = "list_taxonomies";
+
+    type Error = AiError;
+    type Args = ListTaxonomiesArgs;
+    type Output = ListTaxonomiesOutput;
+
+    async fn definition(&self, _prompt: String) -> ToolDefinition {
+        ToolDefinition {
+            name: Self::NAME.to_string(),
+            description: "List all taxonomies and their categories. Use this to discover available classification schemes (e.g., regions, sectors, asset classes) before assigning assets to categories.".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {},
+                "required": []
+            }),
+        }
+    }
+
+    async fn call(&self, _args: Self::Args) -> Result<Self::Output, Self::Error> {
+        let taxonomies_with_categories = self
+            .env
+            .taxonomy_service()
+            .get_taxonomies_with_categories()
+            .map_err(|e| AiError::ToolExecutionFailed(e.to_string()))?;
+
+        let taxonomy_dtos = taxonomies_with_categories
+            .into_iter()
+            .map(|twc| TaxonomyDto {
+                taxonomy_id: twc.taxonomy.id,
+                taxonomy_name: twc.taxonomy.name,
+                is_single_select: twc.taxonomy.is_single_select,
+                categories: twc
+                    .categories
+                    .into_iter()
+                    .map(|c| CategoryDto {
+                        category_id: c.id,
+                        category_name: c.name,
+                        parent_id: c.parent_id,
+                        sort_order: c.sort_order,
+                    })
+                    .collect(),
+            })
+            .collect();
+
+        Ok(ListTaxonomiesOutput {
+            taxonomies: taxonomy_dtos,
+        })
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::env::test_env::{MockEnvironment, MockTaxonomyService};
+    use chrono::NaiveDateTime;
+    use wealthfolio_core::taxonomies::{Category, Taxonomy, TaxonomyWithCategories};
+
+    fn make_taxonomy(id: &str, name: &str, is_single_select: bool) -> Taxonomy {
+        let now = NaiveDateTime::default();
+        Taxonomy {
+            id: id.to_string(),
+            name: name.to_string(),
+            color: "#ffffff".to_string(),
+            description: None,
+            is_system: false,
+            is_single_select,
+            sort_order: 0,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn make_category(
+        id: &str,
+        taxonomy_id: &str,
+        name: &str,
+        parent_id: Option<&str>,
+        sort_order: i32,
+    ) -> Category {
+        let now = NaiveDateTime::default();
+        Category {
+            id: id.to_string(),
+            taxonomy_id: taxonomy_id.to_string(),
+            parent_id: parent_id.map(|s| s.to_string()),
+            name: name.to_string(),
+            key: id.to_string(),
+            color: "#808080".to_string(),
+            description: None,
+            sort_order,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    // Test 1: tool returns empty list when there are no taxonomies.
+    #[tokio::test]
+    async fn test_list_taxonomies_empty() {
+        let mut env = MockEnvironment::new();
+        env.taxonomy_service = Arc::new(MockTaxonomyService { taxonomies: vec![] });
+        let tool = ListTaxonomiesTool::new(Arc::new(env));
+
+        let result = tool.call(ListTaxonomiesArgs {}).await;
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        assert!(output.taxonomies.is_empty());
+    }
+
+    // Test 2: tool maps one taxonomy with flat categories correctly.
+    #[tokio::test]
+    async fn test_list_taxonomies_flat_categories() {
+        let taxonomy = make_taxonomy("regions", "Regions", true);
+        let cat_na = make_category("NORTH_AMERICA", "regions", "North America", None, 0);
+        let cat_eu = make_category("EUROPE", "regions", "Europe", None, 1);
+
+        let mut env = MockEnvironment::new();
+        env.taxonomy_service = Arc::new(MockTaxonomyService {
+            taxonomies: vec![TaxonomyWithCategories {
+                taxonomy,
+                categories: vec![cat_na, cat_eu],
+            }],
+        });
+        let tool = ListTaxonomiesTool::new(Arc::new(env));
+
+        let result = tool.call(ListTaxonomiesArgs {}).await;
+        assert!(result.is_ok());
+        let output = result.unwrap();
+
+        assert_eq!(output.taxonomies.len(), 1);
+        let t = &output.taxonomies[0];
+        assert_eq!(t.taxonomy_id, "regions");
+        assert_eq!(t.taxonomy_name, "Regions");
+        assert!(t.is_single_select);
+        assert_eq!(t.categories.len(), 2);
+        assert!(t.categories.iter().all(|c| c.parent_id.is_none()));
+        assert_eq!(t.categories[0].category_id, "NORTH_AMERICA");
+        assert_eq!(t.categories[1].sort_order, 1);
+    }
+
+    // Test 3: hierarchical categories — parent_id flows through correctly.
+    #[tokio::test]
+    async fn test_list_taxonomies_hierarchical_categories() {
+        let taxonomy = make_taxonomy("industries_gics", "Industries (GICS)", false);
+        let parent = make_category("TECHNOLOGY", "industries_gics", "Technology", None, 0);
+        let child = make_category(
+            "SOFTWARE",
+            "industries_gics",
+            "Software",
+            Some("TECHNOLOGY"),
+            0,
+        );
+
+        let mut env = MockEnvironment::new();
+        env.taxonomy_service = Arc::new(MockTaxonomyService {
+            taxonomies: vec![TaxonomyWithCategories {
+                taxonomy,
+                categories: vec![parent, child],
+            }],
+        });
+        let tool = ListTaxonomiesTool::new(Arc::new(env));
+
+        let result = tool.call(ListTaxonomiesArgs {}).await;
+        assert!(result.is_ok());
+        let output = result.unwrap();
+
+        let categories = &output.taxonomies[0].categories;
+        let parent_cat = categories
+            .iter()
+            .find(|c| c.category_id == "TECHNOLOGY")
+            .unwrap();
+        let child_cat = categories
+            .iter()
+            .find(|c| c.category_id == "SOFTWARE")
+            .unwrap();
+
+        assert!(parent_cat.parent_id.is_none());
+        assert_eq!(child_cat.parent_id.as_deref(), Some("TECHNOLOGY"));
+    }
+}

--- a/crates/ai/src/types.rs
+++ b/crates/ai/src/types.rs
@@ -40,6 +40,7 @@ pub const DEFAULT_TOOLS_ALLOWLIST: &[&str] = &[
     "import_csv",
     "get_health_status",
     "list_taxonomies",
+    "get_asset_taxonomy_assignments",
 ];
 
 const LEGACY_VISIBLE_DATA_TOOLS: &[&str] = &[

--- a/crates/ai/src/types.rs
+++ b/crates/ai/src/types.rs
@@ -41,6 +41,7 @@ pub const DEFAULT_TOOLS_ALLOWLIST: &[&str] = &[
     "get_health_status",
     "list_taxonomies",
     "get_asset_taxonomy_assignments",
+    "set_asset_taxonomy_assignments",
 ];
 
 const LEGACY_VISIBLE_DATA_TOOLS: &[&str] = &[

--- a/crates/ai/src/types.rs
+++ b/crates/ai/src/types.rs
@@ -39,6 +39,7 @@ pub const DEFAULT_TOOLS_ALLOWLIST: &[&str] = &[
     "record_activities",
     "import_csv",
     "get_health_status",
+    "list_taxonomies",
 ];
 
 const LEGACY_VISIBLE_DATA_TOOLS: &[&str] = &[

--- a/crates/core/src/assets/assets_traits.rs
+++ b/crates/core/src/assets/assets_traits.rs
@@ -19,9 +19,10 @@ pub trait AssetServiceTrait: Send + Sync {
         Ok(assets
             .into_iter()
             .filter(|a| {
-                a.instrument_symbol
-                    .as_deref()
-                    .is_some_and(|s| s.to_uppercase() == upper)
+                a.is_active
+                    && a.instrument_symbol
+                        .as_deref()
+                        .is_some_and(|s| s.to_uppercase() == upper)
             })
             .collect())
     }

--- a/crates/core/src/assets/assets_traits.rs
+++ b/crates/core/src/assets/assets_traits.rs
@@ -10,6 +10,21 @@ use crate::errors::Result;
 pub trait AssetServiceTrait: Send + Sync {
     fn get_assets(&self) -> Result<Vec<Asset>>;
     fn get_asset_by_id(&self, asset_id: &str) -> Result<Asset>;
+
+    /// Search for active assets whose `instrument_symbol` exactly matches `query`
+    /// (case-insensitive). Returns all matches; callers apply tie-break logic.
+    fn search_by_symbol(&self, query: &str) -> Result<Vec<Asset>> {
+        let upper = query.trim().to_uppercase();
+        let assets = self.get_assets()?;
+        Ok(assets
+            .into_iter()
+            .filter(|a| {
+                a.instrument_symbol
+                    .as_deref()
+                    .is_some_and(|s| s.to_uppercase() == upper)
+            })
+            .collect())
+    }
     async fn delete_asset(&self, asset_id: &str) -> Result<()>;
     async fn update_asset_profile(
         &self,

--- a/crates/core/src/portfolio/holdings/holdings_service.rs
+++ b/crates/core/src/portfolio/holdings/holdings_service.rs
@@ -1168,6 +1168,15 @@ mod tests {
         async fn remove_asset_assignment(&self, _id: &str) -> Result<usize> {
             unimplemented!("unused in holdings service tests")
         }
+
+        async fn replace_asset_assignments(
+            &self,
+            _asset_id: &str,
+            _taxonomy_id: &str,
+            _assignments: Vec<NewAssetTaxonomyAssignment>,
+        ) -> Result<Vec<AssetTaxonomyAssignment>> {
+            unimplemented!("unused in holdings service tests")
+        }
     }
 
     fn test_asset(id: &str, symbol: &str, instrument_type: InstrumentType) -> Asset {

--- a/crates/core/src/taxonomies/taxonomy_service.rs
+++ b/crates/core/src/taxonomies/taxonomy_service.rs
@@ -292,16 +292,8 @@ impl TaxonomyServiceTrait for TaxonomyService {
         assignments: Vec<NewAssetTaxonomyAssignment>,
     ) -> Result<Vec<AssetTaxonomyAssignment>> {
         self.repository
-            .delete_asset_assignments(asset_id, taxonomy_id)
-            .await?;
-
-        let mut result = Vec::with_capacity(assignments.len());
-        for assignment in assignments {
-            let persisted = self.repository.upsert_assignment(assignment).await?;
-            result.push(persisted);
-        }
-
-        Ok(result)
+            .replace_asset_assignments(asset_id, taxonomy_id, assignments)
+            .await
     }
 }
 
@@ -481,6 +473,45 @@ mod tests {
 
         fn get_all_taxonomies_with_categories(&self) -> Result<Vec<TaxonomyWithCategories>> {
             Ok(vec![])
+        }
+
+        async fn replace_asset_assignments(
+            &self,
+            asset_id: &str,
+            taxonomy_id: &str,
+            assignments: Vec<NewAssetTaxonomyAssignment>,
+        ) -> Result<Vec<AssetTaxonomyAssignment>> {
+            // Delete existing rows for (asset_id, taxonomy_id)
+            let mut guard = self.assignments.lock().unwrap();
+            guard.retain(|a| !(a.asset_id == asset_id && a.taxonomy_id == taxonomy_id));
+
+            // Insert new rows
+            let mut result = Vec::with_capacity(assignments.len());
+            for assignment in assignments {
+                let id = assignment
+                    .id
+                    .clone()
+                    .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+                // On-conflict: remove existing entry with same (asset_id, taxonomy_id, category_id)
+                guard.retain(|a| {
+                    !(a.asset_id == assignment.asset_id
+                        && a.taxonomy_id == assignment.taxonomy_id
+                        && a.category_id == assignment.category_id)
+                });
+                let persisted = AssetTaxonomyAssignment {
+                    id,
+                    asset_id: assignment.asset_id,
+                    taxonomy_id: assignment.taxonomy_id,
+                    category_id: assignment.category_id,
+                    weight: assignment.weight,
+                    source: assignment.source,
+                    created_at: chrono::NaiveDateTime::default(),
+                    updated_at: chrono::NaiveDateTime::default(),
+                };
+                guard.push(persisted.clone());
+                result.push(persisted);
+            }
+            Ok(result)
         }
     }
 

--- a/crates/core/src/taxonomies/taxonomy_service.rs
+++ b/crates/core/src/taxonomies/taxonomy_service.rs
@@ -284,4 +284,281 @@ impl TaxonomyServiceTrait for TaxonomyService {
     async fn remove_asset_assignment(&self, id: &str) -> Result<usize> {
         self.repository.delete_assignment(id).await
     }
+
+    async fn replace_asset_assignments(
+        &self,
+        asset_id: &str,
+        taxonomy_id: &str,
+        assignments: Vec<NewAssetTaxonomyAssignment>,
+    ) -> Result<Vec<AssetTaxonomyAssignment>> {
+        self.repository
+            .delete_asset_assignments(asset_id, taxonomy_id)
+            .await?;
+
+        let mut result = Vec::with_capacity(assignments.len());
+        for assignment in assignments {
+            let persisted = self.repository.upsert_assignment(assignment).await?;
+            result.push(persisted);
+        }
+
+        Ok(result)
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDateTime;
+    use std::sync::Mutex;
+
+    // ---- Minimal in-memory mock repository ----
+
+    #[derive(Default)]
+    struct MockTaxonomyRepo {
+        assignments: Mutex<Vec<AssetTaxonomyAssignment>>,
+    }
+
+    impl MockTaxonomyRepo {
+        fn with_assignments(assignments: Vec<AssetTaxonomyAssignment>) -> Self {
+            Self {
+                assignments: Mutex::new(assignments),
+            }
+        }
+    }
+
+    fn make_assignment(
+        asset_id: &str,
+        taxonomy_id: &str,
+        category_id: &str,
+        weight: i32,
+    ) -> AssetTaxonomyAssignment {
+        AssetTaxonomyAssignment {
+            id: format!("{}-{}-{}", asset_id, taxonomy_id, category_id),
+            asset_id: asset_id.to_string(),
+            taxonomy_id: taxonomy_id.to_string(),
+            category_id: category_id.to_string(),
+            weight,
+            source: "manual".to_string(),
+            created_at: NaiveDateTime::default(),
+            updated_at: NaiveDateTime::default(),
+        }
+    }
+
+    fn new_assignment(
+        asset_id: &str,
+        taxonomy_id: &str,
+        category_id: &str,
+        weight: i32,
+    ) -> NewAssetTaxonomyAssignment {
+        NewAssetTaxonomyAssignment {
+            id: None,
+            asset_id: asset_id.to_string(),
+            taxonomy_id: taxonomy_id.to_string(),
+            category_id: category_id.to_string(),
+            weight,
+            source: "ai".to_string(),
+        }
+    }
+
+    #[async_trait]
+    impl TaxonomyRepositoryTrait for MockTaxonomyRepo {
+        fn get_taxonomies(&self) -> Result<Vec<super::Taxonomy>> {
+            Ok(vec![])
+        }
+
+        fn get_taxonomy(&self, _id: &str) -> Result<Option<super::Taxonomy>> {
+            Ok(None)
+        }
+
+        async fn create_taxonomy(&self, _t: NewTaxonomy) -> Result<super::Taxonomy> {
+            unimplemented!()
+        }
+
+        async fn update_taxonomy(&self, _t: super::Taxonomy) -> Result<super::Taxonomy> {
+            unimplemented!()
+        }
+
+        async fn delete_taxonomy(&self, _id: &str) -> Result<usize> {
+            unimplemented!()
+        }
+
+        fn get_categories(&self, _taxonomy_id: &str) -> Result<Vec<Category>> {
+            Ok(vec![])
+        }
+
+        fn get_category(&self, _taxonomy_id: &str, _category_id: &str) -> Result<Option<Category>> {
+            Ok(None)
+        }
+
+        async fn create_category(&self, _c: NewCategory) -> Result<Category> {
+            unimplemented!()
+        }
+
+        async fn update_category(&self, _c: Category) -> Result<Category> {
+            unimplemented!()
+        }
+
+        async fn delete_category(&self, _taxonomy_id: &str, _category_id: &str) -> Result<usize> {
+            unimplemented!()
+        }
+
+        async fn bulk_create_categories(&self, _cats: Vec<NewCategory>) -> Result<usize> {
+            unimplemented!()
+        }
+
+        fn get_asset_assignments(&self, asset_id: &str) -> Result<Vec<AssetTaxonomyAssignment>> {
+            Ok(self
+                .assignments
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|a| a.asset_id == asset_id)
+                .cloned()
+                .collect())
+        }
+
+        fn get_category_assignments(
+            &self,
+            _taxonomy_id: &str,
+            _category_id: &str,
+        ) -> Result<Vec<AssetTaxonomyAssignment>> {
+            Ok(vec![])
+        }
+
+        async fn upsert_assignment(
+            &self,
+            assignment: NewAssetTaxonomyAssignment,
+        ) -> Result<AssetTaxonomyAssignment> {
+            let id = assignment
+                .id
+                .clone()
+                .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+            let persisted = AssetTaxonomyAssignment {
+                id: id.clone(),
+                asset_id: assignment.asset_id.clone(),
+                taxonomy_id: assignment.taxonomy_id.clone(),
+                category_id: assignment.category_id.clone(),
+                weight: assignment.weight,
+                source: assignment.source.clone(),
+                created_at: NaiveDateTime::default(),
+                updated_at: NaiveDateTime::default(),
+            };
+            let mut guard = self.assignments.lock().unwrap();
+            // Remove existing by id if present
+            guard.retain(|a| a.id != id);
+            guard.push(persisted.clone());
+            Ok(persisted)
+        }
+
+        async fn delete_assignment(&self, id: &str) -> Result<usize> {
+            let mut guard = self.assignments.lock().unwrap();
+            let before = guard.len();
+            guard.retain(|a| a.id != id);
+            Ok(before - guard.len())
+        }
+
+        async fn delete_asset_assignments(
+            &self,
+            asset_id: &str,
+            taxonomy_id: &str,
+        ) -> Result<usize> {
+            let mut guard = self.assignments.lock().unwrap();
+            let before = guard.len();
+            guard.retain(|a| !(a.asset_id == asset_id && a.taxonomy_id == taxonomy_id));
+            Ok(before - guard.len())
+        }
+
+        fn get_taxonomy_with_categories(
+            &self,
+            _id: &str,
+        ) -> Result<Option<TaxonomyWithCategories>> {
+            Ok(None)
+        }
+
+        fn get_all_taxonomies_with_categories(&self) -> Result<Vec<TaxonomyWithCategories>> {
+            Ok(vec![])
+        }
+    }
+
+    fn make_service(repo: MockTaxonomyRepo) -> TaxonomyService {
+        TaxonomyService::new(Arc::new(repo))
+    }
+
+    // ---- Test 1 (RED→GREEN): Replace non-empty set with new set ----
+    #[tokio::test]
+    async fn replace_asset_assignments_replaces_existing_rows() {
+        let existing = vec![make_assignment("AAPL", "regions", "US", 10000)];
+        let svc = make_service(MockTaxonomyRepo::with_assignments(existing));
+
+        let new_assignments = vec![
+            new_assignment("AAPL", "regions", "EU", 6000),
+            new_assignment("AAPL", "regions", "EM", 4000),
+        ];
+
+        let result = svc
+            .replace_asset_assignments("AAPL", "regions", new_assignments)
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 2);
+        let cats: Vec<&str> = result.iter().map(|a| a.category_id.as_str()).collect();
+        assert!(cats.contains(&"EU"));
+        assert!(cats.contains(&"EM"));
+
+        // Old row must be gone
+        let all = svc.get_asset_assignments("AAPL").unwrap();
+        assert!(!all.iter().any(|a| a.category_id == "US"));
+    }
+
+    // ---- Test 2 (RED→GREEN): Replace with empty list clears assignments ----
+    #[tokio::test]
+    async fn replace_asset_assignments_empty_list_clears_assignments() {
+        let existing = vec![make_assignment("AAPL", "regions", "US", 10000)];
+        let svc = make_service(MockTaxonomyRepo::with_assignments(existing));
+
+        let result = svc
+            .replace_asset_assignments("AAPL", "regions", vec![])
+            .await
+            .unwrap();
+
+        assert!(result.is_empty());
+        let all = svc.get_asset_assignments("AAPL").unwrap();
+        assert!(all.is_empty());
+    }
+
+    // ---- Test 3 (RED→GREEN): Other taxonomies on same asset are untouched ----
+    #[tokio::test]
+    async fn replace_asset_assignments_does_not_touch_other_taxonomies() {
+        let existing = vec![
+            make_assignment("AAPL", "regions", "US", 10000),
+            make_assignment("AAPL", "sectors", "TECH", 10000),
+        ];
+        let svc = make_service(MockTaxonomyRepo::with_assignments(existing));
+
+        svc.replace_asset_assignments(
+            "AAPL",
+            "regions",
+            vec![new_assignment("AAPL", "regions", "EU", 10000)],
+        )
+        .await
+        .unwrap();
+
+        let all = svc.get_asset_assignments("AAPL").unwrap();
+        // sectors assignment must still be there
+        assert!(all
+            .iter()
+            .any(|a| a.taxonomy_id == "sectors" && a.category_id == "TECH"));
+        // old regions US must be gone
+        assert!(!all
+            .iter()
+            .any(|a| a.taxonomy_id == "regions" && a.category_id == "US"));
+        // new regions EU must exist
+        assert!(all
+            .iter()
+            .any(|a| a.taxonomy_id == "regions" && a.category_id == "EU"));
+    }
 }

--- a/crates/core/src/taxonomies/taxonomy_traits.rs
+++ b/crates/core/src/taxonomies/taxonomy_traits.rs
@@ -85,4 +85,10 @@ pub trait TaxonomyServiceTrait: Send + Sync {
         assignment: NewAssetTaxonomyAssignment,
     ) -> Result<AssetTaxonomyAssignment>;
     async fn remove_asset_assignment(&self, id: &str) -> Result<usize>;
+    async fn replace_asset_assignments(
+        &self,
+        asset_id: &str,
+        taxonomy_id: &str,
+        assignments: Vec<NewAssetTaxonomyAssignment>,
+    ) -> Result<Vec<AssetTaxonomyAssignment>>;
 }

--- a/crates/core/src/taxonomies/taxonomy_traits.rs
+++ b/crates/core/src/taxonomies/taxonomy_traits.rs
@@ -44,6 +44,15 @@ pub trait TaxonomyRepositoryTrait: Send + Sync {
     // Bulk operations
     fn get_taxonomy_with_categories(&self, id: &str) -> Result<Option<TaxonomyWithCategories>>;
     fn get_all_taxonomies_with_categories(&self) -> Result<Vec<TaxonomyWithCategories>>;
+
+    /// Atomically replaces all assignments for `(asset_id, taxonomy_id)` in a single
+    /// transaction: deletes existing rows, inserts all new rows, returns the persisted set.
+    async fn replace_asset_assignments(
+        &self,
+        asset_id: &str,
+        taxonomy_id: &str,
+        assignments: Vec<NewAssetTaxonomyAssignment>,
+    ) -> Result<Vec<AssetTaxonomyAssignment>>;
 }
 
 /// Service trait for taxonomy business logic.

--- a/crates/storage-sqlite/src/taxonomies/repository.rs
+++ b/crates/storage-sqlite/src/taxonomies/repository.rs
@@ -415,6 +415,69 @@ impl TaxonomyRepositoryTrait for TaxonomyRepository {
             .await
     }
 
+    async fn replace_asset_assignments(
+        &self,
+        asset_id: &str,
+        taxonomy_id: &str,
+        assignments: Vec<NewAssetTaxonomyAssignment>,
+    ) -> Result<Vec<AssetTaxonomyAssignment>> {
+        let asset_id = asset_id.to_string();
+        let taxonomy_id = taxonomy_id.to_string();
+        self.writer
+            .exec_tx(move |tx| -> Result<Vec<AssetTaxonomyAssignment>> {
+                // 1. Collect existing IDs for sync projection
+                let existing_ids = asset_taxonomy_assignments::table
+                    .filter(asset_taxonomy_assignments::asset_id.eq(&asset_id))
+                    .filter(asset_taxonomy_assignments::taxonomy_id.eq(&taxonomy_id))
+                    .select(asset_taxonomy_assignments::id)
+                    .load::<String>(tx.conn())
+                    .map_err(StorageError::from)?;
+
+                // 2. Delete all existing rows
+                diesel::delete(
+                    asset_taxonomy_assignments::table
+                        .filter(asset_taxonomy_assignments::asset_id.eq(&asset_id))
+                        .filter(asset_taxonomy_assignments::taxonomy_id.eq(&taxonomy_id)),
+                )
+                .execute(tx.conn())
+                .map_err(StorageError::from)?;
+
+                // 3. Emit sync delete for each removed row
+                for id in existing_ids {
+                    tx.delete::<AssetTaxonomyAssignmentDB>(id);
+                }
+
+                // 4. Insert new rows, emit sync update for each
+                let mut result = Vec::with_capacity(assignments.len());
+                for assignment in assignments {
+                    let mut db: NewAssetTaxonomyAssignmentDB = assignment.into();
+                    db.id = Some(db.id.unwrap_or_else(|| Uuid::new_v4().to_string()));
+
+                    let persisted = diesel::insert_into(asset_taxonomy_assignments::table)
+                        .values(&db)
+                        .on_conflict((
+                            asset_taxonomy_assignments::asset_id,
+                            asset_taxonomy_assignments::taxonomy_id,
+                            asset_taxonomy_assignments::category_id,
+                        ))
+                        .do_update()
+                        .set((
+                            asset_taxonomy_assignments::weight.eq(&db.weight),
+                            asset_taxonomy_assignments::source.eq(&db.source),
+                        ))
+                        .returning(AssetTaxonomyAssignmentDB::as_returning())
+                        .get_result(tx.conn())
+                        .map_err(StorageError::from)?;
+
+                    tx.update(&persisted)?;
+                    result.push(AssetTaxonomyAssignment::from(persisted));
+                }
+
+                Ok(result)
+            })
+            .await
+    }
+
     fn get_taxonomy_with_categories(&self, id: &str) -> Result<Option<TaxonomyWithCategories>> {
         let taxonomy = self.get_taxonomy(id)?;
         match taxonomy {


### PR DESCRIPTION
## Summary

- Adds three generic AI agent tools — `list_taxonomies`, `get_asset_taxonomy_assignments`, `set_asset_taxonomy_assignments` — so the AI can classify any asset (ETF, stock, …) across any taxonomy (regions, sectors, asset classes, user-defined)
- `set_asset_taxonomy_assignments` performs an atomic replace-all via a new `replace_asset_assignments` service method (single transaction: delete existing + insert new)
- Assets are resolved by symbol (`symbol → asset_id`); multi-match returns an explicit error asking for exchange suffix
- AI-driven assignments are tagged `source = "ai"` for auditability
- Validation mirrors the UI: per-row `0 ≤ w ≤ 10000`, total `≤ 10000` enforced, under-allocation surfaced as `unallocated_basis_points`
- All three tools are added to `DEFAULT_TOOLS_ALLOWLIST`

## Closes

Closes #999
Closes #1000
Closes #1001

## Related

- PRD: #998
- Parent feature request: #992

## Test plan

- [ ] `list_taxonomies` returns all taxonomies with categories from the DB
- [ ] `get_asset_taxonomy_assignments` resolves symbol → asset, returns assignments enriched with taxonomy/category names
- [ ] `set_asset_taxonomy_assignments` replaces assignments atomically; over-allocation (>10000 bp) is rejected
- [ ] Inactive assets are filtered out from symbol resolution
- [ ] Multi-match on symbol returns an error with disambiguation hint
- [ ] Unit tests: 133 tests pass in `wealthfolio-ai`

🤖 Generated with [Claude Code](https://claude.com/claude-code)