### PR TITLE
Polish activity filters and subtype display

### DIFF
--- a/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
+++ b/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
@@ -715,6 +715,7 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
           visibleCount={rows.length}
           totalCount={totalCount}
           isRefreshing={isRefreshing}
+          isMobile={isMobile}
         />
 
         {selectedRowIds.size > 0 && (

--- a/apps/frontend/src/features/spending/components/transactions-filter-bar.tsx
+++ b/apps/frontend/src/features/spending/components/transactions-filter-bar.tsx
@@ -242,9 +242,7 @@ export function TransactionsFilterBar({
       )}
       <span className="text-muted-foreground ml-auto inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap text-xs tabular-nums">
         {countLabel}
-        {isRefreshing && (
-          <Icons.Spinner className="h-3 w-3 animate-spin" aria-label="Refreshing" />
-        )}
+        {isRefreshing && <Icons.Spinner className="h-3 w-3 animate-spin" aria-label="Refreshing" />}
       </span>
     </div>
   );

--- a/apps/frontend/src/features/spending/components/transactions-filter-bar.tsx
+++ b/apps/frontend/src/features/spending/components/transactions-filter-bar.tsx
@@ -1,6 +1,19 @@
+import { useState } from "react";
 import type { DateRange } from "react-day-picker";
 
-import { Button, FacetedFilter, FacetedSearchInput, Icons } from "@wealthfolio/ui";
+import {
+  Button,
+  FacetedFilter,
+  FacetedSearchInput,
+  Icons,
+  Input,
+  ScrollArea,
+  Sheet,
+  SheetContent,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@wealthfolio/ui";
 
 import { AmountRangeFilter, type AmountRange } from "./amount-range-filter";
 import { DateRangeFilter } from "./date-range-filter";
@@ -51,6 +64,7 @@ interface TransactionsFilterBarProps {
   visibleCount: number;
   totalCount: number;
   isRefreshing: boolean;
+  isMobile?: boolean;
 }
 
 export function TransactionsFilterBar({
@@ -83,84 +97,155 @@ export function TransactionsFilterBar({
   visibleCount,
   totalCount,
   isRefreshing,
+  isMobile = false,
 }: TransactionsFilterBarProps) {
-  return (
-    <div className="space-y-2">
-      <div className="flex items-center gap-2">
-        <FacetedSearchInput
-          value={searchInput}
-          onChange={onSearchInputChange}
-          placeholder="Search payee, account, category..."
-          className="w-full sm:w-[200px] lg:w-[280px]"
-        />
-        <span className="text-muted-foreground ml-auto inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap text-xs tabular-nums">
-          {totalCount > 0
-            ? `${visibleCount} / ${totalCount} ${pluralizeTransaction(totalCount)}`
-            : "0 transactions"}
-          {isRefreshing && (
-            <Icons.Spinner className="h-3 w-3 animate-spin" aria-label="Refreshing" />
-          )}
-        </span>
-      </div>
-      <div className="-mx-1 flex items-center gap-2 overflow-x-auto px-1 pb-1 sm:flex-wrap sm:overflow-visible sm:pb-0">
+  const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
+  const statusOptions = [
+    { value: "needs_review", label: "Needs review" },
+    { value: "uncategorized", label: "Uncategorized" },
+    { value: "categorized", label: "Categorized" },
+  ];
+  const controlFiltersActive =
+    statusFilter !== "all" ||
+    selectedAccounts.size > 0 ||
+    selectedTypes.size > 0 ||
+    selectedCategories.size > 0 ||
+    selectedSubcategories.size > 0 ||
+    selectedEvents.size > 0 ||
+    amountRange.min != null ||
+    amountRange.max != null ||
+    !!dateRange?.from ||
+    !!dateRange?.to;
+  const countLabel =
+    totalCount > 0
+      ? `${visibleCount} / ${totalCount} ${pluralizeTransaction(totalCount)}`
+      : "0 transactions";
+
+  const filterControls = (
+    <>
+      <FacetedFilter
+        title="Status"
+        options={statusOptions}
+        selectedValues={new Set(statusFilter === "all" ? [] : [statusFilter])}
+        onFilterChange={(v) => {
+          const arr = Array.from(v);
+          onStatusFilterChange((arr[0] as CashActivityStatusFilter) ?? "all");
+        }}
+      />
+      <DateRangeFilter value={dateRange} onChange={onDateRangeChange} />
+      <FacetedFilter
+        title="Account"
+        options={accountOptions}
+        selectedValues={selectedAccounts}
+        onFilterChange={onAccountsChange}
+      />
+      <FacetedFilter
+        title="Type"
+        options={typeOptions}
+        selectedValues={selectedTypes}
+        onFilterChange={onTypesChange}
+      />
+      <FacetedFilter
+        title="Category"
+        options={categoryOptions}
+        selectedValues={selectedCategories}
+        onFilterChange={onCategoriesChange}
+      />
+      <FacetedFilter
+        title="Subcategory"
+        options={subcategoryOptions}
+        selectedValues={selectedSubcategories}
+        onFilterChange={onSubcategoriesChange}
+      />
+      {hasEvents && (
         <FacetedFilter
-          title="Status"
-          options={[
-            { value: "needs_review", label: "Needs review" },
-            { value: "uncategorized", label: "Uncategorized" },
-            { value: "categorized", label: "Categorized" },
-          ]}
-          selectedValues={new Set(statusFilter === "all" ? [] : [statusFilter])}
-          onFilterChange={(v) => {
-            const arr = Array.from(v);
-            onStatusFilterChange((arr[0] as CashActivityStatusFilter) ?? "all");
-          }}
+          title="Event"
+          options={eventOptions}
+          selectedValues={selectedEvents}
+          onFilterChange={onEventsChange}
         />
-        <DateRangeFilter value={dateRange} onChange={onDateRangeChange} />
-        <FacetedFilter
-          title="Account"
-          options={accountOptions}
-          selectedValues={selectedAccounts}
-          onFilterChange={onAccountsChange}
-        />
-        <FacetedFilter
-          title="Type"
-          options={typeOptions}
-          selectedValues={selectedTypes}
-          onFilterChange={onTypesChange}
-        />
-        <FacetedFilter
-          title="Category"
-          options={categoryOptions}
-          selectedValues={selectedCategories}
-          onFilterChange={onCategoriesChange}
-        />
-        <FacetedFilter
-          title="Subcategory"
-          options={subcategoryOptions}
-          selectedValues={selectedSubcategories}
-          onFilterChange={onSubcategoriesChange}
-        />
-        {hasEvents && (
-          <FacetedFilter
-            title="Event"
-            options={eventOptions}
-            selectedValues={selectedEvents}
-            onFilterChange={onEventsChange}
+      )}
+      <AmountRangeFilter value={amountRange} onChange={onAmountRangeChange} />
+    </>
+  );
+
+  if (isMobile) {
+    return (
+      <div className="space-y-2">
+        <div className="flex shrink-0 items-center gap-2 pt-2">
+          <Input
+            placeholder="Search..."
+            value={searchInput}
+            onChange={(e) => onSearchInputChange(e.target.value)}
+            className="bg-secondary/30 h-10 flex-1 rounded-full border-none md:h-12"
           />
-        )}
-        <AmountRangeFilter value={amountRange} onChange={onAmountRangeChange} />
-        {filtersActive && (
           <Button
-            variant="ghost"
-            size="sm"
-            onClick={onClearAll}
-            className="text-muted-foreground hover:text-foreground h-8 shrink-0 px-2 text-xs"
+            variant="outline"
+            size="icon"
+            className="size-9 flex-shrink-0"
+            onClick={() => setMobileFiltersOpen(true)}
+            aria-label="Filter transactions"
+            title="Filter transactions"
           >
-            Clear all
+            <div className="relative">
+              <Icons.ListFilter className="h-4 w-4" />
+              {controlFiltersActive && (
+                <span className="bg-primary absolute -left-[1.5px] -top-1 h-2 w-2 rounded-full" />
+              )}
+            </div>
           </Button>
-        )}
+        </div>
+        <Sheet open={mobileFiltersOpen} onOpenChange={setMobileFiltersOpen}>
+          <SheetContent side="bottom" className="rounded-t-4xl mx-1 flex h-[80vh] flex-col p-0">
+            <SheetHeader className="border-border border-b px-6 py-4 text-left">
+              <SheetTitle>Filter transactions</SheetTitle>
+            </SheetHeader>
+            <ScrollArea className="flex-1">
+              <div className="flex flex-wrap gap-2 px-6 py-4">{filterControls}</div>
+            </ScrollArea>
+            <SheetFooter className="border-border flex-row border-t px-6 py-4">
+              <Button
+                variant="ghost"
+                className="text-muted-foreground hover:text-foreground"
+                onClick={onClearAll}
+                disabled={!filtersActive}
+              >
+                Clear all
+              </Button>
+              <Button className="ml-auto" onClick={() => setMobileFiltersOpen(false)}>
+                Done
+              </Button>
+            </SheetFooter>
+          </SheetContent>
+        </Sheet>
       </div>
+    );
+  }
+
+  return (
+    <div className="-mx-1 flex flex-wrap items-center gap-2 px-1 pb-1">
+      <FacetedSearchInput
+        value={searchInput}
+        onChange={onSearchInputChange}
+        className="w-[160px] lg:w-[240px]"
+      />
+      {filterControls}
+      {filtersActive && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onClearAll}
+          className="text-muted-foreground hover:text-foreground h-8 shrink-0 px-2 text-xs"
+        >
+          Clear all
+        </Button>
+      )}
+      <span className="text-muted-foreground ml-auto inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap text-xs tabular-nums">
+        {countLabel}
+        {isRefreshing && (
+          <Icons.Spinner className="h-3 w-3 animate-spin" aria-label="Refreshing" />
+        )}
+      </span>
     </div>
   );
 }

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -474,6 +474,8 @@ const ActivityPage = () => {
         />
       ) : (
         <ActivityViewControls
+          accounts={investmentAccounts}
+          portfolios={portfolios}
           searchQuery={searchInput}
           onSearchQueryChange={handleSearchChange}
           accountScope={accountScope}

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/use-activity-columns.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/use-activity-columns.tsx
@@ -190,9 +190,7 @@ export function useActivityColumns({
               return (
                 <ActivityTypeBadge
                   type={value as ActivityType}
-                  subtype={
-                    shouldDisplaySubtype(transaction, value, subtype) ? subtype : undefined
-                  }
+                  subtype={shouldDisplaySubtype(transaction, value, subtype) ? subtype : undefined}
                   className="text-xs font-normal"
                 />
               );
@@ -235,7 +233,7 @@ export function useActivityColumns({
               return (
                 <Badge
                   variant="secondary"
-                  className="max-w-full min-w-0 rounded-sm px-1.5 text-xs"
+                  className="min-w-0 max-w-full rounded-sm px-1.5 text-xs"
                   title={displayLabel}
                 >
                   <span className="min-w-0 truncate">{displayLabel}</span>

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/use-activity-columns.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/use-activity-columns.tsx
@@ -38,6 +38,28 @@ const isTransferActivity = (activityType: string | undefined): boolean => {
   return activityType === ActivityType.TRANSFER_IN || activityType === ActivityType.TRANSFER_OUT;
 };
 
+const normalizeActivityToken = (value: string | null | undefined): string =>
+  value?.trim().toUpperCase() ?? "";
+
+const shouldDisplaySubtype = (
+  transaction: LocalTransaction | undefined,
+  activityType: string | undefined,
+  subtype: string | null | undefined,
+): boolean => {
+  const normalizedSubtype = normalizeActivityToken(subtype);
+  if (!normalizedSubtype) return false;
+
+  const normalizedActivityType = normalizeActivityToken(activityType);
+  return (
+    normalizedSubtype !== normalizedActivityType || (!!transaction && isPendingReview(transaction))
+  );
+};
+
+const getSubtypeDisplayLabel = (subtype: string, optionLabel?: string): string => {
+  const normalizedSubtype = normalizeActivityToken(subtype);
+  return optionLabel ?? SUBTYPE_DISPLAY_NAMES[normalizedSubtype] ?? subtype;
+};
+
 const UNIT_PRICE_HELP_TEXT =
   "For buys and sells, enter the trade price. For staking rewards and in-kind dividends, enter the fair market value per unit at receipt; it sets income amount and cost basis.";
 
@@ -161,13 +183,20 @@ export function useActivityColumns({
           cell: {
             variant: "select",
             options: activityTypeOptions,
-            valueRenderer: (value: string, _option, rowData) => (
-              <ActivityTypeBadge
-                type={value as ActivityType}
-                subtype={(rowData as LocalTransaction | undefined)?.subtype}
-                className="text-xs font-normal"
-              />
-            ),
+            valueRenderer: (value: string, _option, rowData) => {
+              const transaction = rowData as LocalTransaction | undefined;
+              const subtype = transaction?.subtype;
+
+              return (
+                <ActivityTypeBadge
+                  type={value as ActivityType}
+                  subtype={
+                    shouldDisplaySubtype(transaction, value, subtype) ? subtype : undefined
+                  }
+                  className="text-xs font-normal"
+                />
+              );
+            },
           },
         },
       },
@@ -195,6 +224,24 @@ export function useActivityColumns({
             }) as any,
             allowEmpty: true,
             emptyLabel: "None",
+            valueRenderer: (value: string, option, rowData) => {
+              const transaction = rowData as LocalTransaction | undefined;
+              if (!shouldDisplaySubtype(transaction, transaction?.activityType, value)) {
+                return null;
+              }
+
+              const displayLabel = getSubtypeDisplayLabel(value, option?.label);
+
+              return (
+                <Badge
+                  variant="secondary"
+                  className="max-w-full min-w-0 rounded-sm px-1.5 text-xs"
+                  title={displayLabel}
+                >
+                  <span className="min-w-0 truncate">{displayLabel}</span>
+                </Badge>
+              );
+            },
           },
         },
       },

--- a/apps/frontend/src/pages/activity/components/activity-type-badge.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-type-badge.tsx
@@ -38,7 +38,7 @@ export function ActivityTypeBadge({ type, subtype, className }: ActivityTypeBadg
     : undefined;
 
   return (
-    <span className="inline-flex max-w-full min-w-0 items-center gap-1.5 overflow-hidden">
+    <span className="inline-flex min-w-0 max-w-full items-center gap-1.5 overflow-hidden">
       <Badge variant={variant} className={cn("rounded-sm", className)}>
         {ActivityTypeNames[type]}
       </Badge>

--- a/apps/frontend/src/pages/activity/components/activity-type-badge.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-type-badge.tsx
@@ -38,12 +38,14 @@ export function ActivityTypeBadge({ type, subtype, className }: ActivityTypeBadg
     : undefined;
 
   return (
-    <span className="inline-flex min-w-0 items-center gap-1.5">
+    <span className="inline-flex max-w-full min-w-0 items-center gap-1.5 overflow-hidden">
       <Badge variant={variant} className={cn("rounded-sm", className)}>
         {ActivityTypeNames[type]}
       </Badge>
       {subtypeLabel && (
-        <span className="text-muted-foreground truncate text-xs font-normal">{subtypeLabel}</span>
+        <span className="text-muted-foreground min-w-0 flex-1 truncate text-xs font-normal">
+          {subtypeLabel}
+        </span>
       )}
     </span>
   );

--- a/apps/frontend/src/pages/activity/components/activity-view-controls.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-view-controls.tsx
@@ -2,8 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 
 import { ActivityType, ActivityTypeNames, INSTRUMENT_TYPE_OPTIONS } from "@/lib/constants";
 import { debounce } from "@/lib/debounce";
-import type { AccountScope } from "@/lib/types";
-import { AccountScopeSelector } from "@/components/account-filter-selector";
+import type { Account, AccountScope, PortfolioWithAccounts } from "@/lib/types";
 import {
   AnimatedToggleGroup,
   Button,
@@ -16,6 +15,8 @@ import type { ActivityStatusFilter } from "../hooks/use-activity-search";
 export type ActivityViewMode = "table" | "datagrid";
 
 interface ActivityViewControlsProps {
+  accounts: Account[];
+  portfolios: PortfolioWithAccounts[];
   searchQuery: string;
   onSearchQueryChange: (value: string) => void;
   accountScope: AccountScope;
@@ -35,7 +36,24 @@ interface ActivityViewControlsProps {
   isFetching: boolean;
 }
 
+function accountIdsForScope(scope: AccountScope, portfolios: PortfolioWithAccounts[]): string[] {
+  if (scope.type === "account") return [scope.accountId];
+  if (scope.type === "accounts") return scope.accountIds;
+  if (scope.type === "portfolio") {
+    return portfolios.find((portfolio) => portfolio.id === scope.portfolioId)?.accountIds ?? [];
+  }
+  return [];
+}
+
+function scopeFromAccountIds(accountIds: string[]): AccountScope {
+  if (accountIds.length === 0) return { type: "all" };
+  if (accountIds.length === 1) return { type: "account", accountId: accountIds[0] };
+  return { type: "accounts", accountIds };
+}
+
 export function ActivityViewControls({
+  accounts,
+  portfolios,
   searchQuery,
   onSearchQueryChange,
   accountScope,
@@ -71,6 +89,30 @@ export function ActivityViewControls({
   useEffect(() => {
     setLocalSearch(searchQuery);
   }, [searchQuery]);
+
+  const accountOptions = useMemo(
+    () =>
+      accounts.map((account) => ({
+        value: account.id,
+        label: `${account.name} (${account.currency})`,
+      })),
+    [accounts],
+  );
+
+  const selectableAccountIds = useMemo(
+    () => new Set(accountOptions.map((option) => option.value)),
+    [accountOptions],
+  );
+
+  const selectedAccountIds = useMemo(
+    () =>
+      new Set(
+        accountIdsForScope(accountScope, portfolios).filter((accountId) =>
+          selectableAccountIds.has(accountId),
+        ),
+      ),
+    [accountScope, portfolios, selectableAccountIds],
+  );
 
   const activityOptions = useMemo(
     () =>
@@ -114,7 +156,15 @@ export function ActivityViewControls({
           className="w-[160px] lg:w-[240px]"
         />
 
-        <AccountScopeSelector value={accountScope} onChange={onAccountScopeChange} />
+        <FacetedFilter
+          title="Account"
+          contentClassName="w-72"
+          options={accountOptions}
+          selectedValues={selectedAccountIds}
+          onFilterChange={(values: Set<string>) =>
+            onAccountScopeChange(scopeFromAccountIds(Array.from(values)))
+          }
+        />
 
         <FacetedFilter
           title="Type"

--- a/packages/ui/src/components/ui/faceted-filter.tsx
+++ b/packages/ui/src/components/ui/faceted-filter.tsx
@@ -17,6 +17,7 @@ import { cn } from "../../lib/utils";
 
 export interface FacetedFilterProps {
   title?: string;
+  contentClassName?: string;
   options: {
     label: string;
     value: string;
@@ -27,7 +28,13 @@ export interface FacetedFilterProps {
   onFilterChange: (values: Set<string>) => void;
 }
 
-export function FacetedFilter({ title, options, selectedValues, onFilterChange }: FacetedFilterProps) {
+export function FacetedFilter({
+  title,
+  contentClassName,
+  options,
+  selectedValues,
+  onFilterChange,
+}: FacetedFilterProps) {
   return (
     <Popover>
       <PopoverTrigger asChild>
@@ -70,7 +77,7 @@ export function FacetedFilter({ title, options, selectedValues, onFilterChange }
           )}
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[200px] p-0" align="start">
+      <PopoverContent className={cn("w-[200px] p-0", contentClassName)} align="start">
         <Command>
           <CommandInput placeholder={title} />
           <CommandList>


### PR DESCRIPTION
## Summary

- Restore the Activity account control to a faceted multi-select filter with a wider account menu.
- Align the Spending tab search/filter layout with the Investment tab, including mobile search plus a bottom-sheet filter menu.
- Clean up Investment activity subtype display so duplicate subtype labels are hidden unless an activity still needs review, and long subtype text is truncated inside the cell.

## Validation

- `pnpm --filter @wealthfolio/ui build:types`
- `pnpm --filter frontend type-check`
- `pnpm --filter frontend exec eslint --quiet src/features/spending/components/transactions-filter-bar.tsx src/features/spending/components/spending-transactions-tab.tsx`
- `pnpm --filter frontend exec eslint --quiet src/pages/activity/components/activity-data-grid/use-activity-columns.tsx src/pages/activity/components/activity-type-badge.tsx`

## Notes

The PR branch was rewritten to exclude allocation changes and now contains only the activity/session work. The local main worktree still has unrelated unstaged changes that were not included.