### PR TITLE
feat: add toggle to show expanded/collapsed addon on desktop

### DIFF
--- a/apps/frontend/src/lib/settings-provider.tsx
+++ b/apps/frontend/src/lib/settings-provider.tsx
@@ -18,6 +18,7 @@ interface ExtendedSettingsContextType extends SettingsContextType {
         | "onboardingCompleted"
         | "menuBarVisible"
         | "syncEnabled"
+        | "expandAddon"
       >
     >,
   ) => Promise<void>;
@@ -51,6 +52,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         | "onboardingCompleted"
         | "menuBarVisible"
         | "syncEnabled"
+        | "expandAddon"
       >
     >,
   ) => {

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -819,6 +819,7 @@ export interface Settings {
   autoUpdateCheckEnabled: boolean;
   menuBarVisible: boolean;
   syncEnabled: boolean;
+  expandAddon: boolean;
 }
 
 export interface SettingsContextType {

--- a/apps/frontend/src/pages/dashboard/accounts-summary.test.tsx
+++ b/apps/frontend/src/pages/dashboard/accounts-summary.test.tsx
@@ -99,6 +99,7 @@ const mockSettings: Settings = {
   autoUpdateCheckEnabled: true,
   menuBarVisible: true,
   syncEnabled: false,
+  expandAddon: false,
 };
 
 function createAccount(overrides: Partial<Account>): Account {

--- a/apps/frontend/src/pages/layouts/navigation/app-sidebar.tsx
+++ b/apps/frontend/src/pages/layouts/navigation/app-sidebar.tsx
@@ -15,7 +15,7 @@ import { useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { type NavLink, type NavigationProps, isPathActive } from "./app-navigation";
 import { ConnectNavItem } from "./connect-nav-item";
-
+import { useSettingsContext } from "@/lib/settings-provider";
 interface AppSidebarProps {
   navigation: NavigationProps;
 }
@@ -24,6 +24,8 @@ const modKey = isAppleDevice() ? "⌘" : "Ctrl";
 
 export function AppSidebar({ navigation }: AppSidebarProps) {
   const [collapsed, setCollapsed] = useState(true);
+  const { settings } = useSettingsContext();
+  const expandAddon = settings?.expandAddon || false;
   const { logout, requiresAuth } = useAuth();
 
   return (
@@ -120,7 +122,11 @@ export function AppSidebar({ navigation }: AppSidebarProps) {
                 ))}
 
                 {navigation?.addons && navigation.addons.length > 0 && (
-                  <AddonsMenu addons={navigation.addons} collapsed={collapsed} />
+                  <AddonsMenu
+                    addons={navigation.addons}
+                    collapsed={collapsed}
+                    expandAddon={expandAddon}
+                  />
                 )}
               </nav>
             </div>
@@ -227,11 +233,52 @@ function NavItem({ item, collapsed, className, ...props }: NavItemProps) {
 interface AddonsMenuProps {
   addons: NavLink[];
   collapsed: boolean;
+  expandAddon: boolean;
 }
 
-function AddonsMenu({ addons, collapsed }: AddonsMenuProps) {
+function AddonsMenu({ addons, collapsed, expandAddon }: AddonsMenuProps) {
   const location = useLocation();
   const hasActiveAddon = addons.some((addon) => isPathActive(location.pathname, addon.href));
+
+  if (expandAddon) {
+    return (
+      <div className="flex flex-col gap-1">
+        {addons.map((addon) => {
+          const isActive = isPathActive(location.pathname, addon.href);
+          return (
+            <Button
+              key={addon.href}
+              variant={isActive ? "secondary" : "ghost"}
+              asChild
+              className={cn(
+                "text-foreground [&_svg]:size-5! mb-1 h-12 rounded-md transition-all duration-300",
+                collapsed ? "justify-center" : "justify-start",
+              )}
+            >
+              <Link
+                to={addon.href}
+                title={addon.title}
+                aria-current={isActive ? "page" : undefined}
+              >
+                <span aria-hidden="true">
+                  {addon.icon ?? <Icons.ArrowRight className="h-5 w-5" />}
+                </span>
+                <span
+                  className={cn({
+                    "ml-2 overflow-hidden text-ellipsis whitespace-nowrap transition-opacity delay-100 duration-300 ease-in-out": true,
+                    "sr-only opacity-0": collapsed,
+                    "block opacity-100": !collapsed,
+                  })}
+                >
+                  {addon.title}
+                </span>
+              </Link>
+            </Button>
+          );
+        })}
+      </div>
+    );
+  }
 
   return (
     <DropdownMenu>

--- a/apps/frontend/src/pages/settings/appearance/appearance-form.tsx
+++ b/apps/frontend/src/pages/settings/appearance/appearance-form.tsx
@@ -16,7 +16,7 @@ import {
 import { Switch } from "@wealthfolio/ui/components/ui/switch";
 import { usePlatform } from "@/hooks/use-platform";
 import { useSettingsContext } from "@/lib/settings-provider";
-
+import { useIsMobileViewport } from "@/hooks/use-platform";
 const appearanceFormSchema = z.object({
   theme: z.enum(["light", "dark", "system"], {
     required_error: "Please select a theme.",
@@ -26,6 +26,7 @@ const appearanceFormSchema = z.object({
     required_error: "Please select a font.",
   }),
   menuBarVisible: z.boolean(),
+  expandAddon: z.boolean(),
 });
 
 type AppearanceFormValues = z.infer<typeof appearanceFormSchema>;
@@ -33,10 +34,12 @@ type AppearanceFormValues = z.infer<typeof appearanceFormSchema>;
 export function AppearanceForm() {
   const { settings, updateSettings } = useSettingsContext();
   const { isMobile } = usePlatform();
+  const isMobileViewport = useIsMobileViewport();
   const defaultValues: Partial<AppearanceFormValues> = {
     theme: settings?.theme as AppearanceFormValues["theme"],
     font: settings?.font as AppearanceFormValues["font"],
     menuBarVisible: settings?.menuBarVisible ?? true,
+    expandAddon: settings?.expandAddon ?? false,
   };
   const form = useForm<AppearanceFormValues>({
     resolver: zodResolver(appearanceFormSchema),
@@ -118,6 +121,31 @@ export function AppearanceForm() {
                     onCheckedChange={(value) => {
                       field.onChange(value);
                       handlePartialUpdate({ menuBarVisible: value });
+                    }}
+                  />
+                </FormControl>
+              </FormItem>
+            )}
+          />
+        )}
+        {!isMobile && !isMobileViewport && (
+          <FormField
+            control={form.control}
+            name="expandAddon"
+            render={({ field }) => (
+              <FormItem className="flex items-center justify-between rounded-lg border p-3 shadow-sm">
+                <div className="space-y-0.5">
+                  <FormLabel>Expand Add-ons list</FormLabel>
+                  <FormDescription>
+                    Toggle to display all add-ons individually in the sidebar.
+                  </FormDescription>
+                </div>
+                <FormControl>
+                  <Switch
+                    checked={field.value}
+                    onCheckedChange={(value) => {
+                      field.onChange(value);
+                      handlePartialUpdate({ expandAddon: value });
                     }}
                   />
                 </FormControl>

--- a/crates/core/src/settings/settings_model.rs
+++ b/crates/core/src/settings/settings_model.rs
@@ -15,6 +15,7 @@ pub struct Settings {
     pub menu_bar_visible: bool,
     pub sync_enabled: bool,
     pub default_return_metric: String,
+    pub expand_addon: bool,
 }
 
 impl Default for Settings {
@@ -30,6 +31,7 @@ impl Default for Settings {
             menu_bar_visible: true,
             sync_enabled: true,
             default_return_metric: "twr".to_string(),
+            expand_addon: false,
         }
     }
 }
@@ -46,6 +48,7 @@ pub struct SettingsUpdate {
     pub menu_bar_visible: Option<bool>,
     pub sync_enabled: Option<bool>,
     pub default_return_metric: Option<String>,
+    pub expand_addon: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/storage-sqlite/src/settings/repository.rs
+++ b/crates/storage-sqlite/src/settings/repository.rs
@@ -54,6 +54,9 @@ impl SettingsRepositoryTrait for SettingsRepository {
                     settings.sync_enabled = value.parse().unwrap_or(true);
                 }
                 "default_return_metric" => settings.default_return_metric = value,
+                "expand_addon" => {
+                    settings.expand_addon = value.parse().unwrap_or(false);
+                }
                 _ => {} // Ignore unknown settings
             }
         }
@@ -135,6 +138,16 @@ impl SettingsRepositoryTrait for SettingsRepository {
                         .map_err(StorageError::from)?;
                 }
 
+                if let Some(expand_addon) = settings.expand_addon {
+                    diesel::replace_into(app_settings)
+                        .values(&AppSettingDB {
+                            setting_key: "expand_addon".to_string(),
+                            setting_value: expand_addon.to_string(),
+                        })
+                        .execute(conn)
+                        .map_err(StorageError::from)?;
+                }
+
                 if let Some(sync_enabled) = settings.sync_enabled {
                     diesel::replace_into(app_settings)
                         .values(&AppSettingDB {
@@ -180,6 +193,7 @@ impl SettingsRepositoryTrait for SettingsRepository {
                     "menu_bar_visible" => "true",
                     "sync_enabled" => "true",
                     "default_return_metric" => "twr",
+                    "expand_addon" => "false",
                     _ => return Err(StorageError::from(diesel::result::Error::NotFound).into()),
                 };
                 Ok(default_value.to_string())

--- a/packages/addon-sdk/src/data-types.ts
+++ b/packages/addon-sdk/src/data-types.ts
@@ -661,6 +661,7 @@ export interface Settings {
   autoUpdateCheckEnabled: boolean;
   menuBarVisible: boolean;
   syncEnabled: boolean;
+  expandAddon: boolean;
 }
 
 export type GoalType =


### PR DESCRIPTION
## Description

Allow desktop users to expand the Add-ons list in the sidebar while keeping it collapsed by default. This option reduces the number of clicks required to access an add-on.

Collapsed (default)
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/67f24e87-ced3-4a7b-b023-abe7e2c68f7d" />

Expanded
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/dcc2c43a-1346-41a6-b7d2-de7522709f87" />


## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
