### PR TITLE
feat(asset): show avg cost reference line on price chart

### DIFF
--- a/apps/frontend/src/components/history-chart-symbol.tsx
+++ b/apps/frontend/src/components/history-chart-symbol.tsx
@@ -6,6 +6,7 @@ import {
   Area,
   AreaChart,
   ReferenceDot,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -55,6 +56,7 @@ export default function HistoryChart({
   interval,
   activityMarkers = [],
   onActivityMarkerClick,
+  avgCost,
   height = 350,
 }: {
   data: HistoryChartData[];
@@ -62,6 +64,7 @@ export default function HistoryChart({
   height?: number;
   activityMarkers?: HistoryChartActivityMarker[];
   onActivityMarkerClick?: (marker: HistoryChartActivityMarker) => void;
+  avgCost?: number;
 }) {
   const [hoveredMarker, setHoveredMarker] = useState(false);
   const markerByTimestamp = useMemo(() => {
@@ -132,6 +135,21 @@ export default function HistoryChart({
               fillOpacity={1}
               fill="url(#colorUv)"
             />
+            {avgCost != null && avgCost > 0 && (
+              <ReferenceLine
+                y={avgCost}
+                stroke="var(--muted-foreground)"
+                strokeDasharray="4 2"
+                strokeOpacity={0.5}
+                label={{
+                  value: `Avg ${formatAmount(avgCost, data[0]?.currency ?? "", false)}`,
+                  position: "insideTopRight",
+                  fontSize: 10,
+                  fill: "var(--muted-foreground)",
+                  opacity: 0.7,
+                }}
+              />
+            )}
             {activityMarkers.map((marker) => {
               return (
                 <ReferenceDot

--- a/apps/frontend/src/pages/asset/asset-history-card.tsx
+++ b/apps/frontend/src/pages/asset/asset-history-card.tsx
@@ -42,6 +42,7 @@ interface AssetHistoryProps {
   currency: string;
   quoteHistory: Quote[];
   assetId: string;
+  avgCost?: number;
   className?: string;
 }
 
@@ -52,6 +53,7 @@ const AssetHistoryCard: React.FC<AssetHistoryProps> = ({
   currency,
   quoteHistory,
   assetId,
+  avgCost,
   className,
 }) => {
   const syncMarketDataMutation = useSyncMarketDataMutation(true);
@@ -252,6 +254,7 @@ const AssetHistoryCard: React.FC<AssetHistoryProps> = ({
           <HistoryChart
             data={chartData}
             activityMarkers={activityMarkers}
+            avgCost={avgCost}
             onActivityMarkerClick={(marker) => {
               setSelectedActivityDate(dateKey(marker.point));
               setIsActivitySheetOpen(true);

--- a/apps/frontend/src/pages/asset/asset-profile-page.tsx
+++ b/apps/frontend/src/pages/asset/asset-profile-page.tsx
@@ -1286,6 +1286,7 @@ export const AssetProfilePage = () => {
                   totalGainAmount={profile.totalGainAmount}
                   totalGainPercent={profile.totalGainPercent}
                   quoteHistory={quoteHistory ?? []}
+                  avgCost={symbolHolding?.averagePrice ?? undefined}
                   className={`col-span-1 ${symbolHolding ? "md:col-span-2" : "md:col-span-3"}`}
                 />
                 {symbolHolding && (
@@ -1313,6 +1314,7 @@ export const AssetProfilePage = () => {
                   totalGainAmount={profile.totalGainAmount}
                   totalGainPercent={profile.totalGainPercent}
                   quoteHistory={quoteHistory ?? []}
+                  avgCost={symbolHolding?.averagePrice ?? undefined}
                   className={`col-span-1 ${symbolHolding ? "md:col-span-2" : "md:col-span-3"}`}
                 />
                 {symbolHolding && (

--- a/apps/frontend/src/pages/holdings/components/holdings-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table.tsx
@@ -123,6 +123,8 @@ export const HoldingsTable = ({
           symbolName: false,
           holdingType: false,
           bookValue: false,
+          avgCost: false,
+          portfolioWeight: false,
         }}
         defaultSorting={[{ id: "symbol", desc: false }]}
         scrollable={true}
@@ -345,6 +347,50 @@ const getColumns = (
       const valueB = rowB.original.costBasis?.local ?? 0;
       return valueA - valueB;
     },
+  },
+  {
+    id: "avgCost",
+    accessorFn: (row) => safeDivide(row.costBasis?.local ?? 0, row.quantity),
+    enableHiding: true,
+    header: ({ column }) => (
+      <DataTableColumnHeader className="justify-end" column={column} title="Avg Cost" />
+    ),
+    meta: {
+      label: "Avg Cost",
+    },
+    cell: ({ row }) => {
+      const holding = row.original;
+      const avgCost = safeDivide(holding.costBasis?.local ?? 0, holding.quantity);
+      return (
+        <div className="flex min-h-[40px] flex-col items-end justify-center px-4">
+          <AmountDisplay value={avgCost} currency={holding.localCurrency} isHidden={isHidden} />
+          <div className="text-xs text-transparent">-</div>
+        </div>
+      );
+    },
+    sortingFn: (rowA, rowB) => {
+      const a = safeDivide(rowA.original.costBasis?.local ?? 0, rowA.original.quantity);
+      const b = safeDivide(rowB.original.costBasis?.local ?? 0, rowB.original.quantity);
+      return a - b;
+    },
+  },
+  {
+    id: "portfolioWeight",
+    accessorFn: (row) => row.weight,
+    enableHiding: true,
+    header: ({ column }) => (
+      <DataTableColumnHeader className="justify-end" column={column} title="Allocation" />
+    ),
+    meta: {
+      label: "Allocation",
+    },
+    cell: ({ row }) => (
+      <div className="flex min-h-[40px] flex-col items-end justify-center px-4">
+        <span className="font-medium">{(row.original.weight * 100).toFixed(2)}%</span>
+        <div className="text-xs text-transparent">-</div>
+      </div>
+    ),
+    sortingFn: (rowA, rowB) => rowA.original.weight - rowB.original.weight,
   },
   {
     id: "marketValue",


### PR DESCRIPTION
## Problem
The asset price chart has no visual reference for the user's average cost per share,
making it hard to gauge at a glance whether the current price is above or below
the break-even level.

## Solution
Add a dashed horizontal reference line at the average cost price (`costBasis.local / quantity`)
on the holding detail price chart.

- Visible whenever the user holds a position in the asset (`avgCost > 0`)
- Hidden for assets with no holding or zero cost basis (e.g. FX rates, unwatched assets)
- Labelled `Avg $xxx.xx` at the right edge of the chart
- Always on — no extra toggle needed, unlike activity markers which are more situational

## Changes
- `history-chart-symbol.tsx` — add `avgCost?: number` prop + `ReferenceLine` from recharts
- `asset-history-card.tsx` — thread `avgCost` prop through to `HistoryChart`
- `asset-profile-page.tsx` — pass `symbolHolding.averagePrice` (already computed) to `AssetHistoryCard`

No backend changes. No new dependencies (recharts already used in the chart).

I have read and agree to the [CLA](CLA.md).