### PR TITLE
Fix asset resolution for security TRANSFER_IN / TRANSFER_OUT rows in CSV import

### DIFF
--- a/apps/frontend/src/lib/activity-utils.test.ts
+++ b/apps/frontend/src/lib/activity-utils.test.ts
@@ -7,6 +7,7 @@ import {
   isAssetBackedIncomeSubtype,
   isAssetIdentityRequired,
   needsImportAssetResolution,
+  needsImportAssetResolutionForRow,
   calculateActivityValue,
   formatSplitRatio,
 } from "./activity-utils";
@@ -106,6 +107,74 @@ describe("Activity Utilities", () => {
 
     it("does not force cash-only interest imports through asset resolution", () => {
       expect(needsImportAssetResolution(ActivityType.INTEREST)).toBe(false);
+    });
+  });
+
+  describe("needsImportAssetResolutionForRow", () => {
+    it("requires asset resolution for security transfers with a real symbol and quantity", () => {
+      expect(
+        needsImportAssetResolutionForRow({
+          activityType: ActivityType.TRANSFER_IN,
+          symbol: "MSFT",
+          quantity: "10",
+          unitPrice: "0",
+        }),
+      ).toBe(true);
+    });
+
+    it("requires asset resolution for security transfer-outs with a real symbol and unit price", () => {
+      expect(
+        needsImportAssetResolutionForRow({
+          activityType: ActivityType.TRANSFER_OUT,
+          symbol: "MSFT",
+          quantity: "0",
+          unitPrice: "425.50",
+        }),
+      ).toBe(true);
+    });
+
+    it("does not require asset resolution for cash transfers", () => {
+      expect(
+        needsImportAssetResolutionForRow({
+          activityType: ActivityType.TRANSFER_IN,
+          symbol: "CASH:USD",
+          quantity: "10",
+          unitPrice: "100",
+        }),
+      ).toBe(false);
+    });
+
+    it("does not require asset resolution for cash transfer-outs", () => {
+      expect(
+        needsImportAssetResolutionForRow({
+          activityType: ActivityType.TRANSFER_OUT,
+          symbol: "$CASH-USD",
+          quantity: "5",
+          unitPrice: "100",
+        }),
+      ).toBe(false);
+    });
+
+    it("does not auto-resolve transfer rows with a real symbol but no quantity or price", () => {
+      expect(
+        needsImportAssetResolutionForRow({
+          activityType: ActivityType.TRANSFER_IN,
+          symbol: "MSFT",
+          quantity: "0",
+          unitPrice: "0",
+        }),
+      ).toBe(false);
+    });
+
+    it("does not auto-resolve transfer-outs with a real symbol but no quantity or price", () => {
+      expect(
+        needsImportAssetResolutionForRow({
+          activityType: ActivityType.TRANSFER_OUT,
+          symbol: "MSFT",
+          quantity: "",
+          unitPrice: "",
+        }),
+      ).toBe(false);
     });
   });
 

--- a/apps/frontend/src/lib/activity-utils.ts
+++ b/apps/frontend/src/lib/activity-utils.ts
@@ -83,6 +83,24 @@ export const needsImportAssetResolution = (
   return isAssetIdentityRequired(activityType, subtype);
 };
 
