### PR TITLE
Fix OpenAI-compatible endpoint normalization

### DIFF
--- a/crates/ai/src/chat/provider_clients.rs
+++ b/crates/ai/src/chat/provider_clients.rs
@@ -13,6 +13,7 @@ use rig::{
 use std::time::Duration;
 
 use crate::error::AiError;
+use crate::provider_urls::ensure_openai_v1_base_url;
 
 pub(super) fn create_anthropic_client(
     api_key: Option<String>,
@@ -52,7 +53,8 @@ pub(super) fn create_groq_client(
     let key = api_key.ok_or_else(|| AiError::MissingApiKey(provider_id.to_string()))?;
     let mut builder = groq::Client::builder().api_key(&key);
     if let Some(url) = provider_url {
-        builder = builder.base_url(&url);
+        let normalized = ensure_openai_v1_base_url(&url);
+        builder = builder.base_url(&normalized);
     }
     builder
         .build()
@@ -70,12 +72,7 @@ pub(super) fn create_openai_client(
     let key = api_key.ok_or_else(|| AiError::MissingApiKey(provider_id.to_string()))?;
     let mut builder = openai::CompletionsClient::builder().api_key(&key);
     if let Some(url) = provider_url {
-        let base = url.trim_end_matches('/');
-        let normalized = if base.ends_with("/v1") {
-            base.to_string()
-        } else {
-            format!("{}/v1", base)
-        };
+        let normalized = ensure_openai_v1_base_url(&url);
         builder = builder.base_url(&normalized);
     }
     builder
@@ -91,7 +88,8 @@ pub(super) fn create_openrouter_client(
     let key = api_key.ok_or_else(|| AiError::MissingApiKey(provider_id.to_string()))?;
     let mut builder = openrouter::Client::builder().api_key(&key);
     if let Some(url) = provider_url {
-        builder = builder.base_url(&url);
+        let normalized = ensure_openai_v1_base_url(&url);
+        builder = builder.base_url(&normalized);
     }
     builder
         .build()
@@ -230,47 +228,30 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_openai_base_url_normalization() {
-        // Both forms should produce the same /v1-terminated URL for rig
-        let cases = [
-            ("http://localhost:8080", "http://localhost:8080/v1"),
-            ("http://localhost:8080/", "http://localhost:8080/v1"),
-            ("http://localhost:8080/v1", "http://localhost:8080/v1"),
-            ("http://localhost:8080/v1/", "http://localhost:8080/v1"),
-            ("https://api.openai.com", "https://api.openai.com/v1"),
-        ];
-        for (input, expected) in cases {
-            let base = input.trim_end_matches('/');
-            let normalized = if base.ends_with("/v1") {
-                base.to_string()
-            } else {
-                format!("{}/v1", base)
-            };
-            assert_eq!(normalized, expected, "input: {}", input);
-        }
-    }
+    fn test_openai_compatible_clients_normalize_base_url() {
+        let openai = create_openai_client(
+            Some("test-key".to_string()),
+            "openai",
+            Some("http://localhost:8080/".to_string()),
+        )
+        .expect("openai client");
+        assert_eq!(openai.base_url(), "http://localhost:8080/v1");
 
-    #[test]
-    fn test_list_models_url_normalization() {
-        // Both forms should produce the same /v1/models URL for model listing
-        let cases = [
-            ("http://localhost:8080", "http://localhost:8080/v1/models"),
-            ("http://localhost:8080/", "http://localhost:8080/v1/models"),
-            (
-                "http://localhost:8080/v1",
-                "http://localhost:8080/v1/models",
-            ),
-            (
-                "http://localhost:8080/v1/",
-                "http://localhost:8080/v1/models",
-            ),
-        ];
-        for (input, expected) in cases {
-            let base = input.trim_end_matches('/');
-            let base = base.strip_suffix("/v1").unwrap_or(base);
-            let url = format!("{}/v1/models", base);
-            assert_eq!(url, expected, "input: {}", input);
-        }
+        let groq = create_groq_client(
+            Some("test-key".to_string()),
+            "groq",
+            Some("https://api.groq.com/openai".to_string()),
+        )
+        .expect("groq client");
+        assert_eq!(groq.base_url(), "https://api.groq.com/openai/v1");
+
+        let openrouter = create_openrouter_client(
+            Some("test-key".to_string()),
+            "openrouter",
+            Some("https://openrouter.ai/api/v1/".to_string()),
+        )
+        .expect("openrouter client");
+        assert_eq!(openrouter.base_url(), "https://openrouter.ai/api/v1");
     }
 
     #[test]

--- a/crates/ai/src/lib.rs
+++ b/crates/ai/src/lib.rs
@@ -71,6 +71,7 @@ pub mod prompt_template;
 pub mod prompt_template_service;
 pub mod provider_model;
 pub mod provider_service;
+mod provider_urls;
 pub mod providers;
 pub mod stream_hook;
 pub mod title_generator;

--- a/crates/ai/src/provider_service.rs
+++ b/crates/ai/src/provider_service.rs
@@ -15,6 +15,7 @@ use crate::provider_model::{
     SetDefaultProviderRequest, UpdateProviderSettingsRequest, AI_PROVIDER_SETTINGS_KEY,
     AI_PROVIDER_SETTINGS_SCHEMA_VERSION,
 };
+use crate::provider_urls::openai_compatible_models_url;
 use crate::types::normalize_tools_allowlist;
 
 /// Service trait for AI provider operations.
@@ -546,12 +547,7 @@ impl AiProviderServiceTrait for AiProviderService {
             "ollama" => format!("{}/api/tags", base_url.trim_end_matches('/')),
             "google" => format!("{}/v1beta/models", base_url.trim_end_matches('/')),
             // OpenAI-compatible: OpenAI, Groq, OpenRouter.
-            // Strip any trailing /v1 first so we never double-append it.
-            _ => {
-                let base = base_url.trim_end_matches('/');
-                let base = base.strip_suffix("/v1").unwrap_or(base);
-                format!("{}/v1/models", base)
-            }
+            _ => openai_compatible_models_url(base_url),
         };
 
         // Build HTTP client and request

--- a/crates/ai/src/provider_urls.rs
+++ b/crates/ai/src/provider_urls.rs
@@ -1,0 +1,71 @@
+pub(crate) fn ensure_openai_v1_base_url(base_url: &str) -> String {
+    let base = base_url.trim_end_matches('/');
+    if base.ends_with("/v1") {
+        base.to_string()
+    } else {
+        format!("{}/v1", base)
+    }
+}
+
+pub(crate) fn openai_compatible_models_url(base_url: &str) -> String {
+    let base = base_url.trim_end_matches('/');
+    let base = base.strip_suffix("/v1").unwrap_or(base);
+    format!("{}/v1/models", base)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ensure_openai_v1_base_url_accepts_bare_or_v1_url() {
+        let cases = [
+            ("http://localhost:8080", "http://localhost:8080/v1"),
+            ("http://localhost:8080/", "http://localhost:8080/v1"),
+            ("http://localhost:8080/v1", "http://localhost:8080/v1"),
+            ("http://localhost:8080/v1/", "http://localhost:8080/v1"),
+            ("https://api.openai.com", "https://api.openai.com/v1"),
+            (
+                "https://api.groq.com/openai",
+                "https://api.groq.com/openai/v1",
+            ),
+            ("https://openrouter.ai/api", "https://openrouter.ai/api/v1"),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(ensure_openai_v1_base_url(input), expected, "input: {input}");
+        }
+    }
+
+    #[test]
+    fn openai_compatible_models_url_accepts_bare_or_v1_url() {
+        let cases = [
+            ("http://localhost:8080", "http://localhost:8080/v1/models"),
+            ("http://localhost:8080/", "http://localhost:8080/v1/models"),
+            (
+                "http://localhost:8080/v1",
+                "http://localhost:8080/v1/models",
+            ),
+            (
+                "http://localhost:8080/v1/",
+                "http://localhost:8080/v1/models",
+            ),
+            (
+                "https://api.groq.com/openai",
+                "https://api.groq.com/openai/v1/models",
+            ),
+            (
+                "https://openrouter.ai/api/v1",
+                "https://openrouter.ai/api/v1/models",
+            ),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(
+                openai_compatible_models_url(input),
+                expected,
+                "input: {input}"
+            );
+        }
+    }
+}

--- a/crates/ai/src/title_generator.rs
+++ b/crates/ai/src/title_generator.rs
@@ -14,6 +14,7 @@ use rig::{
 
 use crate::env::AiEnvironment;
 use crate::error::AiError;
+use crate::provider_urls::ensure_openai_v1_base_url;
 use crate::providers::ProviderService;
 use std::sync::Arc;
 
@@ -145,7 +146,8 @@ Title:",
                 let key = api_key.ok_or_else(|| AiError::MissingApiKey(provider_id.to_string()))?;
                 let mut builder = groq::Client::<HttpClient>::builder().api_key(&key);
                 if let Some(url) = provider_url {
-                    builder = builder.base_url(&url);
+                    let normalized = ensure_openai_v1_base_url(&url);
+                    builder = builder.base_url(&normalized);
                 }
                 let client = builder
                     .build()
@@ -176,7 +178,8 @@ Title:",
                 let key = api_key.ok_or_else(|| AiError::MissingApiKey(provider_id.to_string()))?;
                 let mut builder = openrouter::Client::<HttpClient>::builder().api_key(&key);
                 if let Some(url) = provider_url {
-                    builder = builder.base_url(&url);
+                    let normalized = ensure_openai_v1_base_url(&url);
+                    builder = builder.base_url(&normalized);
                 }
                 let client = builder
                     .build()
@@ -191,9 +194,10 @@ Title:",
             _ => {
                 // Default to OpenAI-compatible
                 let key = api_key.ok_or_else(|| AiError::MissingApiKey(provider_id.to_string()))?;
-                let mut builder = openai::Client::<HttpClient>::builder().api_key(&key);
+                let mut builder = openai::CompletionsClient::<HttpClient>::builder().api_key(&key);
                 if let Some(url) = provider_url {
-                    builder = builder.base_url(&url);
+                    let normalized = ensure_openai_v1_base_url(&url);
+                    builder = builder.base_url(&normalized);
                 }
                 let client = builder
                     .build()


### PR DESCRIPTION
## Summary

- Share OpenAI-compatible base URL normalization across model listing and rig client setup.
- Normalize Groq and OpenRouter custom endpoints before chat/title-generation requests.
- Keep OpenAI-compatible title generation on Chat Completions so local `/v1/chat/completions` servers work consistently.

## Root cause

The merged fix normalized OpenAI chat and model-listing paths, but Groq/OpenRouter chat clients and title generation still passed raw custom endpoints to rig. Bare host URLs could still produce requests without `/v1` in those paths.

## Validation

- `cargo test -p wealthfolio-ai openai`
- `cargo test -p wealthfolio-ai`