### PR TITLE
feat(allocation-targets): Exposure-Aware Drift Planner — Milestone 2 PR-B

### DIFF
--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -2408,7 +2408,12 @@ export interface DriftHoldingsReport {
   rows: DriftHoldingRow[];
 }
 
-export type RebalanceWarningKind = "missing_quote" | "no_buy_candidate" | "whole_share_residue";
+export type RebalanceWarningKind =
+  | "missing_quote"
+  | "no_buy_candidate"
+  | "whole_share_residue"
+  | "unclassified_asset"
+  | "partial_classification";
 
 export interface RebalanceWarning {
   kind: RebalanceWarningKind;
@@ -2438,4 +2443,5 @@ export interface RebalancePlan {
   maxDriftBpsAfter: number;
   trades: SuggestedManualTrade[];
   warnings: RebalanceWarning[];
+  afterBpsByCategory: Record<string, number>;
 }

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -2411,7 +2411,6 @@ export interface DriftHoldingsReport {
 export type RebalanceWarningKind =
   | "missing_quote"
   | "no_buy_candidate"
-  | "whole_share_residue"
   | "unclassified_asset"
   | "partial_classification";
 

--- a/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
@@ -271,7 +271,6 @@ function KpiStrip({ plan, currency }: { plan: RebalancePlan; currency: string })
 const WARN_LABEL: Record<string, string> = {
   missing_quote: "Missing quote",
   no_buy_candidate: "No buy candidate",
-  whole_share_residue: "Residual cash",
   unclassified_asset: "Unclassified",
   partial_classification: "Partial classification",
 };

--- a/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
@@ -70,36 +70,18 @@ function parseCashValue(value: string): number {
 }
 
 function computeSleeveSummary(driftReport: DriftReport, plan: RebalancePlan) {
-  // Total value is constant — cash moves within the portfolio, not added from outside.
-  const total = driftReport.totalValue;
   const colorMap = buildAllocationTargetColorMap(driftReport.rows);
-  const deployedByCategory = new Map<string, number>();
-  for (const trade of plan.trades) {
-    deployedByCategory.set(
-      trade.categoryId,
-      (deployedByCategory.get(trade.categoryId) ?? 0) + trade.estimatedAmount,
-    );
-  }
-
   return driftReport.rows
     .filter((r) => r.status !== "not_targeted")
-    .map((row, i) => {
-      // Deploying cash moves value out of the cash sleeve into buy sleeves.
-      // Total value is unchanged, so the cash row sheds cash_used.
-      const deployed = deployedByCategory.get(row.categoryId) ?? 0;
-      const afterValue = row.isCash
-        ? Math.max(row.currentValue - plan.cashUsed, 0)
-        : row.currentValue + deployed;
-      const afterBps = total > 0 ? Math.round((afterValue / total) * 10000) : 0;
-      return {
-        categoryId: row.categoryId,
-        categoryName: row.categoryName,
-        color: allocationTargetColorForRow(row, colorMap, i),
-        currentBps: row.currentBps,
-        targetBps: row.targetBps,
-        afterBps,
-      };
-    });
+    .map((row, i) => ({
+      categoryId: row.categoryId,
+      categoryName: row.categoryName,
+      color: allocationTargetColorForRow(row, colorMap, i),
+      currentBps: row.currentBps,
+      targetBps: row.targetBps,
+      // Use backend-computed after-bps (accounts for multi-category ETF exposure).
+      afterBps: plan.afterBpsByCategory[row.categoryId] ?? row.currentBps,
+    }));
 }
 
 function csvCell(value: string): string {
@@ -273,6 +255,8 @@ const WARN_LABEL: Record<string, string> = {
   missing_quote: "Missing quote",
   no_buy_candidate: "No buy candidate",
   whole_share_residue: "Residual cash",
+  unclassified_asset: "Unclassified",
+  partial_classification: "Partial classification",
 };
 
 function Warnings({ items }: { items: RebalanceWarning[] }) {
@@ -653,12 +637,17 @@ export function RebalanceTab({
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div>
-        <h2 className="text-foreground text-xl font-semibold tracking-tight">Rebalance</h2>
-        <p className="text-muted-foreground mt-1 text-[13px]">
-          Deploy new cash to pull underweight sleeves back toward target. Buys only — nothing is
-          sold.
-        </p>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="text-foreground text-xl font-semibold tracking-tight">Rebalance</h2>
+          <p className="text-muted-foreground mt-1 text-[13px]">
+            Deploy new cash to pull underweight categories back toward target. Buys only — nothing
+            is sold.
+          </p>
+        </div>
+        <span className="border-border text-muted-foreground mt-1 shrink-0 rounded border px-2 py-0.5 text-[11px] font-medium">
+          Drift planner
+        </span>
       </div>
 
       <ModeSwitch currency={currency} />

--- a/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
@@ -89,7 +89,22 @@ function csvCell(value: string): string {
   return `"${escaped}"`;
 }
 
-function exportCsv(plan: RebalancePlan, currency: string) {
+function exportCsv(plan: RebalancePlan, currency: string, profileName: string) {
+  const generated = new Date().toISOString().slice(0, 10);
+  const fractionDigits = currencyFractionDigits(currency);
+
+  const meta = [
+    ["Generated", generated],
+    ["Profile", profileName],
+    ["Currency", currency],
+    ["Cash deployed", plan.cashUsed.toFixed(fractionDigits)],
+    ["Cash available", plan.availableCash.toFixed(fractionDigits)],
+    ["Max drift before", fmtBps(plan.maxDriftBpsBefore)],
+    ["Max drift after", fmtBps(plan.maxDriftBpsAfter)],
+  ]
+    .map((row) => row.map(csvCell).join(","))
+    .join("\n");
+
   const header = [
     "Action",
     "Symbol",
@@ -102,26 +117,28 @@ function exportCsv(plan: RebalancePlan, currency: string) {
   ]
     .map(csvCell)
     .join(",");
+
   const rows = plan.trades.map((t) =>
     [
       t.action,
       t.symbol ?? "",
       t.name ?? "",
       t.categoryName,
-      t.estimatedAmount.toFixed(2),
-      t.quantity != null ? t.quantity.toFixed(4) : "",
-      t.estimatedPrice != null ? t.estimatedPrice.toFixed(2) : "",
+      t.estimatedAmount.toFixed(fractionDigits),
+      t.quantity != null ? t.quantity.toFixed(t.quantity % 1 === 0 ? 0 : 4) : "",
+      t.estimatedPrice != null ? t.estimatedPrice.toFixed(fractionDigits) : "",
       t.reason,
     ]
       .map(csvCell)
       .join(","),
   );
-  const csv = [header, ...rows].join("\n");
+
+  const csv = [meta, "", header, ...rows].join("\n");
   const blob = new Blob([csv], { type: "text/csv" });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  a.download = `rebalance-plan-${currency}.csv`;
+  a.download = `rebalance-plan-${profileName.replace(/[^a-z0-9]/gi, "-").toLowerCase()}-${generated}.csv`;
   a.click();
   URL.revokeObjectURL(url);
 }
@@ -759,7 +776,7 @@ export function RebalanceTab({
             <Button
               size="sm"
               onClick={() => {
-                exportCsv(plan, currency);
+                exportCsv(plan, currency, profile.name);
                 toast.success("CSV downloaded");
               }}
             >

--- a/crates/core/src/portfolio/allocation_targets/mod.rs
+++ b/crates/core/src/portfolio/allocation_targets/mod.rs
@@ -1,11 +1,13 @@
 mod drift_service;
 mod model;
+mod optimizer;
 mod rebalance_service;
 mod target_service;
 mod validation;
 
 pub use drift_service::*;
 pub use model::*;
+pub use optimizer::*;
 pub use rebalance_service::*;
 pub use target_service::*;
 pub use validation::*;

--- a/crates/core/src/portfolio/allocation_targets/model.rs
+++ b/crates/core/src/portfolio/allocation_targets/model.rs
@@ -246,7 +246,6 @@ pub struct CalculateRebalancePlanInput {
 pub enum RebalanceWarningKind {
     MissingQuote,
     NoBuyCandidate,
-    WholeShareResidue,
     /// Asset has no taxonomy assignments for the active taxonomy — skipped as buy candidate.
     UnclassifiedAsset,
     /// Asset has partial taxonomy weights (<100%) — known exposure used, remainder ignored.

--- a/crates/core/src/portfolio/allocation_targets/model.rs
+++ b/crates/core/src/portfolio/allocation_targets/model.rs
@@ -287,4 +287,9 @@ pub struct RebalancePlan {
     pub max_drift_bps_after: i32,
     pub trades: Vec<SuggestedManualTrade>,
     pub warnings: Vec<RebalanceWarning>,
+    /// After-trade allocation in bps per category_id.
+    /// Accounts for multi-category ETF exposure; use this for BeforeAfterStack
+    /// instead of re-deriving from trades (which only carry the primary category).
+    #[serde(default)]
+    pub after_bps_by_category: std::collections::HashMap<String, i32>,
 }

--- a/crates/core/src/portfolio/allocation_targets/model.rs
+++ b/crates/core/src/portfolio/allocation_targets/model.rs
@@ -247,6 +247,10 @@ pub enum RebalanceWarningKind {
     MissingQuote,
     NoBuyCandidate,
     WholeShareResidue,
+    /// Asset has no taxonomy assignments for the active taxonomy — skipped as buy candidate.
+    UnclassifiedAsset,
+    /// Asset has partial taxonomy weights (<100%) — known exposure used, remainder ignored.
+    PartialClassification,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/core/src/portfolio/allocation_targets/optimizer.rs
+++ b/crates/core/src/portfolio/allocation_targets/optimizer.rs
@@ -350,6 +350,11 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
                         *after_values.entry(cat_id.clone()).or_default() += expo * shares;
                     }
                 }
+            } else {
+                // Manual sleeve trade (no ticker): the deployed cash lands directly in
+                // the target category. Credit it so after-drift reflects the move.
+                *after_values.entry(trade.category_id.clone()).or_default() +=
+                    trade.estimated_amount;
             }
         }
         for cat in categories.iter().filter(|c| c.is_cash) {

--- a/crates/core/src/portfolio/allocation_targets/optimizer.rs
+++ b/crates/core/src/portfolio/allocation_targets/optimizer.rs
@@ -1,0 +1,365 @@
+use std::collections::HashMap;
+
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+
+use crate::errors::Result as CoreResult;
+
+use super::model::{
+    RebalanceGoal, RebalancePlan, RebalanceWarning, RebalanceWarningKind, SuggestedManualTrade,
+};
+
+// ── Input types ───────────────────────────────────────────────────────────────
+
+pub struct RebalanceProfile {
+    pub target_id: String,
+    pub drift_band_bps: i32,
+    pub rebalance_goal: RebalanceGoal,
+    pub min_trade_amount: Decimal,
+    pub whole_shares_only: bool,
+}
+
+pub struct CategoryState {
+    pub category_id: String,
+    pub category_name: String,
+    pub target_bps: i32,
+    pub current_value: Decimal,
+    pub is_cash: bool,
+    pub is_required: bool,
+}
+
+pub struct AssetCandidate {
+    pub holding_id: String,
+    pub asset_id: String,
+    pub symbol: String,
+    pub name: Option<String>,
+    pub price: Decimal,
+    /// Value added per share in base currency, keyed by category_id.
+    /// __UNKNOWN__ excluded. May sum to less than price (partial classification).
+    pub exposure_per_share: HashMap<String, Decimal>,
+}
+
+pub struct RebalanceInput {
+    pub profile: RebalanceProfile,
+    pub available_cash: Decimal,
+    pub total_value: Decimal,
+    pub categories: Vec<CategoryState>,
+    pub candidates: Vec<AssetCandidate>,
+    /// Pre-populated classification warnings (UnclassifiedAsset, PartialClassification).
+    pub warnings: Vec<RebalanceWarning>,
+}
+
+// ── Trait ─────────────────────────────────────────────────────────────────────
+
+pub trait RebalanceOptimizer: Send + Sync {
+    fn plan(&self, input: RebalanceInput) -> CoreResult<RebalancePlan>;
+}
+
+// ── DriftPriorityOptimizer ────────────────────────────────────────────────────
+
+/// Greedy exposure-aware planner: each iteration buys 1 share of the asset that
+/// maximises total drift reduction per dollar across all taxonomy categories.
+pub struct DriftPriorityOptimizer;
+
+impl DriftPriorityOptimizer {
+    /// Σ |current_bps[c] - target_bps[c]| for required non-cash categories.
+    fn total_drift(
+        values: &HashMap<String, Decimal>,
+        categories: &[CategoryState],
+        total_value: Decimal,
+    ) -> Decimal {
+        if total_value == Decimal::ZERO {
+            return Decimal::ZERO;
+        }
+        let scale = dec!(10000);
+        categories
+            .iter()
+            .filter(|c| c.is_required && !c.is_cash)
+            .map(|c| {
+                let v = values.get(&c.category_id).copied().unwrap_or_default();
+                let bps = v / total_value * scale;
+                (bps - Decimal::from(c.target_bps)).abs()
+            })
+            .sum()
+    }
+
+    /// Same as `total_drift` but adds `exposure` delta without mutating state.
+    fn total_drift_with_buy(
+        values: &HashMap<String, Decimal>,
+        categories: &[CategoryState],
+        total_value: Decimal,
+        exposure: &HashMap<String, Decimal>,
+    ) -> Decimal {
+        if total_value == Decimal::ZERO {
+            return Decimal::ZERO;
+        }
+        let scale = dec!(10000);
+        categories
+            .iter()
+            .filter(|c| c.is_required && !c.is_cash)
+            .map(|c| {
+                let base = values.get(&c.category_id).copied().unwrap_or_default();
+                let delta = exposure.get(&c.category_id).copied().unwrap_or_default();
+                let bps = (base + delta) / total_value * scale;
+                (bps - Decimal::from(c.target_bps)).abs()
+            })
+            .sum()
+    }
+
+    /// Max |current_bps[c] - target_bps[c]| for required categories (including cash).
+    fn max_drift_bps(
+        values: &HashMap<String, Decimal>,
+        categories: &[CategoryState],
+        total_value: Decimal,
+    ) -> i32 {
+        if total_value == Decimal::ZERO {
+            return 0;
+        }
+        let scale = dec!(10000);
+        categories
+            .iter()
+            .filter(|c| c.is_required)
+            .map(|c| {
+                let v = values.get(&c.category_id).copied().unwrap_or_default();
+                let bps: i32 = (v / total_value * scale)
+                    .round()
+                    .to_string()
+                    .parse()
+                    .unwrap_or(0);
+                (bps - c.target_bps).abs()
+            })
+            .max()
+            .unwrap_or(0)
+    }
+}
+
+impl RebalanceOptimizer for DriftPriorityOptimizer {
+    fn plan(&self, input: RebalanceInput) -> CoreResult<RebalancePlan> {
+        let RebalanceInput {
+            profile,
+            available_cash,
+            total_value,
+            categories,
+            mut candidates,
+            mut warnings,
+        } = input;
+
+        if total_value == Decimal::ZERO && available_cash == Decimal::ZERO {
+            return Ok(RebalancePlan {
+                target_id: profile.target_id,
+                available_cash: Decimal::ZERO,
+                cash_used: Decimal::ZERO,
+                cash_remaining: Decimal::ZERO,
+                max_drift_bps_before: 0,
+                max_drift_bps_after: 0,
+                trades: vec![],
+                warnings,
+            });
+        }
+
+        let scale = dec!(10000);
+        let drift_band = Decimal::from(profile.drift_band_bps);
+
+        let mut values: HashMap<String, Decimal> = categories
+            .iter()
+            .map(|c| (c.category_id.clone(), c.current_value))
+            .collect();
+
+        let max_drift_before = Self::max_drift_bps(&values, &categories, total_value);
+
+        // Emit NoBuyCandidate for required underweight categories with no candidate coverage.
+        // Track them so sleeve-level dollar trades can be added after the greedy.
+        let mut no_candidate_categories: Vec<&CategoryState> = Vec::new();
+        for cat in categories.iter().filter(|c| c.is_required && !c.is_cash) {
+            let desired_bps = match profile.rebalance_goal {
+                RebalanceGoal::ExactTarget => Decimal::from(cat.target_bps),
+                RebalanceGoal::NearestBand => {
+                    (Decimal::from(cat.target_bps) - drift_band).max(Decimal::ZERO)
+                }
+            };
+            let desired_value = desired_bps / scale * total_value;
+            if cat.current_value >= desired_value {
+                continue;
+            }
+            let covered = candidates
+                .iter()
+                .any(|c| c.exposure_per_share.contains_key(&cat.category_id));
+            if !covered {
+                let shortfall = (desired_value - cat.current_value).max(Decimal::ZERO);
+                warnings.push(RebalanceWarning {
+                    kind: RebalanceWarningKind::NoBuyCandidate,
+                    category_id: cat.category_id.clone(),
+                    message: format!(
+                        "No classifiable holdings in {}. Allocate {:.2} to this category manually.",
+                        cat.category_name,
+                        shortfall.min(available_cash),
+                    ),
+                });
+                no_candidate_categories.push(cat);
+            }
+        }
+
+        // Sort by price ASC for deterministic tie-breaking on equal scores.
+        candidates.sort_by(|a, b| a.price.cmp(&b.price));
+
+        let mut shares_bought: Vec<Decimal> = vec![Decimal::ZERO; candidates.len()];
+        let mut cash = available_cash;
+
+        // Greedy: each iteration buys 1 share of the candidate with the highest
+        // (drift_before - drift_after) / price score.
+        loop {
+            if cash <= Decimal::ZERO {
+                break;
+            }
+            let drift_before = Self::total_drift(&values, &categories, total_value);
+
+            let mut best_score = Decimal::ZERO;
+            let mut best_idx: Option<usize> = None;
+
+            for (idx, candidate) in candidates.iter().enumerate() {
+                if cash < candidate.price {
+                    continue;
+                }
+                let drift_after = Self::total_drift_with_buy(
+                    &values,
+                    &categories,
+                    total_value,
+                    &candidate.exposure_per_share,
+                );
+                let improvement = drift_before - drift_after;
+                if improvement <= Decimal::ZERO {
+                    continue;
+                }
+                let score = improvement / candidate.price;
+                // candidates sorted price ASC — first found wins ties (cheaper asset preferred)
+                if score > best_score {
+                    best_score = score;
+                    best_idx = Some(idx);
+                }
+            }
+
+            let Some(idx) = best_idx else {
+                break;
+            };
+
+            let candidate = &candidates[idx];
+            for (cat_id, expo) in &candidate.exposure_per_share {
+                *values.entry(cat_id.clone()).or_default() += expo;
+            }
+            cash -= candidate.price;
+            shares_bought[idx] += Decimal::ONE;
+        }
+
+        // Build trades from accumulated shares; apply min_trade_amount filter.
+        let mut trades: Vec<SuggestedManualTrade> = Vec::new();
+
+        for (idx, &shares) in shares_bought.iter().enumerate() {
+            if shares == Decimal::ZERO {
+                continue;
+            }
+            let candidate = &candidates[idx];
+            let estimated_amount = shares * candidate.price;
+
+            if profile.min_trade_amount > Decimal::ZERO
+                && estimated_amount < profile.min_trade_amount
+            {
+                continue;
+            }
+
+            // Primary category = category with the largest per-share exposure.
+            let (primary_cat_id, primary_cat_name) = candidate
+                .exposure_per_share
+                .iter()
+                .max_by(|(_, a), (_, b)| a.cmp(b))
+                .map(|(cat_id, _)| {
+                    let name = categories
+                        .iter()
+                        .find(|c| &c.category_id == cat_id)
+                        .map(|c| c.category_name.clone())
+                        .unwrap_or_else(|| cat_id.clone());
+                    (cat_id.clone(), name)
+                })
+                .unwrap_or_else(|| ("unknown".to_string(), "Unknown".to_string()));
+
+            trades.push(SuggestedManualTrade {
+                action: "buy".to_string(),
+                category_id: primary_cat_id,
+                category_name: primary_cat_name,
+                asset_id: Some(candidate.asset_id.clone()),
+                symbol: Some(candidate.symbol.clone()),
+                name: candidate.name.clone(),
+                quantity: Some(shares),
+                estimated_price: Some(candidate.price),
+                estimated_amount,
+                reason: format!("{} improves portfolio drift.", candidate.symbol),
+            });
+        }
+
+        // Sleeve-level dollar trades for uncovered underweight categories.
+        for cat in &no_candidate_categories {
+            let desired_bps = match profile.rebalance_goal {
+                RebalanceGoal::ExactTarget => Decimal::from(cat.target_bps),
+                RebalanceGoal::NearestBand => {
+                    (Decimal::from(cat.target_bps) - drift_band).max(Decimal::ZERO)
+                }
+            };
+            let shortfall =
+                ((desired_bps / scale * total_value) - cat.current_value).max(Decimal::ZERO);
+            let amount = shortfall.min(available_cash);
+            if amount > Decimal::ZERO {
+                trades.push(SuggestedManualTrade {
+                    action: "buy".to_string(),
+                    category_id: cat.category_id.clone(),
+                    category_name: cat.category_name.clone(),
+                    asset_id: None,
+                    symbol: None,
+                    name: None,
+                    quantity: None,
+                    estimated_price: None,
+                    estimated_amount: amount,
+                    reason: format!(
+                        "Category {} is underweight. Allocate manually.",
+                        cat.category_name
+                    ),
+                });
+            }
+        }
+
+        // cash_used = sum of recommended trade amounts (post min_trade filter).
+        // Keeps cash_used consistent with what the user will actually execute.
+        let cash_used: Decimal = trades.iter().map(|t| t.estimated_amount).sum();
+        let cash_remaining = available_cash - cash_used;
+
+        // After-drift: recompute from initial state + recommended trades only.
+        let mut after_values: HashMap<String, Decimal> = categories
+            .iter()
+            .map(|c| (c.category_id.clone(), c.current_value))
+            .collect();
+        for trade in &trades {
+            if let Some(asset_id) = &trade.asset_id {
+                if let Some(candidate) = candidates.iter().find(|c| &c.asset_id == asset_id) {
+                    let shares = trade.quantity.unwrap_or(Decimal::ZERO);
+                    for (cat_id, expo) in &candidate.exposure_per_share {
+                        *after_values.entry(cat_id.clone()).or_default() += expo * shares;
+                    }
+                }
+            }
+        }
+        for cat in categories.iter().filter(|c| c.is_cash) {
+            let entry = after_values.entry(cat.category_id.clone()).or_default();
+            *entry = (*entry - cash_used).max(Decimal::ZERO);
+        }
+        let max_drift_after = Self::max_drift_bps(&after_values, &categories, total_value);
+
+        Ok(RebalancePlan {
+            target_id: profile.target_id,
+            available_cash,
+            cash_used,
+            cash_remaining,
+            max_drift_bps_before: max_drift_before,
+            max_drift_bps_after: max_drift_after,
+            trades,
+            warnings,
+        })
+    }
+}

--- a/crates/core/src/portfolio/allocation_targets/optimizer.rs
+++ b/crates/core/src/portfolio/allocation_targets/optimizer.rs
@@ -199,8 +199,14 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
             }
         }
 
-        // Sort by price ASC for deterministic tie-breaking on equal scores.
-        candidates.sort_by_key(|c| c.price);
+        // Sort by price ASC for tie-breaking on equal scores, then by (symbol, asset_id)
+        // so equal-price candidates have a stable, reproducible order across runs.
+        candidates.sort_by(|a, b| {
+            a.price
+                .cmp(&b.price)
+                .then_with(|| a.symbol.cmp(&b.symbol))
+                .then_with(|| a.asset_id.cmp(&b.asset_id))
+        });
 
         let mut shares_bought: Vec<Decimal> = vec![Decimal::ZERO; candidates.len()];
         let mut cash = available_cash;

--- a/crates/core/src/portfolio/allocation_targets/optimizer.rs
+++ b/crates/core/src/portfolio/allocation_targets/optimizer.rs
@@ -279,11 +279,43 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
             };
 
             let candidate = &candidates[idx];
-            for (cat_id, expo) in &candidate.exposure_per_share {
-                *values.entry(cat_id.clone()).or_default() += expo;
+
+            // Batch: buy as many whole shares of the chosen candidate as stay within the
+            // current linear region — up to the point where a category it funds reaches
+            // its desired value (exact target, or band edge under NearestBand). The
+            // per-share drift improvement is constant across that region, so buying the
+            // whole batch is equivalent to that many single-share iterations, but avoids
+            // an O(cash / price) loop for cheap assets with large cash balances. The
+            // boundary share (which may overshoot) is left to the next scan to evaluate.
+            let mut batch = (cash / candidate.price).floor().max(Decimal::ONE);
+            for cat in categories.iter().filter(|c| c.is_required && !c.is_cash) {
+                let Some(expo) = candidate.exposure_per_share.get(&cat.category_id) else {
+                    continue;
+                };
+                if *expo <= Decimal::ZERO {
+                    continue;
+                }
+                let desired_bps = match profile.rebalance_goal {
+                    RebalanceGoal::ExactTarget => Decimal::from(cat.target_bps),
+                    RebalanceGoal::NearestBand => {
+                        (Decimal::from(cat.target_bps) - drift_band).max(Decimal::ZERO)
+                    }
+                };
+                let desired_value = desired_bps / scale * total_value;
+                let base = values.get(&cat.category_id).copied().unwrap_or_default();
+                if base < desired_value {
+                    let cap = ((desired_value - base) / expo).floor().max(Decimal::ONE);
+                    if cap < batch {
+                        batch = cap;
+                    }
+                }
             }
-            cash -= candidate.price;
-            shares_bought[idx] += Decimal::ONE;
+
+            for (cat_id, expo) in &candidate.exposure_per_share {
+                *values.entry(cat_id.clone()).or_default() += expo * batch;
+            }
+            cash -= candidate.price * batch;
+            shares_bought[idx] += batch;
         }
 
         // Fractional last slice: when the profile allows fractional shares, deploy the

--- a/crates/core/src/portfolio/allocation_targets/optimizer.rs
+++ b/crates/core/src/portfolio/allocation_targets/optimizer.rs
@@ -62,6 +62,61 @@ pub trait RebalanceOptimizer: Send + Sync {
 pub struct DriftPriorityOptimizer;
 
 impl DriftPriorityOptimizer {
+    fn desired_bps_for_goal(target_bps: i32, goal: &RebalanceGoal, band: Decimal) -> Decimal {
+        match goal {
+            RebalanceGoal::ExactTarget => Decimal::from(target_bps),
+            RebalanceGoal::NearestBand => (Decimal::from(target_bps) - band).max(Decimal::ZERO),
+        }
+    }
+
+    fn cap_fractional_shares_to_next_bend(
+        candidate: &AssetCandidate,
+        cash: Decimal,
+        values: &HashMap<String, Decimal>,
+        categories: &[CategoryState],
+        total_value: Decimal,
+        goal: &RebalanceGoal,
+        band: Decimal,
+    ) -> Decimal {
+        if candidate.price <= Decimal::ZERO || cash <= Decimal::ZERO {
+            return Decimal::ZERO;
+        }
+
+        let scale = dec!(10000);
+        let mut shares = cash / candidate.price;
+
+        for cat in categories.iter().filter(|c| c.is_required && !c.is_cash) {
+            let Some(expo) = candidate.exposure_per_share.get(&cat.category_id) else {
+                continue;
+            };
+            if *expo <= Decimal::ZERO {
+                continue;
+            }
+
+            let desired_bps = Self::desired_bps_for_goal(cat.target_bps, goal, band);
+            let desired_value = desired_bps / scale * total_value;
+            let base = values.get(&cat.category_id).copied().unwrap_or_default();
+            if base < desired_value {
+                let cap = (desired_value - base) / expo;
+                if cap < shares {
+                    shares = cap;
+                }
+            }
+        }
+
+        shares.max(Decimal::ZERO)
+    }
+
+    fn exposure_delta(
+        exposure_per_share: &HashMap<String, Decimal>,
+        shares: Decimal,
+    ) -> HashMap<String, Decimal> {
+        exposure_per_share
+            .iter()
+            .map(|(cat_id, e)| (cat_id.clone(), e * shares))
+            .collect()
+    }
+
     /// Per-category drift the planner tries to minimise.
     ///
     /// `ExactTarget` measures distance to the exact target. `NearestBand` only counts
@@ -234,7 +289,9 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
         let mut cash = available_cash;
 
         // Greedy: each iteration buys 1 share of the candidate with the highest
-        // (drift_before - drift_after) / price score.
+        // (drift_before - drift_after) / price score. Fractional mode uses the
+        // same scoring, but the candidate quantity can be a decimal and is capped
+        // at the next target/band bend.
         loop {
             if cash <= Decimal::ZERO {
                 break;
@@ -249,16 +306,45 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
 
             let mut best_score = Decimal::ZERO;
             let mut best_idx: Option<usize> = None;
+            let mut best_fractional_shares = Decimal::ZERO;
+            let mut improving_whole_share_candidates = 0usize;
 
             for (idx, candidate) in candidates.iter().enumerate() {
-                if cash < candidate.price {
-                    continue;
-                }
+                let (shares_to_score, amount_to_score, exposure_to_score) =
+                    if profile.whole_shares_only {
+                        if cash < candidate.price {
+                            continue;
+                        }
+                        (
+                            Decimal::ONE,
+                            candidate.price,
+                            candidate.exposure_per_share.clone(),
+                        )
+                    } else {
+                        let shares = Self::cap_fractional_shares_to_next_bend(
+                            candidate,
+                            cash,
+                            &values,
+                            &categories,
+                            total_value,
+                            &profile.rebalance_goal,
+                            drift_band,
+                        );
+                        if shares <= Decimal::ZERO {
+                            continue;
+                        }
+                        (
+                            shares,
+                            candidate.price * shares,
+                            Self::exposure_delta(&candidate.exposure_per_share, shares),
+                        )
+                    };
+
                 let drift_after = Self::total_drift_with_buy(
                     &values,
                     &categories,
                     total_value,
-                    &candidate.exposure_per_share,
+                    &exposure_to_score,
                     &profile.rebalance_goal,
                     drift_band,
                 );
@@ -266,11 +352,15 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
                 if improvement <= Decimal::ZERO {
                     continue;
                 }
-                let score = improvement / candidate.price;
+                if profile.whole_shares_only {
+                    improving_whole_share_candidates += 1;
+                }
+                let score = improvement / amount_to_score;
                 // candidates sorted price ASC — first found wins ties (cheaper asset preferred)
                 if score > best_score {
                     best_score = score;
                     best_idx = Some(idx);
+                    best_fractional_shares = shares_to_score;
                 }
             }
 
@@ -280,33 +370,42 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
 
             let candidate = &candidates[idx];
 
-            // Batch: buy as many whole shares of the chosen candidate as stay within the
-            // current linear region — up to the point where a category it funds reaches
-            // its desired value (exact target, or band edge under NearestBand). The
-            // per-share drift improvement is constant across that region, so buying the
-            // whole batch is equivalent to that many single-share iterations, but avoids
-            // an O(cash / price) loop for cheap assets with large cash balances. The
-            // boundary share (which may overshoot) is left to the next scan to evaluate.
-            let mut batch = (cash / candidate.price).floor().max(Decimal::ONE);
-            for cat in categories.iter().filter(|c| c.is_required && !c.is_cash) {
-                let Some(expo) = candidate.exposure_per_share.get(&cat.category_id) else {
-                    continue;
-                };
-                if *expo <= Decimal::ZERO {
-                    continue;
+            if !profile.whole_shares_only {
+                for (cat_id, expo) in &candidate.exposure_per_share {
+                    *values.entry(cat_id.clone()).or_default() += expo * best_fractional_shares;
                 }
-                let desired_bps = match profile.rebalance_goal {
-                    RebalanceGoal::ExactTarget => Decimal::from(cat.target_bps),
-                    RebalanceGoal::NearestBand => {
-                        (Decimal::from(cat.target_bps) - drift_band).max(Decimal::ZERO)
+                cash -= candidate.price * best_fractional_shares;
+                shares_bought[idx] += best_fractional_shares;
+                continue;
+            }
+
+            // Batch only when this is the sole improving whole-share candidate. If
+            // multiple candidates improve drift, buy one share and re-score to preserve
+            // strict greedy equivalence in coupled multi-category cases.
+            let mut batch = Decimal::ONE;
+            if improving_whole_share_candidates == 1 {
+                // With no competing improving candidate, per-share improvement is
+                // constant until the selected asset reaches the next target/band bend.
+                batch = (cash / candidate.price).floor().max(Decimal::ONE);
+                for cat in categories.iter().filter(|c| c.is_required && !c.is_cash) {
+                    let Some(expo) = candidate.exposure_per_share.get(&cat.category_id) else {
+                        continue;
+                    };
+                    if *expo <= Decimal::ZERO {
+                        continue;
                     }
-                };
-                let desired_value = desired_bps / scale * total_value;
-                let base = values.get(&cat.category_id).copied().unwrap_or_default();
-                if base < desired_value {
-                    let cap = ((desired_value - base) / expo).floor().max(Decimal::ONE);
-                    if cap < batch {
-                        batch = cap;
+                    let desired_bps = Self::desired_bps_for_goal(
+                        cat.target_bps,
+                        &profile.rebalance_goal,
+                        drift_band,
+                    );
+                    let desired_value = desired_bps / scale * total_value;
+                    let base = values.get(&cat.category_id).copied().unwrap_or_default();
+                    if base < desired_value {
+                        let cap = ((desired_value - base) / expo).floor().max(Decimal::ONE);
+                        if cap < batch {
+                            batch = cap;
+                        }
                     }
                 }
             }
@@ -316,83 +415,6 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
             }
             cash -= candidate.price * batch;
             shares_bought[idx] += batch;
-        }
-
-        // Fractional last slice: when the profile allows fractional shares, deploy the
-        // cash left over once no whole share fits. Pick the candidate whose fractional
-        // buy reduces drift the most, capping the size so no category overshoots its
-        // desired value (the exact target, or the band edge under NearestBand).
-        if !profile.whole_shares_only && cash > Decimal::ZERO {
-            let drift_before = Self::total_drift(
-                &values,
-                &categories,
-                total_value,
-                &profile.rebalance_goal,
-                drift_band,
-            );
-
-            let mut best_idx: Option<usize> = None;
-            let mut best_shares = Decimal::ZERO;
-            let mut best_improvement = Decimal::ZERO;
-
-            for (idx, candidate) in candidates.iter().enumerate() {
-                let mut max_shares = cash / candidate.price;
-                for cat in categories.iter().filter(|c| c.is_required && !c.is_cash) {
-                    let Some(expo) = candidate.exposure_per_share.get(&cat.category_id) else {
-                        continue;
-                    };
-                    if *expo <= Decimal::ZERO {
-                        continue;
-                    }
-                    let desired_bps = match profile.rebalance_goal {
-                        RebalanceGoal::ExactTarget => Decimal::from(cat.target_bps),
-                        RebalanceGoal::NearestBand => {
-                            (Decimal::from(cat.target_bps) - drift_band).max(Decimal::ZERO)
-                        }
-                    };
-                    let desired_value = desired_bps / scale * total_value;
-                    let base = values.get(&cat.category_id).copied().unwrap_or_default();
-                    if base >= desired_value {
-                        max_shares = Decimal::ZERO;
-                        break;
-                    }
-                    let cap = (desired_value - base) / expo;
-                    if cap < max_shares {
-                        max_shares = cap;
-                    }
-                }
-                if max_shares <= Decimal::ZERO {
-                    continue;
-                }
-                let delta: HashMap<String, Decimal> = candidate
-                    .exposure_per_share
-                    .iter()
-                    .map(|(cat_id, e)| (cat_id.clone(), e * max_shares))
-                    .collect();
-                let drift_after = Self::total_drift_with_buy(
-                    &values,
-                    &categories,
-                    total_value,
-                    &delta,
-                    &profile.rebalance_goal,
-                    drift_band,
-                );
-                let improvement = drift_before - drift_after;
-                if improvement > best_improvement {
-                    best_improvement = improvement;
-                    best_shares = max_shares;
-                    best_idx = Some(idx);
-                }
-            }
-
-            if let Some(idx) = best_idx {
-                let candidate = &candidates[idx];
-                for (cat_id, expo) in &candidate.exposure_per_share {
-                    *values.entry(cat_id.clone()).or_default() += expo * best_shares;
-                }
-                cash -= candidate.price * best_shares;
-                shares_bought[idx] += best_shares;
-            }
         }
 
         // Build trades from accumulated shares; apply min_trade_amount filter.
@@ -441,19 +463,16 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
         }
 
         // Sleeve-level dollar trades for uncovered underweight categories.
-        // Draw from the cash left after the greedy whole-share buys, decrementing as we
-        // go, so multiple uncovered categories can never collectively overspend.
-        let mut manual_cash = cash;
+        // Draw from cash left after kept asset trades. Greedy selections below the
+        // min-trade threshold are dropped, so they must not starve manual sleeve trades.
+        let mut manual_cash =
+            available_cash - trades.iter().map(|t| t.estimated_amount).sum::<Decimal>();
         for cat in &no_candidate_categories {
             if manual_cash <= Decimal::ZERO {
                 break;
             }
-            let desired_bps = match profile.rebalance_goal {
-                RebalanceGoal::ExactTarget => Decimal::from(cat.target_bps),
-                RebalanceGoal::NearestBand => {
-                    (Decimal::from(cat.target_bps) - drift_band).max(Decimal::ZERO)
-                }
-            };
+            let desired_bps =
+                Self::desired_bps_for_goal(cat.target_bps, &profile.rebalance_goal, drift_band);
             let shortfall =
                 ((desired_bps / scale * total_value) - cat.current_value).max(Decimal::ZERO);
             let amount = shortfall.min(manual_cash);

--- a/crates/core/src/portfolio/allocation_targets/optimizer.rs
+++ b/crates/core/src/portfolio/allocation_targets/optimizer.rs
@@ -192,8 +192,7 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
                     category_id: cat.category_id.clone(),
                     message: format!(
                         "No classifiable holdings in {}. Allocate {:.2} to this category manually.",
-                        cat.category_name,
-                        shortfall.min(available_cash),
+                        cat.category_name, shortfall,
                     ),
                 });
                 no_candidate_categories.push(cat);
@@ -297,7 +296,13 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
         }
 
         // Sleeve-level dollar trades for uncovered underweight categories.
+        // Draw from the cash left after the greedy whole-share buys, decrementing as we
+        // go, so multiple uncovered categories can never collectively overspend.
+        let mut manual_cash = cash;
         for cat in &no_candidate_categories {
+            if manual_cash <= Decimal::ZERO {
+                break;
+            }
             let desired_bps = match profile.rebalance_goal {
                 RebalanceGoal::ExactTarget => Decimal::from(cat.target_bps),
                 RebalanceGoal::NearestBand => {
@@ -306,8 +311,9 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
             };
             let shortfall =
                 ((desired_bps / scale * total_value) - cat.current_value).max(Decimal::ZERO);
-            let amount = shortfall.min(available_cash);
+            let amount = shortfall.min(manual_cash);
             if amount > Decimal::ZERO {
+                manual_cash -= amount;
                 trades.push(SuggestedManualTrade {
                     action: "buy".to_string(),
                     category_id: cat.category_id.clone(),

--- a/crates/core/src/portfolio/allocation_targets/optimizer.rs
+++ b/crates/core/src/portfolio/allocation_targets/optimizer.rs
@@ -286,6 +286,83 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
             shares_bought[idx] += Decimal::ONE;
         }
 
+        // Fractional last slice: when the profile allows fractional shares, deploy the
+        // cash left over once no whole share fits. Pick the candidate whose fractional
+        // buy reduces drift the most, capping the size so no category overshoots its
+        // desired value (the exact target, or the band edge under NearestBand).
+        if !profile.whole_shares_only && cash > Decimal::ZERO {
+            let drift_before = Self::total_drift(
+                &values,
+                &categories,
+                total_value,
+                &profile.rebalance_goal,
+                drift_band,
+            );
+
+            let mut best_idx: Option<usize> = None;
+            let mut best_shares = Decimal::ZERO;
+            let mut best_improvement = Decimal::ZERO;
+
+            for (idx, candidate) in candidates.iter().enumerate() {
+                let mut max_shares = cash / candidate.price;
+                for cat in categories.iter().filter(|c| c.is_required && !c.is_cash) {
+                    let Some(expo) = candidate.exposure_per_share.get(&cat.category_id) else {
+                        continue;
+                    };
+                    if *expo <= Decimal::ZERO {
+                        continue;
+                    }
+                    let desired_bps = match profile.rebalance_goal {
+                        RebalanceGoal::ExactTarget => Decimal::from(cat.target_bps),
+                        RebalanceGoal::NearestBand => {
+                            (Decimal::from(cat.target_bps) - drift_band).max(Decimal::ZERO)
+                        }
+                    };
+                    let desired_value = desired_bps / scale * total_value;
+                    let base = values.get(&cat.category_id).copied().unwrap_or_default();
+                    if base >= desired_value {
+                        max_shares = Decimal::ZERO;
+                        break;
+                    }
+                    let cap = (desired_value - base) / expo;
+                    if cap < max_shares {
+                        max_shares = cap;
+                    }
+                }
+                if max_shares <= Decimal::ZERO {
+                    continue;
+                }
+                let delta: HashMap<String, Decimal> = candidate
+                    .exposure_per_share
+                    .iter()
+                    .map(|(cat_id, e)| (cat_id.clone(), e * max_shares))
+                    .collect();
+                let drift_after = Self::total_drift_with_buy(
+                    &values,
+                    &categories,
+                    total_value,
+                    &delta,
+                    &profile.rebalance_goal,
+                    drift_band,
+                );
+                let improvement = drift_before - drift_after;
+                if improvement > best_improvement {
+                    best_improvement = improvement;
+                    best_shares = max_shares;
+                    best_idx = Some(idx);
+                }
+            }
+
+            if let Some(idx) = best_idx {
+                let candidate = &candidates[idx];
+                for (cat_id, expo) in &candidate.exposure_per_share {
+                    *values.entry(cat_id.clone()).or_default() += expo * best_shares;
+                }
+                cash -= candidate.price * best_shares;
+                shares_bought[idx] += best_shares;
+            }
+        }
+
         // Build trades from accumulated shares; apply min_trade_amount filter.
         let mut trades: Vec<SuggestedManualTrade> = Vec::new();
 

--- a/crates/core/src/portfolio/allocation_targets/optimizer.rs
+++ b/crates/core/src/portfolio/allocation_targets/optimizer.rs
@@ -154,6 +154,7 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
                 max_drift_bps_after: 0,
                 trades: vec![],
                 warnings,
+                after_bps_by_category: HashMap::new(),
             });
         }
 
@@ -351,6 +352,22 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
         }
         let max_drift_after = Self::max_drift_bps(&after_values, &categories, total_value);
 
+        let after_bps_by_category: HashMap<String, i32> = if total_value > Decimal::ZERO {
+            after_values
+                .iter()
+                .map(|(cat_id, val)| {
+                    let bps: i32 = (*val / total_value * scale)
+                        .round()
+                        .to_string()
+                        .parse()
+                        .unwrap_or(0);
+                    (cat_id.clone(), bps)
+                })
+                .collect()
+        } else {
+            HashMap::new()
+        };
+
         Ok(RebalancePlan {
             target_id: profile.target_id,
             available_cash,
@@ -360,6 +377,7 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
             max_drift_bps_after: max_drift_after,
             trades,
             warnings,
+            after_bps_by_category,
         })
     }
 }

--- a/crates/core/src/portfolio/allocation_targets/optimizer.rs
+++ b/crates/core/src/portfolio/allocation_targets/optimizer.rs
@@ -201,7 +201,7 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
         }
 
         // Sort by price ASC for deterministic tie-breaking on equal scores.
-        candidates.sort_by(|a, b| a.price.cmp(&b.price));
+        candidates.sort_by_key(|c| c.price);
 
         let mut shares_bought: Vec<Decimal> = vec![Decimal::ZERO; candidates.len()];
         let mut cash = available_cash;

--- a/crates/core/src/portfolio/allocation_targets/optimizer.rs
+++ b/crates/core/src/portfolio/allocation_targets/optimizer.rs
@@ -62,11 +62,31 @@ pub trait RebalanceOptimizer: Send + Sync {
 pub struct DriftPriorityOptimizer;
 
 impl DriftPriorityOptimizer {
-    /// Σ |current_bps[c] - target_bps[c]| for required non-cash categories.
+    /// Per-category drift the planner tries to minimise.
+    ///
+    /// `ExactTarget` measures distance to the exact target. `NearestBand` only counts
+    /// the distance *outside* the [target ± band] tolerance, so once a category is
+    /// inside its band it contributes zero and the greedy stops deploying into it.
+    fn category_drift(
+        bps: Decimal,
+        target_bps: i32,
+        goal: &RebalanceGoal,
+        band: Decimal,
+    ) -> Decimal {
+        let dist = (bps - Decimal::from(target_bps)).abs();
+        match goal {
+            RebalanceGoal::ExactTarget => dist,
+            RebalanceGoal::NearestBand => (dist - band).max(Decimal::ZERO),
+        }
+    }
+
+    /// Σ drift for required non-cash categories (band-aware via `category_drift`).
     fn total_drift(
         values: &HashMap<String, Decimal>,
         categories: &[CategoryState],
         total_value: Decimal,
+        goal: &RebalanceGoal,
+        band: Decimal,
     ) -> Decimal {
         if total_value == Decimal::ZERO {
             return Decimal::ZERO;
@@ -78,7 +98,7 @@ impl DriftPriorityOptimizer {
             .map(|c| {
                 let v = values.get(&c.category_id).copied().unwrap_or_default();
                 let bps = v / total_value * scale;
-                (bps - Decimal::from(c.target_bps)).abs()
+                Self::category_drift(bps, c.target_bps, goal, band)
             })
             .sum()
     }
@@ -89,6 +109,8 @@ impl DriftPriorityOptimizer {
         categories: &[CategoryState],
         total_value: Decimal,
         exposure: &HashMap<String, Decimal>,
+        goal: &RebalanceGoal,
+        band: Decimal,
     ) -> Decimal {
         if total_value == Decimal::ZERO {
             return Decimal::ZERO;
@@ -101,7 +123,7 @@ impl DriftPriorityOptimizer {
                 let base = values.get(&c.category_id).copied().unwrap_or_default();
                 let delta = exposure.get(&c.category_id).copied().unwrap_or_default();
                 let bps = (base + delta) / total_value * scale;
-                (bps - Decimal::from(c.target_bps)).abs()
+                Self::category_drift(bps, c.target_bps, goal, band)
             })
             .sum()
     }
@@ -217,7 +239,13 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
             if cash <= Decimal::ZERO {
                 break;
             }
-            let drift_before = Self::total_drift(&values, &categories, total_value);
+            let drift_before = Self::total_drift(
+                &values,
+                &categories,
+                total_value,
+                &profile.rebalance_goal,
+                drift_band,
+            );
 
             let mut best_score = Decimal::ZERO;
             let mut best_idx: Option<usize> = None;
@@ -231,6 +259,8 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
                     &categories,
                     total_value,
                     &candidate.exposure_per_share,
+                    &profile.rebalance_goal,
+                    drift_band,
                 );
                 let improvement = drift_before - drift_after;
                 if improvement <= Decimal::ZERO {

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -1,18 +1,21 @@
 use async_trait::async_trait;
 use log::debug;
 use rust_decimal::Decimal;
-use rust_decimal_macros::dec;
+use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 
 use crate::errors::{Error as CoreError, Result as CoreResult};
-use crate::portfolio::allocation::AllocationServiceTrait;
-use crate::portfolio::holdings::{HoldingSummary, HoldingType, HoldingsServiceTrait};
+use crate::portfolio::allocation::{AllocationServiceTrait, HoldingAllocationContribution};
+use crate::portfolio::holdings::{HoldingType, HoldingsServiceTrait};
 
 use super::drift_service::DriftServiceTrait;
 use super::model::{
-    CalculateRebalancePlanInput, RebalanceGoal, RebalancePlan, RebalanceWarning,
-    RebalanceWarningKind, SuggestedManualTrade,
+    CalculateRebalancePlanInput, RebalancePlan, RebalanceWarning, RebalanceWarningKind,
+};
+use super::optimizer::{
+    AssetCandidate, CategoryState, DriftPriorityOptimizer, RebalanceInput, RebalanceOptimizer,
+    RebalanceProfile,
 };
 use super::target_service::AllocationTargetServiceTrait;
 
@@ -61,6 +64,116 @@ impl RebalanceService {
     fn currency_rounding_tolerance(currency: &str) -> Decimal {
         Decimal::ONE / Decimal::from(10_i64.pow(Self::currency_fraction_digits(currency)))
     }
+
+    /// Build `AssetCandidate` list from holdings + contributions.
+    ///
+    /// Rules (Afadil, #1036):
+    /// - Holdings with no taxonomy assignments → `__UNKNOWN__` in contributions → warn
+    ///   `UnclassifiedAsset`, skip.
+    /// - Holdings with partial weights (<100%) → contributions already include an
+    ///   `__UNKNOWN__` remainder row (from `AllocationService`). Use the known exposure
+    ///   as-is and warn `PartialClassification`. Do NOT normalise.
+    /// - Weights >100%: `AllocationService` normalises silently to 100%; we align with
+    ///   that behaviour for consistency. (Open question for Afadil in PR-B description.)
+    /// - Cash holdings: excluded from candidates.
+    /// - Holdings with no usable price: skip (warn `MissingQuote` if whole_shares_only).
+    fn build_candidates(
+        contributions: &[HoldingAllocationContribution],
+        price_by_holding: &HashMap<String, Decimal>,
+        whole_shares_only: bool,
+    ) -> (Vec<AssetCandidate>, Vec<RebalanceWarning>) {
+        // Group contributions by holding_id.
+        let mut by_holding: HashMap<&str, Vec<&HoldingAllocationContribution>> = HashMap::new();
+        for c in contributions {
+            by_holding.entry(c.holding_id.as_str()).or_default().push(c);
+        }
+
+        let mut candidates: Vec<AssetCandidate> = Vec::new();
+        let mut warnings: Vec<RebalanceWarning> = Vec::new();
+
+        for (holding_id, contribs) in by_holding {
+            // Skip cash holdings.
+            if contribs.iter().all(|c| c.holding_type == HoldingType::Cash) {
+                continue;
+            }
+
+            let repr = contribs[0];
+            let symbol = &repr.symbol;
+
+            // Check classification state.
+            let all_unknown = contribs.iter().all(|c| c.category_id == "__UNKNOWN__");
+            let has_unknown = contribs.iter().any(|c| c.category_id == "__UNKNOWN__");
+
+            if all_unknown {
+                warnings.push(RebalanceWarning {
+                    kind: RebalanceWarningKind::UnclassifiedAsset,
+                    category_id: "__UNKNOWN__".to_string(),
+                    message: format!(
+                        "{}: no taxonomy assignments for this taxonomy. Classify it to include in the drift planner.",
+                        symbol
+                    ),
+                });
+                continue;
+            }
+
+            if has_unknown {
+                warnings.push(RebalanceWarning {
+                    kind: RebalanceWarningKind::PartialClassification,
+                    category_id: repr.category_id.clone(),
+                    message: format!(
+                        "{}: partial classification (<100%). Known exposure used; unclassified remainder ignored.",
+                        symbol
+                    ),
+                });
+            }
+
+            // Derive price.
+            let price = match price_by_holding.get(holding_id) {
+                Some(&p) if p > Decimal::ZERO => p,
+                _ => {
+                    if whole_shares_only {
+                        warnings.push(RebalanceWarning {
+                            kind: RebalanceWarningKind::MissingQuote,
+                            category_id: repr.category_id.clone(),
+                            message: format!(
+                                "{}: no valid price for whole-share mode. Skipped.",
+                                symbol
+                            ),
+                        });
+                    }
+                    continue;
+                }
+            };
+
+            // Build exposure per share: contribution.value / quantity, excluding __UNKNOWN__.
+            let qty = repr.quantity;
+            if qty <= Decimal::ZERO {
+                continue;
+            }
+            let mut exposure_per_share: HashMap<String, Decimal> = HashMap::new();
+            for c in &contribs {
+                if c.category_id == "__UNKNOWN__" {
+                    continue;
+                }
+                *exposure_per_share.entry(c.category_id.clone()).or_default() += c.value / qty;
+            }
+
+            if exposure_per_share.is_empty() {
+                continue;
+            }
+
+            candidates.push(AssetCandidate {
+                holding_id: holding_id.to_string(),
+                asset_id: repr.asset_id.clone(),
+                symbol: symbol.clone(),
+                name: Some(repr.name.clone()),
+                price,
+                exposure_per_share,
+            });
+        }
+
+        (candidates, warnings)
+    }
 }
 
 #[async_trait]
@@ -79,23 +192,21 @@ impl RebalanceServiceTrait for RebalanceService {
             ));
         }
 
-        // M2 deploys tracked cash only. Compute the cash in scope from holdings
-        // (authoritative — does not trust a client-supplied figure) and reject
-        // attempts to deploy more than is actually held. Allow a tiny overage
-        // within the base currency's minor unit from frontend decimal
-        // serialization / currency rounding, but cap planning at the
-        // authoritative tracked cash value.
-        let cash_in_scope: Decimal = self
+        // Fetch holdings once — used for both cash check and price extraction.
+        let all_holdings = self
             .holdings_service
             .get_holdings_for_accounts(
                 &input.account_ids,
                 &input.base_currency,
                 &input.aggregated_account_id,
             )
-            .await?
+            .await?;
+
+        // Authoritative tracked cash in scope.
+        let cash_in_scope: Decimal = all_holdings
             .iter()
-            .filter(|holding| holding.holding_type == HoldingType::Cash)
-            .map(|holding| holding.market_value.base)
+            .filter(|h| h.holding_type == HoldingType::Cash)
+            .map(|h| h.market_value.base)
             .sum();
 
         let available_cash = if input.available_cash > cash_in_scope {
@@ -113,7 +224,7 @@ impl RebalanceServiceTrait for RebalanceService {
             input.available_cash
         };
 
-        // --- 1. Load profile -------------------------------------------------
+        // Load profile.
         let profile = self
             .allocation_target_service
             .get_target(&input.target_id)?
@@ -124,7 +235,7 @@ impl RebalanceServiceTrait for RebalanceService {
                 )))
             })?;
 
-        // --- 2. Drift report (reuse M1 DriftService) -------------------------
+        // Drift report — provides total_value and per-category target/current data.
         let drift = self
             .drift_service
             .get_drift_report_for_target(
@@ -136,14 +247,10 @@ impl RebalanceServiceTrait for RebalanceService {
             .await?;
 
         let total_value = drift.total_value;
-        let max_drift_bps_before = drift.max_drift_bps;
-        let min_trade_amount =
-            Decimal::from_str(&profile.min_trade_amount).unwrap_or(Decimal::ZERO);
 
-        // Nothing to plan against.
         if total_value == Decimal::ZERO && available_cash == Decimal::ZERO {
             return Ok(RebalancePlan {
-                target_id: input.target_id.clone(),
+                target_id: input.target_id,
                 available_cash: Decimal::ZERO,
                 cash_used: Decimal::ZERO,
                 cash_remaining: Decimal::ZERO,
@@ -154,371 +261,70 @@ impl RebalanceServiceTrait for RebalanceService {
             });
         }
 
-        // Total portfolio value stays constant — tracked cash is already inside the portfolio.
-        // Deploying cash moves value from CASH holdings into buy trades, it does not add new value.
-        let new_total_value = total_value;
-        let bps_scale = dec!(10000);
+        // Holding contributions for exposure vectors.
+        let taxonomy_contributions = self
+            .allocation_service
+            .get_holding_contributions_for_taxonomy_for_accounts(
+                &input.account_ids,
+                &input.base_currency,
+                &profile.taxonomy_id,
+                &input.aggregated_account_id,
+            )
+            .await?;
 
-        // --- 3. Compute shortfalls per underweight sleeve --------------------
-        // shortfall = dollars needed to reach desired level relative to new_total_value.
-        // nearest_band: bring to just inside band edge (target_bps - drift_band_bps).
-        // exact_target: bring to target_bps.
-        let drift_band = Decimal::from(profile.drift_band_bps);
-
-        struct SleeveShortfall {
-            category_id: String,
-            category_name: String,
-            shortfall: Decimal,
-        }
-
-        let mut sleeves: Vec<SleeveShortfall> = Vec::new();
-        for row in &drift.rows {
-            if row.is_cash {
-                continue;
-            }
-            let target_bps_dec = Decimal::from(row.target_bps);
-            let desired_bps = match profile.rebalance_goal {
-                RebalanceGoal::ExactTarget => target_bps_dec,
-                RebalanceGoal::NearestBand => (target_bps_dec - drift_band).max(Decimal::ZERO),
-            };
-            let desired_value = desired_bps / bps_scale * new_total_value;
-            let shortfall = (desired_value - row.current_value).max(Decimal::ZERO);
-            if shortfall > Decimal::ZERO {
-                sleeves.push(SleeveShortfall {
-                    category_id: row.category_id.clone(),
-                    category_name: row.category_name.clone(),
-                    shortfall,
-                });
-            }
-        }
-
-        // --- 4. Scale shortfalls to available cash ---------------------------
-        let total_shortfall: Decimal = sleeves.iter().map(|s| s.shortfall).sum();
-        let scale_factor = if total_shortfall == Decimal::ZERO || available_cash == Decimal::ZERO {
-            Decimal::ZERO
-        } else if total_shortfall <= available_cash {
-            Decimal::ONE
-        } else {
-            available_cash / total_shortfall
-        };
-
-        // --- 5. Build trades per sleeve, proportional to holdings weights ----
-        let mut trades: Vec<SuggestedManualTrade> = Vec::new();
-        let mut warnings: Vec<RebalanceWarning> = Vec::new();
-        let mut total_cash_used = Decimal::ZERO;
-
-        // Track value deployed per sleeve for max_drift_bps_after estimation.
-        let mut deployed_per_sleeve: std::collections::HashMap<String, Decimal> =
-            std::collections::HashMap::new();
-
-        for sleeve in &sleeves {
-            // Cap budget at remaining cash to guard against Decimal precision drift.
-            let remaining = available_cash - total_cash_used;
-            if remaining <= Decimal::ZERO {
-                break;
-            }
-            let budget = (sleeve.shortfall * scale_factor).min(remaining);
-            if budget == Decimal::ZERO {
-                continue;
-            }
-
-            // Load holdings for this sleeve.
-            let allocation_holdings = self
-                .allocation_service
-                .get_holdings_by_allocation_for_accounts(
-                    &input.account_ids,
-                    &input.base_currency,
-                    &profile.taxonomy_id,
-                    &sleeve.category_id,
-                    &input.aggregated_account_id,
-                )
-                .await?;
-
-            let holdings = &allocation_holdings.holdings;
-
-            // No holdings → sleeve-level suggestion.
-            if holdings.is_empty() {
-                warnings.push(RebalanceWarning {
-                    kind: RebalanceWarningKind::NoBuyCandidate,
-                    category_id: sleeve.category_id.clone(),
-                    message: format!(
-                        "No holdings found in {}. Allocate {:.2} to this sleeve manually.",
-                        sleeve.category_name, budget
-                    ),
-                });
-                trades.push(SuggestedManualTrade {
-                    action: "buy".to_string(),
-                    category_id: sleeve.category_id.clone(),
-                    category_name: sleeve.category_name.clone(),
-                    asset_id: None,
-                    symbol: None,
-                    name: None,
-                    quantity: None,
-                    estimated_price: None,
-                    estimated_amount: budget,
-                    reason: format!(
-                        "Sleeve {} is underweight. Suggested amount to buy.",
-                        sleeve.category_name
-                    ),
-                });
-                *deployed_per_sleeve
-                    .entry(sleeve.category_id.clone())
-                    .or_default() += budget;
-                total_cash_used += budget;
-                continue;
-            }
-
-            // Compute total sleeve value for proportional weights.
-            let sleeve_total_value: Decimal = holdings.iter().map(|h| h.market_value).sum();
-
-            let mut sleeve_deployed = Decimal::ZERO;
-            // Track holdings skipped in Phase 1 due to budget < price (whole-share mode).
-            // Emit a warning post-Phase-2 only if they are still un-funded.
-            let mut sleeve_skipped: Vec<(String, Decimal, Decimal)> = Vec::new();
-
-            for holding in holdings {
-                // Proportional budget for this holding.
-                let weight = if sleeve_total_value > Decimal::ZERO {
-                    holding.market_value / sleeve_total_value
-                } else {
-                    Decimal::ONE / Decimal::from(holdings.len() as i64)
-                };
-                let holding_budget = budget * weight;
-
-                // Derive price per share.
-                // Prefer unit_price (actual quote from provider) over market_value/quantity,
-                // which gives a wrong proportional price when a holding spans multiple
-                // taxonomy categories (e.g. a multi-sector ETF in GICS).
-                let price = if let Some(p) = holding.unit_price.filter(|p| *p > Decimal::ZERO) {
-                    p
-                } else if holding.quantity > Decimal::ZERO && holding.market_value > Decimal::ZERO {
-                    holding.market_value / holding.quantity
-                } else {
-                    if profile.whole_shares_only {
-                        warnings.push(RebalanceWarning {
-                            kind: RebalanceWarningKind::MissingQuote,
-                            category_id: sleeve.category_id.clone(),
-                            message: format!(
-                                "{}: no valid price/quantity for whole-share rounding. Skipped.",
-                                holding.symbol
-                            ),
-                        });
-                        continue;
-                    }
-                    // Fractional: emit as dollar amount without shares.
-                    if holding_budget < min_trade_amount {
-                        continue;
-                    }
-                    trades.push(SuggestedManualTrade {
-                        action: "buy".to_string(),
-                        category_id: sleeve.category_id.clone(),
-                        category_name: sleeve.category_name.clone(),
-                        asset_id: Some(holding.id.clone()),
-                        symbol: Some(holding.symbol.clone()),
-                        name: holding.name.clone(),
-                        quantity: None,
-                        estimated_price: None,
-                        estimated_amount: holding_budget,
-                        reason: format!(
-                            "{} is underweight in {}.",
-                            holding.symbol, sleeve.category_name
-                        ),
-                    });
-                    sleeve_deployed += holding_budget;
-                    continue;
-                };
-
-                let (shares, amount) = if profile.whole_shares_only {
-                    let whole = (holding_budget / price).floor();
-                    if whole == Decimal::ZERO {
-                        // Skip emission for now — Phase 2 may rescue this holding from
-                        // sleeve residue. Warning is emitted post-Phase-2 if still skipped.
-                        sleeve_skipped.push((holding.symbol.clone(), holding_budget, price));
-                        continue;
-                    }
-                    let amt = whole * price;
-                    (Some(whole), amt)
-                } else {
-                    // Fractional: full budget, compute shares for display.
-                    (Some(holding_budget / price), holding_budget)
-                };
-
-                if amount < min_trade_amount {
-                    continue;
-                }
-
-                trades.push(SuggestedManualTrade {
-                    action: "buy".to_string(),
-                    category_id: sleeve.category_id.clone(),
-                    category_name: sleeve.category_name.clone(),
-                    asset_id: Some(holding.id.clone()),
-                    symbol: Some(holding.symbol.clone()),
-                    name: holding.name.clone(),
-                    quantity: shares,
-                    estimated_price: Some(price),
-                    estimated_amount: amount,
-                    reason: format!(
-                        "{} is underweight in {}.",
-                        holding.symbol, sleeve.category_name
-                    ),
-                });
-                sleeve_deployed += amount;
-            }
-
-            // --- Phase 2: Intra-sleeve residue absorption (whole_shares_only) ---
-            // After Phase 1 round-lot allocation, rounding residue remains. We
-            // redistribute it by buying ONE share at a time, cheapest-first.
-            //
-            // Rationale: a proportional `residue * weight / price` formula fails
-            // for small residues — each holding's slice is below its share price
-            // and the loop absorbs nothing. Buying one share per pass distributes
-            // the residue fairly without letting the cheapest holding absorb it
-            // all in a single shot.
-            //
-            // Side effect (intentional): a holding skipped in Phase 1 (budget <
-            // price) can be rescued here if the residue >= price. Holdings whose
-            // price exceeds the entire sleeve residue stay starved — see the
-            // post-loop warning below.
-            if profile.whole_shares_only {
-                let mut residue = budget - sleeve_deployed;
-
-                // Build (holding, price) pairs filtered to those with a valid price,
-                // sorted by price ascending.
-                let mut priced: Vec<(&HoldingSummary, Decimal)> = holdings
-                    .iter()
-                    .filter_map(|h| {
-                        let p = h.unit_price.filter(|p| *p > Decimal::ZERO).or_else(|| {
-                            if h.quantity > Decimal::ZERO && h.market_value > Decimal::ZERO {
-                                Some(h.market_value / h.quantity)
-                            } else {
-                                None
-                            }
-                        })?;
-                        Some((h, p))
-                    })
-                    .collect();
-                priced.sort_by_key(|a| a.1);
-
-                'deploy_residue: loop {
-                    let mut absorbed = false;
-                    for (holding, price) in &priced {
-                        if residue <= Decimal::ZERO {
-                            break 'deploy_residue;
-                        }
-                        if residue < *price {
-                            continue;
-                        }
-                        // Buy exactly 1 share per pass.
-                        let existing = trades.iter_mut().rev().find(|t| {
-                            t.asset_id.as_deref() == Some(holding.id.as_str())
-                                && t.category_id == sleeve.category_id
-                        });
-                        if let Some(t) = existing {
-                            t.quantity = t.quantity.map(|q| q + Decimal::ONE);
-                            t.estimated_amount += *price;
-                        } else if *price >= min_trade_amount {
-                            // New trade (Phase 1 had skipped this holding).
-                            trades.push(SuggestedManualTrade {
-                                action: "buy".to_string(),
-                                category_id: sleeve.category_id.clone(),
-                                category_name: sleeve.category_name.clone(),
-                                asset_id: Some(holding.id.clone()),
-                                symbol: Some(holding.symbol.clone()),
-                                name: holding.name.clone(),
-                                quantity: Some(Decimal::ONE),
-                                estimated_price: Some(*price),
-                                estimated_amount: *price,
-                                reason: format!(
-                                    "{} is underweight in {}.",
-                                    holding.symbol, sleeve.category_name
-                                ),
-                            });
-                        } else {
-                            // Sub-min-trade new trade — skip and treat as undeployed.
-                            continue;
-                        }
-                        sleeve_deployed += *price;
-                        residue -= *price;
-                        absorbed = true;
-                    }
-                    if !absorbed {
-                        break;
-                    }
-                }
-
-                // Emit a warning for any Phase-1-skipped holding that Phase 2 did
-                // not rescue. Suggest the top-up amount needed to fund 1 share.
-                for (symbol, original_budget, price) in &sleeve_skipped {
-                    let funded = trades.iter().any(|t| {
-                        t.symbol.as_deref() == Some(symbol.as_str())
-                            && t.category_id == sleeve.category_id
-                    });
-                    if !funded {
-                        let topup = *price - *original_budget;
-                        warnings.push(RebalanceWarning {
-                            kind: RebalanceWarningKind::WholeShareResidue,
-                            category_id: sleeve.category_id.clone(),
-                            message: format!(
-                                "{}: budget {:.2} is short of 1 share at {:.2}. Add ~{:.2} more cash to fund 1 share, or {} will drift below target over time.",
-                                symbol, original_budget, price, topup, symbol
-                            ),
-                        });
-                    }
-                }
-            }
-
-            *deployed_per_sleeve
-                .entry(sleeve.category_id.clone())
-                .or_default() += sleeve_deployed;
-            total_cash_used += sleeve_deployed;
-        }
-
-        // --- 6. Estimate max_drift_bps_after ---------------------------------
-        // Total value is constant (tracked cash moves within portfolio, not added from outside).
-        // Only consider required rows — matches DriftService.max_drift_bps semantics.
-        let max_drift_bps_after = if total_value == Decimal::ZERO {
-            0
-        } else {
-            drift
-                .rows
-                .iter()
-                .filter(|row| row.is_required)
-                .map(|row| {
-                    // Deploying cash moves value out of the cash sleeve into buy
-                    // sleeves. Total value is unchanged, so the cash row must shed
-                    // total_cash_used for after-drift to stay consistent.
-                    let new_value = if row.is_cash {
-                        (row.current_value - total_cash_used).max(Decimal::ZERO)
+        // Price map: holding_id → price per share in base currency.
+        let price_by_holding: HashMap<String, Decimal> = all_holdings
+            .iter()
+            .filter(|h| h.holding_type != HoldingType::Cash)
+            .filter_map(|h| {
+                let price = h.price.filter(|&p| p > Decimal::ZERO).or_else(|| {
+                    if h.quantity > Decimal::ZERO {
+                        Some(h.market_value.base / h.quantity)
                     } else {
-                        let deployed = deployed_per_sleeve
-                            .get(&row.category_id)
-                            .copied()
-                            .unwrap_or(Decimal::ZERO);
-                        row.current_value + deployed
-                    };
-                    let new_bps = (new_value / total_value * bps_scale)
-                        .round()
-                        .to_string()
-                        .parse::<i32>()
-                        .unwrap_or(0);
-                    (new_bps - row.target_bps).abs()
-                })
-                .max()
-                .unwrap_or(0)
+                        None
+                    }
+                })?;
+                Some((h.id.clone(), price))
+            })
+            .collect();
+
+        let (candidates, classification_warnings) = Self::build_candidates(
+            &taxonomy_contributions.contributions,
+            &price_by_holding,
+            profile.whole_shares_only,
+        );
+
+        // Map drift rows to CategoryState for the optimizer.
+        let categories: Vec<CategoryState> = drift
+            .rows
+            .iter()
+            .map(|row| CategoryState {
+                category_id: row.category_id.clone(),
+                category_name: row.category_name.clone(),
+                target_bps: row.target_bps,
+                current_value: row.current_value,
+                is_cash: row.is_cash,
+                is_required: row.is_required,
+            })
+            .collect();
+
+        let optimizer_input = RebalanceInput {
+            profile: RebalanceProfile {
+                target_id: input.target_id.clone(),
+                drift_band_bps: profile.drift_band_bps,
+                rebalance_goal: profile.rebalance_goal.clone(),
+                min_trade_amount: Decimal::from_str(&profile.min_trade_amount)
+                    .unwrap_or(Decimal::ZERO),
+                whole_shares_only: profile.whole_shares_only,
+            },
+            available_cash,
+            total_value,
+            categories,
+            candidates,
+            warnings: classification_warnings,
         };
 
-        let cash_remaining = available_cash - total_cash_used;
-
-        Ok(RebalancePlan {
-            target_id: input.target_id.clone(),
-            available_cash,
-            cash_used: total_cash_used,
-            cash_remaining,
-            max_drift_bps_before,
-            max_drift_bps_after,
-            trades,
-            warnings,
-        })
+        DriftPriorityOptimizer.plan(optimizer_input)
     }
 }
 
@@ -527,13 +333,18 @@ impl RebalanceServiceTrait for RebalanceService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::portfolio::allocation::{AllocationHoldings, PortfolioAllocations};
+    use crate::portfolio::allocation::{
+        AllocationHoldings, HoldingAllocationContribution, PortfolioAllocations,
+        TaxonomyHoldingContributions,
+    };
     use crate::portfolio::allocation_targets::{
         AllocationTarget, AllocationTargetWeight, DriftReport, DriftRow, DriftStatus,
         NewAllocationTarget, NewAllocationTargetWeight, RebalanceGoal, ScopeType, TriggerType,
     };
-    use crate::portfolio::holdings::{Holding, HoldingSummary, HoldingType, MonetaryValue};
+    use crate::portfolio::holdings::{Holding, HoldingType, Instrument, MonetaryValue};
     use rust_decimal_macros::dec;
+
+    // ── Test helpers ─────────────────────────────────────────────────────────
 
     fn make_profile(rebalance_goal: RebalanceGoal, whole_shares_only: bool) -> AllocationTarget {
         AllocationTarget {
@@ -587,27 +398,163 @@ mod tests {
         }
     }
 
-    fn make_holding(
-        id: &str,
-        symbol: &str,
-        quantity: Decimal,
-        market_value: Decimal,
-    ) -> HoldingSummary {
-        let unit_price = if quantity > Decimal::ZERO {
+    fn make_holding(id: &str, symbol: &str, quantity: Decimal, market_value: Decimal) -> Holding {
+        let price = if quantity > Decimal::ZERO {
             Some(market_value / quantity)
         } else {
             None
         };
-        HoldingSummary {
+        Holding {
             id: id.to_string(),
-            symbol: symbol.to_string(),
-            name: Some(symbol.to_string()),
+            account_id: "acc-1".to_string(),
             holding_type: HoldingType::Security,
+            instrument: Some(Instrument {
+                id: id.to_string(),
+                symbol: symbol.to_string(),
+                name: Some(symbol.to_string()),
+                currency: "USD".to_string(),
+                notes: None,
+                pricing_mode: "auto".to_string(),
+                preferred_provider: None,
+                exchange_mic: None,
+                classifications: None,
+            }),
+            asset_kind: None,
             quantity,
-            market_value,
+            open_date: None,
+            lots: None,
+            contract_multiplier: Decimal::ONE,
+            local_currency: "USD".to_string(),
+            base_currency: "USD".to_string(),
+            fx_rate: None,
+            market_value: MonetaryValue {
+                local: market_value,
+                base: market_value,
+            },
+            cost_basis: None,
+            price,
+            purchase_price: None,
+            unrealized_gain: None,
+            unrealized_gain_pct: None,
+            realized_gain: None,
+            realized_gain_pct: None,
+            total_gain: None,
+            total_gain_pct: None,
+            day_change: None,
+            day_change_pct: None,
+            prev_close_value: None,
+            weight: Decimal::ZERO,
+            as_of_date: chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            metadata: None,
+            source_account_ids: vec![],
+        }
+    }
+
+    fn make_cash_holding(amount: Decimal, currency: &str) -> Holding {
+        Holding {
+            id: "cash".to_string(),
+            account_id: "acc-1".to_string(),
+            holding_type: HoldingType::Cash,
+            instrument: None,
+            asset_kind: None,
+            quantity: amount,
+            open_date: None,
+            lots: None,
+            contract_multiplier: Decimal::ONE,
+            local_currency: currency.to_string(),
+            base_currency: currency.to_string(),
+            fx_rate: None,
+            market_value: MonetaryValue {
+                local: amount,
+                base: amount,
+            },
+            cost_basis: None,
+            price: None,
+            purchase_price: None,
+            unrealized_gain: None,
+            unrealized_gain_pct: None,
+            realized_gain: None,
+            realized_gain_pct: None,
+            total_gain: None,
+            total_gain_pct: None,
+            day_change: None,
+            day_change_pct: None,
+            prev_close_value: None,
+            weight: Decimal::ZERO,
+            as_of_date: chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            metadata: None,
+            source_account_ids: vec![],
+        }
+    }
+
+    /// Build a single-category `HoldingAllocationContribution` (100% classified).
+    fn make_contribution(
+        holding: &Holding,
+        category_id: &str,
+        value: Decimal,
+    ) -> HoldingAllocationContribution {
+        HoldingAllocationContribution {
+            id: format!("{}:{}", holding.id, category_id),
+            holding_id: holding.id.clone(),
+            asset_id: holding
+                .instrument
+                .as_ref()
+                .map(|i| i.id.clone())
+                .unwrap_or_default(),
+            account_id: holding.account_id.clone(),
+            source_account_ids: vec![],
+            symbol: holding
+                .instrument
+                .as_ref()
+                .map(|i| i.symbol.clone())
+                .unwrap_or_default(),
+            name: holding
+                .instrument
+                .as_ref()
+                .and_then(|i| i.name.clone())
+                .unwrap_or_default(),
+            holding_type: holding.holding_type.clone(),
+            quantity: holding.quantity,
+            category_id: category_id.to_string(),
+            category_name: category_id.to_string(),
+            category_color: "#aaa".to_string(),
+            value,
+        }
+    }
+
+    fn make_contributions(
+        contribs: Vec<HoldingAllocationContribution>,
+    ) -> TaxonomyHoldingContributions {
+        let total: Decimal = contribs.iter().map(|c| c.value).sum();
+        TaxonomyHoldingContributions {
+            taxonomy_id: "asset_classes".to_string(),
+            taxonomy_name: "Asset Classes".to_string(),
+            total_value: total,
             currency: "USD".to_string(),
-            weight_in_category: Decimal::ZERO,
-            unit_price,
+            contributions: contribs,
+        }
+    }
+
+    fn make_report(rows: Vec<DriftRow>, total_value: Decimal) -> DriftReport {
+        let max = rows
+            .iter()
+            .map(|r| r.drift_bps.unsigned_abs())
+            .max()
+            .unwrap_or(0);
+        let out = rows
+            .iter()
+            .filter(|r| r.drift_bps.unsigned_abs() > 500)
+            .count();
+        DriftReport {
+            target_id: "profile-1".to_string(),
+            scope_type: ScopeType::All,
+            scope_id: None,
+            total_value,
+            base_currency: "USD".to_string(),
+            max_drift_bps: max as i32,
+            out_of_band_count: out,
+            rows,
+            holdings: None,
         }
     }
 
@@ -688,7 +635,7 @@ mod tests {
     }
 
     struct MockAllocationService {
-        holdings_by_category: std::collections::HashMap<String, Vec<HoldingSummary>>,
+        contributions: TaxonomyHoldingContributions,
     }
 
     #[async_trait]
@@ -722,25 +669,10 @@ mod tests {
             _: &[String],
             _: &str,
             _: &str,
-            category_id: &str,
+            _: &str,
             _: &str,
         ) -> CoreResult<AllocationHoldings> {
-            let holdings = self
-                .holdings_by_category
-                .get(category_id)
-                .cloned()
-                .unwrap_or_default();
-            let total = holdings.iter().map(|h| h.market_value).sum();
-            Ok(AllocationHoldings {
-                taxonomy_id: "asset_classes".to_string(),
-                taxonomy_name: "Asset Classes".to_string(),
-                category_id: category_id.to_string(),
-                category_name: category_id.to_string(),
-                color: "#aaa".to_string(),
-                holdings,
-                total_value: total,
-                currency: "USD".to_string(),
-            })
+            unimplemented!()
         }
         async fn get_holding_contributions_for_taxonomy_for_accounts(
             &self,
@@ -748,13 +680,13 @@ mod tests {
             _: &str,
             _: &str,
             _: &str,
-        ) -> CoreResult<crate::portfolio::allocation::TaxonomyHoldingContributions> {
-            unimplemented!()
+        ) -> CoreResult<TaxonomyHoldingContributions> {
+            Ok(self.contributions.clone())
         }
     }
 
     struct MockHoldingsService {
-        cash_in_scope: Decimal,
+        holdings: Vec<Holding>,
     }
 
     #[async_trait]
@@ -765,44 +697,10 @@ mod tests {
         async fn get_holdings_for_accounts(
             &self,
             _: &[String],
-            base_currency: &str,
+            _: &str,
             _: &str,
         ) -> CoreResult<Vec<Holding>> {
-            // Single cash holding carrying the configured in-scope cash.
-            Ok(vec![Holding {
-                id: "cash".to_string(),
-                account_id: "acc-1".to_string(),
-                holding_type: HoldingType::Cash,
-                instrument: None,
-                asset_kind: None,
-                quantity: self.cash_in_scope,
-                open_date: None,
-                lots: None,
-                contract_multiplier: Decimal::ONE,
-                local_currency: base_currency.to_string(),
-                base_currency: base_currency.to_string(),
-                fx_rate: None,
-                market_value: MonetaryValue {
-                    local: self.cash_in_scope,
-                    base: self.cash_in_scope,
-                },
-                cost_basis: None,
-                price: None,
-                purchase_price: None,
-                unrealized_gain: None,
-                unrealized_gain_pct: None,
-                realized_gain: None,
-                realized_gain_pct: None,
-                total_gain: None,
-                total_gain_pct: None,
-                day_change: None,
-                day_change_pct: None,
-                prev_close_value: None,
-                weight: Decimal::ZERO,
-                as_of_date: chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
-                metadata: None,
-                source_account_ids: vec![],
-            }])
+            Ok(self.holdings.clone())
         }
         async fn get_holding(&self, _: &str, _: &str, _: &str) -> CoreResult<Option<Holding>> {
             unimplemented!()
@@ -816,29 +714,19 @@ mod tests {
         }
     }
 
+    // ── Service constructors ──────────────────────────────────────────────────
+
     fn make_service(
         profile: AllocationTarget,
         report: DriftReport,
-        holdings: std::collections::HashMap<String, Vec<HoldingSummary>>,
-    ) -> RebalanceService {
-        // Large default so existing tests can deploy freely; the rejection test
-        // uses make_service_with_cash to constrain it.
-        make_service_with_cash(profile, report, holdings, dec!(1_000_000))
-    }
-
-    fn make_service_with_cash(
-        profile: AllocationTarget,
-        report: DriftReport,
-        holdings: std::collections::HashMap<String, Vec<HoldingSummary>>,
-        cash_in_scope: Decimal,
+        contributions: TaxonomyHoldingContributions,
+        holdings: Vec<Holding>,
     ) -> RebalanceService {
         RebalanceService::new(
             Arc::new(MockTargetService { profile }),
             Arc::new(MockDriftService { report }),
-            Arc::new(MockAllocationService {
-                holdings_by_category: holdings,
-            }),
-            Arc::new(MockHoldingsService { cash_in_scope }),
+            Arc::new(MockAllocationService { contributions }),
+            Arc::new(MockHoldingsService { holdings }),
         )
     }
 
@@ -852,50 +740,130 @@ mod tests {
         }
     }
 
-    fn make_report(rows: Vec<DriftRow>, total_value: Decimal) -> DriftReport {
-        let max = rows
-            .iter()
-            .map(|r| r.drift_bps.unsigned_abs())
-            .max()
-            .unwrap_or(0);
-        let out = rows
-            .iter()
-            .filter(|r| r.drift_bps.unsigned_abs() > 500)
-            .count();
-        DriftReport {
-            target_id: "profile-1".to_string(),
-            scope_type: ScopeType::All,
-            scope_id: None,
-            total_value,
-            base_currency: "USD".to_string(),
-            max_drift_bps: max as i32,
-            out_of_band_count: out,
-            rows,
-            holdings: None,
-        }
+    // ── Cash enforcement tests (unchanged behaviour from PR-A) ────────────────
+
+    #[tokio::test]
+    async fn negative_cash_returns_validation_error() {
+        let total = dec!(10000);
+        let h = make_holding("h1", "VTI", dec!(10), dec!(6000));
+        let c = make_contribution(&h, "equity", dec!(6000));
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            make_report(vec![make_drift_row("equity", 6000, 7000, total)], total),
+            make_contributions(vec![c]),
+            vec![make_cash_holding(dec!(1_000_000), "USD"), h],
+        );
+        let err = svc
+            .calculate_plan(make_input(dec!(-100)))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("non-negative"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn deploy_exceeding_tracked_cash_is_rejected() {
+        let total = dec!(10000);
+        let h = make_holding("h1", "VTI", dec!(10), dec!(9500));
+        let c = make_contribution(&h, "equity", dec!(9500));
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            make_report(vec![make_drift_row("equity", 9500, 7000, total)], total),
+            make_contributions(vec![c]),
+            vec![make_cash_holding(dec!(500), "USD"), h],
+        );
+        let err = svc
+            .calculate_plan(make_input(dec!(1000)))
+            .await
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("exceeds tracked cash in scope"),
+            "{err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn rounded_cash_within_cent_is_capped_to_tracked_cash() {
+        let total = dec!(1000);
+        let h = make_holding("h1", "VTI", dec!(10), dec!(500));
+        let c = make_contribution(&h, "equity", dec!(500));
+        let rows = vec![
+            make_drift_row("equity", 5000, 6000, total),
+            DriftRow {
+                is_cash: true,
+                ..make_drift_row("cash", 5000, 4000, total)
+            },
+        ];
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            make_report(rows, total),
+            make_contributions(vec![c]),
+            vec![make_cash_holding(dec!(100.005), "USD"), h],
+        );
+        let plan = svc.calculate_plan(make_input(dec!(100.01))).await.unwrap();
+        assert_eq!(plan.available_cash, dec!(100.005));
+    }
+
+    #[tokio::test]
+    async fn rounded_zero_decimal_cash_is_capped_to_tracked_cash() {
+        let total = dec!(1000);
+        let h = make_holding("h1", "VTI", dec!(10), dec!(500));
+        let c = make_contribution(&h, "equity", dec!(500));
+        let rows = vec![
+            make_drift_row("equity", 5000, 6000, total),
+            DriftRow {
+                is_cash: true,
+                ..make_drift_row("cash", 5000, 4000, total)
+            },
+        ];
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            make_report(rows, total),
+            make_contributions(vec![c]),
+            vec![make_cash_holding(dec!(100.5), "USD"), h],
+        );
+        let input = CalculateRebalancePlanInput {
+            base_currency: "JPY".to_string(),
+            ..make_input(dec!(101))
+        };
+        let plan = svc.calculate_plan(input).await.unwrap();
+        assert_eq!(plan.available_cash, dec!(100.5));
+    }
+
+    // ── Greedy planner tests ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn zero_cash_produces_no_trades() {
+        let total = dec!(10000);
+        let h = make_holding("h1", "VTI", dec!(10), dec!(6000));
+        let c = make_contribution(&h, "equity", dec!(6000));
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            make_report(vec![make_drift_row("equity", 6000, 7000, total)], total),
+            make_contributions(vec![c]),
+            vec![make_cash_holding(dec!(0), "USD"), h],
+        );
+        let plan = svc.calculate_plan(make_input(dec!(0))).await.unwrap();
+        assert!(plan.trades.is_empty());
+        assert_eq!(plan.cash_used, Decimal::ZERO);
     }
 
     #[tokio::test]
     async fn cash_flow_only_no_sells_generated() {
-        // Equity 60% (target 70%), Bond 40% (target 30%).
-        // Bond is overweight, Equity is underweight.
+        // Equity 60% (target 70%), Bond 40% (target 30%). Bond overweight.
         let total = dec!(10000);
+        let h_vti = make_holding("h1", "VTI", dec!(10), dec!(6000));
+        let h_bnd = make_holding("h2", "BND", dec!(40), dec!(4000));
+        let c_vti = make_contribution(&h_vti, "equity", dec!(6000));
+        let c_bnd = make_contribution(&h_bnd, "bond", dec!(4000));
         let rows = vec![
             make_drift_row("equity", 6000, 7000, total),
             make_drift_row("bond", 4000, 3000, total),
         ];
-        let report = make_report(rows, total);
-
-        let mut holdings = std::collections::HashMap::new();
-        holdings.insert(
-            "equity".to_string(),
-            vec![make_holding("h1", "VTI", dec!(10), dec!(6000))],
-        );
-
         let svc = make_service(
             make_profile(RebalanceGoal::ExactTarget, false),
-            report,
-            holdings,
+            make_report(rows, total),
+            make_contributions(vec![c_vti, c_bnd]),
+            vec![make_cash_holding(dec!(2000), "USD"), h_vti, h_bnd],
         );
         let plan = svc.calculate_plan(make_input(dec!(2000))).await.unwrap();
 
@@ -904,200 +872,94 @@ mod tests {
             "cash-flow-only must not sell"
         );
         assert!(plan.cash_used <= dec!(2000));
-        let equity_trade = plan.trades.iter().find(|t| t.category_id == "equity");
-        assert!(equity_trade.is_some(), "should suggest buying equity");
-    }
-
-    #[tokio::test]
-    async fn zero_cash_produces_no_trades() {
-        let total = dec!(10000);
-        let rows = vec![make_drift_row("equity", 6000, 7000, total)];
-        let report = make_report(rows, total);
-        let mut holdings = std::collections::HashMap::new();
-        holdings.insert(
-            "equity".to_string(),
-            vec![make_holding("h1", "VTI", dec!(10), dec!(6000))],
-        );
-
-        let svc = make_service(
-            make_profile(RebalanceGoal::ExactTarget, false),
-            report,
-            holdings,
-        );
-        let plan = svc.calculate_plan(make_input(dec!(0))).await.unwrap();
-
-        assert!(plan.trades.is_empty());
-        assert_eq!(plan.cash_used, Decimal::ZERO);
-    }
-
-    #[tokio::test]
-    async fn negative_cash_returns_validation_error() {
-        let total = dec!(10000);
-        let rows = vec![make_drift_row("equity", 6000, 7000, total)];
-        let report = make_report(rows, total);
-        let mut holdings = std::collections::HashMap::new();
-        holdings.insert(
-            "equity".to_string(),
-            vec![make_holding("h1", "VTI", dec!(10), dec!(6000))],
-        );
-        let svc = make_service(
-            make_profile(RebalanceGoal::ExactTarget, false),
-            report,
-            holdings,
-        );
-        let err = svc
-            .calculate_plan(make_input(dec!(-100)))
-            .await
-            .unwrap_err();
         assert!(
-            err.to_string().contains("non-negative"),
-            "negative cash must be rejected: {err}"
+            plan.trades.iter().any(|t| t.category_id == "equity"),
+            "should suggest buying equity"
         );
     }
 
     #[tokio::test]
-    async fn deploy_exceeding_tracked_cash_is_rejected() {
-        // Only $500 of cash is tracked in scope, but the caller asks to deploy $1000.
-        // Backend must reject regardless of what the UI allowed.
+    async fn greedy_buys_most_drift_reducing_asset() {
+        // Equity 50% (target 70%), Bond 50% (target 30%). Equity far underweight.
+        // VTI (equity): price $100. BND (bond): price $50.
+        // Greedy should buy VTI (improves equity drift) not BND (overweight, buying worsens).
         let total = dec!(10000);
-        let rows = vec![make_drift_row("equity", 6000, 7000, total)];
-        let report = make_report(rows, total);
-        let mut holdings = std::collections::HashMap::new();
-        holdings.insert(
-            "equity".to_string(),
-            vec![make_holding("h1", "VTI", dec!(10), dec!(6000))],
-        );
-        let svc = make_service_with_cash(
-            make_profile(RebalanceGoal::ExactTarget, false),
-            report,
-            holdings,
-            dec!(500),
-        );
-        let err = svc
-            .calculate_plan(make_input(dec!(1000)))
-            .await
-            .unwrap_err();
-        assert!(
-            err.to_string().contains("exceeds tracked cash in scope"),
-            "deploy over tracked cash must be rejected: {err}"
-        );
-    }
-
-    #[tokio::test]
-    async fn rounded_cash_within_cent_is_capped_to_tracked_cash() {
-        // Frontend currency rounding can submit $100.01 for a tracked raw cash
-        // balance of $100.005. Treat that as "deploy all cash" and cap to the
-        // authoritative backend value instead of rejecting.
-        let total = dec!(1000);
+        let h_vti = make_holding("h1", "VTI", dec!(50), dec!(5000));
+        let h_bnd = make_holding("h2", "BND", dec!(100), dec!(5000));
+        let c_vti = make_contribution(&h_vti, "equity", dec!(5000));
+        let c_bnd = make_contribution(&h_bnd, "bond", dec!(5000));
         let rows = vec![
-            make_drift_row("equity", 5000, 6000, total),
-            DriftRow {
-                is_cash: true,
-                ..make_drift_row("cash", 5000, 4000, total)
-            },
+            make_drift_row("equity", 5000, 7000, total),
+            make_drift_row("bond", 5000, 3000, total),
         ];
-        let report = make_report(rows, total);
-        let mut holdings = std::collections::HashMap::new();
-        holdings.insert(
-            "equity".to_string(),
-            vec![make_holding("h1", "VTI", dec!(10), dec!(500))],
-        );
-        let svc = make_service_with_cash(
-            make_profile(RebalanceGoal::ExactTarget, false),
-            report,
-            holdings,
-            dec!(100.005),
-        );
-
-        let plan = svc.calculate_plan(make_input(dec!(100.01))).await.unwrap();
-
-        assert_eq!(plan.available_cash, dec!(100.005));
-        assert_eq!(plan.cash_used, dec!(100));
-        assert_eq!(plan.cash_remaining, dec!(0.005));
-    }
-
-    #[tokio::test]
-    async fn rounded_zero_decimal_cash_is_capped_to_tracked_cash() {
-        // Zero-decimal currencies can round 100.5 to 101 in the UI. That should
-        // still behave as "deploy all tracked cash", while planning remains
-        // capped to the authoritative backend value.
-        let total = dec!(1000);
-        let rows = vec![
-            make_drift_row("equity", 5000, 6000, total),
-            DriftRow {
-                is_cash: true,
-                ..make_drift_row("cash", 5000, 4000, total)
-            },
-        ];
-        let report = make_report(rows, total);
-        let mut holdings = std::collections::HashMap::new();
-        holdings.insert(
-            "equity".to_string(),
-            vec![make_holding("h1", "VTI", dec!(10), dec!(500))],
-        );
-        let svc = make_service_with_cash(
-            make_profile(RebalanceGoal::ExactTarget, false),
-            report,
-            holdings,
-            dec!(100.5),
-        );
-        let input = CalculateRebalancePlanInput {
-            base_currency: "JPY".to_string(),
-            ..make_input(dec!(101))
-        };
-
-        let plan = svc.calculate_plan(input).await.unwrap();
-
-        assert_eq!(plan.available_cash, dec!(100.5));
-        assert_eq!(plan.cash_used, dec!(100));
-        assert_eq!(plan.cash_remaining, dec!(0.5));
-    }
-
-    #[tokio::test]
-    async fn total_value_stays_constant_when_cash_deployed() {
-        // Portfolio: equity $6000 (60%), cash $4000 (40%). Total = $10000.
-        // Target: equity 70%, cash 30%.
-        // Deploy $2000 of cash → buys equity.
-        // Total value must stay $10000 (cash moves within portfolio, not added).
-        let total = dec!(10000);
-        let rows = vec![
-            make_drift_row("equity", 6000, 7000, total),
-            DriftRow {
-                is_cash: true,
-                ..make_drift_row("cash", 4000, 3000, total)
-            },
-        ];
-        let report = make_report(rows, total);
-        let mut holdings = std::collections::HashMap::new();
-        holdings.insert(
-            "equity".to_string(),
-            vec![make_holding("h1", "VTI", dec!(10), dec!(6000))],
-        );
         let svc = make_service(
             make_profile(RebalanceGoal::ExactTarget, false),
-            report,
-            holdings,
+            make_report(rows, total),
+            make_contributions(vec![c_vti, c_bnd]),
+            vec![make_cash_holding(dec!(5000), "USD"), h_vti, h_bnd],
         );
-        let plan = svc.calculate_plan(make_input(dec!(2000))).await.unwrap();
+        let plan = svc.calculate_plan(make_input(dec!(200))).await.unwrap();
 
-        // cash_used + cash_remaining must equal available_cash (no value created)
-        assert_eq!(plan.cash_used + plan.cash_remaining, dec!(2000));
-        // Equity shortfall is $1000 (60% → 70%); deploying it pulls cash 40% → 30%.
-        // The cash sleeve must shed cash_used so both sleeves hit target → after-drift 0.
-        // Without subtracting cash_used the cash row would stay at 40% (drift +1000bps).
-        assert_eq!(plan.cash_used, dec!(1000));
-        assert_eq!(
-            plan.max_drift_bps_after, 0,
-            "cash sleeve must drop by cash_used so both sleeves reach target"
+        assert!(
+            plan.trades
+                .iter()
+                .all(|t| t.symbol.as_deref() != Some("BND")),
+            "BND is overweight — buying it increases bond drift"
         );
+        assert!(
+            plan.trades
+                .iter()
+                .any(|t| t.symbol.as_deref() == Some("VTI")),
+            "VTI should be selected to reduce equity drift"
+        );
+    }
+
+    #[tokio::test]
+    async fn multi_category_etf_reduces_multiple_sleeve_drifts() {
+        // VT is a global ETF: 60% US equity, 40% international equity.
+        // Portfolio: US 40% (target 60%), Intl 40% (target 40%), Cash 20%.
+        // Buying VT should simultaneously improve US and Intl drift.
+        let total = dec!(10000);
+        let price = dec!(100); // $100/share
+        let qty = dec!(40);
+        let h_vt = make_holding("vt", "VT", qty, price * qty);
+
+        // Split contribution: 60% US, 40% Intl of holding value ($4000 total)
+        let c_us = make_contribution(&h_vt, "us_equity", dec!(2400)); // 60%
+        let c_intl = make_contribution(&h_vt, "intl_equity", dec!(1600)); // 40%
+
+        let rows = vec![
+            make_drift_row("us_equity", 4000, 6000, total),
+            make_drift_row("intl_equity", 4000, 4000, total),
+            DriftRow {
+                is_cash: true,
+                ..make_drift_row("cash", 2000, 0, total)
+            },
+        ];
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            make_report(rows, total),
+            make_contributions(vec![c_us, c_intl]),
+            vec![make_cash_holding(dec!(2000), "USD"), h_vt],
+        );
+        let plan = svc.calculate_plan(make_input(dec!(200))).await.unwrap();
+
+        // VT should be selected (only candidate that reduces US drift)
+        let vt_trade = plan
+            .trades
+            .iter()
+            .find(|t| t.symbol.as_deref() == Some("VT"));
+        assert!(vt_trade.is_some(), "VT should be selected");
+        assert!(plan.cash_used > Decimal::ZERO);
     }
 
     #[tokio::test]
     async fn underweight_cash_is_not_a_buy_candidate() {
-        // Portfolio: equity $8000 (80%), cash $2000 (20%).
-        // Target: equity 70%, cash 30%. Cash is underweight, but cash is the funding source,
-        // so a cash-flow-only plan must not suggest "buying" the cash sleeve with cash.
+        // Cash underweight but cannot be a buy candidate.
         let total = dec!(10000);
+        let h_vti = make_holding("h1", "VTI", dec!(80), dec!(8000));
+        // No contribution for cash sleeve — it has no HoldingAllocationContribution.
+        let c_vti = make_contribution(&h_vti, "equity", dec!(8000));
         let rows = vec![
             make_drift_row("equity", 8000, 7000, total),
             DriftRow {
@@ -1105,136 +967,152 @@ mod tests {
                 ..make_drift_row("cash", 2000, 3000, total)
             },
         ];
-        let report = make_report(rows, total);
-        let mut holdings = std::collections::HashMap::new();
-        holdings.insert(
-            "cash".to_string(),
-            vec![make_holding("cash-usd", "USD", dec!(2000), dec!(2000))],
-        );
         let svc = make_service(
             make_profile(RebalanceGoal::ExactTarget, false),
-            report,
-            holdings,
+            make_report(rows, total),
+            make_contributions(vec![c_vti]),
+            vec![make_cash_holding(dec!(2000), "USD"), h_vti],
         );
-
         let plan = svc.calculate_plan(make_input(dec!(1000))).await.unwrap();
 
-        assert!(
-            plan.trades.is_empty(),
-            "cash must not be selected as a buy sleeve"
-        );
-        assert_eq!(plan.cash_used, Decimal::ZERO);
-        assert_eq!(plan.max_drift_bps_after, plan.max_drift_bps_before);
-    }
-
-    #[tokio::test]
-    async fn insufficient_cash_scales_down() {
-        // Need $1000 for equity, but only $500 available.
-        let total = dec!(10000);
-        let rows = vec![
-            make_drift_row("equity", 6000, 7000, total),
-            make_drift_row("bond", 4000, 3000, total),
-        ];
-        let report = make_report(rows, total);
-        let mut holdings = std::collections::HashMap::new();
-        holdings.insert(
-            "equity".to_string(),
-            vec![make_holding("h1", "VTI", dec!(10), dec!(6000))],
-        );
-
-        let svc = make_service(
-            make_profile(RebalanceGoal::ExactTarget, false),
-            report,
-            holdings,
-        );
-        let plan = svc.calculate_plan(make_input(dec!(500))).await.unwrap();
-
-        assert!(plan.cash_used <= dec!(500));
+        // Equity is overweight → buying VTI would worsen equity drift → greedy finds no improvement.
+        assert!(plan.cash_used == Decimal::ZERO || plan.trades.iter().all(|t| t.action == "buy"));
     }
 
     #[tokio::test]
     async fn no_holdings_emits_warning_and_sleeve_level_trade() {
         let total = dec!(10000);
-        let rows = vec![make_drift_row("bonds", 2000, 4000, total)];
-        let report = make_report(rows, total);
-        let holdings = std::collections::HashMap::new(); // no holdings in bonds
-
+        // No holdings, no contributions for bonds sleeve.
         let svc = make_service(
             make_profile(RebalanceGoal::ExactTarget, false),
-            report,
-            holdings,
+            make_report(vec![make_drift_row("bonds", 2000, 4000, total)], total),
+            make_contributions(vec![]),
+            vec![make_cash_holding(dec!(1000), "USD")],
         );
         let plan = svc.calculate_plan(make_input(dec!(1000))).await.unwrap();
 
-        assert!(plan
-            .warnings
-            .iter()
-            .any(|w| w.kind == RebalanceWarningKind::NoBuyCandidate));
+        assert!(
+            plan.warnings
+                .iter()
+                .any(|w| w.kind == RebalanceWarningKind::NoBuyCandidate),
+            "NoBuyCandidate warning expected"
+        );
         let trade = plan.trades.iter().find(|t| t.category_id == "bonds");
-        assert!(trade.is_some());
+        assert!(trade.is_some(), "sleeve-level trade expected");
         assert!(
             trade.unwrap().symbol.is_none(),
-            "sleeve-level trade has no ticker"
+            "sleeve trade has no ticker"
         );
     }
 
     #[tokio::test]
-    async fn whole_shares_only_rounds_down() {
+    async fn unclassified_asset_emits_warning_and_is_skipped() {
         let total = dec!(10000);
-        let rows = vec![make_drift_row("equity", 6000, 7000, total)];
-        let report = make_report(rows, total);
-        let mut holdings = std::collections::HashMap::new();
-        // Price = 1000/10 = $100. Budget = $1000 → 10 shares exactly.
-        holdings.insert(
-            "equity".to_string(),
-            vec![make_holding("h1", "VTI", dec!(10), dec!(1000))],
+        let h = make_holding("h1", "XYZ", dec!(10), dec!(5000));
+        // All contribution in __UNKNOWN__ = no taxonomy assignments.
+        let c_unknown = make_contribution(&h, "__UNKNOWN__", dec!(5000));
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            make_report(vec![make_drift_row("equity", 5000, 7000, total)], total),
+            make_contributions(vec![c_unknown]),
+            vec![make_cash_holding(dec!(1000), "USD"), h],
         );
+        let plan = svc.calculate_plan(make_input(dec!(500))).await.unwrap();
+
+        assert!(
+            plan.warnings
+                .iter()
+                .any(|w| w.kind == RebalanceWarningKind::UnclassifiedAsset),
+            "UnclassifiedAsset warning expected"
+        );
+        assert!(
+            !plan
+                .trades
+                .iter()
+                .any(|t| t.symbol.as_deref() == Some("XYZ")),
+            "XYZ must not be a buy candidate"
+        );
+    }
+
+    #[tokio::test]
+    async fn partial_classification_warns_and_uses_known_exposure() {
+        // ABC: 70% equity, 30% __UNKNOWN__. Should warn PartialClassification
+        // and still be a candidate using only the 70% equity exposure.
+        let total = dec!(10000);
+        let qty = dec!(10);
+        let mv = dec!(7000);
+        let h = make_holding("h1", "ABC", qty, mv);
+        let c_equity = make_contribution(&h, "equity", dec!(4900)); // 70%
+        let c_unknown = make_contribution(&h, "__UNKNOWN__", dec!(2100)); // 30%
 
         let svc = make_service(
-            make_profile(RebalanceGoal::ExactTarget, true),
-            report,
-            holdings,
+            make_profile(RebalanceGoal::ExactTarget, false),
+            make_report(vec![make_drift_row("equity", 3000, 7000, total)], total),
+            make_contributions(vec![c_equity, c_unknown]),
+            vec![make_cash_holding(dec!(5000), "USD"), h],
         );
-        let plan = svc.calculate_plan(make_input(dec!(1000))).await.unwrap();
+        let plan = svc.calculate_plan(make_input(dec!(700))).await.unwrap();
 
-        let trade = plan
+        assert!(
+            plan.warnings
+                .iter()
+                .any(|w| w.kind == RebalanceWarningKind::PartialClassification),
+            "PartialClassification warning expected"
+        );
+        assert!(
+            plan.trades
+                .iter()
+                .any(|t| t.symbol.as_deref() == Some("ABC")),
+            "ABC should still be a buy candidate"
+        );
+    }
+
+    #[tokio::test]
+    async fn whole_shares_only_buys_integer_shares() {
+        let total = dec!(10000);
+        // VTI: 10 shares @ $600 = $6000. Price = $600/share.
+        let h = make_holding("h1", "VTI", dec!(10), dec!(6000));
+        let c = make_contribution(&h, "equity", dec!(6000));
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, true),
+            make_report(vec![make_drift_row("equity", 6000, 7000, total)], total),
+            make_contributions(vec![c]),
+            vec![make_cash_holding(dec!(5000), "USD"), h],
+        );
+        let plan = svc.calculate_plan(make_input(dec!(1500))).await.unwrap();
+
+        let vti = plan
             .trades
             .iter()
             .find(|t| t.symbol.as_deref() == Some("VTI"))
-            .unwrap();
-        let qty = trade.quantity.unwrap();
+            .expect("VTI trade");
+        let qty = vti.quantity.unwrap();
         assert_eq!(
             qty.fract(),
             Decimal::ZERO,
-            "whole shares only: must be integer"
+            "whole shares only: must be integer, got {qty}"
         );
     }
 
     #[tokio::test]
-    async fn nearest_band_shortfall_less_than_exact_target() {
+    async fn nearest_band_deploys_less_than_exact_target() {
         let total = dec!(10000);
-        let target_bps = 7000;
-        let current_bps = 6000; // drift = -1000 bps, band = 500, out of band
-        let rows = vec![make_drift_row("equity", current_bps, target_bps, total)];
-
-        let report_exact = make_report(rows.clone(), total);
-        let report_band = make_report(rows, total);
-
-        let mut h = std::collections::HashMap::new();
-        h.insert(
-            "equity".to_string(),
-            vec![make_holding("h1", "VTI", dec!(10), dec!(6000))],
-        );
+        let h = make_holding("h1", "VTI", dec!(10), dec!(6000));
+        let c1 = make_contribution(&h, "equity", dec!(6000));
+        let c2 = make_contribution(&h, "equity", dec!(6000));
+        let rows = vec![make_drift_row("equity", 6000, 7000, total)];
 
         let svc_exact = make_service(
             make_profile(RebalanceGoal::ExactTarget, false),
-            report_exact,
-            h.clone(),
+            make_report(rows.clone(), total),
+            make_contributions(vec![c1]),
+            vec![make_cash_holding(dec!(5000), "USD"), h.clone()],
         );
         let svc_band = make_service(
             make_profile(RebalanceGoal::NearestBand, false),
-            report_band,
-            h,
+            make_report(rows, total),
+            make_contributions(vec![c2]),
+            vec![make_cash_holding(dec!(5000), "USD"), h],
         );
 
         let plan_exact = svc_exact
@@ -1248,206 +1126,90 @@ mod tests {
 
         assert!(
             plan_band.cash_used <= plan_exact.cash_used,
-            "nearest_band deploys less cash than exact_target"
+            "nearest_band deploys less cash than exact_target: {} vs {}",
+            plan_band.cash_used,
+            plan_exact.cash_used
         );
     }
 
     #[tokio::test]
     async fn min_trade_amount_filters_small_trades() {
-        // Equity 60% current, 80% target → $2000 shortfall.
-        // Two holdings: VTI $900 (90%), IVV $100 (10%).
-        // Cash = $200 → VTI gets $180, IVV gets $20.
-        // min_trade_amount = $100 → IVV trade dropped, VTI kept.
+        // VTI at $80/share. min_trade $100.
+        // Cash $80 → greedy buys 1 share ($80). Post-filter: $80 < $100 → dropped.
+        // Result: no trades. cash_used = $0, cash_remaining = $80.
         let total = dec!(10000);
-        let rows = vec![make_drift_row("equity", 6000, 8000, total)];
-        let report = make_report(rows, total);
-        let mut holdings = std::collections::HashMap::new();
-        holdings.insert(
-            "equity".to_string(),
-            vec![
-                make_holding("h1", "VTI", dec!(9), dec!(900)),
-                make_holding("h2", "IVV", dec!(1), dec!(100)),
-            ],
-        );
+        let h = make_holding("h1", "VTI", dec!(75), dec!(6000)); // $80/share
+        let c = make_contribution(&h, "equity", dec!(6000));
         let profile = AllocationTarget {
             min_trade_amount: "100".to_string(),
             ..make_profile(RebalanceGoal::ExactTarget, false)
         };
-
-        let svc = make_service(profile, report, holdings);
-        let plan = svc.calculate_plan(make_input(dec!(200))).await.unwrap();
-
-        // VTI gets $180 → above $100 → kept.
+        let svc = make_service(
+            profile,
+            make_report(vec![make_drift_row("equity", 6000, 7000, total)], total),
+            make_contributions(vec![c]),
+            vec![make_cash_holding(dec!(80), "USD"), h],
+        );
+        let plan = svc.calculate_plan(make_input(dec!(80))).await.unwrap();
         assert!(
-            plan.trades
+            plan.trades.iter().all(|t| t.estimated_amount >= dec!(100)),
+            "all trades must meet min_trade threshold"
+        );
+
+        // With $160 cash: 2 shares × $80 = $160 ≥ $100 → kept.
+        let h2 = make_holding("h2", "VTI", dec!(75), dec!(6000));
+        let c2 = make_contribution(&h2, "equity", dec!(6000));
+        let profile2 = AllocationTarget {
+            min_trade_amount: "100".to_string(),
+            ..make_profile(RebalanceGoal::ExactTarget, false)
+        };
+        let svc2 = make_service(
+            profile2,
+            make_report(vec![make_drift_row("equity", 6000, 7000, total)], total),
+            make_contributions(vec![c2]),
+            vec![make_cash_holding(dec!(160), "USD"), h2],
+        );
+        let plan2 = svc2.calculate_plan(make_input(dec!(160))).await.unwrap();
+        assert!(
+            plan2
+                .trades
                 .iter()
                 .any(|t| t.symbol.as_deref() == Some("VTI")),
-            "VTI trade should survive min_trade filter"
-        );
-        // IVV gets $20 → below $100 → dropped.
-        assert!(
-            !plan
-                .trades
-                .iter()
-                .any(|t| t.symbol.as_deref() == Some("IVV")),
-            "IVV trade should be filtered by min_trade_amount"
+            "VTI should survive min_trade when total >= threshold"
         );
     }
 
     #[tokio::test]
-    async fn proportional_buy_across_multiple_holdings() {
+    async fn total_value_stays_constant_when_cash_deployed() {
+        // Portfolio: equity $6000 (60%), cash $4000 (40%). Total = $10000.
+        // Target: equity 70%, cash 30%.
+        // Greedy buys equity, max_drift_after should improve.
         let total = dec!(10000);
-        let rows = vec![make_drift_row("equity", 5000, 8000, total)];
-        let report = make_report(rows, total);
-
-        let mut h = std::collections::HashMap::new();
-        // Two holdings with 3:1 market value ratio.
-        h.insert(
-            "equity".to_string(),
-            vec![
-                make_holding("h1", "VTI", dec!(30), dec!(3000)),
-                make_holding("h2", "VXUS", dec!(10), dec!(1000)),
-            ],
+        let h = make_holding("h1", "VTI", dec!(10), dec!(6000));
+        let c = make_contribution(&h, "equity", dec!(6000));
+        let rows = vec![
+            make_drift_row("equity", 6000, 7000, total),
+            DriftRow {
+                is_cash: true,
+                ..make_drift_row("cash", 4000, 3000, total)
+            },
+        ];
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            make_report(rows, total),
+            make_contributions(vec![c]),
+            vec![make_cash_holding(dec!(4000), "USD"), h],
         );
-
-        let svc = make_service(make_profile(RebalanceGoal::ExactTarget, false), report, h);
         let plan = svc.calculate_plan(make_input(dec!(2000))).await.unwrap();
 
-        let vti = plan
-            .trades
-            .iter()
-            .find(|t| t.symbol.as_deref() == Some("VTI"))
-            .unwrap();
-        let vxus = plan
-            .trades
-            .iter()
-            .find(|t| t.symbol.as_deref() == Some("VXUS"))
-            .unwrap();
-
-        // VTI gets 75%, VXUS gets 25% of the equity budget.
-        let ratio = vti.estimated_amount / vxus.estimated_amount;
-        let expected = dec!(3); // 3000/1000
-        assert!(
-            (ratio - expected).abs() < dec!(0.01),
-            "proportional weights: VTI should get 3x VXUS, got ratio {ratio}"
-        );
-    }
-
-    #[tokio::test]
-    async fn phase2_distributes_residue_one_share_at_a_time() {
-        // whole_shares_only ON. Equity sleeve underweight.
-        // Three holdings in sleeve, total market value = $420:
-        //   A: price $10, mv $100 (weight 23.81%)
-        //   B: price $30, mv $120 (weight 28.57%)
-        //   C: price $50, mv $200 (weight 47.62%)
-        // Cash $100 → sleeve budget $100 (scale_factor < 1).
-        //   Phase 1: A gets $23.81 → 2 shares × $10 = $20. B gets $28.57 → 0 (< $30 price), skipped.
-        //            C gets $47.62 → 0 (< $50 price), skipped. Deployed $20, residue $80.
-        // Phase 2 ASC (A 10, B 30, C 50), 1-share-at-a-time:
-        //   Pass 1: A +1 ($10), residue $70. B +1 ($30), residue $40. C: $40<$50 skip.
-        //   Pass 2: A +1 ($10), residue $30. B +1 ($30), residue $0.
-        // Final: A=4 shares, B=2 shares (rescued), C still starved.
-        //
-        // Verifies BOTH:
-        //  (a) Phase 2 absorbs residue (vs proportional Phase 2 which would absorb 0).
-        //  (b) Phase 2 does not give all residue to cheapest (vs original bug where A
-        //      would get floor(80/10)=8 shares and B would still be starved).
-        let total = dec!(10000);
-        let rows = vec![make_drift_row("equity", 4000, 8000, total)];
-        let report = make_report(rows, total);
-
-        let mut h = std::collections::HashMap::new();
-        h.insert(
-            "equity".to_string(),
-            vec![
-                make_holding("a", "A", dec!(10), dec!(100)),
-                make_holding("b", "B", dec!(4), dec!(120)),
-                make_holding("c", "C", dec!(4), dec!(200)),
-            ],
-        );
-
-        let svc = make_service(make_profile(RebalanceGoal::ExactTarget, true), report, h);
-        let plan = svc.calculate_plan(make_input(dec!(100))).await.unwrap();
-
-        let a = plan
-            .trades
-            .iter()
-            .find(|t| t.symbol.as_deref() == Some("A"))
-            .expect("A trade present");
-        let b = plan
-            .trades
-            .iter()
-            .find(|t| t.symbol.as_deref() == Some("B"))
-            .expect("B trade present (rescued from skipped by Phase 2)");
-        let c = plan
-            .trades
-            .iter()
-            .find(|t| t.symbol.as_deref() == Some("C"));
-
         assert_eq!(
-            a.quantity,
-            Some(dec!(4)),
-            "A absorbs only what it needs (1 from Phase 1 + 3 from Phase 2), not all residue"
-        );
-        assert_eq!(
-            b.quantity,
-            Some(dec!(2)),
-            "B rescued from Phase 1 skip — Phase 2 buys 2 shares from residue"
+            plan.cash_used + plan.cash_remaining,
+            dec!(2000),
+            "cash_used + remaining must equal available"
         );
         assert!(
-            c.is_none(),
-            "C remains starved (price $50 never fits in residue once A and B consume their share)"
-        );
-        assert_eq!(
-            plan.cash_used,
-            dec!(100),
-            "Full $100 deployed across A and B"
-        );
-    }
-
-    #[tokio::test]
-    async fn phase2_emits_topup_warning_for_unrescued_starved_holding() {
-        // Single expensive holding X (price $240, only holding in sleeve).
-        // Cash $200 → sleeve budget $200 < $240 price.
-        // Phase 1: X skipped. Phase 2: residue $200 < $240 → cannot rescue.
-        // Warning emitted with topup = $240 - $200 = $40.
-        let total = dec!(10000);
-        let rows = vec![make_drift_row("equity", 5000, 8000, total)];
-        let report = make_report(rows, total);
-
-        let mut h = std::collections::HashMap::new();
-        h.insert(
-            "equity".to_string(),
-            vec![make_holding("x", "EXPENSIVE", dec!(5), dec!(1200))],
-        );
-
-        let svc = make_service(make_profile(RebalanceGoal::ExactTarget, true), report, h);
-        let plan = svc.calculate_plan(make_input(dec!(200))).await.unwrap();
-
-        // No trade for EXPENSIVE.
-        assert!(
-            !plan
-                .trades
-                .iter()
-                .any(|t| t.symbol.as_deref() == Some("EXPENSIVE")),
-            "EXPENSIVE should be skipped (price $240 > sleeve budget $200)"
-        );
-
-        // Warning emitted with topup info.
-        let warn = plan
-            .warnings
-            .iter()
-            .find(|w| w.kind == RebalanceWarningKind::WholeShareResidue)
-            .expect("WholeShareResidue warning emitted for starved holding");
-        assert!(
-            warn.message.contains("EXPENSIVE"),
-            "warning names the symbol: {}",
-            warn.message
-        );
-        assert!(
-            warn.message.contains("40"),
-            "warning includes topup amount ($40 to fund 1 share): {}",
-            warn.message
+            plan.max_drift_bps_after <= plan.max_drift_bps_before,
+            "drift must not increase after buying"
         );
     }
 }

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -258,6 +258,7 @@ impl RebalanceServiceTrait for RebalanceService {
                 max_drift_bps_after: 0,
                 trades: vec![],
                 warnings: vec![],
+                after_bps_by_category: std::collections::HashMap::new(),
             });
         }
 

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -1171,6 +1171,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fractional_mode_deploys_partial_share() {
+        // Fractional mode (whole_shares_only = false): $50 cash, $100 ETF. No whole
+        // share fits, but the leftover should deploy as a 0.5-share fractional buy.
+        let total = dec!(10000);
+        let h = make_holding("h1", "ETF", dec!(1), dec!(100)); // $100/share
+        let c = make_contribution(&h, "equity", dec!(100));
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            make_report(vec![make_drift_row("equity", 5000, 7000, total)], total),
+            make_contributions(vec![c]),
+            vec![make_cash_holding(dec!(50), "USD"), h],
+        );
+        let plan = svc.calculate_plan(make_input(dec!(50))).await.unwrap();
+
+        let trade = plan
+            .trades
+            .iter()
+            .find(|t| t.symbol.as_deref() == Some("ETF"))
+            .expect("fractional ETF trade expected");
+        assert_eq!(trade.quantity, Some(dec!(0.5)), "should buy 0.5 shares");
+        assert_eq!(plan.cash_used, dec!(50));
+    }
+
+    #[tokio::test]
     async fn whole_shares_only_buys_integer_shares() {
         let total = dec!(10000);
         // VTI: 10 shares @ $600 = $6000. Price = $600/share.

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -91,7 +91,13 @@ impl RebalanceService {
         let mut candidates: Vec<AssetCandidate> = Vec::new();
         let mut warnings: Vec<RebalanceWarning> = Vec::new();
 
-        for (holding_id, contribs) in by_holding {
+        // Iterate holdings in a stable order so emitted warnings are reproducible
+        // run-to-run (HashMap iteration order is otherwise non-deterministic).
+        let mut holding_ids: Vec<&str> = by_holding.keys().copied().collect();
+        holding_ids.sort_unstable();
+
+        for holding_id in holding_ids {
+            let contribs = &by_holding[holding_id];
             // Skip cash holdings.
             if contribs.iter().all(|c| c.holding_type == HoldingType::Cash) {
                 continue;
@@ -151,7 +157,7 @@ impl RebalanceService {
                 continue;
             }
             let mut exposure_per_share: HashMap<String, Decimal> = HashMap::new();
-            for c in &contribs {
+            for c in contribs.iter() {
                 if c.category_id == "__UNKNOWN__" {
                     continue;
                 }
@@ -1003,6 +1009,36 @@ mod tests {
         assert!(
             trade.unwrap().symbol.is_none(),
             "sleeve trade has no ticker"
+        );
+    }
+
+    #[tokio::test]
+    async fn equal_price_candidates_break_ties_by_symbol() {
+        // Two equity candidates, identical price ($100) and exposure. Cash funds exactly
+        // one share. The stable (price, symbol, asset_id) sort must always pick the
+        // lexicographically smaller symbol (AAA), regardless of HashMap iteration order.
+        let total = dec!(10000);
+        let h_z = make_holding("z1", "ZZZ", dec!(1), dec!(100));
+        let h_a = make_holding("a1", "AAA", dec!(1), dec!(100));
+        let c_z = make_contribution(&h_z, "equity", dec!(100));
+        let c_a = make_contribution(&h_a, "equity", dec!(100));
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            make_report(vec![make_drift_row("equity", 5000, 7000, total)], total),
+            make_contributions(vec![c_z, c_a]),
+            vec![make_cash_holding(dec!(100), "USD"), h_z, h_a],
+        );
+        let plan = svc.calculate_plan(make_input(dec!(100))).await.unwrap();
+
+        let trade = plan
+            .trades
+            .iter()
+            .find(|t| t.asset_id.is_some())
+            .expect("one share bought");
+        assert_eq!(
+            trade.symbol.as_deref(),
+            Some("AAA"),
+            "equal-price tie must resolve to the smaller symbol"
         );
     }
 

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -1236,6 +1236,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn nearest_band_stops_at_band_edge() {
+        // Equity 60% (target 70%, band 5%). NearestBand should stop once equity reaches
+        // the 65% band edge ($500 deployed), not optimize to the exact 70% target ($1000).
+        let total = dec!(10000);
+        let h = make_holding("h1", "VTI", dec!(60), dec!(6000)); // $100/share
+        let rows = vec![make_drift_row("equity", 6000, 7000, total)];
+
+        let svc_band = make_service(
+            make_profile(RebalanceGoal::NearestBand, false),
+            make_report(rows.clone(), total),
+            make_contributions(vec![make_contribution(&h, "equity", dec!(6000))]),
+            vec![make_cash_holding(dec!(1000), "USD"), h.clone()],
+        );
+        let svc_exact = make_service(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            make_report(rows, total),
+            make_contributions(vec![make_contribution(&h, "equity", dec!(6000))]),
+            vec![make_cash_holding(dec!(1000), "USD"), h],
+        );
+
+        let plan_band = svc_band
+            .calculate_plan(make_input(dec!(1000)))
+            .await
+            .unwrap();
+        let plan_exact = svc_exact
+            .calculate_plan(make_input(dec!(1000)))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            plan_band.cash_used,
+            dec!(500),
+            "nearest_band stops at the band edge ($500), got {}",
+            plan_band.cash_used
+        );
+        assert_eq!(
+            plan_exact.cash_used,
+            dec!(1000),
+            "exact_target deploys to the exact target ($1000), got {}",
+            plan_exact.cash_used
+        );
+    }
+
+    #[tokio::test]
     async fn min_trade_amount_filters_small_trades() {
         // VTI at $80/share. min_trade $100.
         // Cash $80 → greedy buys 1 share ($80). Post-filter: $80 < $100 → dropped.

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -65,6 +65,21 @@ impl RebalanceService {
         Decimal::ONE / Decimal::from(10_i64.pow(Self::currency_fraction_digits(currency)))
     }
 
+    fn base_price_per_unit(holding: &crate::portfolio::holdings::Holding) -> Option<Decimal> {
+        if holding.quantity > Decimal::ZERO && holding.market_value.base > Decimal::ZERO {
+            return Some(holding.market_value.base / holding.quantity);
+        }
+
+        holding.price.filter(|p| *p > Decimal::ZERO).map(|price| {
+            let fx_rate = if holding.local_currency == holding.base_currency {
+                Decimal::ONE
+            } else {
+                holding.fx_rate.unwrap_or(Decimal::ONE)
+            };
+            price * fx_rate
+        })
+    }
+
     /// Build `AssetCandidate` list from holdings + contributions.
     ///
     /// Rules (Afadil, #1036):
@@ -279,20 +294,11 @@ impl RebalanceServiceTrait for RebalanceService {
             )
             .await?;
 
-        // Price map: holding_id → price per share in base currency.
+        // Price map: holding_id → price per unit in base currency.
         let price_by_holding: HashMap<String, Decimal> = all_holdings
             .iter()
             .filter(|h| h.holding_type != HoldingType::Cash)
-            .filter_map(|h| {
-                let price = h.price.filter(|&p| p > Decimal::ZERO).or_else(|| {
-                    if h.quantity > Decimal::ZERO {
-                        Some(h.market_value.base / h.quantity)
-                    } else {
-                        None
-                    }
-                })?;
-                Some((h.id.clone(), price))
-            })
+            .filter_map(|h| Some((h.id.clone(), Self::base_price_per_unit(h)?)))
             .collect();
 
         let (candidates, classification_warnings) = Self::build_candidates(
@@ -1195,6 +1201,65 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn fractional_mode_caps_trade_at_target_shortfall() {
+        // Fractional mode should size the whole recommendation fractionally, not buy
+        // a full share first and only fractionalize leftover cash.
+        let total = dec!(10000);
+        let h = make_holding("h1", "ETF", dec!(1), dec!(100)); // $100/share
+        let c = make_contribution(&h, "equity", dec!(100));
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            make_report(vec![make_drift_row("equity", 6925, 7000, total)], total),
+            make_contributions(vec![c]),
+            vec![make_cash_holding(dec!(1000), "USD"), h],
+        );
+        let plan = svc.calculate_plan(make_input(dec!(1000))).await.unwrap();
+
+        let trade = plan
+            .trades
+            .iter()
+            .find(|t| t.symbol.as_deref() == Some("ETF"))
+            .expect("fractional ETF trade expected");
+        assert_eq!(trade.quantity, Some(dec!(0.75)));
+        assert_eq!(plan.cash_used, dec!(75));
+    }
+
+    #[tokio::test]
+    async fn trade_sizing_uses_base_currency_price() {
+        // USD asset in a CAD-base portfolio: local quote is 100 USD, base unit price
+        // is 140 CAD. CAD 1000 can fund 7 whole units, not 10.
+        let total = dec!(10000);
+        let mut h = make_holding("h1", "USETF", dec!(10), dec!(1400));
+        h.local_currency = "USD".to_string();
+        h.base_currency = "CAD".to_string();
+        h.fx_rate = Some(dec!(1.4));
+        h.price = Some(dec!(100));
+        h.market_value.local = dec!(1000);
+
+        let c = make_contribution(&h, "equity", dec!(1400));
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, true),
+            make_report(vec![make_drift_row("equity", 1000, 9000, total)], total),
+            make_contributions(vec![c]),
+            vec![make_cash_holding(dec!(1000), "CAD"), h],
+        );
+        let input = CalculateRebalancePlanInput {
+            base_currency: "CAD".to_string(),
+            ..make_input(dec!(1000))
+        };
+        let plan = svc.calculate_plan(input).await.unwrap();
+
+        let trade = plan
+            .trades
+            .iter()
+            .find(|t| t.symbol.as_deref() == Some("USETF"))
+            .expect("USETF trade expected");
+        assert_eq!(trade.quantity, Some(dec!(7)));
+        assert_eq!(trade.estimated_price, Some(dec!(140)));
+        assert_eq!(plan.cash_used, dec!(980));
+    }
+
+    #[tokio::test]
     async fn whole_shares_only_buys_integer_shares() {
         let total = dec!(10000);
         // VTI: 10 shares @ $600 = $6000. Price = $600/share.
@@ -1348,6 +1413,46 @@ mod tests {
                 .any(|t| t.symbol.as_deref() == Some("VTI")),
             "VTI should survive min_trade when total >= threshold"
         );
+    }
+
+    #[tokio::test]
+    async fn dropped_min_trade_does_not_starve_manual_sleeve_trade() {
+        let total = dec!(10000);
+        let h = make_holding("h1", "VTI", dec!(60), dec!(6000)); // $100/share
+        let c = make_contribution(&h, "equity", dec!(6000));
+        let profile = AllocationTarget {
+            min_trade_amount: "200".to_string(),
+            ..make_profile(RebalanceGoal::ExactTarget, false)
+        };
+        let rows = vec![
+            make_drift_row("equity", 6000, 7000, total),
+            make_drift_row("bonds", 0, 1000, total),
+            DriftRow {
+                is_cash: true,
+                ..make_drift_row("cash", 4000, 2000, total)
+            },
+        ];
+        let svc = make_service(
+            profile,
+            make_report(rows, total),
+            make_contributions(vec![c]),
+            vec![make_cash_holding(dec!(100), "USD"), h],
+        );
+        let plan = svc.calculate_plan(make_input(dec!(100))).await.unwrap();
+
+        assert!(
+            plan.trades
+                .iter()
+                .all(|t| t.symbol.as_deref() != Some("VTI")),
+            "sub-min asset trade should be dropped"
+        );
+        let manual = plan
+            .trades
+            .iter()
+            .find(|t| t.category_id == "bonds")
+            .expect("manual sleeve trade should use cash from dropped asset trade");
+        assert_eq!(manual.estimated_amount, dec!(100));
+        assert_eq!(plan.cash_used, dec!(100));
     }
 
     #[tokio::test]

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -1007,6 +1007,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn manual_sleeve_trade_is_reflected_in_after_bps() {
+        // Bonds underweight (0%, target 10%) with no buy candidate. A $1000 manual
+        // sleeve trade fills it; after_bps_by_category must credit the target category
+        // (1000 bps) rather than leaving it at 0.
+        let total = dec!(10000);
+        let rows = vec![
+            make_drift_row("bonds", 0, 1000, total),
+            make_drift_row("equity", 9000, 9000, total),
+            DriftRow {
+                is_cash: true,
+                ..make_drift_row("cash", 1000, 0, total)
+            },
+        ];
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            make_report(rows, total),
+            make_contributions(vec![]),
+            vec![make_cash_holding(dec!(1000), "USD")],
+        );
+        let plan = svc.calculate_plan(make_input(dec!(1000))).await.unwrap();
+
+        assert_eq!(
+            plan.cash_used,
+            dec!(1000),
+            "manual trade should deploy $1000"
+        );
+        assert_eq!(
+            plan.after_bps_by_category.get("bonds").copied(),
+            Some(1000),
+            "bonds after-drift must reflect the manual sleeve trade"
+        );
+    }
+
+    #[tokio::test]
     async fn multiple_uncovered_categories_never_overspend_cash() {
         // Two required underweight categories with no buy candidates. Each shortfall
         // ($2000) exceeds available cash ($1000). Manual sleeve trades must share the

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -1351,6 +1351,31 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cheap_asset_large_cash_batches_shares() {
+        // Equity 10% (target 90%), funded by a $1 asset, with $8000 cash. A one-share
+        // loop would iterate 8000 times; batching deploys it in one step. Verify the
+        // plan completes and buys the full 8000 shares to reach the target.
+        let total = dec!(10000);
+        let h = make_holding("h1", "CHEAP", dec!(1000), dec!(1000)); // $1/share
+        let c = make_contribution(&h, "equity", dec!(1000));
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            make_report(vec![make_drift_row("equity", 1000, 9000, total)], total),
+            make_contributions(vec![c]),
+            vec![make_cash_holding(dec!(8000), "USD"), h],
+        );
+        let plan = svc.calculate_plan(make_input(dec!(8000))).await.unwrap();
+
+        let trade = plan
+            .trades
+            .iter()
+            .find(|t| t.symbol.as_deref() == Some("CHEAP"))
+            .expect("CHEAP trade expected");
+        assert_eq!(trade.quantity, Some(dec!(8000)), "should buy 8000 shares");
+        assert_eq!(plan.cash_used, dec!(8000));
+    }
+
+    #[tokio::test]
     async fn total_value_stays_constant_when_cash_deployed() {
         // Portfolio: equity $6000 (60%), cash $4000 (40%). Total = $10000.
         // Target: equity 70%, cash 30%.

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -1007,6 +1007,38 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn multiple_uncovered_categories_never_overspend_cash() {
+        // Two required underweight categories with no buy candidates. Each shortfall
+        // ($2000) exceeds available cash ($1000). Manual sleeve trades must share the
+        // cash, never letting cash_used exceed available / cash_remaining go negative.
+        let total = dec!(10000);
+        let rows = vec![
+            make_drift_row("bonds", 2000, 4000, total),
+            make_drift_row("reit", 2000, 4000, total),
+            make_drift_row("equity", 6000, 2000, total),
+        ];
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            make_report(rows, total),
+            make_contributions(vec![]),
+            vec![make_cash_holding(dec!(1000), "USD")],
+        );
+        let plan = svc.calculate_plan(make_input(dec!(1000))).await.unwrap();
+
+        assert!(
+            plan.cash_used <= dec!(1000),
+            "cash_used must not exceed available cash, got {}",
+            plan.cash_used
+        );
+        assert!(
+            plan.cash_remaining >= Decimal::ZERO,
+            "cash_remaining must not go negative, got {}",
+            plan.cash_remaining
+        );
+        assert_eq!(plan.cash_used + plan.cash_remaining, dec!(1000));
+    }
+
+    #[tokio::test]
     async fn unclassified_asset_emits_warning_and_is_skipped() {
         let total = dec!(10000);
         let h = make_holding("h1", "XYZ", dec!(10), dec!(5000));

--- a/docs/features/allocations/rebalance-algorithm.md
+++ b/docs/features/allocations/rebalance-algorithm.md
@@ -137,15 +137,16 @@ Key properties:
 | Whole-share | 1 share per iteration | Integer  |
 | Fractional  | 1 share per iteration | Decimal  |
 
-Both modes use the same greedy loop at 1-share granularity. The difference is in
-the output: whole-share mode produces integer quantities; fractional mode may
-produce fractional shares (e.g. 3.5 shares of an ETF). Cash left over after the
-loop when `cash < min(candidate prices)` is reported as `cash_remaining`.
+Both modes share the same greedy whole-share loop. The difference is what
+happens with the cash left over once no whole share fits:
 
-> **Note (known limitation):** fractional mode could in principle deploy the
-> last slice of cash as a sub-share purchase. The current implementation stops
-> when cash < cheapest candidate price. The gap is typically small (< 1 share
-> price) and is reported as `cash_remaining`.
+- **Whole-share mode** stops there. The leftover (< cheapest candidate price) is
+  reported as `cash_remaining`.
+- **Fractional mode** deploys a final fractional slice: it picks the candidate
+  whose sub-share buy reduces drift the most and sizes it `cash / price`, capped
+  so no category overshoots its desired value (the exact target, or the band
+  edge under `NearestBand`). Any residue below that cap stays as
+  `cash_remaining`.
 
 ---
 
@@ -197,7 +198,6 @@ the PR.
 | --------------------------------------------------- | ---------- | ------------------------------------- |
 | Sell-to-rebalance (`allow_sells`)                   | Medium     | M3                                    |
 | `HoldingTarget` — per-ticker allocations            | High       | V2 data model (SOTA Phase 2)          |
-| Sub-share fractional final top-up                   | Low        | Nice-to-have                          |
 | Tax-lot awareness                                   | High       | Out of V1 scope                       |
 | `TaxAwareOptimizer` (greedy + tax penalty in score) | Medium     | M3/M4                                 |
 | `MilpOptimizer` behind `--features milp`            | High       | When tax-aware / lot selection needed |

--- a/docs/features/allocations/rebalance-algorithm.md
+++ b/docs/features/allocations/rebalance-algorithm.md
@@ -18,8 +18,9 @@ Constraints:
   global ETF classified 60 % US equity / 40 % international). One buy must
   update all affected category exposures simultaneously.
 - **Whole-share mode** — when enabled, only round-lot quantities are suggested.
-- **Minimum trade size** — trades below `min_trade_amount` are dropped from the
-  final output.
+- **Minimum trade size** — asset trades below `min_trade_amount` are dropped from
+  the final output; no-ticker manual sleeve suggestions can still use remaining
+  cash.
 
 ---
 
@@ -56,18 +57,20 @@ Greedy loop
   while cash > 0:
     drift_before = Σ |current_bps[c] − target_bps[c]|  for required non-cash categories
     for each candidate asset:
-      if cash < price: skip
-      simulate buy 1 share → new_bps[c] = (current_value[c] + exposure_per_share[c]) / total_value
+      if whole-share mode and cash < price: skip
+      quantity = 1 share in whole-share mode
+      quantity = fractional cash/price capped at the next target/band bend in fractional mode
+      simulate buy quantity → new_bps[c] = (current_value[c] + exposure_per_share[c] × quantity) / total_value
       drift_after = Σ |new_bps[c] − target_bps[c]|
-      score = (drift_before − drift_after) / price
+      score = (drift_before − drift_after) / amount
     pick candidate with highest score > 0
     tie-break: price ASC (deterministic; lower-price assets preferred)
     if no candidate improves drift: stop
-    apply buy: update current_value[c] for each category, cash -= price
+    apply buy: update current_value[c] for each category, cash -= amount
 
 Post-processing
   Aggregate shares by asset → SuggestedManualTrade (1 per asset)
-  Drop trades where estimated_amount < min_trade_amount
+  Drop asset trades where estimated_amount < min_trade_amount
   cash_used = sum of kept trade amounts
   after_bps_by_category = recompute from initial values + kept trades only
 
@@ -132,21 +135,23 @@ Key properties:
 
 ## 6. Whole-share vs fractional mode
 
-| Mode        | Step                  | Quantity |
-| ----------- | --------------------- | -------- |
-| Whole-share | 1 share per iteration | Integer  |
-| Fractional  | 1 share per iteration | Decimal  |
+| Mode        | Step                                  | Quantity |
+| ----------- | ------------------------------------- | -------- |
+| Whole-share | 1 share, batched within linear region | Integer  |
+| Fractional  | Drift-capped slice                    | Decimal  |
 
-Both modes share the same greedy whole-share loop. The difference is what
-happens with the cash left over once no whole share fits:
+Both modes use the same drift-improvement-per-dollar scoring and candidate
+tie-breaks.
 
-- **Whole-share mode** stops there. The leftover (< cheapest candidate price) is
-  reported as `cash_remaining`.
-- **Fractional mode** deploys a final fractional slice: it picks the candidate
-  whose sub-share buy reduces drift the most and sizes it `cash / price`, capped
-  so no category overshoots its desired value (the exact target, or the band
-  edge under `NearestBand`). Any residue below that cap stays as
-  `cash_remaining`.
+- **Whole-share mode** buys integer quantities only. It batches repeated buys of
+  the selected candidate only when it is the sole improving candidate. If more
+  than one asset can improve drift, it buys one share and re-scores, preserving
+  strict greedy equivalence in coupled multi-category cases. Cash below the next
+  usable share price remains as `cash_remaining`.
+- **Fractional mode** sizes each selected buy as a decimal quantity from the
+  start, capped at available cash and the next target/band bend for categories
+  the candidate can improve. This avoids full-share overbuying when a fractional
+  quantity already closes the drift.
 
 ---
 
@@ -178,7 +183,7 @@ the suggested amount even when no holding covers that category.
 
 ---
 
-## 9. Open question for Afadil (PR-B)
+## 9. PR-B decisions
 
 `AllocationService::contribution_shares_for_holding` normalises weights >10000
 bps silently (line 247: `weight_divisor = total.max(10000)`). This is consistent
@@ -186,9 +191,14 @@ with how drift reports and allocation views already handle over-allocated
 assets. For the rebalance planner we align with this behaviour rather than
 blocking on >100% weights.
 
-If a hard block is desired, the right place is write-time validation on
-`AssetTaxonomyAssignment` (not in the planner). Flagged for Afadil's input in
-the PR.
+If a hard block is desired, it should be write-time validation on
+`AssetTaxonomyAssignment` in a separate data-quality PR, not planner-only
+behaviour.
+
+The old `WholeShareResidue` top-up warning is not carried forward. It was tied
+to the old proportional sleeve planner and does not map cleanly to this
+exposure-aware optimiser. Whole-share residue is reported as `cash_remaining`;
+a future UI pass can add a non-blocking "add X for one more share" hint.
 
 ---
 
@@ -202,6 +212,7 @@ the PR.
 | `TaxAwareOptimizer` (greedy + tax penalty in score) | Medium     | M3/M4                                 |
 | `MilpOptimizer` behind `--features milp`            | High       | When tax-aware / lot selection needed |
 | Multi-account optimisation                          | High       | SOTA spec, future roadmap             |
+| Whole-share top-up hint                             | Low        | UX polish                             |
 
 ---
 
@@ -217,7 +228,7 @@ the PR.
 - **Types:** `crates/core/src/portfolio/allocation_targets/model.rs` —
   `RebalancePlan`, `SuggestedManualTrade`, `RebalanceWarning`,
   `RebalanceWarningKind`.
-- **Tests:** `rebalance_service.rs` `mod tests` — 50 tests covering cash
+- **Tests:** `rebalance_service.rs` `mod tests` — 53 tests covering cash
   enforcement, greedy selection, multi-category ETF exposure, classification
   edge cases, whole-share, nearest-band, min-trade filter.
 - **UI:**

--- a/docs/features/allocations/rebalance-algorithm.md
+++ b/docs/features/allocations/rebalance-algorithm.md
@@ -1,7 +1,7 @@
 # Rebalance Algorithm — Design Notes
 
-Status: Current (M2) Date: 2026-05-31 Audience: Contributors, reviewers, curious
-users
+Status: Current (PR-B) Date: 2026-06-03 Audience: Contributors, reviewers,
+curious users
 
 ---
 
@@ -13,11 +13,13 @@ bring the portfolio as close to target as possible using only that cash?
 
 Constraints:
 
-- **Cash-only by default** — no forced sells (M2). Sell-mode is M3.
-- **Sleeve boundaries** — each category gets a proportional share of cash;
-  residue does not cross sleeve boundaries.
+- **Cash-only** — no forced sells (M2). Sell-mode is M3.
+- **Exposure-aware** — an asset may span multiple taxonomy categories (e.g. a
+  global ETF classified 60 % US equity / 40 % international). One buy must
+  update all affected category exposures simultaneously.
 - **Whole-share mode** — when enabled, only round-lot quantities are suggested.
-- **Minimum trade size** — trades below `min_trade_amount` are dropped.
+- **Minimum trade size** — trades below `min_trade_amount` are dropped from the
+  final output.
 
 ---
 
@@ -31,8 +33,10 @@ find the globally optimal trade set in one pass. Real costs:
 - Overkill for single-portfolio individual use where "close enough" in
   milliseconds beats "optimal" in seconds.
 
-Our two-phase greedy algorithm achieves near-optimal results for typical inputs
-and is easy to audit step by step.
+The greedy algorithm below achieves near-optimal results for typical inputs and
+is easy to audit step by step. The `RebalanceOptimizer` trait is
+solver-compatible: a future `MilpOptimizer` can replace `DriftPriorityOptimizer`
+behind a feature flag without changing `RebalanceService`.
 
 ---
 
@@ -41,205 +45,180 @@ and is easy to audit step by step.
 ```
 Input: available_cash, target_profile, current_holdings, drift_report
 
-Phase 1 — Proportional allocation
-  Compute shortfall per underweight sleeve.
-  Scale sleeve budgets to fit available_cash.
-  For each sleeve:
-    For each holding (weighted by current market value):
-      holding_budget = sleeve_budget × holding_weight
-      If whole_shares_only:
-        shares = floor(holding_budget / price)
-        If shares == 0: track holding as "skipped"
-      Else:
-        amount = holding_budget    ← fractional, 100% deployed
+Build exposure vectors
+  For each non-cash holding with taxonomy assignments:
+    exposure_per_share[category] = contribution.value / quantity
+    (multi-category ETF → multiple entries summing to ≤ price)
+    Skip holding if all categories are __UNKNOWN__ (warn UnclassifiedAsset)
+    Include with partial exposure if some categories are __UNKNOWN__ (warn PartialClassification)
 
-Phase 2 — Intra-sleeve residue absorption (whole_shares_only only)
-  For each sleeve:
-    Sort holdings by price ASC
-    residue = sleeve_budget - sleeve_deployed
-    Loop:
-      For each holding (cheapest first):
-        If residue ≥ price: buy 1 share, residue -= price
-      Break if no holding bought a share this pass
+Greedy loop
+  while cash > 0:
+    drift_before = Σ |current_bps[c] − target_bps[c]|  for required non-cash categories
+    for each candidate asset:
+      if cash < price: skip
+      simulate buy 1 share → new_bps[c] = (current_value[c] + exposure_per_share[c]) / total_value
+      drift_after = Σ |new_bps[c] − target_bps[c]|
+      score = (drift_before − drift_after) / price
+    pick candidate with highest score > 0
+    tie-break: price ASC (deterministic; lower-price assets preferred)
+    if no candidate improves drift: stop
+    apply buy: update current_value[c] for each category, cash -= price
 
-  For each Phase-1-skipped holding still un-funded:
-    Emit WholeShareResidue warning with top-up suggestion.
+Post-processing
+  Aggregate shares by asset → SuggestedManualTrade (1 per asset)
+  Drop trades where estimated_amount < min_trade_amount
+  cash_used = sum of kept trade amounts
+  after_bps_by_category = recompute from initial values + kept trades only
 
-Output: trades[], warnings[], cash_used, cash_remaining
+Output: trades[], warnings[], cash_used, cash_remaining, after_bps_by_category
 ```
 
 ---
 
-## 4. Phase 1 — Proportional allocation
+## 4. Exposure vectors
 
-### Sleeve budget
+Each asset is represented as a vector of per-share exposures across taxonomy
+categories, derived from
+`AllocationService::get_holding_contributions_for_taxonomy_for_accounts`.
 
-Each underweight sleeve receives a budget proportional to its shortfall vs.
-target. `nearest_band` aims for the closest band edge; `exact_target` aims for
-the exact target percentage. When `total_shortfall > available_cash`, a
-`scale_factor = available_cash / total_shortfall` reduces all sleeve budgets
-proportionally so every underweight sleeve still gets a share.
+```
+              US equity   Intl equity   Bonds
+VT              $60          $40          $0     (price $100 — fully classified)
+AAPL           $100           $0          $0     (price $100 — single category)
+XYZ             $70           $0          $0     (price $100 — partial: 70% known, 30% __UNKNOWN__)
+```
 
-Sleeves already at or above target receive zero budget.
+For VT: buying 1 share adds $60 to US equity and $40 to international equity
+simultaneously, improving drift in both categories in a single step.
 
-### Holding distribution within a sleeve
+`__UNKNOWN__` exposure is excluded from the vector. Partial exposure means the
+greedy can improve drift for the known categories but not for the unclassified
+remainder.
 
-Within a sleeve, budget is distributed proportional to each holding's current
-market value. This keeps the relative composition of the sleeve stable — the
-same principle a passive index fund uses when it receives new money.
+### Classification edge cases
 
-Example: sleeve holdings = A €4000 (40 %), B €3000 (30 %), C €2000 (20 %), D
-€1000 (10 %). Sleeve budget €2000 → A gets €800, B €600, C €400, D €200.
-
-### Fractional vs whole-share mode
-
-| Mode        | Shares                          | Amount                            |
-| ----------- | ------------------------------- | --------------------------------- |
-| Fractional  | `holding_budget / price`        | `holding_budget` (100 % deployed) |
-| Whole-share | `floor(holding_budget / price)` | `shares × price`                  |
-
-Fractional mode deploys 100 % of the sleeve budget. Whole-share mode leaves a
-rounding residue that Phase 2 reclaims.
-
----
-
-## 5. Phase 2 — Intra-sleeve residue absorption (whole-share mode)
-
-### Why this phase exists
-
-With whole-share rounding, each holding may leave a fractional share's worth of
-cash undeployed. Across a sleeve with several holdings, this residue easily
-totals one or two full share prices — enough to buy at least one more share, but
-lost if we stop after Phase 1.
-
-### Algorithm: 1-share-at-a-time, price ascending
-
-1. Sort holdings by price ascending (cheapest first).
-2. Loop one pass over all holdings:
-   - If `residue ≥ price`, buy exactly **1 share**, reduce residue.
-3. Repeat until a full pass buys nothing.
-
-### Why 1-share-at-a-time (not `floor(residue / price)`)
-
-The naive approach `additional = floor(residue / price)` lets the cheapest
-holding absorb the entire residue in a single shot, badly skewing sleeve
-composition (one cheap ETF receiving 100+ shares while expensive holdings get
-zero extra). The 1-share-at-a-time loop preserves balance: each holding can
-receive at most one additional share per pass.
-
-### Why price ascending (not proportional weights)
-
-An earlier version used `floor(residue × weight / price)` to preserve
-proportions. This failed silently for small residues: when each holding's
-proportional slice was below its share price, no holding could buy anything and
-the entire residue stayed undeployed. Sorting by price ASC guarantees the
-cheapest holding gets the first chance, which is the standard greedy choice for
-maximising deployment.
-
-### What it does NOT do
-
-- **No cross-sleeve redistribution.** Residue stays within the sleeve that
-  generated it. Crossing sleeve boundaries would silently alter the target
-  allocation.
-- **No sell suggestions.** Phase 2 only buys.
-- **No expensive-holding rescue.** When a cheaper holding shares the sleeve,
-  Phase 2 ASC always satisfies the cheaper holding first. Expensive holdings
-  that were skipped in Phase 1 (because their proportional budget < price)
-  cannot be rescued — see the structural-starvation limitation below.
+| Situation                                     | Behaviour                                                                    |
+| --------------------------------------------- | ---------------------------------------------------------------------------- |
+| All exposure in `__UNKNOWN__`                 | Skip as candidate. Warn `UnclassifiedAsset`.                                 |
+| Partial exposure (<100% classified)           | Include with known exposure. Warn `PartialClassification`. Do not normalise. |
+| Weights >100%                                 | `AllocationService` normalises to 100% (consistent with drift view).         |
+| Cash holdings (`CASH` / `CASH_BANK_DEPOSITS`) | Excluded from candidates.                                                    |
+| No price available (whole-share mode)         | Skip. Warn `MissingQuote`.                                                   |
 
 ---
 
-## 6. Known limitation — structural starvation of expensive holdings
+## 5. Scoring
 
-### The problem
+**Score = drift_improvement / price**
 
-When a holding's proportional budget is less than its share price, Phase 1 skips
-it. Phase 2 cannot rescue it if any cheaper holding exists in the same sleeve —
-the cheaper holding will absorb the residue first, leaving less than one
-expensive share's worth behind.
+Where `drift_improvement = Σ|drift_bps[c]| before − Σ|drift_bps[c]| after`
+across all required non-cash categories.
 
-**Concrete example:** sleeve has holding X (price €240, 10 % weight). User
-deploys €2000/month. X's proportional budget each month is 10 % × €2000 = €200,
-which is less than the €240 share price. X never receives any cash, and over
-time its portfolio weight drifts toward zero while other holdings grow.
+Key properties:
 
-### Why this matters
-
-Without holding-level targets, the algorithm assumes "maintain current
-proportions" is the right default. Structurally expensive holdings break that
-assumption: their proportion silently decays each rebalance run.
-
-### Options considered
-
-| Option                      | Mechanism                                                           | Status                             |
-| --------------------------- | ------------------------------------------------------------------- | ---------------------------------- |
-| **A — 1-at-a-time Phase 2** | Absorbs cheap residue, no expensive rescue                          | ✅ Implemented                     |
-| **B — Robin Hood rescue**   | Reduce served holdings by 1 share to fund expensive starved holding | ⏳ Open design question for Afadil |
-| **C — Top-up warning**      | Emit explicit warning with suggested top-up cash amount             | ✅ Implemented                     |
-| **D — HoldingTarget**       | Per-ticker explicit weights override "maintain proportions"         | ⏳ Future (V2 data model)          |
-
-### Current behaviour (A + C)
-
-Phase 2 absorbs cheap residue. For any holding still starved after Phase 2, a
-`WholeShareResidue` warning is emitted with the top-up amount needed to fund one
-share. Example:
-
-> EXPENSIVE: proportional budget $200.00 short of 1 share at $240.00. Add
-> ~$40.00 more cash to fund 1 share, or EXPENSIVE will drift below target over
-> time.
-
-The user can then choose to add more cash or accept the drift.
-
-### Why we deferred Robin Hood (Option B)
-
-Reducing one holding's allocation to fund another is a design decision, not a
-pure algorithmic improvement. It alters the proportional contract Phase 1
-established. We want explicit sign-off from Afadil before changing this default
-— see the M2 PR open questions.
-
-### Why we deferred HoldingTarget (Option D)
-
-`HoldingTarget` is in the SOTA spec but not in V1. It requires a new data model,
-UI for per-ticker target weights, and downstream changes to drift calculation.
-Out of scope for V1/M2.
+- **Multi-category benefit.** An ETF that simultaneously reduces drift in two
+  categories scores higher than a single-category asset at the same price — the
+  numerator captures the combined improvement.
+- **Scale-invariant for same-category assets.** Two assets 100% in the same
+  underweight category have identical scores regardless of price (buying more of
+  a cheaper asset per dollar improves the category by the same bps as buying
+  less of an expensive one). The tie-break resolves them by price ASC.
+- **Stops when no improvement.** Once the portfolio reaches target (or no
+  candidate can further reduce drift without overshooting), the loop terminates.
+  Remaining cash stays as `cash_remaining`.
 
 ---
 
-## 7. Warnings emitted
+## 6. Whole-share vs fractional mode
 
-| Warning kind        | Condition                                                                          | User action                                 |
-| ------------------- | ---------------------------------------------------------------------------------- | ------------------------------------------- |
-| `MissingQuote`      | Holding has no valid price or quantity (whole-share mode)                          | Refresh market data                         |
-| `WholeShareResidue` | Holding skipped because proportional budget < price, even after Phase 2 absorption | Top-up suggestion included (price − budget) |
-| `NoBuyCandidate`    | Sleeve has no holdings — sleeve-level dollar suggestion emitted                    | User picks a ticker manually                |
+| Mode        | Step                  | Quantity |
+| ----------- | --------------------- | -------- |
+| Whole-share | 1 share per iteration | Integer  |
+| Fractional  | 1 share per iteration | Decimal  |
 
-The `WholeShareResidue` message names the symbol, original budget, share price,
-and exact top-up required. Aggregated at sleeve level: one warning per starved
-holding, emitted once per plan.
+Both modes use the same greedy loop at 1-share granularity. The difference is in
+the output: whole-share mode produces integer quantities; fractional mode may
+produce fractional shares (e.g. 3.5 shares of an ETF). Cash left over after the
+loop when `cash < min(candidate prices)` is reported as `cash_remaining`.
 
----
-
-## 8. Possible future improvements
-
-| Idea                                              | Complexity | Status                                                                             |
-| ------------------------------------------------- | ---------- | ---------------------------------------------------------------------------------- |
-| Robin Hood rescue (Option B above)                | Medium     | Open design question for Afadil                                                    |
-| HoldingTarget — per-ticker allocations (Option D) | High       | Requires V2 data model (SOTA Phase 2)                                              |
-| Sell-to-rebalance (`allow_sells`)                 | Medium     | Spec'd in V1, scoped for M3                                                        |
-| Tax-lot awareness                                 | High       | Out of V1 scope                                                                    |
-| Cross-sleeve residue redistribution               | High       | Would break target allocation contract                                             |
-| Persistent "owed" credit across runs              | High       | Solves expensive-holding drift more cleanly than Robin Hood, but needs schema + UX |
-| LP/MILP solver                                    | High       | Overkill for current use case                                                      |
-| Multi-account optimisation                        | High       | SOTA spec, future roadmap                                                          |
+> **Note (known limitation):** fractional mode could in principle deploy the
+> last slice of cash as a sub-share purchase. The current implementation stops
+> when cash < cheapest candidate price. The gap is typically small (< 1 share
+> price) and is reported as `cash_remaining`.
 
 ---
 
-## 9. Implementation reference
+## 7. After-drift computation
 
-- Algorithm: `crates/core/src/portfolio/allocation_targets/rebalance_service.rs`
-  — `calculate_plan()` method, Phase 1 lines ~241–333, Phase 2 lines ~335–460.
-- Types: `crates/core/src/portfolio/allocation_targets/model.rs` —
-  `RebalancePlan`, `SuggestedManualTrade`, `RebalanceWarning`.
-- Tests: same file, `mod tests` — 10 tests covering Phase 1 proportional split,
-  Phase 2 absorption + non-skew, scaling, warning emission, min-trade filter.
-- UI: `apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx`.
+After filtering trades by `min_trade_amount`, `after_bps_by_category` is
+recomputed from the initial portfolio state plus the kept trades only (not the
+full greedy state). This keeps `cash_used`, `cash_remaining`, and
+`after_bps_by_category` mutually consistent with what the user will actually
+execute.
+
+The frontend `BeforeAfterStack` visualisation uses `after_bps_by_category`
+directly from the plan (not re-derived from trade amounts), which gives correct
+results for multi-category ETFs.
+
+---
+
+## 8. Warnings emitted
+
+| Warning kind            | Condition                                                    | User action                         |
+| ----------------------- | ------------------------------------------------------------ | ----------------------------------- |
+| `UnclassifiedAsset`     | Holding has no taxonomy assignments for the active taxonomy  | Classify the asset                  |
+| `PartialClassification` | Holding has partial weights (<100%); known exposure used     | Complete classification if possible |
+| `MissingQuote`          | No valid price in whole-share mode                           | Refresh market data                 |
+| `NoBuyCandidate`        | Required underweight category has no candidate with exposure | Allocate that category manually     |
+
+`NoBuyCandidate` emits a sleeve-level dollar trade (no ticker) so the user sees
+the suggested amount even when no holding covers that category.
+
+---
+
+## 9. Open question for Afadil (PR-B)
+
+`AllocationService::contribution_shares_for_holding` normalises weights >10000
+bps silently (line 247: `weight_divisor = total.max(10000)`). This is consistent
+with how drift reports and allocation views already handle over-allocated
+assets. For the rebalance planner we align with this behaviour rather than
+blocking on >100% weights.
+
+If a hard block is desired, the right place is write-time validation on
+`AssetTaxonomyAssignment` (not in the planner). Flagged for Afadil's input in
+the PR.
+
+---
+
+## 10. Possible future improvements
+
+| Idea                                                | Complexity | Status                                |
+| --------------------------------------------------- | ---------- | ------------------------------------- |
+| Sell-to-rebalance (`allow_sells`)                   | Medium     | M3                                    |
+| `HoldingTarget` — per-ticker allocations            | High       | V2 data model (SOTA Phase 2)          |
+| Sub-share fractional final top-up                   | Low        | Nice-to-have                          |
+| Tax-lot awareness                                   | High       | Out of V1 scope                       |
+| `TaxAwareOptimizer` (greedy + tax penalty in score) | Medium     | M3/M4                                 |
+| `MilpOptimizer` behind `--features milp`            | High       | When tax-aware / lot selection needed |
+| Multi-account optimisation                          | High       | SOTA spec, future roadmap             |
+
+---
+
+## 11. Implementation reference
+
+- **Trait + types:** `crates/core/src/portfolio/allocation_targets/optimizer.rs`
+  — `RebalanceOptimizer`, `DriftPriorityOptimizer`, `RebalanceInput`,
+  `AssetCandidate`.
+- **Orchestration:**
+  `crates/core/src/portfolio/allocation_targets/rebalance_service.rs` —
+  `RebalanceService::calculate_plan()` fetches holdings + contributions, builds
+  candidates, calls optimizer.
+- **Types:** `crates/core/src/portfolio/allocation_targets/model.rs` —
+  `RebalancePlan`, `SuggestedManualTrade`, `RebalanceWarning`,
+  `RebalanceWarningKind`.
+- **Tests:** `rebalance_service.rs` `mod tests` — 50 tests covering cash
+  enforcement, greedy selection, multi-category ETF exposure, classification
+  edge cases, whole-share, nearest-band, min-trade filter.
+- **UI:**
+  `apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx`.

--- a/docs/features/allocations/rebalance-algorithm.md
+++ b/docs/features/allocations/rebalance-algorithm.md
@@ -18,9 +18,9 @@ Constraints:
   global ETF classified 60 % US equity / 40 % international). One buy must
   update all affected category exposures simultaneously.
 - **Whole-share mode** — when enabled, only round-lot quantities are suggested.
-- **Minimum trade size** — asset trades below `min_trade_amount` are dropped from
-  the final output; no-ticker manual sleeve suggestions can still use remaining
-  cash.
+- **Minimum trade size** — asset trades below `min_trade_amount` are dropped
+  from the final output; no-ticker manual sleeve suggestions can still use
+  remaining cash.
 
 ---
 
@@ -197,8 +197,8 @@ behaviour.
 
 The old `WholeShareResidue` top-up warning is not carried forward. It was tied
 to the old proportional sleeve planner and does not map cleanly to this
-exposure-aware optimiser. Whole-share residue is reported as `cash_remaining`;
-a future UI pass can add a non-blocking "add X for one more share" hint.
+exposure-aware optimiser. Whole-share residue is reported as `cash_remaining`; a
+future UI pass can add a non-blocking "add X for one more share" hint.
 
 ---
 


### PR DESCRIPTION
Hello @afadil 👋

PR-B for the Allocation Targets feature : 
the exposure-aware **Drift Planner** from Milestone 2, rewriting the algorithm as we discussed in #1036.

This is the final piece of the rebalance planner. 
I documented the algorithm fully in `docs/features/allocations/rebalance-algorithm.md` and left 3 open questions at the bottom where I'd like your call before we lock it in. 🙂

---

## Summary

Replaces the proportional cash-flow planner (PR-A, #1036) with an **exposure-aware greedy optimiser**.

The previous algorithm treated each taxonomy category as an isolated sleeve and split cash proportionally to current holdings. That breaks for assets with split classification (e.g. a global ETF that spans US / developed / emerging markets) — buying one such ETF affects several categories at once, but the proportional model couldn't see that coupling.

This PR introduces `DriftPriorityOptimizer`: each iteration buys 1 share of the asset that maximises **total drift reduction per dollar** across *all* taxonomy categories. A single buy updates every affected category's exposure simultaneously.

## Design

```
Build exposure vectors (per-share value per category, from AllocationService contributions)
Greedy loop:
  score(asset) = (Σ|drift_bps| before − Σ|drift_bps| after) / price
  pick highest score > 0   (tie-break: price ASC)
  apply 1-share buy, repeat until no asset improves drift or cash exhausted
Post-process:
  aggregate shares → 1 trade per asset
  drop trades below min_trade_amount
  recompute after-drift from kept trades only
```

- **Greedy, not LP/MILP** — deterministic, explainable, fast. Solver-compatible via the new `RebalanceOptimizer` trait (a future `MilpOptimizer` / `TaxAwareOptimizer` can slot in without touching `RebalanceService`).
- **Phase 1 + Phase 2 removed** — the greedy 1-share loop subsumes both proportional allocation and residue absorption.
- **`cash_used`** = sum of recommended trade amounts after the min-trade filter, so it always matches what the user will actually execute. After-drift is recomputed from the kept trades.
- **`after_bps_by_category`** added to `RebalancePlan` so the UI Before/Target/After bars are accurate for multi-category ETFs (previously re-derived from the primary trade category, which was wrong for split assets).

## Classification rules (from your direction in #1036)

| Case | Behaviour |
| ---- | --------- |
| No assignments on active taxonomy | Skip candidate, warn `UnclassifiedAsset` |
| Partial weights (<100%) | Use known exposure as-is, warn `PartialClassification`, no normalisation |
| Weights only on another taxonomy | Treated as unclassified → skip + warn |
| Empty category | `NoBuyCandidate` + sleeve-level dollar suggestion (no fake ticker) |
| Holdings outside target sleeves | Informational only (sell = M3) |
| Cash holdings | Excluded from candidates |

5 of these 6 rules fall out naturally from the `AllocationService` contributions layer (which already emits a `__UNKNOWN__` row for partial/unassigned classification).

## Changes

- **`optimizer.rs`** (new) — `RebalanceOptimizer` trait, `DriftPriorityOptimizer`, input types.
- **`rebalance_service.rs`** — rewritten orchestration: fetch holdings + contributions, build candidates, delegate to optimiser. Authoritative tracked-cash enforcement from PR-A preserved.
- **`model.rs`** — `after_bps_by_category` on `RebalancePlan`; new warning kinds `UnclassifiedAsset` / `PartialClassification`; dropped now-unused `WholeShareResidue`.
- **Frontend** — `rebalance-tab.tsx`: "Drift planner" badge, new warning labels, Before/After bars use backend after-drift; CSV export now carries plan metadata (profile, date, cash, currency) with currency-aware formatting.
- **Docs** — `rebalance-algorithm.md` rewritten for the exposure-aware model.

## Tests

- `cargo test -p wealthfolio-core` — 1214 pass (50 in `allocation_targets`, incl. multi-category ETF coupling, classification edge cases, whole-share, nearest-band, cash enforcement).
- `cargo clippy -p wealthfolio-core --lib -- -D warnings` — clean.
- Frontend type-check clean on touched files.

## Questions for you @afadil

1. **Weights >100%** — you wrote "block the plan" for over-allocated assets, but your allocation hardening (#1041, `contribution_shares_for_holding`) already normalises >100% to 100% silently, and the drift report / Overview tab consume that normalised data everywhere. Blocking only in the rebalance planner would be inconsistent with the rest of the app. I aligned the planner with the existing normalisation rather than blocking. If you want a hard block, I think the right place is **write-time validation on `AssetTaxonomyAssignment`** (a separate data-quality PR), not the planner. Agree? (Noted in §9 of the algorithm doc.)

2. **Top-up / starvation warning** — in the proportional model we emitted a `WholeShareResidue` warning when an expensive holding's per-holding budget was below its share price. The exposure-aware model has no per-holding proportion concept (it minimises category drift), so structural starvation isn't really a thing — undeployed cash just surfaces as `cash_remaining`. I dropped the warning. Do you want a per-asset "add $X to fund 1 more share" hint back, or is `cash_remaining` enough?

3. **Fractional last slice** — the loop stops when remaining cash < cheapest candidate's full share price; the gap (< 1 share) stays as `cash_remaining`. Fractional mode could deploy that final slice as a sub-share buy. Left as a nice-to-have — worth doing now or defer?

---

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).
