### PR TITLE
Fix rebalance cash edge cases

### DIFF
--- a/apps/frontend/src/hooks/use-holdings.ts
+++ b/apps/frontend/src/hooks/use-holdings.ts
@@ -8,6 +8,7 @@ export function useHoldings(accountFilter: AccountScope) {
 
   const {
     data: holdings = [],
+    dataUpdatedAt,
     isLoading,
     isError,
     error,
@@ -17,5 +18,5 @@ export function useHoldings(accountFilter: AccountScope) {
     enabled: isEnabled,
   });
 
-  return { holdings, isLoading, isError, error };
+  return { holdings, dataUpdatedAt, isLoading, isError, error };
 }

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -2430,7 +2430,7 @@ export interface SuggestedManualTrade {
 }
 
 export interface RebalancePlan {
-  profileId: string;
+  targetId: string;
   availableCash: number;
   cashUsed: number;
   cashRemaining: number;

--- a/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
@@ -23,6 +23,7 @@ import {
   allocationTargetColorForRow,
   buildAllocationTargetColorMap,
 } from "./allocation-target-colors";
+import { accountScopeKey } from "./target-scope";
 import { useCalculateRebalancePlan } from "../hooks/use-rebalance";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -43,18 +44,49 @@ function currencySymbol(code: string): string {
   }
 }
 
