### PR TITLE
Add manual transfer linking workflow

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -1,0 +1,115 @@
+name: Warm Rust Cache
+
+# Release builds run on tag refs, which can only restore caches created on the
+# default branch. This workflow compiles the release-profile dependency graph
+# on main and saves it under the shared-keys that release.yml restores.
+#
+# Dependency artifacts (the only thing rust-cache keeps - workspace crates are
+# pruned) only change when Cargo.lock or the toolchain changes, hence the
+# narrow path filter. The weekly run keeps caches alive (GitHub evicts caches
+# unused for 7 days) and re-warms after stable rustc bumps.
+#
+# macOS release jobs (~18 min cold) are deliberately not warmed to stay under
+# the 10 GB per-repo cache limit; Linux and Windows are the expensive ones.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "Cargo.lock"
+      - "rust-toolchain*"
+      - ".github/workflows/cache-warm.yml"
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: cache-warm
+  cancel-in-progress: true
+
+jobs:
+  warm-desktop:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: "ubuntu-24.04"
+            cache-key: linux-x86_64
+            args: ""
+          - platform: "ubuntu-24.04-arm"
+            cache-key: linux-aarch64
+            args: ""
+          - platform: "windows-latest"
+            cache-key: windows-x86_64
+            target: x86_64-pc-windows-msvc
+            args: "--target x86_64-pc-windows-msvc"
+          - platform: "windows-latest"
+            cache-key: windows-aarch64
+            target: aarch64-pc-windows-msvc
+            args: "--target aarch64-pc-windows-msvc"
+
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies (ubuntu only)
+        if: contains(matrix.platform, 'ubuntu')
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf pkg-config libssl-dev libsoup2.4-dev javascriptcoregtk-4.0 webkit2gtk-4.0 xdg-utils
+
+      - name: Rust setup
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target || '' }}
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          shared-key: release-${{ matrix.cache-key }}
+
+      - name: Stub frontend dist
+        # tauri::generate_context! reads frontendDist (../../dist) at compile
+        # time; a placeholder is enough since the app crate itself is pruned
+        # from the cache anyway.
+        shell: bash
+        run:
+          mkdir -p dist && echo '<!DOCTYPE html><html><head></head><body></body></html>' >
+          dist/index.html
+
+      - name: Build release dependencies
+        # Mirrors what tauri-action runs: release profile, custom-protocol on.
+        run: cargo build --release -p wealthfolio-app --features custom-protocol ${{ matrix.args }}
+
+  warm-server:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install system build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libssl-dev libsqlite3-dev build-essential
+
+      - name: Rust setup
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          shared-key: prebuild-server-linux-amd64
+
+      - name: Stub frontend dist
+        run:
+          mkdir -p dist && echo '<!DOCTYPE html><html><head></head><body></body></html>' >
+          dist/index.html
+
+      - name: Build server binary
+        env:
+          # OPENSSL_STATIC affects how openssl-sys (a cached dependency) is
+          # built - must match the release job.
+          OPENSSL_STATIC: "1"
+        run: cargo build --release --manifest-path apps/server/Cargo.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,10 +111,8 @@ jobs:
     # Standalone server tarball for self-hosters (Proxmox LXC, bare metal, systemd).
     # Tracks: https://github.com/wealthfolio/wealthfolio/issues/563
     # Built on ubuntu-22.04 (glibc 2.35) for forward compatibility with Debian 12+/Ubuntu 22.04+.
-    needs: release
-    # Run even if some matrix entries in `release` failed (fail-fast is off).
-    # Only skip on explicit cancellation.
-    if: ${{ !cancelled() }}
+    # Runs in parallel with `release`: the GitHub release is created manually before
+    # the tag push, so there is no creation race — jobs only attach assets to it.
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,16 +15,22 @@ jobs:
         include:
           - platform: "macos-latest"
             args: "--target x86_64-apple-darwin"
+            cache-key: macos-x86_64
           - platform: "macos-latest"
             args: "--target aarch64-apple-darwin"
+            cache-key: macos-aarch64
           - platform: "windows-latest"
             args: "--target x86_64-pc-windows-msvc"
+            cache-key: windows-x86_64
           - platform: "windows-latest"
             args: "--target aarch64-pc-windows-msvc"
+            cache-key: windows-aarch64
           - platform: "ubuntu-24.04"
             args: ""
+            cache-key: linux-x86_64
           - platform: "ubuntu-24.04-arm"
             args: ""
+            cache-key: linux-aarch64
 
     runs-on: ${{ matrix.platform }}
 
@@ -54,6 +60,12 @@ jobs:
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
+        with:
+          # Must match cache-warm.yml: tag refs can only restore caches created
+          # on the default branch, and caches saved on a tag are unreachable
+          # from other tags - so warming happens on main, saving here is wasted.
+          shared-key: release-${{ matrix.cache-key }}
+          save-if: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
       - name: Sync node version and setup cache
         uses: actions/setup-node@v4
@@ -131,7 +143,9 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
-          key: prebuild-server-linux-amd64
+          # Must match cache-warm.yml (see note in the release job above).
+          shared-key: prebuild-server-linux-amd64
+          save-if: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
       - name: pnpm setup
         uses: pnpm/action-setup@v4

--- a/apps/frontend/src/adapters/shared/activities.ts
+++ b/apps/frontend/src/adapters/shared/activities.ts
@@ -16,6 +16,8 @@ import type {
   ImportTemplateData,
   InternalTransferPairRequest,
   InternalTransferPairResponse,
+  TransferMatchCandidate,
+  TransferMatchCandidateRequest,
   BrokerSyncProfileData,
   SaveBrokerSyncProfileRulesRequest,
 } from "@/lib/types";
@@ -151,6 +153,19 @@ export const getTransferPairForActivity = async (
     });
   } catch (err) {
     logger.error("Error fetching transfer pair.");
+    throw err;
+  }
+};
+
+export const findTransferMatchCandidates = async (
+  request: TransferMatchCandidateRequest,
+): Promise<TransferMatchCandidate[]> => {
+  try {
+    return await invoke<TransferMatchCandidate[]>("find_transfer_match_candidates", {
+      request,
+    });
+  } catch (err) {
+    logger.error("Error finding transfer match candidates.");
     throw err;
   }
 };

