### PR TITLE
Add provider-neutral dividend fetching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8291,7 +8291,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-ai"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8321,7 +8321,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-app"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8371,7 +8371,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-connect"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8389,7 +8389,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-core"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8434,7 +8434,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-device-sync"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8458,7 +8458,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-market-data"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8480,7 +8480,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-server"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8528,7 +8528,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-spending"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8546,7 +8546,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-storage-sqlite"
-version = "3.4.0"
+version = "3.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.4.0"
+version = "3.5.0"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.5.0",
   "type": "module",
   "homepage": "https://wealthfolio.app",
   "repository": {

--- a/apps/frontend/src/adapters/shared/market-data.ts
+++ b/apps/frontend/src/adapters/shared/market-data.ts
@@ -213,11 +213,24 @@ export const getExchanges = async (): Promise<ExchangeInfo[]> => {
   }
 };
 
-export const fetchYahooDividends = async (
+export interface FetchDividendsOptions {
+  exchangeMic?: string;
+  instrumentType?: string;
+  quoteCcy?: string;
+  providerId?: string;
+  startDate?: string;
+  endDate?: string;
+}
+
+export const fetchDividends = async (
   symbol: string,
+  options: FetchDividendsOptions = {},
 ): Promise<{ amount: number; date: number }[]> => {
   try {
-    return await invoke<{ amount: number; date: number }[]>("fetch_yahoo_dividends", { symbol });
+    return await invoke<{ amount: number; date: number }[]>("fetch_dividends", {
+      symbol,
+      ...options,
+    });
   } catch (error) {
     logger.error(`Error fetching dividends for ${symbol}.`);
     throw error;

--- a/apps/frontend/src/adapters/web/core.ts
+++ b/apps/frontend/src/adapters/web/core.ts
@@ -146,7 +146,7 @@ export const COMMANDS: CommandMap = {
   search_symbol: { method: "GET", path: "/market-data/search" },
   resolve_symbol_quote: { method: "GET", path: "/market-data/resolve-currency" },
   get_quote_history: { method: "GET", path: "/market-data/quotes/history" },
-  fetch_yahoo_dividends: { method: "GET", path: "/market-data/yahoo/dividends" },
+  fetch_dividends: { method: "GET", path: "/market-data/dividends" },
   get_latest_quotes: { method: "POST", path: "/market-data/quotes/latest" },
   update_quote: { method: "PUT", path: "/market-data/quotes" },
   delete_quote: { method: "DELETE", path: "/market-data/quotes/id" },
@@ -951,10 +951,25 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
       url += `?${params.toString()}`;
       break;
     }
-    case "fetch_yahoo_dividends": {
-      const { symbol } = payload as { symbol: string };
+    case "fetch_dividends": {
+      const { symbol, exchangeMic, instrumentType, quoteCcy, providerId, startDate, endDate } =
+        payload as {
+          symbol: string;
+          exchangeMic?: string;
+          instrumentType?: string;
+          quoteCcy?: string;
+          providerId?: string;
+          startDate?: string;
+          endDate?: string;
+        };
       const params = new URLSearchParams();
       params.set("symbol", symbol);
+      if (exchangeMic) params.set("exchangeMic", exchangeMic);
+      if (instrumentType) params.set("instrumentType", instrumentType);
+      if (quoteCcy) params.set("quoteCcy", quoteCcy);
+      if (providerId) params.set("providerId", providerId);
+      if (startDate) params.set("startDate", startDate);
+      if (endDate) params.set("endDate", endDate);
       url += `?${params.toString()}`;
       break;
     }

--- a/apps/frontend/src/adapters/web/index.ts
+++ b/apps/frontend/src/adapters/web/index.ts
@@ -177,7 +177,7 @@ export {
   createAsset,
   deleteAsset,
   deleteQuote,
-  fetchYahooDividends,
+  fetchDividends,
   getAssetProfile,
   getAssets,
   getExchanges,

--- a/apps/frontend/src/addons/addons-runtime-context.ts
+++ b/apps/frontend/src/addons/addons-runtime-context.ts
@@ -36,7 +36,7 @@ import {
   listenFileDropHover as listenImportFileDropHover,
 } from "@/adapters";
 import {
-  fetchYahooDividends,
+  fetchDividends,
   getAssetProfile,
   getMarketDataProviders,
   getQuoteHistory,
@@ -242,7 +242,7 @@ export function createAddonContext(addonId: string): AddonContext {
 
           // Market data
           searchTicker,
-          fetchYahooDividends,
+          fetchDividends,
           syncHistoryQuotes,
           getAssetProfile,
           updateAssetProfile,

--- a/apps/frontend/src/addons/type-bridge.ts
+++ b/apps/frontend/src/addons/type-bridge.ts
@@ -79,7 +79,17 @@ export interface InternalHostAPI {
 
   // Market data
   searchTicker(query: string): Promise<SymbolSearchResult[]>;
-  fetchYahooDividends(symbol: string): Promise<{ amount: number; date: number }[]>;
+  fetchDividends(
+    symbol: string,
+    options?: {
+      exchangeMic?: string;
+      instrumentType?: string;
+      quoteCcy?: string;
+      providerId?: string;
+      startDate?: string;
+      endDate?: string;
+    },
+  ): Promise<{ amount: number; date: number }[]>;
   syncHistoryQuotes(): Promise<void>;
   getAssetProfile(assetId: string): Promise<Asset>;
   updateAssetProfile(payload: UpdateAssetProfile): Promise<Asset>;
@@ -333,7 +343,7 @@ export function createSDKHostAPIBridge(
       syncHistory: internalAPI.syncHistoryQuotes,
       sync: internalAPI.syncMarketData,
       getProviders: internalAPI.getMarketDataProviders,
-      fetchDividends: internalAPI.fetchYahooDividends,
+      fetchDividends: internalAPI.fetchDividends,
     },
     assets: {
       getProfile: internalAPI.getAssetProfile,

--- a/apps/server/src/api/market_data.rs
+++ b/apps/server/src/api/market_data.rs
@@ -11,11 +11,12 @@ use axum::{
     routing::{delete, get, post, put},
     Json, Router,
 };
+use wealthfolio_core::assets::InstrumentType;
 use wealthfolio_core::portfolio::{snapshot::SnapshotRecalcMode, valuation::ValuationRecalcMode};
 use wealthfolio_core::quotes::{
     LatestQuoteSnapshot, MarketSyncMode, ProviderInfo, Quote, QuoteImport, SymbolSearchResult,
 };
-use wealthfolio_market_data::{ExchangeInfo, YahooDividend, YahooProvider};
+use wealthfolio_market_data::{DividendEvent, ExchangeInfo};
 
 async fn get_market_data_providers(
     State(state): State<Arc<AppState>>,
@@ -77,21 +78,37 @@ async fn get_quote_history(
 }
 
 #[derive(serde::Deserialize)]
-struct YahooDividendsQuery {
+#[serde(rename_all = "camelCase")]
+struct DividendsQuery {
     symbol: String,
+    exchange_mic: Option<String>,
+    instrument_type: Option<String>,
+    quote_ccy: Option<String>,
+    provider_id: Option<String>,
+    start_date: Option<chrono::NaiveDate>,
+    end_date: Option<chrono::NaiveDate>,
 }
 
-async fn fetch_yahoo_dividends(
-    Query(q): Query<YahooDividendsQuery>,
-) -> ApiResult<Json<Vec<YahooDividend>>> {
-    // Addon compatibility endpoint. Keep Yahoo-specific dividend fetching out of core services.
-    let provider = YahooProvider::new()
-        .await
-        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
-    let dividends = provider
-        .fetch_dividends(&q.symbol)
-        .await
-        .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+async fn fetch_dividends(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<DividendsQuery>,
+) -> ApiResult<Json<Vec<DividendEvent>>> {
+    let inst_type = q
+        .instrument_type
+        .as_deref()
+        .and_then(InstrumentType::from_external_str);
+    let dividends = state
+        .quote_service
+        .fetch_dividends(
+            &q.symbol,
+            q.exchange_mic.as_deref(),
+            inst_type.as_ref(),
+            q.quote_ccy.as_deref(),
+            q.provider_id.as_deref(),
+            q.start_date,
+            q.end_date,
+        )
+        .await?;
     Ok(Json(dividends))
 }
 
@@ -302,7 +319,7 @@ pub fn router() -> Router<Arc<AppState>> {
         .route("/market-data/search", get(search_symbol))
         .route("/market-data/resolve-currency", get(resolve_symbol_quote))
         .route("/market-data/quotes/history", get(get_quote_history))
-        .route("/market-data/yahoo/dividends", get(fetch_yahoo_dividends))
+        .route("/market-data/dividends", get(fetch_dividends))
         .route("/market-data/quotes/latest", post(get_latest_quotes))
         .route("/market-data/quotes/{symbol}", put(update_quote))
         .route("/market-data/quotes/id/{id}", delete(delete_quote))

--- a/apps/server/src/api/market_data.rs
+++ b/apps/server/src/api/market_data.rs
@@ -14,7 +14,8 @@ use axum::{
 use wealthfolio_core::assets::InstrumentType;
 use wealthfolio_core::portfolio::{snapshot::SnapshotRecalcMode, valuation::ValuationRecalcMode};
 use wealthfolio_core::quotes::{
-    LatestQuoteSnapshot, MarketSyncMode, ProviderInfo, Quote, QuoteImport, SymbolSearchResult,
+    FetchDividendsParams, LatestQuoteSnapshot, MarketSyncMode, ProviderInfo, Quote, QuoteImport,
+    SymbolSearchResult,
 };
 use wealthfolio_market_data::{DividendEvent, ExchangeInfo};
 
@@ -99,15 +100,15 @@ async fn fetch_dividends(
         .and_then(InstrumentType::from_external_str);
     let dividends = state
         .quote_service
-        .fetch_dividends(
-            &q.symbol,
-            q.exchange_mic.as_deref(),
-            inst_type.as_ref(),
-            q.quote_ccy.as_deref(),
-            q.provider_id.as_deref(),
-            q.start_date,
-            q.end_date,
-        )
+        .fetch_dividends(FetchDividendsParams {
+            symbol: q.symbol,
+            exchange_mic: q.exchange_mic,
+            instrument_type: inst_type,
+            quote_ccy: q.quote_ccy,
+            preferred_provider: q.provider_id,
+            start: q.start_date,
+            end: q.end_date,
+        })
         .await?;
     Ok(Json(dividends))
 }

--- a/apps/tauri/gen/apple/wealthfolio-app_iOS/Info.plist
+++ b/apps/tauri/gen/apple/wealthfolio-app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.4.0</string>
+	<string>3.5.0</string>
 	<key>CFBundleVersion</key>
-	<string>3.4.0</string>
+	<string>3.5.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/apps/tauri/src/commands/market_data.rs
+++ b/apps/tauri/src/commands/market_data.rs
@@ -14,7 +14,7 @@ use wealthfolio_core::quotes::{
     service::ProviderInfo, LatestQuoteSnapshot, MarketSyncMode, Quote, QuoteImport,
     SymbolSearchResult,
 };
-use wealthfolio_market_data::ExchangeInfo;
+use wealthfolio_market_data::{DividendEvent, ExchangeInfo};
 
 #[tauri::command]
 pub async fn search_symbol(
@@ -245,18 +245,43 @@ pub fn get_exchanges() -> Vec<ExchangeInfo> {
     wealthfolio_market_data::get_exchange_list()
 }
 
-/// Fetch dividend events for a symbol from Yahoo Finance.
-/// Routes through the Rust backend to avoid CORS restrictions in the webview.
+/// Fetch dividend events for a symbol through configured market data providers.
 #[tauri::command]
-pub async fn fetch_yahoo_dividends(
+pub async fn fetch_dividends(
     symbol: String,
-) -> Result<Vec<wealthfolio_market_data::YahooDividend>, String> {
-    // Addon compatibility endpoint. Keep Yahoo-specific dividend fetching out of core services.
-    let provider = wealthfolio_market_data::YahooProvider::new()
-        .await
-        .map_err(|e| e.to_string())?;
-    provider
-        .fetch_dividends(&symbol)
+    exchange_mic: Option<String>,
+    instrument_type: Option<String>,
+    quote_ccy: Option<String>,
+    provider_id: Option<String>,
+    start_date: Option<String>,
+    end_date: Option<String>,
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<Vec<DividendEvent>, String> {
+    let inst_type = instrument_type
+        .as_deref()
+        .and_then(wealthfolio_core::assets::InstrumentType::from_external_str);
+    let start = start_date
+        .as_deref()
+        .map(|date| chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d"))
+        .transpose()
+        .map_err(|e| format!("Invalid startDate: {}", e))?;
+    let end = end_date
+        .as_deref()
+        .map(|date| chrono::NaiveDate::parse_from_str(date, "%Y-%m-%d"))
+        .transpose()
+        .map_err(|e| format!("Invalid endDate: {}", e))?;
+
+    state
+        .quote_service()
+        .fetch_dividends(
+            &symbol,
+            exchange_mic.as_deref(),
+            inst_type.as_ref(),
+            quote_ccy.as_deref(),
+            provider_id.as_deref(),
+            start,
+            end,
+        )
         .await
         .map_err(|e| e.to_string())
 }

--- a/apps/tauri/src/commands/market_data.rs
+++ b/apps/tauri/src/commands/market_data.rs
@@ -11,8 +11,8 @@ use crate::{
 use log::{debug, error, warn};
 use tauri::{AppHandle, State};
 use wealthfolio_core::quotes::{
-    service::ProviderInfo, LatestQuoteSnapshot, MarketSyncMode, Quote, QuoteImport,
-    SymbolSearchResult,
+    service::ProviderInfo, FetchDividendsParams, LatestQuoteSnapshot, MarketSyncMode, Quote,
+    QuoteImport, SymbolSearchResult,
 };
 use wealthfolio_market_data::{DividendEvent, ExchangeInfo};
 
@@ -247,6 +247,7 @@ pub fn get_exchanges() -> Vec<ExchangeInfo> {
 
 /// Fetch dividend events for a symbol through configured market data providers.
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn fetch_dividends(
     symbol: String,
     exchange_mic: Option<String>,
@@ -273,15 +274,15 @@ pub async fn fetch_dividends(
 
     state
         .quote_service()
-        .fetch_dividends(
-            &symbol,
-            exchange_mic.as_deref(),
-            inst_type.as_ref(),
-            quote_ccy.as_deref(),
-            provider_id.as_deref(),
+        .fetch_dividends(FetchDividendsParams {
+            symbol,
+            exchange_mic,
+            instrument_type: inst_type,
+            quote_ccy,
+            preferred_provider: provider_id,
             start,
             end,
-        )
+        })
         .await
         .map_err(|e| e.to_string())
 }

--- a/apps/tauri/src/lib.rs
+++ b/apps/tauri/src/lib.rs
@@ -567,7 +567,7 @@ pub fn run() {
             commands::market_data::check_quotes_import,
             commands::market_data::import_quotes_csv,
             commands::market_data::get_exchanges,
-            commands::market_data::fetch_yahoo_dividends,
+            commands::market_data::fetch_dividends,
             // Taxonomy commands
             commands::taxonomy::get_taxonomies,
             commands::taxonomy::get_taxonomy,

--- a/apps/tauri/tauri.conf.json
+++ b/apps/tauri/tauri.conf.json
@@ -32,7 +32,7 @@
   },
   "productName": "Wealthfolio",
   "mainBinaryName": "Wealthfolio",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "identifier": "com.teymz.wealthfolio",
   "plugins": {
     "updater": {

--- a/crates/core/src/quotes/client.rs
+++ b/crates/core/src/quotes/client.rs
@@ -39,8 +39,8 @@ use crate::secrets::SecretStore;
 use wealthfolio_market_data::{
     mic_to_currency, mic_to_exchange_name, yahoo_equity_provider_symbol_to_canonical,
     yahoo_exchange_to_mic, yahoo_suffix_to_mic, AlphaVantageProvider,
-    AssetProfile as MarketAssetProfile, BoerseFrankfurtProvider, BondQuoteMetadata, ExchangeMap,
-    FinnhubProvider, FixtureProvider, MarketDataAppProvider, MetalPriceApiProvider,
+    AssetProfile as MarketAssetProfile, BoerseFrankfurtProvider, BondQuoteMetadata, DividendEvent,
+    ExchangeMap, FinnhubProvider, FixtureProvider, MarketDataAppProvider, MetalPriceApiProvider,
     OpenFigiProvider, ProviderId, ProviderRegistry, Quote as MarketQuote, QuoteContext,
     ResolverChain, SearchResult as MarketSearchResult, SplitEvent, UsTreasuryCalcProvider,
     YahooProvider,
@@ -513,6 +513,22 @@ impl MarketDataClient {
             Err(_) => return vec![],
         };
         self.registry.fetch_splits(&context, start, end).await
+    }
+
+    /// Fetch cash dividend history for an asset over the given date range.
+    pub async fn fetch_dividends(
+        &self,
+        asset: &Asset,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> Result<Vec<DividendEvent>> {
+        let context = self.build_quote_context(asset)?;
+        let dividends = self
+            .registry
+            .fetch_dividends(&context, start, end)
+            .await
+            .map_err(MarketDataClientError::from)?;
+        Ok(dividends)
     }
 
     /// Fetch historical quotes for multiple assets.

--- a/crates/core/src/quotes/custom_scraper_provider.rs
+++ b/crates/core/src/quotes/custom_scraper_provider.rs
@@ -439,6 +439,7 @@ impl MarketDataProvider for CustomScraperProvider {
             supports_historical: true,
             supports_search: false,
             supports_profile: false,
+            supports_dividends: false,
         }
     }
 

--- a/crates/core/src/quotes/mod.rs
+++ b/crates/core/src/quotes/mod.rs
@@ -73,7 +73,9 @@ pub use sync::{
 };
 
 // Re-export unified service types
-pub use service::{LatestQuoteSnapshot, ProviderInfo, QuoteService, QuoteServiceTrait};
+pub use service::{
+    FetchDividendsParams, LatestQuoteSnapshot, ProviderInfo, QuoteService, QuoteServiceTrait,
+};
 
 // Re-export import types
 pub use import::{

--- a/crates/core/src/quotes/provider_settings.rs
+++ b/crates/core/src/quotes/provider_settings.rs
@@ -59,6 +59,7 @@ impl ProviderCapabilities {
                     "Historical".to_string(),
                     "Search".to_string(),
                     "Profiles".to_string(),
+                    "Dividends".to_string(),
                 ],
             }),
             "MARKETDATA_APP" => Some(Self {
@@ -74,6 +75,7 @@ impl ProviderCapabilities {
                     "Historical".to_string(),
                     "Search".to_string(),
                     "Profiles".to_string(),
+                    "Dividends".to_string(),
                 ],
             }),
             "METAL_PRICE_API" => Some(Self {
@@ -89,6 +91,7 @@ impl ProviderCapabilities {
                     "Historical".to_string(),
                     "Search".to_string(),
                     "Profiles".to_string(),
+                    "Dividends".to_string(),
                 ],
             }),
             "BOERSE_FRANKFURT" => Some(Self {

--- a/crates/core/src/quotes/service.rs
+++ b/crates/core/src/quotes/service.rs
@@ -68,6 +68,17 @@ pub struct ProviderInfo {
     pub provider_type: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+pub struct FetchDividendsParams {
+    pub symbol: String,
+    pub exchange_mic: Option<String>,
+    pub instrument_type: Option<InstrumentType>,
+    pub quote_ccy: Option<String>,
+    pub preferred_provider: Option<String>,
+    pub start: Option<NaiveDate>,
+    pub end: Option<NaiveDate>,
+}
+
 fn resolve_effective_quote_currency(asset_quote_ccy: &str, quote_ccy: &str) -> Option<String> {
     if asset_quote_ccy.is_empty() || quote_ccy.is_empty() || asset_quote_ccy == quote_ccy {
         return None;
@@ -444,16 +455,9 @@ pub trait QuoteServiceTrait: Send + Sync {
     ) -> Result<Vec<Quote>>;
 
     /// Fetch cash dividends for a single symbol.
-    async fn fetch_dividends(
-        &self,
-        symbol: &str,
-        exchange_mic: Option<&str>,
-        instrument_type: Option<&InstrumentType>,
-        quote_ccy: Option<&str>,
-        preferred_provider: Option<&str>,
-        start: Option<NaiveDate>,
-        end: Option<NaiveDate>,
-    ) -> Result<Vec<DividendEvent>>;
+    async fn fetch_dividends(&self, _params: FetchDividendsParams) -> Result<Vec<DividendEvent>> {
+        unimplemented!("fetch_dividends is not implemented for this quote service")
+    }
 
     // =========================================================================
     // Sync Operations (via QuoteSyncService)
@@ -1606,16 +1610,17 @@ where
             .await
     }
 
-    async fn fetch_dividends(
-        &self,
-        symbol: &str,
-        exchange_mic: Option<&str>,
-        instrument_type: Option<&InstrumentType>,
-        quote_ccy: Option<&str>,
-        preferred_provider: Option<&str>,
-        start: Option<NaiveDate>,
-        end: Option<NaiveDate>,
-    ) -> Result<Vec<DividendEvent>> {
+    async fn fetch_dividends(&self, params: FetchDividendsParams) -> Result<Vec<DividendEvent>> {
+        let FetchDividendsParams {
+            symbol,
+            exchange_mic,
+            instrument_type,
+            quote_ccy,
+            preferred_provider,
+            start,
+            end,
+        } = params;
+
         let end_date = end.unwrap_or_else(|| Utc::now().date_naive());
         let start_date = start.unwrap_or_else(|| end_date - Duration::days(365 * 5));
         let start_dt = Utc.from_utc_datetime(&start_date.and_hms_opt(0, 0, 0).unwrap());
@@ -1625,15 +1630,19 @@ where
             .map(|provider| serde_json::json!({ "preferred_provider": provider }));
 
         let temp_asset = Asset {
-            id: symbol.to_string(),
-            instrument_symbol: Some(symbol.to_string()),
-            display_code: Some(symbol.to_string()),
+            id: symbol.clone(),
+            instrument_symbol: Some(symbol.clone()),
+            display_code: Some(symbol),
             kind: AssetKind::Investment,
-            instrument_type: Some(instrument_type.cloned().unwrap_or(InstrumentType::Equity)),
-            instrument_exchange_mic: exchange_mic.map(str::to_string),
+            instrument_type: Some(instrument_type.unwrap_or(InstrumentType::Equity)),
+            instrument_exchange_mic: exchange_mic.clone(),
             quote_ccy: quote_ccy
-                .map(str::to_string)
-                .or_else(|| exchange_mic.and_then(mic_to_currency).map(str::to_string))
+                .or_else(|| {
+                    exchange_mic
+                        .as_deref()
+                        .and_then(mic_to_currency)
+                        .map(str::to_string)
+                })
                 .unwrap_or_else(|| "USD".to_string()),
             quote_mode: QuoteMode::Market,
             provider_config,

--- a/crates/core/src/quotes/service.rs
+++ b/crates/core/src/quotes/service.rs
@@ -36,8 +36,8 @@ use crate::portfolio::snapshot::is_quantity_significant;
 use crate::secrets::SecretStore;
 
 use wealthfolio_market_data::{
-    exchanges_for_currency, mic_to_exchange_name, yahoo_equity_provider_symbol_to_canonical,
-    ExchangeMap,
+    exchanges_for_currency, mic_to_currency, mic_to_exchange_name,
+    yahoo_equity_provider_symbol_to_canonical, DividendEvent, ExchangeMap,
 };
 
 /// Provider information combining static info with settings.
@@ -442,6 +442,18 @@ pub trait QuoteServiceTrait: Send + Sync {
         start: NaiveDate,
         end: NaiveDate,
     ) -> Result<Vec<Quote>>;
+
+    /// Fetch cash dividends for a single symbol.
+    async fn fetch_dividends(
+        &self,
+        symbol: &str,
+        exchange_mic: Option<&str>,
+        instrument_type: Option<&InstrumentType>,
+        quote_ccy: Option<&str>,
+        preferred_provider: Option<&str>,
+        start: Option<NaiveDate>,
+        end: Option<NaiveDate>,
+    ) -> Result<Vec<DividendEvent>>;
 
     // =========================================================================
     // Sync Operations (via QuoteSyncService)
@@ -1591,6 +1603,47 @@ where
             .read()
             .await
             .fetch_historical_quotes(&temp_asset, start_dt, end_dt)
+            .await
+    }
+
+    async fn fetch_dividends(
+        &self,
+        symbol: &str,
+        exchange_mic: Option<&str>,
+        instrument_type: Option<&InstrumentType>,
+        quote_ccy: Option<&str>,
+        preferred_provider: Option<&str>,
+        start: Option<NaiveDate>,
+        end: Option<NaiveDate>,
+    ) -> Result<Vec<DividendEvent>> {
+        let end_date = end.unwrap_or_else(|| Utc::now().date_naive());
+        let start_date = start.unwrap_or_else(|| end_date - Duration::days(365 * 5));
+        let start_dt = Utc.from_utc_datetime(&start_date.and_hms_opt(0, 0, 0).unwrap());
+        let end_dt = Utc.from_utc_datetime(&end_date.and_hms_opt(23, 59, 59).unwrap());
+
+        let provider_config = preferred_provider
+            .map(|provider| serde_json::json!({ "preferred_provider": provider }));
+
+        let temp_asset = Asset {
+            id: symbol.to_string(),
+            instrument_symbol: Some(symbol.to_string()),
+            display_code: Some(symbol.to_string()),
+            kind: AssetKind::Investment,
+            instrument_type: Some(instrument_type.cloned().unwrap_or(InstrumentType::Equity)),
+            instrument_exchange_mic: exchange_mic.map(str::to_string),
+            quote_ccy: quote_ccy
+                .map(str::to_string)
+                .or_else(|| exchange_mic.and_then(mic_to_currency).map(str::to_string))
+                .unwrap_or_else(|| "USD".to_string()),
+            quote_mode: QuoteMode::Market,
+            provider_config,
+            ..Default::default()
+        };
+
+        self.client
+            .read()
+            .await
+            .fetch_dividends(&temp_asset, start_dt, end_dt)
             .await
     }
 

--- a/crates/market-data/src/lib.rs
+++ b/crates/market-data/src/lib.rs
@@ -63,9 +63,9 @@ pub mod resolver;
 
 // Re-export all public types from models
 pub use models::{
-    AssetKind, AssetProfile, BondQuoteMetadata, Coverage, Currency, InstrumentId, InstrumentKind,
-    Mic, ProviderId, ProviderInstrument, ProviderOverrides, ProviderSymbol, Quote, QuoteContext,
-    SearchResult, SplitEvent,
+    AssetKind, AssetProfile, BondQuoteMetadata, Coverage, Currency, DividendEvent, InstrumentId,
+    InstrumentKind, Mic, ProviderId, ProviderInstrument, ProviderOverrides, ProviderSymbol, Quote,
+    QuoteContext, SearchResult, SplitEvent,
 };
 
 // Re-export resolver types
@@ -86,7 +86,7 @@ pub use provider::marketdata_app::MarketDataAppProvider;
 pub use provider::metal_price_api::MetalPriceApiProvider;
 pub use provider::openfigi::OpenFigiProvider;
 pub use provider::us_treasury_calc::{TreasuryBondDetails, UsTreasuryCalcProvider};
-pub use provider::yahoo::{YahooDividend, YahooProvider};
+pub use provider::yahoo::YahooProvider;
 pub use provider::{MarketDataProvider, ProviderCapabilities, RateLimit};
 
 // Re-export registry types

--- a/crates/market-data/src/models/dividend.rs
+++ b/crates/market-data/src/models/dividend.rs
@@ -1,0 +1,8 @@
+//! Dividend event data returned by market data providers.
+
+/// A cash dividend event from a market data provider.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DividendEvent {
+    pub amount: f64,
+    pub date: i64, // unix seconds
+}

--- a/crates/market-data/src/models/mod.rs
+++ b/crates/market-data/src/models/mod.rs
@@ -8,8 +8,10 @@
 //! - `profile` - Asset profile data (AssetProfile)
 //! - `coverage` - Provider market coverage restrictions (Coverage)
 //! - `search` - Search result data (SearchResult)
+//! - `dividend` - Dividend event data (DividendEvent)
 
 mod coverage;
+mod dividend;
 mod instrument;
 mod profile;
 mod provider_params;
@@ -18,6 +20,7 @@ mod search;
 mod types;
 
 pub use coverage::Coverage;
+pub use dividend::DividendEvent;
 pub use instrument::{AssetKind, InstrumentId, InstrumentKind};
 pub use profile::AssetProfile;
 pub use provider_params::{ProviderInstrument, ProviderOverrides};

--- a/crates/market-data/src/provider/alpha_vantage/mod.rs
+++ b/crates/market-data/src/provider/alpha_vantage/mod.rs
@@ -22,8 +22,8 @@ use std::time::Duration;
 
 use crate::errors::MarketDataError;
 use crate::models::{
-    AssetProfile, Coverage, InstrumentId, InstrumentKind, ProviderInstrument, Quote, QuoteContext,
-    SearchResult,
+    AssetProfile, Coverage, DividendEvent, InstrumentId, InstrumentKind, ProviderInstrument, Quote,
+    QuoteContext, SearchResult,
 };
 use crate::provider::{MarketDataProvider, ProviderCapabilities, RateLimit};
 use crate::resolver::ResolverChain;
@@ -223,6 +223,24 @@ struct SymbolSearchResponse {
     note: Option<String>,
     #[serde(rename = "Information")]
     information: Option<String>,
+}
+
+/// DIVIDENDS response for equity cash dividends.
+#[derive(Debug, Deserialize)]
+struct DividendsResponse {
+    data: Option<Vec<AlphaDividend>>,
+    #[serde(rename = "Error Message")]
+    error_message: Option<String>,
+    #[serde(rename = "Note")]
+    note: Option<String>,
+    #[serde(rename = "Information")]
+    information: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AlphaDividend {
+    ex_dividend_date: String,
+    amount: String,
 }
 
 /// Individual match from SYMBOL_SEARCH
@@ -893,6 +911,49 @@ impl AlphaVantageProvider {
             .collect()
     }
 
+    /// Fetch cash dividends using DIVIDENDS endpoint.
+    async fn fetch_dividends(
+        &self,
+        symbol: &str,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> Result<Vec<DividendEvent>, MarketDataError> {
+        let params = [("function", "DIVIDENDS"), ("symbol", symbol)];
+
+        let text = self.fetch(&params).await?;
+        let response: DividendsResponse =
+            serde_json::from_str(&text).map_err(|e| MarketDataError::ProviderError {
+                provider: PROVIDER_ID.to_string(),
+                message: format!("Failed to parse dividends response: {}", e),
+            })?;
+
+        Self::check_api_error(
+            &response.error_message,
+            &response.note,
+            &response.information,
+        )?;
+
+        let mut dividends: Vec<DividendEvent> = response
+            .data
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|d| {
+                let timestamp = Self::parse_date(&d.ex_dividend_date)?;
+                if timestamp < start || timestamp > end {
+                    return None;
+                }
+                let amount = d.amount.parse::<f64>().ok()?;
+                Some(DividendEvent {
+                    amount,
+                    date: timestamp.timestamp(),
+                })
+            })
+            .collect();
+
+        dividends.sort_by_key(|d| d.date);
+        Ok(dividends)
+    }
+
     /// Fetch company overview using OVERVIEW endpoint.
     async fn fetch_company_overview(&self, symbol: &str) -> Result<AssetProfile, MarketDataError> {
         let params = [("function", "OVERVIEW"), ("symbol", symbol)];
@@ -1046,6 +1107,7 @@ impl MarketDataProvider for AlphaVantageProvider {
             supports_historical: true,
             supports_search: true,  // Via SYMBOL_SEARCH endpoint
             supports_profile: true, // Via OVERVIEW endpoint for equities
+            supports_dividends: true,
         }
     }
 
@@ -1197,6 +1259,26 @@ impl MarketDataProvider for AlphaVantageProvider {
         Ok(filtered)
     }
 
+    async fn get_dividends(
+        &self,
+        _context: &QuoteContext,
+        instrument: ProviderInstrument,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> Result<Vec<DividendEvent>, MarketDataError> {
+        let symbol = match instrument {
+            ProviderInstrument::EquitySymbol { symbol } => symbol.to_string(),
+            _ => {
+                return Err(MarketDataError::NotSupported {
+                    operation: "dividends".to_string(),
+                    provider: PROVIDER_ID.to_string(),
+                });
+            }
+        };
+
+        self.fetch_dividends(&symbol, start, end).await
+    }
+
     async fn get_profile(&self, symbol: &str) -> Result<AssetProfile, MarketDataError> {
         debug!("Fetching profile for {} from Alpha Vantage", symbol);
 
@@ -1313,6 +1395,7 @@ mod tests {
         assert!(caps.supports_historical);
         assert!(caps.supports_search); // Via SYMBOL_SEARCH endpoint
         assert!(caps.supports_profile); // Via OVERVIEW endpoint
+        assert!(caps.supports_dividends);
     }
 
     #[test]

--- a/crates/market-data/src/provider/boerse_frankfurt/mod.rs
+++ b/crates/market-data/src/provider/boerse_frankfurt/mod.rs
@@ -304,6 +304,7 @@ impl MarketDataProvider for BoerseFrankfurtProvider {
             supports_historical: true,
             supports_search: false,
             supports_profile: true,
+            supports_dividends: false,
         }
     }
 

--- a/crates/market-data/src/provider/capabilities.rs
+++ b/crates/market-data/src/provider/capabilities.rs
@@ -30,6 +30,9 @@ pub struct ProviderCapabilities {
 
     /// Whether the provider supports fetching asset profiles.
     pub supports_profile: bool,
+
+    /// Whether the provider supports fetching cash dividend events.
+    pub supports_dividends: bool,
 }
 
 impl ProviderCapabilities {
@@ -88,6 +91,7 @@ mod tests {
             supports_historical: true,
             supports_search: false,
             supports_profile: false,
+            supports_dividends: false,
         };
 
         let crypto = InstrumentId::Crypto {
@@ -106,6 +110,7 @@ mod tests {
             supports_historical: true,
             supports_search: false,
             supports_profile: false,
+            supports_dividends: false,
         };
 
         // US equity should be supported
@@ -133,6 +138,7 @@ mod tests {
             supports_historical: true,
             supports_search: false,
             supports_profile: false,
+            supports_dividends: false,
         };
 
         let unknown_mic = InstrumentId::Equity {
@@ -149,6 +155,7 @@ mod tests {
             supports_historical: true,
             supports_search: false,
             supports_profile: false,
+            supports_dividends: false,
         };
         assert!(best_effort_caps.supports_instrument(&unknown_mic));
     }

--- a/crates/market-data/src/provider/finnhub/mod.rs
+++ b/crates/market-data/src/provider/finnhub/mod.rs
@@ -20,7 +20,8 @@ use serde::Deserialize;
 
 use crate::errors::MarketDataError;
 use crate::models::{
-    AssetProfile, Coverage, InstrumentKind, ProviderInstrument, Quote, QuoteContext, SearchResult,
+    AssetProfile, Coverage, DividendEvent, InstrumentKind, ProviderInstrument, Quote, QuoteContext,
+    SearchResult,
 };
 use crate::provider::{MarketDataProvider, ProviderCapabilities, RateLimit};
 use crate::resolver::yahoo_suffix_to_mic;
@@ -96,6 +97,20 @@ struct SearchItem {
     /// Security type (e.g., "Common Stock", "ETF")
     #[serde(rename = "type")]
     security_type: String,
+}
+
+/// Response from /stock/dividend2 endpoint.
+#[derive(Debug, Deserialize)]
+struct DividendsResponse {
+    #[serde(default)]
+    data: Vec<FinnhubDividend>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FinnhubDividend {
+    amount: f64,
+    ex_date: String,
 }
 
 /// Response from /stock/profile2 endpoint
@@ -448,6 +463,42 @@ impl FinnhubProvider {
         Ok(quotes)
     }
 
+    /// Fetch cash dividends from /stock/dividend2 endpoint.
+    async fn fetch_dividends(
+        &self,
+        symbol: &str,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> Result<Vec<DividendEvent>, MarketDataError> {
+        let params = [("symbol", symbol)];
+        let text = self.fetch("/stock/dividend2", &params).await?;
+
+        let response: DividendsResponse =
+            serde_json::from_str(&text).map_err(|e| MarketDataError::ProviderError {
+                provider: PROVIDER_ID.to_string(),
+                message: format!("Failed to parse dividends response: {}", e),
+            })?;
+
+        let mut dividends: Vec<DividendEvent> = response
+            .data
+            .into_iter()
+            .filter_map(|d| {
+                let date = chrono::NaiveDate::parse_from_str(&d.ex_date, "%Y-%m-%d").ok()?;
+                let timestamp = Utc.from_utc_datetime(&date.and_hms_opt(0, 0, 0)?);
+                if timestamp < start || timestamp > end {
+                    return None;
+                }
+                Some(DividendEvent {
+                    amount: d.amount,
+                    date: timestamp.timestamp(),
+                })
+            })
+            .collect();
+
+        dividends.sort_by_key(|d| d.date);
+        Ok(dividends)
+    }
+
     /// Fetch company profile from /stock/profile2 endpoint.
     async fn fetch_profile(&self, symbol: &str) -> Result<AssetProfile, MarketDataError> {
         let params = [("symbol", symbol)];
@@ -562,6 +613,7 @@ impl MarketDataProvider for FinnhubProvider {
             supports_historical: true,
             supports_search: true,
             supports_profile: true,
+            supports_dividends: true,
         }
     }
 
@@ -612,6 +664,26 @@ impl MarketDataProvider for FinnhubProvider {
         }
 
         Ok(quotes)
+    }
+
+    async fn get_dividends(
+        &self,
+        _context: &QuoteContext,
+        instrument: ProviderInstrument,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> Result<Vec<DividendEvent>, MarketDataError> {
+        let symbol = match instrument {
+            ProviderInstrument::EquitySymbol { symbol } => symbol.to_string(),
+            _ => {
+                return Err(MarketDataError::NotSupported {
+                    operation: "dividends".to_string(),
+                    provider: PROVIDER_ID.to_string(),
+                });
+            }
+        };
+
+        self.fetch_dividends(&symbol, start, end).await
     }
 
     async fn search(&self, query: &str) -> Result<Vec<SearchResult>, MarketDataError> {
@@ -695,6 +767,7 @@ mod tests {
         assert!(caps.supports_historical);
         assert!(caps.supports_search);
         assert!(caps.supports_profile);
+        assert!(caps.supports_dividends);
     }
 
     #[test]

--- a/crates/market-data/src/provider/fixture/mod.rs
+++ b/crates/market-data/src/provider/fixture/mod.rs
@@ -519,6 +519,7 @@ impl MarketDataProvider for FixtureProvider {
                 supports_historical: true,
                 supports_search: false,
                 supports_profile: true,
+                supports_dividends: false,
             };
         }
 
@@ -535,6 +536,7 @@ impl MarketDataProvider for FixtureProvider {
             supports_historical: true,
             supports_search: true,
             supports_profile: true,
+            supports_dividends: false,
         }
     }
 

--- a/crates/market-data/src/provider/marketdata_app/mod.rs
+++ b/crates/market-data/src/provider/marketdata_app/mod.rs
@@ -173,6 +173,7 @@ impl MarketDataProvider for MarketDataAppProvider {
             supports_historical: true,
             supports_search: false,
             supports_profile: false,
+            supports_dividends: false,
         }
     }
 

--- a/crates/market-data/src/provider/metal_price_api/mod.rs
+++ b/crates/market-data/src/provider/metal_price_api/mod.rs
@@ -161,6 +161,7 @@ impl MarketDataProvider for MetalPriceApiProvider {
             supports_historical: true,
             supports_search: false,
             supports_profile: false,
+            supports_dividends: false,
         }
     }
 

--- a/crates/market-data/src/provider/openfigi/mod.rs
+++ b/crates/market-data/src/provider/openfigi/mod.rs
@@ -259,6 +259,7 @@ impl MarketDataProvider for OpenFigiProvider {
             supports_historical: false,
             supports_search: true,
             supports_profile: true,
+            supports_dividends: false,
         }
     }
 

--- a/crates/market-data/src/provider/traits.rs
+++ b/crates/market-data/src/provider/traits.rs
@@ -8,7 +8,7 @@ use chrono::{DateTime, Utc};
 
 use crate::errors::MarketDataError;
 use crate::models::{
-    AssetProfile, ProviderInstrument, Quote, QuoteContext, SearchResult, SplitEvent,
+    AssetProfile, DividendEvent, ProviderInstrument, Quote, QuoteContext, SearchResult, SplitEvent,
 };
 
 use super::capabilities::{ProviderCapabilities, RateLimit};
@@ -168,6 +168,24 @@ pub trait MarketDataProvider: Send + Sync {
         let _ = (context, instrument, start, end);
         Err(MarketDataError::NotSupported {
             operation: "splits".to_string(),
+            provider: self.id().to_string(),
+        })
+    }
+
+    /// Fetch cash dividend history for an instrument.
+    ///
+    /// A vector of dividend events, or `NotSupported` if the provider doesn't support dividends.
+    /// Default implementation returns `NotSupported`.
+    async fn get_dividends(
+        &self,
+        context: &QuoteContext,
+        instrument: ProviderInstrument,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> Result<Vec<DividendEvent>, MarketDataError> {
+        let _ = (context, instrument, start, end);
+        Err(MarketDataError::NotSupported {
+            operation: "dividends".to_string(),
             provider: self.id().to_string(),
         })
     }

--- a/crates/market-data/src/provider/us_treasury_calc/mod.rs
+++ b/crates/market-data/src/provider/us_treasury_calc/mod.rs
@@ -377,6 +377,7 @@ impl MarketDataProvider for UsTreasuryCalcProvider {
             supports_historical: true,
             supports_search: false,
             supports_profile: false,
+            supports_dividends: false,
         }
     }
 

--- a/crates/market-data/src/provider/yahoo/mod.rs
+++ b/crates/market-data/src/provider/yahoo/mod.rs
@@ -25,8 +25,8 @@ use yahoo_finance_api as yahoo;
 
 use crate::errors::MarketDataError;
 use crate::models::{
-    AssetProfile, Coverage, InstrumentKind, ProviderInstrument, Quote, QuoteContext, SearchResult,
-    SplitEvent,
+    AssetProfile, Coverage, DividendEvent, InstrumentKind, ProviderInstrument, Quote, QuoteContext,
+    SearchResult, SplitEvent,
 };
 use crate::provider::{MarketDataProvider, ProviderCapabilities, RateLimit};
 use crate::resolver::{yahoo_equity_search_queries, yahoo_exchange_to_mic, ResolverChain};
@@ -80,13 +80,6 @@ lazy_static! {
 /// and foreign exchange rates through the Yahoo Finance API.
 pub struct YahooProvider {
     connector: yahoo::YahooConnector,
-}
-
-/// A single dividend event returned by Yahoo Finance.
-#[derive(Debug, serde::Serialize)]
-pub struct YahooDividend {
-    pub amount: f64,
-    pub date: i64, // unix seconds
 }
 
 impl YahooProvider {
@@ -233,23 +226,23 @@ impl YahooProvider {
     // Dividend Fetching
     // ========================================================================
 
-    /// Fetch dividend events for a symbol over the past two years.
+    /// Fetch dividend events for a symbol in the requested date range.
     pub async fn fetch_dividends(
         &self,
         symbol: &str,
-    ) -> Result<Vec<YahooDividend>, MarketDataError> {
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> Result<Vec<DividendEvent>, MarketDataError> {
         use std::collections::HashMap;
 
         let crumb_data = self.ensure_crumb().await?;
 
-        let now = chrono::Utc::now().timestamp();
-        let two_years_ago = now - 2 * 365 * 24 * 60 * 60;
         let encoded = urlencoding::encode(symbol);
         let url = format!(
             "https://query1.finance.yahoo.com/v8/finance/chart/{}?interval=1d&period1={}&period2={}&events=div&crumb={}",
             encoded,
-            two_years_ago,
-            now,
+            start.timestamp(),
+            end.timestamp(),
             urlencoding::encode(&crumb_data.crumb)
         );
 
@@ -358,9 +351,9 @@ impl YahooProvider {
             .and_then(|e| e.dividends)
             .unwrap_or_default();
 
-        let mut result: Vec<YahooDividend> = divs
+        let mut result: Vec<DividendEvent> = divs
             .into_values()
-            .map(|d| YahooDividend {
+            .map(|d| DividendEvent {
                 amount: d.amount,
                 date: d.date,
             })
@@ -918,6 +911,7 @@ impl MarketDataProvider for YahooProvider {
             supports_historical: true,
             supports_search: true,
             supports_profile: true,
+            supports_dividends: true,
         }
     }
 
@@ -1069,6 +1063,26 @@ impl MarketDataProvider for YahooProvider {
             .collect();
 
         Ok(events)
+    }
+
+    async fn get_dividends(
+        &self,
+        _context: &QuoteContext,
+        instrument: ProviderInstrument,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> Result<Vec<DividendEvent>, MarketDataError> {
+        let symbol = match instrument {
+            ProviderInstrument::EquitySymbol { symbol } => symbol.to_string(),
+            _ => {
+                return Err(MarketDataError::NotSupported {
+                    operation: "dividends".to_string(),
+                    provider: self.id().to_string(),
+                });
+            }
+        };
+
+        self.fetch_dividends(&symbol, start, end).await
     }
 
     async fn search(&self, query: &str) -> Result<Vec<SearchResult>, MarketDataError> {
@@ -1380,6 +1394,7 @@ mod tests {
             supports_historical: true,
             supports_search: true,
             supports_profile: true,
+            supports_dividends: true,
         };
 
         assert!(capabilities
@@ -1399,6 +1414,7 @@ mod tests {
         assert!(capabilities.supports_historical);
         assert!(capabilities.supports_search);
         assert!(capabilities.supports_profile);
+        assert!(capabilities.supports_dividends);
     }
 
     #[test]

--- a/crates/market-data/src/registry/provider_registry.rs
+++ b/crates/market-data/src/registry/provider_registry.rs
@@ -19,7 +19,8 @@ use super::{
 };
 use crate::errors::{MarketDataError, RetryClass};
 use crate::models::{
-    AssetProfile, InstrumentId, ProviderId, Quote, QuoteContext, SearchResult, SplitEvent,
+    AssetProfile, DividendEvent, InstrumentId, ProviderId, Quote, QuoteContext, SearchResult,
+    SplitEvent,
 };
 use crate::provider::MarketDataProvider;
 use crate::resolver::SymbolResolver;
@@ -352,6 +353,85 @@ impl ProviderRegistry {
         }
 
         vec![]
+    }
+
+    /// Fetch cash dividend history for an instrument.
+    ///
+    /// Tries dividend-capable providers in order, using provider fallback semantics
+    /// similar to quote fetching.
+    pub async fn fetch_dividends(
+        &self,
+        context: &QuoteContext,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+    ) -> Result<Vec<DividendEvent>, MarketDataError> {
+        let mut providers: Vec<_> = self
+            .providers
+            .iter()
+            .filter(|p| {
+                let caps = p.capabilities();
+                caps.supports_dividends && caps.supports_instrument(&context.instrument)
+            })
+            .collect();
+
+        self.sort_by_preference(&mut providers, context);
+
+        if providers.is_empty() {
+            return Err(MarketDataError::NoProvidersAvailable);
+        }
+
+        let mut last_error: Option<MarketDataError> = None;
+
+        for provider in providers {
+            let provider_id: ProviderId = Cow::Borrowed(provider.id());
+
+            if !self.circuit_breaker.is_allowed(&provider_id) {
+                continue;
+            }
+
+            let resolved = match self.resolver.resolve(&provider_id, context) {
+                Ok(r) => r,
+                Err(e) => {
+                    debug!(
+                        "Dividend resolution failed for provider '{}': {:?}",
+                        provider_id, e
+                    );
+                    continue;
+                }
+            };
+
+            self.rate_limiter.acquire(&provider_id).await;
+
+            match provider
+                .get_dividends(context, resolved.instrument, start, end)
+                .await
+            {
+                Ok(mut dividends) => {
+                    self.circuit_breaker.record_success(&provider_id);
+                    dividends.sort_by_key(|d| d.date);
+                    return Ok(dividends);
+                }
+                Err(MarketDataError::NotSupported { .. }) => continue,
+                Err(e) => {
+                    let retry_class = e.retry_class();
+
+                    if retry_class == RetryClass::Never {
+                        return Err(e);
+                    }
+
+                    if matches!(
+                        retry_class,
+                        RetryClass::FailoverWithPenalty | RetryClass::CircuitOpen
+                    ) {
+                        self.circuit_breaker.record_failure(&provider_id);
+                    }
+
+                    last_error = Some(e);
+                }
+            }
+        }
+
+        Err(last_error.unwrap_or(MarketDataError::AllProvidersFailed))
     }
 
     /// Get providers ordered by preference for the given context.
@@ -918,6 +998,7 @@ mod tests {
                 supports_historical: true,
                 supports_search: false,
                 supports_profile: false,
+                supports_dividends: false,
             }
         }
 
@@ -1088,6 +1169,7 @@ mod tests {
                     supports_historical: true,
                     supports_search: false,
                     supports_profile: false,
+                    supports_dividends: false,
                 }
             }
             fn rate_limit(&self) -> RateLimit {
@@ -1175,6 +1257,7 @@ mod tests {
                     supports_historical: true,
                     supports_search: false,
                     supports_profile: false,
+                    supports_dividends: false,
                 }
             }
             fn rate_limit(&self) -> RateLimit {
@@ -1347,6 +1430,7 @@ mod tests {
                     supports_historical: false,
                     supports_search: false,
                     supports_profile: true,
+                    supports_dividends: false,
                 }
             }
 
@@ -1412,5 +1496,131 @@ mod tests {
         assert_eq!(profile.name.as_deref(), Some("GLOBAL_PROFILE"));
         assert_eq!(us_calls.load(Ordering::SeqCst), 0);
         assert_eq!(global_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_fetch_dividends_falls_back_and_sorts() {
+        struct DividendProvider {
+            id: &'static str,
+            priority: u8,
+            call_count: Arc<AtomicUsize>,
+            should_fail: bool,
+        }
+
+        #[async_trait::async_trait]
+        impl MarketDataProvider for DividendProvider {
+            fn id(&self) -> &'static str {
+                self.id
+            }
+
+            fn priority(&self) -> u8 {
+                self.priority
+            }
+
+            fn capabilities(&self) -> ProviderCapabilities {
+                ProviderCapabilities {
+                    instrument_kinds: &[InstrumentKind::Equity],
+                    coverage: Coverage::global_best_effort(),
+                    supports_latest: false,
+                    supports_historical: false,
+                    supports_search: false,
+                    supports_profile: false,
+                    supports_dividends: true,
+                }
+            }
+
+            fn rate_limit(&self) -> RateLimit {
+                RateLimit::default()
+            }
+
+            async fn get_latest_quote(
+                &self,
+                _: &QuoteContext,
+                _: ProviderInstrument,
+            ) -> Result<Quote, MarketDataError> {
+                unreachable!()
+            }
+
+            async fn get_historical_quotes(
+                &self,
+                _: &QuoteContext,
+                _: ProviderInstrument,
+                _: DateTime<Utc>,
+                _: DateTime<Utc>,
+            ) -> Result<Vec<Quote>, MarketDataError> {
+                unreachable!()
+            }
+
+            async fn get_dividends(
+                &self,
+                _: &QuoteContext,
+                _: ProviderInstrument,
+                _: DateTime<Utc>,
+                _: DateTime<Utc>,
+            ) -> Result<Vec<DividendEvent>, MarketDataError> {
+                self.call_count.fetch_add(1, Ordering::SeqCst);
+
+                if self.should_fail {
+                    return Err(MarketDataError::ProviderError {
+                        provider: self.id.to_string(),
+                        message: "Mock failure".to_string(),
+                    });
+                }
+
+                Ok(vec![
+                    DividendEvent {
+                        amount: 0.3,
+                        date: 2,
+                    },
+                    DividendEvent {
+                        amount: 0.2,
+                        date: 1,
+                    },
+                ])
+            }
+        }
+
+        let first_calls = Arc::new(AtomicUsize::new(0));
+        let fallback_calls = Arc::new(AtomicUsize::new(0));
+        let providers: Vec<Arc<dyn MarketDataProvider>> = vec![
+            Arc::new(DividendProvider {
+                id: "FIRST",
+                priority: 5,
+                call_count: first_calls.clone(),
+                should_fail: true,
+            }),
+            Arc::new(DividendProvider {
+                id: "FALLBACK",
+                priority: 10,
+                call_count: fallback_calls.clone(),
+                should_fail: false,
+            }),
+        ];
+
+        let resolver = Arc::new(MockResolver);
+        let registry = ProviderRegistry::new(providers, resolver);
+        let context = QuoteContext {
+            instrument: InstrumentId::Equity {
+                ticker: Arc::from("TEST"),
+                mic: Some(Cow::Borrowed("XNAS")),
+            },
+            overrides: None,
+            currency_hint: None,
+            preferred_provider: None,
+            bond_metadata: None,
+            custom_provider_code: None,
+        };
+
+        let dividends = registry
+            .fetch_dividends(&context, Utc::now(), Utc::now())
+            .await
+            .unwrap();
+
+        assert_eq!(first_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(fallback_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            dividends.iter().map(|d| d.date).collect::<Vec<_>>(),
+            vec![1, 2]
+        );
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wealthfolio-app",
   "private": true,
-  "version": "3.4.0",
+  "version": "3.5.0",
   "packageManager": "pnpm@10.33.4",
   "type": "module",
   "workspaces": [

--- a/packages/addon-dev-tools/package.json
+++ b/packages/addon-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/addon-dev-tools",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Development tools for Wealthfolio addons - hot reload server and CLI",
   "main": "index.js",
   "bin": {

--- a/packages/addon-sdk/package.json
+++ b/packages/addon-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/addon-sdk",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "type": "module",
   "description": "TypeScript SDK for building Wealthfolio addons with enhanced functionality and type safety",
   "main": "dist/index.js",

--- a/packages/addon-sdk/src/host-api.ts
+++ b/packages/addon-sdk/src/host-api.ts
@@ -207,11 +207,20 @@ export interface ActivitiesAPI {
 }
 
 /**
- * A single dividend event returned by Yahoo Finance.
+ * A cash dividend event returned by a market data provider.
  */
-export interface YahooDividend {
+export interface DividendEvent {
   amount: number;
   date: number; // unix seconds
+}
+
+export interface FetchDividendsOptions {
+  exchangeMic?: string;
+  instrumentType?: string;
+  quoteCcy?: string;
+  providerId?: string;
+  startDate?: string;
+  endDate?: string;
 }
 
 /**
@@ -251,11 +260,11 @@ export interface MarketDataAPI {
   getProviders(): Promise<MarketDataProviderInfo[]>;
 
   /**
-   * Fetch dividend history for a symbol from Yahoo Finance.
+   * Fetch dividend history for a symbol.
    * @param symbol Ticker symbol
    * @returns Promise resolving to array of dividend events
    */
-  fetchDividends(symbol: string): Promise<YahooDividend[]>;
+  fetchDividends(symbol: string, options?: FetchDividendsOptions): Promise<DividendEvent[]>;
 }
 
 /**

--- a/packages/addon-sdk/src/host-api.ts
+++ b/packages/addon-sdk/src/host-api.ts
@@ -264,7 +264,10 @@ export interface MarketDataAPI {
    * @param symbol Ticker symbol
    * @returns Promise resolving to array of dividend events
    */
-  fetchDividends(symbol: string, options?: FetchDividendsOptions): Promise<DividendEvent[]>;
+  fetchDividends(
+    symbol: string,
+    options?: FetchDividendsOptions,
+  ): Promise<DividendEvent[]>;
 }
 
 /**

--- a/packages/addon-sdk/src/index.ts
+++ b/packages/addon-sdk/src/index.ts
@@ -29,7 +29,8 @@ export type {
   HostAPI,
   SnapshotsAPI,
   ToastAPI,
-  YahooDividend,
+  DividendEvent,
+  FetchDividendsOptions,
 } from './host-api';
 
 // Query Client and Keys exports

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/ui",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "type": "module",
   "description": "Wealthfolio UI components based on shadcn/ui and Tailwind CSS",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Rename Yahoo-specific dividend APIs to provider-neutral `fetch_dividends` / `fetchDividends` / `DividendEvent`.
- Add dividend capability metadata and registry fallback support in `wealthfolio-market-data`.
- Implement dividend fetching for Yahoo, Alpha Vantage, and Finnhub.
- Surface dividend support in market data provider settings and update addon SDK types.
- Bump Wealthfolio package/app/crate versions to `3.5.0`.

## Notes

This supersedes #947 by moving dividend fetching out of the Yahoo-only path and into the provider registry.

This intentionally updates the addon SDK naming with no backwards-compatibility alias: `YahooDividend` is now `DividendEvent`, and the host method remains `fetchDividends` with provider-neutral options.

The default dividend lookback changed from the old Yahoo-only two-year window to five years when callers omit `startDate` / `endDate`.

Dividend fetching remains symbol-by-symbol. The currently supported provider endpoints for dividends are symbol-based; bulk market-data endpoints found are for quotes/candles, not dividend history.

## Validation

- `cargo fmt --all`
- `cargo check -p wealthfolio-market-data -p wealthfolio-core -p wealthfolio-server -p wealthfolio-app`
- `cargo test -p wealthfolio-market-data`
- `pnpm --filter @wealthfolio/addon-sdk type-check`
- `pnpm --filter @wealthfolio/addon-sdk build:types`
- `pnpm --filter frontend lint -- src/adapters/shared/market-data.ts src/adapters/web/core.ts src/addons/addons-runtime-context.ts src/addons/type-bridge.ts`
- `git diff --check`

Known unrelated caveat: `pnpm --filter frontend type-check` still fails on existing spending/icon errors outside this change set.