### PR TITLE
feat(valuation): add base-currency columns to daily_account_valuation

### DIFF
--- a/crates/core/src/portfolio/valuation/valuation_calculator.rs
+++ b/crates/core/src/portfolio/valuation/valuation_calculator.rs
@@ -102,6 +102,13 @@ pub fn calculate_valuation(
         cost_basis: cost_basis_acct_ccy,
         net_contribution: net_contribution_acct_ccy,
         calculated_at: Utc::now(),
+        cash_balance_base: total_cash_value_acct_ccy * fx_rate_to_base,
+        investment_market_value_base: total_investment_market_value_acct_ccy * fx_rate_to_base,
+        total_value_base: total_market_value_acct_ccy * fx_rate_to_base,
+        cost_basis_base: cost_basis_acct_ccy * fx_rate_to_base,
+        // net_contribution_base comes from the snapshot: contributions were converted at flow
+        // dates, so multiplying by today's fx_rate would give the wrong value.
+        net_contribution_base: holdings_snapshot.net_contribution_base,
     };
 
     Ok(metrics)

--- a/crates/core/src/portfolio/valuation/valuation_model.rs
+++ b/crates/core/src/portfolio/valuation/valuation_model.rs
@@ -34,4 +34,11 @@ pub struct DailyAccountValuation {
     pub cost_basis: Decimal,
     pub net_contribution: Decimal,
     pub calculated_at: DateTime<Utc>,
+    // Base-currency equivalents — populated at write time, safe to aggregate across accounts.
+    // net_contribution_base comes from the snapshot (converted at flow dates, not valuation date).
+    pub cash_balance_base: Decimal,
+    pub investment_market_value_base: Decimal,
+    pub total_value_base: Decimal,
+    pub cost_basis_base: Decimal,
+    pub net_contribution_base: Decimal,
 }

--- a/crates/core/src/portfolio/valuation/valuation_traits.rs
+++ b/crates/core/src/portfolio/valuation/valuation_traits.rs
@@ -47,4 +47,14 @@ pub trait ValuationRepositoryTrait: Send + Sync {
         &self,
         account_ids: &[String],
     ) -> Result<Vec<NegativeBalanceInfo>>;
+
+    /// Get synthetic portfolio valuation history by aggregating member account valuations.
+    /// Sums base-currency fields by date. Result rows are in base currency (fx_rate = 1).
+    /// Safe to call for any set of accounts regardless of their individual currencies.
+    fn get_portfolio_historical_valuations(
+        &self,
+        account_ids: &[String],
+        start_date: Option<NaiveDate>,
+        end_date: Option<NaiveDate>,
+    ) -> Result<Vec<DailyAccountValuation>>;
 }

--- a/crates/storage-sqlite/migrations/2026-05-20-000001_valuation_base_currency/down.sql
+++ b/crates/storage-sqlite/migrations/2026-05-20-000001_valuation_base_currency/down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE daily_account_valuation DROP COLUMN cash_balance_base;
+ALTER TABLE daily_account_valuation DROP COLUMN investment_market_value_base;
+ALTER TABLE daily_account_valuation DROP COLUMN total_value_base;
+ALTER TABLE daily_account_valuation DROP COLUMN cost_basis_base;
+ALTER TABLE daily_account_valuation DROP COLUMN net_contribution_base;

--- a/crates/storage-sqlite/migrations/2026-05-20-000001_valuation_base_currency/up.sql
+++ b/crates/storage-sqlite/migrations/2026-05-20-000001_valuation_base_currency/up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE daily_account_valuation ADD COLUMN cash_balance_base TEXT NOT NULL DEFAULT '0';
+ALTER TABLE daily_account_valuation ADD COLUMN investment_market_value_base TEXT NOT NULL DEFAULT '0';
+ALTER TABLE daily_account_valuation ADD COLUMN total_value_base TEXT NOT NULL DEFAULT '0';
+ALTER TABLE daily_account_valuation ADD COLUMN cost_basis_base TEXT NOT NULL DEFAULT '0';
+ALTER TABLE daily_account_valuation ADD COLUMN net_contribution_base TEXT NOT NULL DEFAULT '0';
+
+-- Force recalculation so all rows get populated with real base values.
+DELETE FROM daily_account_valuation;

