### PR TITLE
fix: asset id empty string validation & default activity date on mobile

### DIFF
--- a/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
@@ -321,7 +321,9 @@ export function MobileActivityForm({ accounts, activity, open, onClose }: Mobile
     assetId:
       isTransferType && !isSecurityTransferActivity
         ? undefined
-        : (activity?.assetSymbol ?? activity?.assetId),
+        : (activity?.assetSymbol ?? activity?.assetId)
+          ? (activity?.assetSymbol ?? activity?.assetId)
+          : undefined,
     activityDate: activity?.date
       ? new Date(activity.date)
       : (() => {

--- a/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
@@ -324,13 +324,7 @@ export function MobileActivityForm({ accounts, activity, open, onClose }: Mobile
         : (activity?.assetSymbol ?? activity?.assetId)
           ? (activity?.assetSymbol ?? activity?.assetId)
           : undefined,
-    activityDate: activity?.date
-      ? new Date(activity.date)
-      : (() => {
-          const date = new Date();
-          date.setHours(16, 0, 0, 0);
-          return date;
-        })(),
+    activityDate: activity?.date ? new Date(activity.date) : new Date(),
     currency: activity?.currency ?? "",
     quoteMode: activity?.assetQuoteMode === QuoteMode.MANUAL ? QuoteMode.MANUAL : QuoteMode.MARKET,
     exchangeMic: activity?.exchangeMic,


### PR DESCRIPTION
## Description

### Issue (mobile: unable to update activities)
On mobile, form activities like interest, tax, and fee return `assetId: ""` when updating. However, validation expects `assetId` to be `undefined` when it is not needed, not an empty string.

Error:
<img src="https://github.com/user-attachments/assets/24e35e6f-a798-4950-95c7-f373e43cc85d" width="300" />


### Issue (mobile: set current time as default)
When creating a new activity, mobile defaults the activity time to 4:00 PM, which does not match desktop behavior.
<img  src="https://github.com/user-attachments/assets/bddd40fa-909b-4d69-b94e-d018943f19a1" width="300" />

## Fix

- Check if assetID is empty string (`""`) and fallback to `undefined`
- Set `activityDate` to the current time when creating new activities (instead of defaulting to 4:00 PM)

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
