### PR TITLE
Invalidate holdings/portfolio caches on account mutations

### DIFF
--- a/apps/frontend/src/lib/query-invalidation.ts
+++ b/apps/frontend/src/lib/query-invalidation.ts
@@ -1,0 +1,33 @@
+import { QueryKeys } from "@/lib/query-keys";
+
+// Cloud/network-backed queries that should NOT be refetched on a portfolio change.
+const CLOUD_SYNC_INVALIDATION_EXCLUSIONS = new Set<string>([
+  QueryKeys.BROKER_CONNECTIONS,
+  QueryKeys.BROKER_ACCOUNTS,
+  QueryKeys.BROKER_SYNC_STATES,
+  QueryKeys.IMPORT_RUNS,
+  QueryKeys.USER_INFO,
+  QueryKeys.SUBSCRIPTION_PLANS,
+  QueryKeys.SUBSCRIPTION_PLANS_PUBLIC,
+  QueryKeys.SYNCED_ACCOUNTS,
+  QueryKeys.PLATFORMS,
+]);
+
+/**
+ * Predicate for invalidating caches after a portfolio change (recalc, or
+ * including/excluding an account). Invalidates everything except cloud/broker/
+ * subscription queries that have their own lifecycle.
+ */
+export function shouldInvalidateAfterPortfolioUpdate(queryKey: readonly unknown[]): boolean {
+  const rootKey = queryKey[0];
+
+  if (typeof rootKey === "string" && CLOUD_SYNC_INVALIDATION_EXCLUSIONS.has(rootKey)) {
+    return false;
+  }
+
+  if (rootKey === "sync") {
+    return false;
+  }
+
+  return true;
+}

--- a/apps/frontend/src/pages/settings/accounts/components/use-account-mutations.ts
+++ b/apps/frontend/src/pages/settings/accounts/components/use-account-mutations.ts
@@ -1,8 +1,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "@wealthfolio/ui/components/ui/use-toast";
 import { createAccount, updateAccount, deleteAccount, logger } from "@/adapters";
-import { invalidateSpendingCaches } from "@/features/spending/lib/invalidation";
-import { QueryKeys } from "@/lib/query-keys";
+import { shouldInvalidateAfterPortfolioUpdate } from "@/lib/query-invalidation";
 interface UseAccountMutationsProps {
   onSuccess?: () => void;
 }
@@ -17,10 +16,13 @@ export function useAccountMutations({ onSuccess = () => undefined }: UseAccountM
     }
   };
 
+  // Account create/update/delete changes portfolio totals (and including/excluding
+  // via isArchived/isActive changes holdings), so invalidate everything except the
+  // cloud/broker/subscription queries — the same rule the portfolio-update path uses.
   const invalidateAccountDependentQueries = () => {
-    queryClient.invalidateQueries({ queryKey: [QueryKeys.ACCOUNTS] });
-    queryClient.invalidateQueries({ queryKey: [QueryKeys.SPENDING_SETTINGS] });
-    invalidateSpendingCaches(queryClient);
+    queryClient.invalidateQueries({
+      predicate: (query) => shouldInvalidateAfterPortfolioUpdate(query.queryKey),
+    });
   };
 
   const handleError = (action: string) => {

--- a/apps/frontend/src/use-global-event-listener.ts
+++ b/apps/frontend/src/use-global-event-listener.ts
@@ -15,7 +15,7 @@ import {
 } from "@/adapters";
 import { usePortfolioSyncOptional } from "@/context/portfolio-sync-context";
 import { useIsMobileViewport } from "@/hooks/use-platform";
-import { QueryKeys } from "@/lib/query-keys";
+import { shouldInvalidateAfterPortfolioUpdate } from "@/lib/query-invalidation";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
@@ -28,32 +28,6 @@ const TOAST_IDS = {
 
   brokerSyncStart: "broker-sync-start",
 } as const;
-
-const CLOUD_SYNC_INVALIDATION_EXCLUSIONS = new Set<string>([
-  QueryKeys.BROKER_CONNECTIONS,
-  QueryKeys.BROKER_ACCOUNTS,
-  QueryKeys.BROKER_SYNC_STATES,
-  QueryKeys.IMPORT_RUNS,
-  QueryKeys.USER_INFO,
-  QueryKeys.SUBSCRIPTION_PLANS,
-  QueryKeys.SUBSCRIPTION_PLANS_PUBLIC,
-  QueryKeys.SYNCED_ACCOUNTS,
-  QueryKeys.PLATFORMS,
-]);
-
-function shouldInvalidateAfterPortfolioUpdate(queryKey: readonly unknown[]): boolean {
-  const rootKey = queryKey[0];
-
-  if (typeof rootKey === "string" && CLOUD_SYNC_INVALIDATION_EXCLUSIONS.has(rootKey)) {
-    return false;
-  }
-
-  if (rootKey === "sync") {
-    return false;
-  }
-
-  return true;
-}
 
 interface MarketSyncCompletePayload {
   failed_syncs?: [string, string][];


### PR DESCRIPTION
## Problem

When an account is created, updated, or deleted — including toggling **Hide** (`isActive`) or **Archive** (`isArchived`, which removes the account from the portfolio) — the frontend only invalidated \`ACCOUNTS\` and the spending caches. Holdings, portfolio summary, performance, valuation, and net-worth caches stayed stale in the UI until the backend's async portfolio recalc finished and emitted \`portfolio:update-complete\`.

## Fix

Reuse the same \`shouldInvalidateAfterPortfolioUpdate\` predicate the portfolio-update event handler already uses, extracted into a shared module (\`apps/frontend/src/lib/query-invalidation.ts\`) so both call sites share a single source of truth.

The predicate invalidates everything **except** cloud/broker/subscription/sync queries (which have their own lifecycle), so it covers holdings, portfolio totals, performance, valuation, net worth, accounts, spending — without unnecessarily refetching broker connections, subscription plans, user info, etc.

This also makes the previous explicit \`SPENDING_SETTINGS\` + \`invalidateSpendingCaches\` calls redundant (the predicate covers them), so they were removed along with their now-unused imports.

## Changes

- **New** \`apps/frontend/src/lib/query-invalidation.ts\` — shared predicate + cloud-sync exclusion set.
- \`apps/frontend/src/use-global-event-listener.ts\` — imports the predicate from the shared module instead of defining it locally.
- \`apps/frontend/src/pages/settings/accounts/components/use-account-mutations.ts\` — \`invalidateAccountDependentQueries\` collapsed to a single predicate-driven invalidation.

## Verification

- \`pnpm type-check\` ✅
- \`pnpm lint\` — 0 errors (pre-existing warnings unrelated to changed files)