--- a/crates/storage-sqlite/src/portfolio/valuation/model.rs
+++ b/crates/storage-sqlite/src/portfolio/valuation/model.rs
@@ -29,6 +29,11 @@ pub struct DailyAccountValuationDB {
     pub cost_basis: String,
     pub net_contribution: String,
     pub calculated_at: String,
+    pub cash_balance_base: String,
+    pub investment_market_value_base: String,
+    pub total_value_base: String,
+    pub cost_basis_base: String,
+    pub net_contribution_base: String,
 }
 
 impl From<DailyAccountValuation> for DailyAccountValuationDB {
@@ -52,6 +57,26 @@ impl From<DailyAccountValuation> for DailyAccountValuationDB {
                 .round_dp(DECIMAL_PRECISION)
                 .to_string(),
             calculated_at: value.calculated_at.to_rfc3339(),
+            cash_balance_base: value
+                .cash_balance_base
+                .round_dp(DECIMAL_PRECISION)
+                .to_string(),
+            investment_market_value_base: value
+                .investment_market_value_base
+                .round_dp(DECIMAL_PRECISION)
+                .to_string(),
+            total_value_base: value
+                .total_value_base
+                .round_dp(DECIMAL_PRECISION)
+                .to_string(),
+            cost_basis_base: value
+                .cost_basis_base
+                .round_dp(DECIMAL_PRECISION)
+                .to_string(),
+            net_contribution_base: value
+                .net_contribution_base
+                .round_dp(DECIMAL_PRECISION)
+                .to_string(),
         }
     }
 }
@@ -76,6 +101,13 @@ impl From<DailyAccountValuationDB> for DailyAccountValuation {
             calculated_at: DateTime::parse_from_rfc3339(&value.calculated_at)
                 .map(|dt| dt.with_timezone(&Utc))
                 .unwrap_or_else(|_| Utc::now()),
+            cash_balance_base: Decimal::from_str(&value.cash_balance_base).unwrap_or_default(),
+            investment_market_value_base: Decimal::from_str(&value.investment_market_value_base)
+                .unwrap_or_default(),
+            total_value_base: Decimal::from_str(&value.total_value_base).unwrap_or_default(),
+            cost_basis_base: Decimal::from_str(&value.cost_basis_base).unwrap_or_default(),
+            net_contribution_base: Decimal::from_str(&value.net_contribution_base)
+                .unwrap_or_default(),
         }
     }
 }
@@ -109,6 +141,11 @@ mod tests {
             cost_basis: "25".to_string(),
             net_contribution: "5".to_string(),
             calculated_at: "2026-04-22T00:00:00Z".to_string(),
+            cash_balance_base: "0".to_string(),
+            investment_market_value_base: "0".to_string(),
+            total_value_base: "0".to_string(),
+            cost_basis_base: "0".to_string(),
+            net_contribution_base: "0".to_string(),
         };
 
         let valuation = DailyAccountValuation::from(db_value);

--- a/crates/storage-sqlite/src/portfolio/valuation/repository.rs
+++ b/crates/storage-sqlite/src/portfolio/valuation/repository.rs
@@ -168,6 +168,8 @@ impl ValuationRepositoryTrait for ValuationRepository {
                     id, account_id, valuation_date, account_currency, base_currency, \
                     fx_rate_to_base, cash_balance, investment_market_value, total_value, \
                     cost_basis, net_contribution, calculated_at, \
+                    cash_balance_base, investment_market_value_base, total_value_base, \
+                    cost_basis_base, net_contribution_base, \
                     ROW_NUMBER() OVER (PARTITION BY account_id ORDER BY valuation_date DESC) as rn \
                 FROM {} \
                 WHERE account_id IN ({}) \
@@ -175,11 +177,12 @@ impl ValuationRepositoryTrait for ValuationRepository {
             SELECT \
                 id, account_id, valuation_date, account_currency, base_currency, \
                 fx_rate_to_base, cash_balance, investment_market_value, total_value, \
-                cost_basis, net_contribution, calculated_at \
+                cost_basis, net_contribution, calculated_at, \
+                cash_balance_base, investment_market_value_base, total_value_base, \
+                cost_basis_base, net_contribution_base \
             FROM RankedValuations \
             WHERE rn = 1",
-            "daily_account_valuation", // Use direct table name string
-            placeholders
+            "daily_account_valuation", placeholders
         );
 
         let mut query_builder = sql_query(sql).into_boxed::<Sqlite>();
@@ -298,5 +301,93 @@ impl ValuationRepositoryTrait for ValuationRepository {
             .collect();
 
         Ok(history_records)
+    }
+
+    fn get_portfolio_historical_valuations(
+        &self,
+        input_account_ids: &[String],
+        start_date_opt: Option<NaiveDate>,
+        end_date_opt: Option<NaiveDate>,
+    ) -> Result<Vec<DailyAccountValuation>> {
+        use chrono::Utc;
+        use rust_decimal::Decimal;
+        use std::collections::BTreeMap;
+
+        if input_account_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut conn = get_connection(&self.pool)?;
+
+        let mut query = daily_account_valuation::table
+            .filter(account_id.eq_any(input_account_ids))
+            .order(valuation_date.asc())
+            .into_boxed();
+
+        if let Some(start) = start_date_opt {
+            query = query.filter(valuation_date.ge(start));
+        }
+        if let Some(end) = end_date_opt {
+            query = query.filter(valuation_date.le(end));
+        }
+
+        let rows: Vec<DailyAccountValuationDB> = query
+            .load::<DailyAccountValuationDB>(&mut conn)
+            .map_err(StorageError::from)?;
+
+        // Aggregate base-currency fields by date in Rust using Decimal to preserve precision.
+        // BTreeMap keeps dates sorted.
+        struct DateBucket {
+            cash_balance_base: Decimal,
+            investment_market_value_base: Decimal,
+            total_value_base: Decimal,
+            cost_basis_base: Decimal,
+            net_contribution_base: Decimal,
+            base_currency: String,
+        }
+
+        let mut by_date: BTreeMap<NaiveDate, DateBucket> = BTreeMap::new();
+
+        for row in rows {
+            let v = DailyAccountValuation::from(row);
+            let bucket = by_date.entry(v.valuation_date).or_insert(DateBucket {
+                cash_balance_base: Decimal::ZERO,
+                investment_market_value_base: Decimal::ZERO,
+                total_value_base: Decimal::ZERO,
+                cost_basis_base: Decimal::ZERO,
+                net_contribution_base: Decimal::ZERO,
+                base_currency: v.base_currency.clone(),
+            });
+            bucket.cash_balance_base += v.cash_balance_base;
+            bucket.investment_market_value_base += v.investment_market_value_base;
+            bucket.total_value_base += v.total_value_base;
+            bucket.cost_basis_base += v.cost_basis_base;
+            bucket.net_contribution_base += v.net_contribution_base;
+        }
+
+        let result = by_date
+            .into_iter()
+            .map(|(date, b)| DailyAccountValuation {
+                id: format!("PORTFOLIO_{}", date),
+                account_id: String::new(),
+                valuation_date: date,
+                account_currency: b.base_currency.clone(),
+                base_currency: b.base_currency.clone(),
+                fx_rate_to_base: Decimal::ONE,
+                cash_balance: b.cash_balance_base,
+                investment_market_value: b.investment_market_value_base,
+                total_value: b.total_value_base,
+                cost_basis: b.cost_basis_base,
+                net_contribution: b.net_contribution_base,
+                calculated_at: Utc::now(),
+                cash_balance_base: b.cash_balance_base,
+                investment_market_value_base: b.investment_market_value_base,
+                total_value_base: b.total_value_base,
+                cost_basis_base: b.cost_basis_base,
+                net_contribution_base: b.net_contribution_base,
+            })
+            .collect();
+
+        Ok(result)
     }
 }

--- a/crates/storage-sqlite/src/schema.rs
+++ b/crates/storage-sqlite/src/schema.rs
@@ -207,6 +207,11 @@ diesel::table! {
         cost_basis -> Text,
         net_contribution -> Text,
         calculated_at -> Text,
+        cash_balance_base -> Text,
+        investment_market_value_base -> Text,
+        total_value_base -> Text,
+        cost_basis_base -> Text,
+        net_contribution_base -> Text,
     }
 }
 


### PR DESCRIPTION
## Summary

Hello @afadil :) 

I started to work on that but as the PR #972 is not yet merged it will be a draft. 

Adds explicit base-currency columns to `daily_account_valuation` so multi-account portfolio views can aggregate correctly without multiplying account-currency values by today's FX rate at read time.

- `cash_balance_base`
- `investment_market_value_base`
- `total_value_base`
- `cost_basis_base`
- `net_contribution_base`

All five are populated at write time in `calculate_valuation()`. The first four are `account_currency_value * fx_rate_to_base`. `net_contribution_base` is taken directly from the snapshot because contributions are converted at flow dates — multiplying by today's rate would give wrong values.

Adds `ValuationRepositoryTrait::get_portfolio_historical_valuations` which loads member account valuation rows in one query and aggregates `*_base` fields by date in Rust using `Decimal` arithmetic. Result rows are synthetic portfolio points in base currency (`fx_rate_to_base = 1`, `account_id = ""`). Safe for mixed-currency portfolios.

Migration clears existing `daily_account_valuation` rows to force recalculation with real base values.

## Blocked on PR #972

This PR is intentionally left as a draft pending the outcome of #972 (materialized lots, unified valuation, relational snapshot positions).

PR #972 introduces `daily_portfolio_valuation` as a separate table replacing the `TOTAL` pseudo-account rows in `daily_account_valuation`. If that model lands, the service-layer wiring and frontend integration planned here (ValuationService, Tauri/server handlers, performance page AccountScope support) will need to be adapted to the new table structure.

The foundational work here — base-currency columns on individual account rows and the repository aggregation method — should remain valid regardless of how #972 lands, but we want to avoid building on top of `daily_account_valuation` in ways that #972 will replace.

## What's not yet done

- `ValuationService` method to expose `get_portfolio_historical_valuations`
- Tauri and server handlers for portfolio/multi-account valuation history path
- Performance page frontend: connecting `AccountScope` to the new portfolio history path