### PR TITLE
Fix mobile activity defaults and rebalance top-up constraints

### DIFF
--- a/apps/frontend/src/pages/activity/components/mobile-forms/__tests__/validate-transfer-fields.test.ts
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/__tests__/validate-transfer-fields.test.ts
@@ -4,6 +4,7 @@ import {
   validateTransferFields,
   type TransferValidationInput,
 } from "../mobile-activity-form";
+import { getMobileActivityAssetId } from "../mobile-activity-utils";
 
 const base: TransferValidationInput = {
   activityType: "TRANSFER_OUT",
@@ -283,5 +284,16 @@ describe("applyMobileIncomeUpdateClears", () => {
     expect(stakingUpdate.unitPrice).toBe(200);
     expect(cashCreate.quantity).toBeUndefined();
     expect(cashCreate.unitPrice).toBeUndefined();
+  });
+});
+
+describe("getMobileActivityAssetId", () => {
+  it("uses assetId when assetSymbol is blank", () => {
+    expect(getMobileActivityAssetId({ assetSymbol: "", assetId: "AAPL" })).toBe("AAPL");
+    expect(getMobileActivityAssetId({ assetSymbol: "  ", assetId: "MSFT" })).toBe("MSFT");
+  });
+
+  it("returns undefined when both identifiers are blank", () => {
+    expect(getMobileActivityAssetId({ assetSymbol: "", assetId: "" })).toBeUndefined();
   });
 });

--- a/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
@@ -26,13 +26,14 @@ import { buildOccSymbol, parseOccSymbol } from "@/lib/occ-symbol";
 import { generateId } from "@/lib/id";
 import type { ActivityCreate, ActivityDetails, ActivityUpdate } from "@/lib/types";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useForm, type Resolver, type SubmitHandler } from "react-hook-form";
 import { toast } from "sonner";
 import { useActivityMutations } from "../../hooks/use-activity-mutations";
 import { showValidationToast, type AccountSelectOption } from "../forms/fields";
 import { newActivitySchema, type NewActivityFormValues } from "../forms/schemas";
 import { MobileActivitySteps } from "./mobile-activity-steps";
