### PR TITLE
Fix spending transfer overrides and cache warm target

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -62,8 +62,12 @@ jobs:
 
       - name: Rust setup
         uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target || '' }}
+
+      - name: Install Rust target (windows only)
+        # Explicit `rustup target add` like release.yml: the preinstalled
+        # stable toolchain makes the action's targets input a silent no-op.
+        if: matrix.target
+        run: rustup target add ${{ matrix.target }}
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2

--- a/apps/frontend/src/features/spending/components/recent-activity-card.tsx
+++ b/apps/frontend/src/features/spending/components/recent-activity-card.tsx
@@ -9,7 +9,11 @@ import { cn, formatDateISO } from "@/lib/utils";
 import { PrivacyAmount } from "@wealthfolio/ui";
 
 import { getActivityAssignments } from "../adapters/cash-activities";
-import { getActivitySpendingAmount, isCashActivityIncome } from "../lib/constants";
+import {
+  getActivitySpendingAmount,
+  getEffectiveCashActivityType,
+  isCashActivityIncome,
+} from "../lib/constants";
 import { CategoryBadge, ReviewPill, type CategoryMetaMap } from "./category-chips";
 
 const SPENDING_TAXONOMY = "spending_categories";
@@ -32,9 +36,10 @@ export function RecentActivityCard({
       .slice()
       .filter((activity) => {
         const accountType = accountTypeById?.get(activity.accountId);
+        const activityType = getEffectiveCashActivityType(activity);
         return (
           getActivitySpendingAmount(activity, accountType) !== 0 ||
-          isCashActivityIncome(activity.activityType, accountType, activity.subtype)
+          isCashActivityIncome(activityType, accountType, activity.subtype)
         );
       })
       .sort((a, b) => b.activityDate.localeCompare(a.activityDate))

--- a/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
+++ b/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
@@ -50,10 +50,12 @@ import type { QuickCategorizeScope } from "./quick-categorize-popover";
 import {
   CASH_ACTIVITY_TYPES,
   CASH_ACTIVITY_TYPE_LABELS,
+  getEffectiveCashActivityType,
   isCreditCardAccountType,
   isSpendingAccountType,
 } from "../lib/constants";
 import {
+  isTransferCashActivity,
   pluralizeActivity,
   stableArr,
   toRowVM,
@@ -139,15 +141,12 @@ export interface SpendingTransactionsTabHandle {
   openAddForm: () => void;
 }
 
-function isTransferActivityType(activityType: string): boolean {
-  return activityType === ActivityType.TRANSFER_IN || activityType === ActivityType.TRANSFER_OUT;
-}
-
 function toActivityDetails(row: TransactionRowVM, account?: Account): Partial<ActivityDetails> {
   const activity = row.activity;
+  const activityType = getEffectiveCashActivityType(activity);
   return {
     id: activity.id,
-    activityType: activity.activityType as ActivityType,
+    activityType: activityType as ActivityType,
     subtype: activity.subtype ?? null,
     status: activity.status,
     date: new Date(activity.activityDate),
@@ -536,7 +535,7 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
         return createActivity({
           idempotencyKey: generateId("manual-duplicate"),
           accountId: a.accountId,
-          activityType: a.activityType,
+          activityType: getEffectiveCashActivityType(a),
           currency: a.currency,
           amount: a.amount,
           activityDate:
@@ -634,7 +633,7 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
 
     const handleEditRow = useCallback(
       (row: TransactionRowVM) => {
-        if (isTransferActivityType(row.activity.activityType)) {
+        if (isTransferCashActivity(row.activity)) {
           setEditingActivity(undefined);
           setShowForm(false);
           setTransferFormActivity(toActivityDetails(row, accountById.get(row.activity.accountId)));
@@ -649,9 +648,10 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
       [accountById],
     );
     const handleDeleteRow = useCallback((row: TransactionRowVM) => {
+      const activityType = getEffectiveCashActivityType(row.activity);
       setDeletingIds([row.activity.id]);
       setDeletePreview({
-        activityType: row.activity.activityType,
+        activityType,
         amount: row.activity.amount ?? null,
         currency: row.activity.currency,
       });

--- a/apps/frontend/src/features/spending/components/transaction-card.tsx
+++ b/apps/frontend/src/features/spending/components/transaction-card.tsx
@@ -12,15 +12,15 @@ import {
   PrivacyAmount,
 } from "@wealthfolio/ui";
 import type { Account } from "@/lib/types";
-import { ActivityType } from "@/lib/constants";
 import { cn, formatDate } from "@/lib/utils";
 
 import { QuickCategorizePopover } from "./quick-categorize-popover";
 import { QuickEventPopover } from "./quick-event-popover";
-import { getCashActivityLabel } from "../lib/constants";
+import { getCashActivityLabel, getEffectiveCashActivityType } from "../lib/constants";
 import {
   getTransactionDisplay,
   getTransferLinkStatus,
+  isTransferCashActivity,
   type TransactionRowVM,
 } from "../lib/transactions-helpers";
 
@@ -66,8 +66,8 @@ function TransactionCardImpl({
     account?.accountType,
   );
   const accountName = account?.name ?? a.accountId;
-  const isTransfer =
-    a.activityType === ActivityType.TRANSFER_IN || a.activityType === ActivityType.TRANSFER_OUT;
+  const activityType = getEffectiveCashActivityType(a);
+  const isTransfer = isTransferCashActivity(a);
   const transferLinkStatus = getTransferLinkStatus(a);
 
   return (
@@ -101,7 +101,7 @@ function TransactionCardImpl({
           </div>
           <div className="text-muted-foreground mt-0.5 truncate text-[11px]">
             {formatDate(a.activityDate)} · {accountName} ·{" "}
-            {getCashActivityLabel(a.activityType, account?.accountType)}
+            {getCashActivityLabel(activityType, account?.accountType)}
           </div>
         </div>
         <div

--- a/apps/frontend/src/features/spending/components/transaction-row.tsx
+++ b/apps/frontend/src/features/spending/components/transaction-row.tsx
@@ -14,15 +14,15 @@ import {
   TableRow,
 } from "@wealthfolio/ui";
 import type { Account } from "@/lib/types";
-import { ActivityType } from "@/lib/constants";
 import { cn, formatDate } from "@/lib/utils";
 
 import { QuickCategorizePopover } from "./quick-categorize-popover";
 import { QuickEventPopover } from "./quick-event-popover";
-import { getCashActivityLabel } from "../lib/constants";
+import { getCashActivityLabel, getEffectiveCashActivityType } from "../lib/constants";
 import {
   getTransactionDisplay,
   getTransferLinkStatus,
+  isTransferCashActivity,
   type TransactionRowVM,
 } from "../lib/transactions-helpers";
 
@@ -66,8 +66,8 @@ function TransactionRowImpl({
   );
   const accountName = account?.name ?? a.accountId;
   const rowAriaLabel = isSelected ? "Deselect transaction" : "Select transaction";
-  const isTransfer =
-    a.activityType === ActivityType.TRANSFER_IN || a.activityType === ActivityType.TRANSFER_OUT;
+  const activityType = getEffectiveCashActivityType(a);
+  const isTransfer = isTransferCashActivity(a);
   const transferLinkStatus = getTransferLinkStatus(a);
 
   return (
@@ -87,7 +87,7 @@ function TransactionRowImpl({
       </TableCell>
       <TableCell className="hidden md:table-cell">
         <Badge variant="outline" className="text-xs">
-          {getCashActivityLabel(a.activityType, account?.accountType)}
+          {getCashActivityLabel(activityType, account?.accountType)}
         </Badge>
       </TableCell>
       <TableCell className="hidden text-sm lg:table-cell">

--- a/apps/frontend/src/features/spending/lib/constants.test.ts
+++ b/apps/frontend/src/features/spending/lib/constants.test.ts
@@ -3,10 +3,22 @@ import { AccountType } from "@/lib/constants";
 import {
   getActivitySpendingAmount,
   getActivityTypesForAccount,
+  getEffectiveCashActivityType,
   isCashActivityIncome,
 } from "./constants";
 
 describe("spending constants", () => {
+  describe("getEffectiveCashActivityType", () => {
+    it("prefers activity type overrides", () => {
+      expect(
+        getEffectiveCashActivityType({
+          activityType: "WITHDRAWAL",
+          activityTypeOverride: "TRANSFER_OUT",
+        }),
+      ).toBe("TRANSFER_OUT");
+    });
+  });
+
   describe("getActivityTypesForAccount", () => {
     it("uses card-specific activity options for credit cards", () => {
       expect(getActivityTypesForAccount(AccountType.CREDIT_CARD)).toEqual([
@@ -90,6 +102,30 @@ describe("spending constants", () => {
         getActivitySpendingAmount(
           { activityType: "TRANSFER_OUT", amount: "100", sourceGroupId: "transfer-1" },
           AccountType.CASH,
+        ),
+      ).toBe(0);
+    });
+
+    it("uses activity type overrides for transfer spending treatment", () => {
+      expect(
+        getActivitySpendingAmount(
+          {
+            activityType: "WITHDRAWAL",
+            activityTypeOverride: "TRANSFER_OUT",
+            amount: "100",
+            sourceGroupId: "transfer-1",
+          },
+          AccountType.CASH,
+        ),
+      ).toBe(0);
+      expect(
+        getActivitySpendingAmount(
+          {
+            activityType: "WITHDRAWAL",
+            activityTypeOverride: "TRANSFER_IN",
+            amount: "100",
+          },
+          AccountType.CREDIT_CARD,
         ),
       ).toBe(0);
     });

--- a/apps/frontend/src/features/spending/lib/constants.ts
+++ b/apps/frontend/src/features/spending/lib/constants.ts
@@ -73,6 +73,13 @@ export function getCashActivityLabel(activityType: string, accountType?: string)
   return CASH_ACTIVITY_TYPE_LABELS[activityType as CashActivityType] ?? activityType;
 }
 
+export function getEffectiveCashActivityType(activity: {
+  activityType: string;
+  activityTypeOverride?: string | null;
+}): string {
+  return activity.activityTypeOverride ?? activity.activityType;
+}
+
 export function isCashActivityIncome(
   activityType: string,
   accountType?: string,
@@ -97,35 +104,35 @@ export function isCashActivityOutflow(activityType: string, accountType?: string
 export function getActivitySpendingAmount(
   activity: {
     activityType: string;
+    activityTypeOverride?: string | null;
     amount?: string | number | null;
     subtype?: string | null;
     sourceGroupId?: string | null;
   },
   accountType?: string,
 ): number {
+  const activityType = getEffectiveCashActivityType(activity);
   const amount =
     typeof activity.amount === "number" ? activity.amount : parseFloat(activity.amount ?? "0") || 0;
   const absAmount = Math.abs(amount);
 
   if (
     activity.sourceGroupId &&
-    (activity.activityType === "TRANSFER_IN" || activity.activityType === "TRANSFER_OUT")
+    (activityType === "TRANSFER_IN" || activityType === "TRANSFER_OUT")
   ) {
     return 0;
   }
 
   if (isCreditCardAccountType(accountType)) {
-    if (activity.activityType === "CREDIT") {
+    if (activityType === "CREDIT") {
       return -absAmount;
     }
-    return activity.activityType === "WITHDRAWAL" ||
-      activity.activityType === "FEE" ||
-      activity.activityType === "INTEREST"
+    return activityType === "WITHDRAWAL" || activityType === "FEE" || activityType === "INTEREST"
       ? absAmount
       : 0;
   }
 
-  if (activity.activityType === "CREDIT") {
+  if (activityType === "CREDIT") {
     if (activity.subtype === "REFUND" || activity.subtype === "REBATE") {
       return -absAmount;
     }
@@ -136,7 +143,7 @@ export function getActivitySpendingAmount(
     return 0;
   }
 
-  return OUTFLOW_TYPES.includes(activity.activityType as CashActivityType) ? absAmount : 0;
+  return OUTFLOW_TYPES.includes(activityType as CashActivityType) ? absAmount : 0;
 }
 
 export function getPositiveActivitySpendingAmount(

--- a/apps/frontend/src/features/spending/lib/transactions-helpers.test.ts
+++ b/apps/frontend/src/features/spending/lib/transactions-helpers.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import type { CashActivity } from "../types/cash-activity";
+import { getTransferLinkStatus, isTransferCashActivity } from "./transactions-helpers";
+
+function cashActivity(overrides: Partial<CashActivity>): CashActivity {
+  return {
+    id: "activity-1",
+    activityType: "WITHDRAWAL",
+    activityDate: "2026-01-01T00:00:00.000Z",
+    accountId: "account-1",
+    amount: "100",
+    currency: "USD",
+    cashFlowBucket: "neutral",
+    assignments: [],
+    isUserModified: false,
+    needsReview: false,
+    status: "POSTED",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  } as CashActivity;
+}
+
+describe("spending transaction helpers", () => {
+  it("treats activity type overrides as transfer rows", () => {
+    const activity = cashActivity({
+      activityTypeOverride: "TRANSFER_OUT",
+      transferLinkStatus: "unlinked",
+    });
+
+    expect(isTransferCashActivity(activity)).toBe(true);
+    expect(getTransferLinkStatus(activity)).toBe("unlinked");
+  });
+
+  it("does not expose transfer link status for non-transfer effective types", () => {
+    expect(getTransferLinkStatus(cashActivity({ sourceGroupId: "group-1" }))).toBeNull();
+  });
+});

--- a/apps/frontend/src/features/spending/lib/transactions-helpers.ts
+++ b/apps/frontend/src/features/spending/lib/transactions-helpers.ts
@@ -1,6 +1,10 @@
 import type { TaxonomyCategory } from "@/lib/types";
 
-import { getActivitySpendingAmount, isCashActivityIncome } from "./constants";
+import {
+  getActivitySpendingAmount,
+  getEffectiveCashActivityType,
+  isCashActivityIncome,
+} from "./constants";
 import type {
   ActivityTaxonomyAssignment,
   CashActivity,
@@ -56,8 +60,16 @@ export interface TransactionDisplay {
   safeAmount: number;
 }
 
+export function isTransferCashActivity(activity: {
+  activityType: string;
+  activityTypeOverride?: string | null;
+}): boolean {
+  const activityType = getEffectiveCashActivityType(activity);
+  return activityType === "TRANSFER_IN" || activityType === "TRANSFER_OUT";
+}
+
 export function getTransferLinkStatus(activity: CashActivity): TransferLinkStatus | null {
-  if (activity.activityType !== "TRANSFER_IN" && activity.activityType !== "TRANSFER_OUT") {
+  if (!isTransferCashActivity(activity)) {
     return null;
   }
   return activity.transferLinkStatus ?? (activity.sourceGroupId ? "linked" : "unlinked");
@@ -82,12 +94,10 @@ export function getTransactionDisplay(
 
   const spendingAmount = getActivitySpendingAmount(activity, accountType);
   const isOutflow = spendingAmount > 0;
-  const isInternalTransfer =
-    !!activity.sourceGroupId &&
-    (activity.activityType === "TRANSFER_IN" || activity.activityType === "TRANSFER_OUT");
+  const activityType = getEffectiveCashActivityType(activity);
+  const isInternalTransfer = !!activity.sourceGroupId && isTransferCashActivity(activity);
   const isIncome =
-    !isInternalTransfer &&
-    isCashActivityIncome(activity.activityType, accountType, activity.subtype);
+    !isInternalTransfer && isCashActivityIncome(activityType, accountType, activity.subtype);
   const isSaving = false;
   const isRefund = spendingAmount < 0;
   const isNeutral = !isOutflow && !isIncome && !isRefund;

--- a/apps/frontend/src/features/spending/types/cash-activity.ts
+++ b/apps/frontend/src/features/spending/types/cash-activity.ts
@@ -58,7 +58,7 @@ export interface CashActivity extends Activity {
   assignments: ActivityTaxonomyAssignment[];
   /** Spending event tag from the `activity_events` join. `undefined` when untagged. */
   eventId?: string | null;
-  /** Transfer pair validity for TRANSFER_IN / TRANSFER_OUT rows. */
+  /** Transfer pair validity for effective TRANSFER_IN / TRANSFER_OUT rows. */
   transferLinkStatus?: TransferLinkStatus | null;
 }
 


### PR DESCRIPTION
## Summary

- Use effective activity type (`activityTypeOverride ?? activityType`) for spending transfer actions so reclassified transfer rows expose Link/Unlink and open the transfer workflow correctly.
- Keep spending display helpers consistent with effective transfer type and add regression coverage.
- Fix the Windows ARM64 cache warm job by explicitly installing the Rust target.

## Validation

- `pnpm format:check`
- `pnpm lint`
- `pnpm --filter frontend exec vitest run src/features/spending/lib/constants.test.ts src/features/spending/lib/transactions-helpers.test.ts`
- `pnpm --filter frontend type-check`
