### PR TITLE
Fix startup backend errors and sync overwrite risk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ Thumbs.db
 /playwright/.cache/
 /playwright/.auth/
 .playwright-report
+.playwright-mcp
 # AI tools
 .codex/
 .kiro/

--- a/apps/frontend/src/adapters/web/settings.test.ts
+++ b/apps/frontend/src/adapters/web/settings.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("./core", () => ({
+  API_PREFIX: "/api/v1",
+  invoke: mocks.invoke,
+  logger: mocks.logger,
+}));
+
+import { getSettings } from "./settings";
+
+describe("web getSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("propagates backend failures", async () => {
+    const error = new Error("Backend unavailable");
+    mocks.invoke.mockRejectedValue(error);
+
+    await expect(getSettings()).rejects.toThrow("Backend unavailable");
+    expect(mocks.logger.error).toHaveBeenCalledWith("Error fetching settings.");
+  });
+});

--- a/apps/frontend/src/adapters/web/settings.ts
+++ b/apps/frontend/src/adapters/web/settings.ts
@@ -11,9 +11,9 @@ import type { AppInfo, PlatformInfo } from "../types";
 export const getSettings = async (): Promise<Settings> => {
   try {
     return await invoke<Settings>("get_settings");
-  } catch (_error) {
+  } catch (error) {
     logger.error("Error fetching settings.");
-    return {} as Settings;
+    throw error;
   }
 };
 

