### PR TITLE
feat: proportional top-up after drift-improving greedy exhausts gains

### DIFF
--- a/crates/core/src/portfolio/allocation_targets/optimizer.rs
+++ b/crates/core/src/portfolio/allocation_targets/optimizer.rs
@@ -444,6 +444,116 @@ impl DriftPriorityOptimizer {
         (kept_values, proceeds, sell_trades)
     }
 
+    /// Proportional top-up: after the drift-improving greedy exhausts its gains, deploy
+    /// remaining cash proportionally to `target_bps` weights. Each sleeve gets the
+    /// candidate with the highest per-share exposure to that category.
+    ///
+    /// Accumulates into the caller's `shares_bought` so greedy + top-up shares for the
+    /// same asset merge into a single output trade.
+    ///
+    /// Only called for CashFlowOnly and Hybrid (SellToRebalance leaves remaining proceeds
+    /// as cash_remaining to avoid circular sell→buy patterns).
+    fn run_proportional_topup(
+        values: &mut HashMap<String, Decimal>,
+        candidates: &[AssetCandidate],
+        shares_bought: &mut [Decimal],
+        cash: Decimal,
+        categories: &[CategoryState],
+        profile: &RebalanceProfile,
+    ) {
+        if cash <= Decimal::ZERO || candidates.is_empty() {
+            return;
+        }
+
+        let required_cats: Vec<&CategoryState> = categories
+            .iter()
+            .filter(|c| c.is_required && !c.is_cash && c.target_bps > 0)
+            .collect();
+
+        let total_target_bps: i32 = required_cats.iter().map(|c| c.target_bps).sum();
+        if total_target_bps == 0 {
+            return;
+        }
+
+        // Stable allocation order: largest sleeve first, then by category_id.
+        let mut cats_sorted = required_cats;
+        cats_sorted.sort_by(|a, b| {
+            b.target_bps
+                .cmp(&a.target_bps)
+                .then(a.category_id.cmp(&b.category_id))
+        });
+
+        let mut remaining = cash;
+
+        for cat in cats_sorted {
+            if remaining <= Decimal::ZERO {
+                break;
+            }
+
+            // Budget for this sleeve, capped at what's left.
+            let sleeve_budget = (cash * Decimal::from(cat.target_bps)
+                / Decimal::from(total_target_bps))
+            .min(remaining);
+
+            if sleeve_budget <= Decimal::ZERO {
+                continue;
+            }
+
+            // Best candidate = highest per-share exposure to this category.
+            // Tie-break: lower price preferred (consistent with greedy tie-break).
+            let best = candidates
+                .iter()
+                .enumerate()
+                .filter(|(_, c)| {
+                    c.price > Decimal::ZERO
+                        && c.exposure_per_share
+                            .get(&cat.category_id)
+                            .is_some_and(|e| *e > Decimal::ZERO)
+                })
+                .max_by(|(_, a), (_, b)| {
+                    let ea = a
+                        .exposure_per_share
+                        .get(&cat.category_id)
+                        .copied()
+                        .unwrap_or_default();
+                    let eb = b
+                        .exposure_per_share
+                        .get(&cat.category_id)
+                        .copied()
+                        .unwrap_or_default();
+                    ea.cmp(&eb)
+                        .then(b.price.cmp(&a.price))
+                        .then(a.symbol.cmp(&b.symbol))
+                        .then(a.asset_id.cmp(&b.asset_id))
+                });
+
+            let Some((best_idx, best_candidate)) = best else {
+                continue;
+            };
+
+            let shares = if profile.whole_shares_only {
+                (sleeve_budget / best_candidate.price).floor()
+            } else {
+                sleeve_budget / best_candidate.price
+            };
+
+            if shares <= Decimal::ZERO {
+                continue;
+            }
+
+            let amount = shares * best_candidate.price;
+            if profile.min_trade_amount > Decimal::ZERO && amount < profile.min_trade_amount {
+                continue;
+            }
+
+            for (cat_id, expo) in &best_candidate.exposure_per_share {
+                *values.entry(cat_id.clone()).or_default() += expo * shares;
+            }
+            remaining -= amount;
+            shares_bought[best_idx] += shares;
+        }
+    }
+
     /// Greedy buy loop. Mutates `values` and returns shares bought per candidate index.
     #[allow(clippy::too_many_arguments)]
     fn run_buy_greedy(
@@ -815,6 +925,33 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
                 scale,
             ),
         };
