### PR TITLE
Add dashboard performance headline regression test

### DIFF
--- a/apps/frontend/src/pages/dashboard/dashboard-content.test.tsx
+++ b/apps/frontend/src/pages/dashboard/dashboard-content.test.tsx
@@ -1,18 +1,24 @@
-import { render, screen } from "@testing-library/react";
-import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
-import { useQuery } from "@tanstack/react-query";
+import { calculatePerformanceSummary } from "@/adapters";
 import { useHoldings } from "@/hooks/use-holdings";
 import { useValuationHistory } from "@/hooks/use-valuation-history";
 import { useSettingsContext } from "@/lib/settings-provider";
+import type { PerformanceResult } from "@/lib/types";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { DashboardContent } from "./dashboard-content";
 
-vi.mock("@/adapters", () => ({
+const mocks = vi.hoisted(() => ({
   calculatePerformanceSummary: vi.fn(),
 }));
 
+vi.mock("@/adapters", () => ({
+  calculatePerformanceSummary: mocks.calculatePerformanceSummary,
+}));
+
 vi.mock("@/components/history-chart", () => ({
-  HistoryChart: () => <div>history-chart</div>,
+  HistoryChart: () => <div data-testid="history-chart" />,
 }));
 
 vi.mock("@/hooks", () => ({
@@ -31,28 +37,9 @@ vi.mock("@/lib/settings-provider", () => ({
   useSettingsContext: vi.fn(),
 }));
 
-vi.mock("@tanstack/react-query", () => ({
-  useQuery: vi.fn(),
-}));
-
-vi.mock("@wealthfolio/ui", () => ({
-  GainAmount: ({ value }: { value: number }) => <span>{`gain-amount:${value}`}</span>,
-  GainPercent: ({ value }: { value: number }) => <span>{`gain-percent:${value}`}</span>,
-  getInitialIntervalData: () => ({
-    range: { from: new Date("2026-03-01T00:00:00Z"), to: new Date("2026-06-01T00:00:00Z") },
-    description: "3M",
-  }),
-  IntervalSelector: () => <div>interval-selector</div>,
-  usePersistentState: () => ["3M", vi.fn()],
-}));
-
-vi.mock("@wealthfolio/ui/components/ui/skeleton", () => ({
-  Skeleton: () => <div>loading</div>,
-}));
-
 vi.mock("@/pages/dashboard/portfolio-update-trigger", () => ({
   PortfolioUpdateTrigger: ({ children, notices }: { children: ReactNode; notices?: string[] }) => (
-    <div>
+    <div data-testid="portfolio-update-trigger">
       <div data-testid="portfolio-notices">{JSON.stringify(notices ?? [])}</div>
       {children}
     </div>
@@ -60,93 +47,180 @@ vi.mock("@/pages/dashboard/portfolio-update-trigger", () => ({
 }));
 
 vi.mock("./accounts-summary", () => ({
-  AccountsSummary: () => <div>accounts-summary</div>,
+  AccountsSummary: () => <div data-testid="accounts-summary" />,
 }));
 
 vi.mock("./balance", () => ({
-  default: () => <div>balance</div>,
+  default: ({ targetValue }: { targetValue: number }) => (
+    <div data-testid="dashboard-balance">{`balance:${targetValue}`}</div>
+  ),
 }));
 
 vi.mock("./goals", () => ({
-  default: () => <div>saving-goals</div>,
+  default: () => <div data-testid="saving-goals" />,
 }));
 
 vi.mock("./top-holdings", () => ({
-  default: () => <div>top-holdings</div>,
+  default: () => <div data-testid="top-holdings" />,
 }));
 
-const mockUseQuery = vi.mocked(useQuery);
+vi.mock("@wealthfolio/ui", () => ({
+  GainAmount: ({ value, currency }: { value: number; currency: string }) => (
+    <span data-testid="dashboard-gain-amount">{`gain-amount:${currency}:${value}`}</span>
+  ),
+  GainPercent: ({ value }: { value: number }) => (
+    <span data-testid="dashboard-gain-percent">{`gain-percent:${value}`}</span>
+  ),
+  getInitialIntervalData: () => ({
+    description: "year to date",
+    range: { from: new Date(2026, 0, 1), to: new Date(2026, 5, 7) },
+  }),
+  IntervalSelector: () => <div data-testid="interval-selector" />,
+  usePersistentState: () => ["YTD", vi.fn()],
+}));
+
+vi.mock("@wealthfolio/ui/components/ui/skeleton", () => ({
+  Skeleton: () => <div>loading</div>,
+}));
+
+const mockCalculatePerformanceSummary = vi.mocked(calculatePerformanceSummary);
 const mockUseHoldings = vi.mocked(useHoldings);
 const mockUseValuationHistory = vi.mocked(useValuationHistory);
 const mockUseSettingsContext = vi.mocked(useSettingsContext);
 
+function createPerformanceResult(
+  overrides: Partial<PerformanceResult> = {},
+): PerformanceResult {
+  return {
+    scope: { id: "portfolio:all", currency: "USD" },
+    period: { startDate: "2026-01-01", endDate: "2026-06-07" },
+    mode: "timeWeighted",
+    returns: {
+      twr: 0.1267,
+      annualizedTwr: null,
+      irr: null,
+      annualizedIrr: null,
+      valueReturn: null,
+      annualizedValueReturn: null,
+    },
+    attribution: {
+      contributions: 0,
+      distributions: 0,
+      income: 0,
+      realizedPnl: 0,
+      unrealizedPnlChange: 12.34,
+      fxEffect: 0,
+      fees: 0,
+      taxes: 0,
+      residual: 0,
+    },
+    risk: {
+      volatility: null,
+      maxDrawdown: null,
+      peakDate: null,
+      troughDate: null,
+      recoveryDate: null,
+      drawdownDurationDays: null,
+    },
+    dataQuality: {
+      status: "ok",
+      warnings: [],
+      notApplicableReasons: [],
+    },
+    series: [],
+    ...overrides,
+  };
+}
+
+function renderDashboardContent() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <DashboardContent />
+    </QueryClientProvider>,
+  );
+}
+
 describe("DashboardContent", () => {
-  it("does not pass backend performance warnings to dashboard header notices", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockUseSettingsContext.mockReturnValue({
+      settings: { baseCurrency: "USD" },
+    } as ReturnType<typeof useSettingsContext>);
+
     mockUseHoldings.mockReturnValue({
-      holdings: [],
-      isLoading: false,
-      error: null,
-    } as unknown as ReturnType<typeof useHoldings>);
-    mockUseValuationHistory.mockReturnValue({
-      valuationHistory: [
+      holdings: [
         {
-          valuationDate: "2026-06-01",
-          totalValueBase: 1000,
-          netContributionBase: 900,
-          baseCurrency: "USD",
-          calculatedAt: "2026-06-01T12:00:00Z",
+          holdingType: "security",
+          marketValue: { base: 200 },
         },
       ],
       isLoading: false,
+      isError: false,
       error: null,
-    } as unknown as ReturnType<typeof useValuationHistory>);
-    mockUseSettingsContext.mockReturnValue({
-      settings: { baseCurrency: "USD" },
-    } as unknown as ReturnType<typeof useSettingsContext>);
-    mockUseQuery.mockReturnValue({
+    } as unknown as ReturnType<typeof useHoldings>);
+
+    mockUseValuationHistory.mockReturnValue({
+      valuationHistory: [
+        {
+          valuationDate: "2026-01-01",
+          totalValueBase: 100,
+          netContributionBase: 0,
+          baseCurrency: "USD",
+          calculatedAt: "2026-06-07T00:00:00Z",
+        },
+        {
+          valuationDate: "2026-06-07",
+          totalValueBase: 200,
+          netContributionBase: 50,
+          baseCurrency: "USD",
+          calculatedAt: "2026-06-07T00:00:00Z",
+        },
+      ],
       isLoading: false,
-      data: {
-        scope: { id: "portfolio:all", currency: "USD" },
-        period: { startDate: "2026-03-01", endDate: "2026-06-01" },
-        mode: "timeWeighted",
-        returns: {
-          twr: 0.1,
-          annualizedTwr: null,
-          irr: null,
-          annualizedIrr: null,
-          valueReturn: 0.1,
-        },
-        attribution: {
-          contributions: 0,
-          distributions: 0,
-          income: 0,
-          realizedPnl: 0,
-          unrealizedPnlChange: 100,
-          fxEffect: 0,
-          fees: 0,
-          taxes: 0,
-          residual: 0,
-        },
-        risk: {
-          volatility: null,
-          maxDrawdown: null,
-          peakDate: null,
-          troughDate: null,
-          recoveryDate: null,
-          drawdownDurationDays: null,
-        },
+    } as unknown as ReturnType<typeof useValuationHistory>);
+
+    mockCalculatePerformanceSummary.mockResolvedValue(createPerformanceResult());
+  });
+
+  it("uses backend headline performance summary for the dashboard return", async () => {
+    renderDashboardContent();
+
+    await waitFor(() => {
+      expect(mockCalculatePerformanceSummary).toHaveBeenCalledWith({
+        itemType: "account",
+        itemId: "portfolio:all",
+        startDate: "2026-01-01",
+        endDate: "2026-06-07",
+        filter: { type: "all" },
+        profile: "headline",
+      });
+    });
+
+    expect(await screen.findByTestId("dashboard-gain-amount")).toHaveTextContent(
+      "gain-amount:USD:12.34",
+    );
+    expect(screen.getByTestId("dashboard-gain-percent")).toHaveTextContent("gain-percent:0.1267");
+  });
+
+  it("does not pass backend performance warnings to dashboard header notices", async () => {
+    mockCalculatePerformanceSummary.mockResolvedValue(
+      createPerformanceResult({
         dataQuality: {
           status: "partial",
           warnings: ["Backend performance warning that belongs in Health Center."],
           notApplicableReasons: [],
         },
-        series: [],
-      },
-    } as unknown as ReturnType<typeof useQuery>);
+      }),
+    );
 
-    render(<DashboardContent />);
+    renderDashboardContent();
 
-    expect(screen.getByTestId("portfolio-notices")).toHaveTextContent("[]");
+    expect(await screen.findByTestId("portfolio-notices")).toHaveTextContent("[]");
     expect(screen.queryByText(/backend performance warning/i)).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Keep the existing dashboard warning regression coverage while resolving the latest add/add test-file conflict from `main`.
- Add a focused DashboardContent regression test for the dashboard headline performance query.
- Verify the headline uses the backend `calculatePerformanceSummary` result with the `headline` profile and displays values derived from the returned performance result.

## Context

The dashboard headline calculation was recently moved to the backend headline performance summary on `main`. This test locks in that behavior so the headline does not regress to a client-side valuation-history calculation that can diverge from account summary cards around cash flows.

## Test plan

- `npm_config_registry=https://registry.npmjs.org npx --yes pnpm@10.33.4 --filter frontend exec vitest src/pages/dashboard/dashboard-content.test.tsx --run`
- `npm_config_registry=https://registry.npmjs.org npx --yes pnpm@10.33.4 --filter frontend exec eslint src/pages/dashboard/dashboard-content.test.tsx`