### PR TITLE
feat(spending): add transfer support from spending tab

### DIFF
--- a/apps/frontend/src/features/spending/components/cash-activity-form.tsx
+++ b/apps/frontend/src/features/spending/components/cash-activity-form.tsx
@@ -89,9 +89,16 @@ interface CashActivityFormProps {
     categoryTaxonomyId?: string;
     categoryId?: string;
   };
+  /** Called when user selects Transfer in creation mode; receives the selected spending account id */
+  onTransferClick?: (accountId: string) => void;
 }
 
-export function CashActivityForm({ open, onOpenChange, activity }: CashActivityFormProps) {
+export function CashActivityForm({
+  open,
+  onOpenChange,
+  activity,
+  onTransferClick,
+}: CashActivityFormProps) {
   const isEditing = !!activity?.id;
   const qc = useQueryClient();
   const { accounts } = useAccounts({ filterActive: false });
@@ -178,8 +185,11 @@ export function CashActivityForm({ open, onOpenChange, activity }: CashActivityF
   const activityTypeOptions = useMemo(() => {
     const options = getActivityTypesForAccount(selectedAccount?.accountType);
     const currentType = activity?.activityType as FormValues["activityType"] | undefined;
-    return currentType && !options.includes(currentType) ? [...options, currentType] : options;
-  }, [activity?.activityType, selectedAccount?.accountType]);
+    const all = currentType && !options.includes(currentType) ? [...options, currentType] : options;
+    // In creation mode, hide TRANSFER_IN/OUT — user opens the full transfer form via button
+    if (!isEditing) return all.filter((t) => t !== "TRANSFER_IN" && t !== "TRANSFER_OUT");
+    return all;
+  }, [activity?.activityType, isEditing, selectedAccount?.accountType]);
   const isIncomeType = isCashActivityIncome(
     watchType,
     selectedAccount?.accountType,
@@ -335,6 +345,25 @@ export function CashActivityForm({ open, onOpenChange, activity }: CashActivityF
                 </FormItem>
               )}
             />
+
+            {/* Transfer button — creation only, redirects to the full transfer form */}
+            {!isEditing && onTransferClick && (
+              <FormItem>
+                <FormLabel>Transfer</FormLabel>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full justify-start gap-2"
+                  onClick={() => {
+                    onOpenChange(false);
+                    onTransferClick(watchAccountId);
+                  }}
+                >
+                  <Icons.ArrowLeftRight className="h-4 w-4" />
+                  Transfer between accounts
+                </Button>
+              </FormItem>
+            )}
 
             <FormField
               control={form.control}

--- a/apps/frontend/src/features/spending/components/cash-activity-form.tsx
+++ b/apps/frontend/src/features/spending/components/cash-activity-form.tsx
@@ -45,6 +45,7 @@ import {
 import {
   getActivityTypesForAccount,
   getCashActivityLabel,
+  isCreditCardAccountType,
   isCashActivityIncome,
   isSpendingAccountType,
 } from "../lib/constants";
@@ -182,6 +183,8 @@ export function CashActivityForm({
   const watchType = form.watch("activityType");
   const watchAccountId = form.watch("accountId");
   const selectedAccount = spendingAccounts.find((a) => a.id === watchAccountId);
+  const isCreditCardAccount = isCreditCardAccountType(selectedAccount?.accountType);
+  const transferActionLabel = isCreditCardAccount ? "Record payment" : "Transfer between accounts";
   const activityTypeOptions = useMemo(() => {
     const options = getActivityTypesForAccount(selectedAccount?.accountType);
     const currentType = activity?.activityType as FormValues["activityType"] | undefined;
@@ -349,18 +352,19 @@ export function CashActivityForm({
             {/* Transfer button — creation only, redirects to the full transfer form */}
             {!isEditing && onTransferClick && (
               <FormItem>
-                <FormLabel>Transfer</FormLabel>
+                <FormLabel>{isCreditCardAccount ? "Payment" : "Transfer"}</FormLabel>
                 <Button
                   type="button"
                   variant="outline"
                   className="w-full justify-start gap-2"
+                  disabled={!watchAccountId}
                   onClick={() => {
                     onOpenChange(false);
                     onTransferClick(watchAccountId);
                   }}
                 >
                   <Icons.ArrowLeftRight className="h-4 w-4" />
-                  Transfer between accounts
+                  {transferActionLabel}
                 </Button>
               </FormItem>
             )}

--- a/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
+++ b/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
@@ -49,6 +49,7 @@ import type { QuickCategorizeScope } from "./quick-categorize-popover";
 import {
   CASH_ACTIVITY_TYPES,
   CASH_ACTIVITY_TYPE_LABELS,
+  isCreditCardAccountType,
   isSpendingAccountType,
 } from "../lib/constants";
 import {
@@ -159,6 +160,9 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
     const [showForm, setShowForm] = useState(false);
     const [showTransferForm, setShowTransferForm] = useState(false);
     const [transferFromAccountId, setTransferFromAccountId] = useState<string | undefined>();
+    const [transferActivityType, setTransferActivityType] = useState<ActivityType>(
+      ActivityType.TRANSFER_OUT,
+    );
     const [deletingIds, setDeletingIds] = useState<string[] | null>(null);
     const [deletePreview, setDeletePreview] = useState<DeletePreview | undefined>();
 
@@ -308,19 +312,30 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
             value: a.id,
             label: a.name,
             currency: a.currency,
+            accountType: a.accountType,
             restrictionLevel: getActivityRestrictionLevel(a),
           })),
       [accounts],
     );
 
-    const handleTransferClick = useCallback((accountId: string) => {
-      setTransferFromAccountId(accountId);
-      setShowTransferForm(true);
-    }, []);
+    const handleTransferClick = useCallback(
+      (accountId: string) => {
+        const account = accounts.find((a: Account) => a.id === accountId);
+        setTransferActivityType(
+          isCreditCardAccountType(account?.accountType)
+            ? ActivityType.TRANSFER_IN
+            : ActivityType.TRANSFER_OUT,
+        );
+        setTransferFromAccountId(accountId);
+        setShowTransferForm(true);
+      },
+      [accounts],
+    );
 
     const handleTransferFormClose = useCallback(() => {
       setShowTransferForm(false);
       setTransferFromAccountId(undefined);
+      setTransferActivityType(ActivityType.TRANSFER_OUT);
     }, []);
     const { data: events = [] } = useSpendingEvents();
     const { data: eventTypes = [] } = useEventTypes();
@@ -884,7 +899,7 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
           <ActivityForm
             accounts={transferFormAccounts}
             transferAccounts={transferFormAccounts}
-            activity={{ activityType: ActivityType.TRANSFER_OUT, accountId: transferFromAccountId }}
+            activity={{ activityType: transferActivityType, accountId: transferFromAccountId }}
             open={showTransferForm}
             onClose={handleTransferFormClose}
             hidePicker

--- a/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
+++ b/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
@@ -36,6 +36,9 @@ import {
 } from "@wealthfolio/ui";
 
 import { CashActivityForm } from "./cash-activity-form";
+import { ActivityForm } from "@/pages/activity/components/activity-form";
+import { getActivityRestrictionLevel } from "@/lib/activity-restrictions";
+import { ActivityType } from "@/lib/constants";
 import type { AmountRange } from "./amount-range-filter";
 import { DeleteTransactionsDialog, type DeletePreview } from "./delete-transactions-dialog";
 import { TransactionCard } from "./transaction-card";
@@ -154,6 +157,8 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
 
     const [editingActivity, setEditingActivity] = useState<TransactionRowVM | undefined>();
     const [showForm, setShowForm] = useState(false);
+    const [showTransferForm, setShowTransferForm] = useState(false);
+    const [transferFromAccountId, setTransferFromAccountId] = useState<string | undefined>();
     const [deletingIds, setDeletingIds] = useState<string[] | null>(null);
     const [deletePreview, setDeletePreview] = useState<DeletePreview | undefined>();
 
@@ -293,6 +298,30 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
         (a: Account) => isSpendingAccountType(a.accountType) && includedIds.has(a.id),
       );
     }, [accounts, spendingAccountIds]);
+
+    // All active accounts for the transfer form (same full list as the Investments tab uses)
+    const transferFormAccounts = useMemo(
+      () =>
+        accounts
+          .filter((a: Account) => !a.isArchived)
+          .map((a: Account) => ({
+            value: a.id,
+            label: a.name,
+            currency: a.currency,
+            restrictionLevel: getActivityRestrictionLevel(a),
+          })),
+      [accounts],
+    );
+
+    const handleTransferClick = useCallback((accountId: string) => {
+      setTransferFromAccountId(accountId);
+      setShowTransferForm(true);
+    }, []);
+
+    const handleTransferFormClose = useCallback(() => {
+      setShowTransferForm(false);
+      setTransferFromAccountId(undefined);
+    }, []);
     const { data: events = [] } = useSpendingEvents();
     const { data: eventTypes = [] } = useEventTypes();
     const spending = useTaxonomy(SPENDING_TAXONOMY);
@@ -848,7 +877,19 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
           open={showForm}
           onOpenChange={setShowForm}
           activity={editingActivityForForm}
+          onTransferClick={handleTransferClick}
         />
+
+        {showTransferForm && (
+          <ActivityForm
+            accounts={transferFormAccounts}
+            transferAccounts={transferFormAccounts}
+            activity={{ activityType: ActivityType.TRANSFER_OUT, accountId: transferFromAccountId }}
+            open={showTransferForm}
+            onClose={handleTransferFormClose}
+            hidePicker
+          />
+        )}
 
         <DeleteTransactionsDialog
           open={!!deletingIds && deletingIds.length > 0}

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -226,6 +226,7 @@ const ActivityPage = () => {
         value: account.id,
         label: account.name,
         currency: account.currency,
+        accountType: account.accountType,
         restrictionLevel: getActivityRestrictionLevel(account),
       }));
   }, [accounts, investmentAccounts, isSpendingEnabled, selectedActivity?.accountId]);
