### PR TITLE
Fix device sync and rebase regressions

### DIFF
--- a/apps/frontend/src/components/history-chart-scale.test.ts
+++ b/apps/frontend/src/components/history-chart-scale.test.ts
@@ -60,6 +60,78 @@ describe("getAutomaticHistoryChartScale", () => {
     expect(scale.domain).toEqual([0, 2300]);
   });
 
+  it("fits visible values without zero anchoring when requested", () => {
+    const scale = getAutomaticHistoryChartScale(
+      [
+        { totalValue: 2000, netContribution: 0 },
+        { totalValue: 1500, netContribution: 0 },
+        { totalValue: 2000, netContribution: 0 },
+      ],
+      { mode: "fit-visible" },
+    );
+
+    expect(scale.scale).toBe("linear");
+    expect(scale.showNetContribution).toBe(false);
+    expect(scale.domain[0]).toBeCloseTo(1425);
+    expect(scale.domain[1]).toBeCloseTo(2020);
+  });
+
+  it("biases fit-visible padding below the data to reduce empty headroom", () => {
+    const scale = getAutomaticHistoryChartScale(
+      [
+        { totalValue: 1500, netContribution: 0 },
+        { totalValue: 2000, netContribution: 0 },
+      ],
+      { mode: "fit-visible" },
+    );
+
+    expect(1500 - scale.domain[0]).toBeGreaterThan(scale.domain[1] - 2000);
+  });
+
+  it("keeps fit-visible periods calmer when a minimum domain span ratio is provided", () => {
+    const scale = getAutomaticHistoryChartScale(
+      [
+        { totalValue: 90, netContribution: 0 },
+        { totalValue: 100, netContribution: 0 },
+      ],
+      { mode: "fit-visible", minDomainSpanRatio: 0.2 },
+    );
+
+    expect(scale.scale).toBe("linear");
+    expect(scale.domain[1] - scale.domain[0]).toBeCloseTo(19);
+  });
+
+  it("expands fit-visible scale to show net contribution when the span stays reasonable", () => {
+    const scale = getAutomaticHistoryChartScale(
+      [
+        { totalValue: 650_000, netContribution: 531_202.07 },
+        { totalValue: 706_926.56, netContribution: 531_202.07 },
+        { totalValue: 690_000, netContribution: 531_202.07 },
+      ],
+      { mode: "fit-visible", netContributionMaxDomainSpanRatio: 5 },
+    );
+
+    expect(scale.scale).toBe("linear");
+    expect(scale.showNetContribution).toBe(true);
+    expect(scale.domain[0]).toBeLessThan(531_202.07);
+    expect(scale.domain[1]).toBeGreaterThan(706_926.56);
+  });
+
+  it("keeps net contribution hidden when including it would flatten fit-visible data", () => {
+    const scale = getAutomaticHistoryChartScale(
+      [
+        { totalValue: 700_000, netContribution: 531_202.07 },
+        { totalValue: 706_926.56, netContribution: 531_202.07 },
+        { totalValue: 704_000, netContribution: 531_202.07 },
+      ],
+      { mode: "fit-visible", netContributionMaxDomainSpanRatio: 5 },
+    );
+
+    expect(scale.scale).toBe("linear");
+    expect(scale.showNetContribution).toBe(false);
+    expect(scale.domain[0]).toBeGreaterThan(531_202.07);
+  });
+
   it("keeps high-value low-volatility periods readable", () => {
     const scale = getAutomaticHistoryChartScale([
       { totalValue: 1_021_150, netContribution: 1_000_000 },

--- a/apps/frontend/src/components/history-chart-scale.ts
+++ b/apps/frontend/src/components/history-chart-scale.ts
@@ -1,15 +1,23 @@
 const LOG_SCALE_MIN_POINTS = 3;
 const LOG_SCALE_MIN_RATIO = 10;
 const LINEAR_DOMAIN_PADDING_RATIO = 0.15;
+const FIT_VISIBLE_UPPER_PADDING_RATIO = 0.04;
 const LINEAR_ZERO_ANCHOR_RANGE_RATIO = 0.2;
 const LINEAR_MIN_VISIBLE_SPAN_RATIO = 0.0001;
 const LINEAR_MIN_VISIBLE_SPAN = 0.01;
 
 export type HistoryChartScale = "linear" | "log";
+export type HistoryChartScaleMode = "automatic" | "fit-visible";
 
 export interface HistoryChartScaleDataPoint {
   totalValue: number;
   netContribution: number;
+}
+
+export interface HistoryChartScaleOptions {
+  mode?: HistoryChartScaleMode;
+  netContributionMaxDomainSpanRatio?: number;
+  minDomainSpanRatio?: number;
 }
 
 export interface HistoryChartScaleConfig {
@@ -18,14 +26,19 @@ export interface HistoryChartScaleConfig {
   showNetContribution: boolean;
 }
 
-function getLinearDomain(values: number[]): [number, number] {
+function getLinearDomain(
+  values: number[],
+  anchorMaterialRangesToZero = true,
+  minDomainSpanRatio = LINEAR_MIN_VISIBLE_SPAN_RATIO,
+  upperPaddingRatio = LINEAR_DOMAIN_PADDING_RATIO,
+): [number, number] {
   const minValue = Math.min(...values);
   const maxValue = Math.max(...values);
   const range = maxValue - minValue;
   const maxMagnitude = Math.max(Math.abs(minValue), Math.abs(maxValue));
   const relativeRange = maxMagnitude > 0 ? range / maxMagnitude : 0;
 
-  if (relativeRange >= LINEAR_ZERO_ANCHOR_RANGE_RATIO) {
+  if (anchorMaterialRangesToZero && relativeRange >= LINEAR_ZERO_ANCHOR_RANGE_RATIO) {
     if (minValue >= 0) {
       return [0, Math.max(maxValue * (1 + LINEAR_DOMAIN_PADDING_RATIO), LINEAR_MIN_VISIBLE_SPAN)];
     }
@@ -35,14 +48,18 @@ function getLinearDomain(values: number[]): [number, number] {
     }
   }
 
-  const center = (minValue + maxValue) / 2;
   const minVisibleSpan = Math.max(
-    Math.abs(center) * LINEAR_MIN_VISIBLE_SPAN_RATIO,
+    Math.abs((minValue + maxValue) / 2) * minDomainSpanRatio,
     LINEAR_MIN_VISIBLE_SPAN,
   );
-  const span = Math.max(range * (1 + LINEAR_DOMAIN_PADDING_RATIO * 2), minVisibleSpan);
-  let lower = center - span / 2;
-  let upper = center + span / 2;
+  const span = Math.max(
+    range * (1 + LINEAR_DOMAIN_PADDING_RATIO + upperPaddingRatio),
+    minVisibleSpan,
+  );
+  const extraSpan = span - range;
+  const totalPaddingRatio = LINEAR_DOMAIN_PADDING_RATIO + upperPaddingRatio;
+  let lower = minValue - extraSpan * (LINEAR_DOMAIN_PADDING_RATIO / totalPaddingRatio);
+  let upper = maxValue + extraSpan * (upperPaddingRatio / totalPaddingRatio);
 
   if (minValue >= 0 && lower < 0) {
     lower = 0;
@@ -57,8 +74,13 @@ function containsAllValues(domain: [number, number], values: number[]) {
   return values.every((value) => Number.isFinite(value) && value >= lower && value <= upper);
 }
 
+function domainSpan(domain: [number, number]) {
+  return domain[1] - domain[0];
+}
+
 export function getAutomaticHistoryChartScale(
   data: HistoryChartScaleDataPoint[],
+  options: HistoryChartScaleOptions = {},
 ): HistoryChartScaleConfig {
   const totalValues = data.map((item) => item.totalValue).filter(Number.isFinite);
 
@@ -66,9 +88,48 @@ export function getAutomaticHistoryChartScale(
     return { scale: "linear", domain: [0, 1], showNetContribution: false };
   }
 
-  const linearDomain = getLinearDomain(totalValues);
+  const mode = options.mode ?? "automatic";
+  const upperPaddingRatio =
+    mode === "fit-visible" ? FIT_VISIBLE_UPPER_PADDING_RATIO : LINEAR_DOMAIN_PADDING_RATIO;
+  let linearDomain = getLinearDomain(
+    totalValues,
+    mode === "automatic",
+    options.minDomainSpanRatio,
+    upperPaddingRatio,
+  );
   const netContributionValues = data.map((item) => item.netContribution);
-  const showNetContributionInLinearScale = containsAllValues(linearDomain, netContributionValues);
+  let showNetContributionInLinearScale = containsAllValues(linearDomain, netContributionValues);
+
+  if (
+    !showNetContributionInLinearScale &&
+    options.netContributionMaxDomainSpanRatio &&
+    netContributionValues.every(Number.isFinite)
+  ) {
+    const combinedValues = [...totalValues, ...netContributionValues];
+    const combinedDomain = getLinearDomain(
+      combinedValues,
+      mode === "automatic",
+      options.minDomainSpanRatio,
+      upperPaddingRatio,
+    );
+    const maxSpan = domainSpan(linearDomain) * options.netContributionMaxDomainSpanRatio;
+
+    if (
+      containsAllValues(combinedDomain, netContributionValues) &&
+      domainSpan(combinedDomain) <= maxSpan
+    ) {
+      linearDomain = combinedDomain;
+      showNetContributionInLinearScale = true;
+    }
+  }
+
+  if (mode === "fit-visible") {
+    return {
+      scale: "linear",
+      domain: linearDomain,
+      showNetContribution: showNetContributionInLinearScale,
+    };
+  }
 
   if (totalValues.length < LOG_SCALE_MIN_POINTS) {
     return {

--- a/apps/frontend/src/components/history-chart.tsx
+++ b/apps/frontend/src/components/history-chart.tsx
@@ -13,7 +13,10 @@ import {
   type RechartsActiveDotProps,
   type RechartsMarkerShapeProps,
 } from "./history-chart-marker";
-import { getAutomaticHistoryChartScale } from "./history-chart-scale";
+import {
+  getAutomaticHistoryChartScale,
+  type HistoryChartScaleMode,
+} from "./history-chart-scale";
 
 const CHART_SCRUB_HAPTIC_INTERVAL_MS = 80;
 
@@ -33,6 +36,12 @@ interface HistoryChartProps {
   showMarkers?: boolean;
   /** Callback when a marker is clicked */
   onMarkerClick?: (date: string) => void;
+  /** Controls how the Y-axis domain is calculated. */
+  scaleMode?: HistoryChartScaleMode;
+  /** Expands the domain to show net contribution when the widened span stays under this ratio. */
+  netContributionMaxDomainSpanRatio?: number;
+  /** Keeps narrow ranges from zooming too aggressively. Ratio is relative to the visible center. */
+  minDomainSpanRatio?: number;
 }
 
 interface TooltipEntry {
@@ -122,6 +131,9 @@ export function HistoryChart({
   snapshotDates,
   showMarkers,
   onMarkerClick,
+  scaleMode,
+  netContributionMaxDomainSpanRatio,
+  minDomainSpanRatio,
 }: HistoryChartProps) {
   const { triggerHaptic } = useHapticFeedback();
   const { isBalanceHidden } = useBalancePrivacy();
@@ -134,7 +146,17 @@ export function HistoryChart({
   const id = useId();
   const fillGradientId = `historyFill-${id}`;
   const strokeGradientId = `historyStroke-${id}`;
-  const scaleConfig = useMemo(() => getAutomaticHistoryChartScale(data), [data]);
+  const scaleConfig = useMemo(
+    () =>
+      getAutomaticHistoryChartScale(data, {
+        ...(scaleMode ? { mode: scaleMode } : {}),
+        ...(netContributionMaxDomainSpanRatio === undefined
+          ? {}
+          : { netContributionMaxDomainSpanRatio }),
+        ...(minDomainSpanRatio === undefined ? {} : { minDomainSpanRatio }),
+      }),
+    [data, scaleMode, netContributionMaxDomainSpanRatio, minDomainSpanRatio],
+  );
 
   const chartConfig = {
     totalValue: {

--- a/apps/frontend/src/components/history-chart.tsx
+++ b/apps/frontend/src/components/history-chart.tsx
@@ -13,10 +13,7 @@ import {
   type RechartsActiveDotProps,
   type RechartsMarkerShapeProps,
 } from "./history-chart-marker";
-import {
-  getAutomaticHistoryChartScale,
-  type HistoryChartScaleMode,
-} from "./history-chart-scale";
+import { getAutomaticHistoryChartScale, type HistoryChartScaleMode } from "./history-chart-scale";
 
 const CHART_SCRUB_HAPTIC_INTERVAL_MS = 80;
 

--- a/apps/frontend/src/components/page/swipable-page.tsx
+++ b/apps/frontend/src/components/page/swipable-page.tsx
@@ -23,6 +23,7 @@ interface SwipablePageProps {
   withPadding?: boolean;
   withMobileNavOffset?: boolean;
   title?: string;
+  mobileActionsPlacement?: "below" | "header";
   /**
    * When set, the most recently selected view is remembered in localStorage
    * under this key. Used as the fallback when the URL has no `?tab=` param,
@@ -89,15 +90,22 @@ function MobileNavigation({
   views,
   currentView,
   onViewChange,
+  compact = false,
 }: {
   views: SwipablePageView[];
   currentView: string;
   onViewChange: (view: string) => void;
+  compact?: boolean;
 }) {
   const layoutId = React.useId();
 
   return (
-    <div className="bg-muted/50 flex items-center gap-0.5 rounded-full p-1 backdrop-blur-sm">
+    <div
+      className={cn(
+        "bg-muted/50 flex items-center gap-0.5 rounded-full p-1 backdrop-blur-sm",
+        compact && "min-w-0 max-w-full",
+      )}
+    >
       {views.map((item) => {
         const isActive = currentView === item.value;
         const IconComponent = item.icon;
@@ -108,8 +116,10 @@ function MobileNavigation({
             type="button"
             onClick={() => onViewChange(item.value)}
             className={cn(
-              "relative flex cursor-pointer items-center justify-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium transition-colors duration-200",
+              "relative flex cursor-pointer items-center justify-center gap-1.5 rounded-full py-1.5 text-sm font-medium transition-colors duration-200",
               "focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+              compact ? "px-2" : "px-3",
+              isActive ? "min-w-0" : "shrink-0",
               isActive ? "text-foreground" : "text-muted-foreground",
             )}
             aria-label={item.label}
@@ -127,9 +137,11 @@ function MobileNavigation({
                 }}
               />
             )}
-            <span className="relative z-10 flex items-center gap-1.5">
+            <span className={cn("relative z-10 flex items-center gap-1.5", compact && "min-w-0")}>
               {IconComponent && <IconComponent className="size-4" />}
-              {isActive && <span className="whitespace-nowrap">{item.label}</span>}
+              {isActive && (
+                <span className={cn("whitespace-nowrap", compact && "truncate")}>{item.label}</span>
+              )}
             </span>
           </button>
         );
@@ -147,6 +159,7 @@ export function SwipablePage({
   withPadding = true,
   withMobileNavOffset = true,
   title,
+  mobileActionsPlacement = "below",
   persistKey,
 }: SwipablePageProps) {
   const isMobile = useIsMobileViewport();
@@ -180,6 +193,7 @@ export function SwipablePage({
     return idx === -1 ? 0 : idx;
   }, [currentView, views]);
   const currentActions = views.find((v) => v.value === currentView)?.actions;
+  const mobileActionsInHeader = mobileActionsPlacement === "header";
 
   const handleViewChange = React.useCallback(
     (nextView: string) => {
@@ -219,16 +233,32 @@ export function SwipablePage({
           <div className="flex h-full flex-col md:hidden">
             {/* Mobile Navigation at top */}
             <div className="pt-safe flex shrink-0 flex-col gap-2 px-3 pb-2">
-              <div className="grid w-full grid-cols-[1fr_auto_1fr] items-center">
-                <div className="w-10" />
-                <MobileNavigation
-                  views={views}
-                  currentView={currentView}
-                  onViewChange={handleViewChange}
-                />
-                <div />
+              <div
+                className={cn(
+                  "grid w-full items-center gap-2",
+                  mobileActionsInHeader
+                    ? "grid-cols-[2.5rem_minmax(0,1fr)_auto] min-[390px]:grid-cols-[4.5rem_minmax(0,1fr)_auto]"
+                    : "grid-cols-[1fr_auto_1fr]",
+                )}
+              >
+                <div className={mobileActionsInHeader ? "w-10 min-[390px]:w-[4.5rem]" : "w-10"} />
+                <div className={cn("min-w-0", mobileActionsInHeader && "justify-self-center")}>
+                  <MobileNavigation
+                    views={views}
+                    currentView={currentView}
+                    onViewChange={handleViewChange}
+                    compact={mobileActionsInHeader}
+                  />
+                </div>
+                {mobileActionsInHeader ? (
+                  <div className="flex min-w-0 shrink-0 justify-end">{currentActions}</div>
+                ) : (
+                  <div />
+                )}
               </div>
-              {currentActions && <div className="flex min-w-0 justify-end">{currentActions}</div>}
+              {currentActions && !mobileActionsInHeader && (
+                <div className="flex min-w-0 justify-end">{currentActions}</div>
+              )}
             </div>
 
             <div className="min-h-0 flex-1 overflow-hidden">

--- a/apps/frontend/src/components/page/swipable-page.tsx
+++ b/apps/frontend/src/components/page/swipable-page.tsx
@@ -21,6 +21,7 @@ interface SwipablePageProps {
   className?: string;
   contentClassName?: string;
   withPadding?: boolean;
+  withMobileNavOffset?: boolean;
   title?: string;
   /**
    * When set, the most recently selected view is remembered in localStorage
@@ -144,6 +145,7 @@ export function SwipablePage({
   className,
   contentClassName,
   withPadding = true,
+  withMobileNavOffset = true,
   title,
   persistKey,
 }: SwipablePageProps) {
@@ -236,9 +238,8 @@ export function SwipablePage({
                   content: (
                     <div
                       className={cn(
-                        withPadding
-                          ? "p-2 pb-[calc(var(--mobile-nav-ui-height)+max(var(--mobile-nav-gap),env(safe-area-inset-bottom)))]"
-                          : "pb-safe",
+                        withPadding ? "p-2" : "pb-safe",
+                        withMobileNavOffset && "pb-[var(--mobile-nav-total-offset)]",
                       )}
                     >
                       {v.content}

--- a/apps/frontend/src/components/page/swipable-page.tsx
+++ b/apps/frontend/src/components/page/swipable-page.tsx
@@ -179,6 +179,7 @@ export function SwipablePage({
     const idx = views.findIndex((v) => v.value === currentView);
     return idx === -1 ? 0 : idx;
   }, [currentView, views]);
+  const currentActions = views.find((v) => v.value === currentView)?.actions;
 
   const handleViewChange = React.useCallback(
     (nextView: string) => {
@@ -217,16 +218,17 @@ export function SwipablePage({
           /* Mobile: SwipableView with navigation */
           <div className="flex h-full flex-col md:hidden">
             {/* Mobile Navigation at top */}
-            <div className="pt-safe flex shrink-0 items-center justify-between px-3 pb-2">
-              <div className="w-10" />
-              <MobileNavigation
-                views={views}
-                currentView={currentView}
-                onViewChange={handleViewChange}
-              />
-              <div className="flex items-center gap-1.5">
-                {views.find((v) => v.value === currentView)?.actions}
+            <div className="pt-safe flex shrink-0 flex-col gap-2 px-3 pb-2">
+              <div className="grid w-full grid-cols-[1fr_auto_1fr] items-center">
+                <div className="w-10" />
+                <MobileNavigation
+                  views={views}
+                  currentView={currentView}
+                  onViewChange={handleViewChange}
+                />
+                <div />
               </div>
+              {currentActions && <div className="flex min-w-0 justify-end">{currentActions}</div>}
             </div>
 
             <div className="min-h-0 flex-1 overflow-hidden">
@@ -270,9 +272,7 @@ export function SwipablePage({
                 />
               </div>
               {/* Actions slot - renders current view's actions */}
-              <div className="flex items-center gap-2">
-                {views.find((v) => v.value === currentView)?.actions}
-              </div>
+              <div className="flex items-center gap-2">{currentActions}</div>
             </div>
 
             {/* Content - relative for absolute positioned actions within */}

--- a/apps/frontend/src/components/page/swipable-routes-page.tsx
+++ b/apps/frontend/src/components/page/swipable-routes-page.tsx
@@ -213,6 +213,7 @@ export function SwipableRoutesPage({
           <SwipableView
             items={swipableItems}
             displayToggle={false}
+            withMobileNavOffset
             onViewChange={handleSwipe}
             onInit={(api) => {
               if (api) {

--- a/apps/frontend/src/features/ai-assistant/components/chat-shell.tsx
+++ b/apps/frontend/src/features/ai-assistant/components/chat-shell.tsx
@@ -4,7 +4,7 @@ import { AssistantRuntimeProvider, useThreadRuntime } from "@assistant-ui/react"
 import { cn } from "@/lib/utils";
 import { Button } from "@wealthfolio/ui/components/ui/button";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
-import { Badge, EmptyPlaceholder } from "@wealthfolio/ui";
+import { EmptyPlaceholder } from "@wealthfolio/ui";
 import {
   Sheet,
   SheetContent,
@@ -142,16 +142,6 @@ function Header({
       </ButtonWithTooltip>
       <ProviderPicker />
       <div className="flex-1" />
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Badge variant="warning" className="cursor-default">
-            Beta
-          </Badge>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          This feature is in beta. Results may vary as we continue to improve.
-        </TooltipContent>
-      </Tooltip>
     </header>
   );
 }

--- a/apps/frontend/src/features/ai-assistant/components/thread-list.tsx
+++ b/apps/frontend/src/features/ai-assistant/components/thread-list.tsx
@@ -7,6 +7,7 @@ import { ActionConfirm } from "@wealthfolio/ui/components/common";
 import { Button } from "@wealthfolio/ui/components/ui/button";
 import { Input } from "@wealthfolio/ui/components/ui/input";
 import { Skeleton } from "@wealthfolio/ui/components/ui/skeleton";
+import { cn } from "@/lib/utils";
 import { useRuntimeContext } from "../hooks/use-runtime-context";
 import {
   flattenThreadPages,
@@ -124,20 +125,21 @@ interface ThreadSearchInputProps {
 
 const ThreadSearchInput: FC<ThreadSearchInputProps> = ({ value, onChange }) => {
   return (
-    <div className="relative px-1">
-      <Icons.Search className="text-muted-foreground absolute left-3 top-1/2 size-4 -translate-y-1/2" />
+    <div className="relative">
+      <Icons.Search className="text-muted-foreground pointer-events-none absolute left-2 top-1/2 size-4 -translate-y-1/2 opacity-50" />
       <Input
-        type="text"
+        type="search"
         placeholder="Search threads..."
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="h-8 pl-8 pr-8 text-sm"
+        aria-label="Search threads"
+        className="bg-background h-8 pl-8 pr-8 text-sm shadow-none"
       />
       {value && (
         <button
           type="button"
           onClick={() => onChange("")}
-          className="text-muted-foreground hover:text-foreground absolute right-3 top-1/2 -translate-y-1/2"
+          className="text-muted-foreground hover:text-foreground absolute right-2 top-1/2 -translate-y-1/2"
           aria-label="Clear search"
         >
           <Icons.Close className="size-4" />
@@ -353,27 +355,28 @@ const ThreadListItemCustom: FC<ThreadListItemCustomProps> = ({
 }) => {
   return (
     <div
-      className={`aui-thread-list-item hover:bg-muted focus-visible:bg-muted focus-visible:ring-ring group relative rounded-lg transition-all focus-visible:outline-none focus-visible:ring-2 ${
-        isActive ? "bg-muted" : ""
-      }`}
+      className={cn(
+        "aui-thread-list-item hover:bg-muted focus-within:bg-muted focus-visible:ring-ring group relative h-8 overflow-hidden rounded-md transition-all focus-visible:outline-none focus-visible:ring-2",
+        isActive && "bg-muted",
+      )}
       data-active={isActive || undefined}
     >
       <button
         type="button"
-        className="aui-thread-list-item-trigger w-full px-3 py-2 text-start"
+        className="aui-thread-list-item-trigger flex h-full w-full items-center overflow-hidden px-2.5 py-0 text-start transition-[padding] group-focus-within:pr-14 group-hover:pr-14"
         onClick={() => onSelect(thread.id)}
         disabled={isLoading || isDeleting}
       >
-        <span className="aui-thread-list-item-title line-clamp-1 text-sm tracking-tighter [word-spacing:-0.2em]">
+        <span className="aui-thread-list-item-title block min-w-0 truncate text-sm tracking-tighter [word-spacing:-0.2em]">
           {thread.title || "New Chat"}
         </span>
       </button>
       {isLoading ? (
-        <div className="absolute inset-y-0 right-2 flex items-center">
+        <div className="absolute right-2 top-1/2 flex -translate-y-1/2 items-center">
           <Icons.Spinner className="text-muted-foreground size-4 animate-spin" />
         </div>
       ) : (
-        <div className="bg-muted/80 absolute inset-y-0 right-1 flex items-center gap-0.5 rounded-r-lg px-1 opacity-0 backdrop-blur-sm transition-opacity group-hover:opacity-100">
+        <div className="pointer-events-none absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-0.5 opacity-0 transition-opacity group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100">
           <Button
             variant="ghost"
             size="sm"

--- a/apps/frontend/src/features/ai-assistant/components/thread.tsx
+++ b/apps/frontend/src/features/ai-assistant/components/thread.tsx
@@ -53,8 +53,8 @@ export const Thread: FC<ThreadProps> = ({ composerActions }) => {
             }}
           />
           {/* Spacer to prevent last message from being hidden behind sticky composer + mobile nav */}
-          <div className="h-[calc(var(--mobile-nav-ui-height)+max(var(--mobile-nav-gap),env(safe-area-inset-bottom)))] shrink-0 md:h-0" />
-          <ThreadPrimitive.ViewportFooter className="aui-thread-viewport-footer bg-background max-w-(--thread-max-width) sticky bottom-[calc(var(--mobile-nav-ui-height)+max(var(--mobile-nav-gap),env(safe-area-inset-bottom)))] z-10 mx-auto mt-auto flex w-full flex-col gap-4 overflow-visible rounded-t-3xl pb-4 md:bottom-0 md:pb-6">
+          <div className="h-[var(--mobile-nav-total-offset)] shrink-0 md:h-0" />
+          <ThreadPrimitive.ViewportFooter className="aui-thread-viewport-footer bg-background max-w-(--thread-max-width) sticky bottom-[var(--mobile-nav-total-offset)] z-10 mx-auto mt-auto flex w-full flex-col gap-4 overflow-visible rounded-t-3xl pb-4 md:bottom-0 md:pb-6">
             <ThreadScrollToBottom />
             <Composer composerActions={composerActions} />
             <p className="text-muted-foreground/70 text-center text-xs">

--- a/apps/frontend/src/features/devices-sync/components/device-sync-section.test.tsx
+++ b/apps/frontend/src/features/devices-sync/components/device-sync-section.test.tsx
@@ -13,6 +13,7 @@ const hookMocks = vi.hoisted(() => ({
   getPairingSourceStatus: vi.fn(),
   pairingBootstrapActive: false,
   pairingCompletes: false,
+  pairingFails: false,
 }));
 
 interface MutationMock {
@@ -63,12 +64,18 @@ vi.mock("./pairing-flow", async () => {
       title,
       onBootstrapStateChange,
       onComplete,
+      onCancel,
     }: {
       title?: string;
       onBootstrapStateChange?: (state: "idle" | "active" | "failed") => void;
       onComplete?: () => void;
+      onCancel?: () => void;
     }) => {
       React.useEffect(() => {
+        if (hookMocks.pairingFails) {
+          onBootstrapStateChange?.("failed");
+          return () => onBootstrapStateChange?.("idle");
+        }
         if (hookMocks.pairingCompletes) {
           onBootstrapStateChange?.("active");
           onComplete?.();
@@ -79,7 +86,12 @@ vi.mock("./pairing-flow", async () => {
         return () => onBootstrapStateChange?.("idle");
       }, [onBootstrapStateChange, onComplete]);
 
-      return <div>{title ?? "Pairing Flow"}</div>;
+      return (
+        <div>
+          {title ?? "Pairing Flow"}
+          {hookMocks.pairingFails && <button onClick={onCancel}>Done</button>}
+        </div>
+      );
     },
     WaitingState: ({ title }: { title: string }) => <div>{title}</div>,
   };
@@ -94,6 +106,7 @@ describe("DeviceSyncSection", () => {
     vi.clearAllMocks();
     hookMocks.pairingBootstrapActive = false;
     hookMocks.pairingCompletes = false;
+    hookMocks.pairingFails = false;
 
     hookMocks.useRenameDevice.mockReturnValue({
       mutateAsync: vi.fn(),
@@ -480,6 +493,72 @@ describe("DeviceSyncSection", () => {
       await flushAsyncWork();
 
       expect(refetch).toHaveBeenCalled();
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Check again" }));
+        await Promise.resolve();
+      });
+
+      expect(bootstrapSync.mutateAsync).toHaveBeenCalledWith({ allowOverwrite: false });
+      expect(screen.getByText("Replace data on this device?")).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("allows manual bootstrap retry after failed pairing bootstrap is dismissed", async () => {
+    vi.useFakeTimers();
+    try {
+      hookMocks.pairingFails = true;
+
+      const bootstrapSync = {
+        mutateAsync: vi.fn().mockResolvedValue({
+          status: "overwrite_required",
+          localRows: 12,
+          nonEmptyTables: [{ table: "accounts", rows: 1 }],
+        }),
+        isPending: false,
+        error: null,
+      };
+
+      hookMocks.useSyncStatus.mockReturnValue({
+        isLoading: false,
+        error: null,
+        syncState: "READY",
+        trustedDevices: [{ id: "trusted-1", name: "Laptop", platform: "mac", lastSeenAt: null }],
+        device: { trustState: "trusted" },
+        engineStatus: {
+          lastCycleStatus: "stale_cursor",
+          bootstrapRequired: true,
+          backgroundRunning: false,
+        },
+        engineIsFetching: false,
+        refetch: vi.fn(),
+      });
+      hookMocks.useDevices.mockReturnValue({
+        data: [],
+        isLoading: false,
+        error: null,
+      });
+      hookMocks.useSyncActions.mockReturnValue(createActions({ bootstrapSync }));
+      hookMocks.getPairingSourceStatus.mockResolvedValue({
+        status: "ready",
+        message: "Ready",
+        localCursor: 0,
+        serverCursor: 0,
+      });
+
+      renderWithQueryClient(<DeviceSyncSection />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Connect Another Device" }));
+      });
+      await flushAsyncWork();
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Done" }));
+      });
+      await flushAsyncWork();
 
       await act(async () => {
         fireEvent.click(screen.getByRole("button", { name: "Check again" }));

--- a/apps/frontend/src/features/devices-sync/components/device-sync-section.test.tsx
+++ b/apps/frontend/src/features/devices-sync/components/device-sync-section.test.tsx
@@ -225,7 +225,6 @@ describe("DeviceSyncSection", () => {
       vi.useRealTimers();
     }
   });
-
   it("discards a ready-state bootstrap result if pairing opens while the check is in flight", async () => {
     vi.useFakeTimers();
     try {

--- a/apps/frontend/src/features/devices-sync/components/device-sync-section.test.tsx
+++ b/apps/frontend/src/features/devices-sync/components/device-sync-section.test.tsx
@@ -12,6 +12,7 @@ const hookMocks = vi.hoisted(() => ({
   useRevokeDevice: vi.fn(),
   getPairingSourceStatus: vi.fn(),
   pairingBootstrapActive: false,
+  pairingCompletes: false,
 }));
 
 interface MutationMock {
@@ -61,15 +62,22 @@ vi.mock("./pairing-flow", async () => {
     PairingFlow: ({
       title,
       onBootstrapStateChange,
+      onComplete,
     }: {
       title?: string;
       onBootstrapStateChange?: (state: "idle" | "active" | "failed") => void;
+      onComplete?: () => void;
     }) => {
       React.useEffect(() => {
+        if (hookMocks.pairingCompletes) {
+          onBootstrapStateChange?.("active");
+          onComplete?.();
+          return () => onBootstrapStateChange?.("idle");
+        }
         if (!hookMocks.pairingBootstrapActive) return;
         onBootstrapStateChange?.("active");
         return () => onBootstrapStateChange?.("idle");
-      }, [onBootstrapStateChange]);
+      }, [onBootstrapStateChange, onComplete]);
 
       return <div>{title ?? "Pairing Flow"}</div>;
     },
@@ -85,6 +93,7 @@ describe("DeviceSyncSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     hookMocks.pairingBootstrapActive = false;
+    hookMocks.pairingCompletes = false;
 
     hookMocks.useRenameDevice.mockReturnValue({
       mutateAsync: vi.fn(),
@@ -351,6 +360,138 @@ describe("DeviceSyncSection", () => {
       expect(hookMocks.getPairingSourceStatus).toHaveBeenCalledTimes(1);
       expect(screen.queryByText("Replace data on this device?")).not.toBeInTheDocument();
       expect(screen.queryByText("This device already has data")).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not reopen the ready-state replace prompt after pairing overwrite completes", async () => {
+    vi.useFakeTimers();
+    try {
+      hookMocks.pairingCompletes = true;
+
+      const refetch = vi.fn();
+      const bootstrapSync = {
+        mutateAsync: vi.fn().mockResolvedValue({
+          status: "overwrite_required",
+          localRows: 12,
+          nonEmptyTables: [{ table: "accounts", rows: 1 }],
+        }),
+        isPending: false,
+        error: null,
+      };
+
+      hookMocks.useSyncStatus.mockReturnValue({
+        isLoading: false,
+        error: null,
+        syncState: "READY",
+        trustedDevices: [{ id: "trusted-1", name: "Laptop", platform: "mac", lastSeenAt: null }],
+        device: { trustState: "trusted" },
+        engineStatus: {
+          lastCycleStatus: "stale_cursor",
+          bootstrapRequired: true,
+          backgroundRunning: false,
+        },
+        engineIsFetching: false,
+        refetch,
+      });
+      hookMocks.useDevices.mockReturnValue({
+        data: [],
+        isLoading: false,
+        error: null,
+      });
+      hookMocks.useSyncActions.mockReturnValue(createActions({ bootstrapSync }));
+      hookMocks.getPairingSourceStatus.mockResolvedValue({
+        status: "ready",
+        message: "Ready",
+        localCursor: 0,
+        serverCursor: 0,
+      });
+
+      renderWithQueryClient(<DeviceSyncSection />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Connect Another Device" }));
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(refetch).toHaveBeenCalled();
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2500);
+      });
+
+      expect(bootstrapSync.mutateAsync).not.toHaveBeenCalled();
+      expect(screen.queryByText("Replace data on this device?")).not.toBeInTheDocument();
+      expect(screen.queryByText("This device already has data")).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("allows manual bootstrap retry after pairing prompt suppression", async () => {
+    vi.useFakeTimers();
+    try {
+      hookMocks.pairingCompletes = true;
+
+      const refetch = vi.fn();
+      const bootstrapSync = {
+        mutateAsync: vi.fn().mockResolvedValue({
+          status: "overwrite_required",
+          localRows: 12,
+          nonEmptyTables: [{ table: "accounts", rows: 1 }],
+        }),
+        isPending: false,
+        error: null,
+      };
+
+      hookMocks.useSyncStatus.mockReturnValue({
+        isLoading: false,
+        error: null,
+        syncState: "READY",
+        trustedDevices: [{ id: "trusted-1", name: "Laptop", platform: "mac", lastSeenAt: null }],
+        device: { trustState: "trusted" },
+        engineStatus: {
+          lastCycleStatus: "stale_cursor",
+          bootstrapRequired: true,
+          backgroundRunning: false,
+        },
+        engineIsFetching: false,
+        refetch,
+      });
+      hookMocks.useDevices.mockReturnValue({
+        data: [],
+        isLoading: false,
+        error: null,
+      });
+      hookMocks.useSyncActions.mockReturnValue(createActions({ bootstrapSync }));
+      hookMocks.getPairingSourceStatus.mockResolvedValue({
+        status: "ready",
+        message: "Ready",
+        localCursor: 0,
+        serverCursor: 0,
+      });
+
+      renderWithQueryClient(<DeviceSyncSection />);
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Connect Another Device" }));
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(refetch).toHaveBeenCalled();
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole("button", { name: "Check again" }));
+        await Promise.resolve();
+      });
+
+      expect(bootstrapSync.mutateAsync).toHaveBeenCalledWith({ allowOverwrite: false });
+      expect(screen.getByText("Replace data on this device?")).toBeInTheDocument();
     } finally {
       vi.useRealTimers();
     }

--- a/apps/frontend/src/features/devices-sync/components/device-sync-section.test.tsx
+++ b/apps/frontend/src/features/devices-sync/components/device-sync-section.test.tsx
@@ -412,12 +412,10 @@ describe("DeviceSyncSection", () => {
 
       await act(async () => {
         fireEvent.click(screen.getByRole("button", { name: "Connect Another Device" }));
-        await Promise.resolve();
       });
+      await flushAsyncWork();
 
-      await waitFor(() => {
-        expect(refetch).toHaveBeenCalled();
-      });
+      expect(refetch).toHaveBeenCalled();
 
       await act(async () => {
         await vi.advanceTimersByTimeAsync(2500);
@@ -478,12 +476,10 @@ describe("DeviceSyncSection", () => {
 
       await act(async () => {
         fireEvent.click(screen.getByRole("button", { name: "Connect Another Device" }));
-        await Promise.resolve();
       });
+      await flushAsyncWork();
 
-      await waitFor(() => {
-        expect(refetch).toHaveBeenCalled();
-      });
+      expect(refetch).toHaveBeenCalled();
 
       await act(async () => {
         fireEvent.click(screen.getByRole("button", { name: "Check again" }));
@@ -540,4 +536,11 @@ function renderWithQueryClient(ui: ReactElement) {
   });
 
   return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+async function flushAsyncWork() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
 }

--- a/apps/frontend/src/features/devices-sync/components/device-sync-section.tsx
+++ b/apps/frontend/src/features/devices-sync/components/device-sync-section.tsx
@@ -61,12 +61,13 @@ import {
   useRevokeDevice,
   useSyncActions,
   useSyncStatus,
+  type PairingBootstrapState,
 } from "../hooks";
 import { syncService } from "../services/sync-service";
 import { SyncStates, type Device } from "../types";
 import { logSyncError, userFacingSyncErrorMessage } from "../utils/error-messages";
 import { E2EESetupCard } from "./e2ee-setup-card";
-import { PairingFlow, WaitingState, type PairingBootstrapState } from "./pairing-flow";
+import { PairingFlow, WaitingState } from "./pairing-flow";
 import { RecoveryDialog } from "./recovery-dialog";
 
 const PORTAL_DEVICES_URL = "https://connect.wealthfolio.app/settings/devices";
@@ -603,7 +604,7 @@ export function DeviceSyncSection() {
         {/* Pairing Dialog */}
         <Dialog open={isPairingOpen} onOpenChange={handlePairingDialogOpenChange}>
           <DialogContent
-            className="md:max-w-lg"
+            className="sm:max-w-[420px]"
             mobileClassName="pb-8"
             showCloseButton={false}
             onEscapeKeyDown={(e) => e.preventDefault()}
@@ -658,7 +659,7 @@ export function DeviceSyncSection() {
         {/* Pairing Dialog */}
         <Dialog open={isPairingOpen} onOpenChange={handlePairingDialogOpenChange}>
           <DialogContent
-            className="md:max-w-lg"
+            className="sm:max-w-[420px]"
             mobileClassName="pb-8"
             showCloseButton={false}
             onEscapeKeyDown={(e) => e.preventDefault()}
@@ -895,7 +896,7 @@ export function DeviceSyncSection() {
         {/* Pairing Dialog */}
         <Dialog open={isPairingOpen} onOpenChange={handleReadyPairingDialogOpenChange}>
           <DialogContent
-            className="md:max-w-lg"
+            className="sm:max-w-[420px]"
             mobileClassName="pb-8"
             showCloseButton={false}
             onEscapeKeyDown={(e) => e.preventDefault()}
@@ -961,6 +962,12 @@ export function DeviceSyncSection() {
               <AlertDialogDescription className="text-center text-sm">
                 Your local data will be replaced with data from your other connected device.
               </AlertDialogDescription>
+              {overwriteRisk && overwriteRisk.localRows > 0 && (
+                <p className="text-muted-foreground text-center text-xs">
+                  {overwriteRisk.localRows} local {overwriteRisk.localRows === 1 ? "row" : "rows"}{" "}
+                  will be replaced.
+                </p>
+              )}
             </AlertDialogHeader>
 
             <div className="flex flex-col gap-2 sm:flex-row sm:justify-center">

--- a/apps/frontend/src/features/devices-sync/components/device-sync-section.tsx
+++ b/apps/frontend/src/features/devices-sync/components/device-sync-section.tsx
@@ -135,6 +135,18 @@ export function DeviceSyncSection() {
     suppressReadyStateBootstrapPromptRef.current = suppressReadyStateBootstrapPrompt;
   }, [suppressReadyStateBootstrapPrompt]);
 
+  const releasePairingBootstrapOwner = useCallback(() => {
+    if (
+      bootstrapOwnerRef.current === "pairing" ||
+      bootstrapOwnerRef.current === "pairing_failed"
+    ) {
+      bootstrapOwnerRef.current = "none";
+    }
+    setBootstrapOwner((owner) =>
+      owner === "pairing" || owner === "pairing_failed" ? "none" : owner,
+    );
+  }, []);
+
   const canRunReadyStateBootstrap = useCallback((ignorePromptSuppression = false) => {
     return (
       bootstrapOwnerRef.current === "none" &&
@@ -186,36 +198,39 @@ export function DeviceSyncSection() {
     setSuppressReadyStateBootstrapPrompt(true);
     setShowBootstrapOverwriteDialog(false);
     setOverwriteRisk(null);
-    setBootstrapOwner((owner) =>
-      owner === "pairing" || owner === "pairing_failed" ? "none" : owner,
-    );
+    releasePairingBootstrapOwner();
     isPairingOpenRef.current = false;
     setIsPairingOpen(false);
     setIsPreparing(false);
     setPrepareError(null);
     queryClient.invalidateQueries({ queryKey: ["sync", "device", "current"] });
     status.refetch();
-  }, [queryClient, status.refetch]);
+  }, [queryClient, releasePairingBootstrapOwner, status.refetch]);
 
   const handlePairingCancel = useCallback(() => {
-    setBootstrapOwner((owner) => (owner === "pairing" ? "none" : owner));
+    releasePairingBootstrapOwner();
     isPairingOpenRef.current = false;
     setIsPairingOpen(false);
     setIsPreparing(false);
     setPrepareError(null);
-  }, []);
+  }, [releasePairingBootstrapOwner]);
 
   const handlePairingBootstrapStateChange = useCallback((state: PairingBootstrapState) => {
     if (state === "active" || state === "failed") {
       setShowBootstrapOverwriteDialog(false);
       setOverwriteRisk(null);
     }
+    if (state === "idle") {
+      releasePairingBootstrapOwner();
+      return;
+    }
+    bootstrapOwnerRef.current = state === "active" ? "pairing" : "pairing_failed";
     setBootstrapOwner((owner) => {
       if (state === "active") return "pairing";
       if (state === "failed") return "pairing_failed";
       return owner === "pairing" ? "none" : owner;
     });
-  }, []);
+  }, [releasePairingBootstrapOwner]);
 
   const handleRefresh = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: ["sync", "device", "current"] });
@@ -388,6 +403,10 @@ export function DeviceSyncSection() {
 
   const handleRetryBootstrap = useCallback(async () => {
     setSuppressReadyStateBootstrapPrompt(false);
+    if (bootstrapOwnerRef.current === "pairing_failed") {
+      bootstrapOwnerRef.current = "none";
+    }
+    setBootstrapOwner((owner) => (owner === "pairing_failed" ? "none" : owner));
     await runBootstrapCheck(true, true, true);
   }, [runBootstrapCheck]);
 

--- a/apps/frontend/src/features/devices-sync/components/device-sync-section.tsx
+++ b/apps/frontend/src/features/devices-sync/components/device-sync-section.tsx
@@ -136,10 +136,7 @@ export function DeviceSyncSection() {
   }, [suppressReadyStateBootstrapPrompt]);
 
   const releasePairingBootstrapOwner = useCallback(() => {
-    if (
-      bootstrapOwnerRef.current === "pairing" ||
-      bootstrapOwnerRef.current === "pairing_failed"
-    ) {
+    if (bootstrapOwnerRef.current === "pairing" || bootstrapOwnerRef.current === "pairing_failed") {
       bootstrapOwnerRef.current = "none";
     }
     setBootstrapOwner((owner) =>
@@ -215,22 +212,25 @@ export function DeviceSyncSection() {
     setPrepareError(null);
   }, [releasePairingBootstrapOwner]);
 
-  const handlePairingBootstrapStateChange = useCallback((state: PairingBootstrapState) => {
-    if (state === "active" || state === "failed") {
-      setShowBootstrapOverwriteDialog(false);
-      setOverwriteRisk(null);
-    }
-    if (state === "idle") {
-      releasePairingBootstrapOwner();
-      return;
-    }
-    bootstrapOwnerRef.current = state === "active" ? "pairing" : "pairing_failed";
-    setBootstrapOwner((owner) => {
-      if (state === "active") return "pairing";
-      if (state === "failed") return "pairing_failed";
-      return owner === "pairing" ? "none" : owner;
-    });
-  }, [releasePairingBootstrapOwner]);
+  const handlePairingBootstrapStateChange = useCallback(
+    (state: PairingBootstrapState) => {
+      if (state === "active" || state === "failed") {
+        setShowBootstrapOverwriteDialog(false);
+        setOverwriteRisk(null);
+      }
+      if (state === "idle") {
+        releasePairingBootstrapOwner();
+        return;
+      }
+      bootstrapOwnerRef.current = state === "active" ? "pairing" : "pairing_failed";
+      setBootstrapOwner((owner) => {
+        if (state === "active") return "pairing";
+        if (state === "failed") return "pairing_failed";
+        return owner === "pairing" ? "none" : owner;
+      });
+    },
+    [releasePairingBootstrapOwner],
+  );
 
   const handleRefresh = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: ["sync", "device", "current"] });

--- a/apps/frontend/src/features/devices-sync/components/device-sync-section.tsx
+++ b/apps/frontend/src/features/devices-sync/components/device-sync-section.tsx
@@ -104,6 +104,7 @@ export function DeviceSyncSection() {
   const [isBackingUpBeforeBootstrap, setIsBackingUpBeforeBootstrap] = useState(false);
   const [isUploadingSnapshot, setIsUploadingSnapshot] = useState(false);
   const [bootstrapOwner, setBootstrapOwner] = useState<BootstrapOwner>("none");
+  const [suppressReadyStateBootstrapPrompt, setSuppressReadyStateBootstrapPrompt] = useState(false);
 
   // Bootstrap overwrite state — set when bootstrapSync returns overwrite_required
   const [overwriteRisk, setOverwriteRisk] = useState<{
@@ -116,6 +117,7 @@ export function DeviceSyncSection() {
   const bootstrapOwnerRef = useRef<BootstrapOwner>(bootstrapOwner);
   const isPairingOpenRef = useRef(isPairingOpen);
   const isCurrentDeviceTrustedRef = useRef(isCurrentDeviceTrusted);
+  const suppressReadyStateBootstrapPromptRef = useRef(suppressReadyStateBootstrapPrompt);
 
   useEffect(() => {
     bootstrapOwnerRef.current = bootstrapOwner;
@@ -129,11 +131,16 @@ export function DeviceSyncSection() {
     isCurrentDeviceTrustedRef.current = isCurrentDeviceTrusted;
   }, [isCurrentDeviceTrusted]);
 
-  const canRunReadyStateBootstrap = useCallback(() => {
+  useEffect(() => {
+    suppressReadyStateBootstrapPromptRef.current = suppressReadyStateBootstrapPrompt;
+  }, [suppressReadyStateBootstrapPrompt]);
+
+  const canRunReadyStateBootstrap = useCallback((ignorePromptSuppression = false) => {
     return (
       bootstrapOwnerRef.current === "none" &&
       !isPairingOpenRef.current &&
-      isCurrentDeviceTrustedRef.current
+      isCurrentDeviceTrustedRef.current &&
+      (ignorePromptSuppression || !suppressReadyStateBootstrapPromptRef.current)
     );
   }, []);
 
@@ -176,6 +183,9 @@ export function DeviceSyncSection() {
   );
 
   const handlePairingComplete = useCallback(() => {
+    setSuppressReadyStateBootstrapPrompt(true);
+    setShowBootstrapOverwriteDialog(false);
+    setOverwriteRisk(null);
     setBootstrapOwner((owner) =>
       owner === "pairing" || owner === "pairing_failed" ? "none" : owner,
     );
@@ -323,13 +333,16 @@ export function DeviceSyncSection() {
   );
 
   const runBootstrapCheck = useCallback(
-    async (showToast: boolean, autoOpenDialog = false) => {
-      if (!canRunReadyStateBootstrap()) return;
+    async (showToast: boolean, autoOpenDialog = false, ignorePromptSuppression = false) => {
+      if (!canRunReadyStateBootstrap(ignorePromptSuppression)) return;
 
       try {
         const result = await actions.bootstrapSync.mutateAsync({ allowOverwrite: false });
-        if (!canRunReadyStateBootstrap()) return;
+        if (!canRunReadyStateBootstrap(ignorePromptSuppression)) return;
         if (result.status === "overwrite_required") {
+          if (ignorePromptSuppression) {
+            setSuppressReadyStateBootstrapPrompt(false);
+          }
           setOverwriteRisk({
             localRows: result.localRows,
             nonEmptyTables: result.nonEmptyTables,
@@ -374,7 +387,8 @@ export function DeviceSyncSection() {
   );
 
   const handleRetryBootstrap = useCallback(async () => {
-    await runBootstrapCheck(true);
+    setSuppressReadyStateBootstrapPrompt(false);
+    await runBootstrapCheck(true, true, true);
   }, [runBootstrapCheck]);
 
   const handleUploadSnapshotNow = useCallback(async () => {
@@ -509,6 +523,26 @@ export function DeviceSyncSection() {
     overwriteRisk,
     isPairingOpen,
     runBootstrapCheck,
+  ]);
+
+  useEffect(() => {
+    if (!suppressReadyStateBootstrapPrompt) return;
+    if (status.engineIsFetching || !status.engineStatus) return;
+
+    const engineNeedsBootstrap =
+      status.engineStatus.lastCycleStatus === "wait_snapshot" ||
+      status.engineStatus.lastCycleStatus === "stale_cursor" ||
+      status.engineStatus.bootstrapRequired === true;
+
+    if (!engineNeedsBootstrap) {
+      setSuppressReadyStateBootstrapPrompt(false);
+    }
+  }, [
+    suppressReadyStateBootstrapPrompt,
+    status.engineIsFetching,
+    status.engineStatus?.lastCycleStatus,
+    status.engineStatus?.bootstrapRequired,
+    status.engineStatus,
   ]);
 
   // Loading state (detecting)

--- a/apps/frontend/src/features/devices-sync/components/pairing-flow/display-code.tsx
+++ b/apps/frontend/src/features/devices-sync/components/pairing-flow/display-code.tsx
@@ -44,18 +44,18 @@ export function DisplayCode({ code, expiresAt, onCancel }: DisplayCodeProps) {
   const formattedCode = code.length > 3 ? `${code.slice(0, 3)} ${code.slice(3)}` : code;
 
   return (
-    <div className="flex flex-col items-center gap-5 pb-2">
+    <div className="flex flex-col items-center gap-4">
       {/* QR Code */}
-      <div className="rounded-xl bg-white p-2.5">
-        <QRCodeSVG value={code} size={140} level="M" marginSize={0} />
+      <div className="shadow-xs rounded-2xl bg-white p-3 ring-1 ring-black/5">
+        <QRCodeSVG value={code} size={128} level="M" marginSize={0} />
       </div>
 
       {/* Code + Copy - clickable row */}
       <button
         onClick={handleCopy}
-        className="bg-muted hover:bg-muted/80 flex items-center gap-3 rounded-lg px-4 py-2.5 transition-colors"
+        className="bg-muted hover:bg-muted/80 flex items-center gap-3 rounded-xl px-4 py-3 transition-colors"
       >
-        <code className="font-mono text-lg font-semibold tracking-[0.2em]">{formattedCode}</code>
+        <code className="font-mono text-base font-semibold tracking-[0.16em]">{formattedCode}</code>
         {copied ? (
           <Icons.Check className="h-4 w-4 text-green-500" />
         ) : (

--- a/apps/frontend/src/features/devices-sync/components/pairing-flow/index.tsx
+++ b/apps/frontend/src/features/devices-sync/components/pairing-flow/index.tsx
@@ -16,14 +16,13 @@ import { Icons } from "@wealthfolio/ui";
 import { Button } from "@wealthfolio/ui/components/ui/button";
 import { useEffect, useRef, useCallback, useState } from "react";
 import { usePairingIssuer, usePairingClaimer, useSyncStatus } from "../../hooks";
+import type { PairingBootstrapState } from "../../hooks";
 import { logSyncError, userFacingSyncErrorMessage } from "../../utils/error-messages";
 import { DisplayCode } from "./display-code";
 import { SASVerification } from "./sas-verification";
 import { WaitingState } from "./waiting-state";
 import { PairingResult } from "./pairing-result";
 import { EnterCode } from "./enter-code";
-
-export type PairingBootstrapState = "idle" | "active" | "failed";
 
 interface PairingFlowProps {
   onComplete?: () => void;
@@ -41,9 +40,11 @@ interface PairingFlowProps {
 function StepHeader({ title, description }: { title?: string; description?: string }) {
   if (!title) return null;
   return (
-    <div className="mb-1 text-center">
-      <p className="text-foreground text-base font-semibold">{title}</p>
-      {description && <p className="text-muted-foreground mt-1 text-sm">{description}</p>}
+    <div className="mb-5 text-center">
+      <p className="text-foreground text-base font-semibold leading-6">{title}</p>
+      {description && (
+        <p className="text-muted-foreground mt-1.5 text-sm leading-5">{description}</p>
+      )}
     </div>
   );
 }
@@ -195,6 +196,7 @@ function ClaimerFlow({
     sas,
     overwriteInfo,
     isApprovingOverwrite,
+    bootstrapFlowState,
     submitCode,
     approveOverwrite,
     cancel,
@@ -202,26 +204,11 @@ function ClaimerFlow({
   } = usePairingClaimer();
   const [isBackingUp, setIsBackingUp] = useState(false);
   const [backupError, setBackupError] = useState<string | null>(null);
-  const bootstrapStateRef = useRef<PairingBootstrapState>("idle");
 
   useEffect(() => {
-    let nextState: PairingBootstrapState = "idle";
-    if (step === "syncing" || step === "overwrite_required") {
-      nextState = "active";
-    } else if (step === "error" && bootstrapStateRef.current === "active") {
-      nextState = "failed";
-    }
-
-    if (bootstrapStateRef.current === nextState) return;
-    bootstrapStateRef.current = nextState;
-    onBootstrapStateChange?.(nextState);
-  }, [onBootstrapStateChange, step]);
-
-  useEffect(() => {
-    return () => {
-      onBootstrapStateChange?.("idle");
-    };
-  }, [onBootstrapStateChange]);
+    onBootstrapStateChange?.(bootstrapFlowState);
+    return () => onBootstrapStateChange?.("idle");
+  }, [bootstrapFlowState, onBootstrapStateChange]);
 
   const handleCancel = useCallback(async () => {
     await cancel();

--- a/apps/frontend/src/features/devices-sync/components/pairing-flow/waiting-state.tsx
+++ b/apps/frontend/src/features/devices-sync/components/pairing-flow/waiting-state.tsx
@@ -26,7 +26,7 @@ export function WaitingState({
   action,
 }: WaitingStateProps) {
   return (
-    <div className="flex flex-col items-center px-4 py-6">
+    <div className="flex flex-col items-center px-4 py-6 text-center">
       {showQRSkeleton ? (
         <div className="mb-6 flex flex-col items-center gap-4">
           {/* QR Code skeleton */}
@@ -53,26 +53,28 @@ export function WaitingState({
           )}
         </div>
       ) : (
-        <div className="mb-6 flex flex-col items-center gap-4">
+        <div className="mb-6 flex flex-col items-center gap-5">
           {!action && (
-            <div className="flex h-20 w-20 items-center justify-center rounded-full bg-blue-100 dark:bg-blue-900/30">
-              <Icons.Spinner className="h-8 w-8 animate-spin text-blue-600 dark:text-blue-400" />
+            <div className="bg-primary/10 text-primary flex h-20 w-20 items-center justify-center rounded-full">
+              <Icons.Spinner className="h-8 w-8 animate-spin" />
             </div>
           )}
           {action}
         </div>
       )}
 
-      <div className="mb-6 text-center">
-        <p className="text-foreground text-base font-semibold">{title}</p>
+      <div className="mb-6 space-y-2">
+        <p className="text-foreground text-lg font-semibold leading-none">{title}</p>
         {description ? (
-          <p className="text-muted-foreground mt-2 max-w-[240px] text-sm">{description}</p>
+          <p className="text-muted-foreground mx-auto max-w-[260px] text-sm leading-6">
+            {description}
+          </p>
         ) : securityCode ? (
-          <p className="text-muted-foreground mt-2 max-w-[240px] text-sm">
+          <p className="text-muted-foreground mx-auto max-w-[260px] text-sm leading-6">
             Confirm this code matches on your other device
           </p>
         ) : (
-          <p className="text-muted-foreground mt-2 max-w-[240px] text-sm">
+          <p className="text-muted-foreground mx-auto max-w-[260px] text-sm leading-6">
             Please wait while we securely connect your device
           </p>
         )}

--- a/apps/frontend/src/features/devices-sync/hooks/index.ts
+++ b/apps/frontend/src/features/devices-sync/hooks/index.ts
@@ -3,4 +3,8 @@ export { useDevices, useRenameDevice, useRevokeDevice } from "./use-devices";
 export { useSyncStatus } from "./use-sync-status";
 export { useSyncActions } from "./use-sync-actions";
 export { usePairingIssuer, type IssuerStep } from "./use-pairing-issuer";
-export { usePairingClaimer, type ClaimerStep } from "./use-pairing-claimer";
+export {
+  usePairingClaimer,
+  type ClaimerStep,
+  type PairingBootstrapState,
+} from "./use-pairing-claimer";

--- a/apps/frontend/src/features/devices-sync/hooks/use-pairing-claimer.test.tsx
+++ b/apps/frontend/src/features/devices-sync/hooks/use-pairing-claimer.test.tsx
@@ -120,4 +120,25 @@ describe("usePairingClaimer", () => {
     expect(serviceMocks.syncService.cancelPairing).not.toHaveBeenCalled();
     expect(result.current.step).toBe("enter_code");
   });
+
+  it("marks bootstrap as failed when confirmed flow polling fails", async () => {
+    adapterMocks.beginPairingConfirm.mockResolvedValue({
+      flowId: "flow-1",
+      phase: { phase: "syncing" },
+    });
+    adapterMocks.getPairingFlowState.mockRejectedValue(new Error("poll failed"));
+
+    const { result } = renderHook(() => usePairingClaimer(), {
+      wrapper: createWrapper(),
+    });
+
+    await act(async () => {
+      await result.current.submitCode("ABC123");
+    });
+
+    await waitFor(() => expect(result.current.step).toBe("error"));
+
+    expect(result.current.error).toBe("poll failed");
+    expect(result.current.bootstrapFlowState).toBe("failed");
+  });
 });

--- a/apps/frontend/src/features/devices-sync/hooks/use-pairing-claimer.ts
+++ b/apps/frontend/src/features/devices-sync/hooks/use-pairing-claimer.ts
@@ -41,6 +41,8 @@ export type ClaimerStep =
   | "success"
   | "error";
 
+export type PairingBootstrapState = "idle" | "active" | "failed";
+
 export function usePairingClaimer() {
   const queryClient = useQueryClient();
   const [phase, setPhase] = useState<ClaimerPhase>("idle");
@@ -111,6 +113,20 @@ export function usePairingClaimer() {
     }
     return null;
   }, [error, keyPoll.error, flowPoll.error]);
+
+  const bootstrapFlowState = useMemo<PairingBootstrapState>(() => {
+    if (phase === "error" && flowId !== null) {
+      return "failed";
+    }
+    if (
+      phase === "flow_active" ||
+      phase === "overwrite_required" ||
+      (flowId !== null && phase !== "idle")
+    ) {
+      return "active";
+    }
+    return "idle";
+  }, [flowId, phase]);
 
   const processFlowPhase = useCallback(
     (flowPhase: PairingFlowPhase) => {
@@ -257,6 +273,7 @@ export function usePairingClaimer() {
     sas: sasQuery.data ?? null,
     overwriteInfo,
     isApprovingOverwrite,
+    bootstrapFlowState,
     submitCode,
     approveOverwrite,
     cancel,

--- a/apps/frontend/src/features/devices-sync/hooks/use-pairing-claimer.ts
+++ b/apps/frontend/src/features/devices-sync/hooks/use-pairing-claimer.ts
@@ -115,7 +115,7 @@ export function usePairingClaimer() {
   }, [error, keyPoll.error, flowPoll.error]);
 
   const bootstrapFlowState = useMemo<PairingBootstrapState>(() => {
-    if (phase === "error" && flowId !== null) {
+    if (flowId !== null && (phase === "error" || flowPoll.error)) {
       return "failed";
     }
     if (
@@ -126,7 +126,7 @@ export function usePairingClaimer() {
       return "active";
     }
     return "idle";
-  }, [flowId, phase]);
+  }, [flowId, phase, flowPoll.error]);
 
   const processFlowPhase = useCallback(
     (flowPhase: PairingFlowPhase) => {

--- a/apps/frontend/src/features/spending/components/budget-line-chart-card.tsx
+++ b/apps/frontend/src/features/spending/components/budget-line-chart-card.tsx
@@ -422,7 +422,7 @@ export function BudgetLineChartCard({
         ) : (
           <div
             data-no-swipe-drag
-            className="-mx-1 flex gap-3 overflow-x-auto px-1 pb-1"
+            className="-mx-1 flex min-w-0 touch-pan-x gap-3 overflow-x-auto overscroll-x-contain px-1 pb-1 [-webkit-overflow-scrolling:touch] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
             style={{
               maskImage: "linear-gradient(to right, black calc(100% - 32px), transparent 100%)",
               WebkitMaskImage:
@@ -569,7 +569,7 @@ function BudgetRing({
   return (
     <Link
       to={`/activities?tab=spending&category=${encodeURIComponent(ring.categoryId)}`}
-      className="hover:bg-muted/40 flex shrink-0 flex-col items-center gap-1 rounded-md px-1 py-1 transition-colors"
+      className="hover:bg-muted/40 flex w-16 shrink-0 flex-col items-center gap-1 rounded-md px-1 py-1 transition-colors"
       title={`${ring.name}: ${ring.spent.toFixed(2)} / ${ring.target.toFixed(2)}`}
     >
       <div className="relative" style={{ width: size, height: size }}>

--- a/apps/frontend/src/features/spending/components/date-range-filter.test.tsx
+++ b/apps/frontend/src/features/spending/components/date-range-filter.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { DateRangeFilter } from "./date-range-filter";
+
+vi.mock("@wealthfolio/ui", () => ({
+  Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  Button: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    type?: string;
+    variant?: string;
+    size?: string;
+    className?: string;
+  }) => <button onClick={onClick}>{children}</button>,
+  Calendar: () => <div data-testid="calendar" />,
+  Icons: {
+    PlusCircle: () => <span data-testid="plus-circle-icon" />,
+  },
+  Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Separator: () => <span data-testid="separator" />,
+}));
+
+describe("DateRangeFilter", () => {
+  it("shows and clears to-only ranges", () => {
+    const onChange = vi.fn();
+
+    render(
+      <DateRangeFilter value={{ from: undefined, to: new Date(2026, 5, 4) }} onChange={onChange} />,
+    );
+
+    expect(screen.getByText("Until Jun 4, 2026")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear" }));
+
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/apps/frontend/src/features/spending/components/date-range-filter.tsx
+++ b/apps/frontend/src/features/spending/components/date-range-filter.tsx
@@ -20,15 +20,18 @@ interface DateRangeFilterProps {
 }
 
 function summarize(range: DateRange | undefined): string | null {
-  if (!range?.from) return null;
-  if (range.to) {
+  if (!range?.from && !range?.to) return null;
+  if (range.from && range.to) {
     return `${format(range.from, "MMM d")} – ${format(range.to, "MMM d")}`;
   }
-  return format(range.from, "MMM d, y");
+  if (range.from) {
+    return format(range.from, "MMM d, y");
+  }
+  return range.to ? `Until ${format(range.to, "MMM d, y")}` : null;
 }
 
 export function DateRangeFilter({ value, onChange, title = "Date" }: DateRangeFilterProps) {
-  const isActive = !!value?.from;
+  const isActive = !!value?.from || !!value?.to;
   const summary = summarize(value);
 
   return (
@@ -57,7 +60,7 @@ export function DateRangeFilter({ value, onChange, title = "Date" }: DateRangeFi
       <PopoverContent className="w-auto p-0" align="start">
         <Calendar
           mode="range"
-          defaultMonth={value?.from}
+          defaultMonth={value?.from ?? value?.to}
           selected={value}
           onSelect={onChange}
           numberOfMonths={2}

--- a/apps/frontend/src/features/spending/components/event-form-dialog.tsx
+++ b/apps/frontend/src/features/spending/components/event-form-dialog.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useQueryClient } from "@tanstack/react-query";
 import * as z from "zod";
 
 import {
@@ -35,6 +36,7 @@ import {
 } from "@wealthfolio/ui";
 
 import type { Activity } from "@/lib/types";
+import { QueryKeys } from "@/lib/query-keys";
 import { formatDateISO, parseLocalDate } from "@/lib/utils";
 
 import { useCashActivities, useSetActivityEvent } from "../hooks/use-cash-activities";
@@ -97,6 +99,7 @@ export function EventFormDialog({
   const { create, update } = useSpendingEventMutations();
   const { create: createType } = useEventTypeMutations();
   const setEventOnActivity = useSetActivityEvent();
+  const queryClient = useQueryClient();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const isEditing = !!event;
 
@@ -268,7 +271,9 @@ export function EventFormDialog({
         // each tag mutation already surfaces its own error toast, so we settle
         // all of them and finalize regardless.
         if (activityId) {
-          await setEventOnActivity.mutateAsync({ activityId, eventId: created.id }).catch(() => {});
+          await setEventOnActivity
+            .mutateAsync({ activityId, eventId: created.id })
+            .catch(() => undefined);
         } else if (selectedCandidateIds.length > 0) {
           // Bulk-tag the suggested transactions in parallel. No bulk endpoint
           // exists today; the N round-trips are acceptable since the user has
@@ -279,6 +284,11 @@ export function EventFormDialog({
             ),
           );
         }
+        // The dashboard event card reads both the event list and cash activity tags.
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: [QueryKeys.SPENDING_EVENTS] }),
+          queryClient.invalidateQueries({ queryKey: [QueryKeys.SPENDING_TRANSACTIONS] }),
+        ]);
         onCreated?.(created);
       }
       form.reset();

--- a/apps/frontend/src/features/spending/components/events-card.test.tsx
+++ b/apps/frontend/src/features/spending/components/events-card.test.tsx
@@ -8,9 +8,8 @@ import type { SpendingEvent } from "../types/event";
 import { EventsCard } from "./events-card";
 
 vi.mock("@tanstack/react-query", async () => {
-  const actual = await vi.importActual<typeof import("@tanstack/react-query")>(
-    "@tanstack/react-query",
-  );
+  const actual =
+    await vi.importActual<typeof import("@tanstack/react-query")>("@tanstack/react-query");
   return {
     ...actual,
     useQueries: vi.fn(() => []),

--- a/apps/frontend/src/features/spending/components/events-card.test.tsx
+++ b/apps/frontend/src/features/spending/components/events-card.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FOREST_THEME } from "../lib/theme";
+import { useSpendingEvents } from "../hooks/use-spending-events";
+import type { SpendingEvent } from "../types/event";
+import { EventsCard } from "./events-card";
+
+vi.mock("@tanstack/react-query", async () => {
+  const actual = await vi.importActual<typeof import("@tanstack/react-query")>(
+    "@tanstack/react-query",
+  );
+  return {
+    ...actual,
+    useQueries: vi.fn(() => []),
+  };
+});
+
+vi.mock("../hooks/use-spending-events", () => ({
+  useSpendingEvents: vi.fn(),
+}));
+
+vi.mock("./event-dialog-provider", () => ({
+  useEventDialog: () => ({
+    openEventDialog: vi.fn(),
+    openEventTypeDialog: vi.fn(),
+  }),
+}));
+
+const mockUseSpendingEvents = vi.mocked(useSpendingEvents);
+
+function event(overrides: Partial<SpendingEvent> = {}): SpendingEvent {
+  return {
+    id: "event-1",
+    name: "Sister Wedding",
+    description: null,
+    eventTypeId: "type-1",
+    startDate: "2026-04-16",
+    endDate: "2026-04-20",
+    createdAt: "2026-04-01T00:00:00.000Z",
+    updatedAt: "2026-04-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function renderEventsCard(periodStartDate: string, periodEndDate: string) {
+  return render(
+    <MemoryRouter>
+      <EventsCard
+        activities={[]}
+        categoriesMeta={new Map()}
+        periodEndDate={periodEndDate}
+        periodStartDate={periodStartDate}
+        theme={FOREST_THEME}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("EventsCard", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-05T12:00:00.000Z"));
+    mockUseSpendingEvents.mockReturnValue({
+      data: [event()],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useSpendingEvents>);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("shows an event that overlaps the selected dashboard period", () => {
+    renderEventsCard("2026-03-05T05:00:00.000Z", "2026-06-05T03:59:59.999Z");
+
+    expect(screen.getByText("Sister Wedding")).toBeInTheDocument();
+    expect(screen.getByText("PERIOD")).toBeInTheDocument();
+    expect(screen.queryByText("No events in this period")).not.toBeInTheDocument();
+  });
+
+  it("keeps the empty state when events are outside the selected dashboard period", () => {
+    renderEventsCard("2026-05-01T04:00:00.000Z", "2026-06-05T03:59:59.999Z");
+
+    expect(screen.getByText("No events in this period")).toBeInTheDocument();
+    expect(screen.queryByText("Sister Wedding")).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/features/spending/components/events-card.tsx
+++ b/apps/frontend/src/features/spending/components/events-card.tsx
@@ -5,7 +5,7 @@ import { Link } from "react-router-dom";
 import { QueryKeys } from "@/lib/query-keys";
 import type { Activity } from "@/lib/types";
 import { cn, formatDateISO } from "@/lib/utils";
-import { Icons, PrivacyAmount } from "@wealthfolio/ui";
+import { Icons, PrivacyAmount, Skeleton } from "@wealthfolio/ui";
 
 import { getActivityAssignments } from "../adapters/cash-activities";
 import { getActivitySpendingAmount } from "../lib/constants";
@@ -20,25 +20,39 @@ export function EventsCard({
   activities,
   accountTypeById,
   categoriesMeta,
+  periodEndDate,
+  periodStartDate,
   theme,
 }: {
   activities: Activity[];
   accountTypeById?: Map<string, string>;
   categoriesMeta: CategoryMetaMap;
+  periodEndDate: string;
+  periodStartDate: string;
   theme: Palette;
 }) {
-  const { data: events = [], isError: eventsErrored, refetch: refetchEvents } = useSpendingEvents();
+  const {
+    data: events = [],
+    isLoading: eventsLoading,
+    isError: eventsErrored,
+    refetch: refetchEvents,
+  } = useSpendingEvents();
   const { openEventDialog } = useEventDialog();
 
   const pick = useMemo(() => {
     const todayKey = formatDateISO(new Date());
+    const periodStartKey = periodStartDate.slice(0, 10);
+    const periodEndKey = periodEndDate.slice(0, 10);
+    const periodEvents = events.filter(
+      (e) => e.startDate.slice(0, 10) <= periodEndKey && e.endDate.slice(0, 10) >= periodStartKey,
+    );
 
-    const active = events.find(
+    const active = periodEvents.find(
       (e) => e.startDate.slice(0, 10) <= todayKey && e.endDate.slice(0, 10) >= todayKey,
     );
     if (active) return { mode: "active" as const, event: active };
 
-    const upcoming = events
+    const upcoming = periodEvents
       .filter((e) => e.startDate.slice(0, 10) > todayKey)
       .sort((a, b) => a.startDate.localeCompare(b.startDate));
     if (upcoming.length > 0) {
@@ -46,33 +60,16 @@ export function EventsCard({
       if (days <= 30) return { mode: "upcoming" as const, event: upcoming[0], days };
     }
 
-    const recent = events
+    const recent = periodEvents
       .filter((e) => e.endDate.slice(0, 10) < todayKey)
       .sort((a, b) => b.endDate.localeCompare(a.endDate));
     if (recent.length > 0) {
       const days = daysBetween(recent[0].endDate.slice(0, 10), todayKey);
       if (days <= 14) return { mode: "recent" as const, event: recent[0], days };
+      return { mode: "period" as const, event: recent[0] };
     }
     return null;
-  }, [events]);
-
-  // Surface query errors instead of silently rendering nothing — mirrors the
-  // pattern in spending-insights-page after commit de0d4d89. Without this,
-  // a server outage looks identical to "user has no events".
-  if (eventsErrored) {
-    return (
-      <div className="border-border/40 bg-card/70 rounded-xl border p-4 text-center text-xs backdrop-blur-xl md:p-5">
-        <div className="text-muted-foreground">Couldn't load events.</div>
-        <button
-          type="button"
-          onClick={() => void refetchEvents()}
-          className="text-foreground mt-2 inline-flex items-center gap-1 text-xs underline-offset-4 hover:underline"
-        >
-          Retry
-        </button>
-      </div>
-    );
-  }
+  }, [events, periodEndDate, periodStartDate]);
 
   const ev = pick?.event;
   const start = ev ? new Date(ev.startDate.slice(0, 10) + "T00:00:00") : new Date();
@@ -153,7 +150,74 @@ export function EventsCard({
     return total / days;
   }, [accountTypeById, activities, ev, totalDays]);
 
-  if (!pick) return null;
+  // Surface query errors instead of silently rendering nothing — mirrors the
+  // pattern in spending-insights-page after commit de0d4d89. Without this,
+  // a server outage looks identical to "user has no events".
+  if (eventsErrored) {
+    return (
+      <div className="border-border/40 bg-card/70 rounded-xl border p-4 text-center text-xs backdrop-blur-xl md:p-5">
+        <div className="text-muted-foreground">Couldn't load events.</div>
+        <button
+          type="button"
+          onClick={() => void refetchEvents()}
+          className="text-foreground mt-2 inline-flex items-center gap-1 text-xs underline-offset-4 hover:underline"
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (eventsLoading) {
+    return (
+      <div className="border-border/40 bg-card/70 rounded-xl border p-4 backdrop-blur-xl md:p-5">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-4 w-4 rounded-full" />
+          <div className="flex-1 space-y-1.5">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-3 w-32" />
+          </div>
+        </div>
+        <div className="mt-4 space-y-2">
+          <Skeleton className="h-3 w-full" />
+          <Skeleton className="h-3 w-2/3" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!pick) {
+    const hasEvents = events.length > 0;
+
+    return (
+      <div className="border-border/40 bg-card/70 rounded-xl border p-4 backdrop-blur-xl md:p-5">
+        <div className="flex items-center gap-2">
+          <Icons.Calendar className="h-4 w-4 shrink-0" style={{ color: theme.deep }} />
+          <div className="min-w-0 flex-1">
+            <div className="text-foreground text-sm font-semibold">Events</div>
+            <div className="text-muted-foreground/70 text-[11px]">
+              {hasEvents ? "No events in this period" : "No events yet"}
+            </div>
+          </div>
+        </div>
+
+        <div className="text-muted-foreground/80 mt-3 text-xs leading-snug">
+          {hasEvents
+            ? "Create an event for the next trip, move, or spending period."
+            : "Create an event to track spending around trips, moves, or one-off periods."}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => openEventDialog()}
+          className="text-muted-foreground hover:text-foreground mt-3 inline-flex items-center gap-1 text-xs underline-offset-4 hover:underline"
+        >
+          Create event
+          <Icons.ChevronRight className="h-3 w-3" />
+        </button>
+      </div>
+    );
+  }
 
   const dailyAvg = totalDays > 0 ? eventSpent / totalDays : 0;
   const baselineEquivalent = baselineDailyAvg * totalDays;
@@ -166,7 +230,14 @@ export function EventsCard({
       : pick.mode === "recent"
         ? (Icons.History ?? Icons.Calendar)
         : Icons.Calendar;
-  const tag = pick.mode === "active" ? "ACTIVE" : pick.mode === "upcoming" ? "SOON" : "RECENT";
+  const tag =
+    pick.mode === "active"
+      ? "ACTIVE"
+      : pick.mode === "upcoming"
+        ? "SOON"
+        : pick.mode === "recent"
+          ? "RECENT"
+          : "PERIOD";
 
   const dateRangeLabel = (() => {
     const opts: Intl.DateTimeFormatOptions = { month: "short", day: "numeric" };
@@ -188,6 +259,8 @@ export function EventsCard({
     subLine = `Day ${dayInto} of ${totalDays} · ${daysLeft} ${daysLeft === 1 ? "day" : "days"} left`;
   } else if (pick.mode === "recent") {
     subLine = `Wrapped ${pick.days} ${pick.days === 1 ? "day" : "days"} ago`;
+  } else if (pick.mode === "period") {
+    subLine = `${totalDays} ${totalDays === 1 ? "day" : "days"} in selected period`;
   }
 
   return (

--- a/apps/frontend/src/features/spending/components/reports/insights/where-i-am-stage.tsx
+++ b/apps/frontend/src/features/spending/components/reports/insights/where-i-am-stage.tsx
@@ -1103,14 +1103,16 @@ function BreakdownCanvas({
             Open transactions →
           </Link>
         </div>
-        {/* Mobile footer: full-width primary action */}
-        <div className="mt-4 md:hidden">
+        {/* Mobile footer: count + low-emphasis link */}
+        <div className="text-muted-foreground/80 mt-3 flex items-center justify-between gap-3 px-1 text-xs md:hidden">
+          <span className="tabular-nums">
+            {shownCats} of {totalCats} categor{totalCats === 1 ? "y" : "ies"} shown
+          </span>
           <Link
             to="/activities?tab=spending"
-            className="bg-foreground text-background hover:bg-foreground/90 flex h-11 w-full items-center justify-center gap-2 rounded-full text-sm font-medium transition-colors"
+            className="text-foreground hover:text-foreground/80 inline-flex items-center gap-1 font-medium underline-offset-4 hover:underline"
           >
-            Open transactions
-            <Icons.ArrowRight className="h-4 w-4" aria-hidden />
+            Open transactions →
           </Link>
         </div>
       </div>

--- a/apps/frontend/src/features/spending/components/spending-tab-content.tsx
+++ b/apps/frontend/src/features/spending/components/spending-tab-content.tsx
@@ -873,7 +873,7 @@ export default function SpendingTabContent() {
           </div>
         </div>
 
-        <div className="grow px-4 pb-[calc(var(--mobile-nav-ui-height)+max(var(--mobile-nav-gap),env(safe-area-inset-bottom)))] pt-24 md:px-6 md:pb-6 md:pt-20 lg:px-10 lg:pb-8 lg:pt-24">
+        <div className="grow px-4 pb-[var(--mobile-nav-total-offset)] pt-24 md:px-6 md:pb-6 md:pt-20 lg:px-10 lg:pb-8 lg:pt-24">
           <div className="flex flex-col gap-6 lg:grid lg:grid-cols-3 lg:gap-20">
             <div className="contents lg:col-span-2 lg:block lg:space-y-6">
               <DashboardCard

--- a/apps/frontend/src/features/spending/components/spending-tab-content.tsx
+++ b/apps/frontend/src/features/spending/components/spending-tab-content.tsx
@@ -358,19 +358,6 @@ export default function SpendingTabContent() {
   }, [appTimezone]);
   const { data: monthReport } = useSpendingReport(monthReportReq);
 
-  const subsActivitiesReq = useMemo(() => {
-    const end = getZonedDateParts(new Date(), appTimezone);
-    const start = addCalendarDays(end, -90);
-    return {
-      startDate: zonedCalendarDateBoundaryToDate(start, "start", appTimezone).toISOString(),
-      endDate: zonedCalendarDateBoundaryToDate(end, "end", appTimezone).toISOString(),
-    };
-  }, [appTimezone]);
-  const { data: subsActivities = [] } = useCashActivities({
-    startDate: subsActivitiesReq.startDate,
-    endDate: subsActivitiesReq.endDate,
-  });
-
   const historyReportReq = useMemo(() => {
     const today = getZonedDateParts(new Date(), appTimezone);
     const historyStart = addCalendarMonths({ year: today.year, month: today.month, day: 1 }, -3);
@@ -1011,9 +998,13 @@ export default function SpendingTabContent() {
 
               <div className="order-5 lg:order-none">
                 <EventsCard
-                  activities={subsActivities}
+                  activities={activities}
                   accountTypeById={accountTypeById}
                   categoriesMeta={categoriesMeta}
+                  periodEndDate={dateRange?.to ? formatDateISO(dateRange.to) : reportReq.endDate}
+                  periodStartDate={
+                    dateRange?.from ? formatDateISO(dateRange.from) : reportReq.startDate
+                  }
                   theme={theme}
                 />
               </div>

--- a/apps/frontend/src/features/spending/components/transactions-filter-bar.tsx
+++ b/apps/frontend/src/features/spending/components/transactions-filter-bar.tsx
@@ -145,6 +145,7 @@ export function TransactionsFilterBar({
         selectedValues={selectedTypes}
         onFilterChange={onTypesChange}
       />
+      <AmountRangeFilter value={amountRange} onChange={onAmountRangeChange} />
       <FacetedFilter
         title="Category"
         options={categoryOptions}
@@ -165,7 +166,6 @@ export function TransactionsFilterBar({
           onFilterChange={onEventsChange}
         />
       )}
-      <AmountRangeFilter value={amountRange} onChange={onAmountRangeChange} />
     </>
   );
 

--- a/apps/frontend/src/features/spending/pages/spending-insights-page.tsx
+++ b/apps/frontend/src/features/spending/pages/spending-insights-page.tsx
@@ -6,7 +6,7 @@ import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
 import { useTaxonomy } from "@/hooks/use-taxonomies";
 import { useSettingsContext } from "@/lib/settings-provider";
 
-import { Page, PageContent, PageHeader, usePersistentState } from "@wealthfolio/ui";
+import { Page, PageContent, PageHeader, useIsMobile, usePersistentState } from "@wealthfolio/ui";
 
 import { CategoryTransactionsSheet } from "../components/reports/category-transactions-sheet";
 import { HeatmapCellSheet } from "../components/reports/heatmap-cell-sheet";
@@ -127,6 +127,7 @@ function normalizeReportsPeriod(value: string | null | undefined): ReportsPeriod
 export default function SpendingInsightsPage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
+  const isMobile = useIsMobile();
   const { settings } = useSettingsContext();
   const baseCurrency = settings?.baseCurrency ?? "USD";
   const appTimezone = settings?.timezone ?? undefined;
@@ -407,7 +408,7 @@ export default function SpendingInsightsPage() {
   return (
     <Page>
       <PageHeader
-        heading="Spending Insight"
+        heading={isMobile ? undefined : "Spending Insight"}
         onBack={() => {
           if (window.history.length > 1) navigate(-1);
           else navigate("/dashboard?tab=spending");

--- a/apps/frontend/src/globals.css
+++ b/apps/frontend/src/globals.css
@@ -456,6 +456,8 @@
 
   --mobile-nav-ui-height: 64px; /* nav bar height */
   --mobile-nav-gap: 12px; /* space between nav and bottom */
+  --mobile-nav-bottom-offset: max(var(--mobile-nav-gap), env(safe-area-inset-bottom));
+  --mobile-nav-total-offset: calc(var(--mobile-nav-ui-height) + var(--mobile-nav-bottom-offset));
 
   /* Sonner toast overrides - solid backgrounds for better readability */
   --toast-bg: hsl(var(--flexoki-bg-2));
@@ -666,9 +668,7 @@ body.qr-scan-active .scan-hide-target {
   [data-page-scroll-container][data-with-mobile-nav-offset="true"]
     [data-page-content="true"]
     > :last-child {
-    padding-bottom: calc(
-      var(--mobile-nav-ui-height) + max(var(--mobile-nav-gap), env(safe-area-inset-bottom))
-    ) !important;
+    padding-bottom: var(--mobile-nav-total-offset) !important;
   }
 
   .touch-manipulation {
@@ -710,7 +710,7 @@ body.qr-scan-active .scan-hide-target {
 
   /* Scroll-to/focus targets stop above the floating nav */
   .scroll-pb-nav {
-    scroll-padding-bottom: calc(var(--mobile-nav-ui-height) + var(--mobile-nav-gap));
+    scroll-padding-bottom: var(--mobile-nav-total-offset);
   }
 
   /* Scroll-to/focus targets stop below sticky headers (typically ~72px) */

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -1,19 +1,28 @@
 import { getAccounts, getTransferPairForActivity } from "@/adapters";
+import { ActionPalette, type ActionPaletteGroup } from "@/components/action-palette";
+import { SwipablePage, type SwipablePageView } from "@/components/page";
+import {
+  SpendingTransactionsTab,
+  type SpendingTransactionsTabHandle,
+} from "@/features/spending/components/spending-transactions-tab";
+import { useSpendingSettings } from "@/features/spending/hooks/use-spending-settings";
+import { SyncButton } from "@/features/wealthfolio-connect/components/sync-button";
 import { usePersistentState } from "@/hooks/use-persistent-state";
 import { usePortfolios } from "@/hooks/use-portfolios";
 import { useIsCompactTableViewport, useIsMobileViewport } from "@/hooks/use-platform";
-import { debounce } from "@/lib/debounce";
+import { getActivityRestrictionLevel } from "@/lib/activity-restrictions";
 import { ActivityType } from "@/lib/constants";
+import { debounce } from "@/lib/debounce";
 import { QueryKeys } from "@/lib/query-keys";
 import { Account, AccountScope, ActivityDetails } from "@/lib/types";
+import { AlternativeAssetQuickAddModal } from "@/pages/asset/alternative-assets";
 import { useQuery } from "@tanstack/react-query";
 import type { SortingState } from "@tanstack/react-table";
 import { Button, Icons, Page, PageContent, PageHeader } from "@wealthfolio/ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
-import { getActivityRestrictionLevel } from "@/lib/activity-restrictions";
-import { ActivityDeleteModal } from "./components/activity-delete-modal";
 import { ActivityDataGrid } from "./components/activity-data-grid/activity-data-grid";
+import { ActivityDeleteModal } from "./components/activity-delete-modal";
 import { ActivityForm } from "./components/activity-form";
 import { ActivityMobileControls } from "./components/activity-mobile-controls";
 import { ActivityPagination } from "./components/activity-pagination";
@@ -24,15 +33,6 @@ import { BulkHoldingsModal } from "./components/forms/bulk-holdings-modal";
 import { MobileActivityForm } from "./components/mobile-forms/mobile-activity-form";
 import { useActivityMutations } from "./hooks/use-activity-mutations";
 import { useActivitySearch, type ActivityStatusFilter } from "./hooks/use-activity-search";
-import { SyncButton } from "@/features/wealthfolio-connect/components/sync-button";
-import { AlternativeAssetQuickAddModal } from "@/pages/asset/alternative-assets";
-import { ActionPalette, type ActionPaletteGroup } from "@/components/action-palette";
-import { SwipablePage, type SwipablePageView } from "@/components/page";
-import { useSpendingSettings } from "@/features/spending/hooks/use-spending-settings";
-import {
-  SpendingTransactionsTab,
-  type SpendingTransactionsTabHandle,
-} from "@/features/spending/components/spending-transactions-tab";
 import {
   clearActivityUrlFilters,
   resolveActivityTabFromUrlFilters,
@@ -713,7 +713,7 @@ const ActivityPage = () => {
   if (!isSpendingEnabled) {
     return (
       <Page>
-        <PageHeader heading="Activity" actions={investmentActions} />
+        <PageHeader actions={investmentActions} />
         <PageContent className="pb-2 md:pb-4 lg:pb-5">{investmentContent}</PageContent>
         {sharedModals}
       </Page>

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -38,6 +38,7 @@ import { useActivitySearch, type ActivityStatusFilter } from "./hooks/use-activi
 import {
   clearActivityUrlDateFilters,
   clearActivityUrlFilters,
+  clearActivityUrlTypeFilters,
   resolveActivityTabFromUrlFilters,
   resolveActivityUrlFilters,
 } from "./utils/url-filters";
@@ -133,7 +134,8 @@ const ActivityPage = () => {
   const statusFilter = activityUrlFilters.statusFilter ?? persistedStatusFilter;
   // Health Center deeplinks can scope the list to specific activity types / a date
   // window (e.g. transfers around an incomplete-transfer issue). URL wins over persisted.
-  const effectiveActivityTypes = activityUrlFilters.activityTypes ?? selectedActivityTypes;
+  const urlActivityTypes = activityUrlFilters.activityTypes;
+  const effectiveActivityTypes = urlActivityTypes ?? selectedActivityTypes;
   const urlDateFrom = activityUrlFilters.dateFrom;
   const urlDateTo = activityUrlFilters.dateTo;
   const effectiveDateFrom = urlDateFrom ?? selectedDateRange.from;
@@ -199,6 +201,22 @@ const ActivityPage = () => {
       }
     },
     [setSearchParams, setSelectedDateRange, urlDateFrom, urlDateTo],
+  );
+
+  const setInvestmentActivityTypes = useCallback(
+    (types: ActivityType[]) => {
+      setSelectedActivityTypes(types);
+      if (urlActivityTypes) {
+        setSearchParams(
+          (prev) => {
+            const next = clearActivityUrlTypeFilters(prev);
+            return next.toString() === prev.toString() ? prev : next;
+          },
+          { replace: true },
+        );
+      }
+    },
+    [setSearchParams, setSelectedActivityTypes, urlActivityTypes],
   );
 
   // Coerce "spending" URL state back to investments when the module is disabled.
@@ -478,7 +496,7 @@ const ActivityPage = () => {
 
   const investmentsFiltersActive =
     accountScope.type !== "all" ||
-    selectedActivityTypes.length > 0 ||
+    effectiveActivityTypes.length > 0 ||
     selectedInstrumentTypes.length > 0 ||
     statusFilter !== "all" ||
     !!effectiveDateFrom ||
@@ -643,8 +661,8 @@ const ActivityPage = () => {
           onSearchQueryChange={handleSearchChange}
           accountScope={accountScope}
           onAccountScopeChange={setAccountScope}
-          selectedActivityTypes={selectedActivityTypes}
-          onActivityTypesChange={setSelectedActivityTypes}
+          selectedActivityTypes={effectiveActivityTypes}
+          onActivityTypesChange={setInvestmentActivityTypes}
           dateRange={effectiveDateRange}
           onDateRangeChange={setInvestmentDateRange}
           isCompactView={isCompactView}
@@ -658,8 +676,8 @@ const ActivityPage = () => {
           onSearchQueryChange={handleSearchChange}
           accountScope={accountScope}
           onAccountScopeChange={setAccountScope}
-          selectedActivityTypes={selectedActivityTypes}
-          onActivityTypesChange={setSelectedActivityTypes}
+          selectedActivityTypes={effectiveActivityTypes}
+          onActivityTypesChange={setInvestmentActivityTypes}
           selectedInstrumentTypes={selectedInstrumentTypes}
           onInstrumentTypesChange={setSelectedInstrumentTypes}
           statusFilter={statusFilter}

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -15,11 +15,13 @@ import { ActivityType } from "@/lib/constants";
 import { debounce } from "@/lib/debounce";
 import { QueryKeys } from "@/lib/query-keys";
 import { Account, AccountScope, ActivityDetails } from "@/lib/types";
+import { formatDateISO } from "@/lib/utils";
 import { AlternativeAssetQuickAddModal } from "@/pages/asset/alternative-assets";
 import { useQuery } from "@tanstack/react-query";
 import type { SortingState } from "@tanstack/react-table";
 import { Button, Icons, Page, PageContent, PageHeader } from "@wealthfolio/ui";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { DateRange } from "react-day-picker";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { ActivityDataGrid } from "./components/activity-data-grid/activity-data-grid";
 import { ActivityDeleteModal } from "./components/activity-delete-modal";
@@ -34,10 +36,36 @@ import { MobileActivityForm } from "./components/mobile-forms/mobile-activity-fo
 import { useActivityMutations } from "./hooks/use-activity-mutations";
 import { useActivitySearch, type ActivityStatusFilter } from "./hooks/use-activity-search";
 import {
+  clearActivityUrlDateFilters,
   clearActivityUrlFilters,
   resolveActivityTabFromUrlFilters,
   resolveActivityUrlFilters,
 } from "./utils/url-filters";
+
+interface ActivityDateRangeFilter {
+  from?: string;
+  to?: string;
+}
+
+function parseLocalDate(value?: string): Date | undefined {
+  if (!value) return undefined;
+  const [year, month, day] = value.split("-").map(Number);
+  if (!year || !month || !day) return undefined;
+  return new Date(year, month - 1, day);
+}
+
+function toDateRange(value: ActivityDateRangeFilter): DateRange | undefined {
+  const from = parseLocalDate(value.from);
+  const to = parseLocalDate(value.to);
+  return from || to ? { from, to } : undefined;
+}
+
+function fromDateRange(range: DateRange | undefined): ActivityDateRangeFilter {
+  return {
+    ...(range?.from ? { from: formatDateISO(range.from) } : {}),
+    ...(range?.to ? { to: formatDateISO(range.to) } : {}),
+  };
+}
 
 const ActivityPage = () => {
   const [showForm, setShowForm] = useState(false);
@@ -73,6 +101,10 @@ const ActivityPage = () => {
   );
   const [persistedStatusFilter, setPersistedStatusFilter] =
     usePersistentState<ActivityStatusFilter>("activity-filter-status", "all");
+  const [selectedDateRange, setSelectedDateRange] = usePersistentState<ActivityDateRangeFilter>(
+    "activity-filter-date-range",
+    {},
+  );
   const [searchInput, setSearchInput] = usePersistentState<string>("activity-filter-search", "");
   const [searchQuery, setSearchQuery] = useState(searchInput);
   const [viewMode, setViewMode] = usePersistentState<ActivityViewMode>(
@@ -104,6 +136,12 @@ const ActivityPage = () => {
   const effectiveActivityTypes = activityUrlFilters.activityTypes ?? selectedActivityTypes;
   const urlDateFrom = activityUrlFilters.dateFrom;
   const urlDateTo = activityUrlFilters.dateTo;
+  const effectiveDateFrom = urlDateFrom ?? selectedDateRange.from;
+  const effectiveDateTo = urlDateTo ?? selectedDateRange.to;
+  const effectiveDateRange = useMemo(
+    () => toDateRange({ from: effectiveDateFrom, to: effectiveDateTo }),
+    [effectiveDateFrom, effectiveDateTo],
+  );
 
   const clearBrokerReviewUrlFilters = useCallback(() => {
     setSearchParams(
@@ -145,6 +183,22 @@ const ActivityPage = () => {
       setPersistedAccountScope,
       setPersistedStatusFilter,
     ],
+  );
+
+  const setInvestmentDateRange = useCallback(
+    (range: DateRange | undefined) => {
+      setSelectedDateRange(fromDateRange(range));
+      if (urlDateFrom || urlDateTo) {
+        setSearchParams(
+          (prev) => {
+            const next = clearActivityUrlDateFilters(prev);
+            return next.toString() === prev.toString() ? prev : next;
+          },
+          { replace: true },
+        );
+      }
+    },
+    [setSearchParams, setSelectedDateRange, urlDateFrom, urlDateTo],
   );
 
   // Coerce "spending" URL state back to investments when the module is disabled.
@@ -298,8 +352,8 @@ const ActivityPage = () => {
       activityTypes: effectiveActivityTypes,
       instrumentTypes: selectedInstrumentTypes,
       status: statusFilter,
-      dateFrom: urlDateFrom,
-      dateTo: urlDateTo,
+      dateFrom: effectiveDateFrom,
+      dateTo: effectiveDateTo,
     },
     searchQuery,
     sorting,
@@ -313,8 +367,8 @@ const ActivityPage = () => {
       activityTypes: effectiveActivityTypes,
       instrumentTypes: selectedInstrumentTypes,
       status: statusFilter,
-      dateFrom: urlDateFrom,
-      dateTo: urlDateTo,
+      dateFrom: effectiveDateFrom,
+      dateTo: effectiveDateTo,
     },
     searchQuery,
     sorting,
@@ -331,9 +385,11 @@ const ActivityPage = () => {
     effectiveInvestmentAccountIds,
     isDatagridView,
     pageIndex,
-    selectedActivityTypes,
+    effectiveActivityTypes,
     selectedInstrumentTypes,
     statusFilter,
+    effectiveDateFrom,
+    effectiveDateTo,
     searchQuery,
     setPageIndex,
     sorting,
@@ -425,6 +481,8 @@ const ActivityPage = () => {
     selectedActivityTypes.length > 0 ||
     selectedInstrumentTypes.length > 0 ||
     statusFilter !== "all" ||
+    !!effectiveDateFrom ||
+    !!effectiveDateTo ||
     searchInput.trim().length > 0;
 
   const clearInvestmentsFilters = useCallback(() => {
@@ -432,6 +490,7 @@ const ActivityPage = () => {
     setSelectedActivityTypes([]);
     setSelectedInstrumentTypes([]);
     setPersistedStatusFilter("all");
+    setSelectedDateRange({});
     setSearchInput("");
     setSearchQuery("");
     clearBrokerReviewUrlFilters();
@@ -441,6 +500,7 @@ const ActivityPage = () => {
     setSelectedActivityTypes,
     setSelectedInstrumentTypes,
     setPersistedStatusFilter,
+    setSelectedDateRange,
     setSearchInput,
   ]);
 
@@ -585,6 +645,8 @@ const ActivityPage = () => {
           onAccountScopeChange={setAccountScope}
           selectedActivityTypes={selectedActivityTypes}
           onActivityTypesChange={setSelectedActivityTypes}
+          dateRange={effectiveDateRange}
+          onDateRangeChange={setInvestmentDateRange}
           isCompactView={isCompactView}
           onCompactViewChange={setIsCompactView}
         />
@@ -602,6 +664,8 @@ const ActivityPage = () => {
           onInstrumentTypesChange={setSelectedInstrumentTypes}
           statusFilter={statusFilter}
           onStatusFilterChange={setStatusFilter}
+          dateRange={effectiveDateRange}
+          onDateRangeChange={setInvestmentDateRange}
           viewMode={viewMode}
           onViewModeChange={setViewMode}
           totalFetched={shouldUseDatagridView ? undefined : totalFetched}

--- a/apps/frontend/src/pages/activity/components/activity-mobile-controls.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-mobile-controls.tsx
@@ -2,6 +2,7 @@ import { Button, Icons, Input } from "@wealthfolio/ui";
 import { ActivityType } from "@/lib/constants";
 import { Account, AccountScope, PortfolioWithAccounts } from "@/lib/types";
 import { useState } from "react";
+import type { DateRange } from "react-day-picker";
 import { ActivityMobileFilterSheet } from "./activity-mobile-filter-sheet";
 
 interface ActivityMobileControlsProps {
@@ -13,6 +14,8 @@ interface ActivityMobileControlsProps {
   onAccountScopeChange: (accountScope: AccountScope) => void;
   selectedActivityTypes: ActivityType[];
   onActivityTypesChange: (types: ActivityType[]) => void;
+  dateRange: DateRange | undefined;
+  onDateRangeChange: (dateRange: DateRange | undefined) => void;
   isCompactView: boolean;
   onCompactViewChange: (isCompact: boolean) => void;
 }
@@ -26,12 +29,18 @@ export function ActivityMobileControls({
   onAccountScopeChange,
   selectedActivityTypes,
   onActivityTypesChange,
+  dateRange,
+  onDateRangeChange,
   isCompactView,
   onCompactViewChange,
 }: ActivityMobileControlsProps) {
   const [isFilterSheetOpen, setIsFilterSheetOpen] = useState(false);
 
-  const hasActiveFilters = accountScope.type !== "all" || selectedActivityTypes.length > 0;
+  const hasActiveFilters =
+    accountScope.type !== "all" ||
+    selectedActivityTypes.length > 0 ||
+    !!dateRange?.from ||
+    !!dateRange?.to;
 
   return (
     <>
@@ -79,6 +88,8 @@ export function ActivityMobileControls({
         setAccountScope={onAccountScopeChange}
         selectedActivityTypes={selectedActivityTypes}
         setSelectedActivityTypes={onActivityTypesChange}
+        dateRange={dateRange}
+        setDateRange={onDateRangeChange}
       />
     </>
   );

--- a/apps/frontend/src/pages/activity/components/activity-mobile-filter-sheet.test.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-mobile-filter-sheet.test.tsx
@@ -2,12 +2,31 @@ import { AccountType } from "@/lib/constants";
 import type { Account, AccountScope, PortfolioWithAccounts } from "@/lib/types";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { ReactNode } from "react";
+import type { InputHTMLAttributes, ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { ActivityMobileFilterSheet } from "./activity-mobile-filter-sheet";
 
 vi.mock("@wealthfolio/ui", () => ({
+  Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  Button: ({
+    children,
+    onClick,
+    className: _className,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    className?: string;
+  }) => <button onClick={onClick}>{children}</button>,
+  Calendar: () => <div data-testid="calendar" />,
+  Icons: {
+    PlusCircle: () => <span data-testid="plus-circle-icon" />,
+  },
+  Input: (props: InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+  Popover: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
   ScrollArea: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Separator: () => <span data-testid="separator" />,
 }));
 
 vi.mock("@wealthfolio/ui/components/ui/button", () => ({
@@ -86,6 +105,8 @@ describe("ActivityMobileFilterSheet", () => {
         setAccountScope={setAccountScope}
         selectedActivityTypes={[]}
         setSelectedActivityTypes={vi.fn()}
+        dateRange={undefined}
+        setDateRange={vi.fn()}
       />,
     );
 

--- a/apps/frontend/src/pages/activity/components/activity-mobile-filter-sheet.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-mobile-filter-sheet.tsx
@@ -8,10 +8,12 @@ import {
   SheetTitle,
 } from "@wealthfolio/ui/components/ui/sheet";
 import { ActivityType, ActivityTypeNames } from "@/lib/constants";
+import { DateRangeFilter } from "@/features/spending/components/date-range-filter";
 import { Account, AccountScope, PortfolioWithAccounts } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { ScrollArea } from "@wealthfolio/ui";
 import { useEffect, useMemo, useState } from "react";
+import type { DateRange } from "react-day-picker";
 
 interface ActivityMobileFilterSheetProps {
   open: boolean;
@@ -22,6 +24,8 @@ interface ActivityMobileFilterSheetProps {
   setAccountScope: (accountScope: AccountScope) => void;
   selectedActivityTypes: ActivityType[];
   setSelectedActivityTypes: (types: ActivityType[]) => void;
+  dateRange: DateRange | undefined;
+  setDateRange: (dateRange: DateRange | undefined) => void;
 }
 
 function accountIdsForScope(scope: AccountScope, portfolios: PortfolioWithAccounts[]) {
@@ -48,11 +52,14 @@ export const ActivityMobileFilterSheet = ({
   setAccountScope,
   selectedActivityTypes,
   setSelectedActivityTypes,
+  dateRange,
+  setDateRange,
 }: ActivityMobileFilterSheetProps) => {
   // Local state for temporary selections
   const [localAccountScope, setLocalAccountScope] = useState<AccountScope>(accountScope);
   const [localActivityTypes, setLocalActivityTypes] =
     useState<ActivityType[]>(selectedActivityTypes);
+  const [localDateRange, setLocalDateRange] = useState<DateRange | undefined>(dateRange);
 
   const localAccountIds = useMemo(
     () => accountIdsForScope(localAccountScope, portfolios),
@@ -64,12 +71,14 @@ export const ActivityMobileFilterSheet = ({
     if (open) {
       setLocalAccountScope(accountScope);
       setLocalActivityTypes(selectedActivityTypes);
+      setLocalDateRange(dateRange);
     }
-  }, [open, accountScope, selectedActivityTypes]);
+  }, [open, accountScope, selectedActivityTypes, dateRange]);
 
   const handleApply = () => {
     setAccountScope(localAccountScope);
     setSelectedActivityTypes(localActivityTypes);
+    setDateRange(localDateRange);
     onOpenChange(false);
   };
 
@@ -93,6 +102,12 @@ export const ActivityMobileFilterSheet = ({
         </SheetHeader>
         <ScrollArea className="flex-1 py-4">
           <div className="space-y-6 pr-4">
+            {/* Date Filter Section */}
+            <div>
+              <h4 className="mb-3 font-medium">Date</h4>
+              <DateRangeFilter value={localDateRange} onChange={setLocalDateRange} />
+            </div>
+
             {/* Account Filter Section */}
             <div>
               <h4 className="mb-3 font-medium">Account</h4>

--- a/apps/frontend/src/pages/activity/components/activity-view-controls.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-view-controls.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
+import type { DateRange } from "react-day-picker";
 
+import { DateRangeFilter } from "@/features/spending/components/date-range-filter";
 import { ActivityType, ActivityTypeNames, INSTRUMENT_TYPE_OPTIONS } from "@/lib/constants";
 import { debounce } from "@/lib/debounce";
 import type { Account, AccountScope, PortfolioWithAccounts } from "@/lib/types";
@@ -27,6 +29,8 @@ interface ActivityViewControlsProps {
   onInstrumentTypesChange: (types: string[]) => void;
   statusFilter: ActivityStatusFilter;
   onStatusFilterChange: (status: ActivityStatusFilter) => void;
+  dateRange: DateRange | undefined;
+  onDateRangeChange: (range: DateRange | undefined) => void;
   viewMode: ActivityViewMode;
   onViewModeChange: (mode: ActivityViewMode) => void;
   /** Shown only in table view - number of activities fetched so far */
@@ -64,6 +68,8 @@ export function ActivityViewControls({
   onInstrumentTypesChange,
   statusFilter,
   onStatusFilterChange,
+  dateRange,
+  onDateRangeChange,
   viewMode,
   onViewModeChange,
   totalFetched,
@@ -142,7 +148,9 @@ export function ActivityViewControls({
     accountScope.type !== "all" ||
     selectedActivityTypes.length > 0 ||
     selectedInstrumentTypes.length > 0 ||
-    statusFilter !== "all";
+    statusFilter !== "all" ||
+    !!dateRange?.from ||
+    !!dateRange?.to;
 
   return (
     <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
@@ -155,6 +163,20 @@ export function ActivityViewControls({
           }}
           className="w-[160px] lg:w-[240px]"
         />
+
+        <FacetedFilter
+          title="Status"
+          options={statusOptions}
+          selectedValues={new Set(statusFilter === "all" ? [] : [statusFilter])}
+          onFilterChange={(values: Set<string>) => {
+            const selected = Array.from(values);
+            onStatusFilterChange(
+              selected.length === 0 ? "all" : (selected[0] as ActivityStatusFilter),
+            );
+          }}
+        />
+
+        <DateRangeFilter value={dateRange} onChange={onDateRangeChange} />
 
         <FacetedFilter
           title="Account"
@@ -182,18 +204,6 @@ export function ActivityViewControls({
           onFilterChange={(values: Set<string>) => onInstrumentTypesChange(Array.from(values))}
         />
 
-        <FacetedFilter
-          title="Status"
-          options={statusOptions}
-          selectedValues={new Set(statusFilter === "all" ? [] : [statusFilter])}
-          onFilterChange={(values: Set<string>) => {
-            const selected = Array.from(values);
-            onStatusFilterChange(
-              selected.length === 0 ? "all" : (selected[0] as ActivityStatusFilter),
-            );
-          }}
-        />
-
         {hasActiveFilters ? (
           <Button
             variant="ghost"
@@ -206,6 +216,7 @@ export function ActivityViewControls({
               onActivityTypesChange([]);
               onInstrumentTypesChange([]);
               onStatusFilterChange("all");
+              onDateRangeChange(undefined);
             }}
           >
             Reset

--- a/apps/frontend/src/pages/activity/utils/url-filters.test.ts
+++ b/apps/frontend/src/pages/activity/utils/url-filters.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   clearActivityUrlDateFilters,
   clearActivityUrlFilters,
+  clearActivityUrlTypeFilters,
   resolveActivityTabFromUrlFilters,
   resolveActivityUrlFilters,
 } from "./url-filters";
@@ -80,6 +81,18 @@ describe("resolveActivityUrlFilters", () => {
 
     expect(cleared.toString()).toBe(
       "tab=investments&account=acct-1&needsReview=true&types=TRANSFER_IN",
+    );
+  });
+
+  it("clears only type params when replacing investment type filter", () => {
+    const cleared = clearActivityUrlTypeFilters(
+      new URLSearchParams(
+        "tab=investments&account=acct-1&needsReview=true&types=TRANSFER_IN&from=2026-06-01&to=2026-06-04",
+      ),
+    );
+
+    expect(cleared.toString()).toBe(
+      "tab=investments&account=acct-1&needsReview=true&from=2026-06-01&to=2026-06-04",
     );
   });
 });

--- a/apps/frontend/src/pages/activity/utils/url-filters.test.ts
+++ b/apps/frontend/src/pages/activity/utils/url-filters.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  clearActivityUrlDateFilters,
   clearActivityUrlFilters,
   resolveActivityTabFromUrlFilters,
   resolveActivityUrlFilters,
@@ -68,5 +69,17 @@ describe("resolveActivityUrlFilters", () => {
     );
 
     expect(cleared.toString()).toBe("tab=investments");
+  });
+
+  it("clears only date params when replacing investment date filter", () => {
+    const cleared = clearActivityUrlDateFilters(
+      new URLSearchParams(
+        "tab=investments&account=acct-1&needsReview=true&types=TRANSFER_IN&from=2026-06-01&to=2026-06-04",
+      ),
+    );
+
+    expect(cleared.toString()).toBe(
+      "tab=investments&account=acct-1&needsReview=true&types=TRANSFER_IN",
+    );
   });
 });

--- a/apps/frontend/src/pages/activity/utils/url-filters.ts
+++ b/apps/frontend/src/pages/activity/utils/url-filters.ts
@@ -60,3 +60,9 @@ export function clearActivityUrlDateFilters(searchParams: URLSearchParams): URLS
   next.delete("to");
   return next;
 }
+
+export function clearActivityUrlTypeFilters(searchParams: URLSearchParams): URLSearchParams {
+  const next = new URLSearchParams(searchParams);
+  next.delete("types");
+  return next;
+}

--- a/apps/frontend/src/pages/activity/utils/url-filters.ts
+++ b/apps/frontend/src/pages/activity/utils/url-filters.ts
@@ -53,3 +53,10 @@ export function clearActivityUrlFilters(searchParams: URLSearchParams): URLSearc
   next.delete("to");
   return next;
 }
+
+export function clearActivityUrlDateFilters(searchParams: URLSearchParams): URLSearchParams {
+  const next = new URLSearchParams(searchParams);
+  next.delete("from");
+  next.delete("to");
+  return next;
+}

--- a/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
@@ -766,7 +766,7 @@ function PlannerResult({
         <button
           type="button"
           onClick={onReview}
-          className="mt-4 inline-flex w-fit items-center gap-1 font-mono text-xs font-medium text-[#2f6b46] underline-offset-4 hover:underline dark:text-emerald-400 sm:mt-3"
+          className="mt-4 inline-flex w-fit items-center gap-1 font-mono text-xs font-medium text-[#2f6b46] underline-offset-4 hover:underline sm:mt-3 dark:text-emerald-400"
         >
           Review {tradesWord} <Icons.ArrowRight className="h-3.5 w-3.5" />
         </button>
@@ -1007,7 +1007,7 @@ function TradesTable({ trades, currency }: { trades: SuggestedManualTrade[]; cur
 
   return (
     <>
-      <div className="divide-border md:hidden divide-y">
+      <div className="divide-border divide-y md:hidden">
         {trades.map((t, i) => (
           <div key={i} className="px-4 py-3">
             <div className="flex items-start justify-between gap-3">
@@ -1018,7 +1018,9 @@ function TradesTable({ trades, currency }: { trades: SuggestedManualTrade[]; cur
                     {t.symbol ?? "Trade"}
                   </span>
                 </div>
-                {t.name && <div className="text-muted-foreground mt-1 truncate text-xs">{t.name}</div>}
+                {t.name && (
+                  <div className="text-muted-foreground mt-1 truncate text-xs">{t.name}</div>
+                )}
                 <div className="text-muted-foreground mt-1 font-mono text-xs">{t.categoryName}</div>
               </div>
               <div className="shrink-0 text-right">
@@ -1082,10 +1084,7 @@ function TradesTable({ trades, currency }: { trades: SuggestedManualTrade[]; cur
           </thead>
           <tbody>
             {trades.map((t, i) => (
-              <tr
-                key={i}
-                className="border-border hover:bg-muted/30 h-12 border-b last:border-b-0"
-              >
+              <tr key={i} className="border-border hover:bg-muted/30 h-12 border-b last:border-b-0">
                 <td className="pl-5 pr-2">
                   <TradeActionBadge action={t.action} />
                 </td>
@@ -1126,8 +1125,7 @@ function TradesTable({ trades, currency }: { trades: SuggestedManualTrade[]; cur
             <tr className="text-xs">
               <td colSpan={3} className="text-muted-foreground py-3 pl-5 font-mono">
                 {buys.length} buy{buys.length !== 1 ? "s" : ""}
-                {sells.length > 0 &&
-                  ` · ${sells.length} sell${sells.length !== 1 ? "s" : ""}`}
+                {sells.length > 0 && ` · ${sells.length} sell${sells.length !== 1 ? "s" : ""}`}
               </td>
               <td className="text-foreground py-3 pr-3 text-right font-semibold tabular-nums">
                 {formatAmount(buyTotal, currency)}

--- a/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { Button, Card, CardContent, Icons, Skeleton } from "@wealthfolio/ui";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@wealthfolio/ui/components/ui/tooltip";
 import { cn, formatAmount } from "@/lib/utils";
@@ -288,7 +288,7 @@ function copyToText(plan: RebalancePlan, currency: string) {
 
 // ── Eyebrow label ─────────────────────────────────────────────────────────────
 
-function Eyebrow({ children, className }: { children: React.ReactNode; className?: string }) {
+function Eyebrow({ children, className }: { children: ReactNode; className?: string }) {
   return (
     <div
       className={cn(
@@ -314,18 +314,24 @@ function ModeSwitch({
   value: ScenarioMode;
   onChange: (mode: ScenarioMode) => void;
 }) {
-  const modes: { id: ScenarioMode; label: string; hint: string }[] = [
+  const modes: { id: ScenarioMode; label: string; shortLabel: string; hint: string }[] = [
     {
       id: "cash_flow_only",
       label: "Cash-flow only",
+      shortLabel: "Cash-flow",
       hint: `deploy new ${currencySymbol(currency)}`,
     },
-    { id: "sell_to_rebalance", label: "Sell to rebalance", hint: "sells fund buys" },
-    { id: "hybrid", label: "Hybrid", hint: "cash + sells" },
+    {
+      id: "sell_to_rebalance",
+      label: "Sell to rebalance",
+      shortLabel: "Sell",
+      hint: "sells fund buys",
+    },
+    { id: "hybrid", label: "Hybrid", shortLabel: "Hybrid", hint: "cash + sells" },
   ];
 
   return (
-    <div className="border-border/60 bg-card/40 inline-flex items-center gap-1 overflow-x-auto rounded-2xl border p-1 backdrop-blur-xl">
+    <div className="border-border/60 bg-card/40 grid w-full max-w-full grid-cols-3 gap-1 rounded-2xl border p-1 backdrop-blur-xl sm:inline-flex sm:w-auto sm:grid-cols-none">
       {modes.map((m) => {
         const disabled = !allowSells && m.id !== "cash_flow_only";
         const active = value === m.id;
@@ -336,15 +342,18 @@ function ModeSwitch({
             disabled={disabled}
             onClick={() => !disabled && onChange(m.id)}
             className={cn(
-              "group inline-flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full px-4 py-3 font-mono text-xs transition-colors",
+              "group inline-flex min-w-0 shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-full px-2 py-3 font-mono text-xs transition-colors sm:w-auto sm:px-4",
               active
                 ? "bg-foreground text-background"
                 : "text-muted-foreground hover:bg-muted/50 hover:text-foreground",
               disabled && "cursor-not-allowed opacity-40 hover:bg-transparent",
             )}
           >
-            <span className="font-medium">{m.label}</span>
-            <span className={cn(active ? "text-background/65" : "opacity-70")}>{m.hint}</span>
+            <span className="min-w-0 truncate font-medium sm:hidden">{m.shortLabel}</span>
+            <span className="hidden font-medium sm:inline">{m.label}</span>
+            <span className={cn("hidden sm:inline", active ? "text-background/65" : "opacity-70")}>
+              {m.hint}
+            </span>
           </button>
         );
 
@@ -353,7 +362,7 @@ function ModeSwitch({
         return (
           <Tooltip key={m.id}>
             <TooltipTrigger asChild>
-              <span className="inline-flex cursor-not-allowed">{button}</span>
+              <span className="flex min-w-0 cursor-not-allowed">{button}</span>
             </TooltipTrigger>
             <TooltipContent className="text-xs">
               Enable &apos;Allow sells&apos; on this target to use this mode
@@ -406,9 +415,9 @@ function PlannerInput({
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex items-baseline justify-between gap-3">
+      <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-3">
         <Eyebrow>Cash to deploy</Eyebrow>
-        <span className="text-muted-foreground font-mono text-xs">
+        <span className="text-muted-foreground font-mono text-[11px] sm:text-xs">
           of {roundedCurrency(availableCash, currency)} in scope
         </span>
       </div>
@@ -445,7 +454,7 @@ function PlannerInput({
         style={{ ["--lever-pct" as string]: `${pct}%` }}
       />
 
-      <div className="mt-2.5 flex items-center gap-1.5">
+      <div className="mt-2.5 grid grid-cols-4 gap-2 sm:flex sm:items-center sm:gap-1.5">
         {presets.map((p) => (
           <button
             key={p.id}
@@ -453,7 +462,7 @@ function PlannerInput({
             disabled={limit <= 0}
             onClick={() => onCashChange(p.value.toFixed(fraction))}
             className={cn(
-              "rounded-full border px-2.5 py-0.5 font-mono text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-40",
+              "rounded-full border px-2.5 py-0.5 text-center font-mono text-xs transition-colors disabled:cursor-not-allowed disabled:opacity-40 sm:w-auto",
               activePreset === p.id
                 ? "border-foreground bg-foreground text-background"
                 : "border-border text-muted-foreground hover:border-foreground/40 hover:text-foreground",
@@ -464,13 +473,15 @@ function PlannerInput({
         ))}
       </div>
 
-      <p className="text-foreground/80 mt-4 font-mono text-xs leading-relaxed">{description}</p>
+      <p className="text-foreground/80 mt-3 font-mono text-xs leading-relaxed sm:mt-4">
+        {description}
+      </p>
 
       {overBudget && (
         <p className="text-destructive mt-2 font-mono text-xs">Exceeds available cash</p>
       )}
 
-      <div className="mt-auto pt-5">
+      <div className="mt-auto pt-4 sm:pt-5">
         <Button
           onClick={onCalculate}
           disabled={!canCalculate}
@@ -514,6 +525,8 @@ function DriftBar({
   const afterPos = afterBps != null ? clamp(afterBps) : 0;
   const bandPos = clamp(bandBps);
   const isAfter = afterBps != null;
+  const primaryLabel = driftLabelPlacement(isAfter ? afterPos : beforePos);
+  const beforeLabel = driftLabelPlacement(beforePos);
 
   return (
     <div>
@@ -555,8 +568,8 @@ function DriftBar({
       {/* marker labels */}
       <div className="relative mt-1.5 h-7">
         <div
-          className="absolute flex flex-col items-center"
-          style={{ left: `${isAfter ? afterPos : beforePos}%`, transform: "translateX(-50%)" }}
+          className={cn("absolute flex flex-col", primaryLabel.className)}
+          style={primaryLabel.style}
         >
           <span className="text-foreground font-mono text-xs font-semibold tabular-nums leading-none">
             {isAfter ? pp1(afterBps) : fmtBps(beforeBps)}
@@ -567,8 +580,8 @@ function DriftBar({
         </div>
         {isAfter && (
           <div
-            className="absolute flex flex-col items-end"
-            style={{ right: `${100 - beforePos}%`, transform: "translateX(50%)" }}
+            className={cn("absolute flex flex-col", beforeLabel.className)}
+            style={beforeLabel.style}
           >
             <span className="text-muted-foreground font-mono text-xs tabular-nums leading-none">
               {pp1(beforeBps)}
@@ -588,6 +601,15 @@ function DriftBar({
       </div>
     </div>
   );
+}
+
+function driftLabelPlacement(pos: number): { className: string; style: CSSProperties } {
+  if (pos >= 88) return { className: "items-end text-right", style: { right: 0 } };
+  if (pos <= 12) return { className: "items-start text-left", style: { left: 0 } };
+  return {
+    className: "items-center text-center",
+    style: { left: `${pos}%`, transform: "translateX(-50%)" },
+  };
 }
 
 // ── Planner result column (right panel) ───────────────────────────────────────
@@ -700,24 +722,30 @@ function PlannerResult({
         />
       </div>
 
-      <div className="border-border/70 mt-4 grid grid-cols-3 gap-4 border-t pt-3">
+      <div className="border-border/70 mt-4 grid grid-cols-2 gap-x-4 gap-y-3 border-t pt-3 sm:grid-cols-3 sm:gap-4">
         <div>
           <Eyebrow>Trades</Eyebrow>
-          <div className="text-foreground mt-1 font-mono text-base font-semibold tabular-nums leading-none">
+          <div className="text-foreground mt-1 font-mono text-sm font-semibold tabular-nums leading-none sm:text-base">
             {plan.trades.length}
           </div>
           <div className="text-muted-foreground mt-1 font-mono text-xs">{tradeSub}</div>
         </div>
         <div>
-          <Eyebrow>Cash deployed</Eyebrow>
-          <div className="text-foreground mt-1 font-mono text-base font-semibold tabular-nums leading-none">
+          <Eyebrow>
+            <span className="sm:hidden">Deployed</span>
+            <span className="hidden sm:inline">Cash deployed</span>
+          </Eyebrow>
+          <div className="text-foreground mt-1 font-mono text-sm font-semibold tabular-nums leading-none sm:text-base">
             {roundedCurrency(deployed, currency)}
           </div>
           <div className="text-muted-foreground mt-1 font-mono text-xs">{scopePct}% of scope</div>
         </div>
         <div>
-          <Eyebrow>Cash remaining</Eyebrow>
-          <div className="text-foreground mt-1 font-mono text-base font-semibold tabular-nums leading-none">
+          <Eyebrow>
+            <span className="sm:hidden">Remaining</span>
+            <span className="hidden sm:inline">Cash remaining</span>
+          </Eyebrow>
+          <div className="text-foreground mt-1 font-mono text-sm font-semibold tabular-nums leading-none sm:text-base">
             {roundedCurrency(plan.cashRemaining, currency)}
           </div>
           <div className="text-muted-foreground mt-1 font-mono text-xs">
@@ -726,7 +754,7 @@ function PlannerResult({
         </div>
       </div>
 
-      <p className="text-foreground/80 mt-4 font-mono text-xs leading-relaxed">
+      <p className="text-foreground/80 mt-4 hidden font-mono text-xs leading-relaxed sm:block">
         {modeVerb(mode) === "Cash-flow buys" ? "Deploying" : "This plan deploys"}{" "}
         <span className="text-foreground font-semibold">{roundedCurrency(deployed, currency)}</span>{" "}
         across {tradesActionSummary} — cutting max drift{" "}
@@ -738,7 +766,7 @@ function PlannerResult({
         <button
           type="button"
           onClick={onReview}
-          className="mt-3 inline-flex w-fit items-center gap-1 font-mono text-xs font-medium text-[#2f6b46] underline-offset-4 hover:underline dark:text-emerald-400"
+          className="mt-4 inline-flex w-fit items-center gap-1 font-mono text-xs font-medium text-[#2f6b46] underline-offset-4 hover:underline dark:text-emerald-400 sm:mt-3"
         >
           Review {tradesWord} <Icons.ArrowRight className="h-3.5 w-3.5" />
         </button>
@@ -951,94 +979,165 @@ function Warnings({ items }: { items: RebalanceWarning[] }) {
 
 // ── Trades table ──────────────────────────────────────────────────────────────
 
-function TradesTable({ trades, currency }: { trades: SuggestedManualTrade[]; currency: string }) {
+function tradeQuantityLabel(quantity: number | null | undefined): string {
+  if (quantity == null) return "—";
+  return quantity.toFixed(quantity % 1 === 0 ? 0 : 4);
+}
+
+function TradeActionBadge({ action }: { action: string }) {
+  const isSell = action === "sell";
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full table-fixed text-sm">
-        <colgroup>
-          <col className="w-[6%]" />
-          <col className="w-[23%]" />
-          <col className="w-[10%]" />
-          <col className="w-[13%]" />
-          <col className="w-[9%]" />
-          <col className="w-[12%]" />
-          <col className="w-[27%]" />
-        </colgroup>
-        <thead>
-          <tr className="border-border text-muted-foreground border-b font-mono text-xs uppercase tracking-wider">
-            <th className="py-2.5 pl-5 pr-2 text-left font-medium">Action</th>
-            <th className="py-2.5 pr-3 text-left font-medium">Ticker</th>
-            <th className="py-2.5 pl-14 pr-3 text-left font-medium">Category</th>
-            <th className="py-2.5 pr-3 text-right font-medium">Amount</th>
-            <th className="py-2.5 pr-3 text-right font-medium">Shares</th>
-            <th className="py-2.5 pr-7 text-right font-medium">Last price</th>
-            <th className="py-2.5 pl-10 pr-5 text-left font-medium">Reason</th>
-          </tr>
-        </thead>
-        <tbody>
-          {trades.map((t, i) => (
-            <tr key={i} className="border-border hover:bg-muted/30 h-12 border-b last:border-b-0">
-              <td className="pl-5 pr-2">
-                {t.action === "sell" ? (
-                  <span className="inline-flex items-center rounded bg-red-100 px-1.5 py-0.5 font-mono text-xs font-semibold text-red-800 dark:bg-red-900/30 dark:text-red-400">
-                    Sell
+    <span
+      className={cn(
+        "inline-flex items-center rounded px-1.5 py-0.5 font-mono text-xs font-semibold",
+        isSell
+          ? "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400"
+          : "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
+      )}
+    >
+      {isSell ? "Sell" : "Buy"}
+    </span>
+  );
+}
+
+function TradesTable({ trades, currency }: { trades: SuggestedManualTrade[]; currency: string }) {
+  const buys = trades.filter((t) => t.action === "buy");
+  const sells = trades.filter((t) => t.action === "sell");
+  const buyTotal = buys.reduce((s, t) => s + t.estimatedAmount, 0);
+
+  return (
+    <>
+      <div className="divide-border md:hidden divide-y">
+        {trades.map((t, i) => (
+          <div key={i} className="px-4 py-3">
+            <div className="flex items-start justify-between gap-3">
+              <div className="min-w-0 flex-1">
+                <div className="flex min-w-0 items-center gap-2">
+                  <TradeActionBadge action={t.action} />
+                  <span className="text-foreground truncate font-mono text-sm font-semibold">
+                    {t.symbol ?? "Trade"}
                   </span>
-                ) : (
-                  <span className="inline-flex items-center rounded bg-green-100 px-1.5 py-0.5 font-mono text-xs font-semibold text-green-800 dark:bg-green-900/30 dark:text-green-400">
-                    Buy
-                  </span>
-                )}
-              </td>
-              <td className="pr-3">
-                {t.symbol ? (
-                  <>
-                    <div className="text-foreground font-mono text-xs font-medium">{t.symbol}</div>
-                    {t.name && (
-                      <div className="text-muted-foreground truncate text-xs">{t.name}</div>
-                    )}
-                  </>
-                ) : (
-                  <span className="text-muted-foreground">—</span>
-                )}
-              </td>
-              <td className="text-muted-foreground pl-14 pr-3 text-xs">{t.categoryName}</td>
-              <td className="text-foreground pr-3 text-right font-semibold tabular-nums">
-                {formatAmount(t.estimatedAmount, currency)}
-              </td>
-              <td className="text-muted-foreground pr-3 text-right tabular-nums">
-                {t.quantity != null ? t.quantity.toFixed(t.quantity % 1 === 0 ? 0 : 4) : "—"}
-              </td>
-              <td className="text-muted-foreground pr-7 text-right tabular-nums">
-                {t.estimatedPrice != null ? formatAmount(t.estimatedPrice, currency) : "—"}
-              </td>
-              <td
-                className="text-muted-foreground max-w-0 truncate pl-10 pr-5 text-xs"
-                title={t.reason}
-              >
-                {t.reason}
-              </td>
+                </div>
+                {t.name && <div className="text-muted-foreground mt-1 truncate text-xs">{t.name}</div>}
+                <div className="text-muted-foreground mt-1 font-mono text-xs">{t.categoryName}</div>
+              </div>
+              <div className="shrink-0 text-right">
+                <div className="text-foreground font-mono text-sm font-semibold tabular-nums">
+                  {formatAmount(t.estimatedAmount, currency)}
+                </div>
+                <div className="text-muted-foreground mt-1 font-mono text-xs tabular-nums">
+                  {tradeQuantityLabel(t.quantity)} shares
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-3 grid grid-cols-2 gap-3 font-mono text-xs">
+              <div>
+                <div className="text-muted-foreground uppercase tracking-[0.14em]">Price</div>
+                <div className="text-foreground mt-1 tabular-nums">
+                  {t.estimatedPrice != null ? formatAmount(t.estimatedPrice, currency) : "—"}
+                </div>
+              </div>
+              <div className="min-w-0">
+                <div className="text-muted-foreground uppercase tracking-[0.14em]">Reason</div>
+                <div className="text-foreground mt-1 truncate" title={t.reason}>
+                  {t.reason}
+                </div>
+              </div>
+            </div>
+          </div>
+        ))}
+        <div className="bg-muted/20 flex items-center justify-between gap-3 px-4 py-3 font-mono text-xs">
+          <span className="text-muted-foreground">
+            {buys.length} buy{buys.length !== 1 ? "s" : ""}
+            {sells.length > 0 && ` · ${sells.length} sell${sells.length !== 1 ? "s" : ""}`}
+          </span>
+          <span className="text-foreground font-semibold tabular-nums">
+            {formatAmount(buyTotal, currency)}
+          </span>
+        </div>
+      </div>
+
+      <div className="hidden overflow-x-auto md:block">
+        <table className="w-full min-w-[920px] table-fixed text-sm">
+          <colgroup>
+            <col className="w-[6%]" />
+            <col className="w-[23%]" />
+            <col className="w-[10%]" />
+            <col className="w-[13%]" />
+            <col className="w-[9%]" />
+            <col className="w-[12%]" />
+            <col className="w-[27%]" />
+          </colgroup>
+          <thead>
+            <tr className="border-border text-muted-foreground border-b font-mono text-xs uppercase tracking-wider">
+              <th className="py-2.5 pl-5 pr-2 text-left font-medium">Action</th>
+              <th className="py-2.5 pr-3 text-left font-medium">Ticker</th>
+              <th className="py-2.5 pl-14 pr-3 text-left font-medium">Category</th>
+              <th className="py-2.5 pr-3 text-right font-medium">Amount</th>
+              <th className="py-2.5 pr-3 text-right font-medium">Shares</th>
+              <th className="py-2.5 pr-7 text-right font-medium">Last price</th>
+              <th className="py-2.5 pl-10 pr-5 text-left font-medium">Reason</th>
             </tr>
-          ))}
-        </tbody>
-        <tfoot>
-          <tr className="text-xs">
-            <td colSpan={3} className="text-muted-foreground py-3 pl-5 font-mono">
-              {trades.filter((t) => t.action === "buy").length} buy
-              {trades.filter((t) => t.action === "buy").length !== 1 ? "s" : ""}
-              {trades.some((t) => t.action === "sell") &&
-                ` · ${trades.filter((t) => t.action === "sell").length} sell${trades.filter((t) => t.action === "sell").length !== 1 ? "s" : ""}`}
-            </td>
-            <td className="text-foreground py-3 pr-3 text-right font-semibold tabular-nums">
-              {formatAmount(
-                trades.filter((t) => t.action === "buy").reduce((s, t) => s + t.estimatedAmount, 0),
-                currency,
-              )}
-            </td>
-            <td colSpan={3} />
-          </tr>
-        </tfoot>
-      </table>
-    </div>
+          </thead>
+          <tbody>
+            {trades.map((t, i) => (
+              <tr
+                key={i}
+                className="border-border hover:bg-muted/30 h-12 border-b last:border-b-0"
+              >
+                <td className="pl-5 pr-2">
+                  <TradeActionBadge action={t.action} />
+                </td>
+                <td className="pr-3">
+                  {t.symbol ? (
+                    <>
+                      <div className="text-foreground font-mono text-xs font-medium">
+                        {t.symbol}
+                      </div>
+                      {t.name && (
+                        <div className="text-muted-foreground truncate text-xs">{t.name}</div>
+                      )}
+                    </>
+                  ) : (
+                    <span className="text-muted-foreground">—</span>
+                  )}
+                </td>
+                <td className="text-muted-foreground pl-14 pr-3 text-xs">{t.categoryName}</td>
+                <td className="text-foreground pr-3 text-right font-semibold tabular-nums">
+                  {formatAmount(t.estimatedAmount, currency)}
+                </td>
+                <td className="text-muted-foreground pr-3 text-right tabular-nums">
+                  {tradeQuantityLabel(t.quantity)}
+                </td>
+                <td className="text-muted-foreground pr-7 text-right tabular-nums">
+                  {t.estimatedPrice != null ? formatAmount(t.estimatedPrice, currency) : "—"}
+                </td>
+                <td
+                  className="text-muted-foreground max-w-0 truncate pl-10 pr-5 text-xs"
+                  title={t.reason}
+                >
+                  {t.reason}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+          <tfoot>
+            <tr className="text-xs">
+              <td colSpan={3} className="text-muted-foreground py-3 pl-5 font-mono">
+                {buys.length} buy{buys.length !== 1 ? "s" : ""}
+                {sells.length > 0 &&
+                  ` · ${sells.length} sell${sells.length !== 1 ? "s" : ""}`}
+              </td>
+              <td className="text-foreground py-3 pr-3 text-right font-semibold tabular-nums">
+                {formatAmount(buyTotal, currency)}
+              </td>
+              <td colSpan={3} />
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+    </>
   );
 }
 
@@ -1164,7 +1263,7 @@ export function RebalanceTab({
       <Card>
         <CardContent className="p-0">
           <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)]">
-            <div className="border-border/60 px-5 py-5 lg:border-r">
+            <div className="border-border/60 border-b px-4 py-4 sm:px-5 sm:py-5 lg:border-b-0 lg:border-r">
               <PlannerInput
                 description={description}
                 cashValue={cashValue}
@@ -1177,7 +1276,7 @@ export function RebalanceTab({
                 isSourceLoading={!sourceReady}
               />
             </div>
-            <div className="px-5 py-5">
+            <div className="px-4 py-4 sm:px-5 sm:py-5">
               {!driftReport ? (
                 <div className="space-y-3">
                   <Skeleton className="h-3 w-28" />
@@ -1251,8 +1350,8 @@ export function RebalanceTab({
           </Card>
 
           {/* Footer */}
-          <div className="border-border flex items-center justify-between border-t pt-4">
-            <span className="text-muted-foreground font-mono text-xs">
+          <div className="border-border flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">
+            <span className="text-muted-foreground font-mono text-xs leading-relaxed">
               {profile.name} · Calculated{" "}
               {new Date().toLocaleDateString(undefined, {
                 year: "numeric",
@@ -1260,10 +1359,11 @@ export function RebalanceTab({
                 day: "numeric",
               })}
             </span>
-            <div className="flex gap-2">
+            <div className="grid grid-cols-2 gap-2 sm:flex sm:shrink-0">
               <Button
                 variant="outline"
                 size="sm"
+                className="min-w-0 justify-center"
                 onClick={() => {
                   copyToText(plan, currency);
                   toast.success("Copied to clipboard");
@@ -1274,6 +1374,7 @@ export function RebalanceTab({
               </Button>
               <Button
                 size="sm"
+                className="min-w-0 justify-center"
                 onClick={() => {
                   exportCsv(plan, currency, profile.name);
                   toast.success("CSV downloaded");

--- a/apps/frontend/src/pages/allocation-targets/components/target-detail-header.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/target-detail-header.tsx
@@ -30,13 +30,13 @@ export function TargetToolbarActions({
   onEditTarget,
 }: Omit<TargetDetailHeaderProps, "onBack" | "showActions">) {
   return (
-    <div className="flex items-center justify-end gap-2">
+    <div className="flex w-full min-w-0 items-center justify-end gap-2 md:w-auto">
       {targets.length > 0 && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
               variant="outline"
-              className="bg-secondary/30 hover:bg-muted/80 h-10 min-w-[220px] justify-between gap-2 rounded-full border-none px-4 text-sm font-medium"
+              className="bg-secondary/30 hover:bg-muted/80 h-10 min-w-0 flex-1 justify-between gap-2 rounded-full border-none px-4 text-sm font-medium md:min-w-[220px] md:flex-none"
             >
               <Icons.Target className="h-4 w-4 shrink-0 opacity-70" />
               <span className="min-w-0 flex-1 truncate text-left">
@@ -45,7 +45,7 @@ export function TargetToolbarActions({
               <Icons.ChevronsUpDown className="h-3.5 w-3.5 shrink-0 opacity-50" />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-60">
+          <DropdownMenuContent align="end" className="w-[calc(100vw-1.5rem)] md:w-60">
             {targets.map((p) => (
               <DropdownMenuItem
                 key={p.id}
@@ -60,7 +60,7 @@ export function TargetToolbarActions({
       )}
       <Button
         variant="outline"
-        className="bg-secondary/30 hover:bg-muted/80 h-10 w-10 rounded-full border-none p-0"
+        className="bg-secondary/30 hover:bg-muted/80 h-10 w-10 shrink-0 rounded-full border-none p-0"
         onClick={onCreateTarget}
         aria-label="New target"
         title="New target"
@@ -70,7 +70,7 @@ export function TargetToolbarActions({
       {target && onEditTarget && (
         <Button
           variant="outline"
-          className="bg-secondary/30 hover:bg-muted/80 h-10 w-10 rounded-full border-none p-0"
+          className="bg-secondary/30 hover:bg-muted/80 h-10 w-10 shrink-0 rounded-full border-none p-0"
           onClick={onEditTarget}
           aria-label="Edit target"
           title="Edit target"

--- a/apps/frontend/src/pages/allocation-targets/components/targets-tab.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/targets-tab.tsx
@@ -232,6 +232,13 @@ function editorModeFromRequest(
     : { kind: "edit", targetId: liveTargets[0].id };
 }
 
+function isSameEditorMode(left: EditorMode, right: EditorMode): boolean {
+  if (left.kind !== right.kind) return false;
+  if (left.kind === "guided") return true;
+  if (right.kind === "guided") return false;
+  return left.targetId === right.targetId;
+}
+
 function TargetEditor({
   target,
   accountScope,
@@ -501,8 +508,15 @@ function TargetEditor({
 
   return (
     <div className="space-y-5">
-      <div className={cn("flex justify-end", actionsPlacement === "page-header" && "-mt-14 mb-4")}>
-        <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+      <div
+        className={cn(
+          "flex",
+          actionsPlacement === "page-header"
+            ? "mb-4 justify-start lg:-mt-14 lg:justify-end"
+            : "justify-end",
+        )}
+      >
+        <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto sm:justify-end">
           <Button variant="ghost" size="sm" onClick={handleCancel}>
             <Icons.X className="mr-1.5 h-4 w-4" />
             Cancel
@@ -886,11 +900,16 @@ export function TargetsTab({
   useEffect(() => {
     if (!editorMode) return;
     if (editorMode === "create") {
-      setDraftAccountScope(accountScopeRef.current);
-      setMode({ kind: "guided" });
+      setDraftAccountScope((current) =>
+        accountScopeKey(current) === accountScopeKey(accountScopeRef.current)
+          ? current
+          : accountScopeRef.current,
+      );
+      setMode((current) => (current.kind === "guided" ? current : { kind: "guided" }));
       return;
     }
-    setMode(editorModeFromRequest(editorMode, selectedTargetId, liveTargets));
+    const nextMode = editorModeFromRequest(editorMode, selectedTargetId, liveTargets);
+    setMode((current) => (isSameEditorMode(current, nextMode) ? current : nextMode));
   }, [editorMode, selectedTargetId, liveTargets, parentAccountScopeKey]);
 
   useEffect(() => {

--- a/apps/frontend/src/pages/allocation-targets/hooks/use-allocation-targets.test.tsx
+++ b/apps/frontend/src/pages/allocation-targets/hooks/use-allocation-targets.test.tsx
@@ -1,0 +1,44 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { listAllocationTargets } from "@/adapters";
+import { useAllocationTargets } from "./use-allocation-targets";
+
+vi.mock("@/adapters", () => ({
+  listAllocationTargets: vi.fn(),
+}));
+
+const mockListAllocationTargets = vi.mocked(listAllocationTargets);
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+describe("useAllocationTargets", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns a stable empty target list when the query fails", async () => {
+    mockListAllocationTargets.mockRejectedValue(new Error("list failed"));
+
+    const { result, rerender } = renderHook(() => useAllocationTargets(), { wrapper });
+    const emptyTargets = result.current.targets;
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.targets).toBe(emptyTargets);
+
+    rerender();
+    expect(result.current.targets).toBe(emptyTargets);
+  });
+});

--- a/apps/frontend/src/pages/allocation-targets/hooks/use-allocation-targets.ts
+++ b/apps/frontend/src/pages/allocation-targets/hooks/use-allocation-targets.ts
@@ -3,9 +3,11 @@ import { listAllocationTargets } from "@/adapters";
 import { QueryKeys } from "@/lib/query-keys";
 import type { AllocationTarget } from "@/lib/types";
 
+const EMPTY_ALLOCATION_TARGETS: AllocationTarget[] = [];
+
 export function useAllocationTargets() {
   const {
-    data: targets = [],
+    data: targets,
     isLoading,
     isError,
   } = useQuery<AllocationTarget[], Error>({
@@ -13,5 +15,5 @@ export function useAllocationTargets() {
     queryFn: listAllocationTargets,
   });
 
-  return { targets, isLoading, isError };
+  return { targets: targets ?? EMPTY_ALLOCATION_TARGETS, isLoading, isError };
 }

--- a/apps/frontend/src/pages/asset/asset-profile-page.tsx
+++ b/apps/frontend/src/pages/asset/asset-profile-page.tsx
@@ -1214,6 +1214,7 @@ export const AssetProfilePage = () => {
         {isAltAsset && altHolding && assetProfile ? (
           isMobile ? (
             <SwipableView
+              withMobileNavOffset
               items={[
                 {
                   name: "Overview",
@@ -1294,6 +1295,7 @@ export const AssetProfilePage = () => {
               </div>
             )}
             <SwipableView
+              withMobileNavOffset
               items={swipableTabs}
               displayToggle={true}
               onViewChange={(_index: number, name: string) => {

--- a/apps/frontend/src/pages/dashboard/dashboard-content.tsx
+++ b/apps/frontend/src/pages/dashboard/dashboard-content.tsx
@@ -29,6 +29,46 @@ import TopHoldings from "./top-holdings";
 const DEFAULT_INTERVAL: UITimePeriod = "3M";
 const INTERVAL_STORAGE_KEY = "dashboard-interval";
 
+function getDashboardChartMinDomainSpanRatio(period: UITimePeriod): number {
+  switch (period) {
+    case "1D":
+    case "1W":
+      return 0.035;
+    case "1M":
+    case "3M":
+      return 0.08;
+    case "6M":
+    case "YTD":
+    case "1Y":
+      return 0.16;
+    case "5Y":
+    case "ALL":
+      return 0.2;
+    default:
+      return 0.12;
+  }
+}
+
+function getDashboardNetContributionMaxDomainSpanRatio(period: UITimePeriod): number | undefined {
+  switch (period) {
+    case "1D":
+    case "1W":
+      return undefined;
+    case "1M":
+    case "3M":
+      return 1.4;
+    case "6M":
+    case "YTD":
+    case "1Y":
+      return 2.2;
+    case "5Y":
+    case "ALL":
+      return 2.8;
+    default:
+      return 1.8;
+  }
+}
+
 export function DashboardContent() {
   // Use the same persisted state as IntervalSelector for the interval code
   const [intervalCode] = usePersistentState<UITimePeriod>(INTERVAL_STORAGE_KEY, DEFAULT_INTERVAL);
@@ -40,6 +80,7 @@ export function DashboardContent() {
   const [selectedIntervalDescription, setSelectedIntervalDescription] = useState<string>(
     () => getInitialIntervalData(intervalCode).description,
   );
+  const [selectedInterval, setSelectedInterval] = useState<UITimePeriod>(() => intervalCode);
   const [isAllTime, setIsAllTime] = useState<boolean>(() => intervalCode === "ALL");
 
   const { holdings: allHoldings, isLoading: isHoldingsLoading } = useHoldings({ type: "all" });
@@ -126,6 +167,15 @@ export function DashboardContent() {
     );
   }, [valuationHistory, baseCurrency]);
 
+  const chartMinDomainSpanRatio = useMemo(
+    () => getDashboardChartMinDomainSpanRatio(selectedInterval),
+    [selectedInterval],
+  );
+  const chartNetContributionMaxDomainSpanRatio = useMemo(
+    () => getDashboardNetContributionMaxDomainSpanRatio(selectedInterval),
+    [selectedInterval],
+  );
+
   const isNegative = totalValue < 0;
 
   // Callback for IntervalSelector
@@ -134,6 +184,7 @@ export function DashboardContent() {
     description: string,
     range: DateRange | undefined,
   ) => {
+    setSelectedInterval(code);
     setSelectedIntervalDescription(description);
     setDateRange(range);
     setIsAllTime(code === "ALL");
@@ -141,7 +192,7 @@ export function DashboardContent() {
 
   return (
     <div className="flex min-h-full flex-col">
-      <div className="px-4 pb-1 pt-2 md:px-6 md:pb-2 lg:px-8">
+      <div className="px-4 pb-1 pt-2 md:px-6 lg:px-8">
         <PortfolioUpdateTrigger
           lastCalculatedAt={currentValuation?.calculatedAt}
           notices={performanceMessages}
@@ -208,9 +259,15 @@ export function DashboardContent() {
         }`}
       >
         <div className="h-[280px]">
-          <HistoryChart data={chartData} isLoading={isValuationHistoryLoading} />
+          <HistoryChart
+            data={chartData}
+            isLoading={isValuationHistoryLoading}
+            scaleMode="fit-visible"
+            minDomainSpanRatio={chartMinDomainSpanRatio}
+            netContributionMaxDomainSpanRatio={chartNetContributionMaxDomainSpanRatio}
+          />
           {valuationHistory && chartData.length > 0 && (
-            <div className="flex w-full justify-center">
+            <div className="flex w-full -translate-y-6 justify-center">
               <IntervalSelector
                 className="pointer-events-auto relative z-20 w-full max-w-screen-sm sm:max-w-screen-md md:max-w-2xl lg:max-w-3xl"
                 onIntervalSelect={handleIntervalSelect}

--- a/apps/frontend/src/pages/dashboard/dashboard-content.tsx
+++ b/apps/frontend/src/pages/dashboard/dashboard-content.tsx
@@ -223,7 +223,7 @@ export function DashboardContent() {
           )}
         </div>
 
-        <div className="grow px-4 pb-[calc(var(--mobile-nav-ui-height)+max(var(--mobile-nav-gap),env(safe-area-inset-bottom)))] pt-12 md:px-6 md:pb-6 md:pt-6 lg:px-10 lg:pb-8 lg:pt-8">
+        <div className="grow px-4 pb-[var(--mobile-nav-total-offset)] pt-12 md:px-6 md:pb-6 md:pt-6 lg:px-10 lg:pb-8 lg:pt-8">
           <div className="grid grid-cols-1 gap-8 lg:grid-cols-3 lg:gap-20">
             <div className="lg:col-span-2">
               <AccountsSummary dateRange={dateRange} isAllTime={isAllTime} />

--- a/apps/frontend/src/pages/dashboard/portfolio-page.tsx
+++ b/apps/frontend/src/pages/dashboard/portfolio-page.tsx
@@ -162,6 +162,7 @@ export default function PortfolioPage() {
         defaultView="investments"
         withPadding={false}
         withMobileNavOffset={false}
+        mobileActionsPlacement="header"
         persistKey="dashboard-tab"
       />
       <AlternativeAssetQuickAddModal

--- a/apps/frontend/src/pages/dashboard/portfolio-page.tsx
+++ b/apps/frontend/src/pages/dashboard/portfolio-page.tsx
@@ -161,6 +161,7 @@ export default function PortfolioPage() {
         views={views}
         defaultView="investments"
         withPadding={false}
+        withMobileNavOffset={false}
         persistKey="dashboard-tab"
       />
       <AlternativeAssetQuickAddModal

--- a/apps/frontend/src/pages/income/income-history-chart.tsx
+++ b/apps/frontend/src/pages/income/income-history-chart.tsx
@@ -179,9 +179,7 @@ export const IncomeHistoryChart: React.FC<IncomeHistoryChartProps> = ({
       );
     }
     if (chartData.length === 0) return 0;
-    return Math.max(
-      ...chartData.map((d) => Math.max(d.income, d.previousIncome, isMobile ? d.cumulative : 0)),
-    );
+    return Math.max(...chartData.map((d) => Math.max(d.income, d.previousIncome)));
   })();
   const yTicks = getNiceTicks(dataMax);
 
@@ -344,19 +342,18 @@ export const IncomeHistoryChart: React.FC<IncomeHistoryChartProps> = ({
               <CartesianGrid vertical={false} strokeDasharray="3 3" opacity={0.3} />
               <XAxis {...xAxisProps} />
               <YAxis yAxisId="left" {...yAxisProps} />
-              {!isMobile && (
-                <YAxis
-                  yAxisId="right"
-                  orientation="right"
-                  tickLine={false}
-                  axisLine={false}
-                  width={48}
-                  ticks={rightTicks}
-                  domain={[0, rightTicks[rightTicks.length - 1] || 0]}
-                  tick={{ fontSize: 12, fill: "var(--chart-2)" }}
-                  tickFormatter={formatK}
-                />
-              )}
+              <YAxis
+                yAxisId="right"
+                orientation="right"
+                hide={isMobile}
+                tickLine={false}
+                axisLine={false}
+                width={isMobile ? 0 : 48}
+                ticks={rightTicks}
+                domain={[0, rightTicks[rightTicks.length - 1] || 0]}
+                tick={{ fontSize: 12, fill: "var(--chart-2)" }}
+                tickFormatter={formatK}
+              />
               <ChartTooltip
                 content={
                   <ChartTooltipContent
@@ -410,7 +407,7 @@ export const IncomeHistoryChart: React.FC<IncomeHistoryChartProps> = ({
                   bars as background context, with its own stroke acting as the line.
                   One element means exactly one legend/tooltip entry. */}
               <Area
-                yAxisId={isMobile ? "left" : "right"}
+                yAxisId="right"
                 type="monotone"
                 dataKey="cumulative"
                 stroke="var(--color-cumulative)"

--- a/apps/frontend/src/pages/insights/overview/overview-page.tsx
+++ b/apps/frontend/src/pages/insights/overview/overview-page.tsx
@@ -319,13 +319,18 @@ export function OverviewPage({
   if (workspaceView === "rebalance") {
     return (
       <div>
-        <div className="mb-5 flex items-center gap-3">
-          <Button variant="ghost" size="sm" className="-ml-2" onClick={() => backTo("details")}>
+        <div className="mb-5 flex flex-wrap items-center gap-x-3 gap-y-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="-ml-2 shrink-0"
+            onClick={() => backTo("details")}
+          >
             <Icons.ArrowLeft className="mr-1.5 h-4 w-4" />
             Back to overview
           </Button>
           <span className="bg-border hidden h-5 w-px sm:block" />
-          <h2 className="text-foreground text-[16px] font-semibold">Rebalance</h2>
+          <h2 className="text-foreground min-w-0 text-[16px] font-semibold">Rebalance</h2>
         </div>
         <RebalanceTab
           profile={effectiveTarget ?? null}

--- a/apps/frontend/src/pages/layouts/app-layout.tsx
+++ b/apps/frontend/src/pages/layouts/app-layout.tsx
@@ -42,7 +42,7 @@ const AppLayoutContent = () => {
   if (!isSettingsReady) {
     return (
       <div
-        className="flex h-screen items-center justify-center"
+        className="flex h-screen items-center justify-center supports-[height:100dvh]:h-dvh"
         style={{ backgroundColor: "#09090b" }}
       >
         <img src="/logo-gold.png" alt="Wealthfolio" className="h-[100px] w-auto" />
@@ -57,7 +57,7 @@ const AppLayoutContent = () => {
   return (
     <ErrorBoundary>
       <ApplicationShell
-        className="app-shell h-screen overflow-x-hidden"
+        className="app-shell h-screen overflow-x-hidden supports-[height:100dvh]:h-dvh"
         style={
           launchBarHeight ? { ["--mobile-nav-ui-height" as string]: launchBarHeight } : undefined
         }

--- a/apps/frontend/src/pages/layouts/navigation/floating-navigation-bar.tsx
+++ b/apps/frontend/src/pages/layouts/navigation/floating-navigation-bar.tsx
@@ -71,7 +71,7 @@ export function FloatingNavigationBar({ navigation }: FloatingNavigationBarProps
 
   return (
     <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40">
-      <div className="flex justify-center px-4 pb-[max(var(--mobile-nav-gap),env(safe-area-inset-bottom))]">
+      <div className="flex justify-center px-4 pb-[var(--mobile-nav-bottom-offset)]">
         <LiquidGlass
           variant="floating"
           intensity="subtle"

--- a/apps/frontend/src/pages/layouts/navigation/mobile-navbar.tsx
+++ b/apps/frontend/src/pages/layouts/navigation/mobile-navbar.tsx
@@ -80,7 +80,7 @@ export function MobileNavBar({ navigation }: MobileNavBarProps) {
   return (
     <div className={containerClassName}>
       {/* Lift off bottom by the design gap while respecting safe area */}
-      <div className="flex justify-center px-4 pb-[max(var(--mobile-nav-gap),env(safe-area-inset-bottom))]">
+      <div className="flex justify-center px-4 pb-[var(--mobile-nav-bottom-offset)]">
         <LiquidGlass
           variant="floating"
           intensity="subtle"

--- a/apps/frontend/src/pages/net-worth/net-worth-content.tsx
+++ b/apps/frontend/src/pages/net-worth/net-worth-content.tsx
@@ -302,7 +302,7 @@ export function NetWorthContent() {
         </div>
 
         {/* Content section */}
-        <div className="grow px-4 pb-[calc(var(--mobile-nav-ui-height)+max(var(--mobile-nav-gap),env(safe-area-inset-bottom)))] pt-14 md:px-6 md:pb-6 md:pt-12 lg:px-10 lg:pb-8 lg:pt-14">
+        <div className="grow px-4 pb-[var(--mobile-nav-total-offset)] pt-14 md:px-6 md:pb-6 md:pt-12 lg:px-10 lg:pb-8 lg:pt-14">
           <div className="grid grid-cols-1 gap-8 lg:grid-cols-3 lg:gap-12">
             {/* Left column: Breakdown */}
             <div className="lg:col-span-2">

--- a/apps/frontend/src/pages/settings/settings-layout.tsx
+++ b/apps/frontend/src/pages/settings/settings-layout.tsx
@@ -133,7 +133,7 @@ export default function SettingsLayout() {
 
   // Mobile-first: show list view on main page, detail view on specific pages
   return (
-    <ApplicationShell className="settings-root app-shell h-screen overflow-x-hidden">
+    <ApplicationShell className="settings-root app-shell h-screen overflow-x-hidden supports-[height:100dvh]:h-dvh">
       {/* Mobile Layout */}
       <div className="w-full lg:hidden">
         {isMainSettingsPage ? (
@@ -144,7 +144,7 @@ export default function SettingsLayout() {
                 <h1 className="text-lg font-semibold">Settings</h1>
               </div>
             </div>
-            <div className="space-y-6 p-3 pb-[calc(var(--mobile-nav-ui-height)+max(var(--mobile-nav-gap),env(safe-area-inset-bottom)))] lg:p-4 lg:pb-4">
+            <div className="space-y-6 p-3 pb-[var(--mobile-nav-total-offset)] lg:p-4 lg:pb-4">
               {sections.map((section) => (
                 <div key={section.title} className="space-y-3">
                   <div className="text-muted-foreground px-2 text-xs font-semibold uppercase tracking-widest">
@@ -182,7 +182,7 @@ export default function SettingsLayout() {
         ) : (
           <div className="scan-hide-target pt-safe w-full max-w-full overflow-x-hidden">
             <div className="w-full max-w-full overflow-x-hidden scroll-smooth">
-              <div className="p-2 pb-[calc(var(--mobile-nav-ui-height)+max(var(--mobile-nav-gap),env(safe-area-inset-bottom)))] lg:p-4 lg:pb-4">
+              <div className="p-2 pb-[var(--mobile-nav-total-offset)] lg:p-4 lg:pb-4">
                 <Outlet />
               </div>
             </div>

--- a/apps/tauri/gen/apple/wealthfolio-app_iOS/Info.plist
+++ b/apps/tauri/gen/apple/wealthfolio-app_iOS/Info.plist
@@ -42,21 +42,6 @@
 	</array>
 	<key>NSCameraUsageDescription</key>
 	<string>Wealthfolio needs camera access to scan QR codes for device pairing.</string>
-	<key>CFBundleURLTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleURLSchemes</key>
-			<array/>
-			<key>CFBundleURLName</key>
-			<string>https</string>
-		</dict>
-		<dict>
-			<key>CFBundleURLSchemes</key>
-			<array/>
-			<key>CFBundleURLName</key>
-			<string>https</string>
-		</dict>
-	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 </dict>

--- a/crates/core/src/sync/app_sync_model.rs
+++ b/crates/core/src/sync/app_sync_model.rs
@@ -60,6 +60,8 @@ pub const APP_SYNC_TABLES: &[&str] = &[
     "ai_thread_tags",
     // No FK deps (account_id has no FK constraint)
     "holdings_snapshots",
+    // Depends on: holdings_snapshots, assets
+    "snapshot_positions",
     // No FK deps
     "portfolios",
     // Depends on: portfolios, accounts

--- a/crates/storage-sqlite/src/sync/app_sync/repository.rs
+++ b/crates/storage-sqlite/src/sync/app_sync/repository.rs
@@ -151,6 +151,16 @@ const ROWS_WITH_USER_SYNCABLE_ACTIVITY_FILTER_SQL: &str = "\
                AND (source_record_id IS NULL OR TRIM(source_record_id) = ''))
     )";
 
+const OVERWRITE_RISK_ACTIVITY_TAXONOMY_ASSIGNMENTS_FILTER_SQL: &str = "\
+    UPPER(COALESCE(source, '')) = 'MANUAL'
+    OR activity_id IN (
+        SELECT id FROM activities
+        WHERE UPPER(COALESCE(source_system, '')) IN ('MANUAL', 'CSV')
+           OR ((source_system IS NULL OR TRIM(source_system) = '')
+               AND (import_run_id IS NULL OR TRIM(import_run_id) = '')
+               AND (source_record_id IS NULL OR TRIM(source_record_id) = ''))
+    )";
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SyncRowFilter {
     UserSyncableHoldingsSnapshots,
@@ -158,7 +168,8 @@ enum SyncRowFilter {
     ManualQuotes,
     UserImportRuns,
     UserSyncableActivities,
-    UserImportTemplates,
+    OverwriteRiskImportTemplates,
+    OverwriteRiskImportAccountTemplates,
     SpendingSettings,
     SpendingSettingsOverwriteRisk,
     UserTaxonomies,
@@ -174,6 +185,7 @@ enum SyncRowFilter {
     OverwriteRiskAssets,
     ValidPortfolioAccounts,
     RowsWithUserSyncableActivity,
+    OverwriteRiskActivityTaxonomyAssignments,
 }
 
 impl SyncRowFilter {
@@ -194,7 +206,13 @@ impl SyncRowFilter {
                 "UPPER(run_type) = 'IMPORT' AND UPPER(source_system) IN ('CSV', 'MANUAL')"
             }
             Self::UserSyncableActivities => USER_SYNCABLE_ACTIVITIES_FILTER_SQL,
-            Self::UserImportTemplates => "UPPER(scope) != 'SYSTEM'",
+            Self::OverwriteRiskImportTemplates => {
+                "UPPER(scope) != 'SYSTEM' AND UPPER(kind) != 'BROKER_ACTIVITY'"
+            }
+            Self::OverwriteRiskImportAccountTemplates => {
+                "UPPER(context_kind) != 'BROKER_ACTIVITY' \
+                 AND UPPER(COALESCE(source_system, '')) IN ('', 'CSV', 'MANUAL')"
+            }
             Self::SpendingSettings => "setting_key IN ('spending.enabled', 'spending.account_ids')",
             Self::SpendingSettingsOverwriteRisk => {
                 "setting_key = 'spending.account_ids' \
@@ -254,6 +272,9 @@ impl SyncRowFilter {
                 "account_id IN (SELECT id FROM accounts) AND portfolio_id IN (SELECT id FROM portfolios)"
             }
             Self::RowsWithUserSyncableActivity => ROWS_WITH_USER_SYNCABLE_ACTIVITY_FILTER_SQL,
+            Self::OverwriteRiskActivityTaxonomyAssignments => {
+                OVERWRITE_RISK_ACTIVITY_TAXONOMY_ASSIGNMENTS_FILTER_SQL
+            }
         }
     }
 }
@@ -271,14 +292,12 @@ const OVERWRITE_RISK_UNFILTERED_TABLES: &[&str] = &[
     "ai_messages",
     "ai_thread_tags",
     "contribution_limits",
-    "activity_taxonomy_assignments",
     "spending_activity_events",
     "spending_categorization_rules",
     "spending_preset_rule_deletions",
     "spending_events",
     "budget_targets",
     "budget_rollover_settings",
-    "import_account_templates",
     "asset_taxonomy_assignments",
     "goals_allocation",
     "allocation_targets",
@@ -312,7 +331,15 @@ const OVERWRITE_RISK_FILTERED_TABLES: &[SyncTableFilterSpec] = &[
     },
     SyncTableFilterSpec {
         table: "import_templates",
-        filter: SyncRowFilter::UserImportTemplates,
+        filter: SyncRowFilter::OverwriteRiskImportTemplates,
+    },
+    SyncTableFilterSpec {
+        table: "import_account_templates",
+        filter: SyncRowFilter::OverwriteRiskImportAccountTemplates,
+    },
+    SyncTableFilterSpec {
+        table: "activity_taxonomy_assignments",
+        filter: SyncRowFilter::OverwriteRiskActivityTaxonomyAssignments,
     },
     SyncTableFilterSpec {
         table: "app_settings",
@@ -3902,6 +3929,36 @@ mod tests {
         db_path
     }
 
+    fn create_snapshot_db_with_account_asset_snapshot_position(
+        account_id: &str,
+        asset_id: &str,
+    ) -> String {
+        let app_data = tempdir()
+            .expect("tempdir")
+            .keep()
+            .to_string_lossy()
+            .to_string();
+        let db_path = init(&app_data).expect("init db");
+        run_migrations(&db_path).expect("migrate db");
+        let pool = create_pool(&db_path).expect("create pool");
+        let mut conn = get_connection(&pool).expect("conn");
+        insert_account_for_test(&mut conn, account_id).expect("insert account");
+        insert_asset_kind_for_test(&mut conn, asset_id, "INVESTMENT").expect("insert asset");
+        let snapshot_id = format!("snap-{account_id}");
+        let sql = format!(
+            "INSERT INTO holdings_snapshots (id, account_id, snapshot_date, currency, positions, cash_balances, cost_basis, net_contribution, calculated_at, net_contribution_base, cash_total_account_currency, cash_total_base_currency, source)
+             VALUES ('{}', '{}', '2026-01-01', 'USD', '{{}}', '{{}}', '0', '0', '2026-01-01T00:00:00Z', '0', '0', '0', 'MANUAL_ENTRY');
+             INSERT INTO snapshot_positions (snapshot_id, asset_id, quantity, average_cost, total_cost_basis, currency, inception_date, is_alternative, contract_multiplier, created_at, last_updated)
+             VALUES ('{}', '{}', '3', '10', '30', 'USD', '2026-01-01T00:00:00Z', 0, '1', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
+            escape_sqlite_str(&snapshot_id),
+            escape_sqlite_str(account_id),
+            escape_sqlite_str(&snapshot_id),
+            escape_sqlite_str(asset_id)
+        );
+        conn.batch_execute(&sql).expect("insert snapshot position");
+        db_path
+    }
+
     fn insert_portfolio_for_test(
         conn: &mut SqliteConnection,
         portfolio_id: &str,
@@ -5028,6 +5085,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn snapshot_restore_orders_snapshot_positions_after_snapshot_parents() {
+        #[derive(diesel::QueryableByName)]
+        struct CountRow {
+            #[diesel(sql_type = diesel::sql_types::BigInt)]
+            c: i64,
+        }
+
+        let (pool, writer) = setup_db();
+        let repo = AppSyncRepository::new(pool.clone(), writer);
+        let account_id = "acc-position-restore";
+        let asset_id = "asset-position-restore";
+        let snapshot_path =
+            create_snapshot_db_with_account_asset_snapshot_position(account_id, asset_id);
+
+        repo.restore_snapshot_tables_from_file(
+            snapshot_path,
+            vec![
+                "snapshot_positions".to_string(),
+                "holdings_snapshots".to_string(),
+                "assets".to_string(),
+                "accounts".to_string(),
+            ],
+            92,
+            "device-position-restore".to_string(),
+            Some(1),
+        )
+        .await
+        .expect("restore snapshot");
+
+        let mut conn = get_connection(&pool).expect("conn");
+        let position_count: CountRow = diesel::sql_query(
+            "SELECT COUNT(*) AS c
+             FROM snapshot_positions
+             WHERE snapshot_id = 'snap-acc-position-restore'
+               AND asset_id = 'asset-position-restore'",
+        )
+        .get_result(&mut conn)
+        .expect("count restored snapshot positions");
+        assert_eq!(position_count.c, 1);
+    }
+
+    #[tokio::test]
     async fn snapshot_restore_skips_orphan_portfolio_accounts_and_clears_existing_rows() {
         #[derive(diesel::QueryableByName)]
         struct CountRow {
@@ -5314,6 +5413,38 @@ mod tests {
             )
             .execute(&mut conn)
             .expect("insert broker account");
+            insert_broker_import_run_for_test(&mut conn, "broker-run-risk", "broker-account-risk")
+                .expect("insert broker import run");
+            insert_activity_for_snapshot_filter_test(
+                &mut conn,
+                "broker-activity-risk",
+                "broker-account-risk",
+                "SNAPTRADE",
+                Some("broker-run-risk"),
+                Some("broker-row-risk"),
+                0,
+            )
+            .expect("insert broker activity");
+            diesel::sql_query(
+                "INSERT INTO activity_taxonomy_assignments \
+                 (id, activity_id, taxonomy_id, category_id, weight, source, created_at, updated_at) \
+                 VALUES ('broker-assignment-risk', 'broker-activity-risk', 'spending_categories', \
+                         'cat_food', 10000, 'rule', \
+                         '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
+            )
+            .execute(&mut conn)
+            .expect("insert broker activity generated category sidecar");
+            conn.batch_execute(
+                "INSERT INTO import_templates \
+                 (id, name, scope, kind, source_system, config_version, config, created_at, updated_at) \
+                 VALUES ('broker-template-risk', 'Broker Template', 'USER', 'BROKER_ACTIVITY', \
+                         'SNAPTRADE', 1, '{}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+                 INSERT INTO import_account_templates \
+                 (id, account_id, context_kind, source_system, template_id, created_at, updated_at) \
+                 VALUES ('broker-profile-risk', 'broker-account-risk', 'BROKER_ACTIVITY', \
+                         'SNAPTRADE', 'broker-template-risk', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+            )
+            .expect("insert broker import profile");
         }
 
         let summary = repo
@@ -5322,6 +5453,81 @@ mod tests {
 
         assert_eq!(summary.total_rows, 0);
         assert!(summary.non_empty_tables.is_empty());
+    }
+
+    #[tokio::test]
+    async fn overwrite_risk_summary_counts_manual_broker_activity_sidecars() {
+        let (pool, writer) = setup_db();
+        let repo = AppSyncRepository::new(pool.clone(), writer);
+
+        {
+            let mut conn = get_connection(&pool).expect("conn");
+            conn.batch_execute(
+                "INSERT INTO platforms (id, name, url, external_id, kind, website_url, logo_url) \
+                 VALUES ('broker-platform-manual-risk', 'Broker Platform', '', 'external-manual-risk', \
+                         'BROKERAGE', NULL, NULL);
+                 INSERT INTO accounts \
+                 (id, name, account_type, `group`, currency, is_default, is_active, created_at, updated_at, \
+                  platform_id, account_number, meta, provider, provider_account_id, is_archived, tracking_mode) \
+                 VALUES ('broker-account-manual-risk', 'Broker Account', 'cash', NULL, 'USD', 0, 1, \
+                         CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, 'broker-platform-manual-risk', NULL, NULL, \
+                         'SNAPTRADE', 'broker-provider-account-manual-risk', 0, 'portfolio')",
+            )
+            .expect("insert broker account");
+            insert_broker_import_run_for_test(
+                &mut conn,
+                "broker-run-manual-risk",
+                "broker-account-manual-risk",
+            )
+            .expect("insert broker import run");
+            insert_activity_for_snapshot_filter_test(
+                &mut conn,
+                "broker-activity-manual-risk",
+                "broker-account-manual-risk",
+                "SNAPTRADE",
+                Some("broker-run-manual-risk"),
+                Some("broker-row-manual-risk"),
+                0,
+            )
+            .expect("insert broker activity");
+            conn.batch_execute(
+                "INSERT INTO activity_taxonomy_assignments \
+                 (id, activity_id, taxonomy_id, category_id, weight, source, created_at, updated_at) \
+                 VALUES ('broker-manual-assignment-risk', 'broker-activity-manual-risk', \
+                         'spending_categories', 'cat_food', 10000, 'manual', \
+                         '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+                 INSERT INTO spending_event_types (id, key, name, color, created_at, updated_at) \
+                 VALUES ('broker-event-type-risk', 'broker_event', 'Broker Event', NULL, \
+                         '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+                 INSERT INTO spending_events \
+                 (id, name, description, event_type_id, start_date, end_date, created_at, updated_at) \
+                 VALUES ('broker-event-risk', 'Broker Event', NULL, 'broker-event-type-risk', \
+                         '2026-01-01', '2026-01-02', \
+                         '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+                 INSERT INTO spending_activity_events (activity_id, event_id, created_at, updated_at) \
+                 VALUES ('broker-activity-manual-risk', 'broker-event-risk', \
+                         '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
+            )
+            .expect("insert broker manual sidecars");
+        }
+
+        let summary = repo
+            .get_local_sync_overwrite_risk_summary()
+            .expect("overwrite risk summary");
+
+        assert_eq!(summary.total_rows, 3);
+        assert!(summary
+            .non_empty_tables
+            .iter()
+            .any(|row| row.table == "activity_taxonomy_assignments" && row.rows == 1));
+        assert!(summary
+            .non_empty_tables
+            .iter()
+            .any(|row| row.table == "spending_events" && row.rows == 1));
+        assert!(summary
+            .non_empty_tables
+            .iter()
+            .any(|row| row.table == "spending_activity_events" && row.rows == 1));
     }
 
     #[tokio::test]
@@ -7041,6 +7247,353 @@ mod tests {
         repo.validate_snapshot_upload_integrity(vec!["portfolio_accounts".to_string()])
             .await
             .expect("missing portfolio membership should be skipped by snapshot upload validation");
+    }
+
+    #[tokio::test]
+    async fn snapshot_export_keeps_csv_import_parent_and_excludes_broker_rows() {
+        #[derive(diesel::QueryableByName)]
+        struct CountRow {
+            #[diesel(sql_type = diesel::sql_types::BigInt)]
+            c: i64,
+        }
+        #[derive(diesel::QueryableByName)]
+        struct ImportRunIdRow {
+            #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+            import_run_id: Option<String>,
+        }
+
+        let (pool, writer) = setup_db();
+        let repo = AppSyncRepository::new(pool.clone(), writer);
+        let mut conn = get_connection(&pool).expect("conn");
+
+        insert_account_for_test(&mut conn, "acc-activity-broker-parent").expect("insert account");
+        conn.batch_execute(
+            "INSERT INTO import_runs
+             (id, account_id, source_system, run_type, mode, status, started_at, finished_at,
+              review_mode, applied_at, checkpoint_in, checkpoint_out, summary, warnings, error, created_at, updated_at)
+             VALUES
+             ('run-csv-parent', 'acc-activity-broker-parent', 'CSV', 'IMPORT',
+              'INCREMENTAL', 'APPLIED', '2026-02-12T00:00:00Z', '2026-02-12T00:01:00Z',
+              'NEVER', '2026-02-12T00:01:00Z', NULL, NULL, NULL, NULL, NULL,
+              '2026-02-12T00:00:00Z', '2026-02-12T00:01:00Z'),
+             ('run-broker-parent', 'acc-activity-broker-parent', 'SNAPTRADE', 'SYNC',
+              'INCREMENTAL', 'APPLIED', '2026-02-12T00:00:00Z', '2026-02-12T00:01:00Z',
+              'NEVER', '2026-02-12T00:01:00Z', NULL, NULL, NULL, NULL, NULL,
+              '2026-02-12T00:00:00Z', '2026-02-12T00:01:00Z');
+             INSERT INTO activities
+             (id, account_id, asset_id, activity_type, activity_type_override, source_type, subtype, status,
+              activity_date, settlement_date, quantity, unit_price, amount, fee, currency, fx_rate, notes, metadata,
+              source_system, source_record_id, source_group_id, idempotency_key, import_run_id, is_user_modified,
+              needs_review, created_at, updated_at)
+             VALUES
+             ('activity-csv-imported', 'acc-activity-broker-parent', NULL, 'DEPOSIT',
+              NULL, NULL, NULL, 'COMPLETED', '2026-02-12', NULL, NULL, NULL, '100.00',
+              NULL, 'USD', NULL, NULL, NULL, 'CSV', 'csv-row-1', NULL, NULL,
+              'run-csv-parent', 0, 0, '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z'),
+             ('activity-broker-modified', 'acc-activity-broker-parent', NULL, 'DEPOSIT',
+              NULL, NULL, NULL, 'COMPLETED', '2026-02-12', NULL, NULL, NULL, '100.00',
+              NULL, 'USD', NULL, NULL, NULL, 'SNAPTRADE', 'broker-row-1', NULL, NULL,
+              'run-broker-parent', 1, 0, '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z')",
+        )
+        .expect("insert csv and broker activities");
+
+        let payload = repo
+            .export_snapshot_sqlite_image(vec![
+                "accounts".to_string(),
+                "import_runs".to_string(),
+                "activities".to_string(),
+            ])
+            .await
+            .expect("export snapshot");
+
+        let exported_dir = tempdir().expect("tempdir");
+        let exported_path = exported_dir.path().join("snapshot.db");
+        std::fs::write(&exported_path, payload).expect("write snapshot db");
+
+        let mut exported_conn =
+            SqliteConnection::establish(exported_path.to_string_lossy().as_ref())
+                .expect("open snapshot db");
+        let exported_run_count: CountRow =
+            diesel::sql_query("SELECT COUNT(*) AS c FROM import_runs")
+                .get_result(&mut exported_conn)
+                .expect("count exported import runs");
+        assert_eq!(exported_run_count.c, 1);
+        let exported_activity_count: CountRow =
+            diesel::sql_query("SELECT COUNT(*) AS c FROM activities")
+                .get_result(&mut exported_conn)
+                .expect("count exported activities");
+        assert_eq!(exported_activity_count.c, 1);
+        let exported_activity: ImportRunIdRow = diesel::sql_query(
+            "SELECT import_run_id FROM activities WHERE id = 'activity-csv-imported'",
+        )
+        .get_result(&mut exported_conn)
+        .expect("load exported activity");
+        assert_eq!(
+            exported_activity.import_run_id.as_deref(),
+            Some("run-csv-parent")
+        );
+        let exported_broker_count: CountRow = diesel::sql_query(
+            "SELECT COUNT(*) AS c FROM import_runs WHERE id = 'run-broker-parent'
+             UNION ALL
+             SELECT COUNT(*) AS c FROM activities WHERE id = 'activity-broker-modified'",
+        )
+        .get_results::<CountRow>(&mut exported_conn)
+        .expect("count exported broker rows")
+        .into_iter()
+        .fold(CountRow { c: 0 }, |mut acc, row| {
+            acc.c += row.c;
+            acc
+        });
+        assert_eq!(exported_broker_count.c, 0);
+        drop(exported_conn);
+
+        let (restore_pool, restore_writer) = setup_db();
+        let restore_repo = AppSyncRepository::new(restore_pool.clone(), restore_writer);
+        restore_repo
+            .restore_snapshot_tables_from_file(
+                exported_path.to_string_lossy().to_string(),
+                vec![
+                    "activities".to_string(),
+                    "import_runs".to_string(),
+                    "accounts".to_string(),
+                ],
+                203,
+                "device-activity-broker-parent".to_string(),
+                Some(1),
+            )
+            .await
+            .expect("restore snapshot");
+
+        let mut restore_conn = get_connection(&restore_pool).expect("conn");
+        let restored_activity: ImportRunIdRow = diesel::sql_query(
+            "SELECT import_run_id FROM activities WHERE id = 'activity-csv-imported'",
+        )
+        .get_result(&mut restore_conn)
+        .expect("load restored activity");
+        assert_eq!(
+            restored_activity.import_run_id.as_deref(),
+            Some("run-csv-parent")
+        );
+        let restored_run_count: CountRow =
+            diesel::sql_query("SELECT COUNT(*) AS c FROM import_runs WHERE id = 'run-csv-parent'")
+                .get_result(&mut restore_conn)
+                .expect("count restored import run");
+        assert_eq!(restored_run_count.c, 1);
+        let restored_broker_count: CountRow = diesel::sql_query(
+            "SELECT COUNT(*) AS c FROM import_runs WHERE id = 'run-broker-parent'
+             UNION ALL
+             SELECT COUNT(*) AS c FROM activities WHERE id = 'activity-broker-modified'",
+        )
+        .get_results::<CountRow>(&mut restore_conn)
+        .expect("count restored broker rows")
+        .into_iter()
+        .fold(CountRow { c: 0 }, |mut acc, row| {
+            acc.c += row.c;
+            acc
+        });
+        assert_eq!(restored_broker_count.c, 0);
+    }
+
+    #[tokio::test]
+    async fn snapshot_export_restores_allocation_weights_for_custom_taxonomy() {
+        #[derive(diesel::QueryableByName)]
+        struct CountRow {
+            #[diesel(sql_type = diesel::sql_types::BigInt)]
+            c: i64,
+        }
+
+        let (pool, writer) = setup_db();
+        let repo = AppSyncRepository::new(pool.clone(), writer);
+        let mut conn = get_connection(&pool).expect("conn");
+
+        conn.batch_execute(
+            "INSERT INTO taxonomies
+             (id, name, color, description, is_system, is_single_select, sort_order, created_at, updated_at, scope)
+             VALUES ('taxonomy-allocation-custom', 'Allocation Custom', '#000000', NULL, 0, 0, 0,
+                     '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z', 'asset');
+             INSERT INTO taxonomy_categories
+             (id, taxonomy_id, parent_id, name, key, color, description, sort_order, created_at, updated_at, icon)
+             VALUES ('category-allocation-custom', 'taxonomy-allocation-custom', NULL, 'Growth', 'growth',
+                     '#000000', NULL, 0, '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z', NULL);
+             INSERT INTO allocation_targets
+             (id, name, scope_type, scope_id, taxonomy_id, trigger_type, drift_band_bps, rebalance_goal,
+              min_trade_amount, whole_shares_only, allow_sells, created_at, updated_at, archived_at)
+             VALUES ('target-allocation-custom', 'Custom Allocation', 'all', NULL, 'taxonomy-allocation-custom',
+                     'threshold', 500, 'nearest_band', '0', 0, 0,
+                     '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z', NULL);
+             INSERT INTO allocation_target_weights
+             (id, target_id, taxonomy_id, category_id, target_bps, is_locked, is_required, created_at, updated_at)
+             VALUES ('weight-allocation-custom', 'target-allocation-custom', 'taxonomy-allocation-custom',
+                     'category-allocation-custom', 10000, 0, 1,
+                     '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z')",
+        )
+        .expect("insert allocation target with custom taxonomy");
+
+        let payload = repo
+            .export_snapshot_sqlite_image(vec![
+                "taxonomies".to_string(),
+                "taxonomy_categories".to_string(),
+                "allocation_targets".to_string(),
+                "allocation_target_weights".to_string(),
+            ])
+            .await
+            .expect("export snapshot");
+
+        let exported_dir = tempdir().expect("tempdir");
+        let exported_path = exported_dir.path().join("snapshot.db");
+        std::fs::write(&exported_path, payload).expect("write snapshot db");
+
+        let mut exported_conn =
+            SqliteConnection::establish(exported_path.to_string_lossy().as_ref())
+                .expect("open snapshot db");
+        let exported_category_count: CountRow = diesel::sql_query(
+            "SELECT COUNT(*) AS c
+             FROM taxonomy_categories
+             WHERE taxonomy_id = 'taxonomy-allocation-custom'
+               AND id = 'category-allocation-custom'",
+        )
+        .get_result(&mut exported_conn)
+        .expect("count exported custom taxonomy category");
+        assert_eq!(exported_category_count.c, 1);
+        drop(exported_conn);
+
+        let (restore_pool, restore_writer) = setup_db();
+        let restore_repo = AppSyncRepository::new(restore_pool.clone(), restore_writer);
+        restore_repo
+            .restore_snapshot_tables_from_file(
+                exported_path.to_string_lossy().to_string(),
+                vec![
+                    "allocation_target_weights".to_string(),
+                    "allocation_targets".to_string(),
+                    "taxonomy_categories".to_string(),
+                    "taxonomies".to_string(),
+                ],
+                202,
+                "device-allocation-custom".to_string(),
+                Some(1),
+            )
+            .await
+            .expect("restore allocation snapshot");
+
+        let mut restore_conn = get_connection(&restore_pool).expect("conn");
+        let weight_count: CountRow = diesel::sql_query(
+            "SELECT COUNT(*) AS c
+             FROM allocation_target_weights
+             WHERE id = 'weight-allocation-custom'",
+        )
+        .get_result(&mut restore_conn)
+        .expect("count restored allocation weight");
+        assert_eq!(weight_count.c, 1);
+    }
+
+    #[tokio::test]
+    async fn snapshot_restore_skips_budget_rows_with_missing_category_dependencies() {
+        #[derive(diesel::QueryableByName)]
+        struct CountRow {
+            #[diesel(sql_type = diesel::sql_types::BigInt)]
+            c: i64,
+        }
+
+        let (pool, writer) = setup_db();
+        let repo = AppSyncRepository::new(pool.clone(), writer);
+        let mut conn = get_connection(&pool).expect("conn");
+
+        conn.batch_execute(
+            "INSERT INTO taxonomy_categories
+             (id, taxonomy_id, parent_id, name, key, color, description, sort_order, created_at, updated_at, icon)
+             VALUES
+             ('cat_future_budget', 'spending_categories', NULL, 'Future Budget Seed', 'future_budget_seed',
+              '#000000', NULL, 501, '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z', NULL),
+             ('budget-category-custom', 'spending_categories', NULL, 'Custom Budget Category', 'custom_budget_category',
+              '#000000', NULL, 502, '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z', NULL);
+             INSERT INTO budget_groups
+             (id, name, key, color, icon, sort_order, is_system, created_at, updated_at)
+             VALUES
+             ('budget-group-custom', 'Custom Budget Group', 'custom-budget-group',
+              '#000000', NULL, 502, 0, '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z');
+             INSERT INTO budget_group_assignments
+             (id, group_id, taxonomy_id, category_id, is_system, created_at, updated_at)
+             VALUES
+             ('budget-assignment-future', 'budget-group-custom', 'spending_categories', 'cat_future_budget',
+              1, '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z'),
+             ('budget-assignment-custom', 'budget-group-custom', 'spending_categories', 'budget-category-custom',
+              0, '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z');
+             INSERT INTO budget_targets
+             (id, period_key, target_type, taxonomy_id, category_id, group_id, amount, created_at, updated_at)
+             VALUES
+             ('budget-target-future', 'default', 'category', 'spending_categories', 'cat_future_budget',
+              NULL, '100', '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z'),
+             ('budget-target-custom', 'default', 'category', 'spending_categories', 'budget-category-custom',
+              NULL, '100', '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z');
+             INSERT INTO budget_rollover_settings
+             (id, target_type, taxonomy_id, category_id, group_id, enabled, start_month, starting_balance, created_at, updated_at)
+             VALUES
+             ('budget-rollover-future', 'category', 'spending_categories', 'cat_future_budget',
+              NULL, 1, '2026-01', '0', '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z'),
+             ('budget-rollover-custom', 'category', 'spending_categories', 'budget-category-custom',
+              NULL, 1, '2026-01', '0', '2026-02-12T00:00:00Z', '2026-02-12T00:00:00Z')",
+        )
+        .expect("insert budget dependency rows");
+
+        let payload = repo
+            .export_snapshot_sqlite_image(vec![
+                "budget_groups".to_string(),
+                "taxonomy_categories".to_string(),
+                "budget_group_assignments".to_string(),
+                "budget_targets".to_string(),
+                "budget_rollover_settings".to_string(),
+            ])
+            .await
+            .expect("export budget snapshot");
+
+        let exported_dir = tempdir().expect("tempdir");
+        let exported_path = exported_dir.path().join("budget-snapshot.db");
+        std::fs::write(&exported_path, payload).expect("write snapshot db");
+
+        let (restore_pool, restore_writer) = setup_db();
+        let restore_repo = AppSyncRepository::new(restore_pool.clone(), restore_writer);
+        restore_repo
+            .restore_snapshot_tables_from_file(
+                exported_path.to_string_lossy().to_string(),
+                vec![
+                    "budget_group_assignments".to_string(),
+                    "budget_targets".to_string(),
+                    "budget_rollover_settings".to_string(),
+                    "taxonomy_categories".to_string(),
+                    "budget_groups".to_string(),
+                ],
+                204,
+                "device-budget-dependencies".to_string(),
+                Some(1),
+            )
+            .await
+            .expect("restore budget snapshot");
+
+        let mut restore_conn = get_connection(&restore_pool).expect("conn");
+        let custom_assignment_count: CountRow = diesel::sql_query(
+            "SELECT COUNT(*) AS c
+             FROM budget_group_assignments
+             WHERE id = 'budget-assignment-custom'",
+        )
+        .get_result(&mut restore_conn)
+        .expect("count custom budget assignment");
+        assert_eq!(custom_assignment_count.c, 1);
+
+        let missing_dependency_rows: CountRow = diesel::sql_query(
+            "SELECT COUNT(*) AS c FROM budget_group_assignments WHERE id = 'budget-assignment-future'
+             UNION ALL
+             SELECT COUNT(*) AS c FROM budget_targets WHERE id = 'budget-target-future'
+             UNION ALL
+             SELECT COUNT(*) AS c FROM budget_rollover_settings WHERE id = 'budget-rollover-future'",
+        )
+        .get_results::<CountRow>(&mut restore_conn)
+        .expect("count skipped budget rows")
+        .into_iter()
+        .fold(CountRow { c: 0 }, |mut acc, row| {
+            acc.c += row.c;
+            acc
+        });
+        assert_eq!(missing_dependency_rows.c, 0);
     }
 
     #[tokio::test]

--- a/crates/storage-sqlite/src/sync/app_sync/repository.rs
+++ b/crates/storage-sqlite/src/sync/app_sync/repository.rs
@@ -1188,9 +1188,12 @@ fn json_value_to_sql_literal(value: &serde_json::Value) -> String {
 
 fn restore_sql_error(phase: &str, table: &str, err: diesel::result::Error) -> Error {
     let core_error: Error = StorageError::from(err).into();
-    Error::Database(DatabaseError::Internal(format!(
-        "Snapshot restore {phase} failed for table '{table}': {core_error}"
-    )))
+    let message = format!("Snapshot restore {phase} failed for table={table}: {core_error}");
+    if is_foreign_key_error_message(&message) {
+        Error::Database(DatabaseError::ForeignKeyViolation(message))
+    } else {
+        Error::Database(DatabaseError::Internal(message))
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -6783,8 +6786,8 @@ mod tests {
                 .get_result(&mut exported_conn)
                 .expect("count snapshot rows");
         assert_eq!(
-            snapshot_count.c, 2,
-            "manual + broker snapshots should export"
+            snapshot_count.c, 1,
+            "manual snapshots should export; broker snapshots stay local"
         );
 
         let broker_count: CountRow = diesel::sql_query(
@@ -6792,7 +6795,7 @@ mod tests {
         )
         .get_result(&mut exported_conn)
         .expect("count broker snapshots");
-        assert_eq!(broker_count.c, 1, "broker snapshots should be included");
+        assert_eq!(broker_count.c, 0, "broker snapshots should not export");
 
         let calculated_count: CountRow = diesel::sql_query(
             "SELECT COUNT(*) AS c FROM holdings_snapshots WHERE source = 'CALCULATED'",
@@ -7891,7 +7894,7 @@ mod tests {
                     "accountId": "acc-sync-snap",
                     "snapshotDate": "2026-01-01",
                     "currency": "USD",
-                    "positions": "{\"asset-sync-snap-new\":{\"assetId\":\"asset-sync-snap-new\",\"quantity\":\"7\",\"averageCost\":\"110\",\"totalCostBasis\":\"770\",\"currency\":\"USD\",\"inceptionDate\":\"2026-01-01T00:00:00Z\",\"contractMultiplier\":\"1\",\"createdAt\":\"2026-01-01T00:00:00Z\",\"lastUpdated\":\"2026-01-01T00:00:00Z\"}}",
+                    "positions": "{\"asset-sync-snap-new\":{\"id\":\"POS-asset-sync-snap-new-acc-sync-snap\",\"accountId\":\"acc-sync-snap\",\"assetId\":\"asset-sync-snap-new\",\"quantity\":\"7\",\"averageCost\":\"110\",\"totalCostBasis\":\"770\",\"currency\":\"USD\",\"inceptionDate\":\"2026-01-01T00:00:00Z\",\"contractMultiplier\":\"1\",\"createdAt\":\"2026-01-01T00:00:00Z\",\"lastUpdated\":\"2026-01-01T00:00:00Z\"}}",
                     "cashBalances": "{}",
                     "costBasis": "0",
                     "netContribution": "0",

--- a/crates/storage-sqlite/src/sync/app_sync/repository.rs
+++ b/crates/storage-sqlite/src/sync/app_sync/repository.rs
@@ -9,7 +9,9 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, OnceLock};
 use uuid::Uuid;
 
+use wealthfolio_core::constants::DECIMAL_PRECISION;
 use wealthfolio_core::errors::{DatabaseError, Error, Result};
+use wealthfolio_core::portfolio::snapshot::Position;
 use wealthfolio_core::sync::{
     should_apply_lww, SyncEngineStatus, SyncEntity, SyncEntityMetadata, SyncOperation,
     SyncOutboxEvent, SyncOutboxStatus, APP_SYNC_TABLES,
@@ -152,6 +154,7 @@ const ROWS_WITH_USER_SYNCABLE_ACTIVITY_FILTER_SQL: &str = "\
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SyncRowFilter {
     UserSyncableHoldingsSnapshots,
+    UserSyncableSnapshotPositions,
     ManualQuotes,
     UserImportRuns,
     UserSyncableActivities,
@@ -162,6 +165,9 @@ enum SyncRowFilter {
     SyncableTaxonomyCategories,
     UserModifiedBudgetGroups,
     UserModifiedBudgetGroupAssignments,
+    BudgetGroupAssignmentsWithExistingDependencies,
+    BudgetTargetsWithExistingDependencies,
+    BudgetRolloverSettingsWithExistingDependencies,
     UserModifiedSpendingEventTypes,
     OverwriteRiskAccounts,
     OverwriteRiskPlatforms,
@@ -174,7 +180,14 @@ impl SyncRowFilter {
     fn sql(self) -> &'static str {
         match self {
             Self::UserSyncableHoldingsSnapshots => {
-                "account_id IN (SELECT id FROM accounts) AND source IN ('MANUAL_ENTRY', 'CSV_IMPORT', 'SYNTHETIC', 'BROKER_IMPORTED')"
+                "account_id IN (SELECT id FROM accounts) AND source IN ('MANUAL_ENTRY', 'CSV_IMPORT', 'SYNTHETIC')"
+            }
+            Self::UserSyncableSnapshotPositions => {
+                "snapshot_id IN (
+                    SELECT id FROM holdings_snapshots
+                    WHERE account_id IN (SELECT id FROM accounts)
+                      AND source IN ('MANUAL_ENTRY', 'CSV_IMPORT', 'SYNTHETIC')
+                )"
             }
             Self::ManualQuotes => "source = 'MANUAL'",
             Self::UserImportRuns => {
@@ -190,10 +203,44 @@ impl SyncRowFilter {
             Self::UserTaxonomies => "is_system = 0",
             // Spending/income seed category IDs use the `cat_` prefix; user-created rows use UUIDs.
             Self::SyncableTaxonomyCategories => {
-                "taxonomy_id = 'custom_groups' OR (taxonomy_id IN ('spending_categories', 'income_sources', 'savings_categories') AND id NOT LIKE 'cat_%')"
+                "taxonomy_id = 'custom_groups' \
+                 OR taxonomy_id IN (SELECT id FROM taxonomies WHERE is_system = 0) \
+                 OR (taxonomy_id IN ('spending_categories', 'income_sources', 'savings_categories') AND id NOT LIKE 'cat_%')"
             }
             Self::UserModifiedBudgetGroups | Self::UserModifiedBudgetGroupAssignments => {
                 "is_system = 0 OR updated_at != created_at"
+            }
+            Self::BudgetGroupAssignmentsWithExistingDependencies => {
+                "group_id IN (SELECT id FROM budget_groups) \
+                 AND EXISTS (
+                     SELECT 1 FROM taxonomy_categories AS tc
+                     WHERE tc.taxonomy_id = budget_group_assignments.taxonomy_id
+                       AND tc.id = budget_group_assignments.category_id
+                 )"
+            }
+            Self::BudgetTargetsWithExistingDependencies => {
+                "(target_type = 'category' \
+                    AND taxonomy_id IS NOT NULL \
+                    AND category_id IS NOT NULL \
+                    AND EXISTS (
+                        SELECT 1 FROM taxonomy_categories AS tc
+                        WHERE tc.taxonomy_id = budget_targets.taxonomy_id
+                          AND tc.id = budget_targets.category_id
+                    )) \
+                 OR (target_type = 'group_buffer' \
+                    AND group_id IN (SELECT id FROM budget_groups))"
+            }
+            Self::BudgetRolloverSettingsWithExistingDependencies => {
+                "(target_type = 'category' \
+                    AND taxonomy_id IS NOT NULL \
+                    AND category_id IS NOT NULL \
+                    AND EXISTS (
+                        SELECT 1 FROM taxonomy_categories AS tc
+                        WHERE tc.taxonomy_id = budget_rollover_settings.taxonomy_id
+                          AND tc.id = budget_rollover_settings.category_id
+                    )) \
+                 OR (target_type = 'group' \
+                    AND group_id IN (SELECT id FROM budget_groups))"
             }
             Self::UserModifiedSpendingEventTypes => "key IS NULL OR updated_at != created_at",
             Self::OverwriteRiskAccounts => {
@@ -622,6 +669,10 @@ const SYNC_TABLE_SNAPSHOT_COPY_FILTERS: &[SyncTableFilterSpec] = &[
         filter: SyncRowFilter::UserSyncableHoldingsSnapshots,
     },
     SyncTableFilterSpec {
+        table: "snapshot_positions",
+        filter: SyncRowFilter::UserSyncableSnapshotPositions,
+    },
+    SyncTableFilterSpec {
         table: "quotes",
         filter: SyncRowFilter::ManualQuotes,
     },
@@ -660,6 +711,18 @@ const SYNC_TABLE_SNAPSHOT_COPY_FILTERS: &[SyncTableFilterSpec] = &[
         table: "app_settings",
         filter: SyncRowFilter::SpendingSettings,
     },
+    SyncTableFilterSpec {
+        table: "budget_group_assignments",
+        filter: SyncRowFilter::BudgetGroupAssignmentsWithExistingDependencies,
+    },
+    SyncTableFilterSpec {
+        table: "budget_targets",
+        filter: SyncRowFilter::BudgetTargetsWithExistingDependencies,
+    },
+    SyncTableFilterSpec {
+        table: "budget_rollover_settings",
+        filter: SyncRowFilter::BudgetRolloverSettingsWithExistingDependencies,
+    },
     // Drop legacy orphan membership rows at snapshot boundaries. Portfolio
     // settings remains the user-facing repair surface for the source DB.
     SyncTableFilterSpec {
@@ -672,6 +735,10 @@ const SYNC_TABLE_SNAPSHOT_CLEAR_FILTERS: &[SyncTableFilterSpec] = &[
     SyncTableFilterSpec {
         table: "holdings_snapshots",
         filter: SyncRowFilter::UserSyncableHoldingsSnapshots,
+    },
+    SyncTableFilterSpec {
+        table: "snapshot_positions",
+        filter: SyncRowFilter::UserSyncableSnapshotPositions,
     },
     SyncTableFilterSpec {
         table: "quotes",
@@ -704,6 +771,18 @@ const SYNC_TABLE_SNAPSHOT_CLEAR_FILTERS: &[SyncTableFilterSpec] = &[
     SyncTableFilterSpec {
         table: "app_settings",
         filter: SyncRowFilter::SpendingSettings,
+    },
+    SyncTableFilterSpec {
+        table: "budget_group_assignments",
+        filter: SyncRowFilter::BudgetGroupAssignmentsWithExistingDependencies,
+    },
+    SyncTableFilterSpec {
+        table: "budget_targets",
+        filter: SyncRowFilter::BudgetTargetsWithExistingDependencies,
+    },
+    SyncTableFilterSpec {
+        table: "budget_rollover_settings",
+        filter: SyncRowFilter::BudgetRolloverSettingsWithExistingDependencies,
     },
 ];
 
@@ -738,6 +817,158 @@ fn delete_orphan_snapshot_rows(conn: &mut SqliteConnection) -> Result<()> {
     )
     .execute(conn)
     .map_err(StorageError::from)?;
+
+    Ok(())
+}
+
+fn reset_restore_dependent_read_models(
+    conn: &mut SqliteConnection,
+    table_set: &HashSet<String>,
+) -> Result<()> {
+    if table_set.contains("snapshot_positions")
+        || table_set.contains("holdings_snapshots")
+        || table_set.contains("assets")
+    {
+        diesel::sql_query("DELETE FROM snapshot_positions")
+            .execute(conn)
+            .map_err(StorageError::from)?;
+    }
+
+    if table_set.contains("accounts")
+        || table_set.contains("assets")
+        || table_set.contains("activities")
+    {
+        for table in ["lot_disposals", "lots", "daily_account_valuation"] {
+            diesel::sql_query(format!("DELETE FROM {}", quote_identifier(table)))
+                .execute(conn)
+                .map_err(StorageError::from)?;
+        }
+    }
+
+    Ok(())
+}
+
+fn deserialize_snapshot_positions_payload(
+    positions_json: &str,
+    account_id: &str,
+) -> HashMap<String, Position> {
+    if positions_json.is_empty() || positions_json == "{}" {
+        return HashMap::new();
+    }
+
+    match serde_json::from_str::<HashMap<String, Position>>(positions_json) {
+        Ok(mut positions) => {
+            for position in positions.values_mut() {
+                if position.account_id.is_empty() {
+                    position.account_id = account_id.to_string();
+                }
+            }
+            positions
+        }
+        Err(err) => {
+            log::warn!(
+                "Leaving snapshot_positions empty because synced positions JSON could not be decoded (account {}): {}",
+                account_id,
+                err
+            );
+            HashMap::new()
+        }
+    }
+}
+
+fn rebuild_snapshot_positions_from_snapshot_row_tx(
+    conn: &mut SqliteConnection,
+    snapshot_id_value: &str,
+) -> Result<()> {
+    use crate::schema::assets::dsl as asset_dsl;
+    use crate::schema::holdings_snapshots::dsl as snapshot_dsl;
+    use crate::schema::snapshot_positions::dsl as position_dsl;
+
+    let snapshot_row = snapshot_dsl::holdings_snapshots
+        .select((snapshot_dsl::account_id, snapshot_dsl::positions))
+        .filter(snapshot_dsl::id.eq(snapshot_id_value))
+        .first::<(String, String)>(conn)
+        .optional()
+        .map_err(StorageError::from)?;
+
+    diesel::delete(
+        position_dsl::snapshot_positions.filter(position_dsl::snapshot_id.eq(snapshot_id_value)),
+    )
+    .execute(conn)
+    .map_err(StorageError::from)?;
+
+    let Some((account_id, positions_json)) = snapshot_row else {
+        return Ok(());
+    };
+
+    let positions = deserialize_snapshot_positions_payload(&positions_json, &account_id);
+    if positions.is_empty() {
+        return Ok(());
+    }
+
+    let requested_asset_ids = positions
+        .values()
+        .map(|position| position.asset_id.clone())
+        .collect::<HashSet<_>>();
+    let requested_asset_ids_vec = requested_asset_ids.iter().cloned().collect::<Vec<_>>();
+    let existing_asset_ids = asset_dsl::assets
+        .select(asset_dsl::id)
+        .filter(asset_dsl::id.eq_any(&requested_asset_ids_vec))
+        .load::<String>(conn)
+        .map_err(StorageError::from)?
+        .into_iter()
+        .collect::<HashSet<_>>();
+
+    if existing_asset_ids.len() != requested_asset_ids.len() {
+        let missing = requested_asset_ids
+            .difference(&existing_asset_ids)
+            .cloned()
+            .collect::<Vec<_>>();
+        log::warn!(
+            "Leaving snapshot_positions empty for snapshot {} because synced positions reference missing assets: {:?}",
+            snapshot_id_value,
+            missing
+        );
+        return Ok(());
+    }
+
+    for position in positions.values() {
+        let insert_sql = format!(
+            "INSERT INTO snapshot_positions (
+                snapshot_id, asset_id, quantity, average_cost, total_cost_basis,
+                currency, inception_date, is_alternative, contract_multiplier,
+                created_at, last_updated
+            ) VALUES (
+                '{}', '{}', '{}', '{}', '{}',
+                '{}', '{}', {}, '{}',
+                '{}', '{}'
+            )",
+            escape_sqlite_str(snapshot_id_value),
+            escape_sqlite_str(&position.asset_id),
+            escape_sqlite_str(&position.quantity.round_dp(DECIMAL_PRECISION).to_string()),
+            escape_sqlite_str(
+                &position
+                    .average_cost
+                    .round_dp(DECIMAL_PRECISION)
+                    .to_string()
+            ),
+            escape_sqlite_str(
+                &position
+                    .total_cost_basis
+                    .round_dp(DECIMAL_PRECISION)
+                    .to_string()
+            ),
+            escape_sqlite_str(&position.currency),
+            escape_sqlite_str(&position.inception_date.to_rfc3339()),
+            if position.is_alternative { 1 } else { 0 },
+            escape_sqlite_str(&position.contract_multiplier.to_string()),
+            escape_sqlite_str(&position.created_at.to_rfc3339()),
+            escape_sqlite_str(&position.last_updated.to_rfc3339())
+        );
+        diesel::sql_query(insert_sql)
+            .execute(conn)
+            .map_err(StorageError::from)?;
+    }
 
     Ok(())
 }
@@ -955,14 +1186,11 @@ fn json_value_to_sql_literal(value: &serde_json::Value) -> String {
     }
 }
 
-fn snapshot_restore_error(table: &str, err: StorageError) -> Error {
-    let error: Error = err.into();
-    let message = format!("Snapshot restore failed for table={table}: {error}");
-    if is_foreign_key_error_message(&message) {
-        Error::Database(DatabaseError::ForeignKeyViolation(message))
-    } else {
-        Error::Database(DatabaseError::Internal(message))
-    }
+fn restore_sql_error(phase: &str, table: &str, err: diesel::result::Error) -> Error {
+    let core_error: Error = StorageError::from(err).into();
+    Error::Database(DatabaseError::Internal(format!(
+        "Snapshot restore {phase} failed for table '{table}': {core_error}"
+    )))
 }
 
 #[derive(Debug, Clone)]
@@ -1854,27 +2082,9 @@ fn apply_remote_event_lww_tx(
                             .map_err(StorageError::from)?;
                     }
 
-                    // Side effect for SyncEntity::Snapshot: an `ON CONFLICT
-                    // DO UPDATE` updates `holdings_snapshots.positions` JSON
-                    // in place without firing the FK CASCADE that would
-                    // otherwise wipe `snapshot_positions` rows. Without a
-                    // hook here, the relational table keeps the receiving
-                    // device's *old* positions while the JSON column has
-                    // the synced ones, and `get_snapshot_positions` (which
-                    // prefers the relational table over the JSON fallback)
-                    // returns stale data forever.
-                    //
-                    // Drop the relational rows for the affected snapshot.
-                    // The next read falls back to the just-synced JSON;
-                    // the next local snapshot write rebuilds the relational
-                    // rows via `write_snapshot_positions`. A heavier "parse
-                    // JSON and reinsert here" fix is deferred to Phase B's
-                    // read-path switchover.
                     if applied_entity_change && matches!(entity, SyncEntity::Snapshot) {
-                        diesel::sql_query("DELETE FROM snapshot_positions WHERE snapshot_id = ?")
-                            .bind::<diesel::sql_types::Text, _>(entity_id_value.clone())
-                            .execute(conn)
-                            .map_err(StorageError::from)?;
+                        rebuild_snapshot_positions_from_snapshot_row_tx(conn, &entity_id_value)?;
+                        mark_table_incremental_applied_tx(conn, "snapshot_positions")?;
                     }
                 }
             }
@@ -2951,6 +3161,7 @@ impl AppSyncRepository {
         self.writer
             .exec(move |conn| {
                 let table_set = canonical_sync_table_set(tables)?;
+                let table_set_lookup = table_set.iter().cloned().collect::<HashSet<_>>();
 
                 let now = Utc::now().to_rfc3339();
                 let escaped_path = escape_sqlite_str(&snapshot_db_path);
@@ -2987,6 +3198,8 @@ impl AppSyncRepository {
                     )
                     .execute(conn)
                     .map_err(StorageError::from)?;
+
+                    reset_restore_dependent_read_models(conn, &table_set_lookup)?;
 
                     struct RestorePlan {
                         table: String,
@@ -3055,7 +3268,7 @@ impl AppSyncRepository {
                     for plan in restore_plans.iter().rev() {
                         diesel::sql_query(&plan.clear_sql)
                             .execute(conn)
-                            .map_err(StorageError::from)?;
+                            .map_err(|err| restore_sql_error("clear", &plan.table, err))?;
                         if plan.table == "holdings_snapshots" {
                             delete_orphan_snapshot_rows(conn)?;
                         }
@@ -3064,7 +3277,7 @@ impl AppSyncRepository {
                     for plan in &restore_plans {
                         diesel::sql_query(&plan.copy_sql)
                             .execute(conn)
-                            .map_err(|err| snapshot_restore_error(&plan.table, err.into()))?;
+                            .map_err(|err| restore_sql_error("copy", &plan.table, err))?;
 
                         let state_row = SyncTableStateDB {
                             table_name: plan.table.clone(),
@@ -3206,6 +3419,7 @@ mod tests {
         let filter = snapshot_copy_filter_for_table("taxonomy_categories").expect("filter");
 
         assert!(filter.contains("custom_groups"));
+        assert!(filter.contains("SELECT id FROM taxonomies WHERE is_system = 0"));
         assert!(filter.contains("spending_categories"));
         assert!(filter.contains("income_sources"));
         assert!(filter.contains("savings_categories"));
@@ -7603,16 +7817,20 @@ mod tests {
     }
 
     /// Regression: sync upsert on `holdings_snapshots` updates the JSON
-    /// `positions` column in place, but doesn't touch the relational
-    /// `snapshot_positions` rows. Without the explicit DELETE hook,
-    /// `get_snapshot_positions` would return the receiving device's *old*
-    /// relational rows forever, masking the synced JSON.
+    /// `positions` column in place, but SQLite does not cascade-update the
+    /// sibling `snapshot_positions` rows. Replay must rebuild the relational
+    /// rows so reads do not keep returning the receiving device's old state.
     #[tokio::test]
-    async fn replay_snapshot_clears_stale_snapshot_positions() {
+    async fn replay_snapshot_rebuilds_stale_snapshot_positions() {
         #[derive(diesel::QueryableByName)]
         struct CountRow {
             #[diesel(sql_type = diesel::sql_types::BigInt)]
             c: i64,
+        }
+        #[derive(diesel::QueryableByName)]
+        struct AssetIdRow {
+            #[diesel(sql_type = diesel::sql_types::Text)]
+            asset_id: String,
         }
 
         let (pool, writer) = setup_db();
@@ -7689,8 +7907,8 @@ mod tests {
         assert!(applied, "snapshot update event must apply");
 
         let mut conn = get_connection(&pool).expect("conn");
-        // The relational rows for the snapshot must be wiped — read paths
-        // will fall back to the freshly-synced JSON.
+        // The relational rows for the snapshot must be rebuilt from the
+        // freshly synced JSON, not left pointing at the old local asset.
         let after: CountRow = diesel::sql_query(format!(
             "SELECT COUNT(*) AS c FROM snapshot_positions WHERE snapshot_id = '{}'",
             snap_id
@@ -7698,8 +7916,15 @@ mod tests {
         .get_result(&mut conn)
         .expect("count after");
         assert_eq!(
-            after.c, 0,
-            "stale relational rows must be cleared on sync upsert"
+            after.c, 1,
+            "synced relational rows must be rebuilt on sync upsert"
         );
+        let row: AssetIdRow = diesel::sql_query(format!(
+            "SELECT asset_id FROM snapshot_positions WHERE snapshot_id = '{}'",
+            snap_id
+        ))
+        .get_result(&mut conn)
+        .expect("snapshot position asset");
+        assert_eq!(row.asset_id, "asset-sync-snap-new");
     }
 }

--- a/crates/storage-sqlite/src/sync/mod.rs
+++ b/crates/storage-sqlite/src/sync/mod.rs
@@ -45,14 +45,10 @@ pub fn should_sync_outbox_for_platform(platform_id: &str, external_id: Option<&s
 
 pub fn should_sync_outbox_for_activity(
     source_system: Option<&str>,
-    is_user_modified: bool,
+    _is_user_modified: bool,
     import_run_id: Option<&str>,
     source_record_id: Option<&str>,
 ) -> bool {
-    if is_user_modified {
-        return true;
-    }
-
     let normalized_source = source_system
         .map(str::trim)
         .filter(|value| !value.is_empty())
@@ -65,7 +61,8 @@ pub fn should_sync_outbox_for_activity(
         && source_record_id.is_none_or(|value| value.trim().is_empty())
 }
 
-/// Import runs sync only user-initiated CSV/manual runs, not broker sync runs.
+/// Import runs sync only user-authored CSV/manual imports. Broker run history
+/// and cursors are local state; each device refreshes them from broker APIs.
 pub fn should_sync_outbox_for_import_run(run_type: &str, source_system: &str) -> bool {
     run_type.eq_ignore_ascii_case("IMPORT")
         && (source_system.eq_ignore_ascii_case("CSV")
@@ -129,7 +126,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn activity_outbox_rules_match_manual_and_user_override() {
+    fn activity_outbox_rules_match_local_manual_and_csv_rows() {
         assert!(should_sync_outbox_for_activity(
             Some("MANUAL"),
             false,
@@ -161,7 +158,7 @@ mod tests {
             None,
             Some("provider-1")
         ));
-        assert!(should_sync_outbox_for_activity(
+        assert!(!should_sync_outbox_for_activity(
             Some("SNAPTRADE"),
             true,
             Some("run-1"),
@@ -189,18 +186,14 @@ mod tests {
     }
 
     #[test]
-    fn import_run_outbox_rules_only_sync_user_initiated_runs() {
-        // CSV imports sync
+    fn import_run_outbox_rules_only_sync_user_authored_imports() {
         assert!(should_sync_outbox_for_import_run("IMPORT", "csv"));
         assert!(should_sync_outbox_for_import_run("IMPORT", "CSV"));
-        // Manual imports sync
         assert!(should_sync_outbox_for_import_run("IMPORT", "manual"));
         assert!(should_sync_outbox_for_import_run("IMPORT", "MANUAL"));
-        // Broker sync runs do NOT sync
         assert!(!should_sync_outbox_for_import_run("SYNC", "snaptrade"));
         assert!(!should_sync_outbox_for_import_run("SYNC", "plaid"));
         assert!(!should_sync_outbox_for_import_run("SYNC", "csv"));
-        // Import from broker sources do NOT sync
         assert!(!should_sync_outbox_for_import_run("IMPORT", "snaptrade"));
         assert!(!should_sync_outbox_for_import_run("IMPORT", "plaid"));
     }

--- a/e2e/02-activities.spec.ts
+++ b/e2e/02-activities.spec.ts
@@ -282,10 +282,33 @@ test.describe("Activity Creation Tests", () => {
   }
 
   async function fillAmount(value: number, testId = "amount-input") {
-    const amountInput = page.getByTestId(testId);
+    const amountInput = page.getByRole("dialog", { name: "Add Activity" }).getByTestId(testId);
+    await expect(amountInput).toBeVisible({ timeout: 5000 });
     await amountInput.fill(String(value));
     await amountInput.blur();
-    await page.waitForTimeout(200);
+  }
+
+  async function fillInternalTransferCashAmount(value: number) {
+    const activityDialog = page.getByRole("dialog", { name: "Add Activity" });
+    const sentAmountInput = activityDialog.getByTestId("sent-amount-input");
+    const simpleAmountInput = activityDialog.getByTestId("input-amount");
+
+    await expect(sentAmountInput.or(simpleAmountInput)).toBeVisible({ timeout: 5000 });
+
+    if (await sentAmountInput.isVisible()) {
+      await sentAmountInput.fill(String(value));
+      await sentAmountInput.blur();
+
+      const receivedAmountInput = activityDialog.getByTestId("received-amount-input");
+      if (await receivedAmountInput.isVisible()) {
+        await receivedAmountInput.fill(String(value));
+        await receivedAmountInput.blur();
+      }
+      return;
+    }
+
+    await simpleAmountInput.fill(String(value));
+    await simpleAmountInput.blur();
   }
 
   async function fillQuantity(value: number) {
@@ -649,7 +672,7 @@ test.describe("Activity Creation Tests", () => {
     await selectAccount("Test CAD Account", "CAD", "To Account");
 
     await selectDate();
-    await fillAmount(transfer.amount);
+    await fillInternalTransferCashAmount(transfer.amount);
     await fillNotes(transfer.notes);
 
     await submitActivity("Transfer");

--- a/packages/ui/src/components/ui/page.tsx
+++ b/packages/ui/src/components/ui/page.tsx
@@ -20,8 +20,7 @@ interface PageScrollContainerProps extends React.HTMLAttributes<HTMLDivElement> 
   withMobileNavOffset?: boolean;
 }
 
-const MOBILE_NAV_SCROLL_OFFSET =
-  "calc(var(--mobile-nav-ui-height) + max(var(--mobile-nav-gap), env(safe-area-inset-bottom)))";
+const MOBILE_NAV_SCROLL_OFFSET = "var(--mobile-nav-total-offset)";
 
 export const PageScrollContainer = React.forwardRef<HTMLDivElement, PageScrollContainerProps>(
   function PageScrollContainer({ className, children, withMobileNavOffset = false, style, ...props }, ref) {

--- a/packages/ui/src/components/ui/swipable-view.tsx
+++ b/packages/ui/src/components/ui/swipable-view.tsx
@@ -25,6 +25,7 @@ export interface SwipableViewItem {
 export interface SwipableViewProps {
   items: SwipableViewItem[];
   displayToggle?: boolean;
+  withMobileNavOffset?: boolean;
   className?: string;
   dotClassName?: string;
   labelClassName?: string;
@@ -44,6 +45,7 @@ export interface SwipableViewProps {
 export function SwipableView({
   items,
   displayToggle = false,
+  withMobileNavOffset = false,
   className,
   dotClassName,
   labelClassName,
@@ -178,7 +180,12 @@ export function SwipableView({
                  2. This ensures the Header stays fixed while content scrolls.
                  3. touch-pan-y allows vertical scrolling while horizontal swipes trigger the carousel.
                */}
-              <div className="h-full w-full overflow-y-auto overflow-x-hidden">
+              <div
+                className={cn(
+                  "h-full w-full overflow-y-auto overflow-x-hidden",
+                  withMobileNavOffset && "scroll-pb-nav pb-[var(--mobile-nav-total-offset)]",
+                )}
+              >
                 {shouldRender(index) ? (
                   item.content
                 ) : (


### PR DESCRIPTION
## Summary

- Fixes the device sync bootstrap prompt flow so completing pairing with overwrite does not reopen the global ready-state replace dialog.
- Tightens overwrite-risk detection for local broker-derived data by excluding rehydratable broker rows while still counting user-created sidecars.
- Keeps the activity URL/type-filter behavior, AI Assistant badge removal, chart/rebalance formatting fixes, and related E2E/test updates from the rebase work.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p wealthfolio-storage-sqlite overwrite_risk_summary_ignores_broker_rehydratable_accounts -- --nocapture`
- `cargo test -p wealthfolio-storage-sqlite overwrite_risk_summary_counts_manual_broker_activity_sidecars -- --nocapture`
- `cargo test -p wealthfolio-storage-sqlite overwrite_risk_summary_counts_user_curated_sync_tables -- --nocapture`
- `pnpm --filter frontend type-check`
- `pnpm --filter frontend exec eslint src/features/devices-sync/components/device-sync-section.tsx src/features/devices-sync/components/device-sync-section.test.tsx --quiet`
- `pnpm exec prettier --check apps/frontend/src/features/devices-sync/components/device-sync-section.tsx apps/frontend/src/features/devices-sync/components/device-sync-section.test.tsx`
- `git diff --check`

## Notes

`pnpm --filter frontend exec vitest run src/features/devices-sync/components/device-sync-section.test.tsx` is currently blocked before tests execute by the local Vitest/jsdom ESM loader error: `ERR_REQUIRE_ESM` from `html-encoding-sniffer` / `@exodus/bytes`.