### PR TITLE
Fix allocation rebalance scope parity

### DIFF
--- a/apps/server/src/api/allocation_targets.rs
+++ b/apps/server/src/api/allocation_targets.rs
@@ -9,6 +9,7 @@ use axum::{
 use rust_decimal::Decimal;
 use serde::Deserialize;
 use wealthfolio_core::{
+    accounts::AccountPurpose,
     portfolio::allocation_targets::{
         AllocationTarget, AllocationTargetWeight, CalculateRebalancePlanInput, DriftReport,
         NewAllocationTarget, NewAllocationTargetWeight, RebalancePlan, SaveAllocationTargetResult,
@@ -18,7 +19,6 @@ use wealthfolio_core::{
 };
 
 use crate::{
-    api::shared::holdings_account_ids,
     error::{ApiError, ApiResult},
     main_lib::AppState,
 };
@@ -171,17 +171,15 @@ async fn get_drift_for_target(
     let filter = account_scope_for_target(&target)?;
     let resolved = state
         .portfolio_service
-        .resolve_account_scope(&filter, &base_currency)
+        .resolve_account_scope_for_purpose(&filter, &base_currency, AccountPurpose::Holdings)
         .map_err(crate::error::ApiError::from)?;
-
-    let account_ids = holdings_account_ids(&state, &resolved.account_ids)?;
 
     let report = if body.include_holdings {
         state
             .drift_service
             .get_drift_report_with_holdings_for_target(
                 &target_id,
-                &account_ids,
+                &resolved.account_ids,
                 &base_currency,
                 &resolved.scope_id,
             )
@@ -191,7 +189,7 @@ async fn get_drift_for_target(
             .drift_service
             .get_drift_report_for_target(
                 &target_id,
-                &account_ids,
+                &resolved.account_ids,
                 &base_currency,
                 &resolved.scope_id,
             )
@@ -222,7 +220,7 @@ fn resolve_rebalance_input(
     let base_currency = state.base_currency.read().unwrap().clone();
     let resolved = state
         .portfolio_service
-        .resolve_account_scope(filter, &base_currency)
+        .resolve_account_scope_for_purpose(filter, &base_currency, AccountPurpose::Holdings)
         .map_err(crate::error::ApiError::from)?;
     Ok(CalculateRebalancePlanInput {
         target_id,

--- a/apps/tauri/src/commands/allocation_targets.rs
+++ b/apps/tauri/src/commands/allocation_targets.rs
@@ -4,6 +4,7 @@ use tauri::State;
 
 use rust_decimal::Decimal;
 use wealthfolio_core::{
+    accounts::AccountPurpose,
     portfolio::allocation_targets::{
         AllocationTarget, AllocationTargetWeight, CalculateRebalancePlanInput, DriftReport,
         NewAllocationTarget, NewAllocationTargetWeight, RebalancePlan, SaveAllocationTargetResult,
@@ -14,7 +15,7 @@ use wealthfolio_core::{
 
 use crate::context::ServiceContext;
 
-use super::portfolio::{holdings_account_ids, AccountScopeInput};
+use super::portfolio::AccountScopeInput;
 
 fn scope_id_for_target(target: &AllocationTarget) -> Result<String, String> {
     target
@@ -171,21 +172,21 @@ pub async fn get_allocation_target_drift(
         .ok_or_else(|| format!("AllocationTarget {} not found", target_id))?;
     let filter = account_scope_for_target(&target)?;
 
-    let resolved = wealthfolio_core::portfolios::PortfolioServiceTrait::resolve_account_scope(
-        state.portfolio_service.as_ref(),
-        &filter,
-        &base_currency,
-    )
-    .map_err(|e| e.to_string())?;
-
-    let account_ids = holdings_account_ids(&state, &resolved.account_ids)?;
+    let resolved =
+        wealthfolio_core::portfolios::PortfolioServiceTrait::resolve_account_scope_for_purpose(
+            state.portfolio_service.as_ref(),
+            &filter,
+            &base_currency,
+            AccountPurpose::Holdings,
+        )
+        .map_err(|e| e.to_string())?;
 
     if include_holdings.unwrap_or(false) {
         state
             .drift_service()
             .get_drift_report_with_holdings_for_target(
                 &target_id,
-                &account_ids,
+                &resolved.account_ids,
                 &base_currency,
                 &resolved.scope_id,
             )
@@ -196,7 +197,7 @@ pub async fn get_allocation_target_drift(
             .drift_service()
             .get_drift_report_for_target(
                 &target_id,
-                &account_ids,
+                &resolved.account_ids,
                 &base_currency,
                 &resolved.scope_id,
             )
@@ -216,20 +217,18 @@ fn resolve_rebalance_input(
 ) -> Result<CalculateRebalancePlanInput, String> {
     let filter = filter.into_account_filter()?;
     let base_currency = state.get_base_currency();
-    let resolved = wealthfolio_core::portfolios::PortfolioServiceTrait::resolve_account_scope(
-        state.portfolio_service.as_ref(),
-        &filter,
-        &base_currency,
-    )
-    .map_err(|e| e.to_string())?;
-    // Scope cash/holdings to the same accounts the holdings view uses (excludes
-    // non-Holdings accounts like credit cards), so tracked cash matches what the
-    // frontend reads from `get_holdings`.
-    let account_ids = holdings_account_ids(state, &resolved.account_ids)?;
+    let resolved =
+        wealthfolio_core::portfolios::PortfolioServiceTrait::resolve_account_scope_for_purpose(
+            state.portfolio_service.as_ref(),
+            &filter,
+            &base_currency,
+            AccountPurpose::Holdings,
+        )
+        .map_err(|e| e.to_string())?;
     Ok(CalculateRebalancePlanInput {
         target_id,
         available_cash,
-        account_ids,
+        account_ids: resolved.account_ids,
         base_currency,
         aggregated_account_id: resolved.scope_id,
         scenario_mode,

--- a/crates/core/src/portfolios/portfolios_service.rs
+++ b/crates/core/src/portfolios/portfolios_service.rs
@@ -4,7 +4,7 @@ use super::portfolios_model::{
     AccountScope, NewPortfolio, PortfolioUpdate, PortfolioWithAccounts, ResolvedAccountScope,
 };
 use super::portfolios_traits::{PortfolioRepositoryTrait, PortfolioServiceTrait};
-use crate::accounts::AccountRepositoryTrait;
+use crate::accounts::{account_supports_purpose, AccountPurpose, AccountRepositoryTrait};
 use crate::errors::{DatabaseError, Result, ValidationError};
 use crate::Error;
 
@@ -138,5 +138,31 @@ impl PortfolioServiceTrait for PortfolioService {
             account_ids: ids,
             base_currency: base_currency.to_string(),
         })
+    }
+
+    fn resolve_account_scope_for_purpose(
+        &self,
+        filter: &AccountScope,
+        base_currency: &str,
+        purpose: AccountPurpose,
+    ) -> Result<ResolvedAccountScope> {
+        let mut resolved = self.resolve_account_scope(filter, base_currency)?;
+        if resolved.account_ids.is_empty() {
+            return Ok(resolved);
+        }
+
+        let accounts = self
+            .account_repository
+            .list(None, None, Some(&resolved.account_ids))?;
+        let eligible_ids: HashSet<String> = accounts
+            .into_iter()
+            .filter(|account| account_supports_purpose(&account.account_type, purpose))
+            .map(|account| account.id)
+            .collect();
+
+        resolved
+            .account_ids
+            .retain(|account_id| eligible_ids.contains(account_id));
+        Ok(resolved)
     }
 }

--- a/crates/core/src/portfolios/portfolios_service_tests.rs
+++ b/crates/core/src/portfolios/portfolios_service_tests.rs
@@ -4,7 +4,10 @@ mod tests {
     use chrono::NaiveDateTime;
     use std::sync::{Arc, Mutex};
 
-    use crate::accounts::{Account, AccountRepositoryTrait, AccountUpdate, NewAccount};
+    use crate::accounts::{
+        account_types, Account, AccountPurpose, AccountRepositoryTrait, AccountUpdate, NewAccount,
+        TrackingMode,
+    };
     use crate::errors::{DatabaseError, Error, Result};
     use crate::portfolios::{
         AccountScope, NewPortfolio, PortfolioRepositoryTrait, PortfolioService,
@@ -106,29 +109,37 @@ mod tests {
 
     impl MockAccountRepo {
         fn with_ids(ids: &[&str]) -> Self {
-            let dt = NaiveDateTime::default();
             let accounts = ids
                 .iter()
-                .map(|id| Account {
-                    id: id.to_string(),
-                    name: id.to_string(),
-                    account_type: "SECURITIES".to_string(),
-                    group: None,
-                    currency: "USD".to_string(),
-                    is_default: false,
-                    is_active: true,
-                    created_at: dt,
-                    updated_at: dt,
-                    platform_id: None,
-                    account_number: None,
-                    meta: None,
-                    provider: None,
-                    provider_account_id: None,
-                    is_archived: false,
-                    tracking_mode: Default::default(),
-                })
+                .map(|id| mock_account(id, account_types::SECURITIES, TrackingMode::Transactions))
                 .collect();
+            Self::with_accounts(accounts)
+        }
+
+        fn with_accounts(accounts: Vec<Account>) -> Self {
             Self { accounts }
+        }
+    }
+
+    fn mock_account(id: &str, account_type: &str, tracking_mode: TrackingMode) -> Account {
+        let dt = NaiveDateTime::default();
+        Account {
+            id: id.to_string(),
+            name: id.to_string(),
+            account_type: account_type.to_string(),
+            group: None,
+            currency: "USD".to_string(),
+            is_default: false,
+            is_active: true,
+            created_at: dt,
+            updated_at: dt,
+            platform_id: None,
+            account_number: None,
+            meta: None,
+            provider: None,
+            provider_account_id: None,
+            is_archived: false,
+            tracking_mode,
         }
     }
 
@@ -337,5 +348,62 @@ mod tests {
             .unwrap();
         assert_eq!(scope.scope_id, "portfolio:empty");
         assert!(scope.account_ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn resolve_account_scope_for_purpose_filters_by_account_capability() {
+        let svc = PortfolioService::new(
+            Arc::new(MockPortfolioRepo::default()),
+            Arc::new(MockAccountRepo::with_accounts(vec![
+                mock_account(
+                    "security-holdings",
+                    account_types::SECURITIES,
+                    TrackingMode::Holdings,
+                ),
+                mock_account(
+                    "security-transactions",
+                    account_types::SECURITIES,
+                    TrackingMode::Transactions,
+                ),
+                mock_account("cash", account_types::CASH, TrackingMode::Transactions),
+                mock_account(
+                    "crypto",
+                    account_types::CRYPTOCURRENCY,
+                    TrackingMode::Holdings,
+                ),
+                mock_account(
+                    "card",
+                    account_types::CREDIT_CARD,
+                    TrackingMode::Transactions,
+                ),
+            ])),
+        );
+        let filter = AccountScope::Accounts {
+            account_ids: vec![
+                "security-transactions".to_string(),
+                "card".to_string(),
+                "crypto".to_string(),
+                "security-holdings".to_string(),
+                "cash".to_string(),
+                "security-transactions".to_string(),
+            ],
+        };
+
+        let unfiltered = svc.resolve_account_scope(&filter, "CAD").unwrap();
+        let filtered = svc
+            .resolve_account_scope_for_purpose(&filter, "CAD", AccountPurpose::Holdings)
+            .unwrap();
+
+        assert_eq!(filtered.scope_id, unfiltered.scope_id);
+        assert_eq!(filtered.base_currency, "CAD");
+        assert_eq!(
+            filtered.account_ids,
+            vec![
+                "cash".to_string(),
+                "crypto".to_string(),
+                "security-holdings".to_string(),
+                "security-transactions".to_string(),
+            ]
+        );
     }
 }

--- a/crates/core/src/portfolios/portfolios_traits.rs
+++ b/crates/core/src/portfolios/portfolios_traits.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use super::portfolios_model::{
     AccountScope, NewPortfolio, PortfolioUpdate, PortfolioWithAccounts, ResolvedAccountScope,
 };
+use crate::accounts::AccountPurpose;
 use crate::errors::Result;
 
 #[async_trait]
@@ -59,6 +60,14 @@ pub trait PortfolioServiceTrait: Send + Sync {
             base_currency: base_currency.to_string(),
         })
     }
+
+    /// Resolve an AccountScope and keep only accounts eligible for a product surface.
+    fn resolve_account_scope_for_purpose(
+        &self,
+        filter: &AccountScope,
+        base_currency: &str,
+        purpose: AccountPurpose,
+    ) -> Result<ResolvedAccountScope>;
 
     /// Resolve an AccountScope into its runtime reporting form using the app
     /// default base currency. Prefer `resolve_account_scope` where the current


### PR DESCRIPTION
## Summary
- add a purpose-aware account scope resolver in core
- use `AccountPurpose::Holdings` for allocation drift and rebalance in both web and desktop paths
- add coverage for mixed account types and tracking modes

## Why
Web rebalance could resolve a broader account set than desktop/drift because it passed the raw resolved scope into the rebalance service. Allocation should only calculate over holdings-capable accounts: securities, cash, and cryptocurrency accounts, excluding credit cards and other non-holdings accounts.

## Validation
- `cargo test -p wealthfolio-core resolve_account_scope_for_purpose`
- `cargo test -p wealthfolio-core portfolios::portfolios_service_tests`
- `cargo test -p wealthfolio-server allocation_targets`
- `cargo check -p wealthfolio-server`
- `cargo check -p wealthfolio-app`
- `git diff --check`

Note: `cargo check -p wealthfolio` was not run because this workspace has no package named `wealthfolio`; the desktop package is `wealthfolio-app`.