### PR TITLE
Fix broker sync cursor and holdings normalization

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -53,6 +53,10 @@ jobs:
   rust-check:
     name: Rust Check
     runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: 0
+      CARGO_TERM_COLOR: always
+      RUSTFLAGS: "-C debuginfo=0"
 
     steps:
       - name: Checkout code

--- a/apps/frontend/src/features/wealthfolio-connect/lib/import-run-review.test.ts
+++ b/apps/frontend/src/features/wealthfolio-connect/lib/import-run-review.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { hasReviewableActivityWarnings } from "./import-run-review";
+
+describe("hasReviewableActivityWarnings", () => {
+  it("allows activity review whenever imported rows have warnings", () => {
+    expect(hasReviewableActivityWarnings(1)).toBe(true);
+  });
+
+  it("does not show an activities review link for sync-state-only review", () => {
+    expect(hasReviewableActivityWarnings(0)).toBe(false);
+    expect(hasReviewableActivityWarnings(undefined)).toBe(false);
+  });
+});

--- a/apps/frontend/src/features/wealthfolio-connect/lib/import-run-review.ts
+++ b/apps/frontend/src/features/wealthfolio-connect/lib/import-run-review.ts
@@ -1,0 +1,3 @@
+export function hasReviewableActivityWarnings(warnings: number | null | undefined): boolean {
+  return (warnings ?? 0) > 0;
+}

--- a/apps/frontend/src/features/wealthfolio-connect/pages/connect-page.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/pages/connect-page.tsx
@@ -31,16 +31,17 @@ import { formatDistanceToNow } from "date-fns";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { listBrokerConnections } from "../services/broker-service";
-import type { BrokerConnection, ImportRun } from "../types";
+import type { BrokerConnection, BrokerSyncState, ImportRun } from "../types";
 
 import type { Device } from "@/features/devices-sync/types";
 import type { Account } from "@/lib/types";
 import { hasBrokerSync } from "../lib/plan-capabilities";
+import { hasReviewableActivityWarnings } from "../lib/import-run-review";
 import { NewAccountsFoundModal } from "../components/new-accounts-found-modal";
 
 export default function ConnectPage() {
   const { isEnabled, isConnected, isInitializing, userInfo } = useWealthfolioConnect();
-  const { status, lastSyncTime, issueCount } = useAggregatedSyncStatus();
+  const { status, lastSyncTime, syncStates } = useAggregatedSyncStatus();
   const showBrokerSync = hasBrokerSync(userInfo);
   const { data: brokerAccounts = [] } = useBrokerAccounts({ enabled: showBrokerSync });
   const { mutate: syncBrokerData, isPending: isSyncing } = useSyncBrokerData();
@@ -104,6 +105,23 @@ export default function ConnectPage() {
     if (!importRunsData?.pages) return [];
     return importRunsData.pages.flat().slice(0, 10);
   }, [importRunsData]);
