### PR TITLE
Allow a liability to sit at $0 without a stale warning

### DIFF
--- a/apps/frontend/src/pages/asset/alternative-assets/components/alternative-asset-quick-add-schema.ts
+++ b/apps/frontend/src/pages/asset/alternative-assets/components/alternative-asset-quick-add-schema.ts
@@ -64,7 +64,7 @@ export const alternativeAssetQuickAddSchema = z
         required_error: "Please enter a valid value.",
         invalid_type_error: "Value must be a number.",
       })
-      .positive("Value must be greater than 0"),
+      .min(0, "Value cannot be negative"),
     valueDate: z.date({
       required_error: "Value date is required",
     }),

--- a/apps/frontend/src/pages/asset/alternative-assets/components/update-valuation-schema.ts
+++ b/apps/frontend/src/pages/asset/alternative-assets/components/update-valuation-schema.ts
@@ -4,13 +4,13 @@ import * as z from "zod";
  * Zod schema for the update valuation form
  */
 export const updateValuationSchema = z.object({
-  // New value - must be positive
+  // New value - allow zero (e.g. a paid-off liability) but not negative
   value: z.coerce
     .number({
       required_error: "Please enter a valid value.",
       invalid_type_error: "Value must be a number.",
     })
-    .positive("Value must be greater than 0"),
+    .min(0, "Value cannot be negative"),
 
   // As of date - required
   date: z.date({

--- a/crates/core/src/portfolio/net_worth/net_worth_service.rs
+++ b/crates/core/src/portfolio/net_worth/net_worth_service.rs
@@ -260,17 +260,22 @@ impl NetWorthService {
     }
 
     /// Calculate staleness info for valuations.
-    /// Cash-like balances are excluded since they don't need market data updates.
+    /// Cash-like balances and zero-value valuations are excluded since they have no
+    /// market data to keep up to date.
     fn calculate_staleness(
         valuations: &[ValuationInfo],
         reference_date: NaiveDate,
     ) -> (Option<NaiveDate>, Vec<StaleAssetInfo>) {
-        // Exclude cash-like balances from staleness calculations.
-        let non_cash_valuations: Vec<_> = valuations.iter().filter(|v| !v.is_cash_like).collect();
+        // Exclude cash-like balances (no market data to update) and zero-value
+        // valuations (e.g. a paid-off liability sitting at $0 — nothing to update).
+        let trackable_valuations: Vec<_> = valuations
+            .iter()
+            .filter(|v| !v.is_cash_like && !v.market_value_base.is_zero())
+            .collect();
 
-        let oldest_date = non_cash_valuations.iter().map(|v| v.valuation_date).min();
+        let oldest_date = trackable_valuations.iter().map(|v| v.valuation_date).min();
 
-        let stale_assets: Vec<StaleAssetInfo> = non_cash_valuations
+        let stale_assets: Vec<StaleAssetInfo> = trackable_valuations
             .iter()
             .filter_map(|v| {
                 let days_stale = (reference_date - v.valuation_date).num_days();

--- a/crates/core/src/portfolio/net_worth/net_worth_service.rs
+++ b/crates/core/src/portfolio/net_worth/net_worth_service.rs
@@ -260,17 +260,22 @@ impl NetWorthService {
     }
 
     /// Calculate staleness info for valuations.
-    /// Cash-like balances and zero-value valuations are excluded since they have no
-    /// market data to keep up to date.
+    /// Cash-like balances and paid-off ($0) liabilities are excluded since they have
+    /// no market data to keep up to date.
     fn calculate_staleness(
         valuations: &[ValuationInfo],
         reference_date: NaiveDate,
     ) -> (Option<NaiveDate>, Vec<StaleAssetInfo>) {
-        // Exclude cash-like balances (no market data to update) and zero-value
-        // valuations (e.g. a paid-off liability sitting at $0 — nothing to update).
+        // Exclude cash-like balances (no market data to update) and paid-off
+        // liabilities sitting at $0 (nothing to update). A zero value on a
+        // non-liability asset is more likely a data issue (e.g. a bad quote), so
+        // those are still surfaced as stale to prompt the user to refresh them.
         let trackable_valuations: Vec<_> = valuations
             .iter()
-            .filter(|v| !v.is_cash_like && !v.market_value_base.is_zero())
+            .filter(|v| {
+                !v.is_cash_like
+                    && !(v.category == AssetCategory::Liability && v.market_value_base.is_zero())
+            })
             .collect();
 
         let oldest_date = trackable_valuations.iter().map(|v| v.valuation_date).min();

--- a/crates/core/src/portfolio/net_worth/net_worth_service.rs
+++ b/crates/core/src/portfolio/net_worth/net_worth_service.rs
@@ -273,8 +273,8 @@ impl NetWorthService {
         let trackable_valuations: Vec<_> = valuations
             .iter()
             .filter(|v| {
-                !v.is_cash_like
-                    && !(v.category == AssetCategory::Liability && v.market_value_base.is_zero())
+                !(v.is_cash_like
+                    || (v.category == AssetCategory::Liability && v.market_value_base.is_zero()))
             })
             .collect();
 

--- a/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
+++ b/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
@@ -1300,6 +1300,31 @@ async fn test_staleness_detection() {
 }
 
 #[tokio::test]
+async fn test_zero_value_valuation_not_stale() {
+    // A paid-off liability (or any asset) sitting at $0 has nothing to update,
+    // so an old zero-value valuation must not be flagged as stale.
+    let account = create_test_account("acc1", "SECURITIES", "USD");
+    let asset = create_test_asset("AAPL", AssetKind::Investment, "USD");
+    let position = create_test_position("acc1", "AAPL", dec!(100), dec!(15000), "USD");
+    let snapshot = create_test_snapshot("acc1", vec![position], HashMap::new());
+
+    // Old quote (100 days ago) priced at zero → market value of zero.
+    let old_date = NaiveDate::from_ymd_opt(2023, 10, 7).unwrap();
+    let quote = create_test_quote("AAPL", dec!(0), old_date, "USD");
+
+    let service = create_net_worth_service(vec![account], vec![asset], vec![snapshot], vec![quote]);
+
+    let date = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
+    let result = service.get_net_worth(date).await.unwrap();
+
+    // Zero-value valuation is excluded from staleness even though it is >90 days old.
+    assert_eq!(result.stale_assets.len(), 0);
+    // It is also excluded from the oldest-valuation-date signal the widget uses,
+    // so the "stale valuations" banner stays hidden.
+    assert_eq!(result.oldest_valuation_date, None);
+}
+
+#[tokio::test]
 async fn test_multiple_asset_categories() {
     // Securities account
     let sec_account = create_test_account("sec1", "SECURITIES", "USD");

--- a/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
+++ b/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
@@ -1300,9 +1300,31 @@ async fn test_staleness_detection() {
 }
 
 #[tokio::test]
-async fn test_zero_value_valuation_not_stale() {
-    // A paid-off liability (or any asset) sitting at $0 has nothing to update,
-    // so an old zero-value valuation must not be flagged as stale.
+async fn test_zero_value_liability_not_stale() {
+    // A paid-off liability sitting at $0 has nothing to update, so an old
+    // zero-value valuation must not be flagged as stale.
+    let liab_asset = create_test_asset("LIAB-mortgage", AssetKind::Liability, "USD");
+
+    // Old quote (100 days ago) priced at zero → market value of zero.
+    let old_date = NaiveDate::from_ymd_opt(2023, 10, 7).unwrap();
+    let quote = create_test_quote("LIAB-mortgage", dec!(0), old_date, "USD");
+
+    let service = create_net_worth_service(vec![], vec![liab_asset], vec![], vec![quote]);
+
+    let date = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
+    let result = service.get_net_worth(date).await.unwrap();
+
+    // Zero-value liability is excluded from staleness even though it is >90 days old.
+    assert_eq!(result.stale_assets.len(), 0);
+    // It is also excluded from the oldest-valuation-date signal the widget uses,
+    // so the "stale valuations" banner stays hidden.
+    assert_eq!(result.oldest_valuation_date, None);
+}
+
+#[tokio::test]
+async fn test_zero_value_investment_still_stale() {
+    // A zero value on a non-liability asset is more likely a data issue (e.g. a
+    // bad quote), so it must still be flagged as stale to prompt a refresh.
     let account = create_test_account("acc1", "SECURITIES", "USD");
     let asset = create_test_asset("AAPL", AssetKind::Investment, "USD");
     let position = create_test_position("acc1", "AAPL", dec!(100), dec!(15000), "USD");
@@ -1317,11 +1339,8 @@ async fn test_zero_value_valuation_not_stale() {
     let date = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
     let result = service.get_net_worth(date).await.unwrap();
 
-    // Zero-value valuation is excluded from staleness even though it is >90 days old.
-    assert_eq!(result.stale_assets.len(), 0);
-    // It is also excluded from the oldest-valuation-date signal the widget uses,
-    // so the "stale valuations" banner stays hidden.
-    assert_eq!(result.oldest_valuation_date, None);
+    assert_eq!(result.stale_assets.len(), 1);
+    assert_eq!(result.stale_assets[0].asset_id, "AAPL");
 }
 
 #[tokio::test]


### PR DESCRIPTION
Closes #1033

## Problem
Two asks from the issue:
1. A liability whose value legitimately reaches **$0** (e.g. a credit card paid off this month) couldn't be saved — the value form required a positive number.
2. A paid-off liability sitting at $0 kept tripping the **"stale valuations (90+ days)"** warning on the Net Worth page, since it's never updated again.

## Changes
**1. Allow $0 values**
The two alternative-asset value Zod schemas rejected zero via `.positive()`. Relaxed to `.min(0, ...)` — zero is now permitted, negatives still rejected.
- `update-valuation-schema.ts` (the "update value" / Values-tab flow)
- `alternative-asset-quick-add-schema.ts` (`currentValue`)

The Rust backend already accepted any value; no other guards (HTML `min`, disabled-submit) existed. Unrelated activity/trade `.positive()` schemas left untouched.

**2. $0 valuation is never "stale"**
A zero-value valuation has nothing to update, so `calculate_staleness` now excludes it from **both** the stale-asset list **and** `oldest_valuation_date`. The Net Worth widget shows the banner when `staleAssets` is non-empty **OR** `oldestValuationDate > 90 days`, so both had to be filtered consistently to fully suppress the nag.

## Testing
- New regression test `test_zero_value_valuation_not_stale` — an old ($90+ days) $0 valuation is neither stale nor counted in `oldest_valuation_date`.
- `cargo test -p wealthfolio-core net_worth` — 39 passed.
- `cargo check` / `cargo fmt --check` clean.
