### PR TITLE
feat(spending): sync budget card month with spending period selector

### DIFF
--- a/apps/frontend/src/features/spending/components/spending-tab-content.tsx
+++ b/apps/frontend/src/features/spending/components/spending-tab-content.tsx
@@ -93,6 +93,7 @@ const VISIBLE_SPENDING_DASHBOARD_PERIODS: SpendingDashboardPeriod[] = [
 
 const DEFAULT_INTERVAL: SpendingDashboardPeriod = "MTD";
 const INTERVAL_STORAGE_KEY = "spending-interval";
+const MONTH_STORAGE_KEY = "spending-month";
 const MONTH_PARAM = "spendingMonth";
 const INTERVAL_DESCRIPTIONS: Record<SpendingDashboardPeriod, string> = {
   MTD: "this month",
@@ -268,11 +269,12 @@ function insightPeriodForDashboardInterval(code: SpendingDashboardPeriod): Repor
 function selectionFromParams(
   params: URLSearchParams,
   persistedInterval: string,
+  persistedMonth: string | null,
 ): SpendingSelection {
   const restoreCode = normalizeSpendingDashboardPeriod(
     params.get("spendingInterval") ?? persistedInterval,
   );
-  const monthKey = params.get(MONTH_PARAM);
+  const monthKey = params.get(MONTH_PARAM) ?? persistedMonth;
   if (monthKey && parseMonthKey(monthKey)) return { kind: "month", monthKey, restoreCode };
   return { kind: "period", code: restoreCode };
 }
@@ -429,9 +431,13 @@ export default function SpendingTabContent() {
     INTERVAL_STORAGE_KEY,
     DEFAULT_INTERVAL,
   );
+  const [persistedMonth, setPersistedMonth] = usePersistentState<string | null>(
+    MONTH_STORAGE_KEY,
+    null,
+  );
   const selection = useMemo(
-    () => selectionFromParams(searchParams, persistedInterval),
-    [searchParams, persistedInterval],
+    () => selectionFromParams(searchParams, persistedInterval, persistedMonth),
+    [searchParams, persistedInterval, persistedMonth],
   );
   const selectedPeriod = selection.kind === "period" ? selection.code : null;
   const customMonth = selection.kind === "month" ? selection.monthKey : null;
@@ -620,6 +626,7 @@ export default function SpendingTabContent() {
 
   const handleIntervalSelect = (code: SpendingDashboardPeriod) => {
     setPersistedInterval(code);
+    setPersistedMonth(null);
     setSearchParams(
       (prev) => {
         const p = new URLSearchParams(prev);
@@ -639,6 +646,7 @@ export default function SpendingTabContent() {
   };
 
   const handleCustomMonthSelect = (monthKey: string | null) => {
+    setPersistedMonth(monthKey);
     setSearchParams(
       (prev) => {
         const p = new URLSearchParams(prev);

--- a/apps/frontend/src/features/spending/components/spending-tab-content.tsx
+++ b/apps/frontend/src/features/spending/components/spending-tab-content.tsx
@@ -619,6 +619,13 @@ export default function SpendingTabContent() {
       },
       { replace: true },
     );
+    if (code === "LAST_MONTH") {
+      setBudgetMonthKey(addMonthsToMonthKey(currentBudgetMonthKey, -1));
+      setBudgetMonthTouched(true);
+    } else {
+      setBudgetMonthKey(currentBudgetMonthKey);
+      setBudgetMonthTouched(false);
+    }
   };
 
   const handleCustomMonthSelect = (monthKey: string | null) => {
@@ -636,6 +643,13 @@ export default function SpendingTabContent() {
       },
       { replace: true },
     );
+    if (monthKey && monthKey <= currentBudgetMonthKey) {
+      setBudgetMonthKey(monthKey);
+      setBudgetMonthTouched(true);
+    } else {
+      setBudgetMonthKey(currentBudgetMonthKey);
+      setBudgetMonthTouched(false);
+    }
   };
 
   const granularity: "day" | "week" | "month" = useMemo(() => {

--- a/apps/frontend/src/features/spending/components/spending-tab-content.tsx
+++ b/apps/frontend/src/features/spending/components/spending-tab-content.tsx
@@ -486,8 +486,18 @@ export default function SpendingTabContent() {
   const { data: budget, isError: budgetErrored } = useBudget();
   const todayParts = useMemo(() => getZonedDateParts(new Date(), appTimezone), [appTimezone]);
   const currentBudgetMonthKey = useMemo(() => monthKeyFromParts(todayParts), [todayParts]);
-  const [budgetMonthKey, setBudgetMonthKey] = useState(() => monthKeyFromParts(todayParts));
-  const [budgetMonthTouched, setBudgetMonthTouched] = useState(false);
+  const [budgetMonthKey, setBudgetMonthKey] = useState(() => {
+    const current = monthKeyFromParts(todayParts);
+    if (selection.kind === "period" && selection.code === "LAST_MONTH")
+      return addMonthsToMonthKey(current, -1);
+    if (selection.kind === "month" && selection.monthKey <= current) return selection.monthKey;
+    return current;
+  });
+  const [budgetMonthTouched, setBudgetMonthTouched] = useState(
+    () =>
+      (selection.kind === "period" && selection.code === "LAST_MONTH") ||
+      selection.kind === "month",
+  );
   useEffect(() => {
     setBudgetMonthKey((monthKey) => {
       if (!budgetMonthTouched) return currentBudgetMonthKey;


### PR DESCRIPTION
Hey @afadil  😄 

A little add up on the dashboard spending. 

When browsing the spending dashboard, it was a bit frustrating to select "Last Month" (or a specific month via the calendar picker) in the spending chart, only to find the Monthly Budget card still showing the current month — requiring a second click to align them. 
This PR wires the two together so switching the spending period automatically updates the budget card.

## What changed

- **Spending → Budget sync**: selecting `Last Month` or a custom month in the spending period selector now automatically moves the budget card to the same month. Multi-month periods (`MTD`, `3M`, `6M`, etc.) reset the budget card to the current month.
- **Persist across navigation**: previously, custom month selections were stored only in the URL and lost when navigating to another page. Both the interval and the custom month are now persisted to `localStorage`, so the full selection is restored when returning to the spending tab.
- **Budget card initializes from selection**: on mount, the budget card now derives its initial month from the persisted spending selection instead of always defaulting to the current month. This fixes a mismatch where the spending chart would show "Last Month" but the budget card would show the current month after a page navigation.

## Behavior summary

| Spending selection | Budget card on select | Budget card on return |
|---|---|---|
| `Last Month` | Jumps to last month | Restored to last month |
| Custom month (picker) | Jumps to selected month | Restored to selected month |
| `MTD`, `3M`, `6M`, `YTD`, `1Y` | Resets to current month | Resets to current month |

The sync is intentionally **unidirectional** (spending → budget). The budget card's own prev/next navigation remains independent — it wouldn't make sense to change the spending chart range when browsing month-by-month in the budget card.

---


## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).
EOF