+
+  const recentActivityIssueCount = useMemo(() => {
+    return recentActivity.filter((run) => {
+      const summary = run.summary;
+      return (
+        run.status === "FAILED" ||
+        run.status === "NEEDS_REVIEW" ||
+        (summary?.warnings ?? 0) > 0 ||
+        (summary?.errors ?? 0) > 0
+      );
+    }).length;
+  }, [recentActivity]);
+
+  const brokerSyncIssues = useMemo(
+    () => syncStates.filter((s) => s.syncStatus === "NEEDS_REVIEW" || s.syncStatus === "FAILED"),
+    [syncStates],
+  );
 
   const accountNameMap = useMemo(() => {
     const map = new Map<string, string>();
@@ -256,6 +274,16 @@ export default function ConnectPage() {
             </Alert>
           )}
 
+          {showBrokerSync && brokerSyncIssues.length > 0 && (
+            <BrokerSyncAttentionSection
+              issues={brokerSyncIssues}
+              accounts={localAccounts}
+              onRetry={() => syncBrokerData()}
+              onManage={() => openUrlInBrowser(`${WEALTHFOLIO_CONNECT_PORTAL_URL}/connections`)}
+              isSyncing={isSyncRunning}
+            />
+          )}
+
           <div className={`grid grid-cols-1 gap-4 ${showBrokerSync ? "md:grid-cols-2" : ""}`}>
             {showBrokerSync && (
               <Card className="flex flex-col border">
@@ -395,9 +423,9 @@ export default function ConnectPage() {
                     <Icons.History className="text-muted-foreground h-3.5 w-3.5" />
                   </div>
                   Recent Activity
-                  {issueCount > 0 && (
+                  {recentActivityIssueCount > 0 && (
                     <Badge variant="default" className="ml-1 h-5 min-w-5 px-1.5 text-xs">
-                      {issueCount}
+                      {recentActivityIssueCount}
                     </Badge>
                   )}
                 </CardTitle>
@@ -660,6 +688,80 @@ function formatDeviceLastSeen(device: Device): string {
   return `${diffDays}d ago`;
 }
 
+function BrokerSyncAttentionSection({
+  issues,
+  accounts,
+  onRetry,
+  onManage,
+  isSyncing,
+}: {
+  issues: BrokerSyncState[];
+  accounts: Account[];
+  onRetry: () => void;
+  onManage: () => void;
+  isSyncing: boolean;
+}) {
+  const accountById = useMemo(
+    () => new Map(accounts.map((account) => [account.id, account])),
+    [accounts],
+  );
+
+  return (
+    <Alert variant="warning" className="mb-4">
+      <Icons.AlertTriangle className="h-4 w-4" />
+      <div className="flex flex-1 flex-col gap-3">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <p className="font-medium">Broker sync needs attention</p>
+            <p className="text-muted-foreground text-sm">
+              {issues.length} account{issues.length === 1 ? "" : "s"} need a retry or broker review.
+            </p>
+          </div>
+          <div className="flex shrink-0 gap-2">
+            <Button size="sm" variant="outline" onClick={onRetry} disabled={isSyncing}>
+              {isSyncing ? (
+                <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Icons.RefreshCw className="mr-2 h-4 w-4" />
+              )}
+              Retry
+            </Button>
+            <Button size="sm" variant="ghost" onClick={onManage}>
+              <Icons.ExternalLink className="mr-2 h-4 w-4" />
+              Manage
+            </Button>
+          </div>
+        </div>
+        <div className="space-y-2">
+          {issues.map((issue) => {
+            const account = accountById.get(issue.accountId);
+            const accountName = account?.name || issue.accountId;
+            const broker = account?.provider || issue.provider;
+            const message =
+              issue.lastError ||
+              (issue.syncStatus === "FAILED"
+                ? "Broker sync failed."
+                : "Broker sync needs review before the cursor can advance.");
+
+            return (
+              <div key={`${issue.provider}:${issue.accountId}`} className="rounded-md border p-3">
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                  <span className="font-medium">{accountName}</span>
+                  <Badge variant={issue.syncStatus === "FAILED" ? "destructive" : "outline"}>
+                    {issue.syncStatus === "FAILED" ? "Failed" : "Needs Review"}
+                  </Badge>
+                  <span className="text-muted-foreground text-xs">{broker}</span>
+                </div>
+                <p className="text-muted-foreground mt-1 text-sm">{message}</p>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </Alert>
+  );
+}
+
 function SyncHistoryItem({
   run,
   accountName,
@@ -685,6 +787,7 @@ function SyncHistoryItem({
 
   const hasIssues = warnings > 0 || errors > 0;
   const needsAttention = isNeedsReview || hasIssues;
+  const canReviewActivities = hasReviewableActivityWarnings(warnings);
 
   let description = "";
   if (isRunning) {
@@ -693,7 +796,10 @@ function SyncHistoryItem({
     description = "Something went wrong";
   } else if (needsAttention) {
     const issueCount = warnings + errors;
-    description = `${issueCount} ${issueCount === 1 ? "item needs" : "items need"} your review`;
+    description =
+      issueCount > 0
+        ? `${issueCount} ${issueCount === 1 ? "item needs" : "items need"} your review`
+        : run.error || "Sync needs attention";
   } else if (inserted > 0 || updated > 0 || removed > 0) {
     const parts: string[] = [];
     if (inserted > 0) {
@@ -736,7 +842,7 @@ function SyncHistoryItem({
         </span>
         {isRunning && <Icons.Spinner className="h-3 w-3 animate-spin" />}
       </div>
-      {needsAttention && (
+      {canReviewActivities && (
         <Link
           to={`/activities?account=${run.accountId}&needsReview=true`}
           className="text-primary shrink-0 text-sm font-medium hover:underline"

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -33,7 +33,7 @@ import {
   SpendingTransactionsTab,
   type SpendingTransactionsTabHandle,
 } from "@/features/spending/components/spending-transactions-tab";
-import { resolveActivityUrlFilters } from "./utils/url-filters";
+import { clearActivityUrlFilters, resolveActivityUrlFilters } from "./utils/url-filters";
 
 const ActivityPage = () => {
   const [showForm, setShowForm] = useState(false);
@@ -53,9 +53,9 @@ const ActivityPage = () => {
   );
 
   // Filter and search state
-  const [accountScope, setAccountScope] = usePersistentState<AccountScope>(
+  const [persistedAccountScope, setPersistedAccountScope] = usePersistentState<AccountScope>(
     "activity-filter-scope",
-    activityUrlFilters.accountScope ?? { type: "all" },
+    { type: "all" },
   );
   const { data: portfolios = [] } = usePortfolios();
   const [selectedActivityTypes, setSelectedActivityTypes] = usePersistentState<ActivityType[]>(
@@ -66,10 +66,8 @@ const ActivityPage = () => {
     "activity-filter-instrument-types",
     [],
   );
-  const [statusFilter, setStatusFilter] = usePersistentState<ActivityStatusFilter>(
-    "activity-filter-status",
-    activityUrlFilters.statusFilter ?? "all",
-  );
+  const [persistedStatusFilter, setPersistedStatusFilter] =
+    usePersistentState<ActivityStatusFilter>("activity-filter-status", "all");
   const [searchInput, setSearchInput] = usePersistentState<string>("activity-filter-search", "");
   const [searchQuery, setSearchQuery] = useState(searchInput);
   const [viewMode, setViewMode] = usePersistentState<ActivityViewMode>(
@@ -94,19 +92,50 @@ const ActivityPage = () => {
     isLoading: isSpendingSettingsLoading,
   } = useSpendingSettings();
 
-  const activityUrlAccountId =
-    activityUrlFilters.accountScope?.type === "account"
-      ? activityUrlFilters.accountScope.accountId
-      : undefined;
+  const accountScope = activityUrlFilters.accountScope ?? persistedAccountScope;
+  const statusFilter = activityUrlFilters.statusFilter ?? persistedStatusFilter;
 
-  useEffect(() => {
-    if (activityUrlAccountId) {
-      setAccountScope({ type: "account", accountId: activityUrlAccountId });
-    }
-    if (activityUrlFilters.statusFilter) {
-      setStatusFilter(activityUrlFilters.statusFilter);
-    }
-  }, [activityUrlAccountId, activityUrlFilters.statusFilter, setAccountScope, setStatusFilter]);
+  const clearBrokerReviewUrlFilters = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = clearActivityUrlFilters(prev);
+        return next.toString() === prev.toString() ? prev : next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
+
+  const setAccountScope = useCallback(
+    (scope: AccountScope) => {
+      setPersistedAccountScope(scope);
+      if (activityUrlFilters.statusFilter) {
+        setPersistedStatusFilter(activityUrlFilters.statusFilter);
+      }
+      clearBrokerReviewUrlFilters();
+    },
+    [
+      activityUrlFilters.statusFilter,
+      clearBrokerReviewUrlFilters,
+      setPersistedAccountScope,
+      setPersistedStatusFilter,
+    ],
+  );
+
+  const setStatusFilter = useCallback(
+    (status: ActivityStatusFilter) => {
+      if (activityUrlFilters.accountScope) {
+        setPersistedAccountScope(activityUrlFilters.accountScope);
+      }
+      setPersistedStatusFilter(status);
+      clearBrokerReviewUrlFilters();
+    },
+    [
+      activityUrlFilters.accountScope,
+      clearBrokerReviewUrlFilters,
+      setPersistedAccountScope,
+      setPersistedStatusFilter,
+    ],
+  );
 
   // Coerce "spending" URL state back to investments when the module is disabled.
   const urlTab = searchParams.get("tab");
@@ -298,17 +327,19 @@ const ActivityPage = () => {
     searchInput.trim().length > 0;
 
   const clearInvestmentsFilters = useCallback(() => {
-    setAccountScope({ type: "all" });
+    setPersistedAccountScope({ type: "all" });
     setSelectedActivityTypes([]);
     setSelectedInstrumentTypes([]);
-    setStatusFilter("all");
+    setPersistedStatusFilter("all");
     setSearchInput("");
     setSearchQuery("");
+    clearBrokerReviewUrlFilters();
   }, [
-    setAccountScope,
+    clearBrokerReviewUrlFilters,
+    setPersistedAccountScope,
     setSelectedActivityTypes,
     setSelectedInstrumentTypes,
-    setStatusFilter,
+    setPersistedStatusFilter,
     setSearchInput,
   ]);
 

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -33,6 +33,7 @@ import {
   SpendingTransactionsTab,
   type SpendingTransactionsTabHandle,
 } from "@/features/spending/components/spending-transactions-tab";
+import { resolveActivityUrlFilters } from "./utils/url-filters";
 
 const ActivityPage = () => {
   const [showForm, setShowForm] = useState(false);
@@ -42,11 +43,19 @@ const ActivityPage = () => {
   const [showAlternativeAssetModal, setShowAlternativeAssetModal] = useState(false);
   const [showActionPalette, setShowActionPalette] = useState(false);
   const [showSpendingActionPalette, setShowSpendingActionPalette] = useState(false);
+  const isMobileViewport = useIsMobileViewport();
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const activityUrlFilterKey = searchParams.toString();
+  const activityUrlFilters = useMemo(
+    () => resolveActivityUrlFilters(new URLSearchParams(activityUrlFilterKey)),
+    [activityUrlFilterKey],
+  );
 
   // Filter and search state
   const [accountScope, setAccountScope] = usePersistentState<AccountScope>(
     "activity-filter-scope",
-    { type: "all" },
+    activityUrlFilters.accountScope ?? { type: "all" },
   );
   const { data: portfolios = [] } = usePortfolios();
   const [selectedActivityTypes, setSelectedActivityTypes] = usePersistentState<ActivityType[]>(
@@ -59,7 +68,7 @@ const ActivityPage = () => {
   );
   const [statusFilter, setStatusFilter] = usePersistentState<ActivityStatusFilter>(
     "activity-filter-status",
-    "all",
+    activityUrlFilters.statusFilter ?? "all",
   );
   const [searchInput, setSearchInput] = usePersistentState<string>("activity-filter-search", "");
   const [searchQuery, setSearchQuery] = useState(searchInput);
@@ -79,14 +88,25 @@ const ActivityPage = () => {
   const [pageIndex, setPageIndex] = usePersistentState("activity-datagrid-page-index", 0);
   const [pageSize, setPageSize] = usePersistentState("activity-datagrid-page-size", 50);
 
-  const isMobileViewport = useIsMobileViewport();
-  const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
   const {
     isEnabled: isSpendingEnabled,
     accountIds: spendingAccountIds,
     isLoading: isSpendingSettingsLoading,
   } = useSpendingSettings();
+
+  const activityUrlAccountId =
+    activityUrlFilters.accountScope?.type === "account"
+      ? activityUrlFilters.accountScope.accountId
+      : undefined;
+
+  useEffect(() => {
+    if (activityUrlAccountId) {
+      setAccountScope({ type: "account", accountId: activityUrlAccountId });
+    }
+    if (activityUrlFilters.statusFilter) {
+      setStatusFilter(activityUrlFilters.statusFilter);
+    }
+  }, [activityUrlAccountId, activityUrlFilters.statusFilter, setAccountScope, setStatusFilter]);
 
   // Coerce "spending" URL state back to investments when the module is disabled.
   const urlTab = searchParams.get("tab");
@@ -114,7 +134,7 @@ const ActivityPage = () => {
       setSearchInput(value);
       debouncedUpdateSearch(value);
     },
-    [debouncedUpdateSearch],
+    [debouncedUpdateSearch, setSearchInput],
   );
 
   // Cleanup debounced function on unmount
@@ -229,6 +249,7 @@ const ActivityPage = () => {
     selectedInstrumentTypes,
     statusFilter,
     searchQuery,
+    setPageIndex,
     sorting,
   ]);
 

--- a/apps/frontend/src/pages/activity/utils/url-filters.test.ts
+++ b/apps/frontend/src/pages/activity/utils/url-filters.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { resolveActivityUrlFilters } from "./url-filters";
+
+describe("resolveActivityUrlFilters", () => {
+  it("maps review links to an account pending-review filter", () => {
+    expect(
+      resolveActivityUrlFilters(new URLSearchParams("account=acct-1&needsReview=true")),
+    ).toEqual({
+      accountScope: { type: "account", accountId: "acct-1" },
+      statusFilter: "pending",
+    });
+  });
+
+  it("ignores unrelated or false review params", () => {
+    expect(resolveActivityUrlFilters(new URLSearchParams("needsReview=false"))).toEqual({});
+    expect(resolveActivityUrlFilters(new URLSearchParams("tab=spending"))).toEqual({});
+  });
+});

--- a/apps/frontend/src/pages/activity/utils/url-filters.test.ts
+++ b/apps/frontend/src/pages/activity/utils/url-filters.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveActivityUrlFilters } from "./url-filters";
+import { clearActivityUrlFilters, resolveActivityUrlFilters } from "./url-filters";
 
 describe("resolveActivityUrlFilters", () => {
   it("maps review links to an account pending-review filter", () => {
@@ -14,5 +14,13 @@ describe("resolveActivityUrlFilters", () => {
   it("ignores unrelated or false review params", () => {
     expect(resolveActivityUrlFilters(new URLSearchParams("needsReview=false"))).toEqual({});
     expect(resolveActivityUrlFilters(new URLSearchParams("tab=spending"))).toEqual({});
+  });
+
+  it("clears broker review filter params without dropping unrelated params", () => {
+    const cleared = clearActivityUrlFilters(
+      new URLSearchParams("tab=investments&account=acct-1&needsReview=true"),
+    );
+
+    expect(cleared.toString()).toBe("tab=investments");
   });
 });

--- a/apps/frontend/src/pages/activity/utils/url-filters.ts
+++ b/apps/frontend/src/pages/activity/utils/url-filters.ts
@@ -1,0 +1,17 @@
+import type { AccountScope } from "@/lib/types";
+import type { ActivityStatusFilter } from "../hooks/use-activity-search";
+
+interface ActivityUrlFilters {
+  accountScope?: AccountScope;
+  statusFilter?: ActivityStatusFilter;
+}
+
+export function resolveActivityUrlFilters(searchParams: URLSearchParams): ActivityUrlFilters {
+  const accountId = searchParams.get("account")?.trim();
+  const needsReview = searchParams.get("needsReview") === "true";
+
+  return {
+    ...(accountId ? { accountScope: { type: "account" as const, accountId } } : {}),
+    ...(needsReview ? { statusFilter: "pending" as const } : {}),
+  };
+}

--- a/apps/frontend/src/pages/activity/utils/url-filters.ts
+++ b/apps/frontend/src/pages/activity/utils/url-filters.ts
@@ -15,3 +15,10 @@ export function resolveActivityUrlFilters(searchParams: URLSearchParams): Activi
     ...(needsReview ? { statusFilter: "pending" as const } : {}),
   };
 }
+
+export function clearActivityUrlFilters(searchParams: URLSearchParams): URLSearchParams {
+  const next = new URLSearchParams(searchParams);
+  next.delete("account");
+  next.delete("needsReview");
+  return next;
+}

--- a/apps/server/src/api/connect.rs
+++ b/apps/server/src/api/connect.rs
@@ -22,7 +22,8 @@ use crate::main_lib::AppState;
 use axum::http::StatusCode;
 use wealthfolio_connect::{
     broker::{
-        BrokerApiClient, BrokerSyncStatusDetail, PlansResponse, SyncAccountsResponse,
+        resolve_activity_readiness, should_advance_activity_cursor, BrokerApiClient,
+        BrokerSyncStatusDetail, PlansResponse, ProviderReadiness, SyncAccountsResponse,
         SyncActivitiesResponse, SyncConnectionsResponse, UserInfo,
     },
     ensure_valid_access_token, fetch_subscription_plans_public, ConnectApiClient, SyncConfig,
@@ -52,55 +53,6 @@ fn ensure_connect_sync_enabled() -> ApiResult<()> {
             "Connect sync feature is disabled in this build.".to_string(),
         ))
     }
-}
-
-fn parse_provider_sync_date(value: &str) -> Result<chrono::NaiveDate, String> {
-    chrono::DateTime::parse_from_rfc3339(value)
-        .map(|dt| dt.with_timezone(&chrono::Utc).date_naive())
-        .or_else(|_| chrono::NaiveDate::parse_from_str(value, "%Y-%m-%d"))
-        .map_err(|_| format!("Invalid provider sync timestamp '{}'", value))
-}
-
-fn resolve_activity_waterline(
-    status: Option<&BrokerSyncStatusDetail>,
-) -> Result<chrono::NaiveDate, String> {
-    let Some(status) = status else {
-        return Err("Provider transaction sync status is unavailable".to_string());
-    };
-
-    if status.initial_sync_completed == Some(false) {
-        return Err("Provider transaction sync is still preparing".to_string());
-    }
-
-    let Some(last_successful_sync) = status.last_successful_sync.as_deref() else {
-        return Err("Provider transaction sync has no successful waterline".to_string());
-    };
-
-    parse_provider_sync_date(last_successful_sync)
-}
-
-fn should_advance_activity_cursor(
-    fetched: usize,
-    has_local_cursor: bool,
-    inconsistent_empty_page: bool,
-    provider_status: Option<&BrokerSyncStatusDetail>,
-) -> bool {
-    if inconsistent_empty_page {
-        return false;
-    }
-
-    if fetched > 0 || has_local_cursor {
-        return true;
-    }
-
-    matches!(
-        provider_status,
-        Some(BrokerSyncStatusDetail {
-            initial_sync_completed: Some(true),
-            first_transaction_date: None,
-            ..
-        })
-    )
 }
 
 fn ensure_device_sync_enabled() -> ApiResult<()> {
@@ -685,25 +637,49 @@ async fn perform_broker_activities_only_sync(
             continue;
         }
 
-        let local_activity_state = state
+        let local_activity_state = match state
             .connect_sync_service
             .get_activity_sync_state(&account_id)
-            .map_err(|e| e.to_string())?;
+        {
+            Ok(state) => state,
+            Err(err) => {
+                let failure = format!("Activity sync state failed: {}", err);
+                let _ = state
+                    .connect_sync_service
+                    .finalize_activity_sync_failure(account_id.clone(), failure.clone(), None)
+                    .await;
+                error!("[Connect] {} for {}", failure, account_name);
+                summary.accounts_failed += 1;
+                continue;
+            }
+        };
         let local_cursor = local_activity_state
             .as_ref()
             .and_then(|s| s.last_successful_at.as_ref());
         let has_local_cursor = local_cursor.is_some();
         let provider_status = provider_transaction_statuses.get(&provider_account_id);
-        let provider_waterline = match resolve_activity_waterline(provider_status) {
-            Ok(date) => date.min(today),
-            Err(err) => {
-                let warning = format!("Activity sync deferred: {}", err);
+        let provider_waterline = match resolve_activity_readiness(provider_status) {
+            Ok(ProviderReadiness::Ready(date)) => date.min(today),
+            Ok(ProviderReadiness::NotReady(reason)) => {
+                let warning = format!("Activity sync deferred: {}", reason);
                 let _ = state
                     .connect_sync_service
                     .finalize_activity_sync_needs_review(account_id.clone(), warning.clone(), None)
                     .await;
                 summary.accounts_warned += 1;
                 info!("[Connect] {}", warning);
+                continue;
+            }
+            Err(err) => {
+                let _ = state
+                    .connect_sync_service
+                    .finalize_activity_sync_failure(account_id.clone(), err.clone(), None)
+                    .await;
+                summary.accounts_failed += 1;
+                error!(
+                    "[Connect] Failed to resolve provider activity sync status for {}: {}",
+                    account_name, err
+                );
                 continue;
             }
         };
@@ -845,6 +821,10 @@ async fn perform_broker_activities_only_sync(
             continue;
         }
 
+        summary.activities_upserted += account_upserted;
+        summary.assets_inserted += account_assets;
+        summary.new_asset_ids.extend(account_new_asset_ids);
+
         if !should_advance_activity_cursor(
             account_fetched,
             has_local_cursor,
@@ -882,9 +862,6 @@ async fn perform_broker_activities_only_sync(
         }
 
         summary.accounts_synced += 1;
-        summary.activities_upserted += account_upserted;
-        summary.assets_inserted += account_assets;
-        summary.new_asset_ids.extend(account_new_asset_ids);
     }
 
     Ok(summary)

--- a/apps/server/src/api/connect.rs
+++ b/apps/server/src/api/connect.rs
@@ -3,7 +3,7 @@
 //! This module provides REST endpoints for syncing broker accounts and activities
 //! from the Wealthfolio Connect cloud service.
 
-use std::{collections::HashMap, sync::Arc};
+use std::sync::Arc;
 
 use axum::{
     extract::{Query, State},
@@ -22,15 +22,13 @@ use crate::main_lib::AppState;
 use axum::http::StatusCode;
 use wealthfolio_connect::{
     broker::{
-        resolve_activity_readiness, should_advance_activity_cursor, BrokerApiClient,
-        BrokerSyncStatusDetail, PlansResponse, ProviderReadiness, SyncAccountsResponse,
-        SyncActivitiesResponse, SyncConnectionsResponse, UserInfo,
+        BrokerApiClient, PlansResponse, SyncAccountsResponse, SyncActivitiesResponse,
+        SyncConnectionsResponse, UserInfo,
     },
     ensure_valid_access_token, fetch_subscription_plans_public, ConnectApiClient, SyncConfig,
     SyncOrchestrator, SyncProgressPayload, SyncProgressReporter, SyncResult, TokenLifecycleConfig,
     TokenLifecycleError, CLOUD_ACCESS_TOKEN_KEY, CLOUD_REFRESH_TOKEN_KEY,
 };
-use wealthfolio_core::accounts::TrackingMode;
 use wealthfolio_device_sync::{EnableSyncResult, SyncState, SyncStateResult};
 
 const DEVICE_ID_KEY: &str = "sync_device_id";
@@ -590,281 +588,14 @@ async fn perform_broker_activities_only_sync(
     let client = create_connect_client(state)
         .await
         .map_err(|e| e.to_string())?;
+    let reporter = Arc::new(EventBusProgressReporter::new(state.event_bus.clone()));
+    let orchestrator = SyncOrchestrator::new(
+        state.connect_sync_service.clone(),
+        reporter,
+        SyncConfig::default(),
+    );
 
-    let synced_accounts = state
-        .connect_sync_service
-        .get_synced_accounts()
-        .map_err(|e| e.to_string())?;
-    let provider_transaction_statuses: HashMap<String, BrokerSyncStatusDetail> = client
-        .list_accounts(None)
-        .await
-        .map_err(|e| e.to_string())?
-        .into_iter()
-        .filter_map(|account| {
-            Some((
-                account.id?,
-                account.sync_status.as_ref()?.transactions.clone()?,
-            ))
-        })
-        .collect();
-
-    let mut summary = SyncActivitiesResponse::default();
-    let today = chrono::Utc::now().date_naive();
-    let page_limit: i64 = 1000;
-
-    for account in synced_accounts {
-        if account.tracking_mode != TrackingMode::Transactions {
-            continue;
-        }
-
-        let Some(provider_account_id) = account.provider_account_id.clone() else {
-            continue;
-        };
-
-        let account_id = account.id.clone();
-        let account_name = account.name.clone();
-
-        if let Err(err) = state
-            .connect_sync_service
-            .mark_activity_sync_attempt(account_id.clone())
-            .await
-        {
-            error!(
-                "[Connect] Failed to mark activity sync attempt for {}: {}",
-                account_name, err
-            );
-            summary.accounts_failed += 1;
-            continue;
-        }
-
-        let local_activity_state = match state
-            .connect_sync_service
-            .get_activity_sync_state(&account_id)
-        {
-            Ok(state) => state,
-            Err(err) => {
-                let failure = format!("Activity sync state failed: {}", err);
-                let _ = state
-                    .connect_sync_service
-                    .finalize_activity_sync_failure(account_id.clone(), failure.clone(), None)
-                    .await;
-                error!("[Connect] {} for {}", failure, account_name);
-                summary.accounts_failed += 1;
-                continue;
-            }
-        };
-        let local_cursor = local_activity_state
-            .as_ref()
-            .and_then(|s| s.last_successful_at.as_ref());
-        let has_local_cursor = local_cursor.is_some();
-        let provider_status = provider_transaction_statuses.get(&provider_account_id);
-        let provider_waterline = match resolve_activity_readiness(provider_status) {
-            Ok(ProviderReadiness::Ready(date)) => date.min(today),
-            Ok(ProviderReadiness::NotReady(reason)) => {
-                let warning = format!("Activity sync deferred: {}", reason);
-                let _ = state
-                    .connect_sync_service
-                    .finalize_activity_sync_needs_review(account_id.clone(), warning.clone(), None)
-                    .await;
-                summary.accounts_warned += 1;
-                info!("[Connect] {}", warning);
-                continue;
-            }
-            Err(err) => {
-                let _ = state
-                    .connect_sync_service
-                    .finalize_activity_sync_failure(account_id.clone(), err.clone(), None)
-                    .await;
-                summary.accounts_failed += 1;
-                error!(
-                    "[Connect] Failed to resolve provider activity sync status for {}: {}",
-                    account_name, err
-                );
-                continue;
-            }
-        };
-        if let Some(cursor) = local_cursor {
-            if provider_waterline < cursor.date_naive() {
-                let message = format!(
-                    "Activity sync skipped: provider transaction waterline {} is older than local cursor {}",
-                    provider_waterline,
-                    cursor.date_naive()
-                );
-                if let Err(err) = state
-                    .connect_sync_service
-                    .finalize_activity_sync_success(account_id.clone(), cursor.to_rfc3339(), None)
-                    .await
-                {
-                    error!(
-                        "[Connect] Failed to restore activity sync state for {}: {}",
-                        account_name, err
-                    );
-                    summary.accounts_failed += 1;
-                } else {
-                    summary.accounts_synced += 1;
-                    info!("[Connect] {}", message);
-                }
-                continue;
-            }
-        }
-        let end_date_str = provider_waterline.format("%Y-%m-%d").to_string();
-        let start_date = local_activity_state
-            .and_then(|s| s.last_successful_at)
-            .map(|dt| (dt.date_naive() - chrono::Days::new(1)).min(provider_waterline))
-            .map(|d| d.format("%Y-%m-%d").to_string());
-
-        info!(
-            "[Connect] Activities-only sync for account '{}' (provider={}): {} -> {}",
-            account_name,
-            provider_account_id,
-            start_date.as_deref().unwrap_or("ALL"),
-            end_date_str
-        );
-
-        let mut offset: i64 = 0;
-        let mut account_upserted = 0usize;
-        let mut account_assets = 0usize;
-        let mut account_new_asset_ids: Vec<String> = Vec::new();
-        let mut account_failed = false;
-        let mut account_fetched = 0usize;
-        let mut empty_first_page = false;
-        let mut inconsistent_empty_page = false;
-
-        loop {
-            let page = match client
-                .get_account_activities(
-                    &provider_account_id,
-                    start_date.as_deref(),
-                    Some(&end_date_str),
-                    Some(offset),
-                    Some(page_limit),
-                )
-                .await
-            {
-                Ok(page) => page,
-                Err(err) => {
-                    error!(
-                        "[Connect] Failed to fetch activities for {}: {}",
-                        account_name, err
-                    );
-                    let _ = state
-                        .connect_sync_service
-                        .finalize_activity_sync_failure(account_id.clone(), err.to_string(), None)
-                        .await;
-                    summary.accounts_failed += 1;
-                    account_failed = true;
-                    break;
-                }
-            };
-
-            let received = page.data.len() as i64;
-            account_fetched += received as usize;
-            if received == 0 {
-                empty_first_page = offset == 0;
-                inconsistent_empty_page = page.pagination.as_ref().is_some_and(|p| {
-                    p.has_more == Some(true) || p.total.is_some_and(|total| offset < total)
-                });
-                break;
-            }
-
-            match state
-                .connect_sync_service
-                .upsert_account_activities(account_id.clone(), None, page.data)
-                .await
-            {
-                Ok((upserted, assets, new_asset_ids, _needs_review)) => {
-                    account_upserted += upserted;
-                    account_assets += assets;
-                    account_new_asset_ids.extend(new_asset_ids);
-                }
-                Err(err) => {
-                    error!(
-                        "[Connect] Failed to upsert activities for {}: {}",
-                        account_name, err
-                    );
-                    let _ = state
-                        .connect_sync_service
-                        .finalize_activity_sync_failure(account_id.clone(), err.to_string(), None)
-                        .await;
-                    summary.accounts_failed += 1;
-                    account_failed = true;
-                    break;
-                }
-            }
-
-            let next_offset = offset + received;
-            let has_more = match page.pagination.as_ref() {
-                Some(p) => match p.has_more {
-                    Some(true) => true,
-                    Some(false) => false,
-                    None => {
-                        if let Some(total) = p.total {
-                            next_offset < total
-                        } else if let Some(limit) = p.limit {
-                            received >= limit
-                        } else {
-                            received >= page_limit
-                        }
-                    }
-                },
-                None => received >= page_limit,
-            };
-
-            offset = next_offset;
-
-            if !has_more {
-                break;
-            }
-        }
-
-        if account_failed {
-            continue;
-        }
-
-        summary.activities_upserted += account_upserted;
-        summary.assets_inserted += account_assets;
-        summary.new_asset_ids.extend(account_new_asset_ids);
-
-        if !should_advance_activity_cursor(
-            account_fetched,
-            has_local_cursor,
-            inconsistent_empty_page,
-            provider_status,
-        ) {
-            let warning = if inconsistent_empty_page {
-                "Activity sync returned an empty page while provider pagination reported more data"
-            } else if empty_first_page {
-                "Initial activity sync returned no rows even though provider reports transactions may exist"
-            } else {
-                "Initial activity sync did not confirm a complete empty history"
-            }
-            .to_string();
-            let _ = state
-                .connect_sync_service
-                .finalize_activity_sync_needs_review(account_id.clone(), warning.clone(), None)
-                .await;
-            summary.accounts_warned += 1;
-            info!("[Connect] {}", warning);
-            continue;
-        }
-
-        if let Err(err) = state
-            .connect_sync_service
-            .finalize_activity_sync_success(account_id.clone(), end_date_str, None)
-            .await
-        {
-            error!(
-                "[Connect] Failed to finalize activity sync success for {}: {}",
-                account_name, err
-            );
-            summary.accounts_failed += 1;
-            continue;
-        }
-
-        summary.accounts_synced += 1;
-    }
-
-    Ok(summary)
+    orchestrator.sync_activities_only(&client).await
 }
 
 async fn get_subscription_plans(

--- a/apps/server/src/api/connect.rs
+++ b/apps/server/src/api/connect.rs
@@ -3,7 +3,7 @@
 //! This module provides REST endpoints for syncing broker accounts and activities
 //! from the Wealthfolio Connect cloud service.
 
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 use axum::{
     extract::{Query, State},
@@ -22,8 +22,8 @@ use crate::main_lib::AppState;
 use axum::http::StatusCode;
 use wealthfolio_connect::{
     broker::{
-        BrokerApiClient, PlansResponse, SyncAccountsResponse, SyncActivitiesResponse,
-        SyncConnectionsResponse, UserInfo,
+        BrokerApiClient, BrokerSyncStatusDetail, PlansResponse, SyncAccountsResponse,
+        SyncActivitiesResponse, SyncConnectionsResponse, UserInfo,
     },
     ensure_valid_access_token, fetch_subscription_plans_public, ConnectApiClient, SyncConfig,
     SyncOrchestrator, SyncProgressPayload, SyncProgressReporter, SyncResult, TokenLifecycleConfig,
@@ -52,6 +52,55 @@ fn ensure_connect_sync_enabled() -> ApiResult<()> {
             "Connect sync feature is disabled in this build.".to_string(),
         ))
     }
+}
+
+fn parse_provider_sync_date(value: &str) -> Result<chrono::NaiveDate, String> {
+    chrono::DateTime::parse_from_rfc3339(value)
+        .map(|dt| dt.with_timezone(&chrono::Utc).date_naive())
+        .or_else(|_| chrono::NaiveDate::parse_from_str(value, "%Y-%m-%d"))
+        .map_err(|_| format!("Invalid provider sync timestamp '{}'", value))
+}
+
+fn resolve_activity_waterline(
+    status: Option<&BrokerSyncStatusDetail>,
+) -> Result<chrono::NaiveDate, String> {
+    let Some(status) = status else {
+        return Err("Provider transaction sync status is unavailable".to_string());
+    };
+
+    if status.initial_sync_completed == Some(false) {
+        return Err("Provider transaction sync is still preparing".to_string());
+    }
+
+    let Some(last_successful_sync) = status.last_successful_sync.as_deref() else {
+        return Err("Provider transaction sync has no successful waterline".to_string());
+    };
+
+    parse_provider_sync_date(last_successful_sync)
+}
+
+fn should_advance_activity_cursor(
+    fetched: usize,
+    has_local_cursor: bool,
+    inconsistent_empty_page: bool,
+    provider_status: Option<&BrokerSyncStatusDetail>,
+) -> bool {
+    if inconsistent_empty_page {
+        return false;
+    }
+
+    if fetched > 0 || has_local_cursor {
+        return true;
+    }
+
+    matches!(
+        provider_status,
+        Some(BrokerSyncStatusDetail {
+            initial_sync_completed: Some(true),
+            first_transaction_date: None,
+            ..
+        })
+    )
 }
 
 fn ensure_device_sync_enabled() -> ApiResult<()> {
@@ -594,10 +643,21 @@ async fn perform_broker_activities_only_sync(
         .connect_sync_service
         .get_synced_accounts()
         .map_err(|e| e.to_string())?;
+    let provider_transaction_statuses: HashMap<String, BrokerSyncStatusDetail> = client
+        .list_accounts(None)
+        .await
+        .map_err(|e| e.to_string())?
+        .into_iter()
+        .filter_map(|account| {
+            Some((
+                account.id?,
+                account.sync_status.as_ref()?.transactions.clone()?,
+            ))
+        })
+        .collect();
 
     let mut summary = SyncActivitiesResponse::default();
-    let end_date = chrono::Utc::now().date_naive();
-    let end_date_str = end_date.format("%Y-%m-%d").to_string();
+    let today = chrono::Utc::now().date_naive();
     let page_limit: i64 = 1000;
 
     for account in synced_accounts {
@@ -625,12 +685,56 @@ async fn perform_broker_activities_only_sync(
             continue;
         }
 
-        let start_date = state
+        let local_activity_state = state
             .connect_sync_service
             .get_activity_sync_state(&account_id)
-            .map_err(|e| e.to_string())?
+            .map_err(|e| e.to_string())?;
+        let local_cursor = local_activity_state
+            .as_ref()
+            .and_then(|s| s.last_successful_at.as_ref());
+        let has_local_cursor = local_cursor.is_some();
+        let provider_status = provider_transaction_statuses.get(&provider_account_id);
+        let provider_waterline = match resolve_activity_waterline(provider_status) {
+            Ok(date) => date.min(today),
+            Err(err) => {
+                let warning = format!("Activity sync deferred: {}", err);
+                let _ = state
+                    .connect_sync_service
+                    .finalize_activity_sync_needs_review(account_id.clone(), warning.clone(), None)
+                    .await;
+                summary.accounts_warned += 1;
+                info!("[Connect] {}", warning);
+                continue;
+            }
+        };
+        if let Some(cursor) = local_cursor {
+            if provider_waterline < cursor.date_naive() {
+                let message = format!(
+                    "Activity sync skipped: provider transaction waterline {} is older than local cursor {}",
+                    provider_waterline,
+                    cursor.date_naive()
+                );
+                if let Err(err) = state
+                    .connect_sync_service
+                    .finalize_activity_sync_success(account_id.clone(), cursor.to_rfc3339(), None)
+                    .await
+                {
+                    error!(
+                        "[Connect] Failed to restore activity sync state for {}: {}",
+                        account_name, err
+                    );
+                    summary.accounts_failed += 1;
+                } else {
+                    summary.accounts_synced += 1;
+                    info!("[Connect] {}", message);
+                }
+                continue;
+            }
+        }
+        let end_date_str = provider_waterline.format("%Y-%m-%d").to_string();
+        let start_date = local_activity_state
             .and_then(|s| s.last_successful_at)
-            .map(|dt| (dt.date_naive() - chrono::Days::new(1)).min(end_date))
+            .map(|dt| (dt.date_naive() - chrono::Days::new(1)).min(provider_waterline))
             .map(|d| d.format("%Y-%m-%d").to_string());
 
         info!(
@@ -646,6 +750,9 @@ async fn perform_broker_activities_only_sync(
         let mut account_assets = 0usize;
         let mut account_new_asset_ids: Vec<String> = Vec::new();
         let mut account_failed = false;
+        let mut account_fetched = 0usize;
+        let mut empty_first_page = false;
+        let mut inconsistent_empty_page = false;
 
         loop {
             let page = match client
@@ -675,7 +782,12 @@ async fn perform_broker_activities_only_sync(
             };
 
             let received = page.data.len() as i64;
+            account_fetched += received as usize;
             if received == 0 {
+                empty_first_page = offset == 0;
+                inconsistent_empty_page = page.pagination.as_ref().is_some_and(|p| {
+                    p.has_more == Some(true) || p.total.is_some_and(|total| offset < total)
+                });
                 break;
             }
 
@@ -733,10 +845,32 @@ async fn perform_broker_activities_only_sync(
             continue;
         }
 
-        let now = chrono::Utc::now().to_rfc3339();
+        if !should_advance_activity_cursor(
+            account_fetched,
+            has_local_cursor,
+            inconsistent_empty_page,
+            provider_status,
+        ) {
+            let warning = if inconsistent_empty_page {
+                "Activity sync returned an empty page while provider pagination reported more data"
+            } else if empty_first_page {
+                "Initial activity sync returned no rows even though provider reports transactions may exist"
+            } else {
+                "Initial activity sync did not confirm a complete empty history"
+            }
+            .to_string();
+            let _ = state
+                .connect_sync_service
+                .finalize_activity_sync_needs_review(account_id.clone(), warning.clone(), None)
+                .await;
+            summary.accounts_warned += 1;
+            info!("[Connect] {}", warning);
+            continue;
+        }
+
         if let Err(err) = state
             .connect_sync_service
-            .finalize_activity_sync_success(account_id.clone(), now, None)
+            .finalize_activity_sync_success(account_id.clone(), end_date_str, None)
             .await
         {
             error!(

--- a/crates/connect/src/broker/mod.rs
+++ b/crates/connect/src/broker/mod.rs
@@ -3,10 +3,15 @@ mod models;
 pub mod orchestrator;
 pub mod progress;
 mod service;
+pub mod sync_readiness;
 mod traits;
 
 pub use models::*;
 pub use orchestrator::{SyncConfig, SyncOrchestrator};
 pub use progress::{NoOpProgressReporter, SyncProgressPayload, SyncProgressReporter, SyncStatus};
 pub use service::BrokerSyncService;
+pub use sync_readiness::{
+    provider_waterline_precedes_local_cursor, resolve_activity_readiness,
+    resolve_holdings_readiness, should_advance_activity_cursor, ProviderReadiness,
+};
 pub use traits::*;

--- a/crates/connect/src/broker/models.rs
+++ b/crates/connect/src/broker/models.rs
@@ -589,6 +589,9 @@ pub struct SyncHoldingsResponse {
     pub positions_upserted: usize,
     pub assets_inserted: usize,
     pub accounts_failed: usize,
+    /// Accounts with soft warnings (e.g., provider holdings sync is still preparing).
+    #[serde(default)]
+    pub accounts_warned: usize,
     /// IDs of newly created assets (for background enrichment)
     #[serde(default)]
     pub new_asset_ids: Vec<String>,

--- a/crates/connect/src/broker/orchestrator.rs
+++ b/crates/connect/src/broker/orchestrator.rs
@@ -3,13 +3,15 @@
 //! This module provides a unified sync implementation that can be used
 //! by both Tauri (desktop) and Axum (web) platforms.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
+use chrono::{DateTime, NaiveDate, Utc};
 use log::{debug, error, info, warn};
 
 use super::models::{
-    HoldingsDiff, NewAccountInfo, SyncActivitiesResponse, SyncHoldingsResponse, SyncResult,
+    BrokerSyncStatusDetail, HoldingsDiff, NewAccountInfo, SyncActivitiesResponse,
+    SyncHoldingsResponse, SyncResult,
 };
 use super::progress::{SyncProgressPayload, SyncProgressReporter, SyncStatus};
 use super::traits::{BrokerApiClient, BrokerSyncServiceTrait};
@@ -32,6 +34,121 @@ impl Default for SyncConfig {
             max_pages: 10_000,
         }
     }
+}
+
+#[derive(Debug, Clone)]
+struct ActivityQueryWindow {
+    start_date: Option<String>,
+    end_date: String,
+    provider_waterline: String,
+    has_local_cursor: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+struct ActivitySyncOutcome {
+    fetched: u32,
+    inserted: u32,
+    assets_created: u32,
+    needs_review: u32,
+    new_asset_ids: Vec<String>,
+    empty_first_page: bool,
+    inconsistent_empty_page: bool,
+}
+
+enum ProviderReadiness {
+    Ready(NaiveDate),
+    NotReady(String),
+}
+
+fn parse_provider_sync_date(value: &str) -> Result<NaiveDate, String> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|dt| dt.with_timezone(&Utc).date_naive())
+        .or_else(|_| NaiveDate::parse_from_str(value, "%Y-%m-%d"))
+        .map_err(|_| format!("Invalid provider sync timestamp '{}'", value))
+}
+
+fn resolve_activity_readiness(
+    status: Option<&BrokerSyncStatusDetail>,
+) -> Result<ProviderReadiness, String> {
+    let Some(status) = status else {
+        return Ok(ProviderReadiness::NotReady(
+            "Provider transaction sync status is unavailable".to_string(),
+        ));
+    };
+
+    if status.initial_sync_completed == Some(false) {
+        return Ok(ProviderReadiness::NotReady(
+            "Provider transaction sync is still preparing".to_string(),
+        ));
+    }
+
+    let Some(last_successful_sync) = status.last_successful_sync.as_deref() else {
+        return Ok(ProviderReadiness::NotReady(
+            "Provider transaction sync has no successful waterline".to_string(),
+        ));
+    };
+
+    Ok(ProviderReadiness::Ready(parse_provider_sync_date(
+        last_successful_sync,
+    )?))
+}
+
+fn resolve_holdings_readiness(
+    status: Option<&BrokerSyncStatusDetail>,
+) -> Result<ProviderReadiness, String> {
+    let Some(status) = status else {
+        return Ok(ProviderReadiness::NotReady(
+            "Provider holdings sync status is unavailable".to_string(),
+        ));
+    };
+
+    if status.initial_sync_completed == Some(false) {
+        return Ok(ProviderReadiness::NotReady(
+            "Provider holdings sync is still preparing".to_string(),
+        ));
+    }
+
+    let Some(last_successful_sync) = status.last_successful_sync.as_deref() else {
+        return Ok(ProviderReadiness::NotReady(
+            "Provider holdings sync has no successful waterline".to_string(),
+        ));
+    };
+
+    Ok(ProviderReadiness::Ready(parse_provider_sync_date(
+        last_successful_sync,
+    )?))
+}
+
+fn provider_waterline_precedes_local_cursor(
+    local_cursor: Option<&DateTime<Utc>>,
+    provider_waterline: NaiveDate,
+) -> bool {
+    local_cursor
+        .map(|cursor| provider_waterline < cursor.date_naive())
+        .unwrap_or(false)
+}
+
+fn should_advance_activity_cursor(
+    outcome: &ActivitySyncOutcome,
+    window: &ActivityQueryWindow,
+    provider_status: Option<&BrokerSyncStatusDetail>,
+) -> bool {
+    if outcome.inconsistent_empty_page {
+        return false;
+    }
+
+    if outcome.fetched > 0 || window.has_local_cursor {
+        return true;
+    }
+
+    matches!(
+        provider_status,
+        Some(BrokerSyncStatusDetail {
+            initial_sync_completed: Some(true),
+            first_transaction_date: None,
+            ..
+        })
+    )
 }
 
 /// Orchestrates broker data synchronization.
@@ -136,6 +253,25 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
             .await
             .map_err(|e| e.to_string())?;
 
+        let provider_transaction_statuses: HashMap<String, BrokerSyncStatusDetail> = all_accounts
+            .iter()
+            .filter_map(|account| {
+                Some((
+                    account.id.clone()?,
+                    account.sync_status.as_ref()?.transactions.clone()?,
+                ))
+            })
+            .collect();
+        let provider_holdings_statuses: HashMap<String, BrokerSyncStatusDetail> = all_accounts
+            .iter()
+            .filter_map(|account| {
+                Some((
+                    account.id.clone()?,
+                    account.sync_status.as_ref()?.holdings.clone()?,
+                ))
+            })
+            .collect();
+
         // Track sync-enabled broker IDs for data sync
         let sync_enabled_broker_ids: HashSet<String> = all_accounts
             .iter()
@@ -165,7 +301,12 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
         // - HOLDINGS mode: sync holdings (positions)
         // - NOT_SET mode: skip (needs user configuration first)
         let (activities_result, holdings_result) = self
-            .sync_account_data(api_client, &sync_enabled_broker_ids)
+            .sync_account_data(
+                api_client,
+                &sync_enabled_broker_ids,
+                &provider_transaction_statuses,
+                &provider_holdings_statuses,
+            )
             .await?;
 
         // Build the accounts_needing_setup list - sync-enabled accounts with trackingMode=NOT_SET
@@ -198,7 +339,7 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
         };
 
         let total_failed = activities_result.accounts_failed + holdings_result.accounts_failed;
-        let total_warnings = activities_result.accounts_warned;
+        let total_warnings = activities_result.accounts_warned + holdings_result.accounts_warned;
         let result = SyncResult {
             success: total_failed == 0,
             message: format!(
@@ -239,9 +380,9 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
         &self,
         api_client: &dyn BrokerApiClient,
         sync_enabled_broker_ids: &HashSet<String>,
+        provider_transaction_statuses: &HashMap<String, BrokerSyncStatusDetail>,
+        provider_holdings_statuses: &HashMap<String, BrokerSyncStatusDetail>,
     ) -> Result<(SyncActivitiesResponse, SyncHoldingsResponse), String> {
-        let end_date = chrono::Utc::now().date_naive();
-
         let synced_accounts = self
             .sync_service
             .get_synced_accounts()
@@ -314,11 +455,14 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
             let mut activity_import_run_id: Option<String> = None;
 
             if activity_warning.is_none() {
-                let query_window = match self.compute_activity_query_window(&account_id, end_date) {
-                    Ok(window) => Some(window),
+                let local_activity_state = match self
+                    .sync_service
+                    .get_activity_sync_state(&account_id)
+                {
+                    Ok(state) => Some(state),
                     Err(err) => {
                         error!(
-                            "Failed to compute activity query window for '{}': {}",
+                            "Failed to read activity sync state for '{}': {}",
                             account_name, err
                         );
                         if is_holdings_mode {
@@ -329,12 +473,12 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
                                     SyncStatus::NeedsReview,
                                 )
                                 .with_message(format!(
-                                    "Activity reference query window failed; continuing holdings sync: {}",
+                                    "Activity reference sync state failed; continuing holdings sync: {}",
                                     err
                                 )),
                             );
                             activities_summary.accounts_warned += 1;
-                            activity_warning = Some(err);
+                            activity_warning = Some(err.to_string());
                             None
                         } else {
                             activities_summary.accounts_failed += 1;
@@ -343,151 +487,362 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
                     }
                 };
 
-                if let Some((start_date, end_date_filter)) = query_window {
-                    let import_mode = if start_date.is_none() {
-                        ImportRunMode::Initial
-                    } else {
-                        ImportRunMode::Incremental
-                    };
+                if let Some(local_activity_state) = local_activity_state {
+                    let local_cursor = local_activity_state
+                        .as_ref()
+                        .and_then(|state| state.last_successful_at.as_ref());
+                    let provider_activity_status =
+                        provider_transaction_statuses.get(&broker_account_id);
 
-                    let import_run = match self
-                        .sync_service
-                        .create_import_run(&account_id, import_mode)
-                        .await
-                    {
-                        Ok(run) => {
-                            debug!(
-                                "Created import run {} for account '{}'",
-                                run.id, account_name
-                            );
-                            Some(run)
-                        }
-                        Err(e) => {
-                            error!("Failed to create import run for '{}': {}", account_name, e);
-                            None
-                        }
-                    };
-                    activity_import_run_id = import_run.as_ref().map(|r| r.id.clone());
-
-                    let window_label = match (&start_date, &end_date_filter) {
-                        (Some(s), Some(e)) => format!("{} -> {}", s, e),
-                        _ => "ALL".to_string(),
-                    };
-                    info!(
-                        "Syncing activities for account '{}' ({}): {}",
-                        account_name, broker_account_id, window_label
-                    );
-
-                    self.progress_reporter.report_progress(
-                        SyncProgressPayload::new(&account_id, &account_name, SyncStatus::Syncing)
-                            .with_message(format!("Starting sync: {}", window_label)),
-                    );
-
-                    match self
-                        .sync_account_activities(
-                            api_client,
-                            &account_id,
-                            &account_name,
-                            &broker_account_id,
-                            start_date.as_deref(),
-                            end_date_filter.as_deref(),
-                            activity_import_run_id.clone(),
-                        )
-                        .await
-                    {
-                        Ok((fetched, inserted, assets_created, needs_review, new_asset_ids)) => {
-                            let summary = ImportRunSummary {
-                                fetched,
-                                inserted,
-                                updated: 0,
-                                skipped: 0,
-                                warnings: needs_review,
-                                errors: 0,
-                                removed: 0,
-                                assets_created,
+                    let activity_waterline = match resolve_activity_readiness(
+                        provider_activity_status,
+                    ) {
+                        Ok(ProviderReadiness::Ready(date))
+                            if provider_waterline_precedes_local_cursor(local_cursor, date) =>
+                        {
+                            let Some(cursor) = local_cursor else {
+                                unreachable!("stale provider waterline requires local cursor");
                             };
-
-                            let last_synced_date = end_date.format("%Y-%m-%d").to_string();
-                            let sync_state_failed = self
+                            let message = format!(
+                                "Activity sync skipped: provider transaction waterline {} is older than local cursor {}",
+                                date,
+                                cursor.date_naive()
+                            );
+                            if let Err(e) = self
                                 .sync_service
                                 .finalize_activity_sync_success(
                                     account_id.clone(),
-                                    last_synced_date,
-                                    activity_import_run_id.clone(),
+                                    cursor.to_rfc3339(),
+                                    None,
                                 )
                                 .await
-                                .is_err();
-
-                            if sync_state_failed {
+                            {
                                 error!(
-                                    "Failed to update activity sync state for '{}', but activities were synced",
-                                    account_name
+                                    "Failed to restore activity sync state for '{}': {}",
+                                    account_name, e
+                                );
+                                activities_summary.accounts_failed += 1;
+                                if !is_holdings_mode {
+                                    continue;
+                                }
+                                activity_warning = Some(format!(
+                                    "Activity sync skipped, but sync state cleanup failed: {}",
+                                    e
+                                ));
+                            } else {
+                                self.progress_reporter.report_progress(
+                                    SyncProgressPayload::new(
+                                        &account_id,
+                                        &account_name,
+                                        SyncStatus::Complete,
+                                    )
+                                    .with_message(message),
+                                );
+                                activities_summary.accounts_synced += 1;
+                            }
+                            None
+                        }
+                        Ok(ProviderReadiness::Ready(date)) => Some(date),
+                        Ok(ProviderReadiness::NotReady(reason)) => {
+                            let warning = format!("Activity sync deferred: {}", reason);
+                            if let Err(e) = self
+                                .sync_service
+                                .finalize_activity_sync_needs_review(
+                                    account_id.clone(),
+                                    warning.clone(),
+                                    None,
+                                )
+                                .await
+                            {
+                                error!(
+                                    "Failed to mark deferred activity sync for '{}': {}",
+                                    account_name, e
                                 );
                             }
+                            self.progress_reporter.report_progress(
+                                SyncProgressPayload::new(
+                                    &account_id,
+                                    &account_name,
+                                    SyncStatus::NeedsReview,
+                                )
+                                .with_message(warning.clone()),
+                            );
+                            activities_summary.accounts_warned += 1;
+                            activity_warning = Some(warning);
+                            None
+                        }
+                        Err(err) => {
+                            error!(
+                                "Failed to resolve provider activity sync status for '{}': {}",
+                                account_name, err
+                            );
+                            if is_holdings_mode {
+                                let message = format!(
+                                    "Activity reference sync status failed; continuing holdings sync: {}",
+                                    err
+                                );
+                                self.progress_reporter.report_progress(
+                                    SyncProgressPayload::new(
+                                        &account_id,
+                                        &account_name,
+                                        SyncStatus::NeedsReview,
+                                    )
+                                    .with_message(message),
+                                );
+                                activities_summary.accounts_warned += 1;
+                                activity_warning = Some(err);
+                                None
+                            } else {
+                                activities_summary.accounts_failed += 1;
+                                continue;
+                            }
+                        }
+                    };
 
-                            if let Some(ref run_id) = activity_import_run_id {
-                                let status = if needs_review > 0 {
-                                    info!(
-                                        "Import run {} has {} activities needing review",
-                                        run_id, needs_review
+                    let query_window = match activity_waterline {
+                        Some(waterline) => {
+                            match self.compute_activity_query_window(&account_id, waterline) {
+                                Ok(window) => Some(window),
+                                Err(err) => {
+                                    error!(
+                                        "Failed to compute activity query window for '{}': {}",
+                                        account_name, err
                                     );
+                                    if is_holdings_mode {
+                                        let message = format!(
+                                            "Activity reference query window failed; continuing holdings sync: {}",
+                                            err
+                                        );
+                                        self.progress_reporter.report_progress(
+                                            SyncProgressPayload::new(
+                                                &account_id,
+                                                &account_name,
+                                                SyncStatus::NeedsReview,
+                                            )
+                                            .with_message(message),
+                                        );
+                                        activities_summary.accounts_warned += 1;
+                                        activity_warning = Some(err);
+                                        None
+                                    } else {
+                                        activities_summary.accounts_failed += 1;
+                                        continue;
+                                    }
+                                }
+                            }
+                        }
+                        None => None,
+                    };
+
+                    if let Some(query_window) = query_window {
+                        let import_mode = if query_window.start_date.is_none() {
+                            ImportRunMode::Initial
+                        } else {
+                            ImportRunMode::Incremental
+                        };
+
+                        let import_run = match self
+                            .sync_service
+                            .create_import_run(&account_id, import_mode)
+                            .await
+                        {
+                            Ok(run) => {
+                                debug!(
+                                    "Created import run {} for account '{}'",
+                                    run.id, account_name
+                                );
+                                Some(run)
+                            }
+                            Err(e) => {
+                                error!("Failed to create import run for '{}': {}", account_name, e);
+                                None
+                            }
+                        };
+                        activity_import_run_id = import_run.as_ref().map(|r| r.id.clone());
+
+                        let window_label = match &query_window.start_date {
+                            Some(s) => format!("{} -> {}", s, query_window.end_date),
+                            None => format!("ALL -> {}", query_window.end_date),
+                        };
+                        info!(
+                            "Syncing activities for account '{}' ({}): {}",
+                            account_name, broker_account_id, window_label
+                        );
+
+                        self.progress_reporter.report_progress(
+                            SyncProgressPayload::new(
+                                &account_id,
+                                &account_name,
+                                SyncStatus::Syncing,
+                            )
+                            .with_message(format!("Starting sync: {}", window_label)),
+                        );
+
+                        match self
+                            .sync_account_activities(
+                                api_client,
+                                &account_id,
+                                &account_name,
+                                &broker_account_id,
+                                query_window.start_date.as_deref(),
+                                Some(query_window.end_date.as_str()),
+                                activity_import_run_id.clone(),
+                            )
+                            .await
+                        {
+                            Ok(outcome) => {
+                                let mut import_status = if outcome.needs_review > 0 {
                                     ImportRunStatus::NeedsReview
                                 } else {
                                     ImportRunStatus::Applied
                                 };
+                                let summary = ImportRunSummary {
+                                    fetched: outcome.fetched,
+                                    inserted: outcome.inserted,
+                                    updated: 0,
+                                    skipped: 0,
+                                    warnings: outcome.needs_review,
+                                    errors: 0,
+                                    removed: 0,
+                                    assets_created: outcome.assets_created,
+                                };
 
-                                let _ = self
-                                    .sync_service
-                                    .finalize_import_run(run_id, summary, status, None)
-                                    .await;
+                                let should_advance_cursor = should_advance_activity_cursor(
+                                    &outcome,
+                                    &query_window,
+                                    provider_activity_status,
+                                );
+
+                                if should_advance_cursor {
+                                    let sync_state_failed = self
+                                        .sync_service
+                                        .finalize_activity_sync_success(
+                                            account_id.clone(),
+                                            query_window.provider_waterline.clone(),
+                                            activity_import_run_id.clone(),
+                                        )
+                                        .await
+                                        .is_err();
+
+                                    if sync_state_failed {
+                                        error!(
+                                        "Failed to update activity sync state for '{}', but activities were synced",
+                                        account_name
+                                    );
+                                    }
+                                } else {
+                                    let warning = if outcome.inconsistent_empty_page {
+                                        "Activity sync returned an empty page while provider pagination reported more data"
+                                    } else if outcome.empty_first_page {
+                                        "Initial activity sync returned no rows even though provider reports transactions may exist"
+                                    } else {
+                                        "Initial activity sync did not confirm a complete empty history"
+                                }
+                                .to_string();
+                                    if let Err(e) = self
+                                        .sync_service
+                                        .finalize_activity_sync_needs_review(
+                                            account_id.clone(),
+                                            warning.clone(),
+                                            activity_import_run_id.clone(),
+                                        )
+                                        .await
+                                    {
+                                        error!(
+                                        "Failed to mark activity sync as needs review for '{}': {}",
+                                        account_name, e
+                                    );
+                                    }
+                                    import_status = ImportRunStatus::NeedsReview;
+                                    activities_summary.accounts_warned += 1;
+                                    activity_warning = Some(warning.clone());
+                                    self.progress_reporter.report_progress(
+                                        SyncProgressPayload::new(
+                                            &account_id,
+                                            &account_name,
+                                            SyncStatus::NeedsReview,
+                                        )
+                                        .with_activities_fetched(outcome.fetched as usize)
+                                        .with_message(warning),
+                                    );
+                                }
+
+                                if let Some(ref run_id) = activity_import_run_id {
+                                    if outcome.needs_review > 0 {
+                                        info!(
+                                            "Import run {} has {} activities needing review",
+                                            run_id, outcome.needs_review
+                                        );
+                                    }
+
+                                    let _ = self
+                                        .sync_service
+                                        .finalize_import_run(run_id, summary, import_status, None)
+                                        .await;
+                                }
+
+                                if !should_advance_cursor {
+                                    if !is_holdings_mode {
+                                        continue;
+                                    }
+                                } else {
+                                    let status = if outcome.needs_review > 0 {
+                                        SyncStatus::NeedsReview
+                                    } else {
+                                        SyncStatus::Complete
+                                    };
+                                    self.progress_reporter.report_progress(
+                                        SyncProgressPayload::new(
+                                            &account_id,
+                                            &account_name,
+                                            status,
+                                        )
+                                        .with_activities_fetched(outcome.fetched as usize)
+                                        .with_message(
+                                            format!(
+                                                "Synced {} activities ({} need review)",
+                                                outcome.inserted, outcome.needs_review
+                                            ),
+                                        ),
+                                    );
+
+                                    activities_summary.accounts_synced += 1;
+                                }
+
+                                activities_summary.activities_upserted += outcome.inserted as usize;
+                                activities_summary.assets_inserted +=
+                                    outcome.assets_created as usize;
+                                activities_summary
+                                    .new_asset_ids
+                                    .extend(outcome.new_asset_ids);
                             }
+                            Err(err) => {
+                                error!("Failed to sync activities for '{}': {}", account_name, err);
 
-                            let status = if needs_review > 0 {
-                                SyncStatus::NeedsReview
-                            } else {
-                                SyncStatus::Complete
-                            };
-                            self.progress_reporter.report_progress(
-                                SyncProgressPayload::new(&account_id, &account_name, status)
-                                    .with_activities_fetched(fetched as usize)
-                                    .with_message(format!(
-                                        "Synced {} activities ({} need review)",
-                                        inserted, needs_review
-                                    )),
-                            );
-
-                            activities_summary.accounts_synced += 1;
-                            activities_summary.activities_upserted += inserted as usize;
-                            activities_summary.assets_inserted += assets_created as usize;
-                            activities_summary.new_asset_ids.extend(new_asset_ids);
-                        }
-                        Err(err) => {
-                            error!("Failed to sync activities for '{}': {}", account_name, err);
-
-                            let _ = self
-                                .sync_service
-                                .finalize_activity_sync_failure(
-                                    account_id.clone(),
-                                    err.clone(),
-                                    activity_import_run_id.clone(),
-                                )
-                                .await;
-
-                            if let Some(ref run_id) = activity_import_run_id {
-                                let summary = ImportRunSummary::default();
                                 let _ = self
                                     .sync_service
-                                    .finalize_import_run(
-                                        run_id,
-                                        summary,
-                                        ImportRunStatus::Failed,
-                                        Some(err.clone()),
+                                    .finalize_activity_sync_failure(
+                                        account_id.clone(),
+                                        err.clone(),
+                                        activity_import_run_id.clone(),
                                     )
                                     .await;
-                            }
 
-                            if is_holdings_mode {
-                                self.progress_reporter.report_progress(
+                                if let Some(ref run_id) = activity_import_run_id {
+                                    let summary = ImportRunSummary::default();
+                                    let _ = self
+                                        .sync_service
+                                        .finalize_import_run(
+                                            run_id,
+                                            summary,
+                                            ImportRunStatus::Failed,
+                                            Some(err.clone()),
+                                        )
+                                        .await;
+                                }
+
+                                if is_holdings_mode {
+                                    self.progress_reporter.report_progress(
                                     SyncProgressPayload::new(
                                         &account_id,
                                         &account_name,
@@ -498,19 +853,20 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
                                         err
                                     )),
                                 );
-                                activities_summary.accounts_warned += 1;
-                                activity_warning = Some(err);
-                            } else {
-                                self.progress_reporter.report_progress(
-                                    SyncProgressPayload::new(
-                                        &account_id,
-                                        &account_name,
-                                        SyncStatus::Failed,
-                                    )
-                                    .with_message(err.clone()),
-                                );
-                                activities_summary.accounts_failed += 1;
-                                continue;
+                                    activities_summary.accounts_warned += 1;
+                                    activity_warning = Some(err);
+                                } else {
+                                    self.progress_reporter.report_progress(
+                                        SyncProgressPayload::new(
+                                            &account_id,
+                                            &account_name,
+                                            SyncStatus::Failed,
+                                        )
+                                        .with_message(err.clone()),
+                                    );
+                                    activities_summary.accounts_failed += 1;
+                                    continue;
+                                }
                             }
                         }
                     }
@@ -521,14 +877,40 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
                 continue;
             }
 
-            // Determine import run mode from existing sync state.
-            let holdings_import_mode = match self.sync_service.get_activity_sync_state(&account_id)
+            match resolve_holdings_readiness(provider_holdings_statuses.get(&broker_account_id)) {
+                Ok(ProviderReadiness::Ready(_)) => {}
+                Ok(ProviderReadiness::NotReady(reason)) => {
+                    let warning = format!("Holdings sync deferred: {}", reason);
+                    self.progress_reporter.report_progress(
+                        SyncProgressPayload::new(
+                            &account_id,
+                            &account_name,
+                            SyncStatus::NeedsReview,
+                        )
+                        .with_message(warning),
+                    );
+                    holdings_summary.accounts_warned += 1;
+                    continue;
+                }
+                Err(err) => {
+                    error!(
+                        "Failed to resolve provider holdings sync status for '{}': {}",
+                        account_name, err
+                    );
+                    holdings_summary.accounts_failed += 1;
+                    continue;
+                }
+            }
+
+            let holdings_import_mode = match self
+                .sync_service
+                .has_broker_imported_holdings_snapshot(&account_id)
             {
-                Ok(Some(state)) if state.last_successful_at.is_some() => ImportRunMode::Incremental,
-                Ok(_) => ImportRunMode::Initial,
+                Ok(true) => ImportRunMode::Incremental,
+                Ok(false) => ImportRunMode::Initial,
                 Err(e) => {
                     warn!(
-                        "Failed to read sync state for '{}' before holdings sync: {}",
+                        "Failed to read holdings snapshot state for '{}' before holdings sync: {}",
                         account_name, e
                     );
                     ImportRunMode::Initial
@@ -745,11 +1127,13 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
         start_date: Option<&str>,
         end_date: Option<&str>,
         import_run_id: Option<String>,
-    ) -> Result<(u32, u32, u32, u32, Vec<String>), String> {
+    ) -> Result<ActivitySyncOutcome, String> {
         let mut offset: i64 = 0;
         let limit = self.config.page_limit;
         let mut pages_fetched: usize = 0;
         let mut last_page_first_id: Option<String> = None;
+        let mut empty_first_page = false;
+        let mut inconsistent_empty_page = false;
 
         let mut total_fetched: u32 = 0;
         let mut total_inserted: u32 = 0;
@@ -852,6 +1236,10 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
 
             // Avoid spinning forever if API reports more pages but returns no data.
             if received == 0 {
+                empty_first_page = pages_fetched == 1;
+                inconsistent_empty_page = page.pagination.as_ref().is_some_and(|p| {
+                    p.has_more == Some(true) || p.total.is_some_and(|total| offset < total)
+                });
                 break;
             }
 
@@ -882,39 +1270,43 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
             }
         }
 
-        Ok((
-            total_fetched,
-            total_inserted,
-            total_assets_created,
-            total_needs_review,
-            all_new_asset_ids,
-        ))
+        Ok(ActivitySyncOutcome {
+            fetched: total_fetched,
+            inserted: total_inserted,
+            assets_created: total_assets_created,
+            needs_review: total_needs_review,
+            new_asset_ids: all_new_asset_ids,
+            empty_first_page,
+            inconsistent_empty_page,
+        })
     }
 
     /// Compute the activity query window for incremental sync.
     fn compute_activity_query_window(
         &self,
         account_id: &str,
-        end_date: chrono::NaiveDate,
-    ) -> Result<(Option<String>, Option<String>), String> {
+        provider_waterline: NaiveDate,
+    ) -> Result<ActivityQueryWindow, String> {
+        let today = Utc::now().date_naive();
+        let end_date = provider_waterline.min(today);
         let sync_state = self
             .sync_service
             .get_activity_sync_state(account_id)
             .map_err(|e| format!("Failed to read activity sync state: {}", e))?;
 
-        let from_state = sync_state
-            .and_then(|s| s.last_successful_at)
+        let local_cursor = sync_state.and_then(|s| s.last_successful_at);
+        let has_local_cursor = local_cursor.is_some();
+        let start_date = local_cursor
             .map(|dt| dt.date_naive())
-            .map(|d| (d - chrono::Days::new(1)).min(end_date));
+            .map(|d| (d - chrono::Days::new(1)).min(end_date))
+            .map(|d| d.format("%Y-%m-%d").to_string());
 
-        if let Some(d) = from_state {
-            return Ok((
-                Some(d.format("%Y-%m-%d").to_string()),
-                Some(end_date.format("%Y-%m-%d").to_string()),
-            ));
-        }
-
-        Ok((None, None))
+        Ok(ActivityQueryWindow {
+            start_date,
+            end_date: end_date.format("%Y-%m-%d").to_string(),
+            provider_waterline: end_date.format("%Y-%m-%d").to_string(),
+            has_local_cursor,
+        })
     }
 }
 
@@ -927,5 +1319,133 @@ mod tests {
         let config = SyncConfig::default();
         assert_eq!(config.page_limit, 1000);
         assert_eq!(config.max_pages, 10_000);
+    }
+
+    fn transactions_status(
+        initial_sync_completed: Option<bool>,
+        last_successful_sync: Option<&str>,
+        first_transaction_date: Option<&str>,
+    ) -> BrokerSyncStatusDetail {
+        BrokerSyncStatusDetail {
+            initial_sync_completed,
+            last_successful_sync: last_successful_sync.map(str::to_string),
+            first_transaction_date: first_transaction_date.map(str::to_string),
+        }
+    }
+
+    fn window(has_local_cursor: bool) -> ActivityQueryWindow {
+        ActivityQueryWindow {
+            start_date: has_local_cursor.then(|| "2026-05-21".to_string()),
+            end_date: "2026-05-22".to_string(),
+            provider_waterline: "2026-05-22".to_string(),
+            has_local_cursor,
+        }
+    }
+
+    #[test]
+    fn provider_not_ready_defers_first_activity_sync() {
+        let status = transactions_status(Some(false), None, None);
+        let readiness = resolve_activity_readiness(Some(&status)).unwrap();
+
+        assert!(matches!(readiness, ProviderReadiness::NotReady(_)));
+    }
+
+    #[test]
+    fn provider_waterline_without_initial_flag_allows_activity_fetch() {
+        let status = transactions_status(None, Some("2026-05-22"), None);
+        let readiness = resolve_activity_readiness(Some(&status)).unwrap();
+
+        assert!(matches!(
+            readiness,
+            ProviderReadiness::Ready(date)
+                if date == NaiveDate::from_ymd_opt(2026, 5, 22).unwrap()
+        ));
+    }
+
+    #[test]
+    fn provider_waterline_before_local_cursor_is_stale() {
+        let local_cursor = DateTime::parse_from_rfc3339("2026-05-22T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let stale_waterline = NaiveDate::from_ymd_opt(2026, 5, 21).unwrap();
+        let current_waterline = NaiveDate::from_ymd_opt(2026, 5, 22).unwrap();
+
+        assert!(provider_waterline_precedes_local_cursor(
+            Some(&local_cursor),
+            stale_waterline
+        ));
+        assert!(!provider_waterline_precedes_local_cursor(
+            Some(&local_cursor),
+            current_waterline
+        ));
+    }
+
+    #[test]
+    fn initial_empty_activity_sync_with_first_transaction_does_not_advance_cursor() {
+        let status = transactions_status(Some(true), Some("2026-05-22"), Some("2020-01-01"));
+        let outcome = ActivitySyncOutcome {
+            empty_first_page: true,
+            ..ActivitySyncOutcome::default()
+        };
+
+        assert!(!should_advance_activity_cursor(
+            &outcome,
+            &window(false),
+            Some(&status)
+        ));
+    }
+
+    #[test]
+    fn initial_empty_activity_sync_with_confirmed_empty_history_advances_cursor() {
+        let status = transactions_status(Some(true), Some("2026-05-22"), None);
+        let outcome = ActivitySyncOutcome {
+            empty_first_page: true,
+            ..ActivitySyncOutcome::default()
+        };
+
+        assert!(should_advance_activity_cursor(
+            &outcome,
+            &window(false),
+            Some(&status)
+        ));
+    }
+
+    #[test]
+    fn incremental_empty_activity_sync_advances_cursor_to_provider_waterline() {
+        let status = transactions_status(Some(true), Some("2026-05-22"), Some("2020-01-01"));
+        let outcome = ActivitySyncOutcome {
+            empty_first_page: true,
+            ..ActivitySyncOutcome::default()
+        };
+
+        assert!(should_advance_activity_cursor(
+            &outcome,
+            &window(true),
+            Some(&status)
+        ));
+    }
+
+    #[test]
+    fn inconsistent_empty_activity_page_does_not_advance_cursor() {
+        let status = transactions_status(Some(true), Some("2026-05-22"), None);
+        let outcome = ActivitySyncOutcome {
+            empty_first_page: true,
+            inconsistent_empty_page: true,
+            ..ActivitySyncOutcome::default()
+        };
+
+        assert!(!should_advance_activity_cursor(
+            &outcome,
+            &window(true),
+            Some(&status)
+        ));
+    }
+
+    #[test]
+    fn holdings_not_ready_defers_snapshot_sync() {
+        let status = transactions_status(Some(false), None, None);
+        let readiness = resolve_holdings_readiness(Some(&status)).unwrap();
+
+        assert!(matches!(readiness, ProviderReadiness::NotReady(_)));
     }
 }

--- a/crates/connect/src/broker/orchestrator.rs
+++ b/crates/connect/src/broker/orchestrator.rs
@@ -6,17 +6,19 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use chrono::{DateTime, NaiveDate, Utc};
-use log::{debug, error, info, warn};
+mod activity_pagination;
+mod activity_phase;
+mod holdings_phase;
+
+use log::{debug, info};
 
 use super::models::{
-    BrokerSyncStatusDetail, HoldingsDiff, NewAccountInfo, SyncActivitiesResponse,
-    SyncHoldingsResponse, SyncResult,
+    BrokerSyncStatusDetail, NewAccountInfo, SyncActivitiesResponse, SyncHoldingsResponse,
+    SyncResult,
 };
-use super::progress::{SyncProgressPayload, SyncProgressReporter, SyncStatus};
+use super::progress::SyncProgressReporter;
 use super::traits::{BrokerApiClient, BrokerSyncServiceTrait};
-use crate::broker_ingest::{ImportRunMode, ImportRunStatus, ImportRunSummary};
-use wealthfolio_core::accounts::TrackingMode;
+use wealthfolio_core::accounts::{Account, TrackingMode};
 
 /// Configuration for sync operations.
 #[derive(Debug, Clone)]
@@ -37,15 +39,37 @@ impl Default for SyncConfig {
 }
 
 #[derive(Debug, Clone)]
-struct ActivityQueryWindow {
+pub(super) struct AccountSyncJob {
+    account_id: String,
+    account_name: String,
+    broker_account_id: String,
+    tracking_mode: TrackingMode,
+}
+
+impl AccountSyncJob {
+    fn from_account(account: Account) -> Option<Self> {
+        Some(Self {
+            account_id: account.id,
+            account_name: account.name,
+            broker_account_id: account.provider_account_id?,
+            tracking_mode: account.tracking_mode,
+        })
+    }
+
+    fn is_holdings_mode(&self) -> bool {
+        self.tracking_mode == TrackingMode::Holdings
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct ActivityQueryWindow {
     start_date: Option<String>,
     end_date: String,
-    provider_waterline: String,
     has_local_cursor: bool,
 }
 
 #[derive(Debug, Clone, Default)]
-struct ActivitySyncOutcome {
+pub(super) struct ActivitySyncOutcome {
     fetched: u32,
     inserted: u32,
     assets_created: u32,
@@ -55,100 +79,28 @@ struct ActivitySyncOutcome {
     inconsistent_empty_page: bool,
 }
 
-enum ProviderReadiness {
-    Ready(NaiveDate),
-    NotReady(String),
+#[derive(Debug, Clone, Default)]
+pub(super) struct ActivityPhaseResult {
+    summary: SyncActivitiesResponse,
+    activity_warning: Option<String>,
+    activity_import_run_id: Option<String>,
+    continue_account: bool,
 }
 
-fn parse_provider_sync_date(value: &str) -> Result<NaiveDate, String> {
-    DateTime::parse_from_rfc3339(value)
-        .map(|dt| dt.with_timezone(&Utc).date_naive())
-        .or_else(|_| NaiveDate::parse_from_str(value, "%Y-%m-%d"))
-        .map_err(|_| format!("Invalid provider sync timestamp '{}'", value))
-}
-
-fn resolve_activity_readiness(
-    status: Option<&BrokerSyncStatusDetail>,
-) -> Result<ProviderReadiness, String> {
-    let Some(status) = status else {
-        return Ok(ProviderReadiness::NotReady(
-            "Provider transaction sync status is unavailable".to_string(),
-        ));
-    };
-
-    if status.initial_sync_completed == Some(false) {
-        return Ok(ProviderReadiness::NotReady(
-            "Provider transaction sync is still preparing".to_string(),
-        ));
+impl ActivityPhaseResult {
+    fn continue_with(summary: SyncActivitiesResponse) -> Self {
+        Self {
+            summary,
+            continue_account: true,
+            ..Self::default()
+        }
     }
-
-    let Some(last_successful_sync) = status.last_successful_sync.as_deref() else {
-        return Ok(ProviderReadiness::NotReady(
-            "Provider transaction sync has no successful waterline".to_string(),
-        ));
-    };
-
-    Ok(ProviderReadiness::Ready(parse_provider_sync_date(
-        last_successful_sync,
-    )?))
 }
 
-fn resolve_holdings_readiness(
-    status: Option<&BrokerSyncStatusDetail>,
-) -> Result<ProviderReadiness, String> {
-    let Some(status) = status else {
-        return Ok(ProviderReadiness::NotReady(
-            "Provider holdings sync status is unavailable".to_string(),
-        ));
-    };
-
-    if status.initial_sync_completed == Some(false) {
-        return Ok(ProviderReadiness::NotReady(
-            "Provider holdings sync is still preparing".to_string(),
-        ));
-    }
-
-    let Some(last_successful_sync) = status.last_successful_sync.as_deref() else {
-        return Ok(ProviderReadiness::NotReady(
-            "Provider holdings sync has no successful waterline".to_string(),
-        ));
-    };
-
-    Ok(ProviderReadiness::Ready(parse_provider_sync_date(
-        last_successful_sync,
-    )?))
-}
-
-fn provider_waterline_precedes_local_cursor(
-    local_cursor: Option<&DateTime<Utc>>,
-    provider_waterline: NaiveDate,
-) -> bool {
-    local_cursor
-        .map(|cursor| provider_waterline < cursor.date_naive())
-        .unwrap_or(false)
-}
-
-fn should_advance_activity_cursor(
-    outcome: &ActivitySyncOutcome,
-    window: &ActivityQueryWindow,
-    provider_status: Option<&BrokerSyncStatusDetail>,
-) -> bool {
-    if outcome.inconsistent_empty_page {
-        return false;
-    }
-
-    if outcome.fetched > 0 || window.has_local_cursor {
-        return true;
-    }
-
-    matches!(
-        provider_status,
-        Some(BrokerSyncStatusDetail {
-            initial_sync_completed: Some(true),
-            first_transaction_date: None,
-            ..
-        })
-    )
+#[derive(Debug, Clone, Default)]
+pub(super) struct HoldingsPhaseContext {
+    activity_warning: Option<String>,
+    activity_import_run_id: Option<String>,
 }
 
 /// Orchestrates broker data synchronization.
@@ -392,927 +344,88 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
         let mut holdings_summary = SyncHoldingsResponse::default();
 
         for account in synced_accounts {
-            let Some(broker_account_id) = account.provider_account_id.clone() else {
+            let Some(job) = AccountSyncJob::from_account(account) else {
                 continue;
             };
 
-            // Skip accounts that are not sync-enabled
-            if !sync_enabled_broker_ids.contains(&broker_account_id) {
+            if !sync_enabled_broker_ids.contains(&job.broker_account_id) {
                 info!(
                     "Skipping sync for account '{}' (sync disabled)",
-                    account.name
+                    job.account_name
                 );
                 continue;
             }
 
-            let account_id = account.id.clone();
-            let account_name = account.name.clone();
-            let is_holdings_mode = account.tracking_mode == TrackingMode::Holdings;
-
-            if account.tracking_mode == TrackingMode::NotSet {
+            if job.tracking_mode == TrackingMode::NotSet {
                 info!(
                     "Skipping sync for account '{}' (trackingMode=NOT_SET)",
-                    account_name
+                    job.account_name
                 );
                 continue;
             }
 
-            // Track reference-only activity issues for HOLDINGS accounts.
-            let mut activity_warning: Option<String> = None;
+            let activity_result = self
+                .sync_activity_phase(
+                    api_client,
+                    &job,
+                    provider_transaction_statuses.get(&job.broker_account_id),
+                )
+                .await;
+            let ActivityPhaseResult {
+                summary,
+                activity_warning,
+                activity_import_run_id,
+                continue_account,
+            } = activity_result;
+            Self::merge_activities_summary(&mut activities_summary, summary);
 
-            // Mark sync attempt
-            if let Err(err) = self
-                .sync_service
-                .mark_activity_sync_attempt(account_id.clone())
-                .await
-                .map_err(|e| format!("Failed to mark activity sync attempt: {}", e))
-            {
-                error!(
-                    "Failed to mark activity sync attempt for '{}': {}",
-                    account_name, err
-                );
-                if is_holdings_mode {
-                    let warning = err.to_string();
-                    self.progress_reporter.report_progress(
-                        SyncProgressPayload::new(
-                            &account_id,
-                            &account_name,
-                            SyncStatus::NeedsReview,
-                        )
-                        .with_message(format!(
-                            "Activity reference sync setup failed; continuing holdings sync: {}",
-                            warning
-                        )),
-                    );
-                    activities_summary.accounts_warned += 1;
-                    activity_warning = Some(warning);
-                } else {
-                    activities_summary.accounts_failed += 1;
-                    continue;
-                }
-            }
-
-            let mut activity_import_run_id: Option<String> = None;
-
-            if activity_warning.is_none() {
-                let local_activity_state = match self
-                    .sync_service
-                    .get_activity_sync_state(&account_id)
-                {
-                    Ok(state) => Some(state),
-                    Err(err) => {
-                        error!(
-                            "Failed to read activity sync state for '{}': {}",
-                            account_name, err
-                        );
-                        if is_holdings_mode {
-                            self.progress_reporter.report_progress(
-                                SyncProgressPayload::new(
-                                    &account_id,
-                                    &account_name,
-                                    SyncStatus::NeedsReview,
-                                )
-                                .with_message(format!(
-                                    "Activity reference sync state failed; continuing holdings sync: {}",
-                                    err
-                                )),
-                            );
-                            activities_summary.accounts_warned += 1;
-                            activity_warning = Some(err.to_string());
-                            None
-                        } else {
-                            activities_summary.accounts_failed += 1;
-                            continue;
-                        }
-                    }
-                };
-
-                if let Some(local_activity_state) = local_activity_state {
-                    let local_cursor = local_activity_state
-                        .as_ref()
-                        .and_then(|state| state.last_successful_at.as_ref());
-                    let provider_activity_status =
-                        provider_transaction_statuses.get(&broker_account_id);
-
-                    let activity_waterline = match resolve_activity_readiness(
-                        provider_activity_status,
-                    ) {
-                        Ok(ProviderReadiness::Ready(date))
-                            if provider_waterline_precedes_local_cursor(local_cursor, date) =>
-                        {
-                            let Some(cursor) = local_cursor else {
-                                unreachable!("stale provider waterline requires local cursor");
-                            };
-                            let message = format!(
-                                "Activity sync skipped: provider transaction waterline {} is older than local cursor {}",
-                                date,
-                                cursor.date_naive()
-                            );
-                            if let Err(e) = self
-                                .sync_service
-                                .finalize_activity_sync_success(
-                                    account_id.clone(),
-                                    cursor.to_rfc3339(),
-                                    None,
-                                )
-                                .await
-                            {
-                                error!(
-                                    "Failed to restore activity sync state for '{}': {}",
-                                    account_name, e
-                                );
-                                activities_summary.accounts_failed += 1;
-                                if !is_holdings_mode {
-                                    continue;
-                                }
-                                activity_warning = Some(format!(
-                                    "Activity sync skipped, but sync state cleanup failed: {}",
-                                    e
-                                ));
-                            } else {
-                                self.progress_reporter.report_progress(
-                                    SyncProgressPayload::new(
-                                        &account_id,
-                                        &account_name,
-                                        SyncStatus::Complete,
-                                    )
-                                    .with_message(message),
-                                );
-                                activities_summary.accounts_synced += 1;
-                            }
-                            None
-                        }
-                        Ok(ProviderReadiness::Ready(date)) => Some(date),
-                        Ok(ProviderReadiness::NotReady(reason)) => {
-                            let warning = format!("Activity sync deferred: {}", reason);
-                            if let Err(e) = self
-                                .sync_service
-                                .finalize_activity_sync_needs_review(
-                                    account_id.clone(),
-                                    warning.clone(),
-                                    None,
-                                )
-                                .await
-                            {
-                                error!(
-                                    "Failed to mark deferred activity sync for '{}': {}",
-                                    account_name, e
-                                );
-                            }
-                            self.progress_reporter.report_progress(
-                                SyncProgressPayload::new(
-                                    &account_id,
-                                    &account_name,
-                                    SyncStatus::NeedsReview,
-                                )
-                                .with_message(warning.clone()),
-                            );
-                            activities_summary.accounts_warned += 1;
-                            activity_warning = Some(warning);
-                            None
-                        }
-                        Err(err) => {
-                            error!(
-                                "Failed to resolve provider activity sync status for '{}': {}",
-                                account_name, err
-                            );
-                            if is_holdings_mode {
-                                let message = format!(
-                                    "Activity reference sync status failed; continuing holdings sync: {}",
-                                    err
-                                );
-                                self.progress_reporter.report_progress(
-                                    SyncProgressPayload::new(
-                                        &account_id,
-                                        &account_name,
-                                        SyncStatus::NeedsReview,
-                                    )
-                                    .with_message(message),
-                                );
-                                activities_summary.accounts_warned += 1;
-                                activity_warning = Some(err);
-                                None
-                            } else {
-                                activities_summary.accounts_failed += 1;
-                                continue;
-                            }
-                        }
-                    };
-
-                    let query_window = match activity_waterline {
-                        Some(waterline) => {
-                            match self.compute_activity_query_window(&account_id, waterline) {
-                                Ok(window) => Some(window),
-                                Err(err) => {
-                                    error!(
-                                        "Failed to compute activity query window for '{}': {}",
-                                        account_name, err
-                                    );
-                                    if is_holdings_mode {
-                                        let message = format!(
-                                            "Activity reference query window failed; continuing holdings sync: {}",
-                                            err
-                                        );
-                                        self.progress_reporter.report_progress(
-                                            SyncProgressPayload::new(
-                                                &account_id,
-                                                &account_name,
-                                                SyncStatus::NeedsReview,
-                                            )
-                                            .with_message(message),
-                                        );
-                                        activities_summary.accounts_warned += 1;
-                                        activity_warning = Some(err);
-                                        None
-                                    } else {
-                                        activities_summary.accounts_failed += 1;
-                                        continue;
-                                    }
-                                }
-                            }
-                        }
-                        None => None,
-                    };
-
-                    if let Some(query_window) = query_window {
-                        let import_mode = if query_window.start_date.is_none() {
-                            ImportRunMode::Initial
-                        } else {
-                            ImportRunMode::Incremental
-                        };
-
-                        let import_run = match self
-                            .sync_service
-                            .create_import_run(&account_id, import_mode)
-                            .await
-                        {
-                            Ok(run) => {
-                                debug!(
-                                    "Created import run {} for account '{}'",
-                                    run.id, account_name
-                                );
-                                Some(run)
-                            }
-                            Err(e) => {
-                                error!("Failed to create import run for '{}': {}", account_name, e);
-                                None
-                            }
-                        };
-                        activity_import_run_id = import_run.as_ref().map(|r| r.id.clone());
-
-                        let window_label = match &query_window.start_date {
-                            Some(s) => format!("{} -> {}", s, query_window.end_date),
-                            None => format!("ALL -> {}", query_window.end_date),
-                        };
-                        info!(
-                            "Syncing activities for account '{}' ({}): {}",
-                            account_name, broker_account_id, window_label
-                        );
-
-                        self.progress_reporter.report_progress(
-                            SyncProgressPayload::new(
-                                &account_id,
-                                &account_name,
-                                SyncStatus::Syncing,
-                            )
-                            .with_message(format!("Starting sync: {}", window_label)),
-                        );
-
-                        match self
-                            .sync_account_activities(
-                                api_client,
-                                &account_id,
-                                &account_name,
-                                &broker_account_id,
-                                query_window.start_date.as_deref(),
-                                Some(query_window.end_date.as_str()),
-                                activity_import_run_id.clone(),
-                            )
-                            .await
-                        {
-                            Ok(outcome) => {
-                                let mut import_status = if outcome.needs_review > 0 {
-                                    ImportRunStatus::NeedsReview
-                                } else {
-                                    ImportRunStatus::Applied
-                                };
-                                let summary = ImportRunSummary {
-                                    fetched: outcome.fetched,
-                                    inserted: outcome.inserted,
-                                    updated: 0,
-                                    skipped: 0,
-                                    warnings: outcome.needs_review,
-                                    errors: 0,
-                                    removed: 0,
-                                    assets_created: outcome.assets_created,
-                                };
-
-                                let should_advance_cursor = should_advance_activity_cursor(
-                                    &outcome,
-                                    &query_window,
-                                    provider_activity_status,
-                                );
-
-                                if should_advance_cursor {
-                                    let sync_state_failed = self
-                                        .sync_service
-                                        .finalize_activity_sync_success(
-                                            account_id.clone(),
-                                            query_window.provider_waterline.clone(),
-                                            activity_import_run_id.clone(),
-                                        )
-                                        .await
-                                        .is_err();
-
-                                    if sync_state_failed {
-                                        error!(
-                                        "Failed to update activity sync state for '{}', but activities were synced",
-                                        account_name
-                                    );
-                                    }
-                                } else {
-                                    let warning = if outcome.inconsistent_empty_page {
-                                        "Activity sync returned an empty page while provider pagination reported more data"
-                                    } else if outcome.empty_first_page {
-                                        "Initial activity sync returned no rows even though provider reports transactions may exist"
-                                    } else {
-                                        "Initial activity sync did not confirm a complete empty history"
-                                }
-                                .to_string();
-                                    if let Err(e) = self
-                                        .sync_service
-                                        .finalize_activity_sync_needs_review(
-                                            account_id.clone(),
-                                            warning.clone(),
-                                            activity_import_run_id.clone(),
-                                        )
-                                        .await
-                                    {
-                                        error!(
-                                        "Failed to mark activity sync as needs review for '{}': {}",
-                                        account_name, e
-                                    );
-                                    }
-                                    import_status = ImportRunStatus::NeedsReview;
-                                    activities_summary.accounts_warned += 1;
-                                    activity_warning = Some(warning.clone());
-                                    self.progress_reporter.report_progress(
-                                        SyncProgressPayload::new(
-                                            &account_id,
-                                            &account_name,
-                                            SyncStatus::NeedsReview,
-                                        )
-                                        .with_activities_fetched(outcome.fetched as usize)
-                                        .with_message(warning),
-                                    );
-                                }
-
-                                if let Some(ref run_id) = activity_import_run_id {
-                                    if outcome.needs_review > 0 {
-                                        info!(
-                                            "Import run {} has {} activities needing review",
-                                            run_id, outcome.needs_review
-                                        );
-                                    }
-
-                                    let _ = self
-                                        .sync_service
-                                        .finalize_import_run(run_id, summary, import_status, None)
-                                        .await;
-                                }
-
-                                if !should_advance_cursor {
-                                    if !is_holdings_mode {
-                                        continue;
-                                    }
-                                } else {
-                                    let status = if outcome.needs_review > 0 {
-                                        SyncStatus::NeedsReview
-                                    } else {
-                                        SyncStatus::Complete
-                                    };
-                                    self.progress_reporter.report_progress(
-                                        SyncProgressPayload::new(
-                                            &account_id,
-                                            &account_name,
-                                            status,
-                                        )
-                                        .with_activities_fetched(outcome.fetched as usize)
-                                        .with_message(
-                                            format!(
-                                                "Synced {} activities ({} need review)",
-                                                outcome.inserted, outcome.needs_review
-                                            ),
-                                        ),
-                                    );
-
-                                    activities_summary.accounts_synced += 1;
-                                }
-
-                                activities_summary.activities_upserted += outcome.inserted as usize;
-                                activities_summary.assets_inserted +=
-                                    outcome.assets_created as usize;
-                                activities_summary
-                                    .new_asset_ids
-                                    .extend(outcome.new_asset_ids);
-                            }
-                            Err(err) => {
-                                error!("Failed to sync activities for '{}': {}", account_name, err);
-
-                                let _ = self
-                                    .sync_service
-                                    .finalize_activity_sync_failure(
-                                        account_id.clone(),
-                                        err.clone(),
-                                        activity_import_run_id.clone(),
-                                    )
-                                    .await;
-
-                                if let Some(ref run_id) = activity_import_run_id {
-                                    let summary = ImportRunSummary::default();
-                                    let _ = self
-                                        .sync_service
-                                        .finalize_import_run(
-                                            run_id,
-                                            summary,
-                                            ImportRunStatus::Failed,
-                                            Some(err.clone()),
-                                        )
-                                        .await;
-                                }
-
-                                if is_holdings_mode {
-                                    self.progress_reporter.report_progress(
-                                    SyncProgressPayload::new(
-                                        &account_id,
-                                        &account_name,
-                                        SyncStatus::NeedsReview,
-                                    )
-                                    .with_message(format!(
-                                        "Activity reference sync failed; continuing holdings sync: {}",
-                                        err
-                                    )),
-                                );
-                                    activities_summary.accounts_warned += 1;
-                                    activity_warning = Some(err);
-                                } else {
-                                    self.progress_reporter.report_progress(
-                                        SyncProgressPayload::new(
-                                            &account_id,
-                                            &account_name,
-                                            SyncStatus::Failed,
-                                        )
-                                        .with_message(err.clone()),
-                                    );
-                                    activities_summary.accounts_failed += 1;
-                                    continue;
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            if !is_holdings_mode {
+            if !continue_account || !job.is_holdings_mode() {
                 continue;
             }
 
-            match resolve_holdings_readiness(provider_holdings_statuses.get(&broker_account_id)) {
-                Ok(ProviderReadiness::Ready(_)) => {}
-                Ok(ProviderReadiness::NotReady(reason)) => {
-                    let warning = format!("Holdings sync deferred: {}", reason);
-                    self.progress_reporter.report_progress(
-                        SyncProgressPayload::new(
-                            &account_id,
-                            &account_name,
-                            SyncStatus::NeedsReview,
-                        )
-                        .with_message(warning),
-                    );
-                    holdings_summary.accounts_warned += 1;
-                    continue;
-                }
-                Err(err) => {
-                    error!(
-                        "Failed to resolve provider holdings sync status for '{}': {}",
-                        account_name, err
-                    );
-                    holdings_summary.accounts_failed += 1;
-                    continue;
-                }
-            }
-
-            let holdings_import_mode = match self
-                .sync_service
-                .has_broker_imported_holdings_snapshot(&account_id)
-            {
-                Ok(true) => ImportRunMode::Incremental,
-                Ok(false) => ImportRunMode::Initial,
-                Err(e) => {
-                    warn!(
-                        "Failed to read holdings snapshot state for '{}' before holdings sync: {}",
-                        account_name, e
-                    );
-                    ImportRunMode::Initial
-                }
-            };
-
-            let holdings_import_run = match self
-                .sync_service
-                .create_import_run(&account_id, holdings_import_mode)
-                .await
-            {
-                Ok(run) => {
-                    debug!(
-                        "Created holdings import run {} for account '{}'",
-                        run.id, account_name
-                    );
-                    Some(run)
-                }
-                Err(e) => {
-                    error!(
-                        "Failed to create holdings import run for '{}': {}",
-                        account_name, e
-                    );
-                    None
-                }
-            };
-            let holdings_import_run_id = holdings_import_run.as_ref().map(|r| r.id.clone());
-
-            match self
-                .sync_account_holdings(api_client, &account_id, &account_name, &broker_account_id)
-                .await
-            {
-                Ok((diff, assets_created, new_asset_ids)) => {
-                    let summary = ImportRunSummary {
-                        fetched: diff.total_positions as u32,
-                        inserted: diff.added_positions as u32,
-                        updated: diff.updated_positions as u32,
-                        skipped: diff.unchanged_positions as u32,
-                        warnings: 0,
-                        errors: 0,
-                        removed: diff.removed_positions as u32,
-                        assets_created: assets_created as u32,
-                    };
-
-                    if let Some(ref run_id) = holdings_import_run_id {
-                        let _ = self
-                            .sync_service
-                            .finalize_import_run(run_id, summary, ImportRunStatus::Applied, None)
-                            .await;
-                    }
-
-                    holdings_summary.accounts_synced += 1;
-                    holdings_summary.positions_upserted +=
-                        diff.added_positions + diff.updated_positions;
-                    holdings_summary.snapshots_upserted += if diff.snapshot_saved { 1 } else { 0 };
-                    holdings_summary.assets_inserted += assets_created;
-                    holdings_summary.new_asset_ids.extend(new_asset_ids);
-
-                    if let Some(warning) = activity_warning {
-                        let warning_message = format!(
-                            "Holdings synced, but activity reference sync needs review: {}",
-                            warning
-                        );
-                        if let Err(e) = self
-                            .sync_service
-                            .finalize_activity_sync_needs_review(
-                                account_id.clone(),
-                                warning_message.clone(),
-                                activity_import_run_id.clone(),
-                            )
-                            .await
-                        {
-                            error!(
-                                "Failed to mark activity sync state as needs review for '{}': {}",
-                                account_name, e
-                            );
-                        }
-
-                        self.progress_reporter.report_progress(
-                            SyncProgressPayload::new(
-                                &account_id,
-                                &account_name,
-                                SyncStatus::NeedsReview,
-                            )
-                            .with_message(warning_message),
-                        );
-                    }
-                }
-                Err(err) => {
-                    error!("Failed to sync holdings for '{}': {}", account_name, err);
-
-                    if let Some(ref run_id) = holdings_import_run_id {
-                        let _ = self
-                            .sync_service
-                            .finalize_import_run(
-                                run_id,
-                                ImportRunSummary::default(),
-                                ImportRunStatus::Failed,
-                                Some(err.clone()),
-                            )
-                            .await;
-                    }
-
-                    // Holdings is the valuation source for HOLDINGS mode, so this is a hard failure.
-                    let _ = self
-                        .sync_service
-                        .finalize_activity_sync_failure(
-                            account_id.clone(),
-                            format!("Holdings sync failed: {}", err),
-                            holdings_import_run_id.clone(),
-                        )
-                        .await;
-
-                    self.progress_reporter.report_progress(
-                        SyncProgressPayload::new(&account_id, &account_name, SyncStatus::Failed)
-                            .with_message(err),
-                    );
-
-                    holdings_summary.accounts_failed += 1;
-                }
-            }
+            let holdings_result = self
+                .sync_holdings_phase(
+                    api_client,
+                    &job,
+                    provider_holdings_statuses.get(&job.broker_account_id),
+                    HoldingsPhaseContext {
+                        activity_warning,
+                        activity_import_run_id,
+                    },
+                )
+                .await;
+            Self::merge_holdings_summary(&mut holdings_summary, holdings_result);
         }
 
         Ok((activities_summary, holdings_summary))
     }
 
-    /// Sync holdings for a single account (HOLDINGS tracking mode).
-    ///
-    /// Fetches current holdings from the broker API and saves as a snapshot.
-    /// Returns (position_diff, assets_created, new_asset_ids).
-    async fn sync_account_holdings(
-        &self,
-        api_client: &dyn BrokerApiClient,
-        account_id: &str,
-        account_name: &str,
-        broker_account_id: &str,
-    ) -> Result<(HoldingsDiff, usize, Vec<String>), String> {
-        info!(
-            "Syncing holdings for account '{}' ({})",
-            account_name, broker_account_id
-        );
-
-        // Emit progress event
-        self.progress_reporter.report_progress(
-            SyncProgressPayload::new(account_id, account_name, SyncStatus::Syncing)
-                .with_message("Fetching holdings from broker...".to_string()),
-        );
-
-        // Fetch holdings from broker API
-        let holdings = api_client
-            .get_account_holdings(broker_account_id)
-            .await
-            .map_err(|e| e.to_string())?;
-
-        let positions_count = holdings.positions.as_ref().map(|p| p.len()).unwrap_or(0);
-        let option_positions_count = holdings
-            .option_positions
-            .as_ref()
-            .map(|p| p.len())
-            .unwrap_or(0);
-        let balances_count = holdings.balances.as_ref().map(|b| b.len()).unwrap_or(0);
-
-        info!(
-            "Fetched {} positions, {} option positions, and {} balances for '{}'",
-            positions_count, option_positions_count, balances_count, account_name
-        );
-
-        // Save holdings as a snapshot
-        let (diff, assets_created, new_asset_ids) = self
-            .sync_service
-            .save_broker_holdings(
-                account_id.to_string(),
-                holdings.balances.unwrap_or_default(),
-                holdings.positions.unwrap_or_default(),
-                holdings.option_positions.unwrap_or_default(),
-            )
-            .await
-            .map_err(|e| format!("Failed to save broker holdings: {}", e))?;
-
-        let changed_positions =
-            diff.added_positions + diff.updated_positions + diff.removed_positions;
-        let summary_message = if changed_positions == 0 {
-            format!(
-                "No position changes detected ({} positions checked)",
-                diff.total_positions
-            )
-        } else {
-            format!(
-                "Positions: +{}, {} updated, {} removed",
-                diff.added_positions, diff.updated_positions, diff.removed_positions
-            )
-        };
-
-        // Emit completion event
-        self.progress_reporter.report_progress(
-            SyncProgressPayload::new(account_id, account_name, SyncStatus::Complete).with_message(
-                format!("{} ({} assets created)", summary_message, assets_created),
-            ),
-        );
-
-        Ok((diff, assets_created, new_asset_ids))
+    fn merge_activities_summary(total: &mut SyncActivitiesResponse, delta: SyncActivitiesResponse) {
+        total.accounts_synced += delta.accounts_synced;
+        total.activities_upserted += delta.activities_upserted;
+        total.assets_inserted += delta.assets_inserted;
+        total.accounts_failed += delta.accounts_failed;
+        total.accounts_warned += delta.accounts_warned;
+        total.new_asset_ids.extend(delta.new_asset_ids);
     }
 
-    /// Sync activities for a single account with full pagination.
-    ///
-    /// Returns (fetched, inserted, assets_created, needs_review, new_asset_ids).
-    #[allow(clippy::too_many_arguments)]
-    async fn sync_account_activities(
-        &self,
-        api_client: &dyn BrokerApiClient,
-        account_id: &str,
-        account_name: &str,
-        broker_account_id: &str,
-        start_date: Option<&str>,
-        end_date: Option<&str>,
-        import_run_id: Option<String>,
-    ) -> Result<ActivitySyncOutcome, String> {
-        let mut offset: i64 = 0;
-        let limit = self.config.page_limit;
-        let mut pages_fetched: usize = 0;
-        let mut last_page_first_id: Option<String> = None;
-        let mut empty_first_page = false;
-        let mut inconsistent_empty_page = false;
-
-        let mut total_fetched: u32 = 0;
-        let mut total_inserted: u32 = 0;
-        let mut total_assets_created: u32 = 0;
-        let mut total_needs_review: u32 = 0;
-        let mut all_new_asset_ids: Vec<String> = Vec::new();
-
-        loop {
-            // Check max pages limit
-            if pages_fetched >= self.config.max_pages {
-                return Err(format!(
-                    "Pagination exceeded max pages ({}). Aborting.",
-                    self.config.max_pages
-                ));
-            }
-
-            // Fetch page
-            let page = api_client
-                .get_account_activities(
-                    broker_account_id,
-                    start_date,
-                    end_date,
-                    Some(offset),
-                    Some(limit),
-                )
-                .await
-                .map_err(|e| e.to_string())?;
-
-            let data = page.data;
-            pages_fetched += 1;
-            total_fetched += data.len() as u32;
-
-            let page_total = page.pagination.as_ref().and_then(|p| p.total);
-
-            // Emit progress event
-            self.progress_reporter.report_progress(
-                SyncProgressPayload::new(account_id, account_name, SyncStatus::Syncing)
-                    .with_page(pages_fetched)
-                    .with_activities_fetched(total_fetched as usize)
-                    .with_message(format!(
-                        "Fetched {} activities (total: {:?})",
-                        total_fetched, page_total
-                    )),
-            );
-
-            info!(
-                "Fetched {} activities for '{}' (offset {}, total {:?})",
-                data.len(),
-                account_name,
-                offset,
-                page_total
-            );
-
-            if !data.is_empty() {
-                // Check for stuck pagination
-                if let Some(first_id) = data.first().and_then(|a| a.id.clone()) {
-                    if offset > 0 {
-                        if let Some(prev) = &last_page_first_id {
-                            if prev == &first_id {
-                                return Err(
-                                    "Pagination appears stuck (same first activity id returned for multiple pages)."
-                                        .to_string(),
-                                );
-                            }
-                        }
-                    }
-                    last_page_first_id = Some(first_id);
-                }
-
-                // Upsert activities
-                debug!(
-                    "Upserting {} activities for account '{}'...",
-                    data.len(),
-                    account_name
-                );
-
-                let (upserted, assets, new_asset_ids, needs_review) = self
-                    .sync_service
-                    .upsert_account_activities(
-                        account_id.to_string(),
-                        import_run_id.clone(),
-                        data.clone(),
-                    )
-                    .await
-                    .map_err(|e| format!("Failed to upsert activities: {}", e))?;
-
-                info!(
-                    "Upserted {} activities, {} assets for '{}' ({} need review)",
-                    upserted, assets, account_name, needs_review
-                );
-
-                total_inserted += upserted as u32;
-                total_assets_created += assets as u32;
-                total_needs_review += needs_review as u32;
-                all_new_asset_ids.extend(new_asset_ids);
-            }
-
-            let received = data.len() as i64;
-            let next_offset = offset + received;
-
-            // Avoid spinning forever if API reports more pages but returns no data.
-            if received == 0 {
-                empty_first_page = pages_fetched == 1;
-                inconsistent_empty_page = page.pagination.as_ref().is_some_and(|p| {
-                    p.has_more == Some(true) || p.total.is_some_and(|total| offset < total)
-                });
-                break;
-            }
-
-            // Check if there are more pages.
-            // Prefer explicit has_more when provided, then fall back to total/limit inference.
-            let has_more = match page.pagination.as_ref() {
-                Some(p) => match p.has_more {
-                    Some(true) => true,
-                    Some(false) => false,
-                    None => {
-                        if let Some(total) = p.total {
-                            next_offset < total
-                        } else if let Some(page_limit) = p.limit {
-                            received >= page_limit
-                        } else {
-                            received >= limit
-                        }
-                    }
-                },
-                None => received >= limit,
-            };
-
-            // Advance offset by number of items received
-            offset = next_offset;
-
-            if !has_more {
-                break;
-            }
-        }
-
-        Ok(ActivitySyncOutcome {
-            fetched: total_fetched,
-            inserted: total_inserted,
-            assets_created: total_assets_created,
-            needs_review: total_needs_review,
-            new_asset_ids: all_new_asset_ids,
-            empty_first_page,
-            inconsistent_empty_page,
-        })
-    }
-
-    /// Compute the activity query window for incremental sync.
-    fn compute_activity_query_window(
-        &self,
-        account_id: &str,
-        provider_waterline: NaiveDate,
-    ) -> Result<ActivityQueryWindow, String> {
-        let today = Utc::now().date_naive();
-        let end_date = provider_waterline.min(today);
-        let sync_state = self
-            .sync_service
-            .get_activity_sync_state(account_id)
-            .map_err(|e| format!("Failed to read activity sync state: {}", e))?;
-
-        let local_cursor = sync_state.and_then(|s| s.last_successful_at);
-        let has_local_cursor = local_cursor.is_some();
-        let start_date = local_cursor
-            .map(|dt| dt.date_naive())
-            .map(|d| (d - chrono::Days::new(1)).min(end_date))
-            .map(|d| d.format("%Y-%m-%d").to_string());
-
-        Ok(ActivityQueryWindow {
-            start_date,
-            end_date: end_date.format("%Y-%m-%d").to_string(),
-            provider_waterline: end_date.format("%Y-%m-%d").to_string(),
-            has_local_cursor,
-        })
+    fn merge_holdings_summary(total: &mut SyncHoldingsResponse, delta: SyncHoldingsResponse) {
+        total.accounts_synced += delta.accounts_synced;
+        total.snapshots_upserted += delta.snapshots_upserted;
+        total.positions_upserted += delta.positions_upserted;
+        total.assets_inserted += delta.assets_inserted;
+        total.accounts_failed += delta.accounts_failed;
+        total.accounts_warned += delta.accounts_warned;
+        total.new_asset_ids.extend(delta.new_asset_ids);
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use async_trait::async_trait;
+    use chrono::{DateTime, Utc};
+    use std::sync::Mutex;
 
     #[test]
     fn test_sync_config_default() {
@@ -1321,131 +434,423 @@ mod tests {
         assert_eq!(config.max_pages, 10_000);
     }
 
-    fn transactions_status(
-        initial_sync_completed: Option<bool>,
-        last_successful_sync: Option<&str>,
+    use super::super::models::{
+        AccountUniversalActivity, BrokerAccount, BrokerBrokerage, BrokerConnection,
+        BrokerHoldingsResponse, HoldingsBalance, HoldingsDiff, HoldingsOptionPosition,
+        HoldingsPosition, PaginatedUniversalActivity, PaginationDetails, SyncAccountsResponse,
+        SyncConnectionsResponse,
+    };
+    use super::super::progress::NoOpProgressReporter;
+    use super::super::traits::BrokerSyncServiceTrait;
+    use crate::broker_ingest::{
+        BrokerSyncState, ImportRun, ImportRunMode, ImportRunStatus, ImportRunSummary,
+        ImportRunType, ReviewMode,
+    };
+    use wealthfolio_core::accounts::Account;
+    use wealthfolio_core::Result;
+
+    #[derive(Default)]
+    struct MockBrokerApiClient {
+        activity_pages: Mutex<Vec<PaginatedUniversalActivity>>,
+        activity_calls: Mutex<usize>,
+    }
+
+    #[async_trait]
+    impl BrokerApiClient for MockBrokerApiClient {
+        async fn list_connections(&self) -> Result<Vec<BrokerConnection>> {
+            Ok(Vec::new())
+        }
+
+        async fn list_accounts(
+            &self,
+            _authorization_ids: Option<Vec<String>>,
+        ) -> Result<Vec<BrokerAccount>> {
+            Ok(Vec::new())
+        }
+
+        async fn list_brokerages(&self) -> Result<Vec<BrokerBrokerage>> {
+            Ok(Vec::new())
+        }
+
+        async fn get_account_activities(
+            &self,
+            _account_id: &str,
+            _start_date: Option<&str>,
+            _end_date: Option<&str>,
+            _offset: Option<i64>,
+            _limit: Option<i64>,
+        ) -> Result<PaginatedUniversalActivity> {
+            *self.activity_calls.lock().unwrap() += 1;
+            let mut pages = self.activity_pages.lock().unwrap();
+            if pages.is_empty() {
+                return Ok(PaginatedUniversalActivity::default());
+            }
+            Ok(pages.remove(0))
+        }
+
+        async fn get_account_holdings(&self, _account_id: &str) -> Result<BrokerHoldingsResponse> {
+            Ok(BrokerHoldingsResponse::default())
+        }
+    }
+
+    #[derive(Default)]
+    struct MockSyncService {
+        accounts: Vec<Account>,
+        activity_state: Option<BrokerSyncState>,
+        upsert_result: (usize, usize, Vec<String>, usize),
+        holdings_result: (HoldingsDiff, usize, Vec<String>),
+        calls: Mutex<MockSyncServiceCalls>,
+    }
+
+    #[derive(Default)]
+    struct MockSyncServiceCalls {
+        activity_successes: Vec<(String, String, Option<String>)>,
+        activity_failures: Vec<(String, String, Option<String>)>,
+        activity_needs_review: Vec<(String, String, Option<String>)>,
+        finalized_import_runs: Vec<(String, ImportRunSummary, ImportRunStatus, Option<String>)>,
+        save_holdings_calls: usize,
+    }
+
+    #[async_trait]
+    impl BrokerSyncServiceTrait for MockSyncService {
+        async fn sync_connections(
+            &self,
+            _connections: Vec<BrokerConnection>,
+        ) -> Result<SyncConnectionsResponse> {
+            Ok(SyncConnectionsResponse {
+                synced: 0,
+                platforms_created: 0,
+                platforms_updated: 0,
+            })
+        }
+
+        async fn sync_accounts(
+            &self,
+            _broker_accounts: Vec<BrokerAccount>,
+        ) -> Result<SyncAccountsResponse> {
+            Ok(SyncAccountsResponse {
+                synced: 0,
+                created: 0,
+                updated: 0,
+                skipped: 0,
+                created_accounts: Vec::new(),
+                new_accounts_info: Vec::new(),
+            })
+        }
+
+        fn get_synced_accounts(&self) -> Result<Vec<Account>> {
+            Ok(self.accounts.clone())
+        }
+
+        fn has_broker_imported_holdings_snapshot(&self, _account_id: &str) -> Result<bool> {
+            Ok(false)
+        }
+
+        fn get_platforms(&self) -> Result<Vec<crate::platform::Platform>> {
+            Ok(Vec::new())
+        }
+
+        fn get_activity_sync_state(&self, _account_id: &str) -> Result<Option<BrokerSyncState>> {
+            Ok(self.activity_state.clone())
+        }
+
+        async fn mark_activity_sync_attempt(&self, _account_id: String) -> Result<()> {
+            Ok(())
+        }
+
+        async fn upsert_account_activities(
+            &self,
+            _account_id: String,
+            _import_run_id: Option<String>,
+            _activities: Vec<AccountUniversalActivity>,
+        ) -> Result<(usize, usize, Vec<String>, usize)> {
+            Ok(self.upsert_result.clone())
+        }
+
+        async fn finalize_activity_sync_success(
+            &self,
+            account_id: String,
+            last_synced_date: String,
+            import_run_id: Option<String>,
+        ) -> Result<()> {
+            self.calls.lock().unwrap().activity_successes.push((
+                account_id,
+                last_synced_date,
+                import_run_id,
+            ));
+            Ok(())
+        }
+
+        async fn finalize_activity_sync_failure(
+            &self,
+            account_id: String,
+            error: String,
+            import_run_id: Option<String>,
+        ) -> Result<()> {
+            self.calls
+                .lock()
+                .unwrap()
+                .activity_failures
+                .push((account_id, error, import_run_id));
+            Ok(())
+        }
+
+        async fn finalize_activity_sync_needs_review(
+            &self,
+            account_id: String,
+            warning: String,
+            import_run_id: Option<String>,
+        ) -> Result<()> {
+            self.calls.lock().unwrap().activity_needs_review.push((
+                account_id,
+                warning,
+                import_run_id,
+            ));
+            Ok(())
+        }
+
+        fn get_all_sync_states(&self) -> Result<Vec<BrokerSyncState>> {
+            Ok(Vec::new())
+        }
+
+        fn get_import_runs(
+            &self,
+            _run_type: Option<&str>,
+            _limit: i64,
+            _offset: i64,
+        ) -> Result<Vec<ImportRun>> {
+            Ok(Vec::new())
+        }
+
+        async fn create_import_run(
+            &self,
+            account_id: &str,
+            mode: ImportRunMode,
+        ) -> Result<ImportRun> {
+            Ok(ImportRun::new(
+                account_id.to_string(),
+                "TEST".to_string(),
+                ImportRunType::Sync,
+                mode,
+                ReviewMode::Never,
+            ))
+        }
+
+        async fn finalize_import_run(
+            &self,
+            run_id: &str,
+            summary: ImportRunSummary,
+            status: ImportRunStatus,
+            error: Option<String>,
+        ) -> Result<()> {
+            self.calls.lock().unwrap().finalized_import_runs.push((
+                run_id.to_string(),
+                summary,
+                status,
+                error,
+            ));
+            Ok(())
+        }
+
+        async fn save_broker_holdings(
+            &self,
+            _account_id: String,
+            _balances: Vec<HoldingsBalance>,
+            _positions: Vec<HoldingsPosition>,
+            _option_positions: Vec<HoldingsOptionPosition>,
+        ) -> Result<(HoldingsDiff, usize, Vec<String>)> {
+            self.calls.lock().unwrap().save_holdings_calls += 1;
+            Ok(self.holdings_result.clone())
+        }
+    }
+
+    fn synced_account(
+        account_id: &str,
+        broker_account_id: &str,
+        tracking_mode: TrackingMode,
+    ) -> Account {
+        Account {
+            id: account_id.to_string(),
+            name: "Brokerage".to_string(),
+            currency: "USD".to_string(),
+            provider_account_id: Some(broker_account_id.to_string()),
+            tracking_mode,
+            ..Account::default()
+        }
+    }
+
+    fn ready_status(
+        waterline: &str,
         first_transaction_date: Option<&str>,
     ) -> BrokerSyncStatusDetail {
         BrokerSyncStatusDetail {
-            initial_sync_completed,
-            last_successful_sync: last_successful_sync.map(str::to_string),
+            initial_sync_completed: Some(true),
+            last_successful_sync: Some(waterline.to_string()),
             first_transaction_date: first_transaction_date.map(str::to_string),
         }
     }
 
-    fn window(has_local_cursor: bool) -> ActivityQueryWindow {
-        ActivityQueryWindow {
-            start_date: has_local_cursor.then(|| "2026-05-21".to_string()),
-            end_date: "2026-05-22".to_string(),
-            provider_waterline: "2026-05-22".to_string(),
-            has_local_cursor,
-        }
+    fn sync_state(account_id: &str, last_successful_at: &str) -> BrokerSyncState {
+        let mut state = BrokerSyncState::new(account_id.to_string(), "TEST".to_string());
+        state.last_successful_at = Some(
+            DateTime::parse_from_rfc3339(last_successful_at)
+                .unwrap()
+                .with_timezone(&Utc),
+        );
+        state
     }
 
-    #[test]
-    fn provider_not_ready_defers_first_activity_sync() {
-        let status = transactions_status(Some(false), None, None);
-        let readiness = resolve_activity_readiness(Some(&status)).unwrap();
-
-        assert!(matches!(readiness, ProviderReadiness::NotReady(_)));
+    fn orchestrator(service: Arc<MockSyncService>) -> SyncOrchestrator<NoOpProgressReporter> {
+        SyncOrchestrator::new(
+            service,
+            Arc::new(NoOpProgressReporter),
+            SyncConfig::default(),
+        )
     }
 
-    #[test]
-    fn provider_waterline_without_initial_flag_allows_activity_fetch() {
-        let status = transactions_status(None, Some("2026-05-22"), None);
-        let readiness = resolve_activity_readiness(Some(&status)).unwrap();
-
-        assert!(matches!(
-            readiness,
-            ProviderReadiness::Ready(date)
-                if date == NaiveDate::from_ymd_opt(2026, 5, 22).unwrap()
-        ));
-    }
-
-    #[test]
-    fn provider_waterline_before_local_cursor_is_stale() {
-        let local_cursor = DateTime::parse_from_rfc3339("2026-05-22T00:00:00Z")
-            .unwrap()
-            .with_timezone(&Utc);
-        let stale_waterline = NaiveDate::from_ymd_opt(2026, 5, 21).unwrap();
-        let current_waterline = NaiveDate::from_ymd_opt(2026, 5, 22).unwrap();
-
-        assert!(provider_waterline_precedes_local_cursor(
-            Some(&local_cursor),
-            stale_waterline
-        ));
-        assert!(!provider_waterline_precedes_local_cursor(
-            Some(&local_cursor),
-            current_waterline
-        ));
-    }
-
-    #[test]
-    fn initial_empty_activity_sync_with_first_transaction_does_not_advance_cursor() {
-        let status = transactions_status(Some(true), Some("2026-05-22"), Some("2020-01-01"));
-        let outcome = ActivitySyncOutcome {
-            empty_first_page: true,
-            ..ActivitySyncOutcome::default()
+    #[tokio::test]
+    async fn cursor_blocked_activity_sync_reports_upserts_without_advancing_cursor() {
+        let service = Arc::new(MockSyncService {
+            accounts: vec![synced_account(
+                "account-1",
+                "broker-1",
+                TrackingMode::Transactions,
+            )],
+            upsert_result: (1, 1, vec!["asset-1".to_string()], 0),
+            ..MockSyncService::default()
+        });
+        let api_client = MockBrokerApiClient {
+            activity_pages: Mutex::new(vec![
+                PaginatedUniversalActivity {
+                    data: vec![AccountUniversalActivity {
+                        id: Some("activity-1".to_string()),
+                        ..AccountUniversalActivity::default()
+                    }],
+                    pagination: Some(PaginationDetails {
+                        has_more: Some(true),
+                        total: Some(2),
+                        ..PaginationDetails::default()
+                    }),
+                },
+                PaginatedUniversalActivity {
+                    data: Vec::new(),
+                    pagination: Some(PaginationDetails {
+                        has_more: Some(true),
+                        total: Some(2),
+                        ..PaginationDetails::default()
+                    }),
+                },
+            ]),
+            ..MockBrokerApiClient::default()
         };
+        let mut provider_statuses = HashMap::new();
+        provider_statuses.insert("broker-1".to_string(), ready_status("2026-05-22", None));
 
-        assert!(!should_advance_activity_cursor(
-            &outcome,
-            &window(false),
-            Some(&status)
-        ));
+        let (activities, holdings) = orchestrator(service.clone())
+            .sync_account_data(
+                &api_client,
+                &HashSet::from(["broker-1".to_string()]),
+                &provider_statuses,
+                &HashMap::new(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(activities.activities_upserted, 1);
+        assert_eq!(activities.assets_inserted, 1);
+        assert_eq!(activities.new_asset_ids, vec!["asset-1"]);
+        assert_eq!(activities.accounts_warned, 1);
+        assert_eq!(activities.accounts_synced, 0);
+        assert_eq!(holdings.accounts_synced, 0);
+        let calls = service.calls.lock().unwrap();
+        assert_eq!(calls.activity_successes.len(), 0);
+        assert_eq!(calls.activity_needs_review.len(), 1);
     }
 
-    #[test]
-    fn initial_empty_activity_sync_with_confirmed_empty_history_advances_cursor() {
-        let status = transactions_status(Some(true), Some("2026-05-22"), None);
-        let outcome = ActivitySyncOutcome {
-            empty_first_page: true,
-            ..ActivitySyncOutcome::default()
-        };
+    #[tokio::test]
+    async fn holdings_mode_continues_holdings_after_activity_warning() {
+        let service = Arc::new(MockSyncService {
+            accounts: vec![synced_account(
+                "account-1",
+                "broker-1",
+                TrackingMode::Holdings,
+            )],
+            holdings_result: (
+                HoldingsDiff {
+                    total_positions: 1,
+                    added_positions: 1,
+                    snapshot_saved: true,
+                    ..HoldingsDiff::default()
+                },
+                1,
+                vec!["asset-1".to_string()],
+            ),
+            ..MockSyncService::default()
+        });
+        let mut provider_transaction_statuses = HashMap::new();
+        provider_transaction_statuses.insert(
+            "broker-1".to_string(),
+            BrokerSyncStatusDetail {
+                initial_sync_completed: Some(false),
+                last_successful_sync: None,
+                first_transaction_date: None,
+            },
+        );
+        let mut provider_holdings_statuses = HashMap::new();
+        provider_holdings_statuses.insert("broker-1".to_string(), ready_status("2026-05-22", None));
 
-        assert!(should_advance_activity_cursor(
-            &outcome,
-            &window(false),
-            Some(&status)
-        ));
+        let (activities, holdings) = orchestrator(service.clone())
+            .sync_account_data(
+                &MockBrokerApiClient::default(),
+                &HashSet::from(["broker-1".to_string()]),
+                &provider_transaction_statuses,
+                &provider_holdings_statuses,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(activities.accounts_warned, 1);
+        assert_eq!(holdings.accounts_synced, 1);
+        assert_eq!(holdings.positions_upserted, 1);
+        assert_eq!(holdings.snapshots_upserted, 1);
+        assert_eq!(holdings.assets_inserted, 1);
+        let calls = service.calls.lock().unwrap();
+        assert_eq!(calls.save_holdings_calls, 1);
+        assert!(calls
+            .activity_needs_review
+            .iter()
+            .any(|(_, warning, _)| warning.contains("Holdings synced")));
     }
 
-    #[test]
-    fn incremental_empty_activity_sync_advances_cursor_to_provider_waterline() {
-        let status = transactions_status(Some(true), Some("2026-05-22"), Some("2020-01-01"));
-        let outcome = ActivitySyncOutcome {
-            empty_first_page: true,
-            ..ActivitySyncOutcome::default()
-        };
+    #[tokio::test]
+    async fn stale_provider_waterline_restores_cursor_without_fetching_activities() {
+        let service = Arc::new(MockSyncService {
+            accounts: vec![synced_account(
+                "account-1",
+                "broker-1",
+                TrackingMode::Transactions,
+            )],
+            activity_state: Some(sync_state("account-1", "2026-05-22T00:00:00Z")),
+            ..MockSyncService::default()
+        });
+        let api_client = MockBrokerApiClient::default();
+        let mut provider_statuses = HashMap::new();
+        provider_statuses.insert("broker-1".to_string(), ready_status("2026-05-21", None));
 
-        assert!(should_advance_activity_cursor(
-            &outcome,
-            &window(true),
-            Some(&status)
-        ));
-    }
+        let (activities, _holdings) = orchestrator(service.clone())
+            .sync_account_data(
+                &api_client,
+                &HashSet::from(["broker-1".to_string()]),
+                &provider_statuses,
+                &HashMap::new(),
+            )
+            .await
+            .unwrap();
 
-    #[test]
-    fn inconsistent_empty_activity_page_does_not_advance_cursor() {
-        let status = transactions_status(Some(true), Some("2026-05-22"), None);
-        let outcome = ActivitySyncOutcome {
-            empty_first_page: true,
-            inconsistent_empty_page: true,
-            ..ActivitySyncOutcome::default()
-        };
-
-        assert!(!should_advance_activity_cursor(
-            &outcome,
-            &window(true),
-            Some(&status)
-        ));
-    }
-
-    #[test]
-    fn holdings_not_ready_defers_snapshot_sync() {
-        let status = transactions_status(Some(false), None, None);
-        let readiness = resolve_holdings_readiness(Some(&status)).unwrap();
-
-        assert!(matches!(readiness, ProviderReadiness::NotReady(_)));
+        assert_eq!(activities.accounts_synced, 1);
+        assert_eq!(*api_client.activity_calls.lock().unwrap(), 0);
+        let calls = service.calls.lock().unwrap();
+        assert_eq!(calls.activity_successes.len(), 1);
+        assert_eq!(calls.activity_successes[0].1, "2026-05-22T00:00:00+00:00");
     }
 }

--- a/crates/connect/src/broker/orchestrator.rs
+++ b/crates/connect/src/broker/orchestrator.rs
@@ -885,7 +885,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stale_provider_waterline_restores_cursor_without_fetching_activities() {
+    async fn stale_provider_waterline_restores_cursor_without_counting_synced_account() {
         let service = Arc::new(MockSyncService {
             accounts: vec![synced_account(
                 "account-1",
@@ -909,7 +909,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(activities.accounts_synced, 1);
+        assert_eq!(activities.accounts_synced, 0);
         assert_eq!(*api_client.activity_calls.lock().unwrap(), 0);
         let calls = service.calls.lock().unwrap();
         assert_eq!(calls.activity_successes.len(), 1);

--- a/crates/connect/src/broker/orchestrator.rs
+++ b/crates/connect/src/broker/orchestrator.rs
@@ -75,7 +75,6 @@ pub(super) struct ActivitySyncOutcome {
     assets_created: u32,
     needs_review: u32,
     new_asset_ids: Vec<String>,
-    empty_first_page: bool,
     inconsistent_empty_page: bool,
 }
 
@@ -324,6 +323,53 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
         Ok(result)
     }
 
+    /// Sync activities for existing transaction-tracked accounts only.
+    /// This is used by legacy activities-only API endpoints that should not sync
+    /// connections, accounts, or holdings.
+    pub async fn sync_activities_only(
+        &self,
+        api_client: &dyn BrokerApiClient,
+    ) -> Result<SyncActivitiesResponse, String> {
+        let provider_transaction_statuses: HashMap<String, BrokerSyncStatusDetail> = api_client
+            .list_accounts(None)
+            .await
+            .map_err(|e| e.to_string())?
+            .into_iter()
+            .filter_map(|account| {
+                Some((
+                    account.id?,
+                    account.sync_status.as_ref()?.transactions.clone()?,
+                ))
+            })
+            .collect();
+        let synced_accounts = self
+            .sync_service
+            .get_synced_accounts()
+            .map_err(|e| format!("Failed to get synced accounts: {}", e))?;
+        let mut activities_summary = SyncActivitiesResponse::default();
+
+        for account in synced_accounts {
+            let Some(job) = AccountSyncJob::from_account(account) else {
+                continue;
+            };
+
+            if job.tracking_mode != TrackingMode::Transactions {
+                continue;
+            }
+
+            let activity_result = self
+                .sync_activity_phase(
+                    api_client,
+                    &job,
+                    provider_transaction_statuses.get(&job.broker_account_id),
+                )
+                .await;
+            Self::merge_activities_summary(&mut activities_summary, activity_result.summary);
+        }
+
+        Ok(activities_summary)
+    }
+
     /// Sync account data for all synced accounts based on their tracking mode.
     /// - TRANSACTIONS mode: sync activities
     /// - HOLDINGS mode: sync holdings (positions)
@@ -435,10 +481,10 @@ mod tests {
     }
 
     use super::super::models::{
-        AccountUniversalActivity, BrokerAccount, BrokerBrokerage, BrokerConnection,
-        BrokerHoldingsResponse, HoldingsBalance, HoldingsDiff, HoldingsOptionPosition,
-        HoldingsPosition, PaginatedUniversalActivity, PaginationDetails, SyncAccountsResponse,
-        SyncConnectionsResponse,
+        AccountUniversalActivity, BrokerAccount, BrokerAccountSyncStatus, BrokerBrokerage,
+        BrokerConnection, BrokerHoldingsResponse, HoldingsBalance, HoldingsDiff,
+        HoldingsOptionPosition, HoldingsPosition, PaginatedUniversalActivity, PaginationDetails,
+        SyncAccountsResponse, SyncConnectionsResponse,
     };
     use super::super::progress::NoOpProgressReporter;
     use super::super::traits::BrokerSyncServiceTrait;
@@ -451,6 +497,7 @@ mod tests {
 
     #[derive(Default)]
     struct MockBrokerApiClient {
+        broker_accounts: Vec<BrokerAccount>,
         activity_pages: Mutex<Vec<PaginatedUniversalActivity>>,
         activity_calls: Mutex<usize>,
     }
@@ -465,7 +512,7 @@ mod tests {
             &self,
             _authorization_ids: Option<Vec<String>>,
         ) -> Result<Vec<BrokerAccount>> {
-            Ok(Vec::new())
+            Ok(self.broker_accounts.clone())
         }
 
         async fn list_brokerages(&self) -> Result<Vec<BrokerBrokerage>> {
@@ -690,6 +737,21 @@ mod tests {
         }
     }
 
+    fn broker_account(
+        broker_account_id: &str,
+        transactions: Option<BrokerSyncStatusDetail>,
+        holdings: Option<BrokerSyncStatusDetail>,
+    ) -> BrokerAccount {
+        BrokerAccount {
+            id: Some(broker_account_id.to_string()),
+            sync_status: Some(BrokerAccountSyncStatus {
+                transactions,
+                holdings,
+            }),
+            ..BrokerAccount::default()
+        }
+    }
+
     fn sync_state(account_id: &str, last_successful_at: &str) -> BrokerSyncState {
         let mut state = BrokerSyncState::new(account_id.to_string(), "TEST".to_string());
         state.last_successful_at = Some(
@@ -852,5 +914,45 @@ mod tests {
         let calls = service.calls.lock().unwrap();
         assert_eq!(calls.activity_successes.len(), 1);
         assert_eq!(calls.activity_successes[0].1, "2026-05-22T00:00:00+00:00");
+    }
+
+    #[tokio::test]
+    async fn activities_only_sync_uses_shared_activity_phase_for_transaction_accounts() {
+        let service = Arc::new(MockSyncService {
+            accounts: vec![
+                synced_account("account-1", "broker-1", TrackingMode::Transactions),
+                synced_account("account-2", "broker-2", TrackingMode::Holdings),
+            ],
+            upsert_result: (1, 0, Vec::new(), 0),
+            ..MockSyncService::default()
+        });
+        let api_client = MockBrokerApiClient {
+            broker_accounts: vec![
+                broker_account("broker-1", Some(ready_status("2026-05-22", None)), None),
+                broker_account("broker-2", Some(ready_status("2026-05-22", None)), None),
+            ],
+            activity_pages: Mutex::new(vec![PaginatedUniversalActivity {
+                data: vec![AccountUniversalActivity {
+                    id: Some("activity-1".to_string()),
+                    ..AccountUniversalActivity::default()
+                }],
+                pagination: Some(PaginationDetails {
+                    has_more: Some(false),
+                    total: Some(1),
+                    ..PaginationDetails::default()
+                }),
+            }]),
+            ..MockBrokerApiClient::default()
+        };
+
+        let activities = orchestrator(service.clone())
+            .sync_activities_only(&api_client)
+            .await
+            .unwrap();
+
+        assert_eq!(activities.accounts_synced, 1);
+        assert_eq!(activities.activities_upserted, 1);
+        assert_eq!(*api_client.activity_calls.lock().unwrap(), 1);
+        assert_eq!(service.calls.lock().unwrap().save_holdings_calls, 0);
     }
 }

--- a/crates/connect/src/broker/orchestrator/activity_pagination.rs
+++ b/crates/connect/src/broker/orchestrator/activity_pagination.rs
@@ -21,7 +21,6 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
         let limit = self.config.page_limit;
         let mut pages_fetched: usize = 0;
         let mut last_page_first_id: Option<String> = None;
-        let mut empty_first_page = false;
         let mut inconsistent_empty_page = false;
 
         let mut total_fetched: u32 = 0;
@@ -119,7 +118,6 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
             let next_offset = offset + received;
 
             if received == 0 {
-                empty_first_page = offset == 0;
                 inconsistent_empty_page = page.pagination.as_ref().is_some_and(|p| {
                     p.has_more == Some(true) || p.total.is_some_and(|total| offset < total)
                 });
@@ -156,7 +154,6 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
             assets_created: total_assets_created,
             needs_review: total_needs_review,
             new_asset_ids: all_new_asset_ids,
-            empty_first_page,
             inconsistent_empty_page,
         })
     }

--- a/crates/connect/src/broker/orchestrator/activity_pagination.rs
+++ b/crates/connect/src/broker/orchestrator/activity_pagination.rs
@@ -1,0 +1,189 @@
+use chrono::{NaiveDate, Utc};
+use log::{debug, info};
+
+use super::super::progress::{SyncProgressPayload, SyncProgressReporter, SyncStatus};
+use super::super::traits::BrokerApiClient;
+use super::{ActivityQueryWindow, ActivitySyncOutcome, SyncOrchestrator};
+
+impl<P: SyncProgressReporter> SyncOrchestrator<P> {
+    #[allow(clippy::too_many_arguments)]
+    pub(super) async fn sync_account_activities(
+        &self,
+        api_client: &dyn BrokerApiClient,
+        account_id: &str,
+        account_name: &str,
+        broker_account_id: &str,
+        start_date: Option<&str>,
+        end_date: Option<&str>,
+        import_run_id: Option<String>,
+    ) -> Result<ActivitySyncOutcome, String> {
+        let mut offset: i64 = 0;
+        let limit = self.config.page_limit;
+        let mut pages_fetched: usize = 0;
+        let mut last_page_first_id: Option<String> = None;
+        let mut empty_first_page = false;
+        let mut inconsistent_empty_page = false;
+
+        let mut total_fetched: u32 = 0;
+        let mut total_inserted: u32 = 0;
+        let mut total_assets_created: u32 = 0;
+        let mut total_needs_review: u32 = 0;
+        let mut all_new_asset_ids: Vec<String> = Vec::new();
+
+        loop {
+            if pages_fetched >= self.config.max_pages {
+                return Err(format!(
+                    "Pagination exceeded max pages ({}). Aborting.",
+                    self.config.max_pages
+                ));
+            }
+
+            let page = api_client
+                .get_account_activities(
+                    broker_account_id,
+                    start_date,
+                    end_date,
+                    Some(offset),
+                    Some(limit),
+                )
+                .await
+                .map_err(|e| e.to_string())?;
+
+            let data = page.data;
+            pages_fetched += 1;
+            total_fetched += data.len() as u32;
+
+            let page_total = page.pagination.as_ref().and_then(|p| p.total);
+
+            self.progress_reporter.report_progress(
+                SyncProgressPayload::new(account_id, account_name, SyncStatus::Syncing)
+                    .with_page(pages_fetched)
+                    .with_activities_fetched(total_fetched as usize)
+                    .with_message(format!(
+                        "Fetched {} activities (total: {:?})",
+                        total_fetched, page_total
+                    )),
+            );
+
+            info!(
+                "Fetched {} activities for '{}' (offset {}, total {:?})",
+                data.len(),
+                account_name,
+                offset,
+                page_total
+            );
+
+            if !data.is_empty() {
+                if let Some(first_id) = data.first().and_then(|a| a.id.clone()) {
+                    if offset > 0 {
+                        if let Some(prev) = &last_page_first_id {
+                            if prev == &first_id {
+                                return Err(
+                                    "Pagination appears stuck (same first activity id returned for multiple pages)."
+                                        .to_string(),
+                                );
+                            }
+                        }
+                    }
+                    last_page_first_id = Some(first_id);
+                }
+
+                debug!(
+                    "Upserting {} activities for account '{}'...",
+                    data.len(),
+                    account_name
+                );
+
+                let (upserted, assets, new_asset_ids, needs_review) = self
+                    .sync_service
+                    .upsert_account_activities(
+                        account_id.to_string(),
+                        import_run_id.clone(),
+                        data.clone(),
+                    )
+                    .await
+                    .map_err(|e| format!("Failed to upsert activities: {}", e))?;
+
+                info!(
+                    "Upserted {} activities, {} assets for '{}' ({} need review)",
+                    upserted, assets, account_name, needs_review
+                );
+
+                total_inserted += upserted as u32;
+                total_assets_created += assets as u32;
+                total_needs_review += needs_review as u32;
+                all_new_asset_ids.extend(new_asset_ids);
+            }
+
+            let received = data.len() as i64;
+            let next_offset = offset + received;
+
+            if received == 0 {
+                empty_first_page = offset == 0;
+                inconsistent_empty_page = page.pagination.as_ref().is_some_and(|p| {
+                    p.has_more == Some(true) || p.total.is_some_and(|total| offset < total)
+                });
+                break;
+            }
+
+            let has_more = match page.pagination.as_ref() {
+                Some(p) => match p.has_more {
+                    Some(true) => true,
+                    Some(false) => false,
+                    None => {
+                        if let Some(total) = p.total {
+                            next_offset < total
+                        } else if let Some(page_limit) = p.limit {
+                            received >= page_limit
+                        } else {
+                            received >= limit
+                        }
+                    }
+                },
+                None => received >= limit,
+            };
+
+            offset = next_offset;
+
+            if !has_more {
+                break;
+            }
+        }
+
+        Ok(ActivitySyncOutcome {
+            fetched: total_fetched,
+            inserted: total_inserted,
+            assets_created: total_assets_created,
+            needs_review: total_needs_review,
+            new_asset_ids: all_new_asset_ids,
+            empty_first_page,
+            inconsistent_empty_page,
+        })
+    }
+
+    pub(super) fn compute_activity_query_window(
+        &self,
+        account_id: &str,
+        provider_waterline: NaiveDate,
+    ) -> Result<ActivityQueryWindow, String> {
+        let today = Utc::now().date_naive();
+        let end_date = provider_waterline.min(today);
+        let sync_state = self
+            .sync_service
+            .get_activity_sync_state(account_id)
+            .map_err(|e| format!("Failed to read activity sync state: {}", e))?;
+
+        let local_cursor = sync_state.and_then(|s| s.last_successful_at);
+        let has_local_cursor = local_cursor.is_some();
+        let start_date = local_cursor
+            .map(|dt| dt.date_naive())
+            .map(|d| (d - chrono::Days::new(1)).min(end_date))
+            .map(|d| d.format("%Y-%m-%d").to_string());
+
+        Ok(ActivityQueryWindow {
+            start_date,
+            end_date: end_date.format("%Y-%m-%d").to_string(),
+            has_local_cursor,
+        })
+    }
+}

--- a/crates/connect/src/broker/orchestrator/activity_phase.rs
+++ b/crates/connect/src/broker/orchestrator/activity_phase.rs
@@ -1,0 +1,559 @@
+use log::{debug, error, info};
+
+use super::super::models::BrokerSyncStatusDetail;
+use super::super::progress::{SyncProgressPayload, SyncProgressReporter, SyncStatus};
+use super::super::sync_readiness::{
+    provider_waterline_precedes_local_cursor, resolve_activity_readiness,
+    should_advance_activity_cursor, ProviderReadiness,
+};
+use super::super::traits::BrokerApiClient;
+use super::{
+    AccountSyncJob, ActivityPhaseResult, ActivityQueryWindow, ActivitySyncOutcome, SyncOrchestrator,
+};
+use crate::broker_ingest::{ImportRunMode, ImportRunStatus, ImportRunSummary};
+
+impl<P: SyncProgressReporter> SyncOrchestrator<P> {
+    pub(super) async fn sync_activity_phase(
+        &self,
+        api_client: &dyn BrokerApiClient,
+        job: &AccountSyncJob,
+        provider_activity_status: Option<&BrokerSyncStatusDetail>,
+    ) -> ActivityPhaseResult {
+        let mut result = ActivityPhaseResult::continue_with(Default::default());
+
+        if let Err(err) = self
+            .sync_service
+            .mark_activity_sync_attempt(job.account_id.clone())
+            .await
+            .map_err(|e| format!("Failed to mark activity sync attempt: {}", e))
+        {
+            error!(
+                "Failed to mark activity sync attempt for '{}': {}",
+                job.account_name, err
+            );
+            if job.is_holdings_mode() {
+                let warning = err.to_string();
+                self.progress_reporter.report_progress(
+                    SyncProgressPayload::new(
+                        &job.account_id,
+                        &job.account_name,
+                        SyncStatus::NeedsReview,
+                    )
+                    .with_message(format!(
+                        "Activity reference sync setup failed; continuing holdings sync: {}",
+                        warning
+                    )),
+                );
+                result.summary.accounts_warned += 1;
+                result.activity_warning = Some(warning);
+                return result;
+            }
+
+            result.summary.accounts_failed += 1;
+            result.continue_account = false;
+            return result;
+        }
+
+        let local_activity_state = match self.sync_service.get_activity_sync_state(&job.account_id)
+        {
+            Ok(state) => state,
+            Err(err) => {
+                error!(
+                    "Failed to read activity sync state for '{}': {}",
+                    job.account_name, err
+                );
+                if job.is_holdings_mode() {
+                    let warning = format!(
+                        "Activity reference sync state failed; continuing holdings sync: {}",
+                        err
+                    );
+                    if let Err(e) = self
+                        .sync_service
+                        .finalize_activity_sync_needs_review(
+                            job.account_id.clone(),
+                            warning.clone(),
+                            None,
+                        )
+                        .await
+                    {
+                        error!(
+                            "Failed to mark activity sync as needs review for '{}': {}",
+                            job.account_name, e
+                        );
+                    }
+                    self.progress_reporter.report_progress(
+                        SyncProgressPayload::new(
+                            &job.account_id,
+                            &job.account_name,
+                            SyncStatus::NeedsReview,
+                        )
+                        .with_message(warning.clone()),
+                    );
+                    result.summary.accounts_warned += 1;
+                    result.activity_warning = Some(warning);
+                    return result;
+                }
+
+                let failure = format!("Activity sync state failed: {}", err);
+                let _ = self
+                    .sync_service
+                    .finalize_activity_sync_failure(job.account_id.clone(), failure.clone(), None)
+                    .await;
+                self.progress_reporter.report_progress(
+                    SyncProgressPayload::new(
+                        &job.account_id,
+                        &job.account_name,
+                        SyncStatus::Failed,
+                    )
+                    .with_message(failure),
+                );
+                result.summary.accounts_failed += 1;
+                result.continue_account = false;
+                return result;
+            }
+        };
+
+        let local_cursor = local_activity_state
+            .as_ref()
+            .and_then(|state| state.last_successful_at.as_ref());
+
+        let activity_waterline = match resolve_activity_readiness(provider_activity_status) {
+            Ok(ProviderReadiness::Ready(date))
+                if provider_waterline_precedes_local_cursor(local_cursor, date) =>
+            {
+                let Some(cursor) = local_cursor else {
+                    unreachable!("stale provider waterline requires local cursor");
+                };
+                let message = format!(
+                    "Activity sync skipped: provider transaction waterline {} is older than local cursor {}",
+                    date,
+                    cursor.date_naive()
+                );
+                if let Err(e) = self
+                    .sync_service
+                    .finalize_activity_sync_success(
+                        job.account_id.clone(),
+                        cursor.to_rfc3339(),
+                        None,
+                    )
+                    .await
+                {
+                    error!(
+                        "Failed to restore activity sync state for '{}': {}",
+                        job.account_name, e
+                    );
+                    result.summary.accounts_failed += 1;
+                    if !job.is_holdings_mode() {
+                        result.continue_account = false;
+                        return result;
+                    }
+                    result.activity_warning = Some(format!(
+                        "Activity sync skipped, but sync state cleanup failed: {}",
+                        e
+                    ));
+                } else {
+                    self.progress_reporter.report_progress(
+                        SyncProgressPayload::new(
+                            &job.account_id,
+                            &job.account_name,
+                            SyncStatus::Complete,
+                        )
+                        .with_message(message),
+                    );
+                    result.summary.accounts_synced += 1;
+                }
+                return result;
+            }
+            Ok(ProviderReadiness::Ready(date)) => date,
+            Ok(ProviderReadiness::NotReady(reason)) => {
+                let warning = format!("Activity sync deferred: {}", reason);
+                if let Err(e) = self
+                    .sync_service
+                    .finalize_activity_sync_needs_review(
+                        job.account_id.clone(),
+                        warning.clone(),
+                        None,
+                    )
+                    .await
+                {
+                    error!(
+                        "Failed to mark deferred activity sync for '{}': {}",
+                        job.account_name, e
+                    );
+                }
+                self.progress_reporter.report_progress(
+                    SyncProgressPayload::new(
+                        &job.account_id,
+                        &job.account_name,
+                        SyncStatus::NeedsReview,
+                    )
+                    .with_message(warning.clone()),
+                );
+                result.summary.accounts_warned += 1;
+                result.activity_warning = Some(warning);
+                return result;
+            }
+            Err(err) => {
+                error!(
+                    "Failed to resolve provider activity sync status for '{}': {}",
+                    job.account_name, err
+                );
+                if job.is_holdings_mode() {
+                    let message = format!(
+                        "Activity reference sync status failed; continuing holdings sync: {}",
+                        err
+                    );
+                    if let Err(e) = self
+                        .sync_service
+                        .finalize_activity_sync_needs_review(
+                            job.account_id.clone(),
+                            message.clone(),
+                            None,
+                        )
+                        .await
+                    {
+                        error!(
+                            "Failed to mark activity sync as needs review for '{}': {}",
+                            job.account_name, e
+                        );
+                    }
+                    self.progress_reporter.report_progress(
+                        SyncProgressPayload::new(
+                            &job.account_id,
+                            &job.account_name,
+                            SyncStatus::NeedsReview,
+                        )
+                        .with_message(message.clone()),
+                    );
+                    result.summary.accounts_warned += 1;
+                    result.activity_warning = Some(message);
+                    return result;
+                }
+
+                let _ = self
+                    .sync_service
+                    .finalize_activity_sync_failure(job.account_id.clone(), err.clone(), None)
+                    .await;
+                self.progress_reporter.report_progress(
+                    SyncProgressPayload::new(
+                        &job.account_id,
+                        &job.account_name,
+                        SyncStatus::Failed,
+                    )
+                    .with_message(err.clone()),
+                );
+                result.summary.accounts_failed += 1;
+                result.continue_account = false;
+                return result;
+            }
+        };
+
+        let query_window = match self
+            .compute_activity_query_window(&job.account_id, activity_waterline)
+        {
+            Ok(window) => window,
+            Err(err) => {
+                error!(
+                    "Failed to compute activity query window for '{}': {}",
+                    job.account_name, err
+                );
+                if job.is_holdings_mode() {
+                    let message = format!(
+                        "Activity reference query window failed; continuing holdings sync: {}",
+                        err
+                    );
+                    if let Err(e) = self
+                        .sync_service
+                        .finalize_activity_sync_needs_review(
+                            job.account_id.clone(),
+                            message.clone(),
+                            None,
+                        )
+                        .await
+                    {
+                        error!(
+                            "Failed to mark activity sync as needs review for '{}': {}",
+                            job.account_name, e
+                        );
+                    }
+                    self.progress_reporter.report_progress(
+                        SyncProgressPayload::new(
+                            &job.account_id,
+                            &job.account_name,
+                            SyncStatus::NeedsReview,
+                        )
+                        .with_message(message.clone()),
+                    );
+                    result.summary.accounts_warned += 1;
+                    result.activity_warning = Some(message);
+                    return result;
+                }
+
+                let failure = format!("Activity query window failed: {}", err);
+                let _ = self
+                    .sync_service
+                    .finalize_activity_sync_failure(job.account_id.clone(), failure.clone(), None)
+                    .await;
+                self.progress_reporter.report_progress(
+                    SyncProgressPayload::new(
+                        &job.account_id,
+                        &job.account_name,
+                        SyncStatus::Failed,
+                    )
+                    .with_message(failure),
+                );
+                result.summary.accounts_failed += 1;
+                result.continue_account = false;
+                return result;
+            }
+        };
+
+        let import_mode = if query_window.start_date.is_none() {
+            ImportRunMode::Initial
+        } else {
+            ImportRunMode::Incremental
+        };
+
+        let import_run = match self
+            .sync_service
+            .create_import_run(&job.account_id, import_mode)
+            .await
+        {
+            Ok(run) => {
+                debug!(
+                    "Created import run {} for account '{}'",
+                    run.id, job.account_name
+                );
+                Some(run)
+            }
+            Err(e) => {
+                error!(
+                    "Failed to create import run for '{}': {}",
+                    job.account_name, e
+                );
+                None
+            }
+        };
+        result.activity_import_run_id = import_run.as_ref().map(|r| r.id.clone());
+
+        let window_label = match &query_window.start_date {
+            Some(s) => format!("{} -> {}", s, query_window.end_date),
+            None => format!("ALL -> {}", query_window.end_date),
+        };
+        info!(
+            "Syncing activities for account '{}' ({}): {}",
+            job.account_name, job.broker_account_id, window_label
+        );
+
+        self.progress_reporter.report_progress(
+            SyncProgressPayload::new(&job.account_id, &job.account_name, SyncStatus::Syncing)
+                .with_message(format!("Starting sync: {}", window_label)),
+        );
+
+        match self
+            .sync_account_activities(
+                api_client,
+                &job.account_id,
+                &job.account_name,
+                &job.broker_account_id,
+                query_window.start_date.as_deref(),
+                Some(query_window.end_date.as_str()),
+                result.activity_import_run_id.clone(),
+            )
+            .await
+        {
+            Ok(outcome) => {
+                self.handle_activity_sync_success(
+                    job,
+                    provider_activity_status,
+                    &query_window,
+                    outcome,
+                    &mut result,
+                )
+                .await;
+            }
+            Err(err) => {
+                self.handle_activity_sync_error(job, err, &mut result).await;
+            }
+        }
+
+        result
+    }
+
+    async fn handle_activity_sync_success(
+        &self,
+        job: &AccountSyncJob,
+        provider_activity_status: Option<&BrokerSyncStatusDetail>,
+        query_window: &ActivityQueryWindow,
+        outcome: ActivitySyncOutcome,
+        result: &mut ActivityPhaseResult,
+    ) {
+        let mut import_status = if outcome.needs_review > 0 {
+            ImportRunStatus::NeedsReview
+        } else {
+            ImportRunStatus::Applied
+        };
+        let summary = ImportRunSummary {
+            fetched: outcome.fetched,
+            inserted: outcome.inserted,
+            updated: 0,
+            skipped: 0,
+            warnings: outcome.needs_review,
+            errors: 0,
+            removed: 0,
+            assets_created: outcome.assets_created,
+        };
+
+        let should_advance_cursor = should_advance_activity_cursor(
+            outcome.fetched as usize,
+            query_window.has_local_cursor,
+            outcome.inconsistent_empty_page,
+            provider_activity_status,
+        );
+
+        if should_advance_cursor {
+            let sync_state_failed = self
+                .sync_service
+                .finalize_activity_sync_success(
+                    job.account_id.clone(),
+                    query_window.end_date.clone(),
+                    result.activity_import_run_id.clone(),
+                )
+                .await
+                .is_err();
+
+            if sync_state_failed {
+                error!(
+                    "Failed to update activity sync state for '{}', but activities were synced",
+                    job.account_name
+                );
+            }
+        } else {
+            let warning = if outcome.inconsistent_empty_page {
+                "Activity sync returned an empty page while provider pagination reported more data"
+            } else if outcome.empty_first_page {
+                "Initial activity sync returned no rows even though provider reports transactions may exist"
+            } else {
+                "Initial activity sync did not confirm a complete empty history"
+            }
+            .to_string();
+            if let Err(e) = self
+                .sync_service
+                .finalize_activity_sync_needs_review(
+                    job.account_id.clone(),
+                    warning.clone(),
+                    result.activity_import_run_id.clone(),
+                )
+                .await
+            {
+                error!(
+                    "Failed to mark activity sync as needs review for '{}': {}",
+                    job.account_name, e
+                );
+            }
+            import_status = ImportRunStatus::NeedsReview;
+            result.summary.accounts_warned += 1;
+            result.activity_warning = Some(warning.clone());
+            self.progress_reporter.report_progress(
+                SyncProgressPayload::new(
+                    &job.account_id,
+                    &job.account_name,
+                    SyncStatus::NeedsReview,
+                )
+                .with_activities_fetched(outcome.fetched as usize)
+                .with_message(warning),
+            );
+        }
+
+        if let Some(ref run_id) = result.activity_import_run_id {
+            if outcome.needs_review > 0 {
+                info!(
+                    "Import run {} has {} activities needing review",
+                    run_id, outcome.needs_review
+                );
+            }
+
+            let _ = self
+                .sync_service
+                .finalize_import_run(run_id, summary, import_status, None)
+                .await;
+        }
+
+        result.summary.activities_upserted += outcome.inserted as usize;
+        result.summary.assets_inserted += outcome.assets_created as usize;
+        result.summary.new_asset_ids.extend(outcome.new_asset_ids);
+
+        if !should_advance_cursor {
+            result.continue_account = job.is_holdings_mode();
+            return;
+        }
+
+        let status = if outcome.needs_review > 0 {
+            SyncStatus::NeedsReview
+        } else {
+            SyncStatus::Complete
+        };
+        self.progress_reporter.report_progress(
+            SyncProgressPayload::new(&job.account_id, &job.account_name, status)
+                .with_activities_fetched(outcome.fetched as usize)
+                .with_message(format!(
+                    "Synced {} activities ({} need review)",
+                    outcome.inserted, outcome.needs_review
+                )),
+        );
+
+        result.summary.accounts_synced += 1;
+    }
+
+    async fn handle_activity_sync_error(
+        &self,
+        job: &AccountSyncJob,
+        err: String,
+        result: &mut ActivityPhaseResult,
+    ) {
+        error!(
+            "Failed to sync activities for '{}': {}",
+            job.account_name, err
+        );
+
+        let _ = self
+            .sync_service
+            .finalize_activity_sync_failure(
+                job.account_id.clone(),
+                err.clone(),
+                result.activity_import_run_id.clone(),
+            )
+            .await;
+
+        if let Some(ref run_id) = result.activity_import_run_id {
+            let summary = ImportRunSummary::default();
+            let _ = self
+                .sync_service
+                .finalize_import_run(run_id, summary, ImportRunStatus::Failed, Some(err.clone()))
+                .await;
+        }
+
+        if job.is_holdings_mode() {
+            self.progress_reporter.report_progress(
+                SyncProgressPayload::new(
+                    &job.account_id,
+                    &job.account_name,
+                    SyncStatus::NeedsReview,
+                )
+                .with_message(format!(
+                    "Activity reference sync failed; continuing holdings sync: {}",
+                    err
+                )),
+            );
+            result.summary.accounts_warned += 1;
+            result.activity_warning = Some(err);
+        } else {
+            self.progress_reporter.report_progress(
+                SyncProgressPayload::new(&job.account_id, &job.account_name, SyncStatus::Failed)
+                    .with_message(err.clone()),
+            );
+            result.summary.accounts_failed += 1;
+            result.continue_account = false;
+        }
+    }
+}

--- a/crates/connect/src/broker/orchestrator/activity_phase.rs
+++ b/crates/connect/src/broker/orchestrator/activity_phase.rs
@@ -3,8 +3,7 @@ use log::{debug, error, info};
 use super::super::models::BrokerSyncStatusDetail;
 use super::super::progress::{SyncProgressPayload, SyncProgressReporter, SyncStatus};
 use super::super::sync_readiness::{
-    provider_waterline_precedes_local_cursor, resolve_activity_readiness,
-    should_advance_activity_cursor, ProviderReadiness,
+    resolve_activity_readiness, should_advance_activity_cursor, ProviderReadiness,
 };
 use super::super::traits::BrokerApiClient;
 use super::{
@@ -118,53 +117,50 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
             .and_then(|state| state.last_successful_at.as_ref());
 
         let activity_waterline = match resolve_activity_readiness(provider_activity_status) {
-            Ok(ProviderReadiness::Ready(date))
-                if provider_waterline_precedes_local_cursor(local_cursor, date) =>
-            {
-                let Some(cursor) = local_cursor else {
-                    unreachable!("stale provider waterline requires local cursor");
-                };
-                let message = format!(
-                    "Activity sync skipped: provider transaction waterline {} is older than local cursor {}",
-                    date,
-                    cursor.date_naive()
-                );
-                if let Err(e) = self
-                    .sync_service
-                    .finalize_activity_sync_success(
-                        job.account_id.clone(),
-                        cursor.to_rfc3339(),
-                        None,
-                    )
-                    .await
-                {
-                    error!(
-                        "Failed to restore activity sync state for '{}': {}",
-                        job.account_name, e
+            Ok(ProviderReadiness::Ready(date)) => {
+                if let Some(cursor) = local_cursor.filter(|cursor| date < cursor.date_naive()) {
+                    let message = format!(
+                        "Activity sync skipped: provider transaction waterline {} is older than local cursor {}",
+                        date,
+                        cursor.date_naive()
                     );
-                    result.summary.accounts_failed += 1;
-                    if !job.is_holdings_mode() {
-                        result.continue_account = false;
-                        return result;
-                    }
-                    result.activity_warning = Some(format!(
-                        "Activity sync skipped, but sync state cleanup failed: {}",
-                        e
-                    ));
-                } else {
-                    self.progress_reporter.report_progress(
-                        SyncProgressPayload::new(
-                            &job.account_id,
-                            &job.account_name,
-                            SyncStatus::Complete,
+                    if let Err(e) = self
+                        .sync_service
+                        .finalize_activity_sync_success(
+                            job.account_id.clone(),
+                            cursor.to_rfc3339(),
+                            None,
                         )
-                        .with_message(message),
-                    );
-                    result.summary.accounts_synced += 1;
+                        .await
+                    {
+                        error!(
+                            "Failed to restore activity sync state for '{}': {}",
+                            job.account_name, e
+                        );
+                        result.summary.accounts_failed += 1;
+                        if !job.is_holdings_mode() {
+                            result.continue_account = false;
+                            return result;
+                        }
+                        result.activity_warning = Some(format!(
+                            "Activity sync skipped, but sync state cleanup failed: {}",
+                            e
+                        ));
+                    } else {
+                        self.progress_reporter.report_progress(
+                            SyncProgressPayload::new(
+                                &job.account_id,
+                                &job.account_name,
+                                SyncStatus::Complete,
+                            )
+                            .with_message(message),
+                        );
+                        result.summary.accounts_synced += 1;
+                    }
+                    return result;
                 }
-                return result;
+                date
             }
-            Ok(ProviderReadiness::Ready(date)) => date,
             Ok(ProviderReadiness::NotReady(reason)) => {
                 let warning = format!("Activity sync deferred: {}", reason);
                 if let Err(e) = self
@@ -431,10 +427,8 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
         } else {
             let warning = if outcome.inconsistent_empty_page {
                 "Activity sync returned an empty page while provider pagination reported more data"
-            } else if outcome.empty_first_page {
-                "Initial activity sync returned no rows even though provider reports transactions may exist"
             } else {
-                "Initial activity sync did not confirm a complete empty history"
+                "Initial activity sync returned no rows even though provider reports transactions may exist"
             }
             .to_string();
             if let Err(e) = self

--- a/crates/connect/src/broker/orchestrator/activity_phase.rs
+++ b/crates/connect/src/broker/orchestrator/activity_phase.rs
@@ -155,7 +155,6 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
                             )
                             .with_message(message),
                         );
-                        result.summary.accounts_synced += 1;
                     }
                     return result;
                 }

--- a/crates/connect/src/broker/orchestrator/holdings_phase.rs
+++ b/crates/connect/src/broker/orchestrator/holdings_phase.rs
@@ -1,0 +1,286 @@
+use log::{debug, error, info, warn};
+
+use super::super::models::{BrokerSyncStatusDetail, HoldingsDiff, SyncHoldingsResponse};
+use super::super::progress::{SyncProgressPayload, SyncProgressReporter, SyncStatus};
+use super::super::sync_readiness::{resolve_holdings_readiness, ProviderReadiness};
+use super::super::traits::BrokerApiClient;
+use super::{AccountSyncJob, HoldingsPhaseContext, SyncOrchestrator};
+use crate::broker_ingest::{ImportRunMode, ImportRunStatus, ImportRunSummary};
+
+impl<P: SyncProgressReporter> SyncOrchestrator<P> {
+    pub(super) async fn sync_holdings_phase(
+        &self,
+        api_client: &dyn BrokerApiClient,
+        job: &AccountSyncJob,
+        provider_holdings_status: Option<&BrokerSyncStatusDetail>,
+        context: HoldingsPhaseContext,
+    ) -> SyncHoldingsResponse {
+        let mut summary = SyncHoldingsResponse::default();
+
+        match resolve_holdings_readiness(provider_holdings_status) {
+            Ok(ProviderReadiness::Ready(_)) => {}
+            Ok(ProviderReadiness::NotReady(reason)) => {
+                let warning = if let Some(activity_warning) = context.activity_warning.as_ref() {
+                    format!(
+                        "Holdings sync deferred: {}; activity reference sync needs review: {}",
+                        reason, activity_warning
+                    )
+                } else {
+                    format!("Holdings sync deferred: {}", reason)
+                };
+                if let Err(e) = self
+                    .sync_service
+                    .finalize_activity_sync_needs_review(
+                        job.account_id.clone(),
+                        warning.clone(),
+                        None,
+                    )
+                    .await
+                {
+                    error!(
+                        "Failed to mark deferred holdings sync for '{}': {}",
+                        job.account_name, e
+                    );
+                }
+                self.progress_reporter.report_progress(
+                    SyncProgressPayload::new(
+                        &job.account_id,
+                        &job.account_name,
+                        SyncStatus::NeedsReview,
+                    )
+                    .with_message(warning),
+                );
+                summary.accounts_warned += 1;
+                return summary;
+            }
+            Err(err) => {
+                error!(
+                    "Failed to resolve provider holdings sync status for '{}': {}",
+                    job.account_name, err
+                );
+                let _ = self
+                    .sync_service
+                    .finalize_activity_sync_failure(
+                        job.account_id.clone(),
+                        format!("Holdings sync status failed: {}", err),
+                        None,
+                    )
+                    .await;
+                summary.accounts_failed += 1;
+                return summary;
+            }
+        }
+
+        let holdings_import_mode = match self
+            .sync_service
+            .has_broker_imported_holdings_snapshot(&job.account_id)
+        {
+            Ok(true) => ImportRunMode::Incremental,
+            Ok(false) => ImportRunMode::Initial,
+            Err(e) => {
+                warn!(
+                    "Failed to read holdings snapshot state for '{}' before holdings sync: {}",
+                    job.account_name, e
+                );
+                ImportRunMode::Initial
+            }
+        };
+
+        let holdings_import_run = match self
+            .sync_service
+            .create_import_run(&job.account_id, holdings_import_mode)
+            .await
+        {
+            Ok(run) => {
+                debug!(
+                    "Created holdings import run {} for account '{}'",
+                    run.id, job.account_name
+                );
+                Some(run)
+            }
+            Err(e) => {
+                error!(
+                    "Failed to create holdings import run for '{}': {}",
+                    job.account_name, e
+                );
+                None
+            }
+        };
+        let holdings_import_run_id = holdings_import_run.as_ref().map(|r| r.id.clone());
+
+        match self
+            .sync_account_holdings(
+                api_client,
+                &job.account_id,
+                &job.account_name,
+                &job.broker_account_id,
+            )
+            .await
+        {
+            Ok((diff, assets_created, new_asset_ids)) => {
+                let import_summary = ImportRunSummary {
+                    fetched: diff.total_positions as u32,
+                    inserted: diff.added_positions as u32,
+                    updated: diff.updated_positions as u32,
+                    skipped: diff.unchanged_positions as u32,
+                    warnings: 0,
+                    errors: 0,
+                    removed: diff.removed_positions as u32,
+                    assets_created: assets_created as u32,
+                };
+
+                if let Some(ref run_id) = holdings_import_run_id {
+                    let _ = self
+                        .sync_service
+                        .finalize_import_run(run_id, import_summary, ImportRunStatus::Applied, None)
+                        .await;
+                }
+
+                summary.accounts_synced += 1;
+                summary.positions_upserted += diff.added_positions + diff.updated_positions;
+                summary.snapshots_upserted += if diff.snapshot_saved { 1 } else { 0 };
+                summary.assets_inserted += assets_created;
+                summary.new_asset_ids.extend(new_asset_ids);
+
+                if let Some(warning) = context.activity_warning {
+                    let warning_message = format!(
+                        "Holdings synced, but activity reference sync needs review: {}",
+                        warning
+                    );
+                    if let Err(e) = self
+                        .sync_service
+                        .finalize_activity_sync_needs_review(
+                            job.account_id.clone(),
+                            warning_message.clone(),
+                            context.activity_import_run_id,
+                        )
+                        .await
+                    {
+                        error!(
+                            "Failed to mark activity sync state as needs review for '{}': {}",
+                            job.account_name, e
+                        );
+                    }
+
+                    self.progress_reporter.report_progress(
+                        SyncProgressPayload::new(
+                            &job.account_id,
+                            &job.account_name,
+                            SyncStatus::NeedsReview,
+                        )
+                        .with_message(warning_message),
+                    );
+                }
+            }
+            Err(err) => {
+                error!(
+                    "Failed to sync holdings for '{}': {}",
+                    job.account_name, err
+                );
+
+                if let Some(ref run_id) = holdings_import_run_id {
+                    let _ = self
+                        .sync_service
+                        .finalize_import_run(
+                            run_id,
+                            ImportRunSummary::default(),
+                            ImportRunStatus::Failed,
+                            Some(err.clone()),
+                        )
+                        .await;
+                }
+
+                let _ = self
+                    .sync_service
+                    .finalize_activity_sync_failure(
+                        job.account_id.clone(),
+                        format!("Holdings sync failed: {}", err),
+                        holdings_import_run_id,
+                    )
+                    .await;
+
+                self.progress_reporter.report_progress(
+                    SyncProgressPayload::new(
+                        &job.account_id,
+                        &job.account_name,
+                        SyncStatus::Failed,
+                    )
+                    .with_message(err),
+                );
+
+                summary.accounts_failed += 1;
+            }
+        }
+
+        summary
+    }
+
+    async fn sync_account_holdings(
+        &self,
+        api_client: &dyn BrokerApiClient,
+        account_id: &str,
+        account_name: &str,
+        broker_account_id: &str,
+    ) -> Result<(HoldingsDiff, usize, Vec<String>), String> {
+        info!(
+            "Syncing holdings for account '{}' ({})",
+            account_name, broker_account_id
+        );
+
+        self.progress_reporter.report_progress(
+            SyncProgressPayload::new(account_id, account_name, SyncStatus::Syncing)
+                .with_message("Fetching holdings from broker...".to_string()),
+        );
+
+        let holdings = api_client
+            .get_account_holdings(broker_account_id)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        let positions_count = holdings.positions.as_ref().map(|p| p.len()).unwrap_or(0);
+        let option_positions_count = holdings
+            .option_positions
+            .as_ref()
+            .map(|p| p.len())
+            .unwrap_or(0);
+        let balances_count = holdings.balances.as_ref().map(|b| b.len()).unwrap_or(0);
+
+        info!(
+            "Fetched {} positions, {} option positions, and {} balances for '{}'",
+            positions_count, option_positions_count, balances_count, account_name
+        );
+
+        let (diff, assets_created, new_asset_ids) = self
+            .sync_service
+            .save_broker_holdings(
+                account_id.to_string(),
+                holdings.balances.unwrap_or_default(),
+                holdings.positions.unwrap_or_default(),
+                holdings.option_positions.unwrap_or_default(),
+            )
+            .await
+            .map_err(|e| format!("Failed to save broker holdings: {}", e))?;
+
+        let changed_positions =
+            diff.added_positions + diff.updated_positions + diff.removed_positions;
+        let summary_message = if changed_positions == 0 {
+            format!(
+                "No position changes detected ({} positions checked)",
+                diff.total_positions
+            )
+        } else {
+            format!(
+                "Positions: +{}, {} updated, {} removed",
+                diff.added_positions, diff.updated_positions, diff.removed_positions
+            )
+        };
+
+        self.progress_reporter.report_progress(
+            SyncProgressPayload::new(account_id, account_name, SyncStatus::Complete).with_message(
+                format!("{} ({} assets created)", summary_message, assets_created),
+            ),
+        );
+
+        Ok((diff, assets_created, new_asset_ids))
+    }
+}

--- a/crates/connect/src/broker/service.rs
+++ b/crates/connect/src/broker/service.rs
@@ -33,6 +33,7 @@ use wealthfolio_core::assets::{
 };
 use wealthfolio_core::errors::Result;
 use wealthfolio_core::events::{DomainEvent, DomainEventSink, NoOpDomainEventSink};
+use wealthfolio_core::fx::currency::normalize_amount;
 use wealthfolio_core::portfolio::snapshot::{
     AccountStateSnapshot, Position, SnapshotRepositoryTrait, SnapshotServiceTrait, SnapshotSource,
 };
@@ -45,6 +46,14 @@ const DEFAULT_BROKERAGE_PROVIDER: &str = "snaptrade";
 /// Precision used for holdings normalization/diff comparisons.
 /// Higher than generic valuation precision to preserve crypto fidelity.
 const HOLDINGS_DECIMAL_PRECISION: u32 = 12;
+
+fn normalize_holdings_money(amount: Decimal, currency: &str) -> (Decimal, String) {
+    let (amount, currency) = normalize_amount(amount, currency);
+    (
+        amount.round_dp(HOLDINGS_DECIMAL_PRECISION),
+        currency.to_string(),
+    )
+}
 
 /// Service for syncing broker data to the local database
 pub struct BrokerSyncService {
@@ -285,6 +294,15 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
             .into_iter()
             .filter(|a| a.provider_account_id.is_some())
             .collect())
+    }
+
+    fn has_broker_imported_holdings_snapshot(&self, account_id: &str) -> Result<bool> {
+        let tomorrow = valuation_date_today() + chrono::Days::new(1);
+        Ok(self
+            .snapshot_repository
+            .get_latest_snapshot_before_date(account_id, tomorrow)?
+            .map(|snapshot| snapshot.source == SnapshotSource::BrokerImported)
+            .unwrap_or(false))
     }
 
     /// Get all platforms
@@ -704,11 +722,12 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 continue;
             }
 
-            let currency = pos
+            let raw_quote_currency = pos
                 .currency
                 .as_ref()
                 .and_then(|c| c.code.clone())
                 .unwrap_or_else(|| account_currency.clone());
+            let (_, money_currency) = normalize_holdings_money(Decimal::ZERO, &raw_quote_currency);
 
             let instrument_type =
                 map_broker_symbol_type(symbol_type_code.as_deref(), is_crypto_asset);
@@ -722,7 +741,7 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                     symbol.clone(),
                     exchange_mic,
                     instrument_type,
-                    currency.clone(),
+                    raw_quote_currency.clone(),
                 )
             };
 
@@ -730,7 +749,7 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 format!(
                     "{}:{}:{}",
                     symbol.to_uppercase(),
-                    currency.to_uppercase(),
+                    raw_quote_currency.to_uppercase(),
                     if is_crypto_asset { "CRYPTO" } else { "EQUITY" }
                 )
             });
@@ -744,15 +763,14 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
             let quantity = Decimal::from_f64(units)
                 .unwrap_or(Decimal::ZERO)
                 .round_dp(HOLDINGS_DECIMAL_PRECISION);
-            let price = Decimal::from_f64(pos.price.unwrap_or(0.0))
-                .unwrap_or(Decimal::ZERO)
-                .round_dp(HOLDINGS_DECIMAL_PRECISION);
+            let raw_price = Decimal::from_f64(pos.price.unwrap_or(0.0)).unwrap_or(Decimal::ZERO);
+            let price = normalize_holdings_money(raw_price, &raw_quote_currency).0;
             let avg_cost = pos
                 .average_purchase_price
                 .and_then(Decimal::from_f64)
-                .map(|value| value.round_dp(HOLDINGS_DECIMAL_PRECISION));
+                .map(|value| normalize_holdings_money(value, &raw_quote_currency).0);
 
-            position_data.push((spec_key, quantity, price, avg_cost, currency));
+            position_data.push((spec_key, quantity, price, avg_cost, money_currency));
         }
 
         // 1b. Build AssetSpecs and position data from option positions
@@ -788,11 +806,12 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 wealthfolio_core::utils::occ_symbol::normalize_option_symbol(&ticker)
                     .unwrap_or_else(|| ticker.clone());
 
-            let currency = opt_pos
+            let raw_quote_currency = opt_pos
                 .currency
                 .as_ref()
                 .and_then(|c| c.code.clone())
                 .unwrap_or_else(|| account_currency.clone());
+            let (_, money_currency) = normalize_holdings_money(Decimal::ZERO, &raw_quote_currency);
 
             let multiplier = if option_symbol.is_mini_option.unwrap_or(false) {
                 Decimal::from(10)
@@ -814,7 +833,7 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                     normalized_ticker.clone(),
                     None, // OCC symbols are globally unique
                     InstrumentType::Option,
-                    currency.clone(),
+                    raw_quote_currency.clone(),
                 )
             };
 
@@ -831,15 +850,15 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
             let quantity = Decimal::from_f64(units)
                 .unwrap_or(Decimal::ZERO)
                 .round_dp(HOLDINGS_DECIMAL_PRECISION);
-            let price = Decimal::from_f64(opt_pos.price.unwrap_or(0.0))
-                .unwrap_or(Decimal::ZERO)
-                .round_dp(HOLDINGS_DECIMAL_PRECISION);
+            let raw_price =
+                Decimal::from_f64(opt_pos.price.unwrap_or(0.0)).unwrap_or(Decimal::ZERO);
+            let price = normalize_holdings_money(raw_price, &raw_quote_currency).0;
             let avg_cost = opt_pos
                 .average_purchase_price
                 .and_then(Decimal::from_f64)
-                .map(|value| value.round_dp(HOLDINGS_DECIMAL_PRECISION));
+                .map(|value| normalize_holdings_money(value, &raw_quote_currency).0);
 
-            position_data.push((spec_key, quantity, price, avg_cost, currency));
+            position_data.push((spec_key, quantity, price, avg_cost, money_currency));
         }
 
         // 2. Ensure assets exist via service layer (dedup by instrument_key)
@@ -1437,11 +1456,42 @@ mod tests {
     use rust_decimal::Decimal;
     use wealthfolio_core::portfolio::snapshot::{AccountStateSnapshot, Position, SnapshotSource};
 
-    use super::{default_tracking_mode_for_broker_account_type, BrokerSyncService};
+    use super::{
+        default_tracking_mode_for_broker_account_type, normalize_holdings_money, BrokerSyncService,
+    };
     use wealthfolio_core::accounts::{account_types, TrackingMode};
+    use wealthfolio_core::assets::{AssetSpec, InstrumentType};
 
     fn decimal(value: &str) -> Decimal {
         Decimal::from_str(value).expect("valid decimal")
+    }
+
+    #[test]
+    fn normalize_holdings_money_converts_gbp_minor_units_to_major_units() {
+        let (price, currency) = normalize_holdings_money(decimal("85"), "GBp");
+        let (average_cost, cost_currency) = normalize_holdings_money(decimal("82.5"), "GBX");
+
+        assert_eq!(price, decimal("0.85"));
+        assert_eq!(currency, "GBP");
+        assert_eq!(average_cost, decimal("0.825"));
+        assert_eq!(cost_currency, "GBP");
+        assert_eq!((decimal("10") * average_cost).round_dp(12), decimal("8.25"));
+    }
+
+    #[test]
+    fn holdings_asset_spec_preserves_raw_quote_currency_metadata() {
+        let spec = AssetSpec::market_instrument(
+            "VUSA".to_string(),
+            "VUSA".to_string(),
+            Some("XLON".to_string()),
+            InstrumentType::Equity,
+            "GBp".to_string(),
+        );
+        let (broker_price, broker_currency) = normalize_holdings_money(decimal("85"), "GBp");
+
+        assert_eq!(spec.quote_ccy, "GBp");
+        assert_eq!(broker_price, decimal("0.85"));
+        assert_eq!(broker_currency, "GBP");
     }
 
     fn position(

--- a/crates/connect/src/broker/service.rs
+++ b/crates/connect/src/broker/service.rs
@@ -33,7 +33,7 @@ use wealthfolio_core::assets::{
 };
 use wealthfolio_core::errors::Result;
 use wealthfolio_core::events::{DomainEvent, DomainEventSink, NoOpDomainEventSink};
-use wealthfolio_core::fx::currency::normalize_amount;
+use wealthfolio_core::fx::currency::{normalize_amount, normalize_currency_code};
 use wealthfolio_core::portfolio::snapshot::{
     AccountStateSnapshot, Position, SnapshotRepositoryTrait, SnapshotServiceTrait, SnapshotSource,
 };
@@ -53,6 +53,16 @@ fn normalize_holdings_money(amount: Decimal, currency: &str) -> (Decimal, String
         amount.round_dp(HOLDINGS_DECIMAL_PRECISION),
         currency.to_string(),
     )
+}
+
+#[derive(Debug, Clone)]
+struct HoldingsPositionData {
+    spec_key: String,
+    quantity: Decimal,
+    quote_price: Decimal,
+    quote_currency: String,
+    average_cost: Option<Decimal>,
+    position_currency: String,
 }
 
 /// Service for syncing broker data to the local database
@@ -671,9 +681,7 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
         let mut asset_specs: Vec<AssetSpec> = Vec::new();
         // Keyed by (symbol, currency) → index into asset_specs
         let mut spec_key_to_idx: HashMap<String, usize> = HashMap::new();
-        // Position data: (spec_key, quantity, price, avg_cost, currency)
-        let mut position_data: Vec<(String, Decimal, Decimal, Option<Decimal>, String)> =
-            Vec::new();
+        let mut position_data: Vec<HoldingsPositionData> = Vec::new();
 
         for pos in &positions {
             let symbol_info = pos.symbol.as_ref().and_then(|s| s.symbol.as_ref());
@@ -727,7 +735,7 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 .as_ref()
                 .and_then(|c| c.code.clone())
                 .unwrap_or_else(|| account_currency.clone());
-            let (_, money_currency) = normalize_holdings_money(Decimal::ZERO, &raw_quote_currency);
+            let position_currency = normalize_currency_code(&raw_quote_currency).to_string();
 
             let instrument_type =
                 map_broker_symbol_type(symbol_type_code.as_deref(), is_crypto_asset);
@@ -764,13 +772,20 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 .unwrap_or(Decimal::ZERO)
                 .round_dp(HOLDINGS_DECIMAL_PRECISION);
             let raw_price = Decimal::from_f64(pos.price.unwrap_or(0.0)).unwrap_or(Decimal::ZERO);
-            let price = normalize_holdings_money(raw_price, &raw_quote_currency).0;
+            let quote_price = raw_price.round_dp(HOLDINGS_DECIMAL_PRECISION);
             let avg_cost = pos
                 .average_purchase_price
                 .and_then(Decimal::from_f64)
                 .map(|value| normalize_holdings_money(value, &raw_quote_currency).0);
 
-            position_data.push((spec_key, quantity, price, avg_cost, money_currency));
+            position_data.push(HoldingsPositionData {
+                spec_key,
+                quantity,
+                quote_price,
+                quote_currency: raw_quote_currency,
+                average_cost: avg_cost,
+                position_currency,
+            });
         }
 
         // 1b. Build AssetSpecs and position data from option positions
@@ -811,7 +826,7 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 .as_ref()
                 .and_then(|c| c.code.clone())
                 .unwrap_or_else(|| account_currency.clone());
-            let (_, money_currency) = normalize_holdings_money(Decimal::ZERO, &raw_quote_currency);
+            let position_currency = normalize_currency_code(&raw_quote_currency).to_string();
 
             let multiplier = if option_symbol.is_mini_option.unwrap_or(false) {
                 Decimal::from(10)
@@ -852,13 +867,20 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 .round_dp(HOLDINGS_DECIMAL_PRECISION);
             let raw_price =
                 Decimal::from_f64(opt_pos.price.unwrap_or(0.0)).unwrap_or(Decimal::ZERO);
-            let price = normalize_holdings_money(raw_price, &raw_quote_currency).0;
+            let quote_price = raw_price.round_dp(HOLDINGS_DECIMAL_PRECISION);
             let avg_cost = opt_pos
                 .average_purchase_price
                 .and_then(Decimal::from_f64)
                 .map(|value| normalize_holdings_money(value, &raw_quote_currency).0);
 
-            position_data.push((spec_key, quantity, price, avg_cost, money_currency));
+            position_data.push(HoldingsPositionData {
+                spec_key,
+                quantity,
+                quote_price,
+                quote_currency: raw_quote_currency,
+                average_cost: avg_cost,
+                position_currency,
+            });
         }
 
         // 2. Ensure assets exist via service layer (dedup by instrument_key)
@@ -907,11 +929,11 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
             let today_date = today.format("%Y-%m-%d").to_string();
             let mut quotes: Vec<Quote> = Vec::new();
 
-            for (spec_key, _quantity, price, _avg_cost, currency) in &position_data {
-                if *price <= Decimal::ZERO {
+            for position in &position_data {
+                if position.quote_price <= Decimal::ZERO {
                     continue;
                 }
-                let asset_id = match spec_key_to_asset_id.get(spec_key) {
+                let asset_id = match spec_key_to_asset_id.get(&position.spec_key) {
                     Some(id) => id,
                     None => continue,
                 };
@@ -920,13 +942,13 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                     id: format!("{}_{}_{}", asset_id, today_date, DATA_SOURCE_BROKER),
                     asset_id: asset_id.clone(),
                     timestamp: now,
-                    open: *price,
-                    high: *price,
-                    low: *price,
-                    close: *price,
-                    adjclose: *price,
+                    open: position.quote_price,
+                    high: position.quote_price,
+                    low: position.quote_price,
+                    close: position.quote_price,
+                    adjclose: position.quote_price,
                     volume: Decimal::ZERO,
-                    currency: currency.clone(),
+                    currency: position.quote_currency.clone(),
                     data_source: DATA_SOURCE_BROKER.to_string(),
                     created_at: now,
                     notes: None,
@@ -960,41 +982,45 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
         let mut positions_map: HashMap<String, Position> = HashMap::new();
         let mut total_cost_basis = Decimal::ZERO;
 
-        for (spec_key, quantity, _price, broker_avg_cost, currency) in &position_data {
-            let asset_id = match spec_key_to_asset_id.get(spec_key) {
+        for position in &position_data {
+            let asset_id = match spec_key_to_asset_id.get(&position.spec_key) {
                 Some(id) => id.clone(),
                 None => {
-                    warn!("Could not resolve asset for position key '{}'", spec_key);
+                    warn!(
+                        "Could not resolve asset for position key '{}'",
+                        position.spec_key
+                    );
                     continue;
                 }
             };
 
             // Determine contract multiplier from the asset spec metadata
             let contract_multiplier = spec_key_to_idx
-                .get(spec_key)
+                .get(&position.spec_key)
                 .and_then(|idx| asset_specs.get(*idx))
                 .and_then(|spec| spec.option_multiplier())
                 .unwrap_or(Decimal::ONE);
 
             let avg_cost = Self::resolve_position_average_cost(
-                broker_avg_cost.as_ref().copied(),
+                position.average_cost,
                 latest
                     .as_ref()
                     .and_then(|snapshot| snapshot.positions.get(&asset_id)),
-                *quantity,
-                currency,
+                position.quantity,
+                &position.position_currency,
             );
-            let position_cost_basis = (*quantity * avg_cost).round_dp(HOLDINGS_DECIMAL_PRECISION);
+            let position_cost_basis =
+                (position.quantity * avg_cost).round_dp(HOLDINGS_DECIMAL_PRECISION);
             total_cost_basis += position_cost_basis;
 
             let position = Position {
                 id: format!("{}_{}", account_id, asset_id),
                 account_id: account_id.clone(),
                 asset_id: asset_id.clone(),
-                quantity: *quantity,
+                quantity: position.quantity,
                 average_cost: avg_cost,
                 total_cost_basis: position_cost_basis,
-                currency: currency.clone(),
+                currency: position.position_currency.clone(),
                 inception_date: now,
                 lots: VecDeque::new(),
                 created_at: now,
@@ -1492,6 +1518,27 @@ mod tests {
         assert_eq!(spec.quote_ccy, "GBp");
         assert_eq!(broker_price, decimal("0.85"));
         assert_eq!(broker_currency, "GBP");
+    }
+
+    #[test]
+    fn holdings_position_data_keeps_quote_values_in_raw_quote_units() {
+        let raw_quote_currency = "GBp".to_string();
+        let position_currency =
+            wealthfolio_core::fx::currency::normalize_currency_code(&raw_quote_currency)
+                .to_string();
+        let position = super::HoldingsPositionData {
+            spec_key: "SEC:VUSA:XLON".to_string(),
+            quantity: decimal("10"),
+            quote_price: decimal("85"),
+            quote_currency: raw_quote_currency,
+            average_cost: Some(normalize_holdings_money(decimal("82.5"), "GBp").0),
+            position_currency,
+        };
+
+        assert_eq!(position.quote_price, decimal("85"));
+        assert_eq!(position.quote_currency, "GBp");
+        assert_eq!(position.average_cost, Some(decimal("0.825")));
+        assert_eq!(position.position_currency, "GBP");
     }
 
     fn position(

--- a/crates/connect/src/broker/sync_readiness.rs
+++ b/crates/connect/src/broker/sync_readiness.rs
@@ -1,0 +1,212 @@
+use chrono::{DateTime, NaiveDate, Utc};
+
+use super::models::BrokerSyncStatusDetail;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProviderReadiness {
+    Ready(NaiveDate),
+    NotReady(String),
+}
+
+pub fn parse_provider_sync_date(value: &str) -> Result<NaiveDate, String> {
+    DateTime::parse_from_rfc3339(value)
+        .map(|dt| dt.with_timezone(&Utc).date_naive())
+        .or_else(|_| NaiveDate::parse_from_str(value, "%Y-%m-%d"))
+        .map_err(|_| format!("Invalid provider sync timestamp '{}'", value))
+}
+
+pub fn resolve_activity_readiness(
+    status: Option<&BrokerSyncStatusDetail>,
+) -> Result<ProviderReadiness, String> {
+    let Some(status) = status else {
+        return Ok(ProviderReadiness::NotReady(
+            "Provider transaction sync status is unavailable".to_string(),
+        ));
+    };
+
+    if status.initial_sync_completed == Some(false) {
+        return Ok(ProviderReadiness::NotReady(
+            "Provider transaction sync is still preparing".to_string(),
+        ));
+    }
+
+    let Some(last_successful_sync) = status.last_successful_sync.as_deref() else {
+        return Ok(ProviderReadiness::NotReady(
+            "Provider transaction sync has no successful waterline".to_string(),
+        ));
+    };
+
+    Ok(ProviderReadiness::Ready(parse_provider_sync_date(
+        last_successful_sync,
+    )?))
+}
+
+pub fn resolve_holdings_readiness(
+    status: Option<&BrokerSyncStatusDetail>,
+) -> Result<ProviderReadiness, String> {
+    let Some(status) = status else {
+        return Ok(ProviderReadiness::NotReady(
+            "Provider holdings sync status is unavailable".to_string(),
+        ));
+    };
+
+    if status.initial_sync_completed == Some(false) {
+        return Ok(ProviderReadiness::NotReady(
+            "Provider holdings sync is still preparing".to_string(),
+        ));
+    }
+
+    let Some(last_successful_sync) = status.last_successful_sync.as_deref() else {
+        return Ok(ProviderReadiness::NotReady(
+            "Provider holdings sync has no successful waterline".to_string(),
+        ));
+    };
+
+    Ok(ProviderReadiness::Ready(parse_provider_sync_date(
+        last_successful_sync,
+    )?))
+}
+
+pub fn provider_waterline_precedes_local_cursor(
+    local_cursor: Option<&DateTime<Utc>>,
+    provider_waterline: NaiveDate,
+) -> bool {
+    local_cursor
+        .map(|cursor| provider_waterline < cursor.date_naive())
+        .unwrap_or(false)
+}
+
+pub fn should_advance_activity_cursor(
+    fetched: usize,
+    has_local_cursor: bool,
+    inconsistent_empty_page: bool,
+    provider_status: Option<&BrokerSyncStatusDetail>,
+) -> bool {
+    if inconsistent_empty_page {
+        return false;
+    }
+
+    if fetched > 0 || has_local_cursor {
+        return true;
+    }
+
+    matches!(
+        provider_status,
+        Some(BrokerSyncStatusDetail {
+            initial_sync_completed: Some(true),
+            first_transaction_date: None,
+            ..
+        })
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn transactions_status(
+        initial_sync_completed: Option<bool>,
+        last_successful_sync: Option<&str>,
+        first_transaction_date: Option<&str>,
+    ) -> BrokerSyncStatusDetail {
+        BrokerSyncStatusDetail {
+            initial_sync_completed,
+            last_successful_sync: last_successful_sync.map(str::to_string),
+            first_transaction_date: first_transaction_date.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn provider_not_ready_defers_first_activity_sync() {
+        let status = transactions_status(Some(false), None, None);
+        let readiness = resolve_activity_readiness(Some(&status)).unwrap();
+
+        assert!(matches!(readiness, ProviderReadiness::NotReady(_)));
+    }
+
+    #[test]
+    fn provider_waterline_without_initial_flag_allows_activity_fetch() {
+        let status = transactions_status(None, Some("2026-05-22"), None);
+        let readiness = resolve_activity_readiness(Some(&status)).unwrap();
+
+        assert!(matches!(
+            readiness,
+            ProviderReadiness::Ready(date)
+                if date == NaiveDate::from_ymd_opt(2026, 5, 22).unwrap()
+        ));
+    }
+
+    #[test]
+    fn provider_waterline_before_local_cursor_is_stale() {
+        let local_cursor = DateTime::parse_from_rfc3339("2026-05-22T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let stale_waterline = NaiveDate::from_ymd_opt(2026, 5, 21).unwrap();
+        let current_waterline = NaiveDate::from_ymd_opt(2026, 5, 22).unwrap();
+
+        assert!(provider_waterline_precedes_local_cursor(
+            Some(&local_cursor),
+            stale_waterline
+        ));
+        assert!(!provider_waterline_precedes_local_cursor(
+            Some(&local_cursor),
+            current_waterline
+        ));
+    }
+
+    #[test]
+    fn initial_empty_activity_sync_with_first_transaction_does_not_advance_cursor() {
+        let status = transactions_status(Some(true), Some("2026-05-22"), Some("2020-01-01"));
+
+        assert!(!should_advance_activity_cursor(
+            0,
+            false,
+            false,
+            Some(&status)
+        ));
+    }
+
+    #[test]
+    fn initial_empty_activity_sync_with_confirmed_empty_history_advances_cursor() {
+        let status = transactions_status(Some(true), Some("2026-05-22"), None);
+
+        assert!(should_advance_activity_cursor(
+            0,
+            false,
+            false,
+            Some(&status)
+        ));
+    }
+
+    #[test]
+    fn incremental_empty_activity_sync_advances_cursor_to_provider_waterline() {
+        let status = transactions_status(Some(true), Some("2026-05-22"), Some("2020-01-01"));
+
+        assert!(should_advance_activity_cursor(
+            0,
+            true,
+            false,
+            Some(&status)
+        ));
+    }
+
+    #[test]
+    fn inconsistent_empty_activity_page_does_not_advance_cursor() {
+        let status = transactions_status(Some(true), Some("2026-05-22"), None);
+
+        assert!(!should_advance_activity_cursor(
+            0,
+            true,
+            true,
+            Some(&status)
+        ));
+    }
+
+    #[test]
+    fn holdings_not_ready_defers_snapshot_sync() {
+        let status = transactions_status(Some(false), None, None);
+        let readiness = resolve_holdings_readiness(Some(&status)).unwrap();
+
+        assert!(matches!(readiness, ProviderReadiness::NotReady(_)));
+    }
+}

--- a/crates/connect/src/broker/sync_readiness.rs
+++ b/crates/connect/src/broker/sync_readiness.rs
@@ -15,13 +15,15 @@ pub fn parse_provider_sync_date(value: &str) -> Result<NaiveDate, String> {
         .map_err(|_| format!("Invalid provider sync timestamp '{}'", value))
 }
 
+fn legacy_provider_waterline() -> NaiveDate {
+    Utc::now().date_naive()
+}
+
 pub fn resolve_activity_readiness(
     status: Option<&BrokerSyncStatusDetail>,
 ) -> Result<ProviderReadiness, String> {
     let Some(status) = status else {
-        return Ok(ProviderReadiness::NotReady(
-            "Provider transaction sync status is unavailable".to_string(),
-        ));
+        return Ok(ProviderReadiness::Ready(legacy_provider_waterline()));
     };
 
     if status.initial_sync_completed == Some(false) {
@@ -31,9 +33,7 @@ pub fn resolve_activity_readiness(
     }
 
     let Some(last_successful_sync) = status.last_successful_sync.as_deref() else {
-        return Ok(ProviderReadiness::NotReady(
-            "Provider transaction sync has no successful waterline".to_string(),
-        ));
+        return Ok(ProviderReadiness::Ready(legacy_provider_waterline()));
     };
 
     Ok(ProviderReadiness::Ready(parse_provider_sync_date(
@@ -44,27 +44,13 @@ pub fn resolve_activity_readiness(
 pub fn resolve_holdings_readiness(
     status: Option<&BrokerSyncStatusDetail>,
 ) -> Result<ProviderReadiness, String> {
-    let Some(status) = status else {
-        return Ok(ProviderReadiness::NotReady(
-            "Provider holdings sync status is unavailable".to_string(),
-        ));
-    };
-
-    if status.initial_sync_completed == Some(false) {
+    if status.is_some_and(|status| status.initial_sync_completed == Some(false)) {
         return Ok(ProviderReadiness::NotReady(
             "Provider holdings sync is still preparing".to_string(),
         ));
     }
 
-    let Some(last_successful_sync) = status.last_successful_sync.as_deref() else {
-        return Ok(ProviderReadiness::NotReady(
-            "Provider holdings sync has no successful waterline".to_string(),
-        ));
-    };
-
-    Ok(ProviderReadiness::Ready(parse_provider_sync_date(
-        last_successful_sync,
-    )?))
+    Ok(ProviderReadiness::Ready(legacy_provider_waterline()))
 }
 
 pub fn provider_waterline_precedes_local_cursor(
@@ -92,8 +78,12 @@ pub fn should_advance_activity_cursor(
 
     matches!(
         provider_status,
-        Some(BrokerSyncStatusDetail {
+        None | Some(BrokerSyncStatusDetail {
             initial_sync_completed: Some(true),
+            first_transaction_date: None,
+            ..
+        }) | Some(BrokerSyncStatusDetail {
+            initial_sync_completed: None,
             first_transaction_date: None,
             ..
         })
@@ -122,6 +112,23 @@ mod tests {
         let readiness = resolve_activity_readiness(Some(&status)).unwrap();
 
         assert!(matches!(readiness, ProviderReadiness::NotReady(_)));
+    }
+
+    #[test]
+    fn missing_activity_status_uses_legacy_today_waterline() {
+        let today = Utc::now().date_naive();
+        let readiness = resolve_activity_readiness(None).unwrap();
+
+        assert!(matches!(readiness, ProviderReadiness::Ready(date) if date == today));
+    }
+
+    #[test]
+    fn activity_status_without_waterline_uses_legacy_today_waterline() {
+        let status = transactions_status(None, None, None);
+        let today = Utc::now().date_naive();
+        let readiness = resolve_activity_readiness(Some(&status)).unwrap();
+
+        assert!(matches!(readiness, ProviderReadiness::Ready(date) if date == today));
     }
 
     #[test]
@@ -179,6 +186,11 @@ mod tests {
     }
 
     #[test]
+    fn initial_empty_activity_sync_without_provider_status_uses_legacy_cursor_advance() {
+        assert!(should_advance_activity_cursor(0, false, false, None));
+    }
+
+    #[test]
     fn incremental_empty_activity_sync_advances_cursor_to_provider_waterline() {
         let status = transactions_status(Some(true), Some("2026-05-22"), Some("2020-01-01"));
 
@@ -208,5 +220,20 @@ mod tests {
         let readiness = resolve_holdings_readiness(Some(&status)).unwrap();
 
         assert!(matches!(readiness, ProviderReadiness::NotReady(_)));
+    }
+
+    #[test]
+    fn missing_holdings_status_allows_legacy_snapshot_sync() {
+        let readiness = resolve_holdings_readiness(None).unwrap();
+
+        assert!(matches!(readiness, ProviderReadiness::Ready(_)));
+    }
+
+    #[test]
+    fn holdings_readiness_does_not_parse_unused_waterline() {
+        let status = transactions_status(Some(true), Some("not-a-date"), None);
+        let readiness = resolve_holdings_readiness(Some(&status)).unwrap();
+
+        assert!(matches!(readiness, ProviderReadiness::Ready(_)));
     }
 }

--- a/crates/connect/src/broker/traits.rs
+++ b/crates/connect/src/broker/traits.rs
@@ -84,6 +84,9 @@ pub trait BrokerSyncServiceTrait: Send + Sync {
     /// Get all synced accounts (accounts with provider_account_id set)
     fn get_synced_accounts(&self) -> Result<Vec<Account>>;
 
+    /// Whether the account already has a broker-imported holdings snapshot.
+    fn has_broker_imported_holdings_snapshot(&self, account_id: &str) -> Result<bool>;
+
     /// Get all platforms
     fn get_platforms(&self) -> Result<Vec<Platform>>;
 

--- a/crates/core/src/fx/currency.rs
+++ b/crates/core/src/fx/currency.rs
@@ -83,7 +83,35 @@ fn get_rules() -> &'static HashMap<&'static str, CurrencyNormalizationRule> {
 
 /// Returns the normalization rule for a given currency code, if one exists.
 pub fn get_normalization_rule(code: &str) -> Option<&'static CurrencyNormalizationRule> {
-    get_rules().get(code)
+    let rules = get_rules();
+    rules.get(code).or_else(|| {
+        normalization_rule_key(code)
+            .filter(|key| *key != code)
+            .and_then(|key| rules.get(key))
+    })
+}
+
+fn normalization_rule_key(code: &str) -> Option<&'static str> {
+    let trimmed = code.trim();
+    if trimmed == "GBp" {
+        return Some("GBp");
+    }
+    if trimmed.eq_ignore_ascii_case("GBX") {
+        return Some("GBX");
+    }
+    if trimmed.eq_ignore_ascii_case("KWF") {
+        return Some("KWF");
+    }
+    if trimmed == "ZAc" || trimmed.eq_ignore_ascii_case("ZAC") {
+        return Some("ZAc");
+    }
+    if trimmed.eq_ignore_ascii_case("ILA") {
+        return Some("ILA");
+    }
+    if trimmed.eq_ignore_ascii_case("USX") {
+        return Some("USX");
+    }
+    None
 }
 
 /// Converts an amount from its potentially minor unit into its major unit equivalent
@@ -157,5 +185,19 @@ mod tests {
         assert_eq!(currency, "USD");
         assert_eq!(normalize_currency_code("USX"), "USD");
         assert_eq!(denormalization_multiplier("USX"), dec!(100));
+    }
+
+    #[test]
+    fn normalizes_minor_currency_alias_casing_without_treating_gbp_as_pence() {
+        let (amount, currency) = normalize_amount(dec!(85), "GBx");
+
+        assert_eq!(amount, dec!(0.85));
+        assert_eq!(currency, "GBP");
+        assert_eq!(normalize_currency_code("gbx"), "GBP");
+
+        let (amount, currency) = normalize_amount(dec!(85), "gbp");
+
+        assert_eq!(amount, dec!(85));
+        assert_eq!(currency, "gbp");
     }
 }

--- a/crates/storage-sqlite/src/sync/state/repository.rs
+++ b/crates/storage-sqlite/src/sync/state/repository.rs
@@ -1,7 +1,7 @@
 //! Repository for broker sync state persistence.
 
 use async_trait::async_trait;
-use chrono::Utc;
+use chrono::{DateTime, NaiveDate, NaiveTime, Utc};
 use diesel::prelude::*;
 use diesel::r2d2::{self, Pool};
 use diesel::sqlite::SqliteConnection;
@@ -10,13 +10,29 @@ use std::sync::Arc;
 use wealthfolio_connect::broker_ingest::{
     BrokerSyncState, BrokerSyncStateRepositoryTrait as ConnectBrokerSyncStateRepositoryTrait,
 };
-use wealthfolio_core::errors::Result;
+use wealthfolio_core::errors::{Error, Result, ValidationError};
 
 use crate::db::{get_connection, WriteHandle};
 use crate::errors::StorageError;
 use crate::schema::brokers_sync_state;
 
 use super::model::BrokerSyncStateDB;
+
+fn parse_sync_cursor(last_synced_date: &str) -> Result<String> {
+    if let Ok(dt) = DateTime::parse_from_rfc3339(last_synced_date) {
+        return Ok(dt.with_timezone(&Utc).to_rfc3339());
+    }
+
+    if let Ok(date) = NaiveDate::parse_from_str(last_synced_date, "%Y-%m-%d") {
+        let dt = date.and_time(NaiveTime::MIN).and_utc();
+        return Ok(dt.to_rfc3339());
+    }
+
+    Err(Error::Validation(ValidationError::InvalidInput(format!(
+        "Invalid broker sync cursor '{}'",
+        last_synced_date
+    ))))
+}
 
 pub struct BrokerSyncStateRepository {
     pool: Arc<Pool<r2d2::ConnectionManager<SqliteConnection>>>,
@@ -165,9 +181,11 @@ impl BrokerSyncStateRepository {
         &self,
         account_id: String,
         provider: String,
-        _last_synced_date: String,
+        last_synced_date: String,
         import_run_id: Option<String>,
     ) -> Result<()> {
+        let cursor_str = parse_sync_cursor(&last_synced_date)?;
+
         self.writer
             .exec(move |conn| {
                 let now = Utc::now();
@@ -185,7 +203,7 @@ impl BrokerSyncStateRepository {
                         // Update success timestamp and status
                         diesel::update(brokers_sync_state::table.find((&account_id, &provider)))
                             .set((
-                                brokers_sync_state::last_successful_at.eq(&now_str),
+                                brokers_sync_state::last_successful_at.eq(&cursor_str),
                                 brokers_sync_state::sync_status.eq("IDLE"),
                                 brokers_sync_state::last_error.eq::<Option<String>>(None),
                                 brokers_sync_state::last_run_id.eq(&import_run_id),
@@ -201,7 +219,7 @@ impl BrokerSyncStateRepository {
                             provider,
                             checkpoint_json: None,
                             last_attempted_at: Some(now_str.clone()),
-                            last_successful_at: Some(now_str.clone()),
+                            last_successful_at: Some(cursor_str),
                             last_error: None,
                             last_run_id: import_run_id,
                             sync_status: "IDLE".to_string(),
@@ -434,5 +452,81 @@ impl ConnectBrokerSyncStateRepositoryTrait for BrokerSyncStateRepository {
 
     fn get_all(&self) -> Result<Vec<BrokerSyncState>> {
         BrokerSyncStateRepository::get_all(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{parse_sync_cursor, BrokerSyncStateRepository};
+    use crate::db::{create_pool, get_connection, run_migrations, write_actor::spawn_writer};
+    use diesel::sql_query;
+    use diesel::RunQueryDsl;
+    use std::sync::Arc;
+    use tempfile::tempdir;
+
+    fn setup_repo() -> BrokerSyncStateRepository {
+        std::env::set_var("CONNECT_API_URL", "http://test.local");
+        let temp_dir = tempdir().expect("tempdir").keep();
+        let db_path = temp_dir.join("test.db");
+        let db_path = db_path.to_string_lossy().to_string();
+        run_migrations(&db_path).expect("migrate db");
+        let pool = create_pool(&db_path).expect("create pool");
+        let writer = spawn_writer((*pool).clone()).expect("spawn writer");
+
+        {
+            let mut conn = get_connection(&pool).expect("connection");
+            sql_query(
+                "INSERT INTO accounts (
+                    id, name, account_type, `group`, currency, is_default, is_active,
+                    created_at, updated_at, platform_id, account_number, meta, provider,
+                    provider_account_id, is_archived, tracking_mode
+                ) VALUES (
+                    'account-1', 'Broker Account', 'brokerage', NULL, 'GBP', 0, 1,
+                    CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, NULL, NULL, NULL, 'snaptrade',
+                    'provider-account-1', 0, 'TRANSACTIONS'
+                )",
+            )
+            .execute(&mut conn)
+            .expect("insert account");
+        }
+
+        BrokerSyncStateRepository::new(Arc::clone(&pool), writer)
+    }
+
+    #[test]
+    fn parse_sync_cursor_accepts_date_without_using_now() {
+        let cursor = parse_sync_cursor("2026-05-22").expect("valid cursor");
+
+        assert!(cursor.starts_with("2026-05-22T00:00:00"));
+    }
+
+    #[test]
+    fn parse_sync_cursor_rejects_invalid_value() {
+        let err = parse_sync_cursor("not-a-date").expect_err("invalid cursor");
+
+        assert!(err.to_string().contains("Invalid broker sync cursor"));
+    }
+
+    #[tokio::test]
+    async fn upsert_success_stores_passed_cursor_date() {
+        let repo = setup_repo();
+
+        repo.upsert_success(
+            "account-1".to_string(),
+            "snaptrade".to_string(),
+            "2026-05-22".to_string(),
+            None,
+        )
+        .await
+        .expect("upsert success");
+
+        let state = repo
+            .get("account-1", "snaptrade")
+            .expect("state query")
+            .expect("state exists");
+        assert_eq!(
+            state.last_successful_at.expect("cursor").date_naive(),
+            chrono::NaiveDate::from_ymd_opt(2026, 5, 22).unwrap()
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Gate broker activity and holdings sync on provider sync-status readiness and provider waterlines.
- Advance the activity cursor only to the provider-confirmed waterline, and do not advance on unsafe initial empty responses.
- Persist the passed broker sync cursor instead of replacing it with local `Utc::now()`.
- Normalize `GBp`/`GBX` holdings money values to major `GBP` during import while preserving raw asset quote metadata.
- Mirror the activity cursor guard in the web activities-only sync path.

## Context

This prevents Trading212-style empty activity responses from poisoning the local sync cursor and fixes new holdings imports for LSE instruments quoted in pence. This PR intentionally does not include a data migration; existing imported rows are left untouched and future broker holdings syncs will write normalized values.

## Validation

- `cargo test -p wealthfolio-connect`
- `cargo test -p wealthfolio-storage-sqlite`
- `cargo check -p wealthfolio-server`
- `cargo check`
- `git diff --check`