--- a/apps/frontend/src/components/startup-error.tsx
+++ b/apps/frontend/src/components/startup-error.tsx
@@ -1,0 +1,39 @@
+import { Button } from "@wealthfolio/ui/components/ui/button";
+import { Icons } from "@wealthfolio/ui/components/ui/icons";
+
+interface StartupErrorProps {
+  error?: Error | null;
+  isRetrying?: boolean;
+  onRetry: () => void;
+}
+
+export function StartupError({ error, isRetrying = false, onRetry }: StartupErrorProps) {
+  return (
+    <div className="bg-background text-foreground flex min-h-screen items-center justify-center p-6 supports-[min-height:100dvh]:min-h-dvh">
+      <div className="flex w-full max-w-md flex-col items-center text-center">
+        <div className="bg-destructive/10 mb-6 flex h-16 w-16 items-center justify-center rounded-full">
+          <Icons.AlertTriangle className="text-destructive h-8 w-8" strokeWidth={1.5} />
+        </div>
+
+        <div className="mb-6 space-y-2">
+          <h1 className="text-xl font-semibold tracking-tight">Backend unavailable</h1>
+          <p className="text-muted-foreground text-sm leading-relaxed">
+            Wealthfolio could not load settings from the backend.
+          </p>
+          {error?.message && (
+            <p className="text-muted-foreground/80 text-xs leading-relaxed">{error.message}</p>
+          )}
+        </div>
+
+        <Button onClick={onRetry} disabled={isRetrying}>
+          {isRetrying ? (
+            <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <Icons.RefreshCw className="mr-2 h-4 w-4" />
+          )}
+          Retry
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/layouts/app-layout.tsx
+++ b/apps/frontend/src/pages/layouts/app-layout.tsx
@@ -1,6 +1,7 @@
 import AppLauncher from "@/components/app-launcher";
 import { MobileLoadingIndicator } from "@/components/mobile-loading-indicator";
 import { Toaster } from "@/components/sonner";
+import { StartupError } from "@/components/startup-error";
 import { UpdateDialog } from "@/components/update-dialog";
 import { PortfolioSyncProvider } from "@/context/portfolio-sync-context";
 import { useActiveAppSyncTrigger } from "@/features/devices-sync/hooks/use-active-app-sync-trigger";
@@ -19,7 +20,14 @@ import { MobileNavBar } from "./navigation/mobile-navbar";
 import { NavigationModeProvider, useNavigationMode } from "./navigation/navigation-mode-context";
 
 const AppLayoutContent = () => {
-  const { data: settings, isSuccess: isSettingsReady } = useSettings();
+  const {
+    data: settings,
+    error: settingsError,
+    isError: isSettingsError,
+    isFetching: isSettingsFetching,
+    isSuccess: isSettingsReady,
+    refetch: refetchSettings,
+  } = useSettings();
   const location = useLocation();
   const navigation = useNavigation();
   const { isMobile, isTauri } = usePlatform();
@@ -38,6 +46,16 @@ const AppLayoutContent = () => {
   useGlobalEventListener();
   useNavigationEventListener();
   useActiveAppSyncTrigger({ enabled: isTauri, requireWindowFocusForInterval: !isMobile });
+
+  if (isSettingsError) {
+    return (
+      <StartupError
+        error={settingsError}
+        isRetrying={isSettingsFetching}
+        onRetry={() => void refetchSettings()}
+      />
+    );
+  }
 
   if (!isSettingsReady) {
     return (

--- a/apps/frontend/src/pages/onboarding/onboarding-page.tsx
+++ b/apps/frontend/src/pages/onboarding/onboarding-page.tsx
@@ -1,3 +1,4 @@
+import { StartupError } from "@/components/startup-error";
 import { usePlatform } from "@/hooks/use-platform";
 import { useSettings } from "@/hooks/use-settings";
 import { WEALTHFOLIO_CONNECT_PORTAL_URL } from "@/lib/constants";
@@ -16,7 +17,14 @@ const DESKTOP_MAX_STEPS = 4;
 const MOBILE_MAX_STEPS = 3;
 
 const OnboardingPage = () => {
-  const { data: settings, isLoading: isSettingsLoading } = useSettings();
+  const {
+    data: settings,
+    error: settingsError,
+    isError: isSettingsError,
+    isFetching: isSettingsFetching,
+    isLoading: isSettingsLoading,
+    refetch: refetchSettings,
+  } = useSettings();
   const { isMobile } = usePlatform();
   const { updateSettings } = useSettingsContext();
   const [currentStep, setCurrentStep] = useState(1);
@@ -28,6 +36,15 @@ const OnboardingPage = () => {
   const isFinalStep = currentStep === maxSteps;
 
   if (isSettingsLoading) return null;
+  if (isSettingsError) {
+    return (
+      <StartupError
+        error={settingsError}
+        isRetrying={isSettingsFetching}
+        onRetry={() => void refetchSettings()}
+      />
+    );
+  }
   if (settings?.onboardingCompleted) {
     return <Navigate to={completionRoute} replace />;
   }

--- a/crates/storage-sqlite/src/sync/app_sync/repository.rs
+++ b/crates/storage-sqlite/src/sync/app_sync/repository.rs
@@ -151,16 +151,6 @@ const ROWS_WITH_USER_SYNCABLE_ACTIVITY_FILTER_SQL: &str = "\
                AND (source_record_id IS NULL OR TRIM(source_record_id) = ''))
     )";
 
-const OVERWRITE_RISK_ACTIVITY_TAXONOMY_ASSIGNMENTS_FILTER_SQL: &str = "\
-    UPPER(COALESCE(source, '')) = 'MANUAL'
-    OR activity_id IN (
-        SELECT id FROM activities
-        WHERE UPPER(COALESCE(source_system, '')) IN ('MANUAL', 'CSV')
-           OR ((source_system IS NULL OR TRIM(source_system) = '')
-               AND (import_run_id IS NULL OR TRIM(import_run_id) = '')
-               AND (source_record_id IS NULL OR TRIM(source_record_id) = ''))
-    )";
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum SyncRowFilter {
     UserSyncableHoldingsSnapshots,
@@ -168,10 +158,7 @@ enum SyncRowFilter {
     ManualQuotes,
     UserImportRuns,
     UserSyncableActivities,
-    OverwriteRiskImportTemplates,
-    OverwriteRiskImportAccountTemplates,
     SpendingSettings,
-    SpendingSettingsOverwriteRisk,
     UserTaxonomies,
     SyncableTaxonomyCategories,
     UserModifiedBudgetGroups,
@@ -179,13 +166,9 @@ enum SyncRowFilter {
     BudgetGroupAssignmentsWithExistingDependencies,
     BudgetTargetsWithExistingDependencies,
     BudgetRolloverSettingsWithExistingDependencies,
-    UserModifiedSpendingEventTypes,
     OverwriteRiskAccounts,
-    OverwriteRiskPlatforms,
-    OverwriteRiskAssets,
     ValidPortfolioAccounts,
     RowsWithUserSyncableActivity,
-    OverwriteRiskActivityTaxonomyAssignments,
 }
 
 impl SyncRowFilter {
@@ -206,18 +189,7 @@ impl SyncRowFilter {
                 "UPPER(run_type) = 'IMPORT' AND UPPER(source_system) IN ('CSV', 'MANUAL')"
             }
             Self::UserSyncableActivities => USER_SYNCABLE_ACTIVITIES_FILTER_SQL,
-            Self::OverwriteRiskImportTemplates => {
-                "UPPER(scope) != 'SYSTEM' AND UPPER(kind) != 'BROKER_ACTIVITY'"
-            }
-            Self::OverwriteRiskImportAccountTemplates => {
-                "UPPER(context_kind) != 'BROKER_ACTIVITY' \
-                 AND UPPER(COALESCE(source_system, '')) IN ('', 'CSV', 'MANUAL')"
-            }
             Self::SpendingSettings => "setting_key IN ('spending.enabled', 'spending.account_ids')",
-            Self::SpendingSettingsOverwriteRisk => {
-                "setting_key = 'spending.account_ids' \
-                 OR (setting_key = 'spending.enabled' AND LOWER(setting_value) != 'true')"
-            }
             Self::UserTaxonomies => "is_system = 0",
             // Spending/income seed category IDs use the `cat_` prefix; user-created rows use UUIDs.
             Self::SyncableTaxonomyCategories => {
@@ -260,21 +232,13 @@ impl SyncRowFilter {
                  OR (target_type = 'group' \
                     AND group_id IN (SELECT id FROM budget_groups))"
             }
-            Self::UserModifiedSpendingEventTypes => "key IS NULL OR updated_at != created_at",
             Self::OverwriteRiskAccounts => {
                 "provider_account_id IS NULL OR TRIM(provider_account_id) = ''"
-            }
-            Self::OverwriteRiskPlatforms => "external_id IS NULL OR TRIM(external_id) = ''",
-            Self::OverwriteRiskAssets => {
-                "kind IN ('PROPERTY', 'VEHICLE', 'COLLECTIBLE', 'PRECIOUS_METAL', 'PRIVATE_EQUITY', 'LIABILITY', 'OTHER')"
             }
             Self::ValidPortfolioAccounts => {
                 "account_id IN (SELECT id FROM accounts) AND portfolio_id IN (SELECT id FROM portfolios)"
             }
             Self::RowsWithUserSyncableActivity => ROWS_WITH_USER_SYNCABLE_ACTIVITY_FILTER_SQL,
-            Self::OverwriteRiskActivityTaxonomyAssignments => {
-                OVERWRITE_RISK_ACTIVITY_TAXONOMY_ASSIGNMENTS_FILTER_SQL
-            }
         }
     }
 }
@@ -284,70 +248,12 @@ struct SyncTableFilterSpec {
     filter: SyncRowFilter,
 }
 
-const OVERWRITE_RISK_UNFILTERED_TABLES: &[&str] = &[
-    "market_data_custom_providers",
-    "goals",
-    "goal_plans",
-    "ai_threads",
-    "ai_messages",
-    "ai_thread_tags",
-    "contribution_limits",
-    "spending_activity_events",
-    "spending_categorization_rules",
-    "spending_preset_rule_deletions",
-    "spending_events",
-    "budget_targets",
-    "budget_rollover_settings",
-    "asset_taxonomy_assignments",
-    "goals_allocation",
-    "allocation_targets",
-    "allocation_target_weights",
-];
+const OVERWRITE_RISK_UNFILTERED_TABLES: &[&str] = &["goals"];
 
 const OVERWRITE_RISK_FILTERED_TABLES: &[SyncTableFilterSpec] = &[
     SyncTableFilterSpec {
-        table: "platforms",
-        filter: SyncRowFilter::OverwriteRiskPlatforms,
-    },
-    SyncTableFilterSpec {
         table: "accounts",
         filter: SyncRowFilter::OverwriteRiskAccounts,
-    },
-    SyncTableFilterSpec {
-        table: "assets",
-        filter: SyncRowFilter::OverwriteRiskAssets,
-    },
-    SyncTableFilterSpec {
-        table: "quotes",
-        filter: SyncRowFilter::ManualQuotes,
-    },
-    SyncTableFilterSpec {
-        table: "import_runs",
-        filter: SyncRowFilter::UserImportRuns,
-    },
-    SyncTableFilterSpec {
-        table: "activities",
-        filter: SyncRowFilter::UserSyncableActivities,
-    },
-    SyncTableFilterSpec {
-        table: "import_templates",
-        filter: SyncRowFilter::OverwriteRiskImportTemplates,
-    },
-    SyncTableFilterSpec {
-        table: "import_account_templates",
-        filter: SyncRowFilter::OverwriteRiskImportAccountTemplates,
-    },
-    SyncTableFilterSpec {
-        table: "activity_taxonomy_assignments",
-        filter: SyncRowFilter::OverwriteRiskActivityTaxonomyAssignments,
-    },
-    SyncTableFilterSpec {
-        table: "app_settings",
-        filter: SyncRowFilter::SpendingSettingsOverwriteRisk,
-    },
-    SyncTableFilterSpec {
-        table: "spending_event_types",
-        filter: SyncRowFilter::UserModifiedSpendingEventTypes,
     },
     SyncTableFilterSpec {
         table: "budget_groups",
@@ -358,12 +264,12 @@ const OVERWRITE_RISK_FILTERED_TABLES: &[SyncTableFilterSpec] = &[
         filter: SyncRowFilter::UserModifiedBudgetGroupAssignments,
     },
     SyncTableFilterSpec {
-        table: "taxonomies",
-        filter: SyncRowFilter::UserTaxonomies,
+        table: "budget_targets",
+        filter: SyncRowFilter::BudgetTargetsWithExistingDependencies,
     },
     SyncTableFilterSpec {
-        table: "taxonomy_categories",
-        filter: SyncRowFilter::SyncableTaxonomyCategories,
+        table: "budget_rollover_settings",
+        filter: SyncRowFilter::BudgetRolloverSettingsWithExistingDependencies,
     },
 ];
 
@@ -5364,7 +5270,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn overwrite_risk_summary_counts_accounts_and_goals() {
+    async fn overwrite_risk_summary_counts_accounts_goals_and_budgets() {
         let (pool, writer) = setup_db();
         let repo = AppSyncRepository::new(pool.clone(), writer);
 
@@ -5372,13 +5278,27 @@ mod tests {
             let mut conn = get_connection(&pool).expect("conn");
             insert_account_for_test(&mut conn, "acc-overwrite-risk").expect("insert account");
             insert_goal_for_test(&mut conn, "goal-overwrite-risk").expect("insert goal");
+            conn.batch_execute(
+                "INSERT INTO budget_targets \
+                 (id, period_key, target_type, taxonomy_id, category_id, group_id, amount, created_at, updated_at) \
+                 VALUES ('budget-target-overwrite-risk', '2026-01', 'group_buffer', NULL, NULL, \
+                         '032ecb02-5912-42e8-9724-2cd566fc08d5', '100.00', \
+                         '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'); \
+                 INSERT INTO budget_rollover_settings \
+                 (id, target_type, taxonomy_id, category_id, group_id, enabled, start_month, \
+                  starting_balance, created_at, updated_at) \
+                 VALUES ('budget-rollover-overwrite-risk', 'group', NULL, NULL, \
+                         '032ecb02-5912-42e8-9724-2cd566fc08d5', 1, '2026-01', '0', \
+                         '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
+            )
+            .expect("insert budget rows");
         }
 
         let summary = repo
             .get_local_sync_overwrite_risk_summary()
             .expect("overwrite risk summary");
 
-        assert_eq!(summary.total_rows, 2);
+        assert_eq!(summary.total_rows, 4);
         assert!(summary
             .non_empty_tables
             .iter()
@@ -5387,6 +5307,14 @@ mod tests {
             .non_empty_tables
             .iter()
             .any(|row| row.table == "goals" && row.rows == 1));
+        assert!(summary
+            .non_empty_tables
+            .iter()
+            .any(|row| row.table == "budget_targets" && row.rows == 1));
+        assert!(summary
+            .non_empty_tables
+            .iter()
+            .any(|row| row.table == "budget_rollover_settings" && row.rows == 1));
     }
 
     #[tokio::test]
@@ -5456,7 +5384,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn overwrite_risk_summary_counts_manual_broker_activity_sidecars() {
+    async fn overwrite_risk_summary_ignores_broker_activity_sidecars() {
         let (pool, writer) = setup_db();
         let repo = AppSyncRepository::new(pool.clone(), writer);
 
@@ -5515,23 +5443,12 @@ mod tests {
             .get_local_sync_overwrite_risk_summary()
             .expect("overwrite risk summary");
 
-        assert_eq!(summary.total_rows, 3);
-        assert!(summary
-            .non_empty_tables
-            .iter()
-            .any(|row| row.table == "activity_taxonomy_assignments" && row.rows == 1));
-        assert!(summary
-            .non_empty_tables
-            .iter()
-            .any(|row| row.table == "spending_events" && row.rows == 1));
-        assert!(summary
-            .non_empty_tables
-            .iter()
-            .any(|row| row.table == "spending_activity_events" && row.rows == 1));
+        assert_eq!(summary.total_rows, 0);
+        assert!(summary.non_empty_tables.is_empty());
     }
 
     #[tokio::test]
-    async fn overwrite_risk_summary_counts_only_standalone_asset_kinds() {
+    async fn overwrite_risk_summary_ignores_standalone_asset_kinds() {
         let (pool, writer) = setup_db();
         let repo = AppSyncRepository::new(pool.clone(), writer);
         let counted_kinds = [
@@ -5563,19 +5480,12 @@ mod tests {
             .get_local_sync_overwrite_risk_summary()
             .expect("overwrite risk summary");
 
-        assert_eq!(summary.total_rows, counted_kinds.len() as i64);
-        assert_eq!(
-            summary
-                .non_empty_tables
-                .iter()
-                .find(|row| row.table == "assets")
-                .map(|row| row.rows),
-            Some(counted_kinds.len() as i64)
-        );
+        assert_eq!(summary.total_rows, 0);
+        assert!(summary.non_empty_tables.is_empty());
     }
 
     #[tokio::test]
-    async fn overwrite_risk_summary_counts_user_curated_sync_tables() {
+    async fn overwrite_risk_summary_ignores_non_account_goal_budget_tables() {
         let (pool, writer) = setup_db();
         let repo = AppSyncRepository::new(pool.clone(), writer);
 
@@ -5719,44 +5629,19 @@ mod tests {
         let summary = repo
             .get_local_sync_overwrite_risk_summary()
             .expect("overwrite risk summary");
-        let expected_tables = [
-            "platforms",
-            "market_data_custom_providers",
-            "accounts",
-            "quotes",
-            "goals",
-            "goal_plans",
-            "goals_allocation",
-            "ai_threads",
-            "ai_messages",
-            "ai_thread_tags",
-            "contribution_limits",
-            "import_runs",
-            "activities",
-            "import_templates",
-            "import_account_templates",
-            "taxonomies",
-            "taxonomy_categories",
-            "asset_taxonomy_assignments",
-        ];
-
-        assert_eq!(summary.total_rows, expected_tables.len() as i64);
-        for table in expected_tables {
-            assert!(
-                summary
-                    .non_empty_tables
-                    .iter()
-                    .any(|row| row.table == table && row.rows == 1),
-                "expected overwrite risk for {table}"
-            );
-        }
-        assert!(
-            summary
-                .non_empty_tables
-                .iter()
-                .all(|row| row.table != "assets"),
-            "investment support asset should not count as overwrite risk"
-        );
+        assert_eq!(summary.total_rows, 2);
+        assert!(summary
+            .non_empty_tables
+            .iter()
+            .any(|row| row.table == "accounts" && row.rows == 1));
+        assert!(summary
+            .non_empty_tables
+            .iter()
+            .any(|row| row.table == "goals" && row.rows == 1));
+        assert!(summary
+            .non_empty_tables
+            .iter()
+            .all(|row| matches!(row.table.as_str(), "accounts" | "goals")));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Show a retryable backend-unavailable startup error instead of falling through to onboarding when settings cannot load.
- Propagate web `getSettings` failures so React Query can surface the error state.
- Simplify device-sync overwrite-risk detection to accounts, goals, and budgets, excluding broker-rehydratable data and non-requested side tables.
- Ignore `.playwright-mcp` local artifacts.

## Root Cause

The web settings adapter returned an empty settings object on backend failure. That made the frontend treat a failed settings load as a fresh/incomplete onboarding state.

The device-sync overwrite-risk prompt also counted synced broker-derived data and several non-requested user data tables, which made fresh databases look like they needed replacement.

## Validation

- `cargo test -p wealthfolio-storage-sqlite overwrite_risk_summary_ -- --nocapture`
- `pnpm --dir apps/frontend test -- settings.test.ts --run`
- `pnpm --dir apps/frontend type-check`
- `pnpm --dir apps/frontend lint` passed with existing warnings only
