### PR TITLE
feat(spending): show savings categories on expense transactions

### DIFF
--- a/apps/frontend/src/features/spending/components/quick-categorize-popover.tsx
+++ b/apps/frontend/src/features/spending/components/quick-categorize-popover.tsx
@@ -75,7 +75,7 @@ export function QuickCategorizePopover({
     if (scope === "expense" || scope === "both") {
       out.push(...flattenTaxonomy(SPENDING_TAXONOMY, spending.data?.categories ?? [], "Expense"));
     }
-    if (scope === "saving") {
+    if (scope === "saving" || scope === "expense" || scope === "both") {
       out.push(...flattenTaxonomy(SAVINGS_TAXONOMY, savings.data?.categories ?? [], "Savings"));
     }
     if (scope === "income" || scope === "both") {


### PR DESCRIPTION
Hello @afadil, 

I was digging in the spending categories and I remarked something weird to me. 
Currently, savings categories only appear in the category picker when a transaction's `cashFlowBucket` is `'saving',which only happens for `TRANSFER_OUT` from a cash account to an investment account. 
Regular withdrawals (e.g. a life insurance payment, an RRSP contribution by cheque, a savings plan debit) are classified as `'spending'` and therefore can never be tagged with a savings category.

## What changed

One condition in `QuickCategorizePopover`:

```diff
- if (scope === "saving") {
+ if (scope === "saving" || scope === "expense" || scope === "both") {
```

Savings categories now appear alongside expense categories for any outgoing cash transaction. The `cashFlowBucket` is unchanged — categories label the bucket, they do not change it.

## Why this matters

Many real-world cash outflows are savings in nature even though they leave the account as a withdrawal: life insurance premiums, contributions to a savings plan, transfers to a joint savings account without a linked investment account. Without this change users have no way to categorise these correctly.

## Open question for review

The original design restricted savings categories to transfer-type transactions only. This PR relaxes that. Is there a reporting or analytics reason to keep savings categories exclusive to `cashFlowBucket = 'saving'`? If so, a middle ground could be a dedicated `'expense_or_saving'` scope rather than broadening `'expense'`.

## Test plan

- [ ] Open spending tracker, find a regular withdrawal transaction
- [ ] Click + Categorize — confirm Savings group is now visible alongside Expense
- [ ] Assign a savings category (e.g. Life Insurance) — confirm it saves correctly
- [ ] Confirm saving-type transactions (TRANSFER_OUT to investment) still show savings categories
- [ ] Confirm income transactions still show only income categories