+import { getMobileActivityAssetId } from "./mobile-activity-utils";
 
 interface MobileActivityFormProps {
   accounts: AccountSelectOption[];
@@ -95,6 +96,12 @@ const CASH_AMOUNT_ACTIVITY_TYPES: readonly string[] = [
   ActivityType.CREDIT,
 ];
 const INCOME_ACTIVITY_TYPES: readonly string[] = [ActivityType.DIVIDEND, ActivityType.INTEREST];
+
+function isValidMobileActivityType(
+  type: string | undefined,
+): type is NewActivityFormValues["activityType"] {
+  return type ? MOBILE_ACTIVITY_TYPES.includes(type) : false;
+}
 
 /**
  * Validates transfer-specific fields that the Zod schema can't enforce
@@ -256,123 +263,132 @@ export function MobileActivityForm({
     saveInternalTransferPairMutation,
   } = useActivityMutations(onClose);
 
-  const isValidActivityType = (
-    type: string | undefined,
-  ): type is NewActivityFormValues["activityType"] => {
-    return type ? MOBILE_ACTIVITY_TYPES.includes(type) : false;
-  };
-
-  // Derive transfer mode from existing activity data
-  const isTransferType =
-    activity?.activityType === ActivityType.TRANSFER_IN ||
-    activity?.activityType === ActivityType.TRANSFER_OUT;
-  const isSecurityTransferActivity =
-    isTransferType &&
-    isSecuritiesTransfer(activity?.activityType ?? "", activity?.assetSymbol, activity?.assetId);
-  const initialTransferMode = isSecurityTransferActivity ? "securities" : "cash";
-  const flowMetadata = activity?.metadata?.flow as { is_external?: boolean } | undefined;
-  const initialIsExternal = isTransferType ? flowMetadata?.is_external === true : false;
-  const editingTransferIn = activity?.activityType === ActivityType.TRANSFER_IN;
-  const sourceAmount = editingTransferIn
-    ? activity?.counterpartAmount
-      ? Number(activity.counterpartAmount)
-      : undefined
-    : activity?.amount
-      ? Number(activity.amount)
-      : undefined;
-  const destinationAmount = editingTransferIn
-    ? activity?.amount
-      ? Number(activity.amount)
-      : undefined
-    : activity?.counterpartAmount
-      ? Number(activity.counterpartAmount)
+  const defaultValues = useMemo<Partial<NewActivityFormValues>>(() => {
+    // Derive transfer mode from existing activity data
+    const isTransferType =
+      activity?.activityType === ActivityType.TRANSFER_IN ||
+      activity?.activityType === ActivityType.TRANSFER_OUT;
+    const isSecurityTransferActivity =
+      isTransferType &&
+      isSecuritiesTransfer(activity?.activityType ?? "", activity?.assetSymbol, activity?.assetId);
+    const initialTransferMode = isSecurityTransferActivity ? "securities" : "cash";
+    const flowMetadata = activity?.metadata?.flow as { is_external?: boolean } | undefined;
+    const initialIsExternal = isTransferType ? flowMetadata?.is_external === true : false;
+    const editingTransferIn = activity?.activityType === ActivityType.TRANSFER_IN;
+    const sourceAmount = editingTransferIn
+      ? activity?.counterpartAmount
+        ? Number(activity.counterpartAmount)
+        : undefined
       : activity?.amount
         ? Number(activity.amount)
         : undefined;
-  const pairFxRate = activity?.fxRate ?? activity?.counterpartFxRate;
-  const fxRate = pairFxRate ? Number(pairFxRate) : undefined;
+    const destinationAmount = editingTransferIn
+      ? activity?.amount
+        ? Number(activity.amount)
+        : undefined
+      : activity?.counterpartAmount
+        ? Number(activity.counterpartAmount)
+        : activity?.amount
+          ? Number(activity.amount)
+          : undefined;
+    const pairFxRate = activity?.fxRate ?? activity?.counterpartFxRate;
+    const fxRate = pairFxRate ? Number(pairFxRate) : undefined;
 
-  // Detect option/bond activities for editing
-  const isOptionActivity = activity?.instrumentType === "OPTION";
-  const isBondActivity = activity?.instrumentType === "BOND";
-  const parsedOcc = isOptionActivity ? parseOccSymbol(activity?.assetSymbol ?? "") : null;
+    // Detect option/bond activities for editing
+    const isOptionActivity = activity?.instrumentType === "OPTION";
+    const isBondActivity = activity?.instrumentType === "BOND";
+    const parsedOcc = isOptionActivity ? parseOccSymbol(activity?.assetSymbol ?? "") : null;
 
-  const defaultValues: Partial<NewActivityFormValues> = {
-    id: activity?.id,
-    accountId:
-      isTransferType && !initialIsExternal && editingTransferIn
-        ? (activity?.counterpartAccountId ?? "")
-        : (activity?.accountId ?? ""),
-    activityType: isValidActivityType(activity?.activityType) ? activity.activityType : undefined,
-    amount: activity?.amount ? Number(activity.amount) : undefined,
-    sourceAmount,
-    destinationAmount,
-    sourceCurrency: editingTransferIn
-      ? (activity?.counterpartCurrency ?? activity?.currency)
-      : activity?.currency,
-    destinationCurrency: editingTransferIn
-      ? activity?.currency
-      : (activity?.counterpartCurrency ?? activity?.currency),
-    quantity:
-      isTransferType && !isSecurityTransferActivity
-        ? undefined
-        : activity?.quantity
-          ? Number(activity.quantity)
-          : undefined,
-    unitPrice:
-      isTransferType && !isSecurityTransferActivity
-        ? undefined
-        : activity?.unitPrice
-          ? Number(activity.unitPrice)
-          : undefined,
-    fee: activity?.fee ? Number(activity.fee) : 0,
-    comment: activity?.comment ?? null,
-    subtype: activity?.subtype ?? null,
-    fxRate,
-    assetId:
-      isTransferType && !isSecurityTransferActivity
-        ? undefined
-        : (activity?.assetSymbol ?? activity?.assetId)
-          ? (activity?.assetSymbol ?? activity?.assetId)
-          : undefined,
-    activityDate: activity?.date ? new Date(activity.date) : new Date(),
-    currency: activity?.currency ?? "",
-    quoteMode: activity?.assetQuoteMode === QuoteMode.MANUAL ? QuoteMode.MANUAL : QuoteMode.MARKET,
-    exchangeMic: activity?.exchangeMic,
-    showCurrencySelect: false,
-    ...(isTransferType && {
-      transferMode: initialTransferMode,
-      isExternal: initialIsExternal,
-      direction: activity?.activityType === ActivityType.TRANSFER_IN ? "in" : "out",
-      toAccountId: !initialIsExternal
-        ? editingTransferIn
-          ? (activity?.accountId ?? "")
-          : (activity?.counterpartAccountId ?? "")
-        : "",
-    }),
-    // Option defaults when editing an option activity
-    ...(isOptionActivity && {
-      assetType: "option" as const,
-      assetKind: "OPTION",
-      symbolQuoteCcy: activity?.currency ?? undefined,
-      underlyingSymbol: parsedOcc?.underlying ?? "",
-      strikePrice: parsedOcc?.strikePrice,
-      expirationDate: parsedOcc?.expiration,
-      optionType: parsedOcc?.optionType,
-      contractMultiplier: 100,
-    }),
-    // Bond defaults when editing a bond activity
-    ...(isBondActivity && {
-      assetType: "bond" as const,
-      assetKind: "BOND",
-      symbolQuoteCcy: activity?.currency ?? undefined,
-    }),
-  };
+    return {
+      id: activity?.id,
+      accountId:
+        isTransferType && !initialIsExternal && editingTransferIn
+          ? (activity?.counterpartAccountId ?? "")
+          : (activity?.accountId ?? ""),
+      activityType: isValidMobileActivityType(activity?.activityType)
+        ? activity.activityType
+        : undefined,
+      amount: activity?.amount ? Number(activity.amount) : undefined,
+      sourceAmount,
+      destinationAmount,
+      sourceCurrency: editingTransferIn
+        ? (activity?.counterpartCurrency ?? activity?.currency)
+        : activity?.currency,
+      destinationCurrency: editingTransferIn
+        ? activity?.currency
+        : (activity?.counterpartCurrency ?? activity?.currency),
+      quantity:
+        isTransferType && !isSecurityTransferActivity
+          ? undefined
+          : activity?.quantity
+            ? Number(activity.quantity)
+            : undefined,
+      unitPrice:
+        isTransferType && !isSecurityTransferActivity
+          ? undefined
+          : activity?.unitPrice
+            ? Number(activity.unitPrice)
+            : undefined,
+      fee: activity?.fee ? Number(activity.fee) : 0,
+      comment: activity?.comment ?? null,
+      subtype: activity?.subtype ?? null,
+      fxRate,
+      assetId:
+        isTransferType && !isSecurityTransferActivity
+          ? undefined
+          : getMobileActivityAssetId(activity),
+      activityDate: activity?.date ? new Date(activity.date) : new Date(),
+      currency: activity?.currency ?? "",
+      quoteMode:
+        activity?.assetQuoteMode === QuoteMode.MANUAL ? QuoteMode.MANUAL : QuoteMode.MARKET,
+      exchangeMic: activity?.exchangeMic,
+      showCurrencySelect: false,
+      ...(isTransferType && {
+        transferMode: initialTransferMode,
+        isExternal: initialIsExternal,
+        direction: activity?.activityType === ActivityType.TRANSFER_IN ? "in" : "out",
+        toAccountId: !initialIsExternal
+          ? editingTransferIn
+            ? (activity?.accountId ?? "")
+            : (activity?.counterpartAccountId ?? "")
+          : "",
+      }),
+      // Option defaults when editing an option activity
+      ...(isOptionActivity && {
+        assetType: "option" as const,
+        assetKind: "OPTION",
+        symbolQuoteCcy: activity?.currency ?? undefined,
+        underlyingSymbol: parsedOcc?.underlying ?? "",
+        strikePrice: parsedOcc?.strikePrice,
+        expirationDate: parsedOcc?.expiration,
+        optionType: parsedOcc?.optionType,
+        contractMultiplier: 100,
+      }),
+      // Bond defaults when editing a bond activity
+      ...(isBondActivity && {
+        assetType: "bond" as const,
+        assetKind: "BOND",
+        symbolQuoteCcy: activity?.currency ?? undefined,
+      }),
+    };
+  }, [activity]);
 
   const form = useForm<NewActivityFormValues>({
     resolver: zodResolver(newActivitySchema) as Resolver<NewActivityFormValues>,
     defaultValues: defaultValues as any,
   });
+  const { reset } = form;
+
+  useEffect(() => {
+    if (!open) return;
+
+    const nextDefaultValues = activity?.date
+      ? defaultValues
+      : { ...defaultValues, activityDate: new Date() };
+
+    reset(nextDefaultValues);
+    setCurrentStep(activity?.id ? 2 : 1);
+  }, [activity?.date, activity?.id, defaultValues, open, reset]);
 
   // Transfers may target any account (incl. spending/saving accounts the Spending
   // split hides from `accounts`), so widen the list once the type is a transfer.

--- a/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-utils.ts
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-utils.ts
@@ -1,0 +1,5 @@
+import type { ActivityDetails } from "@/lib/types";
+
+export function getMobileActivityAssetId(activity?: Partial<ActivityDetails>): string | undefined {
+  return activity?.assetSymbol?.trim() || activity?.assetId?.trim() || undefined;
+}

--- a/crates/core/src/portfolio/allocation_targets/optimizer.rs
+++ b/crates/core/src/portfolio/allocation_targets/optimizer.rs
@@ -131,6 +131,63 @@ impl DriftPriorityOptimizer {
             .collect()
     }
 
+    fn topup_shares_for_budget(
+        candidate: &AssetCandidate,
+        budget: Decimal,
+        profile: &RebalanceProfile,
+    ) -> Decimal {
+        if budget <= Decimal::ZERO || candidate.price <= Decimal::ZERO {
+            return Decimal::ZERO;
+        }
+
+        let shares = if profile.whole_shares_only {
+            (budget / candidate.price).floor()
+        } else {
+            budget / candidate.price
+        };
+
+        if shares <= Decimal::ZERO {
+            return Decimal::ZERO;
+        }
+
+        let amount = shares * candidate.price;
+        if profile.min_trade_amount > Decimal::ZERO && amount < profile.min_trade_amount {
+            return Decimal::ZERO;
+        }
+
+        shares
+    }
+
+    fn remaining_cash_excess_after_buys(
+        categories: &[CategoryState],
+        total_value: Decimal,
+        profile: &RebalanceProfile,
+        drift_band: Decimal,
+        sell_proceeds: Decimal,
+        buy_amount: Decimal,
+    ) -> Option<Decimal> {
+        let required_cash: Vec<&CategoryState> = categories
+            .iter()
+            .filter(|c| c.is_required && c.is_cash)
+            .collect();
+        if required_cash.is_empty() {
+            return None;
+        }
+        if total_value <= Decimal::ZERO {
+            return Some(Decimal::ZERO);
+        }
+
+        let current_cash: Decimal = required_cash.iter().map(|c| c.current_value).sum();
+        let target_bps: i32 = required_cash.iter().map(|c| c.target_bps).sum();
+        let stop_bps = match profile.rebalance_goal {
+            RebalanceGoal::ExactTarget => Decimal::from(target_bps),
+            RebalanceGoal::NearestBand => (Decimal::from(target_bps) + drift_band).min(dec!(10000)),
+        };
+        let stop_value = stop_bps / dec!(10000) * total_value;
+
+        Some((current_cash + sell_proceeds - stop_value - buy_amount).max(Decimal::ZERO))
+    }
+
     /// Per-category drift the planner tries to minimise.
     ///
     /// `ExactTarget` measures distance to the exact target. `NearestBand` only counts
@@ -446,7 +503,7 @@ impl DriftPriorityOptimizer {
 
     /// Proportional top-up: after the drift-improving greedy exhausts its gains, deploy
     /// remaining cash proportionally to `target_bps` weights. Each sleeve gets the
-    /// candidate with the highest per-share exposure to that category.
+    /// candidate with the highest category exposure per invested dollar.
     ///
     /// Accumulates into the caller's `shares_bought` so greedy + top-up shares for the
     /// same asset merge into a single output trade.
@@ -499,52 +556,39 @@ impl DriftPriorityOptimizer {
                 continue;
             }
 
-            // Best candidate = highest per-share exposure to this category.
+            // Best candidate = highest category exposure per invested dollar.
             // Tie-break: lower price preferred (consistent with greedy tie-break).
             let best = candidates
                 .iter()
                 .enumerate()
-                .filter(|(_, c)| {
-                    c.price > Decimal::ZERO
-                        && c.exposure_per_share
-                            .get(&cat.category_id)
-                            .is_some_and(|e| *e > Decimal::ZERO)
+                .filter_map(|(idx, candidate)| {
+                    let exposure = candidate
+                        .exposure_per_share
+                        .get(&cat.category_id)
+                        .copied()
+                        .filter(|e| *e > Decimal::ZERO)?;
+                    if candidate.price <= Decimal::ZERO {
+                        return None;
+                    }
+                    let shares = Self::topup_shares_for_budget(candidate, sleeve_budget, profile);
+                    if shares <= Decimal::ZERO {
+                        return None;
+                    }
+                    Some((idx, candidate, shares, exposure / candidate.price))
                 })
-                .max_by(|(_, a), (_, b)| {
-                    let ea = a
-                        .exposure_per_share
-                        .get(&cat.category_id)
-                        .copied()
-                        .unwrap_or_default();
-                    let eb = b
-                        .exposure_per_share
-                        .get(&cat.category_id)
-                        .copied()
-                        .unwrap_or_default();
-                    ea.cmp(&eb)
+                .max_by(|(_, a, _, score_a), (_, b, _, score_b)| {
+                    score_a
+                        .cmp(score_b)
                         .then(b.price.cmp(&a.price))
-                        .then(a.symbol.cmp(&b.symbol))
-                        .then(a.asset_id.cmp(&b.asset_id))
+                        .then(b.symbol.cmp(&a.symbol))
+                        .then(b.asset_id.cmp(&a.asset_id))
                 });
 
-            let Some((best_idx, best_candidate)) = best else {
+            let Some((best_idx, best_candidate, shares, _)) = best else {
                 continue;
             };
-
-            let shares = if profile.whole_shares_only {
-                (sleeve_budget / best_candidate.price).floor()
-            } else {
-                sleeve_budget / best_candidate.price
-            };
-
-            if shares <= Decimal::ZERO {
-                continue;
-            }
 
             let amount = shares * best_candidate.price;
-            if profile.min_trade_amount > Decimal::ZERO && amount < profile.min_trade_amount {
-                continue;
-            }
 
             for (cat_id, expo) in &best_candidate.exposure_per_share {
                 *values.entry(cat_id.clone()).or_default() += expo * shares;
@@ -941,6 +985,17 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
                 .map(|(s, c)| s * c.price)
                 .sum();
             let topup_cash = (topup_pool - greedy_used).max(Decimal::ZERO);
+            let topup_cash = match Self::remaining_cash_excess_after_buys(
+                &categories,
+                total_value,
+                &profile,
+                drift_band,
+                sell_proceeds,
+                greedy_used,
+            ) {
+                Some(cash_excess) => topup_cash.min(cash_excess),
+                None => topup_cash,
+            };
             if topup_cash > Decimal::ZERO {
                 Self::run_proportional_topup(
                     &mut values,

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -1984,6 +1984,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn proportional_topup_uses_affordable_whole_share_candidate() {
+        // Both holdings are full equity exposure. The expensive one has higher
+        // exposure per share only because it costs more, but the sleeve budget cannot
+        // buy it. Top-up must fall back to the affordable candidate.
+        let total = dec!(10000);
+        let h_expensive = make_holding("h-expensive", "EXP", dec!(1), dec!(1500));
+        let h_cheap = make_holding("h-cheap", "CHEAP", dec!(1), dec!(100));
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, true),
+            make_report(vec![make_drift_row("equity", 5000, 5000, total)], total),
+            make_contributions(vec![
+                make_contribution(&h_expensive, "equity", dec!(1500)),
+                make_contribution(&h_cheap, "equity", dec!(100)),
+            ]),
+            vec![make_cash_holding(dec!(1000), "USD"), h_expensive, h_cheap],
+        );
+
+        let plan = svc.calculate_plan(make_input(dec!(1000))).await.unwrap();
+
+        let trade = plan
+            .trades
+            .iter()
+            .find(|t| t.symbol.as_deref() == Some("CHEAP"))
+            .expect("top-up should use the affordable equity candidate");
+        assert_eq!(trade.quantity, Some(dec!(10)));
+        assert_eq!(plan.cash_used, dec!(1000));
+    }
+
+    #[tokio::test]
+    async fn proportional_topup_preserves_required_cash_target() {
+        // Portfolio is exactly at its 80% equity / 20% cash target. The available
+        // cash is target cash, not excess cash, so top-up must not spend it and
+        // create drift from a zero-drift starting point.
+        let total = dec!(10000);
+        let h_vti = make_holding("h-vti", "VTI", dec!(80), dec!(8000));
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            make_report(
+                vec![
+                    make_drift_row("equity", 8000, 8000, total),
+                    DriftRow {
+                        is_cash: true,
+                        ..make_drift_row("cash", 2000, 2000, total)
+                    },
+                ],
+                total,
+            ),
+            make_contributions(vec![make_contribution(&h_vti, "equity", dec!(8000))]),
+            vec![make_cash_holding(dec!(2000), "USD"), h_vti],
+        );
+
+        let plan = svc.calculate_plan(make_input(dec!(2000))).await.unwrap();
+
+        assert_eq!(plan.max_drift_bps_before, 0);
+        assert_eq!(plan.cash_used, Decimal::ZERO);
+        assert_eq!(plan.cash_remaining, dec!(2000));
+        assert_eq!(plan.max_drift_bps_after, 0);
+    }
+
+    #[tokio::test]
     async fn sell_to_rebalance_does_not_top_up_remaining_proceeds() {
         // SellToRebalance: sell overweight bonds, use proceeds to buy equity.
         // Any leftover proceeds stay as cash_remaining — no proportional top-up.


### PR DESCRIPTION
## Summary

- Refresh mobile activity default handling and transfer-field validation coverage.
- Preserve required cash targets during rebalance proportional top-up.
- Select affordable top-up candidates by category exposure per invested dollar, with regression coverage for whole-share fallback.

## Why

The rebalance top-up pass could spend target cash from an already-balanced portfolio and could skip affordable whole-share candidates after preferring an unaffordable high-price asset. The branch also includes the mobile activity defaults refresh already committed locally.

## Validation

- `cargo test -p wealthfolio-core --lib portfolio::allocation_targets`
- `cargo fmt --all --check`
- `cargo clippy -p wealthfolio-core --all-targets -- -D warnings`
- `pnpm lint` (completed with existing warnings, no errors)
- `pnpm format:check`