+const hasNonZeroNumericValue = (value?: string | number | null): boolean => {
+  if (value == null) {
+    return false;
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value) && value !== 0;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) && parsed !== 0;
+};
+
 /**
  * Determines if an activity is a cash transfer based on its type and identifiers.
  * A transfer is cash when:
@@ -143,6 +161,32 @@ export const isSecuritiesTransfer = (
     return false;
   }
   return !isCashTransfer(activityType, assetSymbol, assetId);
+};
+
+/**
+ * Import-time asset resolution for transfer rows needs row-level values.
+ * Security transfers require asset resolution only when they have a real
+ * non-cash symbol and a non-zero quantity or unit price, matching backend
+ * import classification.
+ */
+export const needsImportAssetResolutionForRow = (input: {
+  activityType?: string | null;
+  subtype?: string | null;
+  symbol?: string | null;
+  assetId?: string | null;
+  quantity?: string | number | null;
+  unitPrice?: string | number | null;
+}): boolean => {
+  const activityType = input.activityType?.trim() ?? "";
+  if (needsImportAssetResolution(activityType, input.subtype)) {
+    return true;
+  }
+
+  if (!isSecuritiesTransfer(activityType, input.symbol ?? undefined, input.assetId ?? undefined)) {
+    return false;
+  }
+
+  return hasNonZeroNumericValue(input.quantity) || hasNonZeroNumericValue(input.unitPrice);
 };
 
 const isCanonicalCashIdentifier = (identifier: string): boolean => {

--- a/apps/frontend/src/pages/activity/import/activity-import-page.tsx
+++ b/apps/frontend/src/pages/activity/import/activity-import-page.tsx
@@ -1,6 +1,6 @@
 import { getAccounts, logger } from "@/adapters";
 import { usePlatform } from "@/hooks/use-platform";
-import { isCashSymbol, needsImportAssetResolution } from "@/lib/activity-utils";
+import { isCashSymbol, needsImportAssetResolutionForRow } from "@/lib/activity-utils";
 import { canImportCSV } from "@/lib/activity-restrictions";
 import { QueryKeys } from "@/lib/query-keys";
 import type { Account } from "@/lib/types";
@@ -205,6 +205,18 @@ function useStepValidation(isHoldingsMode: boolean, accounts?: Account[]) {
                 .map((h) => headers.indexOf(h))
                 .filter((i) => i !== -1)
             : [];
+          const quantityMapping = mapping.fieldMappings[ImportFormat.QUANTITY];
+          const qtyCols = quantityMapping
+            ? (Array.isArray(quantityMapping) ? quantityMapping : [quantityMapping])
+                .map((h) => headers.indexOf(h))
+                .filter((i) => i !== -1)
+            : [];
+          const unitPriceMapping = mapping.fieldMappings[ImportFormat.UNIT_PRICE];
+          const priceCols = unitPriceMapping
+            ? (Array.isArray(unitPriceMapping) ? unitPriceMapping : [unitPriceMapping])
+                .map((h) => headers.indexOf(h))
+                .filter((i) => i !== -1)
+            : [];
 
           if (symbolHeaderIndex !== -1) {
             const symbolsNeedingResolution = new Set<string>();
@@ -236,9 +248,22 @@ function useStepValidation(isHoldingsMode: boolean, accounts?: Account[]) {
                   csvActivityType,
                   mapping.activityMappings || {},
                 );
+                const quantity = qtyCols
+                  .map((idx) => row[idx]?.trim())
+                  .find((value) => value && value.length > 0);
+                const unitPrice = priceCols
+                  .map((idx) => row[idx]?.trim())
+                  .find((value) => value && value.length > 0);
                 if (
                   mappedType &&
-                  (!needsImportAssetResolution(mappedType, csvSubtype) || isCashSymbol(symbol))
+                  (!needsImportAssetResolutionForRow({
+                    activityType: mappedType,
+                    subtype: csvSubtype,
+                    symbol,
+                    quantity,
+                    unitPrice,
+                  }) ||
+                    isCashSymbol(symbol))
                 ) {
                   return;
                 }

--- a/apps/frontend/src/pages/activity/import/components/import-columns.tsx
+++ b/apps/frontend/src/pages/activity/import/components/import-columns.tsx
@@ -8,7 +8,7 @@ import {
   SUBTYPES_BY_ACTIVITY_TYPE,
   SUBTYPE_DISPLAY_NAMES,
 } from "@/lib/constants";
-import { needsImportAssetResolution } from "@/lib/activity-utils";
+import { needsImportAssetResolutionForRow } from "@/lib/activity-utils";
 import { ActivityTypeBadge } from "../../components/activity-type-badge";
 
 const UNIT_PRICE_HELP_TEXT =
@@ -274,7 +274,13 @@ export function useImportColumns<T extends ImportRowData>({
           onCreateCustomAsset,
           isClearable: (rowData: unknown) => {
             const row = rowData as ImportRowData;
-            return !needsImportAssetResolution(row.activityType ?? "", row.subtype);
+            return !needsImportAssetResolutionForRow({
+              activityType: row.activityType,
+              subtype: row.subtype,
+              symbol: row.symbol ?? row.assetSymbol,
+              quantity: row.quantity,
+              unitPrice: row.unitPrice,
+            });
           },
         },
       },

--- a/apps/frontend/src/pages/activity/import/components/import-review-grid.tsx
+++ b/apps/frontend/src/pages/activity/import/components/import-review-grid.tsx
@@ -18,7 +18,7 @@ import {
   SUBTYPES_BY_ACTIVITY_TYPE,
   SUBTYPE_DISPLAY_NAMES,
 } from "@/lib/constants";
-import { needsImportAssetResolution } from "@/lib/activity-utils";
+import { needsImportAssetResolutionForRow } from "@/lib/activity-utils";
 import { quoteModeFromSearchResult } from "@/lib/asset-utils";
 import { ActivityTypeBadge } from "../../components/activity-type-badge";
 import type { DraftActivity, DraftActivityStatus } from "../context";
@@ -367,7 +367,14 @@ function useImportReviewColumns({
             onCreateCustomAsset,
             isClearable: (rowData: unknown) => {
               const row = rowData as DraftActivity;
-              return !needsImportAssetResolution(row.activityType ?? "", row.subtype);
+              return !needsImportAssetResolutionForRow({
+                activityType: row.activityType,
+                subtype: row.subtype,
+                symbol: row.symbol,
+                assetId: row.assetId,
+                quantity: row.quantity,
+                unitPrice: row.unitPrice,
+              });
             },
           },
         },

--- a/apps/frontend/src/pages/activity/import/components/mapping-table-cells.tsx
+++ b/apps/frontend/src/pages/activity/import/components/mapping-table-cells.tsx
@@ -12,7 +12,7 @@ import {
   type SymbolSearchResult,
 } from "@/lib/types";
 import { cn } from "@/lib/utils";
-import { isCashSymbol, needsImportAssetResolution } from "@/lib/activity-utils";
+import { isCashSymbol, needsImportAssetResolutionForRow } from "@/lib/activity-utils";
 import {
   Badge,
   SearchableSelect,
@@ -400,8 +400,20 @@ export function MappingCell({
     // Skip symbol display when not required (pure cash types, cash symbols)
     const csvType = getMappedValue(row, ImportFormat.ACTIVITY_TYPE)?.trim();
     const csvSubtype = getMappedValue(row, ImportFormat.SUBTYPE)?.trim();
+    const quantity = getMappedValue(row, ImportFormat.QUANTITY)?.trim();
+    const unitPrice = getMappedValue(row, ImportFormat.UNIT_PRICE)?.trim();
     const appType = csvType ? findMappedActivityType(csvType, mapping.activityMappings) : null;
-    if (appType && (!needsImportAssetResolution(appType, csvSubtype) || isCashSymbol(symbol))) {
+    if (
+      appType &&
+      (!needsImportAssetResolutionForRow({
+        activityType: appType,
+        subtype: csvSubtype,
+        symbol,
+        quantity,
+        unitPrice,
+      }) ||
+        isCashSymbol(symbol))
+    ) {
       return <span className="text-muted-foreground text-xs">-</span>;
     }
 

--- a/apps/frontend/src/pages/activity/import/steps/mapping-step-unified.tsx
+++ b/apps/frontend/src/pages/activity/import/steps/mapping-step-unified.tsx
@@ -37,7 +37,7 @@ import {
 } from "../utils/default-activity-template";
 import { mergeDetectedParseConfig } from "../utils/import-flow-utils";
 
-import { isCashSymbol, needsImportAssetResolution } from "@/lib/activity-utils";
+import { isCashSymbol, needsImportAssetResolutionForRow } from "@/lib/activity-utils";
 import { IMPORT_REQUIRED_FIELDS, ImportFormat } from "@/lib/constants";
 import { QueryKeys } from "@/lib/query-keys";
 import type { Account, CsvRowData, ImportTemplateData } from "@/lib/types";
@@ -147,11 +147,23 @@ export function MappingStepUnified() {
 
       const csvType = getMappedValue(row, ImportFormat.ACTIVITY_TYPE)?.trim();
       const csvSubtype = getMappedValue(row, ImportFormat.SUBTYPE)?.trim();
+      const quantity = getMappedValue(row, ImportFormat.QUANTITY)?.trim();
+      const unitPrice = getMappedValue(row, ImportFormat.UNIT_PRICE)?.trim();
       const appType = csvType
         ? findMappedActivityType(csvType, localMapping.activityMappings || {})
         : null;
 
-      if (appType && (!needsImportAssetResolution(appType, csvSubtype) || isCashSymbol(symbol))) {
+      if (
+        appType &&
+        (!needsImportAssetResolutionForRow({
+          activityType: appType,
+          subtype: csvSubtype,
+          symbol,
+          quantity,
+          unitPrice,
+        }) ||
+          isCashSymbol(symbol))
+      ) {
         return;
       }
 
@@ -293,11 +305,23 @@ export function MappingStepUnified() {
 
       const csvType = getMappedValue(row, ImportFormat.ACTIVITY_TYPE)?.trim();
       const csvSubtype = getMappedValue(row, ImportFormat.SUBTYPE)?.trim();
+      const quantity = getMappedValue(row, ImportFormat.QUANTITY)?.trim();
+      const unitPrice = getMappedValue(row, ImportFormat.UNIT_PRICE)?.trim();
       const appType = csvType
         ? findMappedActivityType(csvType, localMapping.activityMappings || {})
         : null;
 
-      if (appType && (!needsImportAssetResolution(appType, csvSubtype) || isCashSymbol(symbol))) {
+      if (
+        appType &&
+        (!needsImportAssetResolutionForRow({
+          activityType: appType,
+          subtype: csvSubtype,
+          symbol,
+          quantity,
+          unitPrice,
+        }) ||
+          isCashSymbol(symbol))
+      ) {
         return;
       }
       if (validateTickerSymbol(symbol) || localMapping.symbolMappings?.[symbol]) return;

--- a/apps/frontend/src/pages/activity/import/utils/asset-review-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/asset-review-utils.ts
@@ -1,4 +1,4 @@
-import { isCashSymbol, needsImportAssetResolution } from "@/lib/activity-utils";
+import { isCashSymbol, needsImportAssetResolutionForRow } from "@/lib/activity-utils";
 import { quoteModeFromSearchResult } from "@/lib/asset-utils";
 import { ActivityType } from "@/lib/constants";
 import type {
@@ -127,7 +127,14 @@ export function buildImportAssetCandidateFromDraft(
     return null;
   }
   if (
-    !needsImportAssetResolution(draft.activityType, draft.subtype) ||
+    !needsImportAssetResolutionForRow({
+      activityType: draft.activityType,
+      subtype: draft.subtype,
+      symbol: draft.symbol,
+      assetId: draft.assetId,
+      quantity: draft.quantity,
+      unitPrice: draft.unitPrice,
+    }) ||
     isCashSymbol(draft.symbol)
   ) {
     return null;

--- a/apps/frontend/src/pages/activity/import/utils/import-asset-rules.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/import-asset-rules.test.ts
@@ -45,6 +45,68 @@ describe("import asset rules", () => {
     expect(candidate?.symbol).toBe("SOL");
   });
 
+  it("builds asset candidates for security transfers", () => {
+    const candidate = buildImportAssetCandidateFromDraft(
+      createDraft({
+        activityType: ActivityType.TRANSFER_IN,
+        symbol: "MSFT",
+        quantity: "0.692",
+        unitPrice: "506.69",
+        instrumentType: "EQUITY",
+        quoteCcy: "USD",
+      }),
+    );
+
+    expect(candidate).not.toBeNull();
+    expect(candidate?.symbol).toBe("MSFT");
+  });
+
+  it("does not build asset candidates for cash transfers", () => {
+    const candidate = buildImportAssetCandidateFromDraft(
+      createDraft({
+        activityType: ActivityType.TRANSFER_IN,
+        symbol: "CASH:USD",
+        quantity: "1",
+        unitPrice: "1",
+        instrumentType: "EQUITY",
+        quoteCcy: "USD",
+      }),
+    );
+
+    expect(candidate).toBeNull();
+  });
+
+  it("builds asset candidates for security transfer-outs", () => {
+    const candidate = buildImportAssetCandidateFromDraft(
+      createDraft({
+        activityType: ActivityType.TRANSFER_OUT,
+        symbol: "MSFT",
+        quantity: "5",
+        unitPrice: "410.25",
+        instrumentType: "EQUITY",
+        quoteCcy: "USD",
+      }),
+    );
+
+    expect(candidate).not.toBeNull();
+    expect(candidate?.symbol).toBe("MSFT");
+  });
+
+  it("does not build asset candidates for ambiguous transfers without quantity or price", () => {
+    const candidate = buildImportAssetCandidateFromDraft(
+      createDraft({
+        activityType: ActivityType.TRANSFER_IN,
+        symbol: "MSFT",
+        quantity: "",
+        unitPrice: "",
+        instrumentType: "EQUITY",
+        quoteCcy: "USD",
+      }),
+    );
+
+    expect(candidate).toBeNull();
+  });
+
   it("keeps otherwise identical candidates distinct when their ISIN differs", () => {
     const first = buildImportAssetCandidateFromDraft(
       createDraft({


### PR DESCRIPTION
## Summary

**Note:** This fix was AI-authored (codex gpt-5.4), but it was reviewed, tested, and is being submitted by a human. The behavior was verified with both targeted unit tests and manual CSV import checks in the web UI.

This PR fixes a CSV import UI issue where symbol-backed transfer activities such as stock transfers were not routed through asset resolution.

Before this change, the import flow relied on a type-level helper to decide whether a row needed symbol/asset resolution. That worked for clearly asset-backed types like `BUY` and `SELL`, but not for `TRANSFER_IN` / `TRANSFER
- cash transfer
- asset/security transfer

As a result, valid security transfer rows could be treated too much like cash during import mapping/review, and symbol resolution could be skipped.

## Root cause

The frontend import flow used a type-only rule:
- `needsImportAssetResolution(activityType, subtype)`

That was insufficient for transfers, because transfer classification depends on row data, not just activity type.

The backend already uses row-aware logic for transfers:
- real non-cash symbol + non-zero `quantity` or `unitPrice` => asset-backed transfer
- cash placeholder / blank symbol => cash transfer
- real symbol but no quantity and no price => review/error

The frontend was not matching that behavior.

## Fix

This PR introduces an import-specific, row-aware helper:
- `needsImportAssetResolutionForRow(...)`

It is used only in the CSV import flow.

Behavior after the change:
- security transfer rows with a real non-cash symbol and non-zero `quantity` or `unitPrice` now go through asset resolution
- cash-like transfer rows continue to bypass asset resolution
- ambiguous transfer rows still go to review/error rather than being auto-resolved

This keeps the fix narrow:
- no backend behavior changes
- no change to the generic type-level helper used elsewhere
- no change to non-import activity flows

## Safety / verification

Verification used:
- unit tests for the row-aware transfer classification and asset-candidate generation via `pnpm test -- --run apps/frontend/src/lib/activity-utils.test.ts apps/frontend/src/pages/activity/import/utils/import-asset-rules.test.ts`
- manual testing in web mode through the actual CSV import flow

### Unit test areas
- security `TRANSFER_IN` triggers asset resolution
- security `TRANSFER_OUT` triggers asset resolution
- cash `TRANSFER_IN` does not trigger asset resolution
- cash `TRANSFER_OUT` does not trigger asset resolution
- ambiguous transfer rows with a real symbol but no qty/price do not auto-resolve

### Manual test coverage
Verified in the UI that:
- security transfer rows now participate in symbol mapping / asset review
- cash-like transfer rows remain cash-like
- ambiguous rows are forced into review with clear validation messages

## Example test cases used

### Security transfer in
```csv
date,account,activityType,symbol,quantity,unitPrice,amount,currency,fee,comment,fxRate,subtype,instrumentType,isin
2026-03-30,IBKR,TRANSFER_IN,MSFT,0.692,506.69,,USD,,Test stock transfer in,,,EQUITY,
```

### Cash-like transfer in
```csv
date,account,activityType,symbol,quantity,unitPrice,amount,currency,fee,comment,fxRate,subtype,instrumentType,isin
2026-03-30,IBKR,TRANSFER_IN,CASH:USD,,,1000,USD,,Test cash transfer in,,,,
```

### Ambiguous transfer row
```csv
date,account,activityType,symbol,quantity,unitPrice,amount,currency,fee,comment,fxRate,subtype,instrumentType,isin
2026-03-30,IBKR,TRANSFER_IN,MSFT,,,,USD,,Ambiguous transfer row,,,EQUITY,
```

## Notes

This PR does not attempt to redesign transfer semantics. It only aligns frontend import behavior with the backend’s existing transfer classification so valid security transfers are handled correctly in the import UI.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
