### PR TITLE
fix(ai): normalize OpenAI-compatible base URL for both model listing …

### DIFF
--- a/crates/ai/src/chat/provider_clients.rs
+++ b/crates/ai/src/chat/provider_clients.rs
@@ -70,7 +70,13 @@ pub(super) fn create_openai_client(
     let key = api_key.ok_or_else(|| AiError::MissingApiKey(provider_id.to_string()))?;
     let mut builder = openai::CompletionsClient::builder().api_key(&key);
     if let Some(url) = provider_url {
-        builder = builder.base_url(&url);
+        let base = url.trim_end_matches('/');
+        let normalized = if base.ends_with("/v1") {
+            base.to_string()
+        } else {
+            format!("{}/v1", base)
+        };
+        builder = builder.base_url(&normalized);
     }
     builder
         .build()
@@ -222,6 +228,50 @@ pub(super) async fn validate_ollama_model_if_possible(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_openai_base_url_normalization() {
+        // Both forms should produce the same /v1-terminated URL for rig
+        let cases = [
+            ("http://localhost:8080", "http://localhost:8080/v1"),
+            ("http://localhost:8080/", "http://localhost:8080/v1"),
+            ("http://localhost:8080/v1", "http://localhost:8080/v1"),
+            ("http://localhost:8080/v1/", "http://localhost:8080/v1"),
+            ("https://api.openai.com", "https://api.openai.com/v1"),
+        ];
+        for (input, expected) in cases {
+            let base = input.trim_end_matches('/');
+            let normalized = if base.ends_with("/v1") {
+                base.to_string()
+            } else {
+                format!("{}/v1", base)
+            };
+            assert_eq!(normalized, expected, "input: {}", input);
+        }
+    }
+
+    #[test]
+    fn test_list_models_url_normalization() {
+        // Both forms should produce the same /v1/models URL for model listing
+        let cases = [
+            ("http://localhost:8080", "http://localhost:8080/v1/models"),
+            ("http://localhost:8080/", "http://localhost:8080/v1/models"),
+            (
+                "http://localhost:8080/v1",
+                "http://localhost:8080/v1/models",
+            ),
+            (
+                "http://localhost:8080/v1/",
+                "http://localhost:8080/v1/models",
+            ),
+        ];
+        for (input, expected) in cases {
+            let base = input.trim_end_matches('/');
+            let base = base.strip_suffix("/v1").unwrap_or(base);
+            let url = format!("{}/v1/models", base);
+            assert_eq!(url, expected, "input: {}", input);
+        }
+    }
 
     #[test]
     fn test_ollama_model_match_without_latest_suffix() {

--- a/crates/ai/src/provider_service.rs
+++ b/crates/ai/src/provider_service.rs
@@ -545,8 +545,13 @@ impl AiProviderServiceTrait for AiProviderService {
         let models_url = match provider_id {
             "ollama" => format!("{}/api/tags", base_url.trim_end_matches('/')),
             "google" => format!("{}/v1beta/models", base_url.trim_end_matches('/')),
-            // OpenAI-compatible: OpenAI, Groq, OpenRouter
-            _ => format!("{}/v1/models", base_url.trim_end_matches('/')),
+            // OpenAI-compatible: OpenAI, Groq, OpenRouter.
+            // Strip any trailing /v1 first so we never double-append it.
+            _ => {
+                let base = base_url.trim_end_matches('/');
+                let base = base.strip_suffix("/v1").unwrap_or(base);
+                format!("{}/v1/models", base)
+            }
         };
 
         // Build HTTP client and request


### PR DESCRIPTION
## Description

Two code paths handled `custom_url` differently, making any configured URL work for one operation but not the other:

- `list_models` treated the URL as a bare host and appended `/v1/models`
- `create_openai_client` passed the URL directly to rig, which appends `/chat/completions` — expecting the URL to already include `/v1`

Result: `http://host` broke chat (missing /v1); `http://host/v1` broke model listing (double /v1/v1/models). Fixes issue #1077.

Fix: strip any trailing `/v1` before appending `/v1/models` in list_models, and ensure the URL ends with `/v1` before handing it to rig's OpenAI client. Both `http://host` and `http://host/v1` now work for all operations.

This addresses https://github.com/wealthfolio/wealthfolio/issues/1077

## Checklist

- [X] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
