### PR TITLE
Fix portfolio scope fail-closed regressions

### DIFF
--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -109,13 +109,13 @@ const ActivityPage = () => {
   const isDatagridView = viewMode === "datagrid";
 
   // Resolve the typed scope to a flat account ID list for the activity search.
-  const effectiveAccountIds = useMemo(() => {
+  const effectiveAccountIds = useMemo<string[] | undefined>(() => {
     if (accountScope.type === "account") return [accountScope.accountId];
     if (accountScope.type === "accounts") return accountScope.accountIds;
     if (accountScope.type === "portfolio") {
       return portfolios.find((p) => p.id === accountScope.portfolioId)?.accountIds ?? [];
     }
-    return []; // "all" → no filter
+    return undefined; // "all" → no filter
   }, [accountScope, portfolios]);
 
   // Infinite scroll search for table view
@@ -268,14 +268,11 @@ const ActivityPage = () => {
           {isMobileViewport ? (
             <ActivityMobileControls
               accounts={accounts}
+              portfolios={portfolios}
               searchQuery={searchInput}
               onSearchQueryChange={handleSearchChange}
-              selectedAccountIds={effectiveAccountIds}
-              onAccountIdsChange={(ids) => {
-                if (ids.length === 0) setAccountScope({ type: "all" });
-                else if (ids.length === 1) setAccountScope({ type: "account", accountId: ids[0] });
-                else setAccountScope({ type: "accounts", accountIds: ids });
-              }}
+              accountScope={accountScope}
+              onAccountScopeChange={setAccountScope}
               selectedActivityTypes={selectedActivityTypes}
               onActivityTypesChange={setSelectedActivityTypes}
               isCompactView={isCompactView}

--- a/apps/frontend/src/pages/activity/components/activity-mobile-controls.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-mobile-controls.tsx
@@ -1,15 +1,16 @@
 import { Button, Icons, Input } from "@wealthfolio/ui";
 import { ActivityType } from "@/lib/constants";
-import { Account } from "@/lib/types";
+import { Account, AccountScope, PortfolioWithAccounts } from "@/lib/types";
 import { useState } from "react";
 import { ActivityMobileFilterSheet } from "./activity-mobile-filter-sheet";
 
 interface ActivityMobileControlsProps {
   accounts: Account[];
+  portfolios: PortfolioWithAccounts[];
   searchQuery: string;
   onSearchQueryChange: (value: string) => void;
-  selectedAccountIds: string[];
-  onAccountIdsChange: (accountIds: string[]) => void;
+  accountScope: AccountScope;
+  onAccountScopeChange: (accountScope: AccountScope) => void;
   selectedActivityTypes: ActivityType[];
   onActivityTypesChange: (types: ActivityType[]) => void;
   isCompactView: boolean;
@@ -18,10 +19,11 @@ interface ActivityMobileControlsProps {
 
 export function ActivityMobileControls({
   accounts,
+  portfolios,
   searchQuery,
   onSearchQueryChange,
-  selectedAccountIds,
-  onAccountIdsChange,
+  accountScope,
+  onAccountScopeChange,
   selectedActivityTypes,
   onActivityTypesChange,
   isCompactView,
@@ -29,7 +31,7 @@ export function ActivityMobileControls({
 }: ActivityMobileControlsProps) {
   const [isFilterSheetOpen, setIsFilterSheetOpen] = useState(false);
 
-  const hasActiveFilters = selectedAccountIds.length > 0 || selectedActivityTypes.length > 0;
+  const hasActiveFilters = accountScope.type !== "all" || selectedActivityTypes.length > 0;
 
   return (
     <>
@@ -71,9 +73,10 @@ export function ActivityMobileControls({
       <ActivityMobileFilterSheet
         open={isFilterSheetOpen}
         onOpenChange={setIsFilterSheetOpen}
-        selectedAccounts={selectedAccountIds}
+        accountScope={accountScope}
         accounts={accounts}
-        setSelectedAccounts={onAccountIdsChange}
+        portfolios={portfolios}
+        setAccountScope={onAccountScopeChange}
         selectedActivityTypes={selectedActivityTypes}
         setSelectedActivityTypes={onActivityTypesChange}
       />

--- a/apps/frontend/src/pages/activity/components/activity-mobile-filter-sheet.test.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-mobile-filter-sheet.test.tsx
@@ -1,0 +1,96 @@
+import { AccountType } from "@/lib/constants";
+import type { Account, AccountScope, PortfolioWithAccounts } from "@/lib/types";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ActivityMobileFilterSheet } from "./activity-mobile-filter-sheet";
+
+vi.mock("@wealthfolio/ui", () => ({
+  ScrollArea: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@wealthfolio/ui/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    className: _className,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    className?: string;
+  }) => <button onClick={onClick}>{children}</button>,
+}));
+
+vi.mock("@wealthfolio/ui/components/ui/icons", () => ({
+  Icons: {
+    Check: () => <span data-testid="check-icon" />,
+    Folder: () => <span data-testid="folder-icon" />,
+  },
+}));
+
+vi.mock("@wealthfolio/ui/components/ui/sheet", () => ({
+  Sheet: ({ children, open }: { children: ReactNode; open: boolean }) =>
+    open ? <>{children}</> : null,
+  SheetContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetFooter: ({ children }: { children: ReactNode }) => <footer>{children}</footer>,
+  SheetHeader: ({ children }: { children: ReactNode }) => <header>{children}</header>,
+  SheetTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+const createdAt = new Date("2026-01-01T00:00:00Z");
+
+function account(id: string, name: string): Account {
+  return {
+    id,
+    name,
+    accountType: AccountType.SECURITIES,
+    balance: 0,
+    currency: "USD",
+    isDefault: false,
+    isActive: true,
+    isArchived: false,
+    trackingMode: "TRANSACTIONS",
+    createdAt,
+    updatedAt: createdAt,
+  };
+}
+
+const accounts = [account("acc_1", "Brokerage"), account("acc_2", "IRA")];
+
+const portfolios: PortfolioWithAccounts[] = [
+  {
+    id: "pf_1",
+    name: "Long Term",
+    description: undefined,
+    sortOrder: 0,
+    accountIds: ["acc_1", "acc_2"],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  },
+];
+
+describe("ActivityMobileFilterSheet", () => {
+  it("preserves portfolio scope when applying without changing account selection", async () => {
+    const user = userEvent.setup();
+    const accountScope: AccountScope = { type: "portfolio", portfolioId: "pf_1" };
+    const setAccountScope = vi.fn();
+
+    render(
+      <ActivityMobileFilterSheet
+        open
+        onOpenChange={vi.fn()}
+        accountScope={accountScope}
+        accounts={accounts}
+        portfolios={portfolios}
+        setAccountScope={setAccountScope}
+        selectedActivityTypes={[]}
+        setSelectedActivityTypes={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Done" }));
+
+    expect(setAccountScope).toHaveBeenCalledWith(accountScope);
+  });
+});

--- a/apps/frontend/src/pages/activity/components/activity-mobile-filter-sheet.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-mobile-filter-sheet.tsx
@@ -8,47 +8,76 @@ import {
   SheetTitle,
 } from "@wealthfolio/ui/components/ui/sheet";
 import { ActivityType, ActivityTypeNames } from "@/lib/constants";
-import { Account } from "@/lib/types";
+import { Account, AccountScope, PortfolioWithAccounts } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { ScrollArea } from "@wealthfolio/ui";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 interface ActivityMobileFilterSheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  selectedAccounts: string[];
+  accountScope: AccountScope;
   accounts: Account[];
-  setSelectedAccounts: (accountIds: string[]) => void;
+  portfolios: PortfolioWithAccounts[];
+  setAccountScope: (accountScope: AccountScope) => void;
   selectedActivityTypes: ActivityType[];
   setSelectedActivityTypes: (types: ActivityType[]) => void;
+}
+
+function accountIdsForScope(scope: AccountScope, portfolios: PortfolioWithAccounts[]) {
+  if (scope.type === "account") return [scope.accountId];
+  if (scope.type === "accounts") return scope.accountIds;
+  if (scope.type === "portfolio") {
+    return portfolios.find((portfolio) => portfolio.id === scope.portfolioId)?.accountIds ?? [];
+  }
+  return [];
+}
+
+function scopeFromAccountIds(accountIds: string[]): AccountScope {
+  if (accountIds.length === 0) return { type: "all" };
+  if (accountIds.length === 1) return { type: "account", accountId: accountIds[0] };
+  return { type: "accounts", accountIds };
 }
 
 export const ActivityMobileFilterSheet = ({
   open,
   onOpenChange,
-  selectedAccounts,
+  accountScope,
   accounts,
-  setSelectedAccounts,
+  portfolios,
+  setAccountScope,
   selectedActivityTypes,
   setSelectedActivityTypes,
 }: ActivityMobileFilterSheetProps) => {
   // Local state for temporary selections
-  const [localAccounts, setLocalAccounts] = useState<string[]>(selectedAccounts);
+  const [localAccountScope, setLocalAccountScope] = useState<AccountScope>(accountScope);
   const [localActivityTypes, setLocalActivityTypes] =
     useState<ActivityType[]>(selectedActivityTypes);
+
+  const localAccountIds = useMemo(
+    () => accountIdsForScope(localAccountScope, portfolios),
+    [localAccountScope, portfolios],
+  );
 
   // Sync local state when sheet opens
   useEffect(() => {
     if (open) {
-      setLocalAccounts(selectedAccounts);
+      setLocalAccountScope(accountScope);
       setLocalActivityTypes(selectedActivityTypes);
     }
-  }, [open, selectedAccounts, selectedActivityTypes]);
+  }, [open, accountScope, selectedActivityTypes]);
 
   const handleApply = () => {
-    setSelectedAccounts(localAccounts);
+    setAccountScope(localAccountScope);
     setSelectedActivityTypes(localActivityTypes);
     onOpenChange(false);
+  };
+
+  const handleAccountToggle = (accountId: string) => {
+    const next = localAccountIds.includes(accountId)
+      ? localAccountIds.filter((id) => id !== accountId)
+      : [...localAccountIds, accountId];
+    setLocalAccountScope(scopeFromAccountIds(next));
   };
 
   const activityTypeOptions = Object.entries(ActivityTypeNames).map(([value, label]) => ({
@@ -71,15 +100,38 @@ export const ActivityMobileFilterSheet = ({
                 <li
                   className={cn(
                     "flex cursor-pointer items-center justify-between rounded-md p-2 text-sm",
-                    localAccounts.length === 0 ? "bg-accent" : "hover:bg-accent/50",
+                    localAccountScope.type === "all" ? "bg-accent" : "hover:bg-accent/50",
                   )}
                   onClick={() => {
-                    setLocalAccounts([]);
+                    setLocalAccountScope({ type: "all" });
                   }}
                 >
                   <span>All Accounts</span>
-                  {localAccounts.length === 0 && <Icons.Check className="h-4 w-4" />}
+                  {localAccountScope.type === "all" && <Icons.Check className="h-4 w-4" />}
                 </li>
+                {portfolios.map((portfolio) => {
+                  const isSelected =
+                    localAccountScope.type === "portfolio" &&
+                    localAccountScope.portfolioId === portfolio.id;
+                  return (
+                    <li
+                      key={portfolio.id}
+                      className={cn(
+                        "flex cursor-pointer items-center justify-between rounded-md p-2 text-sm",
+                        isSelected ? "bg-accent" : "hover:bg-accent/50",
+                      )}
+                      onClick={() => {
+                        setLocalAccountScope({ type: "portfolio", portfolioId: portfolio.id });
+                      }}
+                    >
+                      <span className="flex items-center gap-2">
+                        <Icons.Folder className="h-4 w-4" />
+                        {portfolio.name}
+                      </span>
+                      {isSelected && <Icons.Check className="h-4 w-4" />}
+                    </li>
+                  );
+                })}
                 {accounts
                   .filter((account) => account.isActive)
                   .map((account) => (
@@ -87,19 +139,14 @@ export const ActivityMobileFilterSheet = ({
                       key={account.id}
                       className={cn(
                         "flex cursor-pointer items-center justify-between rounded-md p-2 text-sm",
-                        localAccounts.includes(account.id) ? "bg-accent" : "hover:bg-accent/50",
+                        localAccountIds.includes(account.id) ? "bg-accent" : "hover:bg-accent/50",
                       )}
-                      onClick={() => {
-                        const newAccounts = localAccounts.includes(account.id)
-                          ? localAccounts.filter((id) => id !== account.id)
-                          : [...localAccounts, account.id];
-                        setLocalAccounts(newAccounts);
-                      }}
+                      onClick={() => handleAccountToggle(account.id)}
                     >
                       <span>
                         {account.name} ({account.currency})
                       </span>
-                      {localAccounts.includes(account.id) && <Icons.Check className="h-4 w-4" />}
+                      {localAccountIds.includes(account.id) && <Icons.Check className="h-4 w-4" />}
                     </li>
                   ))}
               </ul>

--- a/apps/frontend/src/pages/activity/hooks/use-activity-search.test.tsx
+++ b/apps/frontend/src/pages/activity/hooks/use-activity-search.test.tsx
@@ -1,0 +1,99 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useActivitySearch } from "./use-activity-search";
+
+const adapterMocks = vi.hoisted(() => ({
+  searchActivities: vi.fn(),
+}));
+
+vi.mock("@/adapters", () => adapterMocks);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useActivitySearch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapterMocks.searchActivities.mockResolvedValue({
+      data: [],
+      meta: { totalRowCount: 0 },
+    });
+  });
+
+  it("does not query activities when account scope resolves to no accounts in infinite mode", async () => {
+    const { result } = renderHook(
+      () =>
+        useActivitySearch({
+          filters: { accountIds: [], activityTypes: [] },
+          searchQuery: "",
+          sorting: [],
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false);
+    });
+
+    expect(adapterMocks.searchActivities).not.toHaveBeenCalled();
+    expect(result.current.data).toEqual([]);
+    expect(result.current.totalRowCount).toBe(0);
+  });
+
+  it("does not query activities when account scope resolves to no accounts in paginated mode", async () => {
+    const { result } = renderHook(
+      () =>
+        useActivitySearch({
+          mode: "paginated",
+          pageIndex: 0,
+          filters: { accountIds: [], activityTypes: [] },
+          searchQuery: "",
+          sorting: [],
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false);
+    });
+
+    expect(adapterMocks.searchActivities).not.toHaveBeenCalled();
+    expect(result.current.data).toEqual([]);
+    expect(result.current.totalRowCount).toBe(0);
+  });
+
+  it("keeps all-account scope distinct from closed-empty scope", async () => {
+    renderHook(
+      () =>
+        useActivitySearch({
+          filters: { accountIds: undefined, activityTypes: [] },
+          searchQuery: "",
+          sorting: [],
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(adapterMocks.searchActivities).toHaveBeenCalledTimes(1);
+    });
+
+    expect(adapterMocks.searchActivities).toHaveBeenCalledWith(
+      0,
+      50,
+      expect.objectContaining({ accountIds: undefined }),
+      "",
+      { id: "date", desc: true },
+    );
+  });
+});

--- a/apps/frontend/src/pages/activity/hooks/use-activity-search.ts
+++ b/apps/frontend/src/pages/activity/hooks/use-activity-search.ts
@@ -9,7 +9,7 @@ import { useMemo } from "react";
 export type ActivityStatusFilter = "all" | "pending" | "validated";
 
 export interface ActivitySearchFilters {
-  accountIds: string[];
+  accountIds?: string[];
   activityTypes: ActivityType[];
   instrumentTypes?: string[];
   status?: ActivityStatusFilter;
@@ -65,6 +65,7 @@ export type UseActivitySearchResult =
 
 const DEFAULT_SORT = { id: "date", desc: true };
 const DEFAULT_PAGE_SIZE = 50;
+const EMPTY_RESPONSE: ActivitySearchResponse = { data: [], meta: { totalRowCount: 0 } };
 
 export function useActivitySearch(
   options: UseActivitySearchInfiniteOptions,
@@ -76,6 +77,7 @@ export function useActivitySearch(options: UseActivitySearchOptions): UseActivit
   const { filters, searchQuery, sorting, pageSize = DEFAULT_PAGE_SIZE } = options;
   const mode = options.mode ?? "infinite";
   const pageIndex = "pageIndex" in options ? options.pageIndex : 0;
+  const hasClosedAccountScope = filters.accountIds !== undefined && filters.accountIds.length === 0;
 
   const normalizedFilters = useMemo(() => {
     // Convert status filter to needsReview boolean
@@ -85,10 +87,10 @@ export function useActivitySearch(options: UseActivitySearchOptions): UseActivit
     } else if (filters.status === "validated") {
       needsReview = false;
     }
-    // "all" or undefined means no filter
+    // Undefined means all accounts; an empty array means a closed-empty scope.
 
     return {
-      accountIds: filters.accountIds.length > 0 ? filters.accountIds : undefined,
+      accountIds: filters.accountIds,
       activityTypes: filters.activityTypes.length > 0 ? filters.activityTypes : undefined,
       instrumentTypes: filters.instrumentTypes?.length ? filters.instrumentTypes : undefined,
       needsReview,
@@ -116,6 +118,7 @@ export function useActivitySearch(options: UseActivitySearchOptions): UseActivit
     ],
     initialPageParam: 0,
     queryFn: async ({ pageParam }) => {
+      if (hasClosedAccountScope) return EMPTY_RESPONSE;
       const page = typeof pageParam === "number" ? pageParam : 0;
       return searchActivities(page, pageSize, normalizedFilters, searchQuery, primarySort);
     },
@@ -139,6 +142,7 @@ export function useActivitySearch(options: UseActivitySearchOptions): UseActivit
       pageSize,
     ],
     queryFn: async () => {
+      if (hasClosedAccountScope) return EMPTY_RESPONSE;
       return searchActivities(pageIndex, pageSize, normalizedFilters, searchQuery, primarySort);
     },
     enabled: mode === "paginated",

--- a/apps/server/src/api/holdings/handlers.rs
+++ b/apps/server/src/api/holdings/handlers.rs
@@ -35,19 +35,10 @@ fn resolve_scope(
     filter: &AccountScope,
     state: &AppState,
 ) -> Result<ResolvedAccountScope, crate::error::ApiError> {
-    match filter {
-        AccountScope::All => Ok(ResolvedAccountScope::TotalSnapshot),
-        AccountScope::Account { account_id } => {
-            Ok(ResolvedAccountScope::Account(account_id.clone()))
-        }
-        AccountScope::Portfolio { .. } | AccountScope::Accounts { .. } => {
-            let ids = state
-                .portfolio_service
-                .resolve_account_filter(filter)
-                .map_err(crate::error::ApiError::from)?;
-            Ok(ResolvedAccountScope::Accounts(ids))
-        }
-    }
+    state
+        .portfolio_service
+        .resolve_account_scope(filter)
+        .map_err(crate::error::ApiError::from)
 }
 
 fn aggregated_id(_filter: &AccountScope) -> String {

--- a/apps/server/src/api/performance.rs
+++ b/apps/server/src/api/performance.rs
@@ -123,16 +123,19 @@ async fn get_income_summary(
     State(state): State<Arc<AppState>>,
     Json(body): Json<IncomeSummaryBody>,
 ) -> ApiResult<Json<Vec<IncomeSummary>>> {
-    use wealthfolio_core::portfolios::AccountScope;
+    use wealthfolio_core::portfolios::ResolvedAccountScope;
+
     let account_ids: Option<Vec<String>> = match &body.filter {
-        None | Some(AccountScope::All) => None,
-        Some(AccountScope::Account { account_id }) => Some(vec![account_id.clone()]),
-        Some(AccountScope::Portfolio { .. }) | Some(AccountScope::Accounts { .. }) => Some(
-            state
-                .portfolio_service
-                .resolve_account_filter(body.filter.as_ref().unwrap())
-                .map_err(crate::error::ApiError::from)?,
-        ),
+        None => None,
+        Some(filter) => match state
+            .portfolio_service
+            .resolve_account_scope(filter)
+            .map_err(crate::error::ApiError::from)?
+        {
+            ResolvedAccountScope::TotalSnapshot => None,
+            ResolvedAccountScope::Account(id) => Some(vec![id]),
+            ResolvedAccountScope::Accounts(ids) => Some(ids),
+        },
     };
     let items = state
         .income_service

--- a/apps/server/tests/income_summary_api.rs
+++ b/apps/server/tests/income_summary_api.rs
@@ -1,0 +1,57 @@
+use std::{net::SocketAddr, time::Duration};
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use tempfile::tempdir;
+use tower::ServiceExt;
+use wealthfolio_server::{api::app_router, build_state, config::Config};
+
+fn test_config(db_path: String, addons_root: String) -> Config {
+    Config {
+        listen_addr: "127.0.0.1:0".parse::<SocketAddr>().unwrap(),
+        db_path,
+        cors_allow: vec!["*".to_string()],
+        request_timeout: Duration::from_secs(30),
+        static_dir: "dist".to_string(),
+        addons_root,
+        raw_secret_key: vec![7; 32],
+        secrets_encryption_key: [7; 32],
+        auth: None,
+    }
+}
+
+#[tokio::test]
+async fn income_summary_query_rejects_empty_resolved_portfolio_scope() {
+    let temp_dir = tempdir().unwrap();
+    let db_path = temp_dir
+        .path()
+        .join("app.db")
+        .to_string_lossy()
+        .into_owned();
+    let addons_root = temp_dir
+        .path()
+        .join("addons")
+        .to_string_lossy()
+        .into_owned();
+    let config = test_config(db_path, addons_root);
+    let state = build_state(&config).await.unwrap();
+    let app = app_router(state, &config);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/income/summary/query")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"filter":{"type":"portfolio","portfolioId":"missing"}}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}

--- a/apps/tauri/src/commands/portfolio.rs
+++ b/apps/tauri/src/commands/portfolio.rs
@@ -129,19 +129,10 @@ async fn resolve_scope(
     filter: &AccountScope,
     state: &ServiceContext,
 ) -> Result<ResolvedAccountScope, String> {
-    match filter {
-        AccountScope::All => Ok(ResolvedAccountScope::TotalSnapshot),
-        AccountScope::Account { account_id } => {
-            Ok(ResolvedAccountScope::Account(account_id.clone()))
-        }
-        AccountScope::Portfolio { .. } | AccountScope::Accounts { .. } => {
-            let ids = state
-                .portfolio_service()
-                .resolve_account_filter(filter)
-                .map_err(|e| e.to_string())?;
-            Ok(ResolvedAccountScope::Accounts(ids))
-        }
-    }
+    state
+        .portfolio_service()
+        .resolve_account_scope(filter)
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]

--- a/crates/core/src/portfolios/portfolios_service_tests.rs
+++ b/crates/core/src/portfolios/portfolios_service_tests.rs
@@ -8,7 +8,7 @@ mod tests {
     use crate::errors::{DatabaseError, Error, Result};
     use crate::portfolios::{
         AccountScope, NewPortfolio, PortfolioRepositoryTrait, PortfolioService,
-        PortfolioServiceTrait, PortfolioUpdate, PortfolioWithAccounts,
+        PortfolioServiceTrait, PortfolioUpdate, PortfolioWithAccounts, ResolvedAccountScope,
     };
 
     // ── Mock portfolio repository ─────────────────────────────────────────────
@@ -89,6 +89,7 @@ mod tests {
             match filter {
                 AccountScope::All => Ok(vec!["a1".to_string(), "a2".to_string()]),
                 AccountScope::Account { account_id } => Ok(vec![account_id.clone()]),
+                AccountScope::Portfolio { portfolio_id } if portfolio_id == "empty" => Ok(vec![]),
                 AccountScope::Portfolio { portfolio_id: _ } => {
                     Ok(vec!["a1".to_string(), "a2".to_string()])
                 }
@@ -279,5 +280,36 @@ mod tests {
             })
             .unwrap();
         assert_eq!(ids, vec!["a1"]);
+    }
+
+    #[tokio::test]
+    async fn resolve_account_scope_all_uses_total_snapshot() {
+        let svc = make_service_with(MockPortfolioRepo::default(), &[]);
+        let scope = svc.resolve_account_scope(&AccountScope::All).unwrap();
+        assert!(matches!(scope, ResolvedAccountScope::TotalSnapshot));
+    }
+
+    #[tokio::test]
+    async fn resolve_account_scope_rejects_empty_accounts_scope() {
+        let svc = make_service_with(MockPortfolioRepo::default(), &[]);
+        let err = svc
+            .resolve_account_scope(&AccountScope::Accounts {
+                account_ids: vec![],
+            })
+            .unwrap_err();
+        assert!(matches!(err, Error::Validation(_)));
+        assert!(err.to_string().contains("no accounts"));
+    }
+
+    #[tokio::test]
+    async fn resolve_account_scope_rejects_empty_portfolio_scope() {
+        let svc = make_service_with(MockPortfolioRepo::default(), &[]);
+        let err = svc
+            .resolve_account_scope(&AccountScope::Portfolio {
+                portfolio_id: "empty".to_string(),
+            })
+            .unwrap_err();
+        assert!(matches!(err, Error::Validation(_)));
+        assert!(err.to_string().contains("no accounts"));
     }
 }

--- a/crates/core/src/portfolios/portfolios_traits.rs
+++ b/crates/core/src/portfolios/portfolios_traits.rs
@@ -1,7 +1,9 @@
 use async_trait::async_trait;
 
-use super::portfolios_model::{AccountScope, NewPortfolio, PortfolioUpdate, PortfolioWithAccounts};
-use crate::errors::Result;
+use super::portfolios_model::{
+    AccountScope, NewPortfolio, PortfolioUpdate, PortfolioWithAccounts, ResolvedAccountScope,
+};
+use crate::errors::{Error, Result, ValidationError};
 
 #[async_trait]
 pub trait PortfolioRepositoryTrait: Send + Sync {
@@ -23,4 +25,23 @@ pub trait PortfolioServiceTrait: Send + Sync {
     fn list_portfolios(&self) -> Result<Vec<PortfolioWithAccounts>>;
     /// Resolve an AccountScope to validated, ordered account IDs.
     fn resolve_account_filter(&self, filter: &AccountScope) -> Result<Vec<String>>;
+
+    /// Resolve an AccountScope into its runtime reporting form.
+    fn resolve_account_scope(&self, filter: &AccountScope) -> Result<ResolvedAccountScope> {
+        match filter {
+            AccountScope::All => Ok(ResolvedAccountScope::TotalSnapshot),
+            AccountScope::Account { account_id } => {
+                Ok(ResolvedAccountScope::Account(account_id.clone()))
+            }
+            AccountScope::Portfolio { .. } | AccountScope::Accounts { .. } => {
+                let ids = self.resolve_account_filter(filter)?;
+                if ids.is_empty() {
+                    return Err(Error::Validation(ValidationError::InvalidInput(
+                        "Account scope resolved to no accounts".to_string(),
+                    )));
+                }
+                Ok(ResolvedAccountScope::Accounts(ids))
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- fail closed when portfolio/account scopes resolve to zero accounts
- keep Activity search from broadening closed-empty account scope into all activities
- preserve portfolio identity in Activity mobile filters
- add regression tests for Activity search, mobile portfolio scope, core scope resolution, and the income summary API route

## Root Cause

The previous scope plumbing treated an empty resolved account list the same as no account filter in a few paths. That silently broadened stale or empty portfolio filters into all-account queries. Activity mobile filters also flattened portfolio scopes into account IDs when applying the sheet, which lost the dynamic portfolio source of truth.

## Validation

- `pnpm --filter frontend exec vitest run src/pages/activity/hooks/use-activity-search.test.tsx src/pages/activity/components/activity-mobile-filter-sheet.test.tsx`
- `pnpm --filter frontend type-check`
- `cargo test -p wealthfolio-server --test income_summary_api`
- `cargo test -p wealthfolio-core portfolios::portfolios_service_tests`
- `git diff --check`
