### PR TITLE
fix(activity): apply contract multiplier to option activity Total

### DIFF
--- a/apps/frontend/src/lib/activity-utils.test.ts
+++ b/apps/frontend/src/lib/activity-utils.test.ts
@@ -1,4 +1,9 @@
-import { ACTIVITY_SUBTYPES, ActivityType } from "./constants";
+import {
+  ACTIVITY_SUBTYPES,
+  ActivityType,
+  InstrumentType,
+  METADATA_CONTRACT_MULTIPLIER,
+} from "./constants";
 import {
   isCashActivity,
   isCashTransfer,
@@ -152,6 +157,33 @@ describe("Activity Utilities", () => {
 
       // (10 * 100) - 10 = 990
       expect(calculateActivityValue(activity)).toBe(990);
+    });
+
+    it("should apply the contract multiplier for option BUY activities", () => {
+      const activity = createActivity({
+        activityType: ActivityType.BUY,
+        instrumentType: InstrumentType.OPTION,
+        quantity: "2",
+        unitPrice: "3",
+        fee: "1",
+      });
+
+      // (2 * 3 * 100) + 1 = 601
+      expect(calculateActivityValue(activity)).toBe(601);
+    });
+
+    it("should honor a non-default contract multiplier from metadata", () => {
+      const activity = createActivity({
+        activityType: ActivityType.SELL,
+        instrumentType: InstrumentType.OPTION,
+        quantity: "2",
+        unitPrice: "5",
+        fee: "0",
+        metadata: { [METADATA_CONTRACT_MULTIPLIER]: 10 },
+      });
+
+      // (2 * 5 * 10) - 0 = 100
+      expect(calculateActivityValue(activity)).toBe(100);
     });
 
     it("should calculate DEPOSIT activity value correctly", () => {

--- a/apps/frontend/src/lib/activity-utils.ts
+++ b/apps/frontend/src/lib/activity-utils.ts
@@ -3,6 +3,8 @@ import {
   ActivityType,
   DECIMAL_PRECISION,
   INCOME_ACTIVITY_TYPES,
+  InstrumentType,
+  METADATA_CONTRACT_MULTIPLIER,
   SYMBOL_REQUIRED_TYPES,
 } from "./constants";
 import { ActivityDetails } from "./types";
@@ -269,6 +271,23 @@ export const getUnitPrice = (activity: ActivityDetails): number => {
 };
 
 /**
+ * Returns the contract multiplier for an activity's instrument. Options trade in
+ * contracts that represent N underlying units (typically 100), so their cash
+ * value is quantity × unitPrice × multiplier. A non-default multiplier is stored
+ * on the activity metadata; otherwise options default to 100 and everything else
+ * to 1.
+ * @param activity The activity
+ * @returns The contract multiplier
+ */
+export const getContractMultiplier = (activity: ActivityDetails): number => {
+  const stored = Number(activity.metadata?.[METADATA_CONTRACT_MULTIPLIER]);
+  if (Number.isFinite(stored) && stored > 0) {
+    return stored;
+  }
+  return activity.instrumentType === InstrumentType.OPTION ? 100 : 1;
+};
+
+/**
  * Calculates the total value of an activity based on its type and data
  * @param activity The activity to calculate the value for
  * @returns The calculated value
@@ -320,7 +339,9 @@ export const calculateActivityValue = (activity: ActivityDetails): number => {
   const quantity = getQuantity(activity);
   const unitPrice = getUnitPrice(activity);
   const fee = getFee(activity);
-  let activityAmount = roundCurrency(Number(quantity) * Number(unitPrice));
+  let activityAmount = roundCurrency(
+    Number(quantity) * Number(unitPrice) * getContractMultiplier(activity),
+  );
 
   // Securities transfers imported without a unit price (legacy / some broker
   // exports) carry their monetary value on `amount`. Fall back to it so those


### PR DESCRIPTION
## Problem
On the Activity list, the Total column for option trades is off by a factor of
~100: `calculateActivityValue` computes `quantity × unitPrice` for trades and
securities transfers but never multiplies by the instrument's contract multiplier
(typically 100 for options).

## Fix
- Add `getContractMultiplier(activity)`: uses `metadata.contract_multiplier` when
  set, otherwise 100 for OPTION instruments and 1 for everything else (mirrors how
  the activity forms store the multiplier).
- Multiply `quantity × unitPrice × multiplier` in `calculateActivityValue` (covers
  BUY/SELL and securities transfers priced via unitPrice).

Cash/income activities and the stored-amount fallback are unchanged.

## Tests
Two new `calculateActivityValue` cases: an option BUY at the default 100x
multiplier, and a SELL honoring a non-default multiplier from metadata.