@@ -242,6 +243,7 @@ const ActivityPage = () => {
           value: account.id,
           label: account.name,
           currency: account.currency,
+          accountType: account.accountType,
           restrictionLevel: getActivityRestrictionLevel(account),
         })),
     [accounts],

--- a/apps/frontend/src/pages/activity/components/activity-form.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-form.tsx
@@ -12,6 +12,7 @@ import {
 } from "@wealthfolio/ui/components/ui/sheet";
 import type { ActivityDetails } from "@/lib/types";
 import { restrictionAllowsType } from "@/lib/activity-restrictions";
+import { isLiabilityAccountType } from "@/lib/constants";
 import { useState, useCallback, useMemo } from "react";
 import { ActivityTypePicker } from "./activity-type-picker";
 import { ActivityFormRenderer } from "./activity-form-renderer";
@@ -22,6 +23,13 @@ import type { PickerActivityType } from "../config/activity-form-config";
 
 // Re-export for consumers
 export type { AccountSelectOption };
+
+function transferAllowsAccount(account: AccountSelectOption): boolean {
+  return (
+    restrictionAllowsType(account.restrictionLevel, "TRANSFER") ||
+    isLiabilityAccountType(account.accountType)
+  );
+}
 
 interface ActivityFormProps {
   accounts: AccountSelectOption[];
@@ -62,6 +70,9 @@ export function ActivityForm({
     const base =
       effectiveSelectedType === "TRANSFER" && transferAccounts ? transferAccounts : accounts;
     if (!effectiveSelectedType) return base;
+    if (effectiveSelectedType === "TRANSFER") {
+      return base.filter(transferAllowsAccount);
+    }
     return base.filter((acc) => restrictionAllowsType(acc.restrictionLevel, effectiveSelectedType));
   }, [accounts, transferAccounts, effectiveSelectedType]);
 

--- a/apps/frontend/src/pages/activity/components/activity-form.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-form.tsx
@@ -34,6 +34,8 @@ interface ActivityFormProps {
   activity?: Partial<ActivityDetails>;
   open?: boolean;
   onClose?: () => void;
+  /** When true, hides the activity type picker (use when type is already determined) */
+  hidePicker?: boolean;
 }
 
 export function ActivityForm({
@@ -42,6 +44,7 @@ export function ActivityForm({
   activity,
   open,
   onClose,
+  hidePicker,
 }: ActivityFormProps) {
   // Derive the editing state and initial type from activity prop
   const isEditing = !!activity?.id;
@@ -101,8 +104,8 @@ export function ActivityForm({
         </SheetHeader>
 
         <div className="flex-1 space-y-6 overflow-y-auto py-4">
-          {/* Activity Type Picker - only show when creating new activity */}
-          {!isEditing && (
+          {/* Activity Type Picker - only show when creating new activity and not locked to a type */}
+          {!isEditing && !hidePicker && (
             <ActivityTypePicker value={effectiveSelectedType} onSelect={setSelectedType} />
           )}
 

--- a/apps/frontend/src/pages/activity/components/forms/fields/account-select.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/fields/account-select.tsx
@@ -17,6 +17,7 @@ export interface AccountSelectOption {
   value: string;
   label: string;
   currency: string;
+  accountType?: string;
   /** Activity restriction level based on account tracking mode. */
   restrictionLevel?: "none" | "limited" | "blocked";
 }

--- a/apps/frontend/src/pages/activity/components/forms/transfer-form.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/transfer-form.tsx
@@ -358,7 +358,7 @@ export function TransferForm({
     () => accounts.filter((account) => !isLiabilityAccountType(account.accountType)),
     [accounts],
   );
-  const destinationAccountOptions = accounts;
+  const destinationAccountOptions = isCashMode ? accounts : sourceAccountOptions;
   const externalAccountOptions =
     direction === "out" ? sourceAccountOptions : destinationAccountOptions;
 
@@ -447,6 +447,23 @@ export function TransferForm({
   }, [destinationAccount?.currency, setValue]);
 
   useEffect(() => {
+    if (isCashMode) return;
+
+    if (destinationAccount && isLiabilityAccountType(destinationAccount.accountType)) {
+      setValue("toAccountId", "", { shouldDirty: true, shouldValidate: false });
+    }
+
+    if (
+      isExternal &&
+      direction === "in" &&
+      selectedAccount &&
+      isLiabilityAccountType(selectedAccount.accountType)
+    ) {
+      setValue("accountId", "", { shouldDirty: true, shouldValidate: false });
+    }
+  }, [destinationAccount, direction, isCashMode, isExternal, selectedAccount, setValue]);
+
+  useEffect(() => {
     if (!isInternalCashTransfer || isCrossCurrencyInternalCash) return;
     if (sourceAmount != null && sourceAmount > 0) {
       setValue("destinationAmount", sourceAmount, {
@@ -477,6 +494,17 @@ export function TransferForm({
       setValue("unitPrice", null);
     } else {
       setValue("amount", null);
+      if (destinationAccount && isLiabilityAccountType(destinationAccount.accountType)) {
+        setValue("toAccountId", "");
+      }
+      if (
+        isExternal &&
+        direction === "in" &&
+        selectedAccount &&
+        isLiabilityAccountType(selectedAccount.accountType)
+      ) {
+        setValue("accountId", "");
+      }
     }
   };
 
@@ -603,6 +631,7 @@ export function TransferForm({
             {/* Account Selection - conditional based on external flag */}
             {isExternal ? (
               <AccountSelect
+                key={`external-${transferMode}-${direction}-${accountId || "none"}`}
                 name="accountId"
                 accounts={externalAccountOptions}
                 currencyName="currency"
@@ -622,6 +651,7 @@ export function TransferForm({
 
                 {/* To Account Selection */}
                 <AccountSelect
+                  key={`to-${transferMode}-${fromAccountId || "none"}-${toAccountId || "none"}`}
                   name="toAccountId"
                   accounts={toAccountOptions}
                   label="To Account"

--- a/apps/frontend/src/pages/activity/components/forms/transfer-form.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/transfer-form.tsx
@@ -1,6 +1,6 @@
 import { useSettings } from "@/hooks/use-settings";
 import { isSecuritiesTransfer } from "@/lib/activity-utils";
-import { ActivityType, QuoteMode } from "@/lib/constants";
+import { ActivityType, isLiabilityAccountType, QuoteMode } from "@/lib/constants";
 import { formatAmount } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { AnimatedToggleGroup } from "@wealthfolio/ui/components/ui/animated-toggle-group";
@@ -354,6 +354,13 @@ export function TransferForm({
   const quantity = watch("quantity");
   const isManualAsset = quoteMode === QuoteMode.MANUAL;
   const isCashMode = transferMode === "cash";
+  const sourceAccountOptions = useMemo(
+    () => accounts.filter((account) => !isLiabilityAccountType(account.accountType)),
+    [accounts],
+  );
+  const destinationAccountOptions = accounts;
+  const externalAccountOptions =
+    direction === "out" ? sourceAccountOptions : destinationAccountOptions;
 
   // Get account currency from selected account (internal: fromAccount, external: accountId)
   const selectedAccount = useMemo(
@@ -366,6 +373,8 @@ export function TransferForm({
     [accounts, toAccountId],
   );
   const isInternalCashTransfer = !isExternal && isCashMode;
+  const isCreditCardPayment =
+    isInternalCashTransfer && isLiabilityAccountType(destinationAccount?.accountType);
   const effectiveSourceCurrency = sourceCurrency || accountCurrency || currency || baseCurrency;
   const effectiveDestinationCurrency =
     destinationCurrency || destinationAccount?.currency || effectiveSourceCurrency;
@@ -500,11 +509,13 @@ export function TransferForm({
   const getSubmitButtonText = () => {
     if (isEditing) return "Update";
 
-    const actionPrefix = isExternal
-      ? direction === "in"
-        ? "Transfer In"
-        : "Transfer Out"
-      : "Transfer";
+    const actionPrefix = isCreditCardPayment
+      ? "Payment"
+      : isExternal
+        ? direction === "in"
+          ? "Transfer In"
+          : "Transfer Out"
+        : "Transfer";
 
     const displayAmount = isInternalCashTransfer ? sourceAmount : amount;
     if (isCashMode && displayAmount && displayAmount > 0) {
@@ -516,11 +527,15 @@ export function TransferForm({
       return `${actionPrefix} ${quantity} ${assetId}`;
     }
 
-    return isExternal ? `Add ${actionPrefix}` : "Add Transfer";
+    return isCreditCardPayment
+      ? "Add Payment"
+      : isExternal
+        ? `Add ${actionPrefix}`
+        : "Add Transfer";
   };
 
   // Filter destination accounts to exclude source account (for internal transfers)
-  const toAccountOptions = accounts.filter((acc) => acc.value !== fromAccountId);
+  const toAccountOptions = destinationAccountOptions.filter((acc) => acc.value !== fromAccountId);
 
   const handleSubmit = createValidatedSubmit(form, async (data) => {
     // Ensure symbolQuoteCcy is set — manual/custom symbols leave it undefined
@@ -589,7 +604,7 @@ export function TransferForm({
             {isExternal ? (
               <AccountSelect
                 name="accountId"
-                accounts={accounts}
+                accounts={externalAccountOptions}
                 currencyName="currency"
                 label={direction === "in" ? "To Account" : "From Account"}
                 placeholder="Select account..."
@@ -599,7 +614,7 @@ export function TransferForm({
                 {/* From Account Selection */}
                 <AccountSelect
                   name="fromAccountId"
-                  accounts={accounts}
+                  accounts={sourceAccountOptions}
                   currencyName="currency"
                   label="From Account"
                   placeholder="Select source account..."


### PR DESCRIPTION
Hey @afadil 👋

This is a follow-up to #1031 
The paired transfer infrastructure was already in place (cascade delete, update propagation, `source_group_id` sync), but there was no way to *initiate* a linked transfer from the Spending tab. Users had to go to the Investments tab to do it, which wasn't obvious at all.

---

## What this does

When a user is in **Spending → Add Transaction**, instead of having TRANSFER_IN / TRANSFER_OUT in the type dropdown (which created standalone, unlinked legs), there's now a **"Transfer between accounts"** button. Clicking it opens the standard transfer form — the same one used on the Investments tab.
With the spending account pre-filled as "From Account". The user picks the destination account and saves. Both legs are created atomically with a shared `source_group_id`, so the existing sync from #1031 kicks in automatically (update propagation, cascade delete, everything).

Changes are minimal:

- **`cash-activity-form.tsx`** — hides TRANSFER_IN/OUT from the type dropdown in creation mode; adds a "Transfer between accounts" button with an `onTransferClick` callback
- **`activity-form.tsx`** — adds a `hidePicker` prop to skip the type carousel when the caller has already determined the type
- **`spending-transactions-tab.tsx`** — wires up the full transfer flow (account list, open/close state, `ActivityForm` instance that remounts fresh on each open)

Editing existing linked or standalone transfer activities from the Spending tab still works as before.

---

## Tests

No unit tests added — the changes are purely UI/wiring with no new business logic. The existing `use-activity-form.test.ts` suite (which covers the transfer pair submission path we rely on) passes unchanged.

**Manual smoke:**
- Spending → Add Transaction → Transfer button → Transfer form opens with spending account pre-set as From Account ✓
- Pick a destination invest account + amount → both legs created, pair linked via `source_group_id` ✓
- Edit the transfer from Spending tab → update propagates to counterpart (PR #1031 sync) ✓
- Delete from Spending tab → both legs removed (PR #1031 cascade) ✓
- Existing non-transfer cash activities (Withdrawal, Deposit, etc.) unaffected ✓

---

## Small question on the saving color 🎨

One thing I noticed while working on this: a cross-scope TRANSFER_OUT (spending → invest) gets `cash_flow_bucket = "saving"` and renders in olive (`#6B8E54`) in the amount column. I understand the intent — it's savings, not a loss — and I've left it exactly as-is.

That said, since olive is close to green visually, some users might find it a bit ambiguous next to income (which is also greenish). Would you consider a neutral color.
Something like amber/gold or a muted blue — to say "this money moved somewhere positive" without reading as income? 
Totally your call, just flagging it in case you had a specific palette in mind for the saving bucket.

---

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).