--- a/apps/frontend/src/adapters/web/core.ts
+++ b/apps/frontend/src/adapters/web/core.ts
@@ -107,6 +107,7 @@ export const COMMANDS: CommandMap = {
   save_activities: { method: "POST", path: "/activities/bulk" },
   delete_activity: { method: "DELETE", path: "/activities" },
   get_transfer_pair_for_activity: { method: "GET", path: "/activities" },
+  find_transfer_match_candidates: { method: "POST", path: "/activities/transfer-match-candidates" },
   save_internal_transfer_pair: { method: "POST", path: "/activities/transfer-pair" },
   link_transfer_activities: { method: "POST", path: "/activities/link" },
   unlink_transfer_activities: { method: "POST", path: "/activities/unlink" },
@@ -823,6 +824,11 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
     case "get_transfer_pair_for_activity": {
       const { activityId } = payload as { activityId: string };
       url += `/${encodeURIComponent(activityId)}/transfer-pair`;
+      break;
+    }
+    case "find_transfer_match_candidates": {
+      const { request } = payload as { request: Record<string, unknown> };
+      body = JSON.stringify(request);
       break;
     }
     case "save_internal_transfer_pair": {

--- a/apps/frontend/src/adapters/web/index.ts
+++ b/apps/frontend/src/adapters/web/index.ts
@@ -90,6 +90,7 @@ export {
   deleteActivity,
   getImportTemplate,
   getBrokerSyncProfile,
+  findTransferMatchCandidates,
   getTransferPairForActivity,
   getAccountImportMapping,
   linkAccountTemplate,

--- a/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
+++ b/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
@@ -20,7 +20,7 @@ import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { useTaxonomy } from "@/hooks/use-taxonomies";
 import { QueryKeys } from "@/lib/query-keys";
 import { formatDateISO } from "@/lib/utils";
-import type { Account, TaxonomyCategory } from "@/lib/types";
+import type { Account, ActivityDetails, TaxonomyCategory } from "@/lib/types";
 
 import {
   Button,
@@ -139,6 +139,43 @@ export interface SpendingTransactionsTabHandle {
   openAddForm: () => void;
 }
 
+function isTransferActivityType(activityType: string): boolean {
+  return activityType === ActivityType.TRANSFER_IN || activityType === ActivityType.TRANSFER_OUT;
+}
+
+function toActivityDetails(row: TransactionRowVM, account?: Account): Partial<ActivityDetails> {
+  const activity = row.activity;
+  return {
+    id: activity.id,
+    activityType: activity.activityType as ActivityType,
+    subtype: activity.subtype ?? null,
+    status: activity.status,
+    date: new Date(activity.activityDate),
+    quantity: activity.quantity ?? null,
+    unitPrice: activity.unitPrice ?? null,
+    amount: activity.amount ?? null,
+    fee: activity.fee ?? null,
+    currency: activity.currency,
+    needsReview: activity.needsReview,
+    comment: activity.notes ?? undefined,
+    fxRate: activity.fxRate ?? null,
+    createdAt: new Date(activity.createdAt),
+    updatedAt: new Date(activity.updatedAt),
+    accountId: activity.accountId,
+    accountName: account?.name ?? activity.accountId,
+    accountCurrency: account?.currency ?? activity.currency,
+    assetId: activity.assetId ?? "",
+    assetSymbol: activity.assetId ?? "",
+    sourceSystem: activity.sourceSystem,
+    sourceRecordId: activity.sourceRecordId,
+    sourceGroupId: activity.sourceGroupId,
+    idempotencyKey: activity.idempotencyKey,
+    importRunId: activity.importRunId,
+    isUserModified: activity.isUserModified,
+    metadata: activity.metadata,
+  };
+}
+
 export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>(
   function SpendingTransactionsTab(_, ref) {
     const [searchParams, setSearchParams] = useSearchParams();
@@ -161,10 +198,9 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
     const [editingActivity, setEditingActivity] = useState<TransactionRowVM | undefined>();
     const [showForm, setShowForm] = useState(false);
     const [showTransferForm, setShowTransferForm] = useState(false);
-    const [transferFromAccountId, setTransferFromAccountId] = useState<string | undefined>();
-    const [transferActivityType, setTransferActivityType] = useState<ActivityType>(
-      ActivityType.TRANSFER_OUT,
-    );
+    const [transferFormActivity, setTransferFormActivity] = useState<
+      Partial<ActivityDetails> | undefined
+    >();
     const [transferMatchDialog, setTransferMatchDialog] = useState<{
       open: boolean;
       mode: "link" | "unlink";
@@ -331,12 +367,12 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
     const handleTransferClick = useCallback(
       (accountId: string) => {
         const account = accounts.find((a: Account) => a.id === accountId);
-        setTransferActivityType(
-          isCreditCardAccountType(account?.accountType)
+        setTransferFormActivity({
+          activityType: isCreditCardAccountType(account?.accountType)
             ? ActivityType.TRANSFER_IN
             : ActivityType.TRANSFER_OUT,
-        );
-        setTransferFromAccountId(accountId);
+          accountId,
+        });
         setShowTransferForm(true);
       },
       [accounts],
@@ -344,8 +380,7 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
 
     const handleTransferFormClose = useCallback(() => {
       setShowTransferForm(false);
-      setTransferFromAccountId(undefined);
-      setTransferActivityType(ActivityType.TRANSFER_OUT);
+      setTransferFormActivity(undefined);
     }, []);
     const { data: events = [] } = useSpendingEvents();
     const { data: eventTypes = [] } = useEventTypes();
@@ -597,10 +632,22 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
       [setEventMutation],
     );
 
-    const handleEditRow = useCallback((row: TransactionRowVM) => {
-      setEditingActivity(row);
-      setShowForm(true);
-    }, []);
+    const handleEditRow = useCallback(
+      (row: TransactionRowVM) => {
+        if (isTransferActivityType(row.activity.activityType)) {
+          setEditingActivity(undefined);
+          setShowForm(false);
+          setTransferFormActivity(toActivityDetails(row, accountById.get(row.activity.accountId)));
+          setShowTransferForm(true);
+          return;
+        }
+        setTransferFormActivity(undefined);
+        setShowTransferForm(false);
+        setEditingActivity(row);
+        setShowForm(true);
+      },
+      [accountById],
+    );
     const handleDeleteRow = useCallback((row: TransactionRowVM) => {
       setDeletingIds([row.activity.id]);
       setDeletePreview({
@@ -917,7 +964,7 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
           <ActivityForm
             accounts={transferFormAccounts}
             transferAccounts={transferFormAccounts}
-            activity={{ activityType: transferActivityType, accountId: transferFromAccountId }}
+            activity={transferFormActivity}
             open={showTransferForm}
             onClose={handleTransferFormClose}
             hidePicker

--- a/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
+++ b/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
@@ -37,6 +37,7 @@ import {
 
 import { CashActivityForm } from "./cash-activity-form";
 import { ActivityForm } from "@/pages/activity/components/activity-form";
+import { TransferMatchDialog } from "@/pages/activity/components/transfer-match-dialog";
 import { getActivityRestrictionLevel } from "@/lib/activity-restrictions";
 import { ActivityType } from "@/lib/constants";
 import type { AmountRange } from "./amount-range-filter";
@@ -164,6 +165,11 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
     const [transferActivityType, setTransferActivityType] = useState<ActivityType>(
       ActivityType.TRANSFER_OUT,
     );
+    const [transferMatchDialog, setTransferMatchDialog] = useState<{
+      open: boolean;
+      mode: "link" | "unlink";
+      row: TransactionRowVM | null;
+    }>({ open: false, mode: "link", row: null });
     const [deletingIds, setDeletingIds] = useState<string[] | null>(null);
     const [deletePreview, setDeletePreview] = useState<DeletePreview | undefined>();
 
@@ -603,6 +609,12 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
         currency: row.activity.currency,
       });
     }, []);
+    const handleLinkTransfer = useCallback((row: TransactionRowVM) => {
+      setTransferMatchDialog({ open: true, mode: "link", row });
+    }, []);
+    const handleUnlinkTransfer = useCallback((row: TransactionRowVM) => {
+      setTransferMatchDialog({ open: true, mode: "unlink", row });
+    }, []);
 
     const handleToggleRow = useCallback((id: string) => {
       setSelectedRowIds((prev) => {
@@ -731,6 +743,8 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
             onEdit={handleEditRow}
             onDuplicate={handleDuplicate}
             onDelete={handleDeleteRow}
+            onLinkTransfer={handleLinkTransfer}
+            onUnlinkTransfer={handleUnlinkTransfer}
           />
         );
       });
@@ -920,6 +934,21 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
             setDeletePreview(undefined);
           }}
           onConfirm={() => deletingIds && deleteMutation.mutate(deletingIds)}
+        />
+
+        <TransferMatchDialog
+          open={transferMatchDialog.open}
+          mode={transferMatchDialog.mode}
+          sourceActivity={transferMatchDialog.row?.activity}
+          accounts={accounts}
+          onOpenChange={(open) =>
+            setTransferMatchDialog((prev) => ({
+              ...prev,
+              open,
+              row: open ? prev.row : null,
+            }))
+          }
+          onComplete={refetch}
         />
       </div>
     );

--- a/apps/frontend/src/features/spending/components/transaction-card.tsx
+++ b/apps/frontend/src/features/spending/components/transaction-card.tsx
@@ -12,6 +12,7 @@ import {
   PrivacyAmount,
 } from "@wealthfolio/ui";
 import type { Account } from "@/lib/types";
+import { ActivityType } from "@/lib/constants";
 import { cn, formatDate } from "@/lib/utils";
 
 import { QuickCategorizePopover } from "./quick-categorize-popover";
@@ -32,6 +33,8 @@ interface TransactionCardProps {
   onEdit: (row: TransactionRowVM) => void;
   onDuplicate: (row: TransactionRowVM) => void;
   onDelete: (row: TransactionRowVM) => void;
+  onLinkTransfer?: (row: TransactionRowVM) => void;
+  onUnlinkTransfer?: (row: TransactionRowVM) => void;
 }
 
 const CHIP =
@@ -50,6 +53,8 @@ function TransactionCardImpl({
   onEdit,
   onDuplicate,
   onDelete,
+  onLinkTransfer,
+  onUnlinkTransfer,
 }: TransactionCardProps) {
   const a = row.activity;
   const { isOutflow, isIncome, isSaving, isNeutral, sign, safeAmount } = getTransactionDisplay(
@@ -57,6 +62,8 @@ function TransactionCardImpl({
     account?.accountType,
   );
   const accountName = account?.name ?? a.accountId;
+  const isTransfer =
+    a.activityType === ActivityType.TRANSFER_IN || a.activityType === ActivityType.TRANSFER_OUT;
 
   return (
     <div
@@ -200,6 +207,21 @@ function TransactionCardImpl({
               <Icons.Copy className="mr-2 h-4 w-4" aria-hidden="true" />
               Duplicate
             </DropdownMenuItem>
+            {isTransfer && (onLinkTransfer || onUnlinkTransfer) ? (
+              a.sourceGroupId ? (
+                onUnlinkTransfer ? (
+                  <DropdownMenuItem onClick={() => onUnlinkTransfer(row)}>
+                    <Icons.Unlink className="mr-2 h-4 w-4" aria-hidden="true" />
+                    Unlink transfer
+                  </DropdownMenuItem>
+                ) : null
+              ) : onLinkTransfer ? (
+                <DropdownMenuItem onClick={() => onLinkTransfer(row)}>
+                  <Icons.Link className="mr-2 h-4 w-4" aria-hidden="true" />
+                  Link transfer...
+                </DropdownMenuItem>
+              ) : null
+            ) : null}
             <DropdownMenuItem className="text-destructive" onClick={() => onDelete(row)}>
               <Icons.Trash className="mr-2 h-4 w-4" aria-hidden="true" />
               Delete

--- a/apps/frontend/src/features/spending/components/transaction-card.tsx
+++ b/apps/frontend/src/features/spending/components/transaction-card.tsx
@@ -18,7 +18,11 @@ import { cn, formatDate } from "@/lib/utils";
 import { QuickCategorizePopover } from "./quick-categorize-popover";
 import { QuickEventPopover } from "./quick-event-popover";
 import { getCashActivityLabel } from "../lib/constants";
-import { getTransactionDisplay, type TransactionRowVM } from "../lib/transactions-helpers";
+import {
+  getTransactionDisplay,
+  getTransferLinkStatus,
+  type TransactionRowVM,
+} from "../lib/transactions-helpers";
 
 interface TransactionCardProps {
   row: TransactionRowVM;
@@ -64,6 +68,7 @@ function TransactionCardImpl({
   const accountName = account?.name ?? a.accountId;
   const isTransfer =
     a.activityType === ActivityType.TRANSFER_IN || a.activityType === ActivityType.TRANSFER_OUT;
+  const transferLinkStatus = getTransferLinkStatus(a);
 
   return (
     <div
@@ -208,7 +213,7 @@ function TransactionCardImpl({
               Duplicate
             </DropdownMenuItem>
             {isTransfer && (onLinkTransfer || onUnlinkTransfer) ? (
-              a.sourceGroupId ? (
+              transferLinkStatus === "linked" ? (
                 onUnlinkTransfer ? (
                   <DropdownMenuItem onClick={() => onUnlinkTransfer(row)}>
                     <Icons.Unlink className="mr-2 h-4 w-4" aria-hidden="true" />

--- a/apps/frontend/src/features/spending/components/transaction-row.tsx
+++ b/apps/frontend/src/features/spending/components/transaction-row.tsx
@@ -14,6 +14,7 @@ import {
   TableRow,
 } from "@wealthfolio/ui";
 import type { Account } from "@/lib/types";
+import { ActivityType } from "@/lib/constants";
 import { cn, formatDate } from "@/lib/utils";
 
 import { QuickCategorizePopover } from "./quick-categorize-popover";
@@ -34,6 +35,8 @@ interface TransactionRowProps {
   onEdit: (row: TransactionRowVM) => void;
   onDuplicate: (row: TransactionRowVM) => void;
   onDelete: (row: TransactionRowVM) => void;
+  onLinkTransfer?: (row: TransactionRowVM) => void;
+  onUnlinkTransfer?: (row: TransactionRowVM) => void;
 }
 
 function TransactionRowImpl({
@@ -49,6 +52,8 @@ function TransactionRowImpl({
   onEdit,
   onDuplicate,
   onDelete,
+  onLinkTransfer,
+  onUnlinkTransfer,
 }: TransactionRowProps) {
   const a = row.activity;
   const { isOutflow, isIncome, isSaving, isNeutral, sign, safeAmount } = getTransactionDisplay(
@@ -57,6 +62,8 @@ function TransactionRowImpl({
   );
   const accountName = account?.name ?? a.accountId;
   const rowAriaLabel = isSelected ? "Deselect transaction" : "Select transaction";
+  const isTransfer =
+    a.activityType === ActivityType.TRANSFER_IN || a.activityType === ActivityType.TRANSFER_OUT;
 
   return (
     <TableRow
@@ -199,6 +206,21 @@ function TransactionRowImpl({
               <Icons.Copy className="mr-2 h-4 w-4" aria-hidden="true" />
               Duplicate
             </DropdownMenuItem>
+            {isTransfer && (onLinkTransfer || onUnlinkTransfer) ? (
+              a.sourceGroupId ? (
+                onUnlinkTransfer ? (
+                  <DropdownMenuItem onClick={() => onUnlinkTransfer(row)}>
+                    <Icons.Unlink className="mr-2 h-4 w-4" aria-hidden="true" />
+                    Unlink transfer
+                  </DropdownMenuItem>
+                ) : null
+              ) : onLinkTransfer ? (
+                <DropdownMenuItem onClick={() => onLinkTransfer(row)}>
+                  <Icons.Link className="mr-2 h-4 w-4" aria-hidden="true" />
+                  Link transfer...
+                </DropdownMenuItem>
+              ) : null
+            ) : null}
             <DropdownMenuItem className="text-destructive" onClick={() => onDelete(row)}>
               <Icons.Trash className="mr-2 h-4 w-4" aria-hidden="true" />
               Delete

--- a/apps/frontend/src/features/spending/components/transaction-row.tsx
+++ b/apps/frontend/src/features/spending/components/transaction-row.tsx
@@ -20,7 +20,11 @@ import { cn, formatDate } from "@/lib/utils";
 import { QuickCategorizePopover } from "./quick-categorize-popover";
 import { QuickEventPopover } from "./quick-event-popover";
 import { getCashActivityLabel } from "../lib/constants";
-import { getTransactionDisplay, type TransactionRowVM } from "../lib/transactions-helpers";
+import {
+  getTransactionDisplay,
+  getTransferLinkStatus,
+  type TransactionRowVM,
+} from "../lib/transactions-helpers";
 
 interface TransactionRowProps {
   row: TransactionRowVM;
@@ -64,6 +68,7 @@ function TransactionRowImpl({
   const rowAriaLabel = isSelected ? "Deselect transaction" : "Select transaction";
   const isTransfer =
     a.activityType === ActivityType.TRANSFER_IN || a.activityType === ActivityType.TRANSFER_OUT;
+  const transferLinkStatus = getTransferLinkStatus(a);
 
   return (
     <TableRow
@@ -207,7 +212,7 @@ function TransactionRowImpl({
               Duplicate
             </DropdownMenuItem>
             {isTransfer && (onLinkTransfer || onUnlinkTransfer) ? (
-              a.sourceGroupId ? (
+              transferLinkStatus === "linked" ? (
                 onUnlinkTransfer ? (
                   <DropdownMenuItem onClick={() => onUnlinkTransfer(row)}>
                     <Icons.Unlink className="mr-2 h-4 w-4" aria-hidden="true" />

--- a/apps/frontend/src/features/spending/lib/transactions-helpers.ts
+++ b/apps/frontend/src/features/spending/lib/transactions-helpers.ts
@@ -1,7 +1,11 @@
 import type { TaxonomyCategory } from "@/lib/types";
 
 import { getActivitySpendingAmount, isCashActivityIncome } from "./constants";
-import type { ActivityTaxonomyAssignment, CashActivity } from "../types/cash-activity";
+import type {
+  ActivityTaxonomyAssignment,
+  CashActivity,
+  TransferLinkStatus,
+} from "../types/cash-activity";
 
 /** Stable sorted Set→array used in React Query keys (insertion order is unstable). */
 export function stableArr(s: Set<string>): string[] | undefined {
@@ -50,6 +54,13 @@ export interface TransactionDisplay {
   sign: string;
   /** Absolute-safe parsed amount (0 when unparseable). */
   safeAmount: number;
+}
+
+export function getTransferLinkStatus(activity: CashActivity): TransferLinkStatus | null {
+  if (activity.activityType !== "TRANSFER_IN" && activity.activityType !== "TRANSFER_OUT") {
+    return null;
+  }
+  return activity.transferLinkStatus ?? (activity.sourceGroupId ? "linked" : "unlinked");
 }
 
 export function getTransactionDisplay(

--- a/apps/frontend/src/features/spending/types/cash-activity.ts
+++ b/apps/frontend/src/features/spending/types/cash-activity.ts
@@ -19,6 +19,7 @@ export interface ActivityTaxonomyAssignment {
 }
 
 export type CashFlowBucket = "spending" | "income" | "saving" | "neutral";
+export type TransferLinkStatus = "linked" | "unlinked" | "invalid";
 
 export type CashActivityStatusFilter = "all" | "needs_review" | "uncategorized" | "categorized";
 
@@ -57,6 +58,8 @@ export interface CashActivity extends Activity {
   assignments: ActivityTaxonomyAssignment[];
   /** Spending event tag from the `activity_events` join. `undefined` when untagged. */
   eventId?: string | null;
+  /** Transfer pair validity for TRANSFER_IN / TRANSFER_OUT rows. */
+  transferLinkStatus?: TransferLinkStatus | null;
 }
 
 export interface CashActivitySearchResponse {

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -356,6 +356,21 @@ export interface InternalTransferPairResponse {
   transferOut: Activity;
   transferIn: Activity;
 }
+
+export interface TransferMatchCandidateRequest {
+  activityId: string;
+  windowDays?: number;
+  limit?: number;
+}
+
+export interface TransferMatchCandidate {
+  activity: Activity;
+  matchKind: "cash" | "security";
+  confidence: "high" | "medium" | "low";
+  score: number;
+  reasons: string[];
+  warnings: string[];
+}
 export type ActivityImport = z.infer<typeof importActivitySchema>;
 export type ImportMappingData = z.infer<typeof importMappingSchema>;
 export type ParseConfig = z.infer<typeof parseConfigSchema>;

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -33,6 +33,7 @@ import ActivityTableMobile from "./components/activity-table/activity-table-mobi
 import { ActivityViewControls, type ActivityViewMode } from "./components/activity-view-controls";
 import { BulkHoldingsModal } from "./components/forms/bulk-holdings-modal";
 import { MobileActivityForm } from "./components/mobile-forms/mobile-activity-form";
+import { TransferMatchDialog } from "./components/transfer-match-dialog";
 import { useActivityMutations } from "./hooks/use-activity-mutations";
 import { useActivitySearch, type ActivityStatusFilter } from "./hooks/use-activity-search";
 import {
@@ -85,6 +86,11 @@ const ActivityPage = () => {
   const [showDeleteAlert, setShowDeleteAlert] = useState(false);
   const [showBulkHoldingsForm, setShowBulkHoldingsForm] = useState(false);
   const [showAlternativeAssetModal, setShowAlternativeAssetModal] = useState(false);
+  const [transferMatchDialog, setTransferMatchDialog] = useState<{
+    open: boolean;
+    mode: "link" | "unlink";
+    activity: ActivityDetails | null;
+  }>({ open: false, mode: "link", activity: null });
   const [showActionPalette, setShowActionPalette] = useState(false);
   const [showSpendingActionPalette, setShowSpendingActionPalette] = useState(false);
   const isMobileViewport = useIsMobileViewport();
@@ -521,6 +527,14 @@ const ActivityPage = () => {
     [duplicateActivityMutation],
   );
 
+  const handleLinkTransfer = useCallback((activity: ActivityDetails) => {
+    setTransferMatchDialog({ open: true, mode: "link", activity });
+  }, []);
+
+  const handleUnlinkTransfer = useCallback((activity: ActivityDetails) => {
+    setTransferMatchDialog({ open: true, mode: "unlink", activity });
+  }, []);
+
   const handleDeleteConfirm = async () => {
     if (!selectedActivity?.id) return;
     await deleteActivityMutation.mutateAsync(selectedActivity.id);
@@ -740,6 +754,8 @@ const ActivityPage = () => {
           handleEdit={handleEdit}
           handleDelete={handleDelete}
           onDuplicate={handleDuplicate}
+          onLinkTransfer={handleLinkTransfer}
+          onUnlinkTransfer={handleUnlinkTransfer}
           filtersActive={investmentsFiltersActive}
           onAdd={() => handleEdit(undefined)}
           onClearFilters={clearInvestmentsFilters}
@@ -747,6 +763,7 @@ const ActivityPage = () => {
       ) : shouldUseDatagridView ? (
         <ActivityDataGrid
           accounts={investmentAccounts}
+          transferMatchAccounts={accounts}
           activities={datagridActivities}
           onRefetch={paginatedSearch.refetch}
           onEditActivity={handleEdit}
@@ -768,6 +785,8 @@ const ActivityPage = () => {
           onSortingChange={setSorting}
           handleEdit={handleEdit}
           handleDelete={handleDelete}
+          onLinkTransfer={handleLinkTransfer}
+          onUnlinkTransfer={handleUnlinkTransfer}
           filtersActive={investmentsFiltersActive}
           onAdd={() => handleEdit(undefined)}
           onClearFilters={clearInvestmentsFilters}
@@ -826,6 +845,20 @@ const ActivityPage = () => {
       <AlternativeAssetQuickAddModal
         open={showAlternativeAssetModal}
         onOpenChange={setShowAlternativeAssetModal}
+      />
+      <TransferMatchDialog
+        open={transferMatchDialog.open}
+        mode={transferMatchDialog.mode}
+        sourceActivity={transferMatchDialog.activity}
+        accounts={accounts}
+        onOpenChange={(open) =>
+          setTransferMatchDialog((prev) => ({
+            ...prev,
+            open,
+            activity: open ? prev.activity : null,
+          }))
+        }
+        onComplete={infiniteSearch.refetch}
       />
     </>
   );

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -494,16 +494,7 @@ const ActivityPage = () => {
           return;
         } catch {
           // Fall back to single-leg editing for invalid groups that are not valid internal pairs.
-          setSelectedActivity({
-            ...activity,
-            metadata: {
-              ...activity.metadata,
-              flow: {
-                ...((activity.metadata?.flow as Record<string, unknown> | undefined) ?? {}),
-                is_external: true,
-              },
-            },
-          });
+          setSelectedActivity(activity);
           setShowForm(true);
           return;
         }

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-data-grid.tsx
@@ -12,6 +12,7 @@ import { ActivityType } from "@/lib/constants";
 import { isManualSearchResult, quoteModeFromSearchResult } from "@/lib/asset-utils";
 import { generateId } from "@/lib/id";
 import { LinkTransferModal } from "../link-transfer-modal";
+import { TransferMatchDialog } from "../transfer-match-dialog";
 import { ActivityDeleteModal } from "../activity-delete-modal";
 import { useActivityMutations } from "../../hooks/use-activity-mutations";
 import { ActivityDataGridPagination } from "./activity-data-grid-pagination";
@@ -31,6 +32,7 @@ import { useSaveActivities } from "./use-save-activities";
 
 interface ActivityDataGridProps {
   accounts: Account[];
+  transferMatchAccounts?: Account[];
   activities: ActivityDetails[];
   onRefetch: () => Promise<unknown>;
   onEditActivity: (activity: ActivityDetails) => void;
@@ -67,6 +69,7 @@ const DEFAULT_COLUMN_VISIBILITY: VisibilityState = {
  */
 export function ActivityDataGrid({
   accounts,
+  transferMatchAccounts,
   activities,
   onRefetch,
   onEditActivity,
@@ -172,6 +175,11 @@ export function ActivityDataGrid({
   );
 
   const [pendingDeleteActivity, setPendingDeleteActivity] = useState<ActivityDetails | null>(null);
+  const [rowTransferDialog, setRowTransferDialog] = useState<{
+    open: boolean;
+    mode: "link" | "unlink";
+    activity: ActivityDetails | null;
+  }>({ open: false, mode: "link", activity: null });
 
   const executePairedDelete = useCallback(
     (activity: ActivityDetails) => {
@@ -197,6 +205,36 @@ export function ActivityDataGrid({
       }
     },
     [markForDeletion],
+  );
+
+  const handleRowLinkTransfer = useCallback(
+    (activity: ActivityDetails) => {
+      if ((activity as LocalTransaction).isNew || dirtyTransactionIds.has(activity.id)) {
+        toast({
+          title: "Save edits first",
+          description: "Save or discard pending edits before linking this transfer.",
+          variant: "destructive",
+        });
+        return;
+      }
+      setRowTransferDialog({ open: true, mode: "link", activity });
+    },
+    [dirtyTransactionIds],
+  );
+
+  const handleRowUnlinkTransfer = useCallback(
+    (activity: ActivityDetails) => {
+      if ((activity as LocalTransaction).isNew || dirtyTransactionIds.has(activity.id)) {
+        toast({
+          title: "Save edits first",
+          description: "Save or discard pending edits before unlinking this transfer.",
+          variant: "destructive",
+        });
+        return;
+      }
+      setRowTransferDialog({ open: true, mode: "unlink", activity });
+    },
+    [dirtyTransactionIds],
   );
 
   // Race condition guard for async quote resolution
@@ -364,6 +402,8 @@ export function ActivityDataGrid({
     onEditActivity,
     onDuplicate: handleDuplicate,
     onDelete: handleDelete,
+    onLinkTransfer: handleRowLinkTransfer,
+    onUnlinkTransfer: handleRowUnlinkTransfer,
     onSymbolSelect: handleSymbolSelect,
     onCreateCustomAsset: handleCreateCustomAsset,
   });
@@ -795,6 +835,24 @@ export function ActivityDataGrid({
         warnings={transferDialogMode === "link" ? linkWarnings : []}
         onConfirm={transferDialogMode === "link" ? handleLinkConfirm : handleUnlinkConfirm}
         onCancel={() => setTransferDialogOpen(false)}
+      />
+
+      <TransferMatchDialog
+        open={rowTransferDialog.open}
+        mode={rowTransferDialog.mode}
+        sourceActivity={rowTransferDialog.activity}
+        accounts={transferMatchAccounts ?? accounts}
+        onOpenChange={(open) =>
+          setRowTransferDialog((prev) => ({
+            ...prev,
+            open,
+            activity: open ? prev.activity : null,
+          }))
+        }
+        onComplete={() => {
+          dataGrid.table.resetRowSelection();
+          return onRefetch();
+        }}
       />
 
       <ActivityDeleteModal

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/use-activity-columns.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/use-activity-columns.tsx
@@ -68,6 +68,8 @@ interface UseActivityColumnsOptions {
   onEditActivity: (activity: ActivityDetails) => void;
   onDuplicate: (activity: ActivityDetails) => void;
   onDelete: (activity: ActivityDetails) => void;
+  onLinkTransfer?: (activity: ActivityDetails) => void;
+  onUnlinkTransfer?: (activity: ActivityDetails) => void;
   /** Called when a symbol is selected from search, with the full result including exchangeMic */
   onSymbolSelect?: (rowIndex: number, result: SymbolSearchResult) => void;
   /** Called when user wants to create a custom asset. Opens a dialog to collect asset metadata. */
@@ -82,6 +84,8 @@ export function useActivityColumns({
   onEditActivity,
   onDuplicate,
   onDelete,
+  onLinkTransfer,
+  onUnlinkTransfer,
   onSymbolSelect,
   onCreateCustomAsset,
 }: UseActivityColumnsOptions) {
@@ -436,6 +440,8 @@ export function useActivityColumns({
               onEdit={onEditActivity}
               onDuplicate={onDuplicate}
               onDelete={onDelete}
+              onLinkTransfer={onLinkTransfer}
+              onUnlinkTransfer={onUnlinkTransfer}
             />
           </div>
         ),
@@ -449,6 +455,8 @@ export function useActivityColumns({
       onDelete,
       onDuplicate,
       onEditActivity,
+      onLinkTransfer,
+      onUnlinkTransfer,
       onSymbolSelect,
     ],
   );

--- a/apps/frontend/src/pages/activity/components/activity-operations.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-operations.tsx
@@ -8,6 +8,7 @@ import {
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
 
 import type { Activity, ActivityDetails } from "@/lib/types";
+import { ActivityType } from "@/lib/constants";
 import { Row } from "@tanstack/react-table";
 import { useState } from "react";
 import { ActivityDetailSheet } from "./activity-detail-sheet";
@@ -18,6 +19,8 @@ export interface ActivityOperationsProps<TData> {
   onEdit: (activity: ActivityDetails) => void | undefined;
   onDelete: (activity: ActivityDetails) => void | undefined;
   onDuplicate: (activity: ActivityDetails) => void | undefined | Promise<void> | Promise<Activity>;
+  onLinkTransfer?: (activity: ActivityDetails) => void | undefined;
+  onUnlinkTransfer?: (activity: ActivityDetails) => void | undefined;
 }
 
 export function ActivityOperations<TData>({
@@ -26,9 +29,16 @@ export function ActivityOperations<TData>({
   onEdit,
   onDelete,
   onDuplicate,
+  onLinkTransfer,
+  onUnlinkTransfer,
 }: ActivityOperationsProps<TData>) {
   const activity = activityProp ?? (row?.original as ActivityDetails);
   const [detailSheetOpen, setDetailSheetOpen] = useState(false);
+  const isTransfer =
+    activity.activityType === ActivityType.TRANSFER_IN ||
+    activity.activityType === ActivityType.TRANSFER_OUT;
+  const isNew = (activity as ActivityDetails & { isNew?: boolean }).isNew === true;
+  const canShowTransferActions = isTransfer && !isNew && (onLinkTransfer || onUnlinkTransfer);
 
   return (
     <>
@@ -51,6 +61,23 @@ export function ActivityOperations<TData>({
             <Icons.Copy className="mr-2 h-4 w-4" />
             Duplicate
           </DropdownMenuItem>
+          {canShowTransferActions ? (
+            <>
+              {activity.sourceGroupId ? (
+                onUnlinkTransfer ? (
+                  <DropdownMenuItem onClick={() => onUnlinkTransfer(activity)}>
+                    <Icons.Unlink className="mr-2 h-4 w-4" />
+                    Unlink transfer
+                  </DropdownMenuItem>
+                ) : null
+              ) : onLinkTransfer ? (
+                <DropdownMenuItem onClick={() => onLinkTransfer(activity)}>
+                  <Icons.Link className="mr-2 h-4 w-4" />
+                  Link transfer...
+                </DropdownMenuItem>
+              ) : null}
+            </>
+          ) : null}
           <DropdownMenuSeparator />
           <DropdownMenuItem
             className="text-destructive focus:text-destructive flex cursor-pointer items-center"

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
@@ -27,6 +27,8 @@ interface ActivityTableMobileProps {
   handleEdit: (activity?: ActivityDetails) => void;
   handleDelete: (activity: ActivityDetails) => void;
   onDuplicate: (activity: ActivityDetails) => Promise<void>;
+  onLinkTransfer?: (activity: ActivityDetails) => void;
+  onUnlinkTransfer?: (activity: ActivityDetails) => void;
   filtersActive?: boolean;
   onAdd?: () => void;
   onClearFilters?: () => void;
@@ -38,6 +40,8 @@ export const ActivityTableMobile = ({
   handleEdit,
   handleDelete,
   onDuplicate,
+  onLinkTransfer,
+  onUnlinkTransfer,
   filtersActive = false,
   onAdd,
   onClearFilters,
@@ -155,6 +159,8 @@ export const ActivityTableMobile = ({
                   onEdit={handleEdit}
                   onDelete={handleDelete}
                   onDuplicate={onDuplicate}
+                  onLinkTransfer={onLinkTransfer}
+                  onUnlinkTransfer={onUnlinkTransfer}
                 />
               </div>
             </Card>
@@ -195,6 +201,8 @@ export const ActivityTableMobile = ({
                   onEdit={handleEdit}
                   onDelete={handleDelete}
                   onDuplicate={onDuplicate}
+                  onLinkTransfer={onLinkTransfer}
+                  onUnlinkTransfer={onUnlinkTransfer}
                 />
               </div>
 

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
@@ -56,6 +56,8 @@ interface ActivityTableProps {
   onSortingChange: (sorting: SortingState) => void;
   handleEdit: (activity?: ActivityDetails) => void;
   handleDelete: (activity: ActivityDetails) => void;
+  onLinkTransfer?: (activity: ActivityDetails) => void;
+  onUnlinkTransfer?: (activity: ActivityDetails) => void;
   filtersActive?: boolean;
   onAdd?: () => void;
   onClearFilters?: () => void;
@@ -68,6 +70,8 @@ export const ActivityTable = ({
   onSortingChange,
   handleEdit,
   handleDelete,
+  onLinkTransfer,
+  onUnlinkTransfer,
   filtersActive = false,
   onAdd,
   onClearFilters,
@@ -488,13 +492,22 @@ export const ActivityTable = ({
               onEdit={handleEdit}
               onDelete={handleDelete}
               onDuplicate={handleDuplicate}
+              onLinkTransfer={onLinkTransfer}
+              onUnlinkTransfer={onUnlinkTransfer}
             />
           );
         },
         enableHiding: false,
       },
     ],
-    [handleEdit, handleDelete, handleDuplicate, symbolExchangeCountMap],
+    [
+      handleEdit,
+      handleDelete,
+      handleDuplicate,
+      onLinkTransfer,
+      onUnlinkTransfer,
+      symbolExchangeCountMap,
+    ],
   );
 
   const handleSortingChange = React.useCallback<OnChangeFn<SortingState>>(

--- a/apps/frontend/src/pages/activity/components/forms/__tests__/form-schemas.test.ts
+++ b/apps/frontend/src/pages/activity/components/forms/__tests__/form-schemas.test.ts
@@ -854,6 +854,43 @@ describe("Form Schemas Validation", () => {
       expect(defaults.assetId).toBeNull();
     });
 
+    it("does not infer external mode for unpaired existing transfers", () => {
+      const defaults = ACTIVITY_FORM_CONFIG.TRANSFER.getDefaults(
+        {
+          id: "transfer-in-1",
+          activityType: ActivityType.TRANSFER_IN,
+          accountId: "acc-123",
+          date: new Date(),
+          amount: "1000",
+          currency: "USD",
+        },
+        [],
+      ) as any;
+
+      expect(defaults.isExternal).toBe(false);
+      expect(defaults.accountId).toBe("");
+      expect(defaults.toAccountId).toBe("acc-123");
+    });
+
+    it("uses persisted external metadata for existing transfers", () => {
+      const defaults = ACTIVITY_FORM_CONFIG.TRANSFER.getDefaults(
+        {
+          id: "transfer-in-1",
+          activityType: ActivityType.TRANSFER_IN,
+          accountId: "acc-123",
+          date: new Date(),
+          amount: "1000",
+          currency: "USD",
+          metadata: { flow: { is_external: true } },
+        },
+        [],
+      ) as any;
+
+      expect(defaults.isExternal).toBe(true);
+      expect(defaults.accountId).toBe("acc-123");
+      expect(defaults.toAccountId).toBe("");
+    });
+
     it("includes unitPrice in payload for external securities transfer-in", () => {
       const formData = {
         isExternal: true,

--- a/apps/frontend/src/pages/activity/components/forms/transfer-form.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/transfer-form.tsx
@@ -513,16 +513,24 @@ export function TransferForm({
     setValue("isExternal", checked, { shouldValidate: false });
     // Reset account fields when toggling
     if (checked) {
-      // Switching to external: copy fromAccountId to accountId if set
-      if (fromAccountId) {
-        setValue("accountId", fromAccountId);
+      // Switching to external: keep the account from the side represented by the direction.
+      const externalAccountId =
+        direction === "in"
+          ? toAccountId || accountId || fromAccountId
+          : fromAccountId || accountId || toAccountId;
+      if (externalAccountId) {
+        setValue("accountId", externalAccountId);
       }
       setValue("fromAccountId", "");
       setValue("toAccountId", "");
     } else {
-      // Switching to internal: copy accountId to fromAccountId if set
+      // Switching to internal: put the account back on the side represented by the direction.
       if (accountId) {
-        setValue("fromAccountId", accountId);
+        if (direction === "in") {
+          setValue("toAccountId", accountId);
+        } else {
+          setValue("fromAccountId", accountId);
+        }
       }
       setValue("accountId", "");
     }

--- a/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
@@ -273,7 +273,12 @@ export function MobileActivityForm({
       isSecuritiesTransfer(activity?.activityType ?? "", activity?.assetSymbol, activity?.assetId);
     const initialTransferMode = isSecurityTransferActivity ? "securities" : "cash";
     const flowMetadata = activity?.metadata?.flow as { is_external?: boolean } | undefined;
-    const initialIsExternal = isTransferType ? flowMetadata?.is_external === true : false;
+    const hasInternalPair = Boolean(activity?.transferOutId && activity?.transferInId);
+    const initialIsExternal = isTransferType
+      ? activity?.id
+        ? flowMetadata?.is_external === true || !hasInternalPair
+        : flowMetadata?.is_external === true
+      : false;
     const editingTransferIn = activity?.activityType === ActivityType.TRANSFER_IN;
     const sourceAmount = editingTransferIn
       ? activity?.counterpartAmount
@@ -536,6 +541,12 @@ export function MobileActivityForm({
             (activity?.activityType === ActivityType.TRANSFER_IN
               ? activity.id
               : activity?.counterpartActivityId);
+
+          if (id && (!transferOutId || !transferInId)) {
+            throw new Error(
+              "Use Link transfer... to pair this existing transfer before saving it as internal.",
+            );
+          }
 
           await saveInternalTransferPairMutation.mutateAsync({
             transferOutId: id ? transferOutId : undefined,

--- a/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
@@ -273,12 +273,7 @@ export function MobileActivityForm({
       isSecuritiesTransfer(activity?.activityType ?? "", activity?.assetSymbol, activity?.assetId);
     const initialTransferMode = isSecurityTransferActivity ? "securities" : "cash";
     const flowMetadata = activity?.metadata?.flow as { is_external?: boolean } | undefined;
-    const hasInternalPair = Boolean(activity?.transferOutId && activity?.transferInId);
-    const initialIsExternal = isTransferType
-      ? activity?.id
-        ? flowMetadata?.is_external === true || !hasInternalPair
-        : flowMetadata?.is_external === true
-      : false;
+    const initialIsExternal = isTransferType ? flowMetadata?.is_external === true : false;
     const editingTransferIn = activity?.activityType === ActivityType.TRANSFER_IN;
     const sourceAmount = editingTransferIn
       ? activity?.counterpartAmount

--- a/apps/frontend/src/pages/activity/components/mobile-forms/mobile-details-step.tsx
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/mobile-details-step.tsx
@@ -233,14 +233,21 @@ export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileD
   const handleExternalChange = (checked: boolean) => {
     setValue("isExternal" as any, checked, { shouldValidate: false });
     if (checked) {
-      // Copy current account to accountId for external
-      if (accountId) {
-        setValue("accountId", accountId);
+      const externalAccountId =
+        direction === "in" ? toAccountId || accountId : accountId || toAccountId;
+      if (externalAccountId) {
+        setValue("accountId", externalAccountId);
       }
       setValue("toAccountId" as any, "");
     } else {
-      // Internal: use accountId as fromAccountId
-      setValue("toAccountId" as any, "");
+      if (direction === "in") {
+        if (accountId) {
+          setValue("toAccountId" as any, accountId);
+        }
+        setValue("accountId", "");
+      } else {
+        setValue("toAccountId" as any, "");
+      }
     }
   };
 

--- a/apps/frontend/src/pages/activity/components/transfer-match-dialog.tsx
+++ b/apps/frontend/src/pages/activity/components/transfer-match-dialog.tsx
@@ -1,0 +1,843 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  findTransferMatchCandidates,
+  getTransferPairForActivity,
+  searchActivities,
+} from "@/adapters";
+import { ActivityStatus, ActivityType, ActivityTypeNames } from "@/lib/constants";
+import type { Account, Activity, ActivityDetails, TransferMatchCandidate } from "@/lib/types";
+import { cn, formatDateISO, formatDateTime } from "@/lib/utils";
+import {
+  Badge,
+  Button,
+  formatAmount,
+  Icons,
+  Input,
+  ScrollArea,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@wealthfolio/ui";
+import { useActivityMutations } from "../hooks/use-activity-mutations";
+
+export type TransferDialogActivity = Activity | ActivityDetails;
+
+interface SelectedCandidate {
+  activity: TransferDialogActivity;
+  reasons: string[];
+  warnings: string[];
+}
+
+interface TransferMatchDialogProps {
+  open: boolean;
+  mode: "link" | "unlink";
+  sourceActivity?: TransferDialogActivity | null;
+  accounts: Account[];
+  onOpenChange: (open: boolean) => void;
+  onComplete?: () => void | Promise<unknown>;
+}
+
+interface NormalizedTransferActivity {
+  id: string;
+  accountId: string;
+  accountName: string;
+  accountType: string;
+  accountCurrency: string;
+  activityType: string;
+  date: Date | string;
+  amount?: string | null;
+  quantity?: string | null;
+  unitPrice?: string | null;
+  currency: string;
+  assetId?: string;
+  assetSymbol?: string;
+  notes?: string;
+  sourceGroupId?: string;
+  status?: string;
+}
+
+const ALL = "__all__";
+const STRICT = "strict";
+const ANY = "any";
+const SAME_ASSET = "same";
+const CASH_ASSET = "cash";
+
+function isTransferType(activityType: string | undefined): boolean {
+  return activityType === ActivityType.TRANSFER_IN || activityType === ActivityType.TRANSFER_OUT;
+}
+
+function oppositeTransferType(activityType: string | undefined): ActivityType | undefined {
+  if (activityType === ActivityType.TRANSFER_IN) return ActivityType.TRANSFER_OUT;
+  if (activityType === ActivityType.TRANSFER_OUT) return ActivityType.TRANSFER_IN;
+  return undefined;
+}
+
+function parseNumber(value: string | number | null | undefined): number | undefined {
+  if (value == null) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function absEquals(a: number | undefined, b: number | undefined, tolerance = 0.000001): boolean {
+  if (a == null || b == null) return false;
+  return Math.abs(Math.abs(a) - Math.abs(b)) <= tolerance;
+}
+
+function getActivityDate(activity: TransferDialogActivity): Date | string {
+  return "date" in activity ? activity.date : activity.activityDate;
+}
+
+function getActivityNotes(activity: TransferDialogActivity): string | undefined {
+  if ("comment" in activity) return activity.comment;
+  return (activity as Activity).notes;
+}
+
+function getActivityAssetSymbol(activity: TransferDialogActivity): string | undefined {
+  if ("assetSymbol" in activity && activity.assetSymbol?.trim()) return activity.assetSymbol;
+  return activity.assetId;
+}
+
+function getAccountName(
+  activity: TransferDialogActivity,
+  accountMap: Map<string, Account>,
+): string {
+  if ("accountName" in activity && activity.accountName?.trim()) return activity.accountName;
+  return accountMap.get(activity.accountId)?.name ?? activity.accountId;
+}
+
+function getAccountCurrency(
+  activity: TransferDialogActivity,
+  accountMap: Map<string, Account>,
+): string {
+  if ("accountCurrency" in activity && activity.accountCurrency?.trim()) {
+    return activity.accountCurrency;
+  }
+  return accountMap.get(activity.accountId)?.currency ?? activity.currency;
+}
+
+function normalizeActivity(
+  activity: TransferDialogActivity,
+  accountMap: Map<string, Account>,
+): NormalizedTransferActivity {
+  const account = accountMap.get(activity.accountId);
+  return {
+    id: activity.id,
+    accountId: activity.accountId,
+    accountName: getAccountName(activity, accountMap),
+    accountType: account?.accountType ?? "",
+    accountCurrency: getAccountCurrency(activity, accountMap),
+    activityType: activity.activityType,
+    date: getActivityDate(activity),
+    amount: activity.amount,
+    quantity: activity.quantity,
+    unitPrice: activity.unitPrice,
+    currency: activity.currency,
+    assetId: activity.assetId,
+    assetSymbol: getActivityAssetSymbol(activity),
+    notes: getActivityNotes(activity),
+    sourceGroupId: activity.sourceGroupId,
+    status: activity.status,
+  };
+}
+
+function assetKey(activity: NormalizedTransferActivity): string | undefined {
+  const raw = (activity.assetId ?? activity.assetSymbol ?? "").trim();
+  if (!raw) return undefined;
+  const key = raw.toUpperCase();
+  if (key === "CASH" || key.startsWith("$CASH") || key.startsWith("CASH:")) return undefined;
+  return key;
+}
+
+function amountValue(activity: NormalizedTransferActivity): number | undefined {
+  const amount = parseNumber(activity.amount);
+  if (amount != null) return amount;
+  const quantity = parseNumber(activity.quantity);
+  const unitPrice = parseNumber(activity.unitPrice);
+  if (quantity != null && unitPrice != null) return quantity * unitPrice;
+  return undefined;
+}
+
+function isSecurityTransfer(activity: NormalizedTransferActivity): boolean {
+  return Boolean(assetKey(activity));
+}
+
+function sameExactShape(
+  source: NormalizedTransferActivity,
+  candidate: NormalizedTransferActivity,
+): boolean {
+  if (isSecurityTransfer(source) || isSecurityTransfer(candidate)) {
+    return (
+      assetKey(source) === assetKey(candidate) &&
+      absEquals(parseNumber(source.quantity), parseNumber(candidate.quantity))
+    );
+  }
+  return (
+    source.currency === candidate.currency && absEquals(amountValue(source), amountValue(candidate))
+  );
+}
+
+function canLinkCandidate(
+  source: NormalizedTransferActivity,
+  candidate: NormalizedTransferActivity,
+): boolean {
+  if (isSecurityTransfer(source) || isSecurityTransfer(candidate)) {
+    return (
+      assetKey(source) === assetKey(candidate) &&
+      absEquals(parseNumber(source.quantity), parseNumber(candidate.quantity))
+    );
+  }
+  return true;
+}
+
+function dateDiffDays(a: Date | string, b: Date | string): number | undefined {
+  const left = new Date(a).getTime();
+  const right = new Date(b).getTime();
+  if (!Number.isFinite(left) || !Number.isFinite(right)) return undefined;
+  return Math.round(Math.abs(left - right) / (1000 * 60 * 60 * 24));
+}
+
+function dateWindow(date: Date | string, windowDays: number): { from: string; to: string } {
+  const center = new Date(date);
+  const from = new Date(center);
+  const to = new Date(center);
+  from.setDate(center.getDate() - windowDays);
+  to.setDate(center.getDate() + windowDays);
+  return { from: formatDateISO(from), to: formatDateISO(to) };
+}
+
+function activityMatchesText(activity: NormalizedTransferActivity, searchText: string): boolean {
+  const needle = searchText.trim().toLowerCase();
+  if (!needle) return true;
+  const haystack = [activity.notes, activity.assetSymbol, activity.assetId, activity.accountName]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(needle);
+}
+
+function manualWarnings(
+  source: NormalizedTransferActivity,
+  candidate: NormalizedTransferActivity,
+): string[] {
+  const warnings: string[] = [];
+  const diff = dateDiffDays(source.date, candidate.date);
+  if (diff && diff > 0) warnings.push(`Dates differ by ${diff} day${diff === 1 ? "" : "s"}.`);
+  if (source.currency !== candidate.currency) {
+    warnings.push(`Currencies differ (${source.currency} / ${candidate.currency}).`);
+  }
+  const sourcePrice = parseNumber(source.unitPrice);
+  const candidatePrice = parseNumber(candidate.unitPrice);
+  if (
+    sourcePrice != null &&
+    candidatePrice != null &&
+    !absEquals(sourcePrice, candidatePrice, 0.01)
+  ) {
+    warnings.push("Prices differ.");
+  }
+  if (!sameExactShape(source, candidate)) {
+    warnings.push("Amount or quantity does not exactly match.");
+  }
+  return warnings;
+}
+
+function activitySortKey(activity: TransferDialogActivity): string {
+  return `${new Date(getActivityDate(activity)).getTime()}-${activity.id}`;
+}
+
+function ActivitySummaryRow({
+  activity,
+  accountMap,
+  label,
+}: {
+  activity: TransferDialogActivity;
+  accountMap: Map<string, Account>;
+  label?: string;
+}) {
+  const normalized = normalizeActivity(activity, accountMap);
+  const date = formatDateTime(normalized.date).date;
+  const amount = amountValue(normalized);
+  const quantity = parseNumber(normalized.quantity);
+  const symbol = normalized.assetSymbol || normalized.assetId || "Cash";
+  const typeName =
+    ActivityTypeNames[normalized.activityType as ActivityType] ?? normalized.activityType;
+
+  return (
+    <div className="bg-muted/30 flex flex-col gap-1 rounded-md border px-3 py-2 text-sm">
+      <div className="text-muted-foreground flex items-center justify-between gap-3 text-xs uppercase">
+        <span>{label ?? typeName}</span>
+        <span>{date}</span>
+      </div>
+      <div className="flex items-center justify-between gap-3">
+        <span className="min-w-0 truncate font-medium">{normalized.accountName}</span>
+        <span className="shrink-0">
+          {amount != null
+            ? formatAmount(Math.abs(amount), normalized.currency)
+            : normalized.currency}
+        </span>
+      </div>
+      <div className="text-muted-foreground flex items-center justify-between gap-3 text-xs">
+        <span className="min-w-0 truncate">{normalized.notes || symbol}</span>
+        <span className="shrink-0">
+          {quantity != null ? `${Math.abs(quantity)} ${symbol}` : normalized.accountCurrency}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function CandidateButton({
+  candidate,
+  accountMap,
+  selected,
+  onSelect,
+}: {
+  candidate: SelectedCandidate;
+  accountMap: Map<string, Account>;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        "hover:bg-muted/50 w-full rounded-md border p-2 text-left transition-colors",
+        selected && "border-primary bg-primary/5",
+      )}
+      onClick={onSelect}
+    >
+      <ActivitySummaryRow activity={candidate.activity} accountMap={accountMap} />
+      {candidate.reasons.length > 0 ? (
+        <div className="text-muted-foreground mt-2 flex flex-wrap gap-1 text-[11px]">
+          {candidate.reasons.map((reason) => (
+            <Badge key={reason} variant="secondary" className="rounded-sm px-1.5 py-0">
+              {reason}
+            </Badge>
+          ))}
+        </div>
+      ) : null}
+      {candidate.warnings.length > 0 ? (
+        <div className="mt-2 flex items-start gap-1.5 text-[11px] text-amber-600">
+          <Icons.AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+          <span>{candidate.warnings.join(" ")}</span>
+        </div>
+      ) : null}
+    </button>
+  );
+}
+
+export function TransferMatchDialog({
+  open,
+  mode,
+  sourceActivity,
+  accounts,
+  onOpenChange,
+  onComplete,
+}: TransferMatchDialogProps) {
+  const accountMap = useMemo(
+    () => new Map(accounts.map((account) => [account.id, account])),
+    [accounts],
+  );
+  const activeAccounts = useMemo(
+    () => accounts.filter((account) => !account.isArchived),
+    [accounts],
+  );
+  const accountTypeOptions = useMemo(
+    () => Array.from(new Set(activeAccounts.map((account) => account.accountType))).sort(),
+    [activeAccounts],
+  );
+  const currencyOptions = useMemo(
+    () => Array.from(new Set(activeAccounts.map((account) => account.currency))).sort(),
+    [activeAccounts],
+  );
+
+  const source = useMemo(
+    () => (sourceActivity ? normalizeActivity(sourceActivity, accountMap) : null),
+    [accountMap, sourceActivity],
+  );
+  const oppositeType = oppositeTransferType(source?.activityType);
+
+  const { linkTransferActivitiesMutation, unlinkTransferActivitiesMutation } =
+    useActivityMutations();
+  const isProcessing =
+    mode === "link"
+      ? linkTransferActivitiesMutation.isPending
+      : unlinkTransferActivitiesMutation.isPending;
+
+  const [suggestions, setSuggestions] = useState<TransferMatchCandidate[]>([]);
+  const [suggestionsLoading, setSuggestionsLoading] = useState(false);
+  const [suggestionsError, setSuggestionsError] = useState<string | null>(null);
+  const [manualResults, setManualResults] = useState<ActivityDetails[]>([]);
+  const [manualSearched, setManualSearched] = useState(false);
+  const [manualLoading, setManualLoading] = useState(false);
+  const [manualError, setManualError] = useState<string | null>(null);
+  const [selectedCandidate, setSelectedCandidate] = useState<SelectedCandidate | null>(null);
+  const [counterpart, setCounterpart] = useState<TransferDialogActivity | null>(null);
+  const [counterpartError, setCounterpartError] = useState<string | null>(null);
+  const [counterpartLoading, setCounterpartLoading] = useState(false);
+
+  const [searchText, setSearchText] = useState("");
+  const [accountId, setAccountId] = useState(ALL);
+  const [accountType, setAccountType] = useState(ALL);
+  const [windowDays, setWindowDays] = useState("7");
+  const [currency, setCurrency] = useState(ALL);
+  const [assetFilter, setAssetFilter] = useState(ALL);
+  const [matchMode, setMatchMode] = useState(STRICT);
+
+  const resetFilters = useCallback(() => {
+    setSearchText("");
+    setAccountId(ALL);
+    setAccountType(ALL);
+    setWindowDays("7");
+    setCurrency(ALL);
+    setAssetFilter(ALL);
+    setMatchMode(STRICT);
+    setManualResults([]);
+    setManualSearched(false);
+    setManualError(null);
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    setSelectedCandidate(null);
+    setSuggestions([]);
+    setSuggestionsError(null);
+    setManualResults([]);
+    setManualSearched(false);
+    setManualError(null);
+    setCounterpart(null);
+    setCounterpartError(null);
+
+    if (!sourceActivity?.id) return;
+
+    if (mode === "link") {
+      setSuggestionsLoading(true);
+      findTransferMatchCandidates({ activityId: sourceActivity.id, windowDays: 7, limit: 25 })
+        .then((result) => setSuggestions(result))
+        .catch((error) =>
+          setSuggestionsError(
+            error instanceof Error ? error.message : "Could not load suggested matches.",
+          ),
+        )
+        .finally(() => setSuggestionsLoading(false));
+    } else {
+      setCounterpartLoading(true);
+      getTransferPairForActivity(sourceActivity.id)
+        .then((pair) => {
+          setCounterpart(
+            sourceActivity.id === pair.transferIn.id ? pair.transferOut : pair.transferIn,
+          );
+        })
+        .catch((error) =>
+          setCounterpartError(
+            error instanceof Error ? error.message : "Could not load the linked transfer pair.",
+          ),
+        )
+        .finally(() => setCounterpartLoading(false));
+    }
+  }, [mode, open, sourceActivity]);
+
+  const suggestedCandidates = useMemo<SelectedCandidate[]>(
+    () =>
+      suggestions.map((candidate) => ({
+        activity: candidate.activity,
+        reasons: candidate.reasons,
+        warnings: candidate.warnings,
+      })),
+    [suggestions],
+  );
+
+  const filteredManualResults = useMemo<SelectedCandidate[]>(() => {
+    if (!source || !oppositeType) return [];
+    return manualResults
+      .filter((activity) => {
+        const candidate = normalizeActivity(activity, accountMap);
+        const candidateAccount = accountMap.get(candidate.accountId);
+        if (candidate.id === source.id) return false;
+        if (candidate.accountId === source.accountId) return false;
+        if (candidate.sourceGroupId) return false;
+        if (candidate.activityType !== oppositeType) return false;
+        if (candidate.status && candidate.status !== ActivityStatus.POSTED) return false;
+        if (accountId !== ALL && candidate.accountId !== accountId) return false;
+        if (accountType !== ALL && candidateAccount?.accountType !== accountType) return false;
+        if (currency !== ALL && candidate.currency !== currency) return false;
+        if (assetFilter === SAME_ASSET && assetKey(candidate) !== assetKey(source)) return false;
+        if (assetFilter === CASH_ASSET && assetKey(candidate)) return false;
+        if (!canLinkCandidate(source, candidate)) return false;
+        if (matchMode === STRICT && !sameExactShape(source, candidate)) return false;
+        return activityMatchesText(candidate, searchText);
+      })
+      .sort((left, right) => activitySortKey(right).localeCompare(activitySortKey(left)))
+      .map((activity) => {
+        const candidate = normalizeActivity(activity, accountMap);
+        const reasons = sameExactShape(source, candidate)
+          ? [isSecurityTransfer(source) ? "Same asset and quantity" : "Same amount and currency"]
+          : ["Eligible opposite transfer"];
+        return {
+          activity,
+          reasons,
+          warnings: manualWarnings(source, candidate),
+        };
+      });
+  }, [
+    accountId,
+    accountMap,
+    accountType,
+    assetFilter,
+    currency,
+    manualResults,
+    matchMode,
+    oppositeType,
+    searchText,
+    source,
+  ]);
+
+  const runManualSearch = useCallback(async () => {
+    if (!source || !oppositeType) return;
+    const days = Number(windowDays);
+    const safeWindowDays = Number.isFinite(days) ? days : 7;
+    const { from, to } = dateWindow(source.date, safeWindowDays);
+    setManualLoading(true);
+    setManualError(null);
+    try {
+      const response = await searchActivities(
+        0,
+        250,
+        {
+          activityTypes: [oppositeType],
+          accountIds: accountId === ALL ? undefined : [accountId],
+          dateFrom: from,
+          dateTo: to,
+        },
+        "",
+        { id: "date", desc: true },
+      );
+      setManualResults(response.data);
+      setManualSearched(true);
+    } catch (error) {
+      setManualError(error instanceof Error ? error.message : "Could not search activities.");
+    } finally {
+      setManualLoading(false);
+    }
+  }, [accountId, oppositeType, source, windowDays]);
+
+  const confirmLink = useCallback(async () => {
+    if (!sourceActivity?.id || !selectedCandidate?.activity.id) return;
+    await linkTransferActivitiesMutation.mutateAsync({
+      activityAId: sourceActivity.id,
+      activityBId: selectedCandidate.activity.id,
+    });
+    await onComplete?.();
+    onOpenChange(false);
+  }, [
+    linkTransferActivitiesMutation,
+    onComplete,
+    onOpenChange,
+    selectedCandidate?.activity.id,
+    sourceActivity?.id,
+  ]);
+
+  const confirmUnlink = useCallback(async () => {
+    if (!sourceActivity?.id || !counterpart?.id) return;
+    await unlinkTransferActivitiesMutation.mutateAsync({
+      activityAId: sourceActivity.id,
+      activityBId: counterpart.id,
+    });
+    await onComplete?.();
+    onOpenChange(false);
+  }, [
+    counterpart?.id,
+    onComplete,
+    onOpenChange,
+    sourceActivity?.id,
+    unlinkTransferActivitiesMutation,
+  ]);
+
+  const title = mode === "link" ? "Link transfer" : "Unlink transfer";
+  const description =
+    mode === "link"
+      ? "Choose the existing opposite transfer to pair with this activity."
+      : "This transfer pair will be split back into two external transfers.";
+
+  if (!sourceActivity || !source || !isTransferType(source.activityType)) {
+    return null;
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="flex w-full flex-col overflow-hidden sm:max-w-[760px]">
+        <SheetHeader>
+          <SheetTitle>{title}</SheetTitle>
+          <SheetDescription>{description}</SheetDescription>
+        </SheetHeader>
+
+        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto py-4">
+          <div className="space-y-2">
+            <div className="text-muted-foreground text-xs font-medium uppercase">Selected row</div>
+            <ActivitySummaryRow activity={sourceActivity} accountMap={accountMap} />
+          </div>
+
+          {mode === "unlink" ? (
+            <div className="space-y-3">
+              <div className="text-muted-foreground text-xs font-medium uppercase">
+                Linked counterpart
+              </div>
+              {counterpartLoading ? (
+                <div className="text-muted-foreground rounded-md border p-3 text-sm">
+                  Loading linked transfer...
+                </div>
+              ) : counterpart ? (
+                <ActivitySummaryRow activity={counterpart} accountMap={accountMap} />
+              ) : (
+                <div className="text-destructive rounded-md border p-3 text-sm">
+                  {counterpartError ?? "No valid linked counterpart found."}
+                </div>
+              )}
+            </div>
+          ) : (
+            <>
+              <div className="space-y-2">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="text-muted-foreground text-xs font-medium uppercase">
+                    Suggested matches
+                  </div>
+                  <Badge variant="outline" className="rounded-sm">
+                    {oppositeType
+                      ? (ActivityTypeNames[oppositeType] ?? oppositeType)
+                      : "Opposite transfer"}
+                  </Badge>
+                </div>
+                {suggestionsLoading ? (
+                  <div className="text-muted-foreground rounded-md border p-3 text-sm">
+                    Loading suggestions...
+                  </div>
+                ) : suggestionsError ? (
+                  <div className="text-destructive rounded-md border p-3 text-sm">
+                    {suggestionsError}
+                  </div>
+                ) : suggestedCandidates.length > 0 ? (
+                  <div className="space-y-2">
+                    {suggestedCandidates.map((candidate) => (
+                      <CandidateButton
+                        key={candidate.activity.id}
+                        candidate={candidate}
+                        accountMap={accountMap}
+                        selected={selectedCandidate?.activity.id === candidate.activity.id}
+                        onSelect={() => setSelectedCandidate(candidate)}
+                      />
+                    ))}
+                  </div>
+                ) : (
+                  <div className="text-muted-foreground rounded-md border p-3 text-sm">
+                    No suggested matches in the default 7-day window.
+                  </div>
+                )}
+              </div>
+
+              <div className="space-y-3 rounded-md border p-3">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="min-w-0">
+                    <div className="text-sm font-medium">Search eligible transfers</div>
+                    <div className="text-muted-foreground text-xs">
+                      Opposite transfer type is locked; filters narrow the candidate list.
+                    </div>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="w-full sm:w-auto"
+                    onClick={resetFilters}
+                  >
+                    Reset filters
+                  </Button>
+                </div>
+
+                <div className="grid grid-cols-1 gap-2 md:grid-cols-3">
+                  <div className="md:col-span-2">
+                    <Input
+                      value={searchText}
+                      onChange={(event) => setSearchText(event.target.value)}
+                      placeholder="Search notes, symbol, account"
+                    />
+                  </div>
+                  <Input
+                    value={
+                      oppositeType
+                        ? (ActivityTypeNames[oppositeType] ?? oppositeType)
+                        : "Opposite transfer"
+                    }
+                    readOnly
+                    aria-label="Locked opposite transfer type"
+                  />
+
+                  <Select value={accountId} onValueChange={setAccountId}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Account" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={ALL}>All accounts</SelectItem>
+                      {activeAccounts.map((account) => (
+                        <SelectItem key={account.id} value={account.id}>
+                          {account.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+
+                  <Select value={accountType} onValueChange={setAccountType}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Account type" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={ALL}>All account types</SelectItem>
+                      {accountTypeOptions.map((type) => (
+                        <SelectItem key={type} value={type}>
+                          {type}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+
+                  <Select value={windowDays} onValueChange={setWindowDays}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Date range" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="7">Within 7 days</SelectItem>
+                      <SelectItem value="30">Within 30 days</SelectItem>
+                      <SelectItem value="90">Within 90 days</SelectItem>
+                      <SelectItem value="180">Within 180 days</SelectItem>
+                    </SelectContent>
+                  </Select>
+
+                  <Select value={currency} onValueChange={setCurrency}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Currency" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={ALL}>All currencies</SelectItem>
+                      {currencyOptions.map((option) => (
+                        <SelectItem key={option} value={option}>
+                          {option}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+
+                  <Select value={assetFilter} onValueChange={setAssetFilter}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Asset" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={ALL}>All assets</SelectItem>
+                      {isSecurityTransfer(source) ? (
+                        <SelectItem value={SAME_ASSET}>Same asset</SelectItem>
+                      ) : (
+                        <SelectItem value={CASH_ASSET}>Cash only</SelectItem>
+                      )}
+                    </SelectContent>
+                  </Select>
+
+                  <Select value={matchMode} onValueChange={setMatchMode}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Match mode" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={STRICT}>Exact amount/quantity</SelectItem>
+                      <SelectItem value={ANY}>Any eligible transfer</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="flex items-center justify-between gap-2">
+                  <div className="text-muted-foreground text-xs">
+                    Search scans up to 250 matching transfer rows in the selected date window.
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => void runManualSearch()}
+                    disabled={manualLoading}
+                  >
+                    {manualLoading ? (
+                      <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />
+                    ) : (
+                      <Icons.Search className="mr-2 h-4 w-4" />
+                    )}
+                    Search
+                  </Button>
+                </div>
+
+                {manualError ? (
+                  <div className="text-destructive rounded-md border p-3 text-sm">
+                    {manualError}
+                  </div>
+                ) : null}
+
+                {manualSearched ? (
+                  <ScrollArea className="max-h-72">
+                    <div className="space-y-2 pr-3">
+                      {filteredManualResults.length > 0 ? (
+                        filteredManualResults.map((candidate) => (
+                          <CandidateButton
+                            key={candidate.activity.id}
+                            candidate={candidate}
+                            accountMap={accountMap}
+                            selected={selectedCandidate?.activity.id === candidate.activity.id}
+                            onSelect={() => setSelectedCandidate(candidate)}
+                          />
+                        ))
+                      ) : (
+                        <div className="text-muted-foreground rounded-md border p-3 text-sm">
+                          No eligible transfers match the current filters.
+                        </div>
+                      )}
+                    </div>
+                  </ScrollArea>
+                ) : null}
+              </div>
+            </>
+          )}
+        </div>
+
+        <SheetFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isProcessing}>
+            Cancel
+          </Button>
+          {mode === "link" ? (
+            <Button
+              onClick={() => void confirmLink()}
+              disabled={!selectedCandidate || isProcessing}
+            >
+              {isProcessing ? (
+                <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Icons.Link className="mr-2 h-4 w-4" />
+              )}
+              Link transfers
+            </Button>
+          ) : (
+            <Button onClick={() => void confirmUnlink()} disabled={!counterpart || isProcessing}>
+              {isProcessing ? (
+                <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Icons.Unlink className="mr-2 h-4 w-4" />
+              )}
+              Unlink transfers
+            </Button>
+          )}
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/apps/frontend/src/pages/activity/components/transfer-match-dialog.tsx
+++ b/apps/frontend/src/pages/activity/components/transfer-match-dialog.tsx
@@ -11,6 +11,9 @@ import { cn, formatDateISO, formatDateTime } from "@/lib/utils";
 import {
   Badge,
   Button,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
   formatAmount,
   Icons,
   Input,
@@ -26,7 +29,10 @@ import {
   SheetFooter,
   SheetHeader,
   SheetTitle,
+  Skeleton,
 } from "@wealthfolio/ui";
+import { ActivityTypeBadge } from "./activity-type-badge";
+import type { NewActivityFormValues } from "./forms/schemas";
 import { useActivityMutations } from "../hooks/use-activity-mutations";
 
 export type TransferDialogActivity = Activity | ActivityDetails;
@@ -253,32 +259,57 @@ function activitySortKey(activity: TransferDialogActivity): string {
   return `${new Date(getActivityDate(activity)).getTime()}-${activity.id}`;
 }
 
+function externalTransferUpdatePayload(
+  activity: TransferDialogActivity,
+): NewActivityFormValues & { id: string; currentAssetId?: string } {
+  const amount = parseNumber(activity.amount);
+  const quantity = parseNumber(activity.quantity);
+  const unitPrice = parseNumber(activity.unitPrice);
+  const fee = parseNumber(activity.fee);
+  const fxRate = parseNumber(activity.fxRate);
+
+  return {
+    id: activity.id,
+    accountId: activity.accountId,
+    activityType: activity.activityType as Extract<ActivityType, "TRANSFER_IN" | "TRANSFER_OUT">,
+    activityDate: getActivityDate(activity),
+    currency: activity.currency,
+    amount,
+    quantity,
+    unitPrice,
+    fee,
+    fxRate,
+    comment: getActivityNotes(activity),
+    subtype: activity.subtype ?? null,
+    currentAssetId: activity.assetId,
+    metadata: { flow: { is_external: true } },
+  } as NewActivityFormValues & { id: string; currentAssetId?: string };
+}
+
 function ActivitySummaryRow({
   activity,
   accountMap,
-  label,
+  className,
 }: {
   activity: TransferDialogActivity;
   accountMap: Map<string, Account>;
-  label?: string;
+  className?: string;
 }) {
   const normalized = normalizeActivity(activity, accountMap);
   const date = formatDateTime(normalized.date).date;
   const amount = amountValue(normalized);
   const quantity = parseNumber(normalized.quantity);
   const symbol = normalized.assetSymbol || normalized.assetId || "Cash";
-  const typeName =
-    ActivityTypeNames[normalized.activityType as ActivityType] ?? normalized.activityType;
 
   return (
-    <div className="bg-muted/30 flex flex-col gap-1 rounded-md border px-3 py-2 text-sm">
-      <div className="text-muted-foreground flex items-center justify-between gap-3 text-xs uppercase">
-        <span>{label ?? typeName}</span>
-        <span>{date}</span>
+    <div className={cn("flex flex-col gap-1.5 rounded-md px-3 py-2.5 text-sm", className)}>
+      <div className="flex items-center justify-between gap-3">
+        <ActivityTypeBadge type={normalized.activityType as ActivityType} />
+        <span className="text-muted-foreground shrink-0 text-xs">{date}</span>
       </div>
       <div className="flex items-center justify-between gap-3">
         <span className="min-w-0 truncate font-medium">{normalized.accountName}</span>
-        <span className="shrink-0">
+        <span className="shrink-0 font-medium tabular-nums">
           {amount != null
             ? formatAmount(Math.abs(amount), normalized.currency)
             : normalized.currency}
@@ -309,27 +340,41 @@ function CandidateButton({
     <button
       type="button"
       className={cn(
-        "hover:bg-muted/50 w-full rounded-md border p-2 text-left transition-colors",
-        selected && "border-primary bg-primary/5",
+        "hover:bg-muted/50 flex w-full items-start rounded-md border text-left transition-colors",
+        selected && "border-primary bg-primary/5 hover:bg-primary/5",
       )}
       onClick={onSelect}
+      aria-pressed={selected}
     >
-      <ActivitySummaryRow activity={candidate.activity} accountMap={accountMap} />
-      {candidate.reasons.length > 0 ? (
-        <div className="text-muted-foreground mt-2 flex flex-wrap gap-1 text-[11px]">
-          {candidate.reasons.map((reason) => (
-            <Badge key={reason} variant="secondary" className="rounded-sm px-1.5 py-0">
-              {reason}
-            </Badge>
-          ))}
-        </div>
-      ) : null}
-      {candidate.warnings.length > 0 ? (
-        <div className="mt-2 flex items-start gap-1.5 text-[11px] text-amber-600">
-          <Icons.AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
-          <span>{candidate.warnings.join(" ")}</span>
-        </div>
-      ) : null}
+      <div className="py-3 pl-3">
+        {selected ? (
+          <Icons.CheckCircle className="text-primary h-4 w-4" />
+        ) : (
+          <Icons.Circle className="text-muted-foreground/30 h-4 w-4" />
+        )}
+      </div>
+      <div className="min-w-0 flex-1">
+        <ActivitySummaryRow activity={candidate.activity} accountMap={accountMap} />
+        {candidate.reasons.length > 0 || candidate.warnings.length > 0 ? (
+          <div className="space-y-1.5 px-3 pb-2.5">
+            {candidate.reasons.length > 0 ? (
+              <div className="text-muted-foreground flex flex-wrap gap-1 text-[11px]">
+                {candidate.reasons.map((reason) => (
+                  <Badge key={reason} variant="secondary" className="rounded-sm px-1.5 py-0">
+                    {reason}
+                  </Badge>
+                ))}
+              </div>
+            ) : null}
+            {candidate.warnings.length > 0 ? (
+              <div className="flex items-start gap-1.5 text-[11px] text-amber-600">
+                <Icons.AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+                <span>{candidate.warnings.join(" ")}</span>
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
     </button>
   );
 }
@@ -365,12 +410,15 @@ export function TransferMatchDialog({
   );
   const oppositeType = oppositeTransferType(source?.activityType);
 
-  const { linkTransferActivitiesMutation, unlinkTransferActivitiesMutation } =
-    useActivityMutations();
+  const {
+    linkTransferActivitiesMutation,
+    unlinkTransferActivitiesMutation,
+    updateActivityMutation,
+  } = useActivityMutations();
   const isProcessing =
     mode === "link"
       ? linkTransferActivitiesMutation.isPending
-      : unlinkTransferActivitiesMutation.isPending;
+      : unlinkTransferActivitiesMutation.isPending || updateActivityMutation.isPending;
 
   const [suggestions, setSuggestions] = useState<TransferMatchCandidate[]>([]);
   const [suggestionsLoading, setSuggestionsLoading] = useState(false);
@@ -379,6 +427,10 @@ export function TransferMatchDialog({
   const [manualSearched, setManualSearched] = useState(false);
   const [manualLoading, setManualLoading] = useState(false);
   const [manualError, setManualError] = useState<string | null>(null);
+  const [manualLinkedCandidateIds, setManualLinkedCandidateIds] = useState<Set<string>>(new Set());
+  const [manualGroupCheckPendingIds, setManualGroupCheckPendingIds] = useState<Set<string>>(
+    new Set(),
+  );
   const [selectedCandidate, setSelectedCandidate] = useState<SelectedCandidate | null>(null);
   const [counterpart, setCounterpart] = useState<TransferDialogActivity | null>(null);
   const [counterpartError, setCounterpartError] = useState<string | null>(null);
@@ -391,6 +443,7 @@ export function TransferMatchDialog({
   const [currency, setCurrency] = useState(ALL);
   const [assetFilter, setAssetFilter] = useState(ALL);
   const [matchMode, setMatchMode] = useState(STRICT);
+  const [filtersOpen, setFiltersOpen] = useState(false);
 
   const resetFilters = useCallback(() => {
     setSearchText("");
@@ -413,6 +466,8 @@ export function TransferMatchDialog({
     setManualResults([]);
     setManualSearched(false);
     setManualError(null);
+    setManualLinkedCandidateIds(new Set());
+    setManualGroupCheckPendingIds(new Set());
     setCounterpart(null);
     setCounterpartError(null);
 
@@ -445,6 +500,44 @@ export function TransferMatchDialog({
     }
   }, [mode, open, sourceActivity]);
 
+  useEffect(() => {
+    if (!open || mode !== "link") {
+      setManualLinkedCandidateIds(new Set());
+      setManualGroupCheckPendingIds(new Set());
+      return;
+    }
+
+    const groupedCandidates = manualResults.filter((activity) => activity.sourceGroupId);
+    if (groupedCandidates.length === 0) {
+      setManualLinkedCandidateIds(new Set());
+      setManualGroupCheckPendingIds(new Set());
+      return;
+    }
+
+    let cancelled = false;
+    setManualLinkedCandidateIds(new Set());
+    setManualGroupCheckPendingIds(new Set(groupedCandidates.map((activity) => activity.id)));
+
+    void Promise.all(
+      groupedCandidates.map(async (activity) => {
+        try {
+          await getTransferPairForActivity(activity.id);
+          return activity.id;
+        } catch {
+          return null;
+        }
+      }),
+    ).then((linkedIds) => {
+      if (cancelled) return;
+      setManualLinkedCandidateIds(new Set(linkedIds.filter((id): id is string => Boolean(id))));
+      setManualGroupCheckPendingIds(new Set());
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [manualResults, mode, open]);
+
   const suggestedCandidates = useMemo<SelectedCandidate[]>(
     () =>
       suggestions.map((candidate) => ({
@@ -463,7 +556,8 @@ export function TransferMatchDialog({
         const candidateAccount = accountMap.get(candidate.accountId);
         if (candidate.id === source.id) return false;
         if (candidate.accountId === source.accountId) return false;
-        if (candidate.sourceGroupId) return false;
+        if (manualLinkedCandidateIds.has(candidate.id)) return false;
+        if (manualGroupCheckPendingIds.has(candidate.id)) return false;
         if (candidate.activityType !== oppositeType) return false;
         if (candidate.status && candidate.status !== ActivityStatus.POSTED) return false;
         if (accountId !== ALL && candidate.accountId !== accountId) return false;
@@ -481,10 +575,14 @@ export function TransferMatchDialog({
         const reasons = sameExactShape(source, candidate)
           ? [isSecurityTransfer(source) ? "Same asset and quantity" : "Same amount and currency"]
           : ["Eligible opposite transfer"];
+        const warnings = manualWarnings(source, candidate);
+        if (candidate.sourceGroupId) {
+          warnings.push("Existing stale transfer link will be replaced.");
+        }
         return {
           activity,
           reasons,
-          warnings: manualWarnings(source, candidate),
+          warnings,
         };
       });
   }, [
@@ -494,40 +592,57 @@ export function TransferMatchDialog({
     assetFilter,
     currency,
     manualResults,
+    manualGroupCheckPendingIds,
+    manualLinkedCandidateIds,
     matchMode,
     oppositeType,
     searchText,
     source,
   ]);
 
-  const runManualSearch = useCallback(async () => {
-    if (!source || !oppositeType) return;
-    const days = Number(windowDays);
-    const safeWindowDays = Number.isFinite(days) ? days : 7;
-    const { from, to } = dateWindow(source.date, safeWindowDays);
-    setManualLoading(true);
-    setManualError(null);
-    try {
-      const response = await searchActivities(
-        0,
-        250,
-        {
-          activityTypes: [oppositeType],
-          accountIds: accountId === ALL ? undefined : [accountId],
-          dateFrom: from,
-          dateTo: to,
-        },
-        "",
-        { id: "date", desc: true },
-      );
-      setManualResults(response.data);
-      setManualSearched(true);
-    } catch (error) {
-      setManualError(error instanceof Error ? error.message : "Could not search activities.");
-    } finally {
-      setManualLoading(false);
-    }
-  }, [accountId, oppositeType, source, windowDays]);
+  const runManualSearch = useCallback(
+    async (windowDaysOverride?: number) => {
+      if (!source || !oppositeType) return;
+      const days = windowDaysOverride ?? Number(windowDays);
+      const safeWindowDays = Number.isFinite(days) ? days : 7;
+      const { from, to } = dateWindow(source.date, safeWindowDays);
+      setManualLoading(true);
+      setManualError(null);
+      try {
+        const response = await searchActivities(
+          0,
+          250,
+          {
+            activityTypes: [oppositeType],
+            accountIds: accountId === ALL ? undefined : [accountId],
+            dateFrom: from,
+            dateTo: to,
+          },
+          "",
+          { id: "date", desc: true },
+        );
+        setManualResults(response.data);
+        setManualSearched(true);
+      } catch (error) {
+        setManualError(error instanceof Error ? error.message : "Could not search activities.");
+      } finally {
+        setManualLoading(false);
+      }
+    },
+    [accountId, oppositeType, source, windowDays],
+  );
+
+  const widenSearch = useCallback(() => {
+    setWindowDays("30");
+    void runManualSearch(30);
+  }, [runManualSearch]);
+
+  const advancedFilterCount = [
+    accountType !== ALL,
+    currency !== ALL,
+    assetFilter !== ALL,
+    matchMode !== STRICT,
+  ].filter(Boolean).length;
 
   const confirmLink = useCallback(async () => {
     if (!sourceActivity?.id || !selectedCandidate?.activity.id) return;
@@ -545,27 +660,42 @@ export function TransferMatchDialog({
     sourceActivity?.id,
   ]);
 
+  const canClearInvalidLink =
+    mode === "unlink" && !counterpartLoading && !counterpart && Boolean(source?.sourceGroupId);
+
   const confirmUnlink = useCallback(async () => {
-    if (!sourceActivity?.id || !counterpart?.id) return;
-    await unlinkTransferActivitiesMutation.mutateAsync({
-      activityAId: sourceActivity.id,
-      activityBId: counterpart.id,
-    });
+    if (!sourceActivity?.id) return;
+
+    if (counterpart?.id) {
+      await unlinkTransferActivitiesMutation.mutateAsync({
+        activityAId: sourceActivity.id,
+        activityBId: counterpart.id,
+      });
+    } else if (source?.sourceGroupId) {
+      await updateActivityMutation.mutateAsync(externalTransferUpdatePayload(sourceActivity));
+    } else {
+      return;
+    }
+
     await onComplete?.();
     onOpenChange(false);
   }, [
     counterpart?.id,
     onComplete,
     onOpenChange,
-    sourceActivity?.id,
+    source?.sourceGroupId,
+    sourceActivity,
     unlinkTransferActivitiesMutation,
+    updateActivityMutation,
   ]);
 
   const title = mode === "link" ? "Link transfer" : "Unlink transfer";
   const description =
     mode === "link"
       ? "Choose the existing opposite transfer to pair with this activity."
-      : "This transfer pair will be split back into two external transfers.";
+      : canClearInvalidLink
+        ? "This stale transfer link will be cleared and the transfer will be marked external."
+        : "This transfer pair will be split back into two external transfers.";
 
   if (!sourceActivity || !source || !isTransferType(source.activityType)) {
     return null;
@@ -582,7 +712,11 @@ export function TransferMatchDialog({
         <div className="min-h-0 flex-1 space-y-4 overflow-y-auto py-4">
           <div className="space-y-2">
             <div className="text-muted-foreground text-xs font-medium uppercase">Selected row</div>
-            <ActivitySummaryRow activity={sourceActivity} accountMap={accountMap} />
+            <ActivitySummaryRow
+              activity={sourceActivity}
+              accountMap={accountMap}
+              className="bg-muted/30 border"
+            />
           </div>
 
           {mode === "unlink" ? (
@@ -595,7 +729,18 @@ export function TransferMatchDialog({
                   Loading linked transfer...
                 </div>
               ) : counterpart ? (
-                <ActivitySummaryRow activity={counterpart} accountMap={accountMap} />
+                <ActivitySummaryRow
+                  activity={counterpart}
+                  accountMap={accountMap}
+                  className="bg-muted/30 border"
+                />
+              ) : canClearInvalidLink ? (
+                <div className="rounded-md border p-3 text-sm">
+                  <div className="font-medium">No valid linked counterpart found.</div>
+                  <div className="text-muted-foreground mt-1">
+                    Unlinking will clear the stale transfer link on this row and mark it external.
+                  </div>
+                </div>
               ) : (
                 <div className="text-destructive rounded-md border p-3 text-sm">
                   {counterpartError ?? "No valid linked counterpart found."}
@@ -609,15 +754,17 @@ export function TransferMatchDialog({
                   <div className="text-muted-foreground text-xs font-medium uppercase">
                     Suggested matches
                   </div>
-                  <Badge variant="outline" className="rounded-sm">
-                    {oppositeType
-                      ? (ActivityTypeNames[oppositeType] ?? oppositeType)
-                      : "Opposite transfer"}
-                  </Badge>
+                  {oppositeType ? (
+                    <div className="flex items-center gap-1.5">
+                      <span className="text-muted-foreground text-xs">Looking for</span>
+                      <ActivityTypeBadge type={oppositeType} />
+                    </div>
+                  ) : null}
                 </div>
                 {suggestionsLoading ? (
-                  <div className="text-muted-foreground rounded-md border p-3 text-sm">
-                    Loading suggestions...
+                  <div className="space-y-2">
+                    <Skeleton className="h-[88px] w-full rounded-md" />
+                    <Skeleton className="h-[88px] w-full rounded-md" />
                   </div>
                 ) : suggestionsError ? (
                   <div className="text-destructive rounded-md border p-3 text-sm">
@@ -636,147 +783,178 @@ export function TransferMatchDialog({
                     ))}
                   </div>
                 ) : (
-                  <div className="text-muted-foreground rounded-md border p-3 text-sm">
-                    No suggested matches in the default 7-day window.
+                  <div className="flex flex-col items-center gap-2 rounded-md border border-dashed px-4 py-6 text-center">
+                    <Icons.Search className="text-muted-foreground h-5 w-5" />
+                    <p className="text-muted-foreground text-sm">
+                      No matches within 7 days of this activity.
+                    </p>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      onClick={widenSearch}
+                      disabled={manualLoading}
+                    >
+                      Search within 30 days
+                    </Button>
                   </div>
                 )}
               </div>
 
               <div className="space-y-3 rounded-md border p-3">
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex items-center justify-between gap-2">
                   <div className="min-w-0">
                     <div className="text-sm font-medium">Search eligible transfers</div>
                     <div className="text-muted-foreground text-xs">
-                      Opposite transfer type is locked; filters narrow the candidate list.
+                      Only{" "}
+                      {oppositeType
+                        ? (ActivityTypeNames[oppositeType] ?? oppositeType)
+                        : "opposite transfer"}{" "}
+                      activities are searched.
                     </div>
                   </div>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    className="w-full sm:w-auto"
-                    onClick={resetFilters}
-                  >
+                  <Button type="button" variant="ghost" size="sm" onClick={resetFilters}>
                     Reset filters
                   </Button>
                 </div>
 
-                <div className="grid grid-cols-1 gap-2 md:grid-cols-3">
-                  <div className="md:col-span-2">
-                    <Input
-                      value={searchText}
-                      onChange={(event) => setSearchText(event.target.value)}
-                      placeholder="Search notes, symbol, account"
-                    />
-                  </div>
-                  <Input
-                    value={
-                      oppositeType
-                        ? (ActivityTypeNames[oppositeType] ?? oppositeType)
-                        : "Opposite transfer"
-                    }
-                    readOnly
-                    aria-label="Locked opposite transfer type"
-                  />
-
-                  <Select value={accountId} onValueChange={setAccountId}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Account" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value={ALL}>All accounts</SelectItem>
-                      {activeAccounts.map((account) => (
-                        <SelectItem key={account.id} value={account.id}>
-                          {account.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-
-                  <Select value={accountType} onValueChange={setAccountType}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Account type" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value={ALL}>All account types</SelectItem>
-                      {accountTypeOptions.map((type) => (
-                        <SelectItem key={type} value={type}>
-                          {type}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-
-                  <Select value={windowDays} onValueChange={setWindowDays}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Date range" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="7">Within 7 days</SelectItem>
-                      <SelectItem value="30">Within 30 days</SelectItem>
-                      <SelectItem value="90">Within 90 days</SelectItem>
-                      <SelectItem value="180">Within 180 days</SelectItem>
-                    </SelectContent>
-                  </Select>
-
-                  <Select value={currency} onValueChange={setCurrency}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Currency" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value={ALL}>All currencies</SelectItem>
-                      {currencyOptions.map((option) => (
-                        <SelectItem key={option} value={option}>
-                          {option}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-
-                  <Select value={assetFilter} onValueChange={setAssetFilter}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Asset" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value={ALL}>All assets</SelectItem>
-                      {isSecurityTransfer(source) ? (
-                        <SelectItem value={SAME_ASSET}>Same asset</SelectItem>
+                <form
+                  className="space-y-2"
+                  onSubmit={(event) => {
+                    event.preventDefault();
+                    void runManualSearch();
+                  }}
+                >
+                  <div className="flex gap-2">
+                    <div className="relative flex-1">
+                      <Icons.Search className="text-muted-foreground absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2" />
+                      <Input
+                        value={searchText}
+                        onChange={(event) => setSearchText(event.target.value)}
+                        placeholder="Search notes, symbol, account"
+                        className="pl-9"
+                      />
+                    </div>
+                    <Button type="submit" disabled={manualLoading}>
+                      {manualLoading ? (
+                        <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />
                       ) : (
-                        <SelectItem value={CASH_ASSET}>Cash only</SelectItem>
+                        <Icons.Search className="mr-2 h-4 w-4" />
                       )}
-                    </SelectContent>
-                  </Select>
-
-                  <Select value={matchMode} onValueChange={setMatchMode}>
-                    <SelectTrigger>
-                      <SelectValue placeholder="Match mode" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value={STRICT}>Exact amount/quantity</SelectItem>
-                      <SelectItem value={ANY}>Any eligible transfer</SelectItem>
-                    </SelectContent>
-                  </Select>
-                </div>
-
-                <div className="flex items-center justify-between gap-2">
-                  <div className="text-muted-foreground text-xs">
-                    Search scans up to 250 matching transfer rows in the selected date window.
+                      Search
+                    </Button>
                   </div>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    onClick={() => void runManualSearch()}
-                    disabled={manualLoading}
-                  >
-                    {manualLoading ? (
-                      <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />
-                    ) : (
-                      <Icons.Search className="mr-2 h-4 w-4" />
-                    )}
-                    Search
-                  </Button>
-                </div>
+
+                  <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+                    <Select value={accountId} onValueChange={setAccountId}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Account" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value={ALL}>All accounts</SelectItem>
+                        {activeAccounts.map((account) => (
+                          <SelectItem key={account.id} value={account.id}>
+                            {account.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+
+                    <Select value={windowDays} onValueChange={setWindowDays}>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Date range" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="7">Within 7 days</SelectItem>
+                        <SelectItem value="30">Within 30 days</SelectItem>
+                        <SelectItem value="90">Within 90 days</SelectItem>
+                        <SelectItem value="180">Within 180 days</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+
+                  <Collapsible open={filtersOpen} onOpenChange={setFiltersOpen}>
+                    <CollapsibleTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="text-muted-foreground h-7 px-2 text-xs"
+                      >
+                        <Icons.ChevronDown
+                          className={cn(
+                            "mr-1 h-3.5 w-3.5 transition-transform",
+                            filtersOpen && "rotate-180",
+                          )}
+                        />
+                        More filters
+                        {advancedFilterCount > 0 ? (
+                          <Badge
+                            variant="secondary"
+                            className="ml-1.5 rounded-sm px-1.5 py-0 text-[10px]"
+                          >
+                            {advancedFilterCount}
+                          </Badge>
+                        ) : null}
+                      </Button>
+                    </CollapsibleTrigger>
+                    <CollapsibleContent className="pt-2">
+                      <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+                        <Select value={accountType} onValueChange={setAccountType}>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Account type" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value={ALL}>All account types</SelectItem>
+                            {accountTypeOptions.map((type) => (
+                              <SelectItem key={type} value={type}>
+                                {type}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+
+                        <Select value={currency} onValueChange={setCurrency}>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Currency" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value={ALL}>All currencies</SelectItem>
+                            {currencyOptions.map((option) => (
+                              <SelectItem key={option} value={option}>
+                                {option}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+
+                        <Select value={assetFilter} onValueChange={setAssetFilter}>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Asset" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value={ALL}>All assets</SelectItem>
+                            {isSecurityTransfer(source) ? (
+                              <SelectItem value={SAME_ASSET}>Same asset</SelectItem>
+                            ) : (
+                              <SelectItem value={CASH_ASSET}>Cash only</SelectItem>
+                            )}
+                          </SelectContent>
+                        </Select>
+
+                        <Select value={matchMode} onValueChange={setMatchMode}>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Match mode" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value={STRICT}>Exact amount/quantity</SelectItem>
+                            <SelectItem value={ANY}>Any eligible transfer</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    </CollapsibleContent>
+                  </Collapsible>
+                </form>
 
                 {manualError ? (
                   <div className="text-destructive rounded-md border p-3 text-sm">
@@ -785,25 +963,32 @@ export function TransferMatchDialog({
                 ) : null}
 
                 {manualSearched ? (
-                  <ScrollArea className="max-h-72">
-                    <div className="space-y-2 pr-3">
-                      {filteredManualResults.length > 0 ? (
-                        filteredManualResults.map((candidate) => (
-                          <CandidateButton
-                            key={candidate.activity.id}
-                            candidate={candidate}
-                            accountMap={accountMap}
-                            selected={selectedCandidate?.activity.id === candidate.activity.id}
-                            onSelect={() => setSelectedCandidate(candidate)}
-                          />
-                        ))
-                      ) : (
-                        <div className="text-muted-foreground rounded-md border p-3 text-sm">
-                          No eligible transfers match the current filters.
-                        </div>
-                      )}
+                  <div className="space-y-2">
+                    <div className="text-muted-foreground text-xs">
+                      {filteredManualResults.length === 1
+                        ? "1 eligible transfer"
+                        : `${filteredManualResults.length} eligible transfers`}
                     </div>
-                  </ScrollArea>
+                    <ScrollArea className="max-h-72">
+                      <div className="space-y-2 pr-3">
+                        {filteredManualResults.length > 0 ? (
+                          filteredManualResults.map((candidate) => (
+                            <CandidateButton
+                              key={candidate.activity.id}
+                              candidate={candidate}
+                              accountMap={accountMap}
+                              selected={selectedCandidate?.activity.id === candidate.activity.id}
+                              onSelect={() => setSelectedCandidate(candidate)}
+                            />
+                          ))
+                        ) : (
+                          <div className="text-muted-foreground rounded-md border border-dashed p-4 text-center text-sm">
+                            No eligible transfers match the current filters.
+                          </div>
+                        )}
+                      </div>
+                    </ScrollArea>
+                  </div>
                 ) : null}
               </div>
             </>
@@ -827,13 +1012,18 @@ export function TransferMatchDialog({
               Link transfers
             </Button>
           ) : (
-            <Button onClick={() => void confirmUnlink()} disabled={!counterpart || isProcessing}>
+            <Button
+              onClick={() => void confirmUnlink()}
+              disabled={
+                isProcessing || counterpartLoading || (!counterpart && !canClearInvalidLink)
+              }
+            >
               {isProcessing ? (
                 <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />
               ) : (
                 <Icons.Unlink className="mr-2 h-4 w-4" />
               )}
-              Unlink transfers
+              {counterpart ? "Unlink transfers" : "Unlink transfer"}
             </Button>
           )}
         </SheetFooter>

--- a/apps/frontend/src/pages/activity/config/activity-form-config.ts
+++ b/apps/frontend/src/pages/activity/config/activity-form-config.ts
@@ -372,7 +372,10 @@ export const ACTIVITY_FORM_CONFIG: Record<
       const transferMode = transferIsSecurity ? "securities" : "cash";
       // Derive isExternal from metadata (if flow.is_external is true)
       const flowMetadata = activity?.metadata?.flow as { is_external?: boolean } | undefined;
-      const isExternal = flowMetadata?.is_external === true;
+      const hasInternalPair = Boolean(activity?.transferOutId && activity?.transferInId);
+      const isExternal = activity?.id
+        ? flowMetadata?.is_external === true || !hasInternalPair
+        : flowMetadata?.is_external === true;
       // Derive direction from activity type
       const direction = activity?.activityType === ActivityType.TRANSFER_IN ? "in" : "out";
       const editingTransferIn = activity?.activityType === ActivityType.TRANSFER_IN;

--- a/apps/frontend/src/pages/activity/config/activity-form-config.ts
+++ b/apps/frontend/src/pages/activity/config/activity-form-config.ts
@@ -370,12 +370,10 @@ export const ACTIVITY_FORM_CONFIG: Record<
         activity?.assetId,
       );
       const transferMode = transferIsSecurity ? "securities" : "cash";
-      // Derive isExternal from metadata (if flow.is_external is true)
+      // Reflect only the persisted external flag. Unpaired transfers stay unchecked
+      // until the user explicitly marks them external.
       const flowMetadata = activity?.metadata?.flow as { is_external?: boolean } | undefined;
-      const hasInternalPair = Boolean(activity?.transferOutId && activity?.transferInId);
-      const isExternal = activity?.id
-        ? flowMetadata?.is_external === true || !hasInternalPair
-        : flowMetadata?.is_external === true;
+      const isExternal = flowMetadata?.is_external === true;
       // Derive direction from activity type
       const direction = activity?.activityType === ActivityType.TRANSFER_IN ? "in" : "out";
       const editingTransferIn = activity?.activityType === ActivityType.TRANSFER_IN;

--- a/apps/frontend/src/pages/activity/hooks/use-activity-form.test.ts
+++ b/apps/frontend/src/pages/activity/hooks/use-activity-form.test.ts
@@ -10,6 +10,19 @@ const mutationMocks = vi.hoisted(() => ({
   updateMutateAsync: vi.fn(),
   saveMutateAsync: vi.fn(),
   savePairMutateAsync: vi.fn(),
+  unlinkMutateAsync: vi.fn(),
+}));
+
+const adapterMocks = vi.hoisted(() => ({
+  getTransferPairForActivity: vi.fn(),
+  loggerError: vi.fn(),
+}));
+
+vi.mock("@/adapters", () => ({
+  getTransferPairForActivity: adapterMocks.getTransferPairForActivity,
+  logger: {
+    error: adapterMocks.loggerError,
+  },
 }));
 
 vi.mock("./use-activity-mutations", () => ({
@@ -38,6 +51,12 @@ vi.mock("./use-activity-mutations", () => ({
       error: null,
       isError: false,
     },
+    unlinkTransferActivitiesMutation: {
+      mutateAsync: mutationMocks.unlinkMutateAsync,
+      isPending: false,
+      error: null,
+      isError: false,
+    },
   }),
 }));
 
@@ -53,6 +72,9 @@ describe("useActivityForm", () => {
     mutationMocks.updateMutateAsync.mockResolvedValue({});
     mutationMocks.saveMutateAsync.mockResolvedValue({});
     mutationMocks.savePairMutateAsync.mockResolvedValue({});
+    mutationMocks.unlinkMutateAsync.mockResolvedValue({});
+    adapterMocks.getTransferPairForActivity.mockReset();
+    adapterMocks.loggerError.mockReset();
   });
 
   it("preserves user-selected currency for DEPOSIT", async () => {
@@ -216,5 +238,65 @@ describe("useActivityForm", () => {
         }),
       ],
     });
+  });
+
+  it("unlinks a valid grouped transfer before saving it as external", async () => {
+    adapterMocks.getTransferPairForActivity.mockResolvedValue({
+      transferOut: { id: "transfer-out-id" },
+      transferIn: { id: "transfer-in-id" },
+    });
+
+    const { result } = renderHook(() =>
+      useActivityForm({
+        accounts,
+        selectedType: "TRANSFER",
+        activity: {
+          id: "transfer-in-id",
+          activityType: ActivityType.TRANSFER_IN,
+          accountId: "acc-cad",
+          sourceGroupId: "group-1",
+        },
+      }),
+    );
+
+    const formData = {
+      isExternal: true,
+      direction: "in",
+      accountId: "acc-cad",
+      fromAccountId: "",
+      toAccountId: "",
+      activityDate: new Date("2026-02-01T10:00:00.000Z"),
+      transferMode: "cash",
+      amount: 250,
+      assetId: null,
+      quantity: null,
+      unitPrice: null,
+      comment: "external transfer",
+      currency: "CAD",
+      fxRate: null,
+      subtype: null,
+      quoteMode: "MARKET",
+    } as ActivityFormValues;
+
+    await act(async () => {
+      await result.current.handleSubmit(formData);
+    });
+
+    expect(adapterMocks.getTransferPairForActivity).toHaveBeenCalledWith("transfer-in-id");
+    expect(mutationMocks.unlinkMutateAsync).toHaveBeenCalledWith({
+      activityAId: "transfer-out-id",
+      activityBId: "transfer-in-id",
+    });
+    expect(mutationMocks.updateMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "transfer-in-id",
+        accountId: "acc-cad",
+        activityType: ActivityType.TRANSFER_IN,
+        metadata: { flow: { is_external: true } },
+      }),
+    );
+    expect(mutationMocks.unlinkMutateAsync.mock.invocationCallOrder[0]).toBeLessThan(
+      mutationMocks.updateMutateAsync.mock.invocationCallOrder[0],
+    );
   });
 });

--- a/apps/frontend/src/pages/activity/hooks/use-activity-form.ts
+++ b/apps/frontend/src/pages/activity/hooks/use-activity-form.ts
@@ -138,6 +138,12 @@ export function useActivityForm({
                   ? activity.id
                   : activity?.counterpartActivityId);
 
+              if (isEditing && (!transferOutId || !transferInId)) {
+                throw new Error(
+                  "Use Link transfer... to pair this existing transfer before saving it as internal.",
+                );
+              }
+
               await saveInternalTransferPairMutation.mutateAsync({
                 transferOutId: isEditing ? transferOutId : undefined,
                 transferInId: isEditing ? transferInId : undefined,

--- a/apps/frontend/src/pages/activity/hooks/use-activity-form.ts
+++ b/apps/frontend/src/pages/activity/hooks/use-activity-form.ts
@@ -1,4 +1,4 @@
-import { logger } from "@/adapters";
+import { getTransferPairForActivity, logger } from "@/adapters";
 import { buildAssetResolutionInput } from "@/lib/asset-resolution-input";
 import { ActivityType } from "@/lib/constants";
 import { generateId } from "@/lib/id";
@@ -28,6 +28,24 @@ function extractErrorMessage(error: unknown): string {
     if (typeof raw.message === "string" && raw.message.trim()) return raw.message;
   }
   return "Failed to save activity. Please check your inputs and try again.";
+}
+
+function transferPairIds(activity: Partial<ActivityDetails> | undefined): {
+  transferOutId?: string;
+  transferInId?: string;
+} {
+  return {
+    transferOutId:
+      activity?.transferOutId ??
+      (activity?.activityType === ActivityType.TRANSFER_OUT
+        ? activity.id
+        : activity?.counterpartActivityId),
+    transferInId:
+      activity?.transferInId ??
+      (activity?.activityType === ActivityType.TRANSFER_IN
+        ? activity.id
+        : activity?.counterpartActivityId),
+  };
 }
 
 export interface UseActivityFormParams {
@@ -67,6 +85,7 @@ export function useActivityForm({
     updateActivityMutation,
     saveActivitiesMutation,
     saveInternalTransferPairMutation,
+    unlinkTransferActivitiesMutation,
   } = useActivityMutations(onSuccess);
 
   const isEditing = !!activity?.id;
@@ -74,17 +93,20 @@ export function useActivityForm({
     addActivityMutation.isPending ||
     updateActivityMutation.isPending ||
     saveActivitiesMutation.isPending ||
-    saveInternalTransferPairMutation.isPending;
+    saveInternalTransferPairMutation.isPending ||
+    unlinkTransferActivitiesMutation.isPending;
   const error =
     addActivityMutation.error ??
     updateActivityMutation.error ??
     saveActivitiesMutation.error ??
-    saveInternalTransferPairMutation.error;
+    saveInternalTransferPairMutation.error ??
+    unlinkTransferActivitiesMutation.error;
   const isError =
     addActivityMutation.isError ||
     updateActivityMutation.isError ||
     saveActivitiesMutation.isError ||
-    saveInternalTransferPairMutation.isError;
+    saveInternalTransferPairMutation.isError ||
+    unlinkTransferActivitiesMutation.isError;
 
   // Get config for selected type (undefined if no type selected)
   const config = selectedType ? ACTIVITY_FORM_CONFIG[selectedType] : undefined;
@@ -127,16 +149,7 @@ export function useActivityForm({
                 throw new Error("Transfer amount and currencies are required.");
               }
 
-              const transferOutId =
-                activity?.transferOutId ??
-                (activity?.activityType === ActivityType.TRANSFER_OUT
-                  ? activity.id
-                  : activity?.counterpartActivityId);
-              const transferInId =
-                activity?.transferInId ??
-                (activity?.activityType === ActivityType.TRANSFER_IN
-                  ? activity.id
-                  : activity?.counterpartActivityId);
+              const { transferOutId, transferInId } = transferPairIds(activity);
 
               if (isEditing && (!transferOutId || !transferInId)) {
                 throw new Error(
@@ -211,16 +224,7 @@ export function useActivityForm({
               : undefined;
 
             if (isEditing) {
-              const transferOutId =
-                activity?.transferOutId ??
-                (activity?.activityType === ActivityType.TRANSFER_OUT
-                  ? activity.id
-                  : activity?.counterpartActivityId);
-              const transferInId =
-                activity?.transferInId ??
-                (activity?.activityType === ActivityType.TRANSFER_IN
-                  ? activity.id
-                  : activity?.counterpartActivityId);
+              const { transferOutId, transferInId } = transferPairIds(activity);
 
               if (!transferOutId || !transferInId) {
                 throw new Error("Editing an internal securities transfer requires both legs.");
@@ -297,6 +301,22 @@ export function useActivityForm({
           }
 
           if (isEditing && activity?.id) {
+            let { transferOutId, transferInId } = transferPairIds(activity);
+            if (activity.sourceGroupId && (!transferOutId || !transferInId)) {
+              try {
+                const pair = await getTransferPairForActivity(activity.id);
+                transferOutId = pair.transferOut.id;
+                transferInId = pair.transferIn.id;
+              } catch {
+                // Invalid/orphan groups are cleared by the single-row external update below.
+              }
+            }
+            if (activity.sourceGroupId && transferOutId && transferInId) {
+              await unlinkTransferActivitiesMutation.mutateAsync({
+                activityAId: transferOutId,
+                activityBId: transferInId,
+              });
+            }
             await updateActivityMutation.mutateAsync({
               id: activity.id,
               currentAssetId: activity.assetId,
@@ -343,12 +363,13 @@ export function useActivityForm({
       config,
       accounts,
       isEditing,
-      activity?.id,
+      activity,
       selectedType,
       addActivityMutation,
       updateActivityMutation,
       saveActivitiesMutation,
       saveInternalTransferPairMutation,
+      unlinkTransferActivitiesMutation,
     ],
   );
 

--- a/apps/frontend/src/pages/activity/import/components/mapping-table-cells.tsx
+++ b/apps/frontend/src/pages/activity/import/components/mapping-table-cells.tsx
@@ -117,6 +117,7 @@ interface ActivityTypeDisplayCellProps {
   appType: string | null;
   subtype?: string;
   allowedActivityTypes?: readonly ActivityType[];
+  getActivityTypeLabel?: (activityType: ActivityType) => string;
   handleActivityTypeMapping: (csvActivity: string, activityType: string) => void;
 }
 function ActivityTypeDisplayCell({
@@ -124,6 +125,7 @@ function ActivityTypeDisplayCell({
   appType,
   subtype,
   allowedActivityTypes,
+  getActivityTypeLabel = (activityType) => activityType,
   handleActivityTypeMapping,
 }: ActivityTypeDisplayCellProps) {
   const trimmedCsvType = csvType.trim().toUpperCase();
@@ -156,7 +158,7 @@ function ActivityTypeDisplayCell({
             )}
             onClick={() => handleActivityTypeMapping(trimmedCsvType, "" as ActivityType)}
           >
-            {appType === ACTIVITY_SKIP ? "Skipped" : appType}
+            {appType === ACTIVITY_SKIP ? "Skipped" : getActivityTypeLabel(appType as ActivityType)}
           </Badge>
         ) : (
           <SearchableSelect
@@ -167,7 +169,7 @@ function ActivityTypeDisplayCell({
                     t !== ActivityType.UNKNOWN &&
                     (!allowedActivityTypes || allowedActivityTypes.includes(t)),
                 )
-                .map((type) => ({ value: type, label: type })),
+                .map((type) => ({ value: type, label: getActivityTypeLabel(type) })),
               {
                 value: ACTIVITY_SKIP,
                 label: "SKIP",
@@ -180,6 +182,7 @@ function ActivityTypeDisplayCell({
             }
             placeholder="Map type"
             className={cn(MAPPING_TRIGGER_UNMAPPED_CLASS, "w-[140px]")}
+            contentClassName="w-[220px]"
           />
         )}
       </div>
@@ -358,6 +361,7 @@ export function MappingCell({
   invalidSymbols,
   invalidAccounts,
   allowedActivityTypes,
+  getActivityTypeLabel,
 }: {
   field: ImportFormat;
   row: CsvRowData;
@@ -374,6 +378,7 @@ export function MappingCell({
   invalidSymbols: string[];
   invalidAccounts: string[];
   allowedActivityTypes?: readonly ActivityType[];
+  getActivityTypeLabel?: (activityType: ActivityType) => string;
 }) {
   // Get the field's value from the row
   const value = getMappedValue(row, field);
@@ -406,6 +411,7 @@ export function MappingCell({
         appType={appType}
         subtype={subtype}
         allowedActivityTypes={allowedActivityTypes}
+        getActivityTypeLabel={getActivityTypeLabel}
         handleActivityTypeMapping={handleActivityTypeMapping}
       />
     );

--- a/apps/frontend/src/pages/activity/import/components/mapping-table.tsx
+++ b/apps/frontend/src/pages/activity/import/components/mapping-table.tsx
@@ -39,6 +39,7 @@ interface MappingTableProps {
   visibleFields?: readonly ImportFormat[];
   requiredFields?: readonly ImportFormat[];
   allowedActivityTypes?: readonly ActivityType[];
+  getActivityTypeLabel?: (activityType: ActivityType) => string;
   className?: string;
 }
 
@@ -59,6 +60,7 @@ export function MappingTable({
   visibleFields = importFormatFields,
   requiredFields = IMPORT_REQUIRED_FIELDS,
   allowedActivityTypes,
+  getActivityTypeLabel,
   className,
 }: MappingTableProps) {
   // Check if a field is mapped (supports fallback column arrays)
@@ -146,6 +148,7 @@ export function MappingTable({
                             invalidSymbols={invalidSymbols}
                             invalidAccounts={invalidAccounts}
                             allowedActivityTypes={allowedActivityTypes}
+                            getActivityTypeLabel={getActivityTypeLabel}
                           />
                         </TableCell>
                       );

--- a/apps/frontend/src/pages/activity/import/steps/mapping-step-unified.tsx
+++ b/apps/frontend/src/pages/activity/import/steps/mapping-step-unified.tsx
@@ -39,13 +39,14 @@ import { mergeDetectedParseConfig } from "../utils/import-flow-utils";
 import {
   activityTypeAllowedForImportProfile,
   getActivityImportProfileForImportContext,
+  getActivityTypeLabelForImportProfile,
   isTransactionImportProfile,
   mergeActivityMappingsForImportProfile,
   sanitizeImportMappingForProfile,
 } from "../utils/activity-import-profile";
 
 import { isCashSymbol, needsImportAssetResolution } from "@/lib/activity-utils";
-import { ImportFormat } from "@/lib/constants";
+import { ImportFormat, type ActivityType } from "@/lib/constants";
 import { QueryKeys } from "@/lib/query-keys";
 import type { Account, CsvRowData, ImportTemplateData } from "@/lib/types";
 import { ImportType } from "@/lib/types";
@@ -121,6 +122,11 @@ export function MappingStepUnified() {
       localMapping.fieldMappings,
       parsedRows,
     ],
+  );
+  const getActivityTypeLabel = useCallback(
+    (activityType: ActivityType) =>
+      getActivityTypeLabelForImportProfile(activityType, importProfile),
+    [importProfile],
   );
 
   const effectiveActivityMappings = useMemo(
@@ -874,6 +880,7 @@ export function MappingStepUnified() {
                 visibleFields={importProfile.visibleMappingFields}
                 requiredFields={importProfile.requiredMappingFields}
                 allowedActivityTypes={importProfile.allowedActivityTypes}
+                getActivityTypeLabel={getActivityTypeLabel}
                 className="max-h-[50vh]"
               />
             </TabsContent>

--- a/apps/frontend/src/pages/activity/import/utils/activity-import-profile.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/activity-import-profile.test.ts
@@ -5,6 +5,7 @@ import {
   activityTypeAllowedForImportProfile,
   getActivityImportProfileForImportContext,
   getActivityImportProfileForAccountType,
+  getActivityTypeLabelForImportProfile,
   getDefaultActivityMappingsForImportProfile,
   mergeActivityMappingsForImportProfile,
   sanitizeImportMappingForProfile,
@@ -44,13 +45,31 @@ describe("activity import profiles", () => {
     expect(activityTypeAllowedForImportProfile(ActivityType.TRANSFER_OUT, profile)).toBe(false);
   });
 
+  it("uses credit-card labels for credit card transaction imports", () => {
+    const creditCard = getActivityImportProfileForAccountType(AccountType.CREDIT_CARD);
+    const cash = getActivityImportProfileForAccountType(AccountType.CASH);
+
+    expect(getActivityTypeLabelForImportProfile(ActivityType.WITHDRAWAL, creditCard)).toBe(
+      "Charge",
+    );
+    expect(getActivityTypeLabelForImportProfile(ActivityType.TRANSFER_IN, creditCard)).toBe(
+      "Payment",
+    );
+    expect(getActivityTypeLabelForImportProfile(ActivityType.WITHDRAWAL, cash)).toBe("Withdrawal");
+  });
+
   it("includes transaction-specific default aliases", () => {
     const profile = getActivityImportProfileForAccountType(AccountType.CREDIT_CARD);
     const mappings = getDefaultActivityMappingsForImportProfile(profile);
+    const cashMappings = getDefaultActivityMappingsForImportProfile(
+      getActivityImportProfileForAccountType(AccountType.CASH),
+    );
 
     expect(mappings[ActivityType.WITHDRAWAL]).toContain("PURCHASE");
     expect(mappings[ActivityType.TRANSFER_IN]).toContain("PAYMENT");
     expect(mappings[ActivityType.CREDIT]).toContain("REFUND");
+    expect(mappings[ActivityType.CREDIT]).toContain("CASHBACK");
+    expect(cashMappings[ActivityType.CREDIT]).toContain("CASHBACK");
     expect(mappings[ActivityType.BUY]).toBeUndefined();
   });
 

--- a/apps/frontend/src/pages/activity/import/utils/activity-import-profile.ts
+++ b/apps/frontend/src/pages/activity/import/utils/activity-import-profile.ts
@@ -1,4 +1,10 @@
-import { AccountType, ActivityType, IMPORT_REQUIRED_FIELDS, ImportFormat } from "@/lib/constants";
+import {
+  AccountType,
+  ActivityType,
+  ActivityTypeNames,
+  IMPORT_REQUIRED_FIELDS,
+  ImportFormat,
+} from "@/lib/constants";
 import type { Account, ImportMappingData } from "@/lib/types";
 
 const ACTIVITY_SKIP = "_SKIP_";
@@ -28,6 +34,7 @@ export interface ActivityImportProfile {
   requiredMappingFields: readonly ImportFormat[];
   assetResolutionEnabled: boolean;
   allowedActivityTypes: readonly ActivityType[];
+  activityTypeLabels?: Partial<Record<ActivityType, string>>;
   reviewColumns: readonly ImportReviewColumnId[];
 }
 
@@ -123,6 +130,12 @@ export const CASH_TRANSACTION_IMPORT_PROFILE: ActivityImportProfile = {
 export const CREDIT_CARD_TRANSACTION_IMPORT_PROFILE: ActivityImportProfile = {
   ...CASH_TRANSACTION_IMPORT_PROFILE,
   allowedActivityTypes: CREDIT_CARD_ACTIVITY_TYPES,
+  activityTypeLabels: {
+    [ActivityType.WITHDRAWAL]: "Charge",
+    [ActivityType.TRANSFER_IN]: "Payment",
+    [ActivityType.CREDIT]: "Refund / Credit",
+    [ActivityType.INTEREST]: "Interest Charge",
+  },
 };
 
 export function getActivityImportProfileForAccountType(
@@ -238,6 +251,13 @@ export function activityTypeAllowedForImportProfile(
   return profile.allowedActivityTypes.includes(activityType.toUpperCase() as ActivityType);
 }
 
+export function getActivityTypeLabelForImportProfile(
+  activityType: ActivityType,
+  profile: ActivityImportProfile,
+): string {
+  return profile.activityTypeLabels?.[activityType] ?? ActivityTypeNames[activityType];
+}
+
 function appendAliases(
   mappings: Record<string, string[]>,
   activityType: ActivityType,
@@ -289,6 +309,9 @@ export function getDefaultActivityMappingsForImportProfile(
       "REVERSAL",
       "STATEMENT CREDIT",
       "CREDIT ADJUSTMENT",
+      "CASHBACK",
+      "CASH BACK",
+      "REWARDS",
     ]);
     appendAliases(mappings, ActivityType.FEE, ["ANNUAL FEE", "LATE FEE", "SERVICE FEE"]);
     appendAliases(mappings, ActivityType.INTEREST, ["INTEREST CHARGE", "FINANCE CHARGE"]);
@@ -313,7 +336,14 @@ export function getDefaultActivityMappingsForImportProfile(
     appendAliases(mappings, ActivityType.TRANSFER_IN, ["TRANSFER IN", "TRANSFER_IN"]);
     appendAliases(mappings, ActivityType.TRANSFER_OUT, ["TRANSFER OUT", "TRANSFER_OUT"]);
     appendAliases(mappings, ActivityType.INTEREST, ["INTEREST", "INTEREST EARNED"]);
-    appendAliases(mappings, ActivityType.CREDIT, ["REFUND", "REVERSAL", "CREDIT"]);
+    appendAliases(mappings, ActivityType.CREDIT, [
+      "REFUND",
+      "REVERSAL",
+      "CREDIT",
+      "CASHBACK",
+      "CASH BACK",
+      "REWARDS",
+    ]);
   }
 
   return mappings;

--- a/apps/frontend/src/pages/asset/asset-detail-card.tsx
+++ b/apps/frontend/src/pages/asset/asset-detail-card.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@wealthfolio/ui/components/ui/card";
 import { Separator } from "@wealthfolio/ui/components/ui/separator";
 import { formatPercent } from "@wealthfolio/ui";
+import { GainPercent } from "@wealthfolio/ui";
 import { AmountDisplay } from "@wealthfolio/ui";
 import { QuantityDisplay } from "@wealthfolio/ui";
 import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
@@ -55,6 +56,12 @@ interface AssetDetailProps {
   className?: string;
 }
 
+const SectionHeader: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <div className="text-muted-foreground mb-2 text-xs font-medium uppercase tracking-wider">
+    {children}
+  </div>
+);
+
 const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) => {
   const { isBalanceHidden } = useBalancePrivacy();
 
@@ -89,22 +96,12 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
   const quantityLabel = isOption ? "contracts" : "shares";
   const averageCostLabel = isOption ? "Average premium" : "Average cost";
 
-  const renderAmountWithPercent = (amount: number | null, percent: number | null) => {
-    if (amount == null) return <span className="text-muted-foreground">N/A</span>;
-    return (
-      <>
-        <AmountDisplay value={amount} currency={currency} isHidden={isBalanceHidden} />
-        {percent != null && <> ({formatPercent(percent)})</>}
-      </>
-    );
-  };
-
   const amountTone = (amount: number | null) => {
     if (amount == null || amount === 0) return "";
     return amount < 0 ? "text-destructive" : "text-success";
   };
 
-  const holdingRows = [
+  const positionRows = [
     {
       label: "Book value",
       value: <AmountDisplay value={costBasis} currency={currency} isHidden={isBalanceHidden} />,
@@ -114,72 +111,73 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
       value: <AmountDisplay value={averagePrice} currency={currency} isHidden={isBalanceHidden} />,
     },
     { label: "% of my portfolio", value: formatPercent(portfolioPercent) },
+  ];
+
+  const performanceRows: {
+    label: string;
+    amount: number | null;
+    currency: string;
+    percent: number | null;
+    color: string;
+  }[] = [
     ...(todaysReturn !== null && todaysReturnPercent !== null
       ? [
           {
             label: "Today's return",
-            value: (
-              <>
-                <AmountDisplay
-                  value={todaysReturn}
-                  currency={currency}
-                  isHidden={isBalanceHidden}
-                />{" "}
-                ({formatPercent(todaysReturnPercent)})
-              </>
-            ),
-            color: todaysReturn < 0 ? "text-destructive" : "text-success",
+            amount: todaysReturn,
+            currency,
+            percent: todaysReturnPercent,
+            color: amountTone(todaysReturn),
           },
         ]
       : []),
     {
       label: "Unrealized P&L",
-      value: renderAmountWithPercent(unrealizedPnl, unrealizedPnlPercent),
+      amount: unrealizedPnl,
+      currency,
+      percent: unrealizedPnlPercent,
       color: amountTone(unrealizedPnl),
     },
     {
       label: "Realized P&L",
-      value: renderAmountWithPercent(realizedPnl, realizedPnlPercent),
+      amount: realizedPnl,
+      currency,
+      percent: realizedPnlPercent,
       color: amountTone(realizedPnl),
     },
     {
       label: "Income",
-      value:
-        income == null ? (
-          <span className="text-muted-foreground">N/A</span>
-        ) : (
-          <AmountDisplay value={income} currency={currency} isHidden={isBalanceHidden} />
-        ),
+      amount: income,
+      currency,
+      percent: null,
       color: amountTone(income),
     },
     {
       label: "FX effect",
-      value:
-        fxEffect == null ? (
-          <span className="text-muted-foreground">N/A</span>
-        ) : (
-          <AmountDisplay value={fxEffect} currency={baseCurrency} isHidden={isBalanceHidden} />
-        ),
+      amount: fxEffect,
+      currency: baseCurrency,
+      percent: null,
       color: amountTone(fxEffect),
     },
     {
       label: "Price return",
-      value:
-        priceReturnPercent == null ? (
-          <span className="text-muted-foreground">N/A</span>
-        ) : (
-          formatPercent(priceReturnPercent)
-        ),
+      amount: null,
+      currency,
+      percent: priceReturnPercent,
       color: amountTone(priceReturnPercent),
     },
     {
       label: "Total P&L",
-      value: renderAmountWithPercent(totalPnl, totalPnlPercent),
+      amount: totalPnl,
+      currency,
+      percent: totalPnlPercent,
       color: amountTone(totalPnl),
     },
     {
       label: "Total Return",
-      value: renderAmountWithPercent(totalReturn, totalReturnPercent),
+      amount: totalReturn,
+      currency,
+      percent: totalReturnPercent,
       color: amountTone(totalReturn),
     },
   ];
@@ -205,20 +203,58 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
 
       <CardContent>
         <Separator className="my-3" />
-        <div className="space-y-4 text-sm">
-          {holdingRows.map(({ label, value, color }, idx) => (
-            <div key={idx} className="flex justify-between">
-              <span className="text-muted-foreground">{label}</span>
-              <span className={`font-medium ${color || ""}`}>{value}</span>
-            </div>
-          ))}
+        <div>
+          <SectionHeader>Position</SectionHeader>
+          <div className="space-y-1.5 text-sm">
+            {positionRows.map(({ label, value }, idx) => (
+              <div key={idx} className="flex justify-between">
+                <span className="text-muted-foreground">{label}</span>
+                <span className="font-medium">{value}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <Separator className="my-3" />
+        <div>
+          <SectionHeader>Performance</SectionHeader>
+          <div className="space-y-1.5 text-sm">
+            {performanceRows.map(
+              ({ label, amount, currency: rowCurrency, percent, color }, idx) => (
+                <div key={idx} className="flex items-center justify-between">
+                  <span className="text-muted-foreground">{label}</span>
+                  <span className="flex items-center gap-2">
+                    {amount == null && percent == null ? (
+                      <span className="text-muted-foreground">N/A</span>
+                    ) : (
+                      <>
+                        {amount != null && (
+                          <span className={`font-medium ${color || ""}`}>
+                            <AmountDisplay
+                              value={amount}
+                              currency={rowCurrency}
+                              isHidden={isBalanceHidden}
+                            />
+                          </span>
+                        )}
+                        {percent != null && (
+                          <GainPercent variant="badge" value={percent} className="text-xs" />
+                        )}
+                      </>
+                    )}
+                  </span>
+                </div>
+              ),
+            )}
+          </div>
         </div>
 
         {quote && (
           <>
-            <Separator className="my-4" />
+            <Separator className="my-3" />
             <div>
-              <div className="grid grid-cols-2 gap-x-6 gap-y-3">
+              <SectionHeader>Day Range</SectionHeader>
+              <div className="grid grid-cols-2 gap-x-6 gap-y-2">
                 <div className="flex flex-col">
                   <span className="text-muted-foreground text-xs">Open</span>
                   <div className="text-sm font-medium">
@@ -282,7 +318,7 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
 
         {bondSpec && (
           <>
-            <Separator className="my-4" />
+            <Separator className="my-3" />
             <div className="grid grid-cols-2 gap-x-6">
               {bondSpec.couponRate != null && (
                 <div className="flex flex-col">
@@ -315,7 +351,7 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
 
         {optionSpec && (
           <>
-            <Separator className="my-4" />
+            <Separator className="my-3" />
             <div className="grid grid-cols-3 gap-x-4">
               {optionSpec.right && (
                 <div className="flex flex-col">

--- a/apps/frontend/src/pages/health/components/issue-detail-sheet.test.tsx
+++ b/apps/frontend/src/pages/health/components/issue-detail-sheet.test.tsx
@@ -40,7 +40,11 @@ vi.mock("@wealthfolio/ui", () => ({
     </div>
   ),
   Sheet: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
-  SheetContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SheetContent: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div data-testid="sheet-content" className={className}>
+      {children}
+    </div>
+  ),
   SheetHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
   SheetTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>,
 }));
@@ -129,5 +133,16 @@ describe("IssueDetailSheet", () => {
     expect(scrollArea).not.toContainElement(
       screen.getByRole("link", { name: /Open General Settings/i }),
     );
+  });
+
+  it("uses a wider responsive sheet for dense issue details", () => {
+    renderIssueSheet({
+      ...baseIssue,
+      category: "DATA_CONSISTENCY",
+      title: "7 incomplete transfers detected",
+      affectedCount: 7,
+    });
+
+    expect(screen.getByTestId("sheet-content")).toHaveClass("sm:max-w-xl", "lg:max-w-2xl");
   });
 });

--- a/apps/frontend/src/pages/health/components/issue-detail-sheet.tsx
+++ b/apps/frontend/src/pages/health/components/issue-detail-sheet.tsx
@@ -123,7 +123,7 @@ export function IssueDetailSheet({
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent side="right" className="flex w-full flex-col sm:max-w-md">
+      <SheetContent side="right" className="flex w-full flex-col sm:max-w-xl lg:max-w-2xl">
         <SheetHeader className="shrink-0 space-y-3 pb-6">
           <div className="flex items-center gap-2 text-xs">
             <span className={cn("font-medium", severityConfig.color)}>{severityConfig.label}</span>

--- a/apps/server/src/api/activities.rs
+++ b/apps/server/src/api/activities.rs
@@ -110,6 +110,7 @@ async fn create_activity(
     Json(activity): Json<NewActivity>,
 ) -> ApiResult<Json<Activity>> {
     let created = state.activity_service.create_activity(activity).await?;
+    state.health_service.clear_cache().await;
 
     // Domain events handle asset enrichment and portfolio recalculation
     Ok(Json(created))
@@ -120,6 +121,7 @@ async fn update_activity(
     Json(activity): Json<ActivityUpdate>,
 ) -> ApiResult<Json<Activity>> {
     let updated = state.activity_service.update_activity(activity).await?;
+    state.health_service.clear_cache().await;
     // Domain events handle asset enrichment and portfolio recalculation
     Ok(Json(updated))
 }
@@ -132,6 +134,7 @@ async fn save_activities(
         .activity_service
         .bulk_mutate_activities(request)
         .await?;
+    state.health_service.clear_cache().await;
     // Domain events handle asset enrichment and portfolio recalculation
     Ok(Json(result))
 }
@@ -141,6 +144,7 @@ async fn delete_activity(
     State(state): State<Arc<AppState>>,
 ) -> ApiResult<Json<Activity>> {
     let deleted = state.activity_service.delete_activity(id).await?;
+    state.health_service.clear_cache().await;
     // Domain events handle portfolio recalculation
     Ok(Json(deleted))
 }
@@ -171,6 +175,7 @@ async fn save_internal_transfer_pair(
         .activity_service
         .save_internal_transfer_pair(request)
         .await?;
+    state.health_service.clear_cache().await;
     Ok(Json(pair))
 }
 
@@ -189,6 +194,7 @@ async fn link_transfer_activities(
         .activity_service
         .link_transfer_activities(body.activity_a_id, body.activity_b_id)
         .await?;
+    state.health_service.clear_cache().await;
     // Domain events handle portfolio recalculation
     Ok(Json(pair))
 }
@@ -201,6 +207,7 @@ async fn unlink_transfer_activities(
         .activity_service
         .unlink_transfer_activities(body.activity_a_id, body.activity_b_id)
         .await?;
+    state.health_service.clear_cache().await;
     // Domain events handle portfolio recalculation
     Ok(Json(pair))
 }
@@ -234,6 +241,7 @@ async fn import_activities(
         .activity_service
         .import_activities(body.activities)
         .await?;
+    state.health_service.clear_cache().await;
     // Domain events handle asset enrichment and portfolio recalculation
     Ok(Json(result))
 }

--- a/apps/server/src/api/activities.rs
+++ b/apps/server/src/api/activities.rs
@@ -12,6 +12,7 @@ use wealthfolio_core::activities::{
     ActivitySearchResponse, ActivityUpdate, ImportActivitiesResult, ImportAssetCandidate,
     ImportAssetPreviewItem, ImportMappingData, ImportTemplateData, InternalTransferPairRequest,
     InternalTransferPairResponse, NewActivity, ParseConfig, ParsedCsvResult,
+    TransferMatchCandidate, TransferMatchCandidateRequest,
 };
 
 use super::shared::parse_date_optional;
@@ -143,6 +144,16 @@ async fn get_transfer_pair_for_activity(
 ) -> ApiResult<Json<InternalTransferPairResponse>> {
     let pair = state.activity_service.get_transfer_pair_for_activity(id)?;
     Ok(Json(pair))
+}
+
+async fn find_transfer_match_candidates(
+    State(state): State<Arc<AppState>>,
+    Json(request): Json<TransferMatchCandidateRequest>,
+) -> ApiResult<Json<Vec<TransferMatchCandidate>>> {
+    let candidates = state
+        .activity_service
+        .find_transfer_match_candidates(request)?;
+    Ok(Json(candidates))
 }
 
 async fn save_internal_transfer_pair(
@@ -417,6 +428,10 @@ pub fn router() -> Router<Arc<AppState>> {
         .route(
             "/activities/transfer-pair",
             post(save_internal_transfer_pair),
+        )
+        .route(
+            "/activities/transfer-match-candidates",
+            post(find_transfer_match_candidates),
         )
         .route("/activities/link", post(link_transfer_activities))
         .route("/activities/unlink", post(unlink_transfer_activities))

--- a/apps/server/src/api/activities.rs
+++ b/apps/server/src/api/activities.rs
@@ -14,6 +14,9 @@ use wealthfolio_core::activities::{
     InternalTransferPairResponse, NewActivity, ParseConfig, ParsedCsvResult,
     TransferMatchCandidate, TransferMatchCandidateRequest,
 };
+use wealthfolio_core::utils::time_utils::{
+    local_date_range_utc_bounds, parse_user_timezone_or_default,
+};
 
 use super::shared::parse_date_optional;
 
@@ -82,8 +85,12 @@ async fn search_activities(
     // Parse date filters
     let date_from_parsed = parse_date_optional(body.date_from, "dateFrom")?;
     let date_to_parsed = parse_date_optional(body.date_to, "dateTo")?;
+    let timezone = state.timezone.read().unwrap().clone();
+    let tz = parse_user_timezone_or_default(&timezone);
+    let (date_from_utc, date_to_utc_exclusive) =
+        local_date_range_utc_bounds(date_from_parsed, date_to_parsed, tz)?;
 
-    let resp = state.activity_service.search_activities(
+    let resp = state.activity_service.search_activities_in_utc_range(
         body.page,
         body.page_size,
         account_ids,
@@ -91,8 +98,8 @@ async fn search_activities(
         body.asset_id_keyword,
         sort_normalized,
         body.needs_review_filter,
-        date_from_parsed,
-        date_to_parsed,
+        date_from_utc,
+        date_to_utc_exclusive,
         instrument_types,
     )?;
     Ok(Json(resp))

--- a/apps/tauri/src/commands/activity.rs
+++ b/apps/tauri/src/commands/activity.rs
@@ -11,6 +11,7 @@ use wealthfolio_core::activities::{
     InternalTransferPairResponse, NewActivity, ParseConfig, ParsedCsvResult, Sort,
     TransferMatchCandidate, TransferMatchCandidateRequest,
 };
+use wealthfolio_core::health::HealthServiceTrait;
 use wealthfolio_core::utils::time_utils::{
     local_date_range_utc_bounds, parse_user_timezone_or_default,
 };
@@ -68,11 +69,13 @@ pub async fn create_activity(
 ) -> Result<Activity, String> {
     debug!("Creating activity...");
     // Domain events handle recalculation and asset enrichment automatically
-    state
+    let created = state
         .activity_service()
         .create_activity(activity)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    state.health_service().clear_cache().await;
+    Ok(created)
 }
 
 #[tauri::command]
@@ -82,11 +85,13 @@ pub async fn update_activity(
 ) -> Result<Activity, String> {
     debug!("Updating activity...");
     // Domain events handle recalculation and asset enrichment automatically
-    state
+    let updated = state
         .activity_service()
         .update_activity(activity)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    state.health_service().clear_cache().await;
+    Ok(updated)
 }
 
 #[tauri::command]
@@ -96,11 +101,13 @@ pub async fn delete_activity(
 ) -> Result<Activity, String> {
     debug!("Deleting activity...");
     // Domain events handle recalculation automatically
-    state
+    let deleted = state
         .activity_service()
         .delete_activity(activity_id)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    state.health_service().clear_cache().await;
+    Ok(deleted)
 }
 
 #[tauri::command]
@@ -133,11 +140,13 @@ pub async fn save_internal_transfer_pair(
     state: State<'_, Arc<ServiceContext>>,
 ) -> Result<InternalTransferPairResponse, String> {
     debug!("Saving internal transfer pair...");
-    state
+    let pair = state
         .activity_service()
         .save_internal_transfer_pair(request)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    state.health_service().clear_cache().await;
+    Ok(pair)
 }
 
 #[tauri::command]
@@ -148,11 +157,13 @@ pub async fn link_transfer_activities(
 ) -> Result<(Activity, Activity), String> {
     debug!("Linking transfer activities...");
     // Domain events handle recalculation automatically
-    state
+    let pair = state
         .activity_service()
         .link_transfer_activities(activity_a_id, activity_b_id)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    state.health_service().clear_cache().await;
+    Ok(pair)
 }
 
 #[tauri::command]
@@ -163,11 +174,13 @@ pub async fn unlink_transfer_activities(
 ) -> Result<(Activity, Activity), String> {
     debug!("Unlinking transfer activities...");
     // Domain events handle recalculation automatically
-    state
+    let pair = state
         .activity_service()
         .unlink_transfer_activities(activity_a_id, activity_b_id)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    state.health_service().clear_cache().await;
+    Ok(pair)
 }
 
 #[tauri::command]
@@ -184,11 +197,13 @@ pub async fn save_activities(
     );
 
     // Domain events handle recalculation and asset enrichment automatically
-    state
+    let result = state
         .activity_service()
         .bulk_mutate_activities(request)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    state.health_service().clear_cache().await;
+    Ok(result)
 }
 
 #[tauri::command]
@@ -302,11 +317,13 @@ pub async fn import_activities(
 ) -> Result<ImportActivitiesResult, String> {
     debug!("Importing {} activities", activities.len());
     // Domain events handle recalculation and asset enrichment automatically
-    state
+    let result = state
         .activity_service()
         .import_activities(activities)
         .await
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?;
+    state.health_service().clear_cache().await;
+    Ok(result)
 }
 
 #[tauri::command]

--- a/apps/tauri/src/commands/activity.rs
+++ b/apps/tauri/src/commands/activity.rs
@@ -9,6 +9,7 @@ use wealthfolio_core::activities::{
     ActivitySearchResponse, ActivityUpdate, ImportActivitiesResult, ImportAssetCandidate,
     ImportAssetPreviewItem, ImportMappingData, ImportTemplateData, InternalTransferPairRequest,
     InternalTransferPairResponse, NewActivity, ParseConfig, ParsedCsvResult, Sort,
+    TransferMatchCandidate, TransferMatchCandidateRequest,
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -103,6 +104,18 @@ pub async fn get_transfer_pair_for_activity(
     state
         .activity_service()
         .get_transfer_pair_for_activity(activity_id)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn find_transfer_match_candidates(
+    request: TransferMatchCandidateRequest,
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<Vec<TransferMatchCandidate>, String> {
+    debug!("Finding transfer match candidates...");
+    state
+        .activity_service()
+        .find_transfer_match_candidates(request)
         .map_err(|e| e.to_string())
 }
 

--- a/apps/tauri/src/commands/activity.rs
+++ b/apps/tauri/src/commands/activity.rs
@@ -11,6 +11,9 @@ use wealthfolio_core::activities::{
     InternalTransferPairResponse, NewActivity, ParseConfig, ParsedCsvResult, Sort,
     TransferMatchCandidate, TransferMatchCandidateRequest,
 };
+use wealthfolio_core::utils::time_utils::{
+    local_date_range_utc_bounds, parse_user_timezone_or_default,
+};
 
 #[allow(clippy::too_many_arguments)]
 #[tauri::command]
@@ -38,8 +41,13 @@ pub async fn search_activities(
         .map(|s| chrono::NaiveDate::parse_from_str(&s, "%Y-%m-%d"))
         .transpose()
         .map_err(|e| format!("Invalid date_to format: {}", e))?;
+    let timezone = state.get_timezone();
+    let tz = parse_user_timezone_or_default(&timezone);
+    let (date_from_utc, date_to_utc_exclusive) =
+        local_date_range_utc_bounds(date_from_parsed, date_to_parsed, tz)
+            .map_err(|e| e.to_string())?;
 
-    Ok(state.activity_service().search_activities(
+    Ok(state.activity_service().search_activities_in_utc_range(
         page,
         page_size,
         account_id_filter,
@@ -47,8 +55,8 @@ pub async fn search_activities(
         asset_id_keyword,
         sort,
         needs_review_filter,
-        date_from_parsed,
-        date_to_parsed,
+        date_from_utc,
+        date_to_utc_exclusive,
         instrument_type_filter,
     )?)
 }

--- a/apps/tauri/src/lib.rs
+++ b/apps/tauri/src/lib.rs
@@ -413,6 +413,7 @@ pub fn run() {
             commands::activity::save_activities,
             commands::activity::delete_activity,
             commands::activity::get_transfer_pair_for_activity,
+            commands::activity::find_transfer_match_candidates,
             commands::activity::save_internal_transfer_pair,
             commands::activity::link_transfer_activities,
             commands::activity::unlink_transfer_activities,

--- a/crates/ai/src/env/test_env.rs
+++ b/crates/ai/src/env/test_env.rs
@@ -15,6 +15,7 @@ use wealthfolio_core::{
         ActivityUpdate, BrokerSyncProfileData, ImportAssetCandidate, ImportAssetPreviewItem,
         ImportMappingData, ImportTemplateData, ImportTemplateScope, InternalTransferPairRequest,
         InternalTransferPairResponse, NewActivity, SaveBrokerSyncProfileRulesRequest, Sort,
+        TransferMatchCandidate, TransferMatchCandidateRequest,
     },
     assets::{
         Asset, AssetMetadata, AssetResolutionInput, AssetResolutionOutput, AssetServiceTrait,
@@ -433,6 +434,13 @@ impl ActivityServiceTrait for MockActivityService {
                 total_row_count: self.activities.len() as i64,
             },
         })
+    }
+
+    fn find_transfer_match_candidates(
+        &self,
+        _request: TransferMatchCandidateRequest,
+    ) -> CoreResult<Vec<TransferMatchCandidate>> {
+        Ok(Vec::new())
     }
 
     fn get_first_activity_date(

--- a/crates/ai/src/tools/propose_categories.rs
+++ b/crates/ai/src/tools/propose_categories.rs
@@ -1025,6 +1025,7 @@ mod tests {
             cash_flow_bucket: CashFlowBucket::Spending,
             assignments,
             event_id: None,
+            transfer_link_status: None,
         }
     }
 

--- a/crates/core/src/activities/activities_model.rs
+++ b/crates/core/src/activities/activities_model.rs
@@ -660,6 +660,27 @@ pub struct InternalTransferPairResponse {
     pub transfer_in: Activity,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransferMatchCandidateRequest {
+    pub activity_id: String,
+    #[serde(default)]
+    pub window_days: Option<i64>,
+    #[serde(default)]
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransferMatchCandidate {
+    pub activity: Activity,
+    pub match_kind: String,
+    pub confidence: String,
+    pub score: i32,
+    pub reasons: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
 /// Structured error reported for a single bulk mutation entry.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -714,6 +714,151 @@ impl ActivityService {
         }
     }
 
+    fn transfer_match_tolerance() -> Decimal {
+        Decimal::new(1, 6)
+    }
+
+    fn opposite_transfer_type(activity_type: &str) -> Option<&'static str> {
+        match activity_type {
+            ACTIVITY_TYPE_TRANSFER_IN => Some(ACTIVITY_TYPE_TRANSFER_OUT),
+            ACTIVITY_TYPE_TRANSFER_OUT => Some(ACTIVITY_TYPE_TRANSFER_IN),
+            _ => None,
+        }
+    }
+
+    fn non_cash_transfer_asset_key(activity: &Activity) -> Option<String> {
+        activity
+            .asset_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|asset_id| !asset_id.is_empty())
+            .filter(|asset_id| !is_cash_symbol(asset_id))
+            .map(str::to_uppercase)
+    }
+
+    fn is_security_transfer_activity(activity: &Activity) -> bool {
+        matches!(
+            activity.effective_type(),
+            ACTIVITY_TYPE_TRANSFER_IN | ACTIVITY_TYPE_TRANSFER_OUT
+        ) && Self::non_cash_transfer_asset_key(activity).is_some()
+    }
+
+    fn transfer_abs_value(activity: &Activity) -> Option<Decimal> {
+        activity
+            .amount
+            .or_else(|| Some(activity.quantity? * activity.unit_price?))
+            .map(|value| value.abs())
+    }
+
+    fn decimals_match(left: Option<Decimal>, right: Option<Decimal>) -> bool {
+        match (left, right) {
+            (Some(left), Some(right)) => {
+                (left.abs() - right.abs()).abs() <= Self::transfer_match_tolerance()
+            }
+            _ => false,
+        }
+    }
+
+    fn transfer_date_diff_days(left: &Activity, right: &Activity) -> i64 {
+        (left.activity_date.date_naive() - right.activity_date.date_naive())
+            .num_days()
+            .abs()
+    }
+
+    fn transfer_candidate_score(day_diff: i64) -> (i32, String) {
+        let score = (100 - (day_diff as i32 * 10)).max(1);
+        let confidence = if day_diff == 0 {
+            "high"
+        } else if day_diff <= 3 {
+            "medium"
+        } else {
+            "low"
+        };
+        (score, confidence.to_string())
+    }
+
+    fn build_transfer_match_candidate(
+        source: &Activity,
+        candidate: &Activity,
+        day_diff: i64,
+    ) -> Option<TransferMatchCandidate> {
+        let source_is_security = Self::is_security_transfer_activity(source);
+        let candidate_is_security = Self::is_security_transfer_activity(candidate);
+        let (score, confidence) = Self::transfer_candidate_score(day_diff);
+        let mut reasons = Vec::new();
+        let mut warnings = Vec::new();
+
+        if source_is_security || candidate_is_security {
+            let source_asset = Self::non_cash_transfer_asset_key(source)?;
+            let candidate_asset = Self::non_cash_transfer_asset_key(candidate)?;
+            if source_asset != candidate_asset {
+                return None;
+            }
+            if !Self::decimals_match(source.quantity, candidate.quantity) {
+                return None;
+            }
+            reasons.push("Same asset".to_string());
+            reasons.push("Same quantity".to_string());
+            if source.currency != candidate.currency {
+                warnings.push(format!(
+                    "Currencies differ ({} vs {}).",
+                    source.currency, candidate.currency
+                ));
+            }
+            if let (Some(source_price), Some(candidate_price)) =
+                (source.unit_price, candidate.unit_price)
+            {
+                let max = source_price.abs().max(candidate_price.abs());
+                if !max.is_zero()
+                    && (source_price.abs() - candidate_price.abs()).abs() / max > Decimal::new(1, 2)
+                {
+                    warnings.push("Prices differ by more than 1%.".to_string());
+                }
+            }
+
+            if day_diff == 0 {
+                reasons.push("Same date".to_string());
+            } else {
+                warnings.push(format!("Dates differ by {} day(s).", day_diff));
+            }
+
+            return Some(TransferMatchCandidate {
+                activity: candidate.clone(),
+                match_kind: "security".to_string(),
+                confidence,
+                score,
+                reasons,
+                warnings,
+            });
+        }
+
+        if !source.currency.eq_ignore_ascii_case(&candidate.currency) {
+            return None;
+        }
+        if !Self::decimals_match(
+            Self::transfer_abs_value(source),
+            Self::transfer_abs_value(candidate),
+        ) {
+            return None;
+        }
+        reasons.push("Same amount".to_string());
+        reasons.push("Same currency".to_string());
+        if day_diff == 0 {
+            reasons.push("Same date".to_string());
+        } else {
+            warnings.push(format!("Dates differ by {} day(s).", day_diff));
+        }
+
+        Some(TransferMatchCandidate {
+            activity: candidate.clone(),
+            match_kind: "cash".to_string(),
+            confidence,
+            score,
+            reasons,
+            warnings,
+        })
+    }
+
     fn load_internal_transfer_pair_for_activity(
         &self,
         activity_id: &str,
@@ -3702,6 +3847,60 @@ impl ActivityServiceTrait for ActivityService {
     ) -> Result<InternalTransferPairResponse> {
         let pair = self.require_internal_transfer_pair_for_activity(&activity_id)?;
         Ok(Self::transfer_pair_response(pair))
+    }
+
+    fn find_transfer_match_candidates(
+        &self,
+        request: TransferMatchCandidateRequest,
+    ) -> Result<Vec<TransferMatchCandidate>> {
+        let source = self
+            .activity_repository
+            .get_activity(&request.activity_id)?;
+        let Some(opposite_type) = Self::opposite_transfer_type(source.effective_type()) else {
+            return Err(Self::invalid_activity_data(
+                "Transfer match candidates require a transfer activity",
+            ));
+        };
+        if source.source_group_id.is_some() {
+            return Ok(Vec::new());
+        }
+
+        let window_days = request.window_days.unwrap_or(7).clamp(0, 90);
+        let limit = request.limit.unwrap_or(25).clamp(1, 100);
+
+        let mut candidates: Vec<TransferMatchCandidate> = self
+            .activity_repository
+            .get_activities()?
+            .into_iter()
+            .filter(|candidate| {
+                candidate.id != source.id
+                    && candidate.account_id != source.account_id
+                    && candidate.is_posted()
+                    && candidate.source_group_id.is_none()
+                    && candidate.effective_type() == opposite_type
+            })
+            .filter_map(|candidate| {
+                let day_diff = Self::transfer_date_diff_days(&source, &candidate);
+                if day_diff > window_days {
+                    return None;
+                }
+                Self::build_transfer_match_candidate(&source, &candidate, day_diff)
+            })
+            .collect();
+
+        candidates.sort_by(|left, right| {
+            right
+                .score
+                .cmp(&left.score)
+                .then_with(|| {
+                    left.activity
+                        .activity_date
+                        .cmp(&right.activity.activity_date)
+                })
+                .then_with(|| left.activity.id.cmp(&right.activity.id))
+        });
+        candidates.truncate(limit);
+        Ok(candidates)
     }
 
     async fn save_internal_transfer_pair(

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -15,7 +15,9 @@ use crate::activities::activities_errors::ActivityError;
 use crate::activities::activities_model::*;
 use crate::activities::csv_parser::{self, ParseConfig, ParsedCsvResult};
 use crate::activities::idempotency::compute_idempotency_key;
-use crate::activities::{ActivityRepositoryTrait, ActivityServiceTrait, TransferPair};
+use crate::activities::{
+    ActivityRepositoryTrait, ActivityServiceTrait, TransferPair, TransferPairResolution,
+};
 use crate::activities::{
     ImportRun, ImportRunMode, ImportRunRepositoryTrait, ImportRunSummary, ImportRunType, ReviewMode,
 };
@@ -3890,22 +3892,24 @@ impl ActivityServiceTrait for ActivityService {
                 "Transfer match candidates require a transfer activity",
             ));
         };
-        if source.source_group_id.is_some() {
+        let all_activities = self.activity_repository.get_activities()?;
+        let transfer_resolution = TransferPairResolution::from_activities(&all_activities);
+        if transfer_resolution.pair_for_activity(&source.id).is_some() {
             return Ok(Vec::new());
         }
 
         let window_days = request.window_days.unwrap_or(7).clamp(0, 90);
         let limit = request.limit.unwrap_or(25).clamp(1, 100);
 
-        let mut candidates: Vec<TransferMatchCandidate> = self
-            .activity_repository
-            .get_activities()?
+        let mut candidates: Vec<TransferMatchCandidate> = all_activities
             .into_iter()
             .filter(|candidate| {
                 candidate.id != source.id
                     && candidate.account_id != source.account_id
                     && candidate.is_posted()
-                    && candidate.source_group_id.is_none()
+                    && transfer_resolution
+                        .pair_for_activity(&candidate.id)
+                        .is_none()
                     && candidate.effective_type() == opposite_type
             })
             .filter_map(|candidate| {

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -3613,6 +3613,35 @@ impl ActivityServiceTrait for ActivityService {
         )
     }
 
+    /// Searches activities using an exact UTC timestamp window for date filters.
+    #[allow(clippy::too_many_arguments)]
+    fn search_activities_in_utc_range(
+        &self,
+        page: i64,
+        page_size: i64,
+        account_id_filter: Option<Vec<String>>,
+        activity_type_filter: Option<Vec<String>>,
+        asset_id_keyword: Option<String>,
+        sort: Option<Sort>,
+        needs_review_filter: Option<bool>,
+        date_from_utc: Option<DateTime<Utc>>,
+        date_to_utc_exclusive: Option<DateTime<Utc>>,
+        instrument_type_filter: Option<Vec<String>>,
+    ) -> Result<ActivitySearchResponse> {
+        self.activity_repository.search_activities_in_utc_range(
+            page,
+            page_size,
+            account_id_filter,
+            activity_type_filter,
+            asset_id_keyword,
+            sort,
+            needs_review_filter,
+            date_from_utc,
+            date_to_utc_exclusive,
+            instrument_type_filter,
+        )
+    }
+
     /// Creates a new activity
     async fn create_activity(&self, activity: NewActivity) -> Result<Activity> {
         let prepared = self.prepare_new_activity(activity).await?;

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -1719,6 +1719,93 @@ mod tests {
         }
     }
 
+    struct TransferActivitySeed<'a> {
+        id: &'a str,
+        account_id: &'a str,
+        activity_type: &'a str,
+        date: &'a str,
+        amount: Option<Decimal>,
+        currency: &'a str,
+        asset_id: Option<&'a str>,
+        quantity: Option<Decimal>,
+        unit_price: Option<Decimal>,
+    }
+
+    fn create_transfer_activity(seed: TransferActivitySeed<'_>) -> Activity {
+        Activity {
+            id: seed.id.to_string(),
+            account_id: seed.account_id.to_string(),
+            asset_id: seed.asset_id.map(str::to_string),
+            activity_type: seed.activity_type.to_string(),
+            activity_type_override: None,
+            source_type: None,
+            subtype: None,
+            status: ActivityStatus::Posted,
+            activity_date: parse_test_activity_datetime(seed.date),
+            settlement_date: None,
+            quantity: seed.quantity,
+            unit_price: seed.unit_price,
+            amount: seed.amount,
+            fee: Some(dec!(0)),
+            currency: seed.currency.to_string(),
+            fx_rate: None,
+            notes: None,
+            metadata: Some(json!({ "flow": { "is_external": true } })),
+            source_system: Some("MANUAL".to_string()),
+            source_record_id: None,
+            source_group_id: None,
+            idempotency_key: None,
+            import_run_id: None,
+            is_user_modified: false,
+            needs_review: false,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn create_cash_transfer_activity(
+        id: &str,
+        account_id: &str,
+        activity_type: &str,
+        date: &str,
+        amount: Decimal,
+        currency: &str,
+    ) -> Activity {
+        create_transfer_activity(TransferActivitySeed {
+            id,
+            account_id,
+            activity_type,
+            date,
+            amount: Some(amount),
+            currency,
+            asset_id: None,
+            quantity: None,
+            unit_price: None,
+        })
+    }
+
+    fn create_security_transfer_activity(
+        id: &str,
+        account_id: &str,
+        activity_type: &str,
+        date: &str,
+        asset_id: &str,
+        quantity: Decimal,
+        unit_price: Decimal,
+    ) -> Activity {
+        create_transfer_activity(TransferActivitySeed {
+            id,
+            account_id,
+            activity_type,
+            date,
+            amount: None,
+            currency: "USD",
+            asset_id: Some(asset_id),
+            quantity: Some(quantity),
+            unit_price: Some(unit_price),
+        })
+    }
+
     fn create_test_activity_update(
         id: &str,
         account_id: &str,
@@ -7383,6 +7470,150 @@ mod tests {
             Some(true),
             "unpaired inserted leg should keep its external flag"
         );
+    }
+
+    #[test]
+    fn find_transfer_match_candidates_returns_cash_matches_only() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        activity_repository.add_activity(create_cash_transfer_activity(
+            "source-out",
+            "acc-a",
+            "TRANSFER_OUT",
+            "2024-01-15T00:00:00Z",
+            dec!(100),
+            "USD",
+        ));
+        activity_repository.add_activity(create_cash_transfer_activity(
+            "cash-match",
+            "acc-b",
+            "TRANSFER_IN",
+            "2024-01-17T00:00:00Z",
+            dec!(100),
+            "USD",
+        ));
+        activity_repository.add_activity(create_cash_transfer_activity(
+            "wrong-amount",
+            "acc-b",
+            "TRANSFER_IN",
+            "2024-01-17T00:00:00Z",
+            dec!(101),
+            "USD",
+        ));
+        activity_repository.add_activity(create_cash_transfer_activity(
+            "same-account",
+            "acc-a",
+            "TRANSFER_IN",
+            "2024-01-17T00:00:00Z",
+            dec!(100),
+            "USD",
+        ));
+        let mut linked = create_cash_transfer_activity(
+            "already-linked",
+            "acc-c",
+            "TRANSFER_IN",
+            "2024-01-17T00:00:00Z",
+            dec!(100),
+            "USD",
+        );
+        linked.source_group_id = Some("group-1".to_string());
+        activity_repository.add_activity(linked);
+
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            Arc::new(MockQuoteService),
+        );
+
+        let candidates = activity_service
+            .find_transfer_match_candidates(TransferMatchCandidateRequest {
+                activity_id: "source-out".to_string(),
+                window_days: Some(7),
+                limit: Some(25),
+            })
+            .expect("candidate search should succeed");
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].activity.id, "cash-match");
+        assert_eq!(candidates[0].match_kind, "cash");
+        assert!(candidates[0]
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("Dates differ")));
+    }
+
+    #[test]
+    fn find_transfer_match_candidates_matches_security_by_asset_and_quantity() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        activity_repository.add_activity(create_security_transfer_activity(
+            "security-out",
+            "acc-a",
+            "TRANSFER_OUT",
+            "2024-01-15T00:00:00Z",
+            "SEC:AAPL:XNAS",
+            dec!(10),
+            dec!(150),
+        ));
+        activity_repository.add_activity(create_security_transfer_activity(
+            "security-match",
+            "acc-b",
+            "TRANSFER_IN",
+            "2024-01-15T00:00:00Z",
+            "SEC:AAPL:XNAS",
+            dec!(10),
+            dec!(153),
+        ));
+        activity_repository.add_activity(create_security_transfer_activity(
+            "wrong-quantity",
+            "acc-b",
+            "TRANSFER_IN",
+            "2024-01-15T00:00:00Z",
+            "SEC:AAPL:XNAS",
+            dec!(9),
+            dec!(150),
+        ));
+        activity_repository.add_activity(create_security_transfer_activity(
+            "wrong-asset",
+            "acc-b",
+            "TRANSFER_IN",
+            "2024-01-15T00:00:00Z",
+            "SEC:MSFT:XNAS",
+            dec!(10),
+            dec!(150),
+        ));
+
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            Arc::new(MockQuoteService),
+        );
+
+        let candidates = activity_service
+            .find_transfer_match_candidates(TransferMatchCandidateRequest {
+                activity_id: "security-out".to_string(),
+                window_days: Some(7),
+                limit: Some(25),
+            })
+            .expect("candidate search should succeed");
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].activity.id, "security-match");
+        assert_eq!(candidates[0].match_kind, "security");
+        assert!(candidates[0]
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("Prices differ")));
     }
 
     #[tokio::test]

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -7521,6 +7521,16 @@ mod tests {
         );
         linked.source_group_id = Some("group-1".to_string());
         activity_repository.add_activity(linked);
+        let mut linked_counterpart = create_cash_transfer_activity(
+            "already-linked-out",
+            "acc-d",
+            "TRANSFER_OUT",
+            "2024-01-17T00:00:00Z",
+            dec!(100),
+            "USD",
+        );
+        linked_counterpart.source_group_id = Some("group-1".to_string());
+        activity_repository.add_activity(linked_counterpart);
 
         let activity_service = ActivityService::new(
             activity_repository,
@@ -7545,6 +7555,52 @@ mod tests {
             .warnings
             .iter()
             .any(|warning| warning.contains("Dates differ")));
+    }
+
+    #[test]
+    fn find_transfer_match_candidates_allows_orphan_source_group() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let mut source = create_cash_transfer_activity(
+            "source-out",
+            "acc-a",
+            "TRANSFER_OUT",
+            "2024-01-15T00:00:00Z",
+            dec!(100),
+            "USD",
+        );
+        source.source_group_id = Some("orphan-group".to_string());
+        activity_repository.add_activity(source);
+        activity_repository.add_activity(create_cash_transfer_activity(
+            "cash-match",
+            "acc-b",
+            "TRANSFER_IN",
+            "2024-01-15T00:00:00Z",
+            dec!(100),
+            "USD",
+        ));
+
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            Arc::new(MockQuoteService),
+        );
+
+        let candidates = activity_service
+            .find_transfer_match_candidates(TransferMatchCandidateRequest {
+                activity_id: "source-out".to_string(),
+                window_days: Some(7),
+                limit: Some(25),
+            })
+            .expect("candidate search should succeed");
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].activity.id, "cash-match");
     }
 
     #[test]

--- a/crates/core/src/activities/activities_traits.rs
+++ b/crates/core/src/activities/activities_traits.rs
@@ -299,6 +299,10 @@ pub trait ActivityServiceTrait: Send + Sync {
         &self,
         activity_id: String,
     ) -> Result<InternalTransferPairResponse>;
+    fn find_transfer_match_candidates(
+        &self,
+        request: TransferMatchCandidateRequest,
+    ) -> Result<Vec<TransferMatchCandidate>>;
     async fn save_internal_transfer_pair(
         &self,
         request: InternalTransferPairRequest,

--- a/crates/core/src/activities/activities_traits.rs
+++ b/crates/core/src/activities/activities_traits.rs
@@ -139,6 +139,37 @@ pub trait ActivityRepositoryTrait: Send + Sync {
         date_to: Option<NaiveDate>,
         instrument_type_filter: Option<Vec<String>>,
     ) -> Result<ActivitySearchResponse>;
+    #[allow(clippy::too_many_arguments)]
+    fn search_activities_in_utc_range(
+        &self,
+        page: i64,
+        page_size: i64,
+        account_id_filter: Option<Vec<String>>,
+        activity_type_filter: Option<Vec<String>>,
+        asset_id_keyword: Option<String>,
+        sort: Option<Sort>,
+        needs_review_filter: Option<bool>,
+        date_from_utc: Option<DateTime<Utc>>,
+        date_to_utc_exclusive: Option<DateTime<Utc>>,
+        instrument_type_filter: Option<Vec<String>>,
+    ) -> Result<ActivitySearchResponse> {
+        let date_from = date_from_utc.map(|dt| dt.date_naive());
+        let date_to =
+            date_to_utc_exclusive.map(|dt| (dt - chrono::Duration::seconds(1)).date_naive());
+
+        self.search_activities(
+            page,
+            page_size,
+            account_id_filter,
+            activity_type_filter,
+            asset_id_keyword,
+            sort,
+            needs_review_filter,
+            date_from,
+            date_to,
+            instrument_type_filter,
+        )
+    }
     async fn create_activity(&self, new_activity: NewActivity) -> Result<Activity>;
     async fn update_activity(&self, activity_update: ActivityUpdate) -> Result<Activity>;
     async fn delete_activity(&self, activity_id: String) -> Result<Activity>;
@@ -281,6 +312,37 @@ pub trait ActivityServiceTrait: Send + Sync {
         date_to: Option<NaiveDate>,
         instrument_type_filter: Option<Vec<String>>,
     ) -> Result<ActivitySearchResponse>;
+    #[allow(clippy::too_many_arguments)]
+    fn search_activities_in_utc_range(
+        &self,
+        page: i64,
+        page_size: i64,
+        account_id_filter: Option<Vec<String>>,
+        activity_type_filter: Option<Vec<String>>,
+        asset_id_keyword: Option<String>,
+        sort: Option<Sort>,
+        needs_review_filter: Option<bool>,
+        date_from_utc: Option<DateTime<Utc>>,
+        date_to_utc_exclusive: Option<DateTime<Utc>>,
+        instrument_type_filter: Option<Vec<String>>,
+    ) -> Result<ActivitySearchResponse> {
+        let date_from = date_from_utc.map(|dt| dt.date_naive());
+        let date_to =
+            date_to_utc_exclusive.map(|dt| (dt - chrono::Duration::seconds(1)).date_naive());
+
+        self.search_activities(
+            page,
+            page_size,
+            account_id_filter,
+            activity_type_filter,
+            asset_id_keyword,
+            sort,
+            needs_review_filter,
+            date_from,
+            date_to,
+            instrument_type_filter,
+        )
+    }
     fn get_first_activity_date(
         &self,
         account_ids: Option<&[String]>,

--- a/crates/core/src/activities/mod.rs
+++ b/crates/core/src/activities/mod.rs
@@ -31,6 +31,7 @@ pub use activities_model::{
     ImportAssetPreviewStatus, ImportMapping, ImportMappingData, ImportTemplate, ImportTemplateData,
     ImportTemplateScope, IncomeData, InternalTransferPairRequest, InternalTransferPairResponse,
     NewActivity, PrepareActivitiesResult, SaveBrokerSyncProfileRulesRequest, Sort, TemplateKind,
+    TransferMatchCandidate, TransferMatchCandidateRequest,
 };
 pub use activities_service::ActivityService;
 pub use activities_traits::{ActivityRepositoryTrait, ActivityServiceTrait};

--- a/crates/core/src/health/service.rs
+++ b/crates/core/src/health/service.rs
@@ -596,17 +596,18 @@ fn invalid_transfer_groups_from_activities(
     let mut groups: Vec<InvalidTransferGroupInfo> = resolution
         .invalid_groups()
         .iter()
-        .map(|group| {
-            let legs = group
+        .filter_map(|group| {
+            let legs: Vec<_> = group
                 .activity_ids
                 .iter()
                 .filter_map(|id| by_id.get(id.as_str()).copied())
+                .filter(|act| act.is_posted() && !is_external_transfer(act))
                 .map(|act| transfer_leg_detail(act, account_names, tz))
                 .collect();
-            InvalidTransferGroupInfo {
+            (!legs.is_empty()).then(|| InvalidTransferGroupInfo {
                 group_id: group.group_id.clone(),
                 legs,
-            }
+            })
         })
         .collect();
 
@@ -1268,6 +1269,22 @@ mod tests {
                 "acc_tfsa",
                 ACTIVITY_TYPE_TRANSFER_IN,
                 None,
+                false,
+                ActivityStatus::Pending,
+            ),
+            transfer_activity(
+                "external-orphan-transfer",
+                "acc_tfsa",
+                ACTIVITY_TYPE_TRANSFER_IN,
+                Some("orphan-transfer-group"),
+                true,
+                ActivityStatus::Posted,
+            ),
+            transfer_activity(
+                "pending-orphan-transfer",
+                "acc_tfsa",
+                ACTIVITY_TYPE_TRANSFER_IN,
+                Some("pending-transfer-group"),
                 false,
                 ActivityStatus::Pending,
             ),

--- a/crates/core/src/health/service.rs
+++ b/crates/core/src/health/service.rs
@@ -488,14 +488,18 @@ impl HealthService {
 
         // Detect invalid, incomplete, or unreviewed transfer flows across all
         // activities so the Health Center can surface them.
-        let invalid_transfer_groups =
-            gather_invalid_transfer_groups(activity_service.as_ref(), &account_name_map);
+        let effective_timezone = effective_timezone(configured_timezone, client_timezone);
+        let invalid_transfer_groups = gather_invalid_transfer_groups(
+            activity_service.as_ref(),
+            &account_name_map,
+            effective_timezone,
+        );
         let missing_lot_disposal_sells = gather_missing_lot_disposal_sells(
             activity_service.as_ref(),
             lot_repository.as_ref(),
             asset_service.as_ref(),
             &accounts,
-            configured_timezone.or(client_timezone),
+            effective_timezone,
         )
         .await;
         consistency_issues.extend(missing_lot_disposal_sells);
@@ -549,12 +553,22 @@ impl HealthService {
     }
 }
 
+fn effective_timezone<'a>(
+    configured_timezone: Option<&'a str>,
+    client_timezone: Option<&'a str>,
+) -> Option<&'a str> {
+    configured_timezone
+        .filter(|tz| !tz.trim().is_empty())
+        .or_else(|| client_timezone.filter(|tz| !tz.trim().is_empty()))
+}
+
 /// Loads all activities and resolves transfer groups, returning the ones that
 /// don't form a valid pair, plus posted ungrouped transfers that are not
 /// explicitly marked as external.
 fn gather_invalid_transfer_groups(
     activity_service: &dyn ActivityServiceTrait,
     account_names: &HashMap<String, String>,
+    timezone: Option<&str>,
 ) -> Vec<InvalidTransferGroupInfo> {
     let activities = match activity_service.get_activities() {
         Ok(activities) => activities,
@@ -567,13 +581,15 @@ fn gather_invalid_transfer_groups(
         }
     };
 
-    invalid_transfer_groups_from_activities(&activities, account_names)
+    invalid_transfer_groups_from_activities(&activities, account_names, timezone)
 }
 
 fn invalid_transfer_groups_from_activities(
     activities: &[Activity],
     account_names: &HashMap<String, String>,
+    timezone: Option<&str>,
 ) -> Vec<InvalidTransferGroupInfo> {
+    let tz = parse_user_timezone_or_default(timezone.unwrap_or_default());
     let resolution = TransferPairResolution::from_activities(activities);
     let by_id: HashMap<&str, &Activity> = activities.iter().map(|a| (a.id.as_str(), a)).collect();
 
@@ -585,7 +601,7 @@ fn invalid_transfer_groups_from_activities(
                 .activity_ids
                 .iter()
                 .filter_map(|id| by_id.get(id.as_str()).copied())
-                .map(|act| transfer_leg_detail(act, account_names))
+                .map(|act| transfer_leg_detail(act, account_names, tz))
                 .collect();
             InvalidTransferGroupInfo {
                 group_id: group.group_id.clone(),
@@ -601,7 +617,7 @@ fn invalid_transfer_groups_from_activities(
         {
             groups.push(InvalidTransferGroupInfo {
                 group_id: format!("ungrouped:{}", activity.id),
-                legs: vec![transfer_leg_detail(activity, account_names)],
+                legs: vec![transfer_leg_detail(activity, account_names, tz)],
             });
         }
     }
@@ -803,6 +819,7 @@ fn health_sell_net_proceeds(activity: &Activity, asset: Option<&Asset>) -> Decim
 fn transfer_leg_detail(
     activity: &Activity,
     account_names: &HashMap<String, String>,
+    timezone: chrono_tz::Tz,
 ) -> TransferLegDetail {
     TransferLegDetail {
         account_id: activity.account_id.clone(),
@@ -813,7 +830,7 @@ fn transfer_leg_detail(
         activity_type: activity.effective_type().to_string(),
         amount: activity.amount,
         currency: activity.currency.clone(),
-        date: activity.activity_date.date_naive(),
+        date: activity_date_in_tz(activity.activity_date, timezone),
     }
 }
 
@@ -1195,13 +1212,40 @@ mod tests {
             ActivityStatus::Posted,
         )];
 
-        let groups = invalid_transfer_groups_from_activities(&activities, &account_names);
+        let groups = invalid_transfer_groups_from_activities(&activities, &account_names, None);
 
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].group_id, "ungrouped:transfer-in-1");
         assert_eq!(groups[0].legs.len(), 1);
         assert_eq!(groups[0].legs[0].account_name, "TFSA");
         assert_eq!(groups[0].legs[0].activity_type, ACTIVITY_TYPE_TRANSFER_IN);
+    }
+
+    #[test]
+    fn invalid_transfer_group_dates_use_configured_timezone() {
+        let account_names = HashMap::from([("acc_tfsa".to_string(), "TFSA".to_string())]);
+        let mut activity = transfer_activity(
+            "transfer-in-1",
+            "acc_tfsa",
+            ACTIVITY_TYPE_TRANSFER_IN,
+            None,
+            false,
+            ActivityStatus::Posted,
+        );
+        activity.activity_date = Utc.with_ymd_and_hms(2024, 1, 4, 2, 13, 0).unwrap();
+        let activities = vec![activity];
+
+        let groups = invalid_transfer_groups_from_activities(
+            &activities,
+            &account_names,
+            Some("America/Toronto"),
+        );
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(
+            groups[0].legs[0].date,
+            chrono::NaiveDate::from_ymd_opt(2024, 1, 3).unwrap()
+        );
     }
 
     #[test]
@@ -1245,7 +1289,7 @@ mod tests {
             ),
         ];
 
-        let groups = invalid_transfer_groups_from_activities(&activities, &account_names);
+        let groups = invalid_transfer_groups_from_activities(&activities, &account_names, None);
 
         assert!(groups.is_empty());
     }

--- a/crates/core/src/utils/time_utils.rs
+++ b/crates/core/src/utils/time_utils.rs
@@ -3,6 +3,8 @@ use chrono::{DateTime, Datelike, Duration, LocalResult, NaiveDate, TimeZone, Utc
 use chrono_tz::Tz;
 use wealthfolio_market_data::resolver::exchange_metadata;
 
+pub type UtcDateRangeBounds = (Option<DateTime<Utc>>, Option<DateTime<Utc>>);
+
 /// Default timezone for valuation dates.
 /// This is used as a runtime fallback when user timezone is missing.
 pub const DEFAULT_VALUATION_TZ: Tz = chrono_tz::UTC;
@@ -84,6 +86,38 @@ pub fn local_year_utc_bounds(year: i32, tz: Tz) -> Result<(DateTime<Utc>, DateTi
         start_local.with_timezone(&Utc),
         end_exclusive_local.with_timezone(&Utc),
     ))
+}
+
+/// Returns UTC boundaries for an inclusive local date range in a timezone.
+/// The returned range is [start_utc, end_utc_exclusive).
+pub fn local_date_range_utc_bounds(
+    start: Option<NaiveDate>,
+    end: Option<NaiveDate>,
+    tz: Tz,
+) -> Result<UtcDateRangeBounds> {
+    let start_utc = start
+        .map(|date| local_date_start_utc(date, tz))
+        .transpose()?;
+    let end_exclusive_utc = end
+        .map(|date| {
+            let next_date = date.succ_opt().ok_or_else(|| {
+                Error::Validation(ValidationError::InvalidInput(format!(
+                    "Invalid local date range end: {date}"
+                )))
+            })?;
+            local_date_start_utc(next_date, tz)
+        })
+        .transpose()?;
+
+    Ok((start_utc, end_exclusive_utc))
+}
+
+fn local_date_start_utc(date: NaiveDate, tz: Tz) -> Result<DateTime<Utc>> {
+    let local = resolve_local_datetime(
+        tz.with_ymd_and_hms(date.year(), date.month(), date.day(), 0, 0, 0),
+        date.year(),
+    )?;
+    Ok(local.with_timezone(&Utc))
 }
 
 fn resolve_local_datetime(
@@ -260,6 +294,26 @@ mod tests {
         assert_eq!(
             end_exclusive_utc,
             Utc.with_ymd_and_hms(2026, 12, 31, 10, 0, 0).unwrap()
+        );
+    }
+
+    #[test]
+    fn local_date_range_utc_bounds_match_local_midnight_boundaries() {
+        let tz = chrono_tz::America::Toronto;
+        let (start_utc, end_exclusive_utc) = local_date_range_utc_bounds(
+            Some(NaiveDate::from_ymd_opt(2024, 1, 3).unwrap()),
+            Some(NaiveDate::from_ymd_opt(2024, 1, 3).unwrap()),
+            tz,
+        )
+        .unwrap();
+
+        assert_eq!(
+            start_utc,
+            Some(Utc.with_ymd_and_hms(2024, 1, 3, 5, 0, 0).unwrap())
+        );
+        assert_eq!(
+            end_exclusive_utc,
+            Some(Utc.with_ymd_and_hms(2024, 1, 4, 5, 0, 0).unwrap())
         );
     }
 }

--- a/crates/spending/src/cash_activities/model.rs
+++ b/crates/spending/src/cash_activities/model.rs
@@ -99,6 +99,14 @@ pub enum CashFlowBucket {
     Neutral,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransferLinkStatus {
+    Linked,
+    Unlinked,
+    Invalid,
+}
+
 /// Canonical cash-activity row, returned by every spending read path
 /// (`list()` and `search()`). Flattens the portfolio-wide `Activity` and
 /// adds the spending-domain enrichments — single-select category assignment
@@ -124,6 +132,11 @@ pub struct CashActivity {
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub event_id: Option<String>,
+    /// Transfer link state for TRANSFER_IN / TRANSFER_OUT rows. Distinguishes
+    /// valid pairs from orphaned or malformed source groups.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transfer_link_status: Option<TransferLinkStatus>,
 }
 
 /// Paginated response for cash-activity search.

--- a/crates/spending/src/cash_activities/service.rs
+++ b/crates/spending/src/cash_activities/service.rs
@@ -7,12 +7,16 @@ use rust_decimal::prelude::ToPrimitive;
 use wealthfolio_core::accounts::{
     account_supports_purpose, account_types, AccountPurpose, AccountRepositoryTrait,
 };
-use wealthfolio_core::activities::{Activity, ActivityRepositoryTrait};
+use wealthfolio_core::activities::{
+    Activity, ActivityRepositoryTrait, TransferPairResolution, ACTIVITY_TYPE_TRANSFER_IN,
+    ACTIVITY_TYPE_TRANSFER_OUT,
+};
 
 use super::{
     model::{
         CashActivity, CashActivityFilter, CashActivitySearchRequest, CashActivitySearchResponse,
         CashActivitySortField, CashActivityStatusFilter, CashFlowBucket, SortDirection,
+        TransferLinkStatus,
     },
     CASH_ACTIVITY_TYPES,
 };
@@ -102,6 +106,7 @@ impl CashActivityService {
             .activity_repo
             .get_activities_by_account_ids(&all_spending_accounts)
             .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let transfer_link_resolution = self.transfer_link_resolution()?;
         let transfer_context_acts: Vec<&Activity> = activities.iter().collect();
         let transfer_groups = within_spending_transfer_groups(&transfer_context_acts);
         activities.retain(|a| target_accounts.contains(&a.account_id));
@@ -133,11 +138,13 @@ impl CashActivityService {
                 let assignments = by_activity.remove(&a.id).unwrap_or_default();
                 let event_id = tag_map.remove(&a.id);
                 let cash_flow_bucket = cash_flow_bucket_for(&a, &account_types, &transfer_groups);
+                let transfer_link_status = transfer_link_status_for(&a, &transfer_link_resolution);
                 CashActivity {
                     activity: a,
                     cash_flow_bucket,
                     assignments,
                     event_id,
+                    transfer_link_status,
                 }
             })
             .collect();
@@ -186,6 +193,7 @@ impl CashActivityService {
             .activity_repo
             .get_activities_by_account_ids(&all_spending_accounts)
             .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let transfer_link_resolution = self.transfer_link_resolution()?;
         let transfer_context_acts: Vec<&Activity> = activities.iter().collect();
         let transfer_groups = within_spending_transfer_groups(&transfer_context_acts);
         activities.retain(|a| target_accounts.contains(&a.account_id));
@@ -370,11 +378,13 @@ impl CashActivityService {
                 let assignments = by_activity.remove(&a.id).unwrap_or_default();
                 let event_id = tag_map.remove(&a.id);
                 let cash_flow_bucket = cash_flow_bucket_for(&a, &account_types, &transfer_groups);
+                let transfer_link_status = transfer_link_status_for(&a, &transfer_link_resolution);
                 CashActivity {
                     activity: a,
                     cash_flow_bucket,
                     assignments,
                     event_id,
+                    transfer_link_status,
                 }
             })
             .collect();
@@ -404,6 +414,7 @@ impl CashActivityService {
             .activity_repo
             .get_activities_by_account_ids(&target_accounts)
             .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let transfer_link_resolution = self.transfer_link_resolution()?;
         let transfer_context_acts: Vec<&Activity> = context_activities.iter().collect();
         let transfer_groups = within_spending_transfer_groups(&transfer_context_acts);
         let requested_ids: HashSet<&str> = activity_ids.iter().map(String::as_str).collect();
@@ -425,11 +436,14 @@ impl CashActivityService {
                 let event_id = tag_map.remove(&activity.id);
                 let cash_flow_bucket =
                     cash_flow_bucket_for(&activity, &account_types, &transfer_groups);
+                let transfer_link_status =
+                    transfer_link_status_for(&activity, &transfer_link_resolution);
                 CashActivity {
                     activity,
                     cash_flow_bucket,
                     assignments,
                     event_id,
+                    transfer_link_status,
                 }
             })
             .collect())
@@ -540,6 +554,14 @@ impl CashActivityService {
             .collect();
 
         Ok((target_accounts, account_types))
+    }
+
+    fn transfer_link_resolution(&self) -> Result<TransferPairResolution> {
+        let activities = self
+            .activity_repo
+            .get_activities()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        Ok(TransferPairResolution::from_activities(&activities))
     }
 
     async fn ensure_activity_assignment_allowed(
@@ -687,6 +709,30 @@ fn taxonomy_for_bucket(bucket: CashFlowBucket) -> Option<&'static str> {
         CashFlowBucket::Saving => Some(SAVINGS_TAXONOMY),
         CashFlowBucket::Neutral => None,
     }
+}
+
+fn transfer_link_status_for(
+    activity: &Activity,
+    resolution: &TransferPairResolution,
+) -> Option<TransferLinkStatus> {
+    if !matches!(
+        activity.effective_type(),
+        ACTIVITY_TYPE_TRANSFER_IN | ACTIVITY_TYPE_TRANSFER_OUT
+    ) {
+        return None;
+    }
+    if resolution.pair_for_activity(&activity.id).is_some() {
+        return Some(TransferLinkStatus::Linked);
+    }
+    if activity
+        .source_group_id
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|group_id| !group_id.is_empty())
+    {
+        return Some(TransferLinkStatus::Invalid);
+    }
+    Some(TransferLinkStatus::Unlinked)
 }
 
 impl CashFlowBucket {

--- a/crates/storage-sqlite/src/activities/model.rs
+++ b/crates/storage-sqlite/src/activities/model.rs
@@ -115,6 +115,7 @@ pub struct ActivityDB {
     // Source identity
     pub source_system: Option<String>,
     pub source_record_id: Option<String>,
+    #[diesel(treat_none_as_null = true)]
     pub source_group_id: Option<String>,
     pub idempotency_key: Option<String>,
     pub import_run_id: Option<String>,

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -15,10 +15,10 @@ use uuid::Uuid;
 use wealthfolio_core::accounts::{account_supports_purpose, AccountPurpose};
 use wealthfolio_core::activities::ActivityError;
 use wealthfolio_core::activities::{
-    import_type, Activity, ActivityBulkIdentifierMapping, ActivityBulkMutationResult,
-    ActivityDetails, ActivityRepositoryTrait, ActivitySearchResponse, ActivitySearchResponseMeta,
-    ActivityUpdate, ActivityUpsert, BulkUpsertResult, ImportMapping, ImportTemplate, IncomeData,
-    NewActivity, Sort, INCOME_ACTIVITY_TYPES, TRADING_ACTIVITY_TYPES,
+    import_type, is_cash_symbol, Activity, ActivityBulkIdentifierMapping,
+    ActivityBulkMutationResult, ActivityDetails, ActivityRepositoryTrait, ActivitySearchResponse,
+    ActivitySearchResponseMeta, ActivityUpdate, ActivityUpsert, BulkUpsertResult, ImportMapping,
+    ImportTemplate, IncomeData, NewActivity, Sort, INCOME_ACTIVITY_TYPES, TRADING_ACTIVITY_TYPES,
 };
 use wealthfolio_core::limits::ContributionActivity;
 use wealthfolio_core::{Error, Result};
@@ -200,6 +200,64 @@ fn set_transfer_flow_external(metadata: Option<String>, is_external: bool) -> Op
     }
 
     Some(value.to_string())
+}
+
+fn link_transfer_tolerance() -> Decimal {
+    Decimal::new(1, 6)
+}
+
+fn non_cash_transfer_asset_key(activity: &ActivityDB) -> Option<String> {
+    activity
+        .asset_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|asset_id| !asset_id.is_empty())
+        .filter(|asset_id| !is_cash_symbol(asset_id))
+        .map(str::to_uppercase)
+}
+
+fn effective_activity_type(activity: &ActivityDB) -> &str {
+    activity
+        .activity_type_override
+        .as_deref()
+        .unwrap_or(activity.activity_type.as_str())
+}
+
+fn parse_optional_decimal(value: Option<&String>) -> Option<Decimal> {
+    value
+        .and_then(|value| Decimal::from_str(value.trim()).ok())
+        .map(|value| value.abs())
+}
+
+fn validate_link_transfer_asset_shape(
+    transfer_in: &ActivityDB,
+    transfer_out: &ActivityDB,
+) -> Result<()> {
+    let in_asset = non_cash_transfer_asset_key(transfer_in);
+    let out_asset = non_cash_transfer_asset_key(transfer_out);
+    if in_asset.is_none() && out_asset.is_none() {
+        return Ok(());
+    }
+
+    if in_asset != out_asset {
+        return Err(Error::from(ActivityError::InvalidData(
+            "Security transfer legs use different assets".to_string(),
+        )));
+    }
+
+    let in_qty = parse_optional_decimal(transfer_in.quantity.as_ref());
+    let out_qty = parse_optional_decimal(transfer_out.quantity.as_ref());
+    match (in_qty, out_qty) {
+        (Some(in_qty), Some(out_qty)) if (in_qty - out_qty).abs() <= link_transfer_tolerance() => {
+            Ok(())
+        }
+        (Some(_), Some(_)) => Err(Error::from(ActivityError::InvalidData(
+            "Security transfer legs use different quantities".to_string(),
+        ))),
+        _ => Err(Error::from(ActivityError::InvalidData(
+            "Security transfer legs must both include quantity".to_string(),
+        ))),
+    }
 }
 
 // Inherent methods for ActivityRepository
@@ -668,7 +726,7 @@ impl ActivityRepositoryTrait for ActivityRepository {
                     .map_err(|e| Error::from(ActivityError::NotFound(e.to_string())))?;
 
                 let (mut transfer_in, mut transfer_out) =
-                    match (a.activity_type.as_str(), b.activity_type.as_str()) {
+                    match (effective_activity_type(&a), effective_activity_type(&b)) {
                         (ACTIVITY_TYPE_TRANSFER_IN, ACTIVITY_TYPE_TRANSFER_OUT) => (a, b),
                         (ACTIVITY_TYPE_TRANSFER_OUT, ACTIVITY_TYPE_TRANSFER_IN) => (b, a),
                         _ => {
@@ -689,6 +747,7 @@ impl ActivityRepositoryTrait for ActivityRepository {
                         "Both transfer legs share the same account".to_string(),
                     )));
                 }
+                validate_link_transfer_asset_shape(&transfer_in, &transfer_out)?;
 
                 let group_id = Uuid::new_v4().to_string();
                 let now = chrono::Utc::now().to_rfc3339();
@@ -758,7 +817,7 @@ impl ActivityRepositoryTrait for ActivityRepository {
                     .map_err(|e| Error::from(ActivityError::NotFound(e.to_string())))?;
 
                 let (mut transfer_in, mut transfer_out) =
-                    match (a.activity_type.as_str(), b.activity_type.as_str()) {
+                    match (effective_activity_type(&a), effective_activity_type(&b)) {
                         (ACTIVITY_TYPE_TRANSFER_IN, ACTIVITY_TYPE_TRANSFER_OUT) => (a, b),
                         (ACTIVITY_TYPE_TRANSFER_OUT, ACTIVITY_TYPE_TRANSFER_IN) => (b, a),
                         _ => {
@@ -3332,6 +3391,120 @@ mod tests {
         assert_eq!(activity_user_modified(&mut conn, "transfer-in"), 1);
         assert_eq!(activity_user_modified(&mut conn, "transfer-out"), 1);
         assert_eq!(sync_outbox_count(&mut conn), 2);
+    }
+
+    #[tokio::test]
+    async fn link_transfer_activities_rejects_security_asset_or_quantity_mismatch() {
+        let (pool, writer) = setup_db();
+        let repo = ActivityRepository::new(pool.clone(), writer);
+        let mut conn = get_connection(&pool).expect("conn");
+
+        insert_account(&mut conn, "acc-a");
+        insert_account(&mut conn, "acc-b");
+
+        let insert_asset = |conn: &mut SqliteConnection, id: &str| {
+            diesel::insert_into(assets::table)
+                .values((
+                    assets::id.eq(id.to_string()),
+                    assets::kind.eq("INVESTMENT".to_string()),
+                    assets::is_active.eq(1),
+                    assets::quote_mode.eq("MANUAL".to_string()),
+                    assets::quote_ccy.eq("USD".to_string()),
+                    assets::created_at.eq("2024-01-15T00:00:00+00:00".to_string()),
+                    assets::updated_at.eq("2024-01-15T00:00:00+00:00".to_string()),
+                ))
+                .execute(conn)
+                .expect("insert asset");
+        };
+        insert_asset(&mut conn, "SEC:AAPL:XNAS");
+        insert_asset(&mut conn, "SEC:MSFT:XNAS");
+
+        let set_security_fields =
+            |conn: &mut SqliteConnection, id: &str, asset_id: &str, quantity: &str| {
+                diesel::update(activities::table.find(id))
+                    .set((
+                        activities::asset_id.eq(Some(asset_id.to_string())),
+                        activities::quantity.eq(Some(quantity.to_string())),
+                        activities::unit_price.eq(Some("100".to_string())),
+                        activities::amount.eq(None::<String>),
+                    ))
+                    .execute(conn)
+                    .expect("set security transfer fields");
+            };
+
+        insert_transfer_activity(&mut conn, "asset-out", "acc-a", "TRANSFER_OUT", None, None);
+        insert_transfer_activity(&mut conn, "asset-in", "acc-b", "TRANSFER_IN", None, None);
+        set_security_fields(&mut conn, "asset-out", "SEC:AAPL:XNAS", "10");
+        set_security_fields(&mut conn, "asset-in", "SEC:MSFT:XNAS", "10");
+
+        let asset_mismatch = repo
+            .link_transfer_activities("asset-in".to_string(), "asset-out".to_string())
+            .await;
+        assert!(asset_mismatch.is_err());
+
+        insert_transfer_activity(
+            &mut conn,
+            "quantity-out",
+            "acc-a",
+            "TRANSFER_OUT",
+            None,
+            None,
+        );
+        insert_transfer_activity(&mut conn, "quantity-in", "acc-b", "TRANSFER_IN", None, None);
+        set_security_fields(&mut conn, "quantity-out", "SEC:AAPL:XNAS", "10");
+        set_security_fields(&mut conn, "quantity-in", "SEC:AAPL:XNAS", "9");
+
+        let quantity_mismatch = repo
+            .link_transfer_activities("quantity-in".to_string(), "quantity-out".to_string())
+            .await;
+        assert!(quantity_mismatch.is_err());
+
+        let groups: Vec<Option<String>> = activities::table
+            .filter(activities::id.eq_any(["asset-out", "asset-in", "quantity-out", "quantity-in"]))
+            .select(activities::source_group_id)
+            .load(&mut conn)
+            .expect("load source groups");
+        assert!(groups.iter().all(Option::is_none));
+    }
+
+    #[tokio::test]
+    async fn link_and_unlink_transfer_activities_use_effective_activity_type() {
+        let (pool, writer) = setup_db();
+        let repo = ActivityRepository::new(pool.clone(), writer);
+        let mut conn = get_connection(&pool).expect("conn");
+
+        insert_account(&mut conn, "acc-a");
+        insert_account(&mut conn, "acc-b");
+        insert_transfer_activity(&mut conn, "override-out", "acc-a", "FEE", None, None);
+        diesel::update(activities::table.find("override-out"))
+            .set(activities::activity_type_override.eq(Some("TRANSFER_OUT".to_string())))
+            .execute(&mut conn)
+            .expect("set transfer override");
+        insert_transfer_activity(&mut conn, "override-in", "acc-b", "TRANSFER_IN", None, None);
+
+        let (transfer_in, transfer_out) = repo
+            .link_transfer_activities("override-out".to_string(), "override-in".to_string())
+            .await
+            .expect("link effective transfer pair");
+
+        assert_eq!(transfer_in.id, "override-in");
+        assert_eq!(transfer_out.id, "override-out");
+        assert_eq!(
+            transfer_out.activity_type_override.as_deref(),
+            Some("TRANSFER_OUT")
+        );
+        assert!(transfer_in.source_group_id.is_some());
+        assert_eq!(transfer_in.source_group_id, transfer_out.source_group_id);
+
+        let (unlinked_in, unlinked_out) = repo
+            .unlink_transfer_activities("override-out".to_string(), "override-in".to_string())
+            .await
+            .expect("unlink effective transfer pair");
+
+        assert_eq!(unlinked_in.id, "override-in");
+        assert_eq!(unlinked_out.id, "override-out");
+        assert!(unlinked_in.source_group_id.is_none());
+        assert!(unlinked_out.source_group_id.is_none());
     }
 
     #[tokio::test]

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -18,7 +18,8 @@ use wealthfolio_core::activities::{
     import_type, is_cash_symbol, Activity, ActivityBulkIdentifierMapping,
     ActivityBulkMutationResult, ActivityDetails, ActivityRepositoryTrait, ActivitySearchResponse,
     ActivitySearchResponseMeta, ActivityUpdate, ActivityUpsert, BulkUpsertResult, ImportMapping,
-    ImportTemplate, IncomeData, NewActivity, Sort, INCOME_ACTIVITY_TYPES, TRADING_ACTIVITY_TYPES,
+    ImportTemplate, IncomeData, NewActivity, Sort, ACTIVITY_TYPE_TRANSFER_IN,
+    ACTIVITY_TYPE_TRANSFER_OUT, INCOME_ACTIVITY_TYPES, TRADING_ACTIVITY_TYPES,
 };
 use wealthfolio_core::limits::ContributionActivity;
 use wealthfolio_core::{Error, Result};
@@ -221,6 +222,35 @@ fn effective_activity_type(activity: &ActivityDB) -> &str {
         .activity_type_override
         .as_deref()
         .unwrap_or(activity.activity_type.as_str())
+}
+
+fn source_group_blocks_transfer_link(
+    conn: &mut SqliteConnection,
+    source_group_id: Option<&str>,
+) -> Result<bool> {
+    let Some(group_id) = source_group_id
+        .map(str::trim)
+        .filter(|group_id| !group_id.is_empty())
+    else {
+        return Ok(false);
+    };
+
+    let group_activities = activities::table
+        .filter(activities::source_group_id.eq(group_id))
+        .select(ActivityDB::as_select())
+        .load::<ActivityDB>(conn)
+        .map_err(StorageError::from)?;
+    if group_activities.len() != 2 {
+        return Ok(false);
+    }
+
+    let has_transfer_in = group_activities
+        .iter()
+        .any(|activity| effective_activity_type(activity) == ACTIVITY_TYPE_TRANSFER_IN);
+    let has_transfer_out = group_activities
+        .iter()
+        .any(|activity| effective_activity_type(activity) == ACTIVITY_TYPE_TRANSFER_OUT);
+    Ok(has_transfer_in && has_transfer_out)
 }
 
 fn parse_optional_decimal(value: Option<&String>) -> Option<Decimal> {
@@ -792,7 +822,13 @@ impl ActivityRepositoryTrait for ActivityRepository {
                         }
                     };
 
-                if transfer_in.source_group_id.is_some() || transfer_out.source_group_id.is_some() {
+                if source_group_blocks_transfer_link(
+                    tx.conn(),
+                    transfer_in.source_group_id.as_deref(),
+                )? || source_group_blocks_transfer_link(
+                    tx.conn(),
+                    transfer_out.source_group_id.as_deref(),
+                )? {
                     return Err(Error::from(ActivityError::InvalidData(
                         "One or both activities are already linked to another transfer".to_string(),
                     )));
@@ -3505,6 +3541,51 @@ mod tests {
         assert_eq!(activity_user_modified(&mut conn, "transfer-in"), 1);
         assert_eq!(activity_user_modified(&mut conn, "transfer-out"), 1);
         assert_eq!(sync_outbox_count(&mut conn), 2);
+    }
+
+    #[tokio::test]
+    async fn link_transfer_activities_repairs_orphan_source_group() {
+        let (pool, writer) = setup_db();
+        let repo = ActivityRepository::new(pool.clone(), writer);
+        let mut conn = get_connection(&pool).expect("conn");
+
+        insert_account(&mut conn, "acc-a");
+        insert_account(&mut conn, "acc-b");
+        insert_transfer_activity(
+            &mut conn,
+            "orphan-in",
+            "acc-a",
+            "TRANSFER_IN",
+            Some("orphan-group"),
+            Some(r#"{"flow":{"is_external":false}}"#),
+        );
+        insert_transfer_activity(
+            &mut conn,
+            "transfer-out",
+            "acc-b",
+            "TRANSFER_OUT",
+            None,
+            None,
+        );
+
+        let (transfer_in, transfer_out) = repo
+            .link_transfer_activities("orphan-in".to_string(), "transfer-out".to_string())
+            .await
+            .expect("orphaned transfer should be repairable");
+
+        assert_eq!(transfer_in.id, "orphan-in");
+        assert_eq!(transfer_out.id, "transfer-out");
+        assert_ne!(transfer_in.source_group_id.as_deref(), Some("orphan-group"));
+        assert!(transfer_in.source_group_id.is_some());
+        assert_eq!(transfer_in.source_group_id, transfer_out.source_group_id);
+        assert_eq!(
+            transfer_in.metadata.as_ref().and_then(|m| {
+                m.get("flow")
+                    .and_then(|flow| flow.get("is_external"))
+                    .and_then(|value| value.as_bool())
+            }),
+            Some(false)
+        );
     }
 
     #[tokio::test]

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -203,6 +203,18 @@ fn set_transfer_flow_external(metadata: Option<String>, is_external: bool) -> Op
     Some(value.to_string())
 }
 
+fn transfer_flow_is_external(metadata: Option<&str>) -> bool {
+    metadata
+        .and_then(|metadata| serde_json::from_str::<serde_json::Value>(metadata).ok())
+        .and_then(|value| {
+            value
+                .get("flow")
+                .and_then(|flow| flow.get("is_external"))
+                .and_then(|value| value.as_bool())
+        })
+        .unwrap_or(false)
+}
+
 fn link_transfer_tolerance() -> Decimal {
     Decimal::new(1, 6)
 }
@@ -244,13 +256,38 @@ fn source_group_blocks_transfer_link(
         return Ok(false);
     }
 
-    let has_transfer_in = group_activities
+    let transfer_in = group_activities
         .iter()
-        .any(|activity| effective_activity_type(activity) == ACTIVITY_TYPE_TRANSFER_IN);
-    let has_transfer_out = group_activities
+        .find(|activity| effective_activity_type(activity) == ACTIVITY_TYPE_TRANSFER_IN);
+    let transfer_out = group_activities
         .iter()
-        .any(|activity| effective_activity_type(activity) == ACTIVITY_TYPE_TRANSFER_OUT);
-    Ok(has_transfer_in && has_transfer_out)
+        .find(|activity| effective_activity_type(activity) == ACTIVITY_TYPE_TRANSFER_OUT);
+
+    let (Some(transfer_in), Some(transfer_out)) = (transfer_in, transfer_out) else {
+        return Ok(false);
+    };
+    if transfer_in.account_id == transfer_out.account_id {
+        return Ok(false);
+    }
+
+    Ok(validate_link_transfer_asset_shape(transfer_in, transfer_out).is_ok())
+}
+
+fn clear_invalid_source_group_for_external_transfer(
+    conn: &mut SqliteConnection,
+    activity: &mut ActivityDB,
+) -> Result<()> {
+    let is_transfer = matches!(
+        effective_activity_type(activity),
+        ACTIVITY_TYPE_TRANSFER_IN | ACTIVITY_TYPE_TRANSFER_OUT
+    );
+    if !is_transfer || !transfer_flow_is_external(activity.metadata.as_deref()) {
+        return Ok(());
+    }
+    if !source_group_blocks_transfer_link(conn, activity.source_group_id.as_deref())? {
+        activity.source_group_id = None;
+    }
+    Ok(())
 }
 
 fn parse_optional_decimal(value: Option<&String>) -> Option<Decimal> {
@@ -720,6 +757,10 @@ impl ActivityRepositoryTrait for ActivityRepository {
                 if activity_to_update.metadata.is_none() {
                     activity_to_update.metadata = metadata;
                 }
+                clear_invalid_source_group_for_external_transfer(
+                    tx.conn(),
+                    &mut activity_to_update,
+                )?;
                 preserve_broker_base_type(
                     &mut activity_to_update,
                     &existing_activity_type,
@@ -1113,6 +1154,7 @@ impl ActivityRepositoryTrait for ActivityRepository {
                     if activity_db.metadata.is_none() {
                         activity_db.metadata = metadata;
                     }
+                    clear_invalid_source_group_for_external_transfer(tx.conn(), &mut activity_db)?;
                     preserve_broker_base_type(
                         &mut activity_db,
                         &existing_activity_type,
@@ -3586,6 +3628,60 @@ mod tests {
             }),
             Some(false)
         );
+    }
+
+    #[tokio::test]
+    async fn update_external_transfer_clears_invalid_source_group() {
+        let (pool, writer) = setup_db();
+        let repo = ActivityRepository::new(pool.clone(), writer);
+        let mut conn = get_connection(&pool).expect("conn");
+
+        insert_account(&mut conn, "acc-a");
+        insert_transfer_activity(
+            &mut conn,
+            "orphan-in",
+            "acc-a",
+            "TRANSFER_IN",
+            Some("orphan-group"),
+            Some(r#"{"flow":{"is_external":false}}"#),
+        );
+
+        let updated = repo
+            .update_activity(ActivityUpdate {
+                id: "orphan-in".to_string(),
+                account_id: "acc-a".to_string(),
+                asset: None,
+                activity_type: "TRANSFER_IN".to_string(),
+                subtype: None,
+                activity_date: "2024-01-15T00:00:00Z".to_string(),
+                quantity: Some(None),
+                unit_price: Some(None),
+                currency: "USD".to_string(),
+                fee: Some(None),
+                amount: Some(Some(Decimal::new(100, 0))),
+                status: Some(ActivityStatus::Posted),
+                notes: None,
+                fx_rate: None,
+                metadata: Some(r#"{"flow":{"is_external":true}}"#.to_string()),
+            })
+            .await
+            .expect("external transfer update should succeed");
+
+        assert_eq!(updated.source_group_id, None);
+        assert_eq!(
+            updated.metadata.as_ref().and_then(|m| {
+                m.get("flow")
+                    .and_then(|flow| flow.get("is_external"))
+                    .and_then(|value| value.as_bool())
+            }),
+            Some(true)
+        );
+        let stored_group: Option<String> = activities::table
+            .filter(activities::id.eq("orphan-in"))
+            .select(activities::source_group_id)
+            .first(&mut conn)
+            .expect("stored source group");
+        assert_eq!(stored_group, None);
     }
 
     #[tokio::test]

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, NaiveDate, Utc};
+use chrono::{DateTime, NaiveDate, NaiveTime, Utc};
 use diesel::expression_methods::ExpressionMethods;
 use diesel::prelude::*;
 use diesel::r2d2::{ConnectionManager, Pool};
@@ -266,6 +266,191 @@ impl ActivityRepository {
     pub fn new(pool: Arc<Pool<ConnectionManager<SqliteConnection>>>, writer: WriteHandle) -> Self {
         Self { pool, writer }
     }
+
+    fn naive_date_start_utc(date: NaiveDate) -> DateTime<Utc> {
+        DateTime::from_naive_utc_and_offset(date.and_time(NaiveTime::MIN), Utc)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn search_activities_with_utc_bounds(
+        &self,
+        page: i64,
+        page_size: i64,
+        account_id_filter: Option<Vec<String>>,
+        activity_type_filter: Option<Vec<String>>,
+        asset_id_keyword: Option<String>,
+        sort: Option<Sort>,
+        needs_review_filter: Option<bool>,
+        date_from_utc: Option<DateTime<Utc>>,
+        date_to_utc_exclusive: Option<DateTime<Utc>>,
+        instrument_type_filter: Option<Vec<String>>,
+    ) -> Result<ActivitySearchResponse> {
+        let mut conn = get_connection(&self.pool)?;
+
+        let offset = page * page_size;
+
+        let create_base_query = |_conn: &SqliteConnection| {
+            let mut query = activities::table
+                .inner_join(accounts::table.on(activities::account_id.eq(accounts::id)))
+                .left_join(assets::table.on(activities::asset_id.eq(assets::id.nullable())))
+                .filter(accounts::is_archived.eq(false))
+                .into_boxed();
+
+            if let Some(ref account_ids) = account_id_filter {
+                query = query.filter(activities::account_id.eq_any(account_ids));
+            }
+            if let Some(ref activity_types) = activity_type_filter {
+                query = query.filter(
+                    sql::<Text>(
+                        "COALESCE(activities.activity_type_override, activities.activity_type)",
+                    )
+                    .eq_any(activity_types),
+                );
+            }
+            if let Some(ref keyword) = asset_id_keyword {
+                let pattern = format!("%{}%", keyword);
+                query = query.filter(
+                    assets::id
+                        .like(pattern.clone())
+                        .or(assets::name.like(pattern.clone()))
+                        .or(assets::display_code.like(pattern.clone()))
+                        .or(activities::notes.like(pattern)),
+                );
+            }
+            if let Some(needs_review) = needs_review_filter {
+                if needs_review {
+                    query = query.filter(activities::status.eq("DRAFT"));
+                } else {
+                    query = query.filter(activities::status.ne("DRAFT"));
+                }
+            }
+            if let Some(from_utc) = date_from_utc {
+                query = query.filter(activities::activity_date.ge(from_utc.to_rfc3339()));
+            }
+            if let Some(to_utc) = date_to_utc_exclusive {
+                query = query.filter(activities::activity_date.lt(to_utc.to_rfc3339()));
+            }
+            if let Some(ref instrument_types) = instrument_type_filter {
+                query = query.filter(assets::instrument_type.eq_any(instrument_types));
+            }
+
+            if let Some(ref sort) = sort {
+                match sort.id.as_str() {
+                    "date" => {
+                        if sort.desc {
+                            query = query.order((
+                                activities::activity_date.desc(),
+                                activities::created_at.asc(),
+                            ));
+                        } else {
+                            query = query.order((
+                                activities::activity_date.asc(),
+                                activities::created_at.asc(),
+                            ));
+                        }
+                    }
+                    "activityType" => {
+                        if sort.desc {
+                            query = query.order(
+                                sql::<Text>(
+                                    "COALESCE(activities.activity_type_override, activities.activity_type)",
+                                )
+                                .desc(),
+                            );
+                        } else {
+                            query = query.order(
+                                sql::<Text>(
+                                    "COALESCE(activities.activity_type_override, activities.activity_type)",
+                                )
+                                .asc(),
+                            );
+                        }
+                    }
+                    "assetSymbol" => {
+                        if sort.desc {
+                            query = query.order(activities::asset_id.desc());
+                        } else {
+                            query = query.order(activities::asset_id.asc());
+                        }
+                    }
+                    "accountName" => {
+                        if sort.desc {
+                            query = query.order(accounts::name.desc());
+                        } else {
+                            query = query.order(accounts::name.asc());
+                        }
+                    }
+                    _ => {
+                        query = query.order((
+                            activities::activity_date.desc(),
+                            activities::created_at.asc(),
+                        ))
+                    }
+                }
+            } else {
+                query = query.order((
+                    activities::activity_date.desc(),
+                    activities::created_at.asc(),
+                ));
+            }
+
+            query
+        };
+
+        let total_row_count = create_base_query(&conn)
+            .count()
+            .get_result::<i64>(&mut conn)
+            .map_err(StorageError::from)?;
+
+        let results_db = create_base_query(&conn)
+            .select((
+                activities::id,
+                activities::account_id,
+                activities::asset_id,
+                sql::<Text>(
+                    "COALESCE(activities.activity_type_override, activities.activity_type)",
+                ),
+                activities::subtype,
+                activities::status,
+                activities::activity_date,
+                activities::quantity,
+                activities::unit_price,
+                activities::currency,
+                activities::fee,
+                activities::amount,
+                activities::notes,
+                activities::fx_rate,
+                activities::needs_review,
+                activities::is_user_modified,
+                activities::source_system,
+                activities::source_record_id,
+                activities::source_group_id,
+                activities::idempotency_key,
+                activities::import_run_id,
+                activities::created_at,
+                activities::updated_at,
+                accounts::name,
+                accounts::currency,
+                assets::display_code.nullable(),
+                assets::name.nullable(),
+                assets::instrument_exchange_mic.nullable(),
+                assets::quote_mode.nullable(),
+                assets::instrument_type.nullable(),
+                activities::metadata,
+            ))
+            .limit(page_size)
+            .offset(offset)
+            .load::<ActivityDetailsDB>(&mut conn)
+            .map_err(StorageError::from)?;
+
+        let results: Vec<ActivityDetails> =
+            results_db.into_iter().map(ActivityDetails::from).collect();
+
+        Ok(ActivitySearchResponse {
+            data: results,
+            meta: ActivitySearchResponseMeta { total_row_count },
+        })
+    }
 }
 
 // Implement the trait for the repository
@@ -354,181 +539,51 @@ impl ActivityRepositoryTrait for ActivityRepository {
         date_to: Option<NaiveDate>,        // Optional end date filter (inclusive)
         instrument_type_filter: Option<Vec<String>>, // Optional instrument_type filter
     ) -> Result<ActivitySearchResponse> {
-        let mut conn = get_connection(&self.pool)?;
+        let date_from_utc = date_from.map(Self::naive_date_start_utc);
+        let date_to_utc_exclusive = date_to
+            .and_then(|date| date.succ_opt())
+            .map(Self::naive_date_start_utc);
 
-        let offset = page * page_size;
+        self.search_activities_with_utc_bounds(
+            page,
+            page_size,
+            account_id_filter,
+            activity_type_filter,
+            asset_id_keyword,
+            sort,
+            needs_review_filter,
+            date_from_utc,
+            date_to_utc_exclusive,
+            instrument_type_filter,
+        )
+    }
 
-        // Function to create base query - now using LEFT JOIN for assets since asset_id can be NULL
-        let create_base_query = |_conn: &SqliteConnection| {
-            let mut query = activities::table
-                .inner_join(accounts::table.on(activities::account_id.eq(accounts::id)))
-                .left_join(assets::table.on(activities::asset_id.eq(assets::id.nullable())))
-                .filter(accounts::is_archived.eq(false))
-                .into_boxed();
-
-            if let Some(ref account_ids) = account_id_filter {
-                query = query.filter(activities::account_id.eq_any(account_ids));
-            }
-            if let Some(ref activity_types) = activity_type_filter {
-                query = query.filter(
-                    sql::<Text>(
-                        "COALESCE(activities.activity_type_override, activities.activity_type)",
-                    )
-                    .eq_any(activity_types),
-                );
-            }
-            if let Some(ref keyword) = asset_id_keyword {
-                let pattern = format!("%{}%", keyword);
-                query = query.filter(
-                    assets::id
-                        .like(pattern.clone())
-                        .or(assets::name.like(pattern.clone()))
-                        .or(assets::display_code.like(pattern.clone()))
-                        .or(activities::notes.like(pattern)),
-                );
-            }
-            // Map needs_review_filter to status filter (DRAFT status means needs review)
-            if let Some(needs_review) = needs_review_filter {
-                if needs_review {
-                    query = query.filter(activities::status.eq("DRAFT"));
-                } else {
-                    query = query.filter(activities::status.ne("DRAFT"));
-                }
-            }
-            // Date range filters (activity_date is stored as RFC3339 string, compare lexicographically)
-            if let Some(from_date) = date_from {
-                // Start of day in RFC3339 format for lexicographic comparison
-                let from_str = format!("{}T00:00:00", from_date);
-                query = query.filter(activities::activity_date.ge(from_str));
-            }
-            if let Some(to_date) = date_to {
-                // End of day in RFC3339 format for lexicographic comparison
-                let to_str = format!("{}T23:59:59", to_date);
-                query = query.filter(activities::activity_date.le(to_str));
-            }
-            if let Some(ref instrument_types) = instrument_type_filter {
-                query = query.filter(assets::instrument_type.eq_any(instrument_types));
-            }
-
-            // Apply sorting
-            if let Some(ref sort) = sort {
-                match sort.id.as_str() {
-                    "date" => {
-                        if sort.desc {
-                            query = query.order((
-                                activities::activity_date.desc(),
-                                activities::created_at.asc(),
-                            ));
-                        } else {
-                            query = query.order((
-                                activities::activity_date.asc(),
-                                activities::created_at.asc(),
-                            ));
-                        }
-                    }
-                    "activityType" => {
-                        if sort.desc {
-                            query = query.order(
-                                sql::<Text>(
-                                    "COALESCE(activities.activity_type_override, activities.activity_type)",
-                                )
-                                .desc(),
-                            );
-                        } else {
-                            query = query.order(
-                                sql::<Text>(
-                                    "COALESCE(activities.activity_type_override, activities.activity_type)",
-                                )
-                                .asc(),
-                            );
-                        }
-                    }
-                    "assetSymbol" => {
-                        if sort.desc {
-                            query = query.order(activities::asset_id.desc());
-                        } else {
-                            query = query.order(activities::asset_id.asc());
-                        }
-                    }
-                    "accountName" => {
-                        if sort.desc {
-                            query = query.order(accounts::name.desc());
-                        } else {
-                            query = query.order(accounts::name.asc());
-                        }
-                    }
-                    _ => {
-                        query = query.order((
-                            activities::activity_date.desc(),
-                            activities::created_at.asc(),
-                        ))
-                    } // Default order
-                }
-            } else {
-                query = query.order((
-                    activities::activity_date.desc(),
-                    activities::created_at.asc(),
-                )); // Default order
-            }
-
-            query
-        };
-
-        // Count query
-        let total_row_count = create_base_query(&conn)
-            .count()
-            .get_result::<i64>(&mut conn)
-            .map_err(StorageError::from)?;
-
-        // Data fetching query - updated to match new schema fields
-        let results_db = create_base_query(&conn)
-            .select((
-                activities::id,
-                activities::account_id,
-                activities::asset_id,
-                sql::<Text>(
-                    "COALESCE(activities.activity_type_override, activities.activity_type)",
-                ),
-                activities::subtype,
-                activities::status,
-                activities::activity_date,
-                activities::quantity,
-                activities::unit_price,
-                activities::currency,
-                activities::fee,
-                activities::amount,
-                activities::notes,
-                activities::fx_rate,
-                activities::needs_review,
-                activities::is_user_modified,
-                activities::source_system,
-                activities::source_record_id,
-                activities::source_group_id,
-                activities::idempotency_key,
-                activities::import_run_id,
-                activities::created_at,
-                activities::updated_at,
-                accounts::name,
-                accounts::currency,
-                assets::display_code.nullable(),
-                assets::name.nullable(),
-                assets::instrument_exchange_mic.nullable(),
-                assets::quote_mode.nullable(),
-                assets::instrument_type.nullable(),
-                activities::metadata,
-            ))
-            .limit(page_size)
-            .offset(offset)
-            .load::<ActivityDetailsDB>(&mut conn)
-            .map_err(StorageError::from)?;
-
-        let results: Vec<ActivityDetails> =
-            results_db.into_iter().map(ActivityDetails::from).collect();
-
-        Ok(ActivitySearchResponse {
-            data: results,
-            meta: ActivitySearchResponseMeta { total_row_count },
-        })
+    #[allow(clippy::too_many_arguments)]
+    fn search_activities_in_utc_range(
+        &self,
+        page: i64,
+        page_size: i64,
+        account_id_filter: Option<Vec<String>>,
+        activity_type_filter: Option<Vec<String>>,
+        asset_id_keyword: Option<String>,
+        sort: Option<Sort>,
+        needs_review_filter: Option<bool>,
+        date_from_utc: Option<DateTime<Utc>>,
+        date_to_utc_exclusive: Option<DateTime<Utc>>,
+        instrument_type_filter: Option<Vec<String>>,
+    ) -> Result<ActivitySearchResponse> {
+        self.search_activities_with_utc_bounds(
+            page,
+            page_size,
+            account_id_filter,
+            activity_type_filter,
+            asset_id_keyword,
+            sort,
+            needs_review_filter,
+            date_from_utc,
+            date_to_utc_exclusive,
+            instrument_type_filter,
+        )
     }
 
     async fn create_activity(&self, new_activity: NewActivity) -> Result<Activity> {
@@ -2871,6 +2926,65 @@ mod tests {
             .map(|activity| activity.id.as_str())
             .collect();
         assert_eq!(ids, vec!["broker-dividend", "broker-buy-override"]);
+    }
+
+    #[tokio::test]
+    async fn search_activities_in_utc_range_uses_exact_timestamp_bounds() {
+        let (pool, writer) = setup_db();
+        let repo = ActivityRepository::new(pool.clone(), writer);
+
+        {
+            let mut conn = get_connection(&pool).expect("conn");
+            insert_broker_account_and_import_run(&mut conn);
+            diesel::sql_query(
+                "INSERT INTO activities \
+                 (id, account_id, asset_id, activity_type, activity_type_override, source_type, subtype, \
+                  status, activity_date, settlement_date, quantity, unit_price, amount, fee, currency, \
+                  fx_rate, notes, metadata, source_system, source_record_id, source_group_id, \
+                  idempotency_key, import_run_id, is_user_modified, needs_review, created_at, updated_at) \
+                 VALUES \
+                 ('local-evening-transfer', 'broker-local-account', NULL, 'TRANSFER_IN', NULL, NULL, NULL, \
+                  'POSTED', '2024-01-04T02:13:00+00:00', NULL, NULL, NULL, '1685.43', NULL, 'USD', \
+                  NULL, 'Belongs to Jan 3 in Toronto', NULL, 'CSV', 'range-1', NULL, \
+                  'local-evening-transfer-key', 'local-import-run', 0, 0, \
+                  '2024-01-04T02:13:00+00:00', '2024-01-04T02:13:00+00:00'), \
+                 ('next-local-day-transfer', 'broker-local-account', NULL, 'TRANSFER_IN', NULL, NULL, NULL, \
+                  'POSTED', '2024-01-04T05:30:00+00:00', NULL, NULL, NULL, '10', NULL, 'USD', \
+                  NULL, 'Belongs to Jan 4 in Toronto', NULL, 'CSV', 'range-2', NULL, \
+                  'next-local-day-transfer-key', 'local-import-run', 0, 0, \
+                  '2024-01-04T05:30:00+00:00', '2024-01-04T05:30:00+00:00')",
+            )
+            .execute(&mut conn)
+            .expect("insert activities");
+        }
+
+        let date_from_utc = DateTime::parse_from_rfc3339("2024-01-03T05:00:00+00:00")
+            .unwrap()
+            .with_timezone(&Utc);
+        let date_to_utc_exclusive = DateTime::parse_from_rfc3339("2024-01-04T05:00:00+00:00")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let response = repo
+            .search_activities_in_utc_range(
+                0,
+                10,
+                None,
+                Some(vec!["TRANSFER_IN".to_string()]),
+                None,
+                Some(Sort {
+                    id: "date".to_string(),
+                    desc: true,
+                }),
+                None,
+                Some(date_from_utc),
+                Some(date_to_utc_exclusive),
+                None,
+            )
+            .expect("search by utc range");
+
+        assert_eq!(response.meta.total_row_count, 1);
+        assert_eq!(response.data[0].id, "local-evening-transfer");
     }
 
     #[tokio::test]

--- a/packages/ui/src/components/common/searchable-select.tsx
+++ b/packages/ui/src/components/common/searchable-select.tsx
@@ -20,6 +20,7 @@ interface SearchableSelectProps {
   searchPlaceholder?: string;
   emptyMessage?: string;
   className?: string;
+  contentClassName?: string;
 }
 
 export function SearchableSelect({
@@ -31,6 +32,7 @@ export function SearchableSelect({
   searchPlaceholder = "Search...",
   emptyMessage = "No results found.",
   className = "",
+  contentClassName = "",
 }: SearchableSelectProps) {
   const [open, setOpen] = React.useState(false);
 
@@ -50,7 +52,9 @@ export function SearchableSelect({
           <Icons.ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[var(--radix-popover-trigger-width)] p-0">
+      <PopoverContent
+        className={cn("w-[var(--radix-popover-trigger-width)] p-0", contentClassName)}
+      >
         <Command>
           <CommandInput placeholder={searchPlaceholder} className="h-9" />
           <CommandEmpty>{emptyMessage}</CommandEmpty>

--- a/packages/ui/src/components/common/searchable-select.tsx
+++ b/packages/ui/src/components/common/searchable-select.tsx
@@ -52,9 +52,7 @@ export function SearchableSelect({
           <Icons.ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>
-      <PopoverContent
-        className={cn("w-[var(--radix-popover-trigger-width)] p-0", contentClassName)}
-      >
+      <PopoverContent className={cn("w-[var(--radix-popover-trigger-width)] p-0", contentClassName)}>
         <Command>
           <CommandInput placeholder={searchPlaceholder} className="h-9" />
           <CommandEmpty>{emptyMessage}</CommandEmpty>


### PR DESCRIPTION
## Summary
- Adds row-menu transfer linking and unlinking for Spending and Investment activity views.
- Adds a shared transfer match dialog with suggestions, search, filters, warnings, and explicit confirmation.
- Adds backend match discovery plus stricter transfer link validation for cash and security transfers.
- Fixes single-leg transfer edit behavior so unpaired transfers remain external instead of triggering missing-leg errors.

## Validation
- `pnpm format:check`
- `pnpm lint`
- `pnpm type-check`
- `CI=1 pnpm test`
- `pnpm build`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo check -p wealthfolio-server --release`
- Mobile responsiveness checked at 390x844 for Spending and Investment row menus plus the link dialog.