### PR TITLE
Fix holdings return warning copy

### DIFF
--- a/apps/frontend/src/pages/dashboard/accounts-summary.test.tsx
+++ b/apps/frontend/src/pages/dashboard/accounts-summary.test.tsx
@@ -448,6 +448,41 @@ describe("AccountsSummary", () => {
     expect(within(badRow as HTMLElement).getByText(/return % unavailable/i)).toBeInTheDocument();
   });
 
+  it("uses holdings-mode copy when a holdings account has unavailable return percent", () => {
+    renderAccountsSummary({
+      accounts: [
+        createAccount({
+          id: "holdings-account",
+          name: "Holdings Account",
+          trackingMode: "HOLDINGS",
+        }),
+      ],
+      valuations: [
+        createValuation({
+          accountId: "holdings-account",
+          totalValue: 125,
+        }),
+      ],
+      performanceByAccountId: {
+        "holdings-account": {
+          pnl: 25,
+          returnValue: null,
+        },
+      },
+    });
+
+    const row = screen.getByText("Holdings Account").closest("a");
+    expect(row).not.toBeNull();
+    expect(
+      within(row as HTMLElement).getByText(
+        "Return % unavailable - missing cost basis or starting holdings value.",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      within(row as HTMLElement).queryByText(/activity history may be inconsistent/i),
+    ).not.toBeInTheDocument();
+  });
+
   it("does not flag normal transaction-mode not-applicable details as dashboard warnings", () => {
     renderAccountsSummary({
       accounts: [createAccount({ id: "td-invest", name: "TD Invest" })],

--- a/apps/frontend/src/pages/dashboard/accounts-summary.tsx
+++ b/apps/frontend/src/pages/dashboard/accounts-summary.tsx
@@ -7,7 +7,12 @@ import { AccountPurpose } from "@/lib/constants";
 import { performanceHeadlineReturn, performancePeriodPnl } from "@/lib/performance";
 import { QueryKeys } from "@/lib/query-keys";
 import { useSettingsContext } from "@/lib/settings-provider";
-import type { AccountValuation, DateRange, PerformanceSummaryScope } from "@/lib/types";
+import type {
+  AccountValuation,
+  DateRange,
+  PerformanceSummaryScope,
+  TrackingMode,
+} from "@/lib/types";
 import { useQuery } from "@tanstack/react-query";
 import { GainAmount, GainPercent, PrivacyAmount } from "@wealthfolio/ui";
 import { Button } from "@wealthfolio/ui/components/ui/button";
@@ -31,6 +36,7 @@ interface AccountSummaryDisplayData {
   accountId?: string;
   accountType?: string;
   accountGroup?: string | null;
+  trackingMode?: TrackingMode;
   isGroup?: boolean;
   accountCount?: number;
   accounts?: AccountSummaryDisplayData[];
@@ -126,7 +132,11 @@ const AccountSummaryComponent = React.memo(
       gainAmountToDisplay !== null &&
       gainAmountToDisplay !== 0;
     const warningMessages = hasBadData
-      ? ["Return % unavailable - activity history may be inconsistent."]
+      ? [
+          item.trackingMode === "HOLDINGS"
+            ? "Return % unavailable - missing cost basis or starting holdings value."
+            : "Return % unavailable - activity history may be inconsistent.",
+        ]
       : [];
     const shouldShowWarning = hasBadData;
     const shouldRenderGainMetrics = gainPercentToDisplay !== null && (isNested || !isZeroGain);
@@ -352,6 +362,7 @@ export const AccountsSummary = React.memo(
             accountId: acc.id,
             accountType: acc.accountType,
             accountGroup: acc.group ?? null,
+            trackingMode: acc.trackingMode,
             isGroup: false,
           };
         }
@@ -376,6 +387,7 @@ export const AccountsSummary = React.memo(
           accountId: acc.id,
           accountType: acc.accountType,
           accountGroup: acc.group ?? null,
+          trackingMode: acc.trackingMode,
           isGroup: false,
         };
       });
@@ -487,6 +499,9 @@ export const AccountsSummary = React.memo(
               isGroup: true,
               accountCount: groupAccounts.length,
               accounts: groupAccounts,
+              trackingMode: groupAccounts.every((account) => account.trackingMode === "HOLDINGS")
+                ? "HOLDINGS"
+                : undefined,
               displayInAccountCurrency: false,
             });
           }


### PR DESCRIPTION
## Summary

- Show holdings-specific dashboard warning copy when return percent is unavailable for holdings-mode accounts.
- Carry tracking mode into dashboard account summary rows and all-holdings groups so the tooltip copy matches the account mode.
- Add a regression test for the holdings-mode warning text.

## Root Cause

The dashboard warning used one generic message for any non-zero gain where return percent was unavailable. That message mentioned activity history, which is misleading for holdings-mode accounts because holdings performance is based on snapshots/cost basis, not transaction activity history.

## Validation

- `pnpm test -- accounts-summary.test.tsx`
- `pnpm --filter frontend type-check`
- `pnpm format:check`
- `pnpm lint:quiet`
- `pnpm lint` exited 0; existing frontend warnings remain outside this change.