+
+        // Proportional top-up: deploy remaining cash proportionally to target_bps.
+        // Skipped for SellToRebalance (proceeds left over stay as cash_remaining to avoid
+        // circular sell→rebuy patterns).
+        let mut shares_bought = shares_bought;
+        if !matches!(scenario_mode, ScenarioMode::SellToRebalance) {
+            let topup_pool = match &scenario_mode {
+                ScenarioMode::Hybrid => available_cash + sell_proceeds,
+                _ => buy_pool,
+            };
+            let greedy_used: Decimal = shares_bought
+                .iter()
+                .zip(candidates.iter())
+                .map(|(s, c)| s * c.price)
+                .sum();
+            let topup_cash = (topup_pool - greedy_used).max(Decimal::ZERO);
+            if topup_cash > Decimal::ZERO {
+                Self::run_proportional_topup(
+                    &mut values,
+                    &candidates,
+                    &mut shares_bought,
+                    topup_cash,
+                    &categories,
+                    &profile,
+                );
+            }
+        }
 
         // Build trades from accumulated shares; apply min_trade_amount filter.
         let mut trades: Vec<SuggestedManualTrade> = Vec::new();

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -1292,8 +1292,9 @@ mod tests {
 
     #[tokio::test]
     async fn fractional_mode_caps_trade_at_target_shortfall() {
-        // Fractional mode should size the whole recommendation fractionally, not buy
-        // a full share first and only fractionalize leftover cash.
+        // Fractional mode: greedy sizes the drift-closing buy fractionally (0.75 sh = $75),
+        // then the proportional top-up deploys the remaining $925 into the same ETF
+        // (9.25 sh). Combined: one ETF trade of 10 sh, cash_used = $1000.
         let total = dec!(10000);
         let h = make_holding("h1", "ETF", dec!(1), dec!(100)); // $100/share
         let c = make_contribution(&h, "equity", dec!(100));
@@ -1310,8 +1311,8 @@ mod tests {
             .iter()
             .find(|t| t.symbol.as_deref() == Some("ETF"))
             .expect("fractional ETF trade expected");
-        assert_eq!(trade.quantity, Some(dec!(0.75)));
-        assert_eq!(plan.cash_used, dec!(75));
+        assert_eq!(trade.quantity, Some(dec!(10.0000)));
+        assert_eq!(plan.cash_used, dec!(1000));
     }
 
     #[tokio::test]
@@ -1416,8 +1417,15 @@ mod tests {
 
     #[tokio::test]
     async fn nearest_band_stops_at_band_edge() {
-        // Equity 60% (target 70%, band 5%). NearestBand should stop once equity reaches
-        // the 65% band edge ($500 deployed), not optimize to the exact 70% target ($1000).
+        // Equity 60% (target 70%, band 5%).
+        //
+        // Greedy phase: NearestBand stops at the 65% band edge ($500 deployed);
+        // ExactTarget deploys all the way to 70% ($1000).
+        //
+        // Proportional top-up phase: both goals then deploy remaining cash
+        // proportionally to target_bps. So for this single-category portfolio both
+        // end up with cash_used = $1000. The difference between goals shows up in
+        // multi-category portfolios where scoring and stopping criteria diverge.
         let total = dec!(10000);
         let h = make_holding("h1", "VTI", dec!(60), dec!(6000)); // $100/share
         let rows = vec![make_drift_row("equity", 6000, 7000, total)];
@@ -1444,16 +1452,17 @@ mod tests {
             .await
             .unwrap();
 
+        // Both deploy all $1000: greedy + proportional top-up.
         assert_eq!(
             plan_band.cash_used,
-            dec!(500),
-            "nearest_band stops at the band edge ($500), got {}",
+            dec!(1000),
+            "nearest_band + top-up deploys all available cash, got {}",
             plan_band.cash_used
         );
         assert_eq!(
             plan_exact.cash_used,
             dec!(1000),
-            "exact_target deploys to the exact target ($1000), got {}",
+            "exact_target deploys all available cash, got {}",
             plan_exact.cash_used
         );
     }
@@ -1928,5 +1937,103 @@ mod tests {
         // Both should improve drift.
         assert!(plan_sell.max_drift_bps_after < plan_sell.max_drift_bps_before);
         assert!(plan_hybrid.max_drift_bps_after < plan_hybrid.max_drift_bps_before);
+    }
+
+    #[tokio::test]
+    async fn proportional_topup_deploys_remaining_cash_after_drift_resolved() {
+        // Portfolio: Equity 50% Bond 50% (both at target — no drift).
+        // User deposits $2000 cash. Greedy finds no drift-improving trade (drift=0).
+        // Top-up should deploy $2000 proportionally: $1000 equity (VTI), $1000 bond (BND).
+        let total = dec!(10000);
+        let h_vti = make_holding("h1", "VTI", dec!(50), dec!(5000)); // $100/share
+        let h_bnd = make_holding("h2", "BND", dec!(50), dec!(5000)); // $100/share
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            make_report(
+                vec![
+                    make_drift_row("equity", 5000, 5000, total),
+                    make_drift_row("bond", 5000, 5000, total),
+                ],
+                total,
+            ),
+            make_contributions(vec![
+                make_contribution(&h_vti, "equity", dec!(5000)),
+                make_contribution(&h_bnd, "bond", dec!(5000)),
+            ]),
+            vec![make_cash_holding(dec!(2000), "USD"), h_vti, h_bnd],
+        );
+        let plan = svc.calculate_plan(make_input(dec!(2000))).await.unwrap();
+
+        assert_eq!(plan.cash_used, dec!(2000), "all cash should be deployed");
+        assert_eq!(plan.cash_remaining, dec!(0));
+
+        let vti_trade = plan
+            .trades
+            .iter()
+            .find(|t| t.symbol.as_deref() == Some("VTI"))
+            .expect("VTI trade expected");
+        let bnd_trade = plan
+            .trades
+            .iter()
+            .find(|t| t.symbol.as_deref() == Some("BND"))
+            .expect("BND trade expected");
+
+        // Each sleeve gets 50% of $2000 = $1000 → 10 shares each.
+        assert_eq!(vti_trade.estimated_amount, dec!(1000));
+        assert_eq!(bnd_trade.estimated_amount, dec!(1000));
+    }
+
+    #[tokio::test]
+    async fn sell_to_rebalance_does_not_top_up_remaining_proceeds() {
+        // SellToRebalance: sell overweight bonds, use proceeds to buy equity.
+        // Any leftover proceeds stay as cash_remaining — no proportional top-up.
+        // Portfolio: Equity 30% (target 50%), Bond 70% (target 50%). Cash = $0.
+        let total = dec!(10000);
+        let h_vti = make_holding("h1", "VTI", dec!(30), dec!(3000));
+        let h_bnd = make_holding("h2", "BND", dec!(70), dec!(7000)); // $100/share
+        let svc = make_service(
+            make_sell_profile(RebalanceGoal::ExactTarget),
+            make_report(
+                vec![
+                    make_drift_row("equity", 3000, 5000, total),
+                    make_drift_row("bond", 7000, 5000, total),
+                ],
+                total,
+            ),
+            make_contributions(vec![
+                make_contribution(&h_vti, "equity", dec!(3000)),
+                make_contribution(&h_bnd, "bond", dec!(7000)),
+            ]),
+            vec![make_cash_holding(dec!(0), "USD"), h_vti, h_bnd],
+        );
+        let plan = svc
+            .calculate_plan(make_input_with_mode(dec!(0), ScenarioMode::SellToRebalance))
+            .await
+            .unwrap();
+
+        // Sells BND to fund VTI buys. After rebalance, drift should be resolved.
+        let sells: Decimal = plan
+            .trades
+            .iter()
+            .filter(|t| t.action == "sell")
+            .map(|t| t.estimated_amount)
+            .sum();
+        let buys: Decimal = plan
+            .trades
+            .iter()
+            .filter(|t| t.action == "buy")
+            .map(|t| t.estimated_amount)
+            .sum();
+
+        assert!(sells > Decimal::ZERO, "should sell overweight bonds");
+        // No additional BND repurchase from top-up (circular sell→rebuy avoided).
+        let bnd_buys = plan
+            .trades
+            .iter()
+            .filter(|t| t.action == "buy" && t.symbol.as_deref() == Some("BND"))
+            .count();
+        assert_eq!(bnd_buys, 0, "SellToRebalance must not rebuy BND via top-up");
+        // Buys funded entirely by sell proceeds.
+        assert!(buys <= sells, "buys must not exceed sell proceeds");
     }
 }


### PR DESCRIPTION
Hey @afadil 👋

While testing the rebalance planner I noticed a common scenario that felt unintuitive: a user with €10,000 to invest and only €1,000 of actual drift to fix would get €9,000 returned as unused cash. 

The greedy correctly stops once drift is resolved, but users generally expect their full deposit to be invested. 
This PR adds a proportional top-up pass that deploys any remaining cash after the drift-improving greedy finishes.

---

## What it does

After the greedy buy loop stops (no candidate improves drift), remaining cash is deployed proportionally to `target_bps` weights. Each sleeve receives `cash_remaining × (sleeve_target_bps / total_target_bps)` and buys the candidate with the highest per-share exposure to that category.

**Skipped for `SellToRebalance`** — proceeds left over stay as `cash_remaining` to avoid circular sell→rebuy patterns (e.g. selling GOLD then rebuying it in the top-up pass).

**Applied for `CashFlowOnly` and `Hybrid`** — these modes deploy new user cash and should fully invest it.

Top-up shares accumulate into the same `shares_bought` array as the greedy, so greedy + top-up buys for the same asset merge into one output trade.

## Algorithm

```
if scenario != SellToRebalance and cash_remaining > 0:
    total_target_bps = Σ target_bps for required non-cash categories
    for each category (sorted by target_bps DESC):
        sleeve_budget = cash_remaining × (cat.target_bps / total_target_bps)
        candidate = highest exposure_per_share[cat] among available candidates
        shares = sleeve_budget / price  (floor if whole_shares_only)
        if amount < min_trade_amount → skip
        apply buy, accumulate into shares_bought[idx]
```

## Changes

- **`optimizer.rs`** — new `run_proportional_topup` method; called after `run_buy_greedy` / Hybrid two-pass for CashFlowOnly and Hybrid scenarios
- **`rebalance_service.rs`** — two updated tests (greedy + top-up now deploys all cash), two new regression tests

## Tests

`cargo test -p wealthfolio-core --lib portfolio::allocation_targets` → **69 passed**

| Test | Covers |
|------|--------|
| `proportional_topup_deploys_remaining_cash_after_drift_resolved` | Portfolio at target → full cash deployed proportionally |
| `sell_to_rebalance_does_not_top_up_remaining_proceeds` | SellToRebalance skips top-up, no circular rebuy |
| `fractional_mode_caps_trade_at_target_shortfall` (updated) | Greedy + top-up merge into one trade |
| `nearest_band_stops_at_band_edge` (updated) | Both goals now deploy all cash via top-up |

## Open question — deploy remaining cash after drift is resolved

This implements Option A from the open question in PR #1054. 
Still waiting on your call if you prefer Option B (keep current behaviour + add a UI hint toward Exact target mode) instead — happy to revert if so.

---

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).