### PR TITLE
fix(allocation): normalize weights >100% and guard parent/child double-counting in regions

### DIFF
--- a/crates/core/src/portfolio/allocation/allocation_service.rs
+++ b/crates/core/src/portfolio/allocation/allocation_service.rs
@@ -156,12 +156,6 @@ impl AllocationService {
                         .entry("__UNKNOWN__".to_string())
                         .or_insert(Decimal::ZERO) += market_value;
                 } else {
-                    // Normalize weights: if total exceeds 10000 bps (100%), scale down
-                    // proportionally so a single asset never contributes more than its
-                    // full market value to the portfolio total.
-                    let total_weight: i32 = taxonomy_assignments.iter().map(|(_, _, w)| w).sum();
-                    let weight_divisor = Decimal::from(total_weight.max(10000));
-
                     // In rollup mode: skip top-level category assignments when a child of
                     // that category is also assigned for this asset (leaf-wins principle).
                     // Without this guard, Americas + United States both roll up to Americas
@@ -183,7 +177,29 @@ impl AllocationService {
                             std::collections::HashSet::new()
                         };
 
-                    for (_, category_id, weight) in &taxonomy_assignments {
+                    // Build active assignment set after applying leaf-wins filter, then
+                    // normalize over only those active assignments. Computing total_weight
+                    // before filtering would dilute kept leaf weights by skipped parents.
+                    let active_assignments: Vec<_> = taxonomy_assignments
+                        .iter()
+                        .filter(|(_, category_id, _)| {
+                            if !rollup_to_top_level {
+                                return true;
+                            }
+                            let top = top_level_map
+                                .get(category_id.as_str())
+                                .copied()
+                                .unwrap_or(category_id.as_str());
+                            !(top == category_id.as_str()
+                                && top_levels_covered_by_children.contains(top))
+                        })
+                        .collect();
+
+                    let total_active_weight: i32 =
+                        active_assignments.iter().map(|(_, _, w)| *w).sum();
+                    let weight_divisor = Decimal::from(total_active_weight.max(10000));
+
+                    for (_, category_id, weight) in active_assignments.iter() {
                         let top_level_id = if rollup_to_top_level {
                             top_level_map
                                 .get(category_id.as_str())
@@ -192,14 +208,6 @@ impl AllocationService {
                         } else {
                             category_id.as_str()
                         };
-
-                        // Skip parent if a child assignment already covers this top-level
-                        if rollup_to_top_level
-                            && top_level_id == category_id.as_str()
-                            && top_levels_covered_by_children.contains(top_level_id)
-                        {
-                            continue;
-                        }
 
                         let weight_decimal = Decimal::from(*weight) / weight_divisor;
                         let weighted_value = market_value * weight_decimal;
@@ -551,22 +559,41 @@ impl AllocationService {
                 .collect()
         };
 
-        // Get assignments for all matching categories
-        let mut asset_to_weight: HashMap<String, i32> = HashMap::new();
+        // Get assignments for all matching categories, applying leaf-wins to avoid
+        // double-counting when both a parent and its child are assigned to the same asset.
+        // Separate direct (target category itself) from child category assignments.
+        // If an asset has child-level assignments, use those; otherwise fall back to direct.
+        let mut direct_weight: HashMap<String, i32> = HashMap::new();
+        let mut child_weight: HashMap<String, i32> = HashMap::new();
         for cat_id in &matching_category_ids {
             if *cat_id == "__UNKNOWN__" {
                 continue;
             }
+            let is_direct = *cat_id == category_id;
             if let Ok(assignments) = self
                 .taxonomy_service
                 .get_category_assignments(taxonomy_id, cat_id)
             {
                 for assignment in assignments {
-                    *asset_to_weight
-                        .entry(assignment.asset_id.clone())
-                        .or_insert(0) += assignment.weight;
+                    if is_direct {
+                        *direct_weight
+                            .entry(assignment.asset_id.clone())
+                            .or_insert(0) += assignment.weight;
+                    } else {
+                        *child_weight.entry(assignment.asset_id.clone()).or_insert(0) +=
+                            assignment.weight;
+                    }
                 }
             }
+        }
+        // Leaf-wins: prefer child weights; fall back to direct only when no child exists.
+        // Also normalize each asset's weight to at most 10000 bps (100%).
+        let mut asset_to_weight: HashMap<String, i32> = child_weight;
+        for (asset_id, weight) in direct_weight {
+            asset_to_weight.entry(asset_id).or_insert(weight);
+        }
+        for weight in asset_to_weight.values_mut() {
+            *weight = (*weight).min(10000);
         }
 
         // Calculate total value of matched holdings for weight calculation

--- a/crates/core/src/portfolio/allocation/allocation_service.rs
+++ b/crates/core/src/portfolio/allocation/allocation_service.rs
@@ -156,12 +156,34 @@ impl AllocationService {
                         .entry("__UNKNOWN__".to_string())
                         .or_insert(Decimal::ZERO) += market_value;
                 } else {
-                    for (_, category_id, weight) in taxonomy_assignments {
-                        // Convert weight from basis points (0-10000) to decimal (0-1)
-                        let weight_decimal = Decimal::from(*weight) / dec!(10000);
-                        let weighted_value = market_value * weight_decimal;
+                    // Normalize weights: if total exceeds 10000 bps (100%), scale down
+                    // proportionally so a single asset never contributes more than its
+                    // full market value to the portfolio total.
+                    let total_weight: i32 = taxonomy_assignments.iter().map(|(_, _, w)| w).sum();
+                    let weight_divisor = Decimal::from(total_weight.max(10000));
 
-                        // Get top-level category
+                    // In rollup mode: skip top-level category assignments when a child of
+                    // that category is also assigned for this asset (leaf-wins principle).
+                    // Without this guard, Americas + United States both roll up to Americas
+                    // and double-count the US portion.
+                    let top_levels_covered_by_children: std::collections::HashSet<&str> =
+                        if rollup_to_top_level {
+                            taxonomy_assignments
+                                .iter()
+                                .filter_map(|(_, cat_id, _)| {
+                                    let top = *top_level_map.get(cat_id.as_str())?;
+                                    if top != cat_id.as_str() {
+                                        Some(top)
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect()
+                        } else {
+                            std::collections::HashSet::new()
+                        };
+
+                    for (_, category_id, weight) in &taxonomy_assignments {
                         let top_level_id = if rollup_to_top_level {
                             top_level_map
                                 .get(category_id.as_str())
@@ -170,6 +192,17 @@ impl AllocationService {
                         } else {
                             category_id.as_str()
                         };
+
+                        // Skip parent if a child assignment already covers this top-level
+                        if rollup_to_top_level
+                            && top_level_id == category_id.as_str()
+                            && top_levels_covered_by_children.contains(top_level_id)
+                        {
+                            continue;
+                        }
+
+                        let weight_decimal = Decimal::from(*weight) / weight_divisor;
+                        let weighted_value = market_value * weight_decimal;
 
                         // Track original category values (for children)
                         let entry = original_values
@@ -700,5 +733,280 @@ impl AllocationServiceTrait for AllocationService {
             category_id,
         )
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::portfolio::holdings::holdings_model::{Instrument, MonetaryValue};
+    use crate::taxonomies::{
+        AssetTaxonomyAssignment, Category, NewAssetTaxonomyAssignment, NewCategory, NewTaxonomy,
+        Taxonomy, TaxonomyWithCategories,
+    };
+    use async_trait::async_trait;
+    use chrono::{NaiveDateTime, Utc};
+    use rust_decimal_macros::dec;
+
+    // Minimal mocks — aggregate_by_taxonomy is pure data, does not call these
+    struct NoopHoldings;
+    struct NoopTaxonomies;
+
+    #[async_trait]
+    impl HoldingsServiceTrait for NoopHoldings {
+        async fn get_holdings(&self, _: &str, _: &str) -> Result<Vec<Holding>> {
+            unimplemented!()
+        }
+        async fn get_holdings_for_accounts(
+            &self,
+            _: &[String],
+            _: &str,
+            _: &str,
+        ) -> Result<Vec<Holding>> {
+            unimplemented!()
+        }
+        async fn get_holding(&self, _: &str, _: &str, _: &str) -> Result<Option<Holding>> {
+            unimplemented!()
+        }
+        async fn holdings_from_snapshot(
+            &self,
+            _: &crate::portfolio::snapshot::AccountStateSnapshot,
+            _: &str,
+        ) -> Result<Vec<Holding>> {
+            unimplemented!()
+        }
+    }
+
+    #[async_trait]
+    impl TaxonomyServiceTrait for NoopTaxonomies {
+        fn get_taxonomies(&self) -> Result<Vec<Taxonomy>> {
+            unimplemented!()
+        }
+        fn get_taxonomy(&self, _: &str) -> Result<Option<TaxonomyWithCategories>> {
+            unimplemented!()
+        }
+        fn get_taxonomies_with_categories(&self) -> Result<Vec<TaxonomyWithCategories>> {
+            unimplemented!()
+        }
+        async fn create_taxonomy(&self, _: NewTaxonomy) -> Result<Taxonomy> {
+            unimplemented!()
+        }
+        async fn update_taxonomy(&self, _: Taxonomy) -> Result<Taxonomy> {
+            unimplemented!()
+        }
+        async fn delete_taxonomy(&self, _: &str) -> Result<usize> {
+            unimplemented!()
+        }
+        async fn create_category(&self, _: NewCategory) -> Result<Category> {
+            unimplemented!()
+        }
+        async fn update_category(&self, _: Category) -> Result<Category> {
+            unimplemented!()
+        }
+        async fn delete_category(&self, _: &str, _: &str) -> Result<usize> {
+            unimplemented!()
+        }
+        async fn move_category(
+            &self,
+            _: &str,
+            _: &str,
+            _: Option<String>,
+            _: i32,
+        ) -> Result<Category> {
+            unimplemented!()
+        }
+        async fn import_taxonomy_json(&self, _: &str) -> Result<Taxonomy> {
+            unimplemented!()
+        }
+        fn export_taxonomy_json(&self, _: &str) -> Result<String> {
+            unimplemented!()
+        }
+        fn get_asset_assignments(&self, _: &str) -> Result<Vec<AssetTaxonomyAssignment>> {
+            unimplemented!()
+        }
+        fn get_category_assignments(
+            &self,
+            _: &str,
+            _: &str,
+        ) -> Result<Vec<AssetTaxonomyAssignment>> {
+            unimplemented!()
+        }
+        async fn assign_asset_to_category(
+            &self,
+            _: NewAssetTaxonomyAssignment,
+        ) -> Result<AssetTaxonomyAssignment> {
+            unimplemented!()
+        }
+        async fn remove_asset_assignment(&self, _: &str) -> Result<usize> {
+            unimplemented!()
+        }
+    }
+
+    fn svc() -> AllocationService {
+        AllocationService::new(Arc::new(NoopHoldings), Arc::new(NoopTaxonomies))
+    }
+
+    fn now() -> NaiveDateTime {
+        Utc::now().naive_utc()
+    }
+
+    fn make_category(id: &str, parent_id: Option<&str>) -> Category {
+        Category {
+            id: id.to_string(),
+            taxonomy_id: "regions".to_string(),
+            parent_id: parent_id.map(|s| s.to_string()),
+            name: id.to_string(),
+            key: id.to_string(),
+            color: "#808080".to_string(),
+            description: None,
+            sort_order: 0,
+            created_at: now(),
+            updated_at: now(),
+        }
+    }
+
+    fn make_holding(asset_id: &str, base_value: Decimal) -> Holding {
+        Holding {
+            id: asset_id.to_string(),
+            account_id: "acc".to_string(),
+            holding_type: HoldingType::Security,
+            instrument: Some(Instrument {
+                id: asset_id.to_string(),
+                symbol: asset_id.to_string(),
+                name: None,
+                currency: "USD".to_string(),
+                notes: None,
+                pricing_mode: "MARKET".to_string(),
+                preferred_provider: None,
+                exchange_mic: None,
+                classifications: None,
+            }),
+            asset_kind: None,
+            quantity: dec!(1),
+            open_date: None,
+            lots: None,
+            contract_multiplier: Decimal::ONE,
+            local_currency: "USD".to_string(),
+            base_currency: "USD".to_string(),
+            fx_rate: None,
+            market_value: MonetaryValue {
+                local: base_value,
+                base: base_value,
+            },
+            cost_basis: None,
+            price: None,
+            purchase_price: None,
+            unrealized_gain: None,
+            unrealized_gain_pct: None,
+            realized_gain: None,
+            realized_gain_pct: None,
+            total_gain: None,
+            total_gain_pct: None,
+            day_change: None,
+            day_change_pct: None,
+            prev_close_value: None,
+            weight: Decimal::ZERO,
+            as_of_date: chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            metadata: None,
+            source_account_ids: vec![],
+        }
+    }
+
+    /// Weights summing above 100% must not cause any category percentage to exceed
+    /// the portfolio total. With AAPL assigned 60% North_America + 60% Europe (120% total),
+    /// the normalized sum across all regions must equal 100%.
+    #[test]
+    fn weights_above_100_pct_are_normalized() {
+        let svc = svc();
+        let holdings = vec![make_holding("AAPL", dec!(1000))];
+
+        // North_America and Europe are both top-level (no parent)
+        let categories = vec![
+            make_category("North_America", None),
+            make_category("Europe", None),
+        ];
+
+        // 60% + 60% = 120% (invalid, should be normalized to 50% + 50%)
+        let mut assignments: HashMap<String, Vec<(String, String, i32)>> = HashMap::new();
+        assignments.insert(
+            "AAPL".to_string(),
+            vec![
+                ("regions".to_string(), "North_America".to_string(), 6000),
+                ("regions".to_string(), "Europe".to_string(), 6000),
+            ],
+        );
+
+        let result = svc.aggregate_by_taxonomy(
+            &holdings,
+            "regions",
+            "Regions",
+            "#ccc",
+            &categories,
+            &assignments,
+            dec!(1000),
+            false,
+        );
+
+        let total_pct: Decimal = result.categories.iter().map(|c| c.percentage).sum();
+        assert!(
+            total_pct <= dec!(100.01),
+            "Total percentage {total_pct} exceeds 100% — normalization failed"
+        );
+    }
+
+    /// When an asset is assigned to both a parent region (Americas) and a child (United_States),
+    /// rolling up to the top level must not double-count: United_States rolls up to Americas,
+    /// so the direct Americas assignment should be skipped (leaf-wins).
+    #[test]
+    fn parent_child_region_not_double_counted_on_rollup() {
+        let svc = svc();
+        let holdings = vec![make_holding("AAPL", dec!(1000))];
+
+        // Americas is top-level; United_States is its child
+        let categories = vec![
+            make_category("Americas", None),
+            make_category("United_States", Some("Americas")),
+        ];
+
+        // 60% Americas (parent) + 40% United_States (child of Americas)
+        // Leaf-wins: Americas direct assignment should be skipped, only US rolls up
+        let mut assignments: HashMap<String, Vec<(String, String, i32)>> = HashMap::new();
+        assignments.insert(
+            "AAPL".to_string(),
+            vec![
+                ("regions".to_string(), "Americas".to_string(), 6000),
+                ("regions".to_string(), "United_States".to_string(), 4000),
+            ],
+        );
+
+        let result = svc.aggregate_by_taxonomy(
+            &holdings,
+            "regions",
+            "Regions",
+            "#ccc",
+            &categories,
+            &assignments,
+            dec!(1000),
+            true, // rollup_to_top_level
+        );
+
+        let americas = result
+            .categories
+            .iter()
+            .find(|c| c.category_id == "Americas")
+            .expect("Americas category missing");
+
+        // Only the United_States leaf (40%) should count — not Americas direct (60%) + US (40%)
+        assert!(
+            americas.value <= dec!(1000),
+            "Americas value {} exceeds total holding value — parent/child double-counted",
+            americas.value
+        );
+        assert_eq!(
+            americas.value,
+            dec!(400),
+            "Expected Americas = 400 (leaf US only), got {}",
+            americas.value
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes two bugs in `aggregate_by_taxonomy` that caused region/country allocation percentages to exceed the portfolio total. Pre-existing debt flagged during PR #995 review.

**Bug 1 — Weights above 100% not normalized**
If an asset had taxonomy assignments summing above 10000 bps (100%), each weight was applied directly, so the asset could contribute more than its full market value to the totals. Fix: divide by `max(total_weight, 10000)` so contributions are always proportional and never exceed market value.

**Bug 2 — Parent/child region assignments double-counted on rollup**
In rollup mode (`rollup_to_top_level = true`), if an asset was assigned to both a parent category (Americas) and a child (United States), rolling up United States to Americas while also counting the direct Americas assignment would sum both. Fix: leaf-wins — skip a top-level assignment when a child of that top-level is already assigned for the same asset.

## Tests

Two regression tests added directly to `allocation_service.rs`:
- `weights_above_100_pct_are_normalized` — 60%+60% AAPL scenario, total % must not exceed 100%
- `parent_child_region_not_double_counted_on_rollup` — Americas+United_States scenario, Americas value must equal leaf-only contribution (400, not 1000)

## Related

Requested as follow-up in [#995 review](https://github.com/wealthfolio/wealthfolio/pull/995#issuecomment-0) by @afadil:
> normalize or validate assignment weights per asset/taxonomy; guard against overlapping parent/child region assignments being double-counted; add a regression test where one asset has region weights above 100% and verify portfolio percentages do not exceed the scoped total.


## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).