+function currencyFractionDigits(code: string): number {
+  try {
+    return (
+      new Intl.NumberFormat(undefined, { style: "currency", currency: code }).resolvedOptions()
+        .maximumFractionDigits ?? 2
+    );
+  } catch {
+    return 2;
+  }
+}
+
+function cashInputLimit(availableCash: number, currency: string): number {
+  const factor = 10 ** currencyFractionDigits(currency);
+  return Math.round((availableCash + Number.EPSILON) * factor) / factor;
+}
+
+function cashValueFromAvailable(availableCash: number, currency: string): string {
+  const amount = cashInputLimit(availableCash, currency);
+  return amount > 0 ? amount.toFixed(currencyFractionDigits(currency)) : "";
+}
+
+function parseCashValue(value: string): number {
+  return parseFloat(value.replace(/,/g, "")) || 0;
+}
+
 function computeSleeveSummary(driftReport: DriftReport, plan: RebalancePlan) {
   // Total value is constant — cash moves within the portfolio, not added from outside.
   const total = driftReport.totalValue;
   const colorMap = buildAllocationTargetColorMap(driftReport.rows);
+  const deployedByCategory = new Map<string, number>();
+  for (const trade of plan.trades) {
+    deployedByCategory.set(
+      trade.categoryId,
+      (deployedByCategory.get(trade.categoryId) ?? 0) + trade.estimatedAmount,
+    );
+  }
+
   return driftReport.rows
     .filter((r) => r.status !== "not_targeted")
     .map((row, i) => {
       // Deploying cash moves value out of the cash sleeve into buy sleeves.
       // Total value is unchanged, so the cash row sheds cash_used.
-      const deployed = plan.trades
-        .filter((t) => t.categoryId === row.categoryId)
-        .reduce((sum, t) => sum + t.estimatedAmount, 0);
+      const deployed = deployedByCategory.get(row.categoryId) ?? 0;
       const afterValue = row.isCash
         ? Math.max(row.currentValue - plan.cashUsed, 0)
         : row.currentValue + deployed;
@@ -441,6 +473,7 @@ function InputBar({
   onCalculate,
   hasPlan,
   isCalculating,
+  isSourceLoading,
 }: {
   cashValue: string;
   availableCash: number;
@@ -449,9 +482,18 @@ function InputBar({
   onCalculate: () => void;
   hasPlan: boolean;
   isCalculating: boolean;
+  isSourceLoading: boolean;
 }) {
-  const deploy = parseFloat(cashValue.replace(/,/g, "")) || 0;
-  const overBudget = availableCash > 0 && deploy > availableCash;
+  const deploy = parseCashValue(cashValue);
+  const availableCashLimit = cashInputLimit(availableCash, currency);
+  const overBudget = deploy > availableCashLimit;
+  const canCalculate =
+    !isCalculating &&
+    !isSourceLoading &&
+    availableCashLimit > 0 &&
+    cashValue.trim().length > 0 &&
+    deploy > 0 &&
+    !overBudget;
 
   return (
     <Card>
@@ -488,10 +530,11 @@ function InputBar({
               <input
                 value={cashValue}
                 onChange={(e) => onCashChange(e.target.value)}
-                onKeyDown={(e) => e.key === "Enter" && onCalculate()}
+                onKeyDown={(e) => e.key === "Enter" && canCalculate && onCalculate()}
+                disabled={isSourceLoading || availableCash <= 0}
                 inputMode="decimal"
                 placeholder="0"
-                className="text-foreground placeholder:text-muted-foreground/60 w-32 bg-transparent text-[15px] font-medium tabular-nums outline-none"
+                className="text-foreground placeholder:text-muted-foreground/60 disabled:text-muted-foreground w-32 bg-transparent text-[15px] font-medium tabular-nums outline-none disabled:cursor-not-allowed"
               />
             </div>
             {overBudget && (
@@ -500,9 +543,15 @@ function InputBar({
           </div>
         </div>
 
-        <Button onClick={onCalculate} disabled={isCalculating || !cashValue.trim() || deploy <= 0}>
+        <Button onClick={onCalculate} disabled={!canCalculate}>
           <Icons.BarChart className="mr-1.5 h-4 w-4" />
-          {isCalculating ? "Calculating…" : hasPlan ? "Recalculate" : "Calculate plan"}
+          {isCalculating
+            ? "Calculating…"
+            : isSourceLoading
+              ? "Loading…"
+              : hasPlan
+                ? "Recalculate"
+                : "Calculate plan"}
         </Button>
       </CardContent>
     </Card>
@@ -516,6 +565,8 @@ interface RebalanceTabProps {
   driftReport: DriftReport | null;
   accountScope: AccountScope;
   availableCash: number;
+  sourceVersion: string;
+  isSourceLoading: boolean;
 }
 
 export function RebalanceTab({
@@ -523,30 +574,62 @@ export function RebalanceTab({
   driftReport,
   accountScope,
   availableCash,
+  sourceVersion,
+  isSourceLoading,
 }: RebalanceTabProps) {
-  const [cashValue, setCashValue] = useState(() =>
-    availableCash > 0 ? String(availableCash) : "",
-  );
-  const [plan, setPlan] = useState<RebalancePlan | null>(null);
+  const [cashDraft, setCashDraft] = useState<{ key: string; value: string } | null>(null);
+  const [planResult, setPlanResult] = useState<{
+    key: string;
+    sourceKey: string;
+    inputContextKey: string;
+    plan: RebalancePlan;
+  } | null>(null);
 
   const calculatePlan = useCalculateRebalancePlan();
   const currency = driftReport?.baseCurrency ?? "USD";
+  const inputContextKey = `${profile?.id ?? "no-profile"}:${accountScopeKey(accountScope)}:${currency}`;
+  const cashValue =
+    cashDraft?.key === inputContextKey
+      ? cashDraft.value
+      : cashValueFromAvailable(availableCash, currency);
+  const cash = parseCashValue(cashValue);
+  const availableCashLimit = cashInputLimit(availableCash, currency);
+  const sourceReady = !isSourceLoading && !!driftReport;
+  const sourceKey = `${inputContextKey}:${availableCash}:${sourceVersion}`;
+  const planKey = `${sourceKey}:${cash}`;
+  const plan = planResult?.key === planKey ? planResult.plan : null;
+  const hasStalePlan =
+    !!planResult &&
+    planResult.inputContextKey === inputContextKey &&
+    planResult.sourceKey !== sourceKey;
 
-  function parseCash(): number {
-    return parseFloat(cashValue.replace(/,/g, "")) || 0;
+  function handleCashChange(value: string) {
+    setCashDraft({ key: inputContextKey, value });
   }
 
   function handleCalculate() {
     if (!profile) return;
-    const cash = parseCash();
+    if (!sourceReady) {
+      toast.error("Portfolio data is still loading");
+      return;
+    }
+    if (availableCashLimit <= 0) {
+      toast.error("No cash available in scope");
+      return;
+    }
     if (cash <= 0) {
       toast.error("Enter a valid cash amount");
+      return;
+    }
+    if (cash > availableCashLimit) {
+      toast.error("Cash to deploy exceeds available cash");
       return;
     }
     calculatePlan.mutate(
       { targetId: profile.id, availableCash: cash, filter: accountScope },
       {
-        onSuccess: (result) => setPlan(result),
+        onSuccess: (result) =>
+          setPlanResult({ key: planKey, sourceKey, inputContextKey, plan: result }),
         onError: (err) => toast.error(`Failed to calculate plan: ${err.message}`),
       },
     );
@@ -584,11 +667,18 @@ export function RebalanceTab({
         cashValue={cashValue}
         availableCash={availableCash}
         currency={currency}
-        onCashChange={setCashValue}
+        onCashChange={handleCashChange}
         onCalculate={handleCalculate}
-        hasPlan={!!plan}
+        hasPlan={!!plan || hasStalePlan}
         isCalculating={isCalculating}
+        isSourceLoading={!sourceReady}
       />
+
+      {hasStalePlan && sourceReady && !isCalculating && (
+        <div className="border-border bg-muted/40 text-muted-foreground rounded-lg border px-4 py-3 text-[13px]">
+          Portfolio data changed. Recalculate to refresh this plan.
+        </div>
+      )}
 
       {/* Loading skeletons */}
       {isCalculating && (

--- a/apps/frontend/src/pages/allocation-targets/hooks/use-allocation-target-drift.ts
+++ b/apps/frontend/src/pages/allocation-targets/hooks/use-allocation-target-drift.ts
@@ -15,6 +15,7 @@ export function useAllocationTargetDrift(
   const includeHoldings = options?.includeHoldings ?? false;
   const {
     data: driftReport,
+    dataUpdatedAt,
     isLoading,
     isError,
   } = useQuery<DriftReport | null, Error>({
@@ -23,5 +24,5 @@ export function useAllocationTargetDrift(
     enabled: !!targetId,
   });
 
-  return { driftReport: driftReport ?? null, isLoading, isError };
+  return { driftReport: driftReport ?? null, dataUpdatedAt, isLoading, isError };
 }

--- a/apps/frontend/src/pages/insights/overview/overview-page.tsx
+++ b/apps/frontend/src/pages/insights/overview/overview-page.tsx
@@ -51,7 +51,11 @@ export function OverviewPage({
   const accountFilter: AccountScope = useMemo(() => filterProp ?? { type: "all" }, [filterProp]);
   const selectedAccountScopeKey = accountScopeKey(accountFilter);
 
-  const { holdings, isLoading: holdingsLoading } = useHoldings(accountFilter);
+  const {
+    holdings,
+    dataUpdatedAt: holdingsUpdatedAt,
+    isLoading: holdingsLoading,
+  } = useHoldings(accountFilter);
   const { allocations, isLoading: allocationsLoading } = usePortfolioAllocations(accountFilter);
   const { accounts } = useAccounts();
   const { data: portfolios = [] } = usePortfolios();
@@ -90,11 +94,13 @@ export function OverviewPage({
     ? accountFilter
     : (accountScopeFromTarget(effectiveTarget) ?? accountFilter);
 
-  const { driftReport, isLoading: driftLoading } = useAllocationTargetDrift(
-    effectiveTargetId,
-    accountFilter,
-    { includeHoldings: workspaceView === "details" },
-  );
+  const {
+    driftReport,
+    dataUpdatedAt: driftUpdatedAt,
+    isLoading: driftLoading,
+  } = useAllocationTargetDrift(effectiveTargetId, accountFilter, {
+    includeHoldings: workspaceView === "details",
+  });
 
   const isLoading = holdingsLoading || allocationsLoading;
   const targetLoading = targetsLoading || driftLoading;
@@ -121,6 +127,14 @@ export function OverviewPage({
     () => portfolioHoldings.filter((h) => h.holdingType?.toLowerCase() !== "cash"),
     [portfolioHoldings],
   );
+  const availableCash = useMemo(
+    () =>
+      holdings
+        .filter((h) => h.holdingType === HoldingType.CASH)
+        .reduce((sum, h) => sum + (h.marketValue.base ?? 0), 0),
+    [holdings],
+  );
+  const rebalanceSourceVersion = `${holdingsUpdatedAt}:${driftUpdatedAt}:${effectiveTarget?.updatedAt ?? ""}`;
 
   const valueStrip = useMemo(
     () => computeValueStrip(portfolioHoldings, accounts),
@@ -317,11 +331,9 @@ export function OverviewPage({
           profile={effectiveTarget ?? null}
           driftReport={driftReport ?? null}
           accountScope={accountFilter}
-          availableCash={
-            holdings
-              ?.filter((h) => h.holdingType === HoldingType.CASH)
-              .reduce((sum, h) => sum + (h.marketValue.base ?? 0), 0) ?? 0
-          }
+          availableCash={availableCash}
+          sourceVersion={rebalanceSourceVersion}
+          isSourceLoading={holdingsLoading || driftLoading || !driftReport}
         />
       </div>
     );

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -67,7 +67,9 @@ impl RebalanceServiceTrait for RebalanceService {
 
         // M2 deploys tracked cash only. Compute the cash in scope from holdings
         // (authoritative — does not trust a client-supplied figure) and reject
-        // attempts to deploy more than is actually held.
+        // attempts to deploy more than is actually held. Allow a tiny sub-cent
+        // overage from frontend decimal serialization / currency rounding, but
+        // cap planning at the authoritative tracked cash value.
         let cash_in_scope: Decimal = self
             .holdings_service
             .get_holdings_for_accounts(
@@ -81,13 +83,20 @@ impl RebalanceServiceTrait for RebalanceService {
             .map(|holding| holding.market_value.base)
             .sum();
 
-        if input.available_cash > cash_in_scope {
-            return Err(CoreError::Validation(
-                crate::errors::ValidationError::InvalidInput(
-                    "cash to deploy exceeds tracked cash in scope".to_string(),
-                ),
-            ));
-        }
+        let available_cash = if input.available_cash > cash_in_scope {
+            let overage = input.available_cash - cash_in_scope;
+            if overage <= dec!(0.01) {
+                cash_in_scope
+            } else {
+                return Err(CoreError::Validation(
+                    crate::errors::ValidationError::InvalidInput(
+                        "cash to deploy exceeds tracked cash in scope".to_string(),
+                    ),
+                ));
+            }
+        } else {
+            input.available_cash
+        };
 
         // --- 1. Load profile -------------------------------------------------
         let profile = self
@@ -117,7 +126,7 @@ impl RebalanceServiceTrait for RebalanceService {
             Decimal::from_str(&profile.min_trade_amount).unwrap_or(Decimal::ZERO);
 
         // Nothing to plan against.
-        if total_value == Decimal::ZERO && input.available_cash == Decimal::ZERO {
+        if total_value == Decimal::ZERO && available_cash == Decimal::ZERO {
             return Ok(RebalancePlan {
                 target_id: input.target_id.clone(),
                 available_cash: Decimal::ZERO,
@@ -149,6 +158,9 @@ impl RebalanceServiceTrait for RebalanceService {
 
         let mut sleeves: Vec<SleeveShortfall> = Vec::new();
         for row in &drift.rows {
+            if row.is_cash {
+                continue;
+            }
             let target_bps_dec = Decimal::from(row.target_bps);
             let desired_bps = match profile.rebalance_goal {
                 RebalanceGoal::ExactTarget => target_bps_dec,
@@ -167,14 +179,13 @@ impl RebalanceServiceTrait for RebalanceService {
 
         // --- 4. Scale shortfalls to available cash ---------------------------
         let total_shortfall: Decimal = sleeves.iter().map(|s| s.shortfall).sum();
-        let scale_factor =
-            if total_shortfall == Decimal::ZERO || input.available_cash == Decimal::ZERO {
-                Decimal::ZERO
-            } else if total_shortfall <= input.available_cash {
-                Decimal::ONE
-            } else {
-                input.available_cash / total_shortfall
-            };
+        let scale_factor = if total_shortfall == Decimal::ZERO || available_cash == Decimal::ZERO {
+            Decimal::ZERO
+        } else if total_shortfall <= available_cash {
+            Decimal::ONE
+        } else {
+            available_cash / total_shortfall
+        };
 
         // --- 5. Build trades per sleeve, proportional to holdings weights ----
         let mut trades: Vec<SuggestedManualTrade> = Vec::new();
@@ -187,7 +198,7 @@ impl RebalanceServiceTrait for RebalanceService {
 
         for sleeve in &sleeves {
             // Cap budget at remaining cash to guard against Decimal precision drift.
-            let remaining = input.available_cash - total_cash_used;
+            let remaining = available_cash - total_cash_used;
             if remaining <= Decimal::ZERO {
                 break;
             }
@@ -481,11 +492,11 @@ impl RebalanceServiceTrait for RebalanceService {
                 .unwrap_or(0)
         };
 
-        let cash_remaining = input.available_cash - total_cash_used;
+        let cash_remaining = available_cash - total_cash_used;
 
         Ok(RebalancePlan {
             target_id: input.target_id.clone(),
-            available_cash: input.available_cash,
+            available_cash,
             cash_used: total_cash_used,
             cash_remaining,
             max_drift_bps_before,
@@ -958,6 +969,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rounded_cash_within_cent_is_capped_to_tracked_cash() {
+        // Frontend currency rounding can submit $100.01 for a tracked raw cash
+        // balance of $100.005. Treat that as "deploy all cash" and cap to the
+        // authoritative backend value instead of rejecting.
+        let total = dec!(1000);
+        let rows = vec![
+            make_drift_row("equity", 5000, 6000, total),
+            DriftRow {
+                is_cash: true,
+                ..make_drift_row("cash", 5000, 4000, total)
+            },
+        ];
+        let report = make_report(rows, total);
+        let mut holdings = std::collections::HashMap::new();
+        holdings.insert(
+            "equity".to_string(),
+            vec![make_holding("h1", "VTI", dec!(10), dec!(500))],
+        );
+        let svc = make_service_with_cash(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            report,
+            holdings,
+            dec!(100.005),
+        );
+
+        let plan = svc.calculate_plan(make_input(dec!(100.01))).await.unwrap();
+
+        assert_eq!(plan.available_cash, dec!(100.005));
+        assert_eq!(plan.cash_used, dec!(100));
+        assert_eq!(plan.cash_remaining, dec!(0.005));
+    }
+
+    #[tokio::test]
     async fn total_value_stays_constant_when_cash_deployed() {
         // Portfolio: equity $6000 (60%), cash $4000 (40%). Total = $10000.
         // Target: equity 70%, cash 30%.
@@ -994,6 +1038,41 @@ mod tests {
             plan.max_drift_bps_after, 0,
             "cash sleeve must drop by cash_used so both sleeves reach target"
         );
+    }
+
+    #[tokio::test]
+    async fn underweight_cash_is_not_a_buy_candidate() {
+        // Portfolio: equity $8000 (80%), cash $2000 (20%).
+        // Target: equity 70%, cash 30%. Cash is underweight, but cash is the funding source,
+        // so a cash-flow-only plan must not suggest "buying" the cash sleeve with cash.
+        let total = dec!(10000);
+        let rows = vec![
+            make_drift_row("equity", 8000, 7000, total),
+            DriftRow {
+                is_cash: true,
+                ..make_drift_row("cash", 2000, 3000, total)
+            },
+        ];
+        let report = make_report(rows, total);
+        let mut holdings = std::collections::HashMap::new();
+        holdings.insert(
+            "cash".to_string(),
+            vec![make_holding("cash-usd", "USD", dec!(2000), dec!(2000))],
+        );
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            report,
+            holdings,
+        );
+
+        let plan = svc.calculate_plan(make_input(dec!(1000))).await.unwrap();
+
+        assert!(
+            plan.trades.is_empty(),
+            "cash must not be selected as a buy sleeve"
+        );
+        assert_eq!(plan.cash_used, Decimal::ZERO);
+        assert_eq!(plan.max_drift_bps_after, plan.max_drift_bps_before);
     }
 
     #[tokio::test]

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -47,6 +47,20 @@ impl RebalanceService {
             holdings_service,
         }
     }
+
+    fn currency_fraction_digits(currency: &str) -> u32 {
+        match currency.to_ascii_uppercase().as_str() {
+            "BIF" | "CLP" | "DJF" | "GNF" | "ISK" | "JPY" | "KMF" | "KRW" | "PYG" | "RWF"
+            | "UGX" | "VND" | "VUV" | "XAF" | "XOF" | "XPF" => 0,
+            "BHD" | "IQD" | "JOD" | "KWD" | "LYD" | "OMR" | "TND" => 3,
+            "CLF" => 4,
+            _ => 2,
+        }
+    }
+
+    fn currency_rounding_tolerance(currency: &str) -> Decimal {
+        Decimal::ONE / Decimal::from(10_i64.pow(Self::currency_fraction_digits(currency)))
+    }
 }
 
 #[async_trait]
@@ -67,9 +81,10 @@ impl RebalanceServiceTrait for RebalanceService {
 
         // M2 deploys tracked cash only. Compute the cash in scope from holdings
         // (authoritative — does not trust a client-supplied figure) and reject
-        // attempts to deploy more than is actually held. Allow a tiny sub-cent
-        // overage from frontend decimal serialization / currency rounding, but
-        // cap planning at the authoritative tracked cash value.
+        // attempts to deploy more than is actually held. Allow a tiny overage
+        // within the base currency's minor unit from frontend decimal
+        // serialization / currency rounding, but cap planning at the
+        // authoritative tracked cash value.
         let cash_in_scope: Decimal = self
             .holdings_service
             .get_holdings_for_accounts(
@@ -85,7 +100,7 @@ impl RebalanceServiceTrait for RebalanceService {
 
         let available_cash = if input.available_cash > cash_in_scope {
             let overage = input.available_cash - cash_in_scope;
-            if overage <= dec!(0.01) {
+            if overage <= Self::currency_rounding_tolerance(&input.base_currency) {
                 cash_in_scope
             } else {
                 return Err(CoreError::Validation(
@@ -999,6 +1014,43 @@ mod tests {
         assert_eq!(plan.available_cash, dec!(100.005));
         assert_eq!(plan.cash_used, dec!(100));
         assert_eq!(plan.cash_remaining, dec!(0.005));
+    }
+
+    #[tokio::test]
+    async fn rounded_zero_decimal_cash_is_capped_to_tracked_cash() {
+        // Zero-decimal currencies can round 100.5 to 101 in the UI. That should
+        // still behave as "deploy all tracked cash", while planning remains
+        // capped to the authoritative backend value.
+        let total = dec!(1000);
+        let rows = vec![
+            make_drift_row("equity", 5000, 6000, total),
+            DriftRow {
+                is_cash: true,
+                ..make_drift_row("cash", 5000, 4000, total)
+            },
+        ];
+        let report = make_report(rows, total);
+        let mut holdings = std::collections::HashMap::new();
+        holdings.insert(
+            "equity".to_string(),
+            vec![make_holding("h1", "VTI", dec!(10), dec!(500))],
+        );
+        let svc = make_service_with_cash(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            report,
+            holdings,
+            dec!(100.5),
+        );
+        let input = CalculateRebalancePlanInput {
+            base_currency: "JPY".to_string(),
+            ..make_input(dec!(101))
+        };
+
+        let plan = svc.calculate_plan(input).await.unwrap();
+
+        assert_eq!(plan.available_cash, dec!(100.5));
+        assert_eq!(plan.cash_used, dec!(100));
+        assert_eq!(plan.cash_remaining, dec!(0.5));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- prevent cash from being selected as a buy sleeve in cash-flow rebalance plans
- subtract deployed cash from the cash sleeve in after-drift display/modeling and keep frontend plan state keyed to fresh holdings/drift data
- default deployable cash to currency precision and cap sub-cent backend overages to tracked cash to avoid false "exceeds tracked cash" rejections
- expose React Query freshness metadata for rebalance source invalidation

## Root cause
The merged rebalance flow treated tracked cash as both the funding source and, in some cases, a target buy sleeve. The frontend also kept local plan state without a reliable source freshness key and defaulted the cash input from raw floating precision, which could exceed the backend's authoritative tracked cash by tiny rounding differences.

## Validation
- `cargo test -p wealthfolio-core --lib allocation_targets`
- frontend allocation-target Vitest run: 74 files / 720 tests passed
- `cargo fmt --check`
- `git diff --check`

`pnpm --filter frontend type-check` still fails on existing unrelated errors in `apps/frontend/src/addons/type-bridge.ts` and `apps/frontend/src/pages/performance/performance-page.tsx`.