### PR TITLE
Fix spending flows, addon updates, and sync messaging

### DIFF
--- a/apps/frontend/src/features/spending/components/cash-activity-form.tsx
+++ b/apps/frontend/src/features/spending/components/cash-activity-form.tsx
@@ -7,8 +7,10 @@ import { toast } from "sonner";
 
 import { createActivity, updateActivity } from "@/adapters";
 import { useAccounts } from "@/hooks/use-accounts";
+import { useIsMobileViewport } from "@/hooks/use-platform";
 import { useTaxonomy } from "@/hooks/use-taxonomies";
 import { QueryKeys } from "@/lib/query-keys";
+import { cn } from "@/lib/utils";
 import { invalidateSpendingCaches } from "../lib/invalidation";
 import type { Account, Activity, ActivityCreate, ActivityUpdate } from "@/lib/types";
 
@@ -23,6 +25,8 @@ import {
   FormMessage,
   Icons,
   MoneyInput,
+  RadioGroup,
+  RadioGroupItem,
   Select,
   SelectContent,
   SelectItem,
@@ -81,6 +85,46 @@ const formSchema = z.object({
 
 type FormValues = z.infer<typeof formSchema>;
 
+function getMobileTypeIcon(type: FormValues["activityType"]) {
+  switch (type) {
+    case "DEPOSIT":
+      return Icons.ArrowDown;
+    case "WITHDRAWAL":
+      return Icons.ArrowUp;
+    case "INTEREST":
+      return Icons.Percent;
+    case "CREDIT":
+      return Icons.RefreshCw;
+    case "FEE":
+      return Icons.DollarSign;
+    case "TAX":
+      return Icons.Receipt;
+    case "TRANSFER_IN":
+    case "TRANSFER_OUT":
+      return Icons.ArrowLeftRight;
+  }
+}
+
+function getMobileTypeDescription(type: FormValues["activityType"]) {
+  switch (type) {
+    case "DEPOSIT":
+      return "Money received in this account";
+    case "WITHDRAWAL":
+      return "Money spent or paid from this account";
+    case "INTEREST":
+      return "Interest earned on this account";
+    case "CREDIT":
+      return "Refund or credit adjustment";
+    case "FEE":
+      return "Account or transaction fee";
+    case "TAX":
+      return "Tax payment from this account";
+    case "TRANSFER_IN":
+    case "TRANSFER_OUT":
+      return "Move money between accounts";
+  }
+}
+
 interface CashActivityFormProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -101,6 +145,8 @@ export function CashActivityForm({
   onTransferClick,
 }: CashActivityFormProps) {
   const isEditing = !!activity?.id;
+  const isMobile = useIsMobileViewport();
+  const [currentStep, setCurrentStep] = useState<1 | 2>(isEditing ? 2 : 1);
   const qc = useQueryClient();
   const { accounts } = useAccounts({ filterActive: false });
   const { settings } = useSpendingSettings();
@@ -177,6 +223,7 @@ export function CashActivityForm({
             : "",
       });
       setEventId(activity?.eventId ?? null);
+      setCurrentStep(activity?.id ? 2 : 1);
     }
   }, [open, activity, spendingAccounts, form]);
 
@@ -193,6 +240,16 @@ export function CashActivityForm({
     if (!isEditing) return all.filter((t) => t !== "TRANSFER_IN" && t !== "TRANSFER_OUT");
     return all;
   }, [activity?.activityType, isEditing, selectedAccount?.accountType]);
+  const mobileTypeOptions = useMemo(
+    () =>
+      activityTypeOptions.map((type) => ({
+        type,
+        label: getCashActivityLabel(type, selectedAccount?.accountType),
+        description: getMobileTypeDescription(type),
+        Icon: getMobileTypeIcon(type),
+      })),
+    [activityTypeOptions, selectedAccount?.accountType],
+  );
   const isIncomeType = isCashActivityIncome(
     watchType,
     selectedAccount?.accountType,
@@ -283,280 +340,467 @@ export function CashActivityForm({
     },
   });
 
+  const isMobileCreate = isMobile && !isEditing;
+  const showChoiceFields = !isMobileCreate || currentStep === 1;
+  const showDetailsFields = !isMobileCreate || currentStep === 2;
+
+  const handleMobileNext = async () => {
+    const isValid = await form.trigger(["accountId", "activityType"]);
+    if (isValid) setCurrentStep(2);
+  };
+
+  const handleTransferAction = async () => {
+    if (!onTransferClick) return;
+    const isValid = await form.trigger("accountId");
+    if (!isValid || !watchAccountId) return;
+    onOpenChange(false);
+    onTransferClick(watchAccountId);
+  };
+
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
-      <SheetContent className="w-full sm:max-w-md">
-        <SheetHeader>
-          <SheetTitle>{isEditing ? "Edit Transaction" : "Add Transaction"}</SheetTitle>
-          <SheetDescription>
-            {isEditing
-              ? "Update an existing transaction."
-              : "Add a new transaction on a tracked spending account."}
-          </SheetDescription>
+      <SheetContent
+        side={isMobile ? "bottom" : "right"}
+        className={cn(
+          isMobile
+            ? "rounded-t-4xl mx-1 flex h-[90vh] flex-col p-0"
+            : "flex w-full flex-col overflow-hidden sm:max-w-md",
+        )}
+      >
+        <SheetHeader className={cn(isMobile && "border-b px-6 py-4 text-center")}>
+          <div className={cn(isMobile && "flex flex-col items-center space-y-2")}>
+            <SheetTitle>{isEditing ? "Edit Transaction" : "Add Transaction"}</SheetTitle>
+            {isMobileCreate && (
+              <div className="flex gap-1.5">
+                {[1, 2].map((step) => (
+                  <div
+                    key={step}
+                    className={cn(
+                      "h-1.5 w-10 rounded-full transition-colors",
+                      step === currentStep
+                        ? "bg-primary"
+                        : step < currentStep
+                          ? "bg-primary/50"
+                          : "bg-muted",
+                    )}
+                  />
+                ))}
+              </div>
+            )}
+            {!isMobileCreate && (
+              <SheetDescription>
+                {isEditing
+                  ? "Update an existing transaction."
+                  : "Add a new transaction on a tracked spending account."}
+              </SheetDescription>
+            )}
+          </div>
         </SheetHeader>
         <Form {...form}>
           <form
             onSubmit={form.handleSubmit((v) => saveMutation.mutate(v))}
-            className="mt-6 space-y-4 px-1"
+            className={cn(
+              isMobile
+                ? "flex min-h-0 flex-1 flex-col"
+                : "mt-6 min-h-0 flex-1 overflow-y-auto px-1 pb-1",
+            )}
           >
-            <FormField
-              control={form.control}
-              name="accountId"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Account</FormLabel>
-                  <Select onValueChange={field.onChange} value={field.value}>
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder="Select an account" />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {spendingAccounts.map((acc) => (
-                        <SelectItem key={acc.id} value={acc.id}>
-                          {acc.name} ({acc.currency})
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+            <div className={cn(isMobile && "flex-1 overflow-y-auto")}>
+              <div className={cn("space-y-4", isMobile && "p-4")}>
+                {showChoiceFields && (
+                  <>
+                    <FormField
+                      control={form.control}
+                      name="accountId"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Account</FormLabel>
+                          <Select onValueChange={field.onChange} value={field.value}>
+                            <FormControl>
+                              <SelectTrigger>
+                                <SelectValue placeholder="Select an account" />
+                              </SelectTrigger>
+                            </FormControl>
+                            <SelectContent>
+                              {spendingAccounts.map((acc) => (
+                                <SelectItem key={acc.id} value={acc.id}>
+                                  {acc.name} ({acc.currency})
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
 
-            <FormField
-              control={form.control}
-              name="activityType"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Type</FormLabel>
-                  <Select onValueChange={field.onChange} value={field.value}>
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {activityTypeOptions.map((t) => (
-                        <SelectItem key={t} value={t}>
-                          {getCashActivityLabel(t, selectedAccount?.accountType)}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+                    {isMobileCreate ? (
+                      <FormField
+                        control={form.control}
+                        name="activityType"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel className="text-lg font-semibold">
+                              Select Transaction Type
+                            </FormLabel>
+                            <FormControl>
+                              <RadioGroup onValueChange={field.onChange} value={field.value}>
+                                <div className="space-y-2">
+                                  {mobileTypeOptions.map(({ type, label, description, Icon }) => (
+                                    <div key={type}>
+                                      <RadioGroupItem
+                                        value={type}
+                                        id={`spending-mobile-type-${type}`}
+                                        className="peer sr-only"
+                                      />
+                                      <label
+                                        htmlFor={`spending-mobile-type-${type}`}
+                                        className={cn(
+                                          "flex cursor-pointer items-start gap-3 rounded-lg border p-4 transition-all",
+                                          "hover:bg-muted/50",
+                                          "peer-data-[state=checked]:border-primary peer-data-[state=checked]:bg-primary/5",
+                                          "active:scale-[0.98]",
+                                        )}
+                                      >
+                                        <div className="mt-0.5 flex-shrink-0">
+                                          <div className="bg-muted flex h-10 w-10 items-center justify-center rounded-full transition-colors">
+                                            <Icon className="text-muted-foreground h-5 w-5" />
+                                          </div>
+                                        </div>
+                                        <div className="min-w-0 flex-1">
+                                          <div className="text-foreground font-medium">{label}</div>
+                                          <div className="text-muted-foreground mt-1 text-sm">
+                                            {description}
+                                          </div>
+                                        </div>
+                                      </label>
+                                    </div>
+                                  ))}
+                                </div>
+                              </RadioGroup>
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+                    ) : (
+                      <>
+                        <FormField
+                          control={form.control}
+                          name="activityType"
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>Type</FormLabel>
+                              <Select onValueChange={field.onChange} value={field.value}>
+                                <FormControl>
+                                  <SelectTrigger>
+                                    <SelectValue />
+                                  </SelectTrigger>
+                                </FormControl>
+                                <SelectContent>
+                                  {activityTypeOptions.map((t) => (
+                                    <SelectItem key={t} value={t}>
+                                      {getCashActivityLabel(t, selectedAccount?.accountType)}
+                                    </SelectItem>
+                                  ))}
+                                </SelectContent>
+                              </Select>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
 
-            {/* Transfer button — creation only, redirects to the full transfer form */}
-            {!isEditing && onTransferClick && (
-              <FormItem>
-                <FormLabel>{isCreditCardAccount ? "Payment" : "Transfer"}</FormLabel>
+                        {/* Transfer button — creation only, redirects to the full transfer form */}
+                        {!isEditing && onTransferClick && (
+                          <FormItem>
+                            <FormLabel>{isCreditCardAccount ? "Payment" : "Transfer"}</FormLabel>
+                            <Button
+                              type="button"
+                              variant="outline"
+                              className="w-full justify-start gap-2"
+                              disabled={!watchAccountId}
+                              onClick={handleTransferAction}
+                            >
+                              <Icons.ArrowLeftRight className="h-4 w-4" />
+                              {transferActionLabel}
+                            </Button>
+                          </FormItem>
+                        )}
+                      </>
+                    )}
+
+                    {isMobileCreate && onTransferClick && (
+                      <button
+                        type="button"
+                        className={cn(
+                          "flex w-full items-start gap-3 rounded-lg border p-4 text-left transition-all",
+                          "hover:bg-muted/50 active:scale-[0.98]",
+                          "disabled:cursor-not-allowed disabled:opacity-50",
+                        )}
+                        disabled={!watchAccountId}
+                        onClick={handleTransferAction}
+                      >
+                        <div className="mt-0.5 flex-shrink-0">
+                          <div className="bg-muted flex h-10 w-10 items-center justify-center rounded-full transition-colors">
+                            <Icons.ArrowLeftRight className="text-muted-foreground h-5 w-5" />
+                          </div>
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <div className="text-foreground font-medium">{transferActionLabel}</div>
+                          <div className="text-muted-foreground mt-1 text-sm">
+                            {isCreditCardAccount
+                              ? "Pay this card from another account"
+                              : "Move money between accounts"}
+                          </div>
+                        </div>
+                      </button>
+                    )}
+                  </>
+                )}
+
+                {showDetailsFields && (
+                  <>
+                    <FormField
+                      control={form.control}
+                      name="activityDate"
+                      render={({ field }) => (
+                        <FormItem className="flex flex-col">
+                          <FormLabel>Date</FormLabel>
+                          <DatePickerInput
+                            value={field.value}
+                            onChange={(d?: Date) => field.onChange(d)}
+                            disabled={field.disabled}
+                            enableTime
+                          />
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="amount"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Amount</FormLabel>
+                          <FormControl>
+                            <MoneyInput
+                              value={field.value}
+                              onValueChange={(v: number | undefined) => field.onChange(v ?? 0)}
+                              placeholder="0.00"
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="category"
+                      render={({ field }) => {
+                        const [, currentCatId] = field.value?.split(":") ?? [];
+                        const currentCat = currentCatId
+                          ? allCategoriesById.get(currentCatId)
+                          : null;
+                        const currentParent = currentCat?.parentId
+                          ? allCategoriesById.get(currentCat.parentId)
+                          : null;
+                        return (
+                          <FormItem>
+                            <FormLabel>{isNeutralBucket ? "Category" : categoryLabel}</FormLabel>
+                            {isNeutralBucket ? (
+                              <div className="border-input bg-muted/40 text-muted-foreground h-input-height flex items-center rounded-md border px-3 py-2 text-sm">
+                                Neutral transfer
+                              </div>
+                            ) : (
+                              <QuickCategorizePopover
+                                scope={categoryScope}
+                                selectedCategoryId={currentCatId ?? null}
+                                onSelect={(tax, catId) => field.onChange(`${tax}:${catId}`)}
+                                onClear={() => field.onChange("")}
+                                trigger={
+                                  <FormControl>
+                                    <button
+                                      type="button"
+                                      className="border-input bg-input-bg dark:bg-input/30 hover:bg-accent/30 ring-offset-background focus:ring-ring h-input-height flex w-full items-center justify-between rounded-md border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2"
+                                      aria-label={
+                                        currentCat
+                                          ? `Change category (${currentCat.name})`
+                                          : "Pick a category"
+                                      }
+                                    >
+                                      {currentCat ? (
+                                        <span className="flex min-w-0 items-center gap-2">
+                                          {currentCat.color && (
+                                            <span
+                                              className="h-2.5 w-2.5 shrink-0 rounded-full"
+                                              style={{ backgroundColor: currentCat.color }}
+                                              aria-hidden="true"
+                                            />
+                                          )}
+                                          <span className="truncate">
+                                            {currentParent ? `${currentParent.name} / ` : ""}
+                                            {currentCat.name}
+                                          </span>
+                                        </span>
+                                      ) : (
+                                        <span className="text-muted-foreground">
+                                          Pick a category (optional)
+                                        </span>
+                                      )}
+                                      <Icons.ChevronDown
+                                        className="ml-2 h-4 w-4 shrink-0 opacity-50"
+                                        aria-hidden="true"
+                                      />
+                                    </button>
+                                  </FormControl>
+                                }
+                              />
+                            )}
+                            <FormMessage />
+                          </FormItem>
+                        );
+                      }}
+                    />
+
+                    <FormItem>
+                      <FormLabel>Event</FormLabel>
+                      <QuickEventPopover
+                        selectedEventId={eventId}
+                        onSelect={setEventId}
+                        onClear={() => setEventId(null)}
+                        defaultDate={form.watch("activityDate") ?? undefined}
+                        trigger={
+                          <button
+                            type="button"
+                            className="border-input bg-input-bg dark:bg-input/30 hover:bg-accent/30 ring-offset-background focus:ring-ring h-input-height flex w-full items-center justify-between rounded-md border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2"
+                            aria-label={
+                              eventId && eventsById.get(eventId)
+                                ? `Change event (${eventsById.get(eventId)?.name})`
+                                : "Tag an event"
+                            }
+                          >
+                            {(() => {
+                              const ev = eventId ? eventsById.get(eventId) : null;
+                              if (!ev) {
+                                return (
+                                  <span className="text-muted-foreground">
+                                    Tag an event (optional)
+                                  </span>
+                                );
+                              }
+                              const color =
+                                eventTypeById.get(ev.eventTypeId)?.color ??
+                                "var(--muted-foreground)";
+                              return (
+                                <span className="flex min-w-0 items-center gap-2">
+                                  <span
+                                    className="h-2.5 w-2.5 shrink-0 rounded-full"
+                                    style={{ backgroundColor: color }}
+                                    aria-hidden="true"
+                                  />
+                                  <span className="truncate">{ev.name}</span>
+                                </span>
+                              );
+                            })()}
+                            <Icons.ChevronDown
+                              className="ml-2 h-4 w-4 shrink-0 opacity-50"
+                              aria-hidden="true"
+                            />
+                          </button>
+                        }
+                      />
+                    </FormItem>
+
+                    <FormField
+                      control={form.control}
+                      name="notes"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Notes / Payee</FormLabel>
+                          <FormControl>
+                            <Textarea
+                              placeholder="e.g., AMAZON*MARKETPLACE, STARBUCKS COFFEE"
+                              className="resize-none"
+                              {...field}
+                            />
+                          </FormControl>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                  </>
+                )}
+              </div>
+            </div>
+
+            {isMobile ? (
+              <SheetFooter className="mt-auto border-t px-6 py-4 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)]">
+                <div className="flex w-full gap-3">
+                  {currentStep > 1 && !isEditing && (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => setCurrentStep(1)}
+                      className="flex-1"
+                      disabled={saveMutation.isPending}
+                    >
+                      <Icons.ArrowLeft className="mr-2 h-4 w-4" />
+                      Back
+                    </Button>
+                  )}
+
+                  {currentStep < 2 && !isEditing ? (
+                    <Button
+                      type="button"
+                      onClick={handleMobileNext}
+                      className="flex-1 font-medium"
+                      disabled={!watchAccountId}
+                    >
+                      Next
+                      <Icons.ArrowRight className="ml-2 h-4 w-4" />
+                    </Button>
+                  ) : (
+                    <Button
+                      type="submit"
+                      className="flex-1 font-medium"
+                      disabled={saveMutation.isPending}
+                    >
+                      {saveMutation.isPending ? (
+                        <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />
+                      ) : (
+                        <Icons.Check className="mr-2 h-4 w-4" />
+                      )}
+                      {isEditing ? "Update" : "Create"} Transaction
+                    </Button>
+                  )}
+                </div>
+              </SheetFooter>
+            ) : (
+              <SheetFooter className="gap-2 pt-4">
                 <Button
                   type="button"
                   variant="outline"
-                  className="w-full justify-start gap-2"
-                  disabled={!watchAccountId}
-                  onClick={() => {
-                    onOpenChange(false);
-                    onTransferClick(watchAccountId);
-                  }}
+                  onClick={() => onOpenChange(false)}
+                  disabled={saveMutation.isPending}
                 >
-                  <Icons.ArrowLeftRight className="h-4 w-4" />
-                  {transferActionLabel}
+                  Cancel
                 </Button>
-              </FormItem>
+                <Button type="submit" disabled={saveMutation.isPending}>
+                  {saveMutation.isPending ? (
+                    <>
+                      <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />
+                      Saving...
+                    </>
+                  ) : isEditing ? (
+                    "Update"
+                  ) : (
+                    "Create"
+                  )}
+                </Button>
+              </SheetFooter>
             )}
-
-            <FormField
-              control={form.control}
-              name="activityDate"
-              render={({ field }) => (
-                <FormItem className="flex flex-col">
-                  <FormLabel>Date</FormLabel>
-                  <DatePickerInput
-                    value={field.value}
-                    onChange={(d?: Date) => field.onChange(d)}
-                    disabled={field.disabled}
-                    enableTime
-                  />
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="amount"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Amount</FormLabel>
-                  <FormControl>
-                    <MoneyInput
-                      value={field.value}
-                      onValueChange={(v: number | undefined) => field.onChange(v ?? 0)}
-                      placeholder="0.00"
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <FormField
-              control={form.control}
-              name="category"
-              render={({ field }) => {
-                const [, currentCatId] = field.value?.split(":") ?? [];
-                const currentCat = currentCatId ? allCategoriesById.get(currentCatId) : null;
-                const currentParent = currentCat?.parentId
-                  ? allCategoriesById.get(currentCat.parentId)
-                  : null;
-                return (
-                  <FormItem>
-                    <FormLabel>{isNeutralBucket ? "Category" : categoryLabel}</FormLabel>
-                    {isNeutralBucket ? (
-                      <div className="border-input bg-muted/40 text-muted-foreground h-input-height flex items-center rounded-md border px-3 py-2 text-sm">
-                        Neutral transfer
-                      </div>
-                    ) : (
-                      <QuickCategorizePopover
-                        scope={categoryScope}
-                        selectedCategoryId={currentCatId ?? null}
-                        onSelect={(tax, catId) => field.onChange(`${tax}:${catId}`)}
-                        onClear={() => field.onChange("")}
-                        trigger={
-                          <FormControl>
-                            <button
-                              type="button"
-                              className="border-input bg-input-bg dark:bg-input/30 hover:bg-accent/30 ring-offset-background focus:ring-ring h-input-height flex w-full items-center justify-between rounded-md border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2"
-                              aria-label={
-                                currentCat
-                                  ? `Change category (${currentCat.name})`
-                                  : "Pick a category"
-                              }
-                            >
-                              {currentCat ? (
-                                <span className="flex min-w-0 items-center gap-2">
-                                  {currentCat.color && (
-                                    <span
-                                      className="h-2.5 w-2.5 shrink-0 rounded-full"
-                                      style={{ backgroundColor: currentCat.color }}
-                                      aria-hidden="true"
-                                    />
-                                  )}
-                                  <span className="truncate">
-                                    {currentParent ? `${currentParent.name} / ` : ""}
-                                    {currentCat.name}
-                                  </span>
-                                </span>
-                              ) : (
-                                <span className="text-muted-foreground">
-                                  Pick a category (optional)
-                                </span>
-                              )}
-                              <Icons.ChevronDown
-                                className="ml-2 h-4 w-4 shrink-0 opacity-50"
-                                aria-hidden="true"
-                              />
-                            </button>
-                          </FormControl>
-                        }
-                      />
-                    )}
-                    <FormMessage />
-                  </FormItem>
-                );
-              }}
-            />
-
-            <FormItem>
-              <FormLabel>Event</FormLabel>
-              <QuickEventPopover
-                selectedEventId={eventId}
-                onSelect={setEventId}
-                onClear={() => setEventId(null)}
-                defaultDate={form.watch("activityDate") ?? undefined}
-                trigger={
-                  <button
-                    type="button"
-                    className="border-input bg-input-bg dark:bg-input/30 hover:bg-accent/30 ring-offset-background focus:ring-ring h-input-height flex w-full items-center justify-between rounded-md border px-3 py-2 text-sm transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2"
-                    aria-label={
-                      eventId && eventsById.get(eventId)
-                        ? `Change event (${eventsById.get(eventId)?.name})`
-                        : "Tag an event"
-                    }
-                  >
-                    {(() => {
-                      const ev = eventId ? eventsById.get(eventId) : null;
-                      if (!ev) {
-                        return (
-                          <span className="text-muted-foreground">Tag an event (optional)</span>
-                        );
-                      }
-                      const color =
-                        eventTypeById.get(ev.eventTypeId)?.color ?? "var(--muted-foreground)";
-                      return (
-                        <span className="flex min-w-0 items-center gap-2">
-                          <span
-                            className="h-2.5 w-2.5 shrink-0 rounded-full"
-                            style={{ backgroundColor: color }}
-                            aria-hidden="true"
-                          />
-                          <span className="truncate">{ev.name}</span>
-                        </span>
-                      );
-                    })()}
-                    <Icons.ChevronDown
-                      className="ml-2 h-4 w-4 shrink-0 opacity-50"
-                      aria-hidden="true"
-                    />
-                  </button>
-                }
-              />
-            </FormItem>
-
-            <FormField
-              control={form.control}
-              name="notes"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Notes / Payee</FormLabel>
-                  <FormControl>
-                    <Textarea
-                      placeholder="e.g., AMAZON*MARKETPLACE, STARBUCKS COFFEE"
-                      className="resize-none"
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <SheetFooter className="gap-2 pt-4">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => onOpenChange(false)}
-                disabled={saveMutation.isPending}
-              >
-                Cancel
-              </Button>
-              <Button type="submit" disabled={saveMutation.isPending}>
-                {saveMutation.isPending ? (
-                  <>
-                    <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />
-                    Saving...
-                  </>
-                ) : isEditing ? (
-                  "Update"
-                ) : (
-                  "Create"
-                )}
-              </Button>
-            </SheetFooter>
           </form>
         </Form>
       </SheetContent>

--- a/apps/frontend/src/features/spending/components/events-card.test.tsx
+++ b/apps/frontend/src/features/spending/components/events-card.test.tsx
@@ -3,21 +3,12 @@ import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { FOREST_THEME } from "../lib/theme";
-import { useSpendingEvents } from "../hooks/use-spending-events";
-import type { SpendingEvent } from "../types/event";
+import { useEventSpendingSummaries } from "../hooks/use-spending-events";
+import type { EventSpendingSummary } from "../types/event";
 import { EventsCard } from "./events-card";
 
-vi.mock("@tanstack/react-query", async () => {
-  const actual =
-    await vi.importActual<typeof import("@tanstack/react-query")>("@tanstack/react-query");
-  return {
-    ...actual,
-    useQueries: vi.fn(() => []),
-  };
-});
-
 vi.mock("../hooks/use-spending-events", () => ({
-  useSpendingEvents: vi.fn(),
+  useEventSpendingSummaries: vi.fn(),
 }));
 
 vi.mock("./event-dialog-provider", () => ({
@@ -27,18 +18,22 @@ vi.mock("./event-dialog-provider", () => ({
   }),
 }));
 
-const mockUseSpendingEvents = vi.mocked(useSpendingEvents);
+const mockUseEventSpendingSummaries = vi.mocked(useEventSpendingSummaries);
 
-function event(overrides: Partial<SpendingEvent> = {}): SpendingEvent {
+function eventSummary(overrides: Partial<EventSpendingSummary> = {}): EventSpendingSummary {
   return {
-    id: "event-1",
-    name: "Sister Wedding",
-    description: null,
+    eventId: "event-1",
+    eventName: "Sister Wedding",
     eventTypeId: "type-1",
+    eventTypeName: "Wedding",
+    eventTypeColor: "#123456",
     startDate: "2026-04-16",
     endDate: "2026-04-20",
-    createdAt: "2026-04-01T00:00:00.000Z",
-    updatedAt: "2026-04-01T00:00:00.000Z",
+    totalSpending: 0,
+    transactionCount: 0,
+    currency: "USD",
+    byCategory: {},
+    dailySpending: {},
     ...overrides,
   };
 }
@@ -49,6 +44,8 @@ function renderEventsCard(periodStartDate: string, periodEndDate: string) {
       <EventsCard
         activities={[]}
         categoriesMeta={new Map()}
+        eventSummaryEndDate={periodEndDate}
+        eventSummaryStartDate={periodStartDate}
         periodEndDate={periodEndDate}
         periodStartDate={periodStartDate}
         theme={FOREST_THEME}
@@ -61,12 +58,12 @@ describe("EventsCard", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-05T12:00:00.000Z"));
-    mockUseSpendingEvents.mockReturnValue({
-      data: [event()],
+    mockUseEventSpendingSummaries.mockReturnValue({
+      data: [eventSummary()],
       isLoading: false,
       isError: false,
       refetch: vi.fn(),
-    } as unknown as ReturnType<typeof useSpendingEvents>);
+    } as unknown as ReturnType<typeof useEventSpendingSummaries>);
   });
 
   afterEach(() => {
@@ -87,5 +84,51 @@ describe("EventsCard", () => {
 
     expect(screen.getByText("No events in this period")).toBeInTheDocument();
     expect(screen.queryByText("Sister Wedding")).not.toBeInTheDocument();
+  });
+
+  it("shows event-reporting totals from summaries even without period activities", () => {
+    mockUseEventSpendingSummaries.mockReturnValue({
+      data: [
+        eventSummary({
+          totalSpending: 450,
+          transactionCount: 1,
+          dailySpending: { "2026-03-20": 450 },
+        }),
+      ],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useEventSpendingSummaries>);
+
+    renderEventsCard("2026-03-05T05:00:00.000Z", "2026-06-05T03:59:59.999Z");
+
+    expect(screen.getByText("Sister Wedding")).toBeInTheDocument();
+    expect(screen.getByText(/spent so far/)).toHaveTextContent("1 transaction");
+    expect(screen.queryByText("No tagged transactions yet")).not.toBeInTheDocument();
+  });
+
+  it("shows prepaid spend for an upcoming event instead of the countdown-only state", () => {
+    mockUseEventSpendingSummaries.mockReturnValue({
+      data: [
+        eventSummary({
+          eventName: "Summer Trip",
+          startDate: "2026-06-20",
+          endDate: "2026-06-25",
+          totalSpending: 450,
+          transactionCount: 1,
+          dailySpending: { "2026-06-01": 450 },
+        }),
+      ],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useEventSpendingSummaries>);
+
+    renderEventsCard("2026-06-01T04:00:00.000Z", "2026-06-30T03:59:59.999Z");
+
+    expect(screen.getByText("Summer Trip")).toBeInTheDocument();
+    expect(screen.getByText("SOON")).toBeInTheDocument();
+    expect(screen.getByText(/spent so far/)).toHaveTextContent("1 transaction");
+    expect(screen.queryByText(/planned/)).not.toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/features/spending/components/events-card.tsx
+++ b/apps/frontend/src/features/spending/components/events-card.tsx
@@ -1,25 +1,22 @@
 import { useMemo } from "react";
-import { useQueries } from "@tanstack/react-query";
 import { Link } from "react-router-dom";
 
-import { QueryKeys } from "@/lib/query-keys";
 import type { Activity } from "@/lib/types";
 import { cn, formatDateISO } from "@/lib/utils";
 import { Icons, PrivacyAmount, Skeleton } from "@wealthfolio/ui";
 
-import { getActivityAssignments } from "../adapters/cash-activities";
 import { getActivitySpendingAmount } from "../lib/constants";
-import { useSpendingEvents } from "../hooks/use-spending-events";
+import { useEventSpendingSummaries } from "../hooks/use-spending-events";
 import { themeBg, type Palette } from "../lib/theme";
 import { CategoryIcon, type CategoryMetaMap } from "./category-chips";
 import { useEventDialog } from "./event-dialog-provider";
-
-const SPENDING_TAXONOMY = "spending_categories";
 
 export function EventsCard({
   activities,
   accountTypeById,
   categoriesMeta,
+  eventSummaryEndDate,
+  eventSummaryStartDate,
   periodEndDate,
   periodStartDate,
   theme,
@@ -27,23 +24,29 @@ export function EventsCard({
   activities: Activity[];
   accountTypeById?: Map<string, string>;
   categoriesMeta: CategoryMetaMap;
+  eventSummaryEndDate: string;
+  eventSummaryStartDate: string;
   periodEndDate: string;
   periodStartDate: string;
   theme: Palette;
 }) {
+  const eventSummaryRequest = useMemo(
+    () => ({ startDate: eventSummaryStartDate, endDate: eventSummaryEndDate }),
+    [eventSummaryEndDate, eventSummaryStartDate],
+  );
   const {
-    data: events = [],
-    isLoading: eventsLoading,
-    isError: eventsErrored,
-    refetch: refetchEvents,
-  } = useSpendingEvents();
+    data: eventSummaries = [],
+    isLoading: eventSummariesLoading,
+    isError: eventSummariesErrored,
+    refetch: refetchEventSummaries,
+  } = useEventSpendingSummaries(eventSummaryRequest);
   const { openEventDialog } = useEventDialog();
 
   const pick = useMemo(() => {
     const todayKey = formatDateISO(new Date());
     const periodStartKey = periodStartDate.slice(0, 10);
     const periodEndKey = periodEndDate.slice(0, 10);
-    const periodEvents = events.filter(
+    const periodEvents = eventSummaries.filter(
       (e) => e.startDate.slice(0, 10) <= periodEndKey && e.endDate.slice(0, 10) >= periodStartKey,
     );
 
@@ -69,65 +72,37 @@ export function EventsCard({
       return { mode: "period" as const, event: recent[0] };
     }
     return null;
-  }, [events, periodEndDate, periodStartDate]);
+  }, [eventSummaries, periodEndDate, periodStartDate]);
 
   const ev = pick?.event;
   const start = ev ? new Date(ev.startDate.slice(0, 10) + "T00:00:00") : new Date();
   const end = ev ? new Date(ev.endDate.slice(0, 10) + "T00:00:00") : new Date();
   const totalDays = Math.floor((end.getTime() - start.getTime()) / (24 * 3600 * 1000)) + 1;
 
-  const eventActivities = useMemo(
-    () =>
-      ev
-        ? activities.filter(
-            (a) =>
-              (a as { eventId?: string | null }).eventId === ev.id &&
-              getActivitySpendingAmount(a, accountTypeById?.get(a.accountId)) !== 0,
-          )
-        : [],
-    [accountTypeById, activities, ev],
-  );
-  const eventSpent = Math.max(
-    0,
-    eventActivities.reduce(
-      (s, a) => s + getActivitySpendingAmount(a, accountTypeById?.get(a.accountId)),
-      0,
-    ),
-  );
-  const currency = eventActivities[0]?.currency ?? "USD";
-
-  const assignmentQueries = useQueries({
-    queries: eventActivities.map((a) => ({
-      queryKey: [QueryKeys.SPENDING_TRANSACTIONS, "assignments", a.id],
-      queryFn: () => getActivityAssignments(a.id),
-      staleTime: 30_000,
-    })),
-  });
+  const eventSpent = Math.max(0, ev?.totalSpending ?? 0);
+  const currency = ev?.currency ?? "USD";
 
   const topCategories = useMemo(() => {
     const totals = new Map<
       string,
       { name: string; color: string | null; icon: string | null; amount: number }
     >();
-    eventActivities.forEach((a, i) => {
-      const assignments = assignmentQueries[i]?.data ?? [];
-      const spending = assignments.find((x) => x.taxonomyId === SPENDING_TAXONOMY);
-      const amount = getActivitySpendingAmount(a, accountTypeById?.get(a.accountId));
-      const meta = spending ? categoriesMeta.get(spending.categoryId) : undefined;
-      const topId = meta?.parentId ?? spending?.categoryId ?? "__unc__";
+    Object.values(ev?.byCategory ?? {}).forEach((category) => {
+      const meta = category.categoryId ? categoriesMeta.get(category.categoryId) : undefined;
+      const topId = meta?.parentId ?? category.categoryId ?? "__unc__";
       const top = categoriesMeta.get(topId) ?? meta;
-      const name = top?.name ?? "Uncategorized";
-      const color = top?.color ?? null;
+      const name = top?.name ?? category.categoryName ?? "Uncategorized";
+      const color = top?.color ?? category.color ?? null;
       const icon = meta?.icon ?? top?.icon ?? null;
       const e = totals.get(topId) ?? { name, color, icon, amount: 0 };
-      e.amount += amount;
+      e.amount += category.amount;
       totals.set(topId, e);
     });
     return Array.from(totals.values())
       .filter((row) => row.amount > 0)
       .sort((a, b) => b.amount - a.amount)
       .slice(0, 2);
-  }, [accountTypeById, eventActivities, assignmentQueries, categoriesMeta]);
+  }, [categoriesMeta, ev]);
 
   const baselineDailyAvg = useMemo(() => {
     if (!ev) return 0;
@@ -153,13 +128,13 @@ export function EventsCard({
   // Surface query errors instead of silently rendering nothing — mirrors the
   // pattern in spending-insights-page after commit de0d4d89. Without this,
   // a server outage looks identical to "user has no events".
-  if (eventsErrored) {
+  if (eventSummariesErrored) {
     return (
       <div className="border-border/40 bg-card/70 rounded-xl border p-4 text-center text-xs backdrop-blur-xl md:p-5">
         <div className="text-muted-foreground">Couldn't load events.</div>
         <button
           type="button"
-          onClick={() => void refetchEvents()}
+          onClick={() => void refetchEventSummaries()}
           className="text-foreground mt-2 inline-flex items-center gap-1 text-xs underline-offset-4 hover:underline"
         >
           Retry
@@ -168,7 +143,7 @@ export function EventsCard({
     );
   }
 
-  if (eventsLoading) {
+  if (eventSummariesLoading) {
     return (
       <div className="border-border/40 bg-card/70 rounded-xl border p-4 backdrop-blur-xl md:p-5">
         <div className="flex items-center gap-2">
@@ -187,24 +162,18 @@ export function EventsCard({
   }
 
   if (!pick) {
-    const hasEvents = events.length > 0;
-
     return (
       <div className="border-border/40 bg-card/70 rounded-xl border p-4 backdrop-blur-xl md:p-5">
         <div className="flex items-center gap-2">
           <Icons.Calendar className="h-4 w-4 shrink-0" style={{ color: theme.deep }} />
           <div className="min-w-0 flex-1">
             <div className="text-foreground text-sm font-semibold">Events</div>
-            <div className="text-muted-foreground/70 text-[11px]">
-              {hasEvents ? "No events in this period" : "No events yet"}
-            </div>
+            <div className="text-muted-foreground/70 text-[11px]">No events in this period</div>
           </div>
         </div>
 
         <div className="text-muted-foreground/80 mt-3 text-xs leading-snug">
-          {hasEvents
-            ? "Create an event for the next trip, move, or spending period."
-            : "Create an event to track spending around trips, moves, or one-off periods."}
+          Create an event to track spending around trips, moves, or one-off periods.
         </div>
 
         <button
@@ -259,6 +228,8 @@ export function EventsCard({
     subLine = `Day ${dayInto} of ${totalDays} · ${daysLeft} ${daysLeft === 1 ? "day" : "days"} left`;
   } else if (pick.mode === "recent") {
     subLine = `Wrapped ${pick.days} ${pick.days === 1 ? "day" : "days"} ago`;
+  } else if (pick.mode === "upcoming") {
+    subLine = `${pick.days} ${pick.days === 1 ? "day" : "days"} until start`;
   } else if (pick.mode === "period") {
     subLine = `${totalDays} ${totalDays === 1 ? "day" : "days"} in selected period`;
   }
@@ -268,7 +239,7 @@ export function EventsCard({
       <div className="flex items-center gap-2">
         <HeaderIcon className="h-4 w-4 shrink-0" style={{ color: theme.deep }} />
         <div className="min-w-0 flex-1">
-          <div className="text-foreground truncate text-sm font-semibold">{ev!.name}</div>
+          <div className="text-foreground truncate text-sm font-semibold">{ev!.eventName}</div>
           <div className="text-muted-foreground/70 text-[11px]">{dateRangeLabel}</div>
         </div>
         <span
@@ -279,13 +250,13 @@ export function EventsCard({
         </span>
       </div>
 
-      {pick.mode === "upcoming" ? (
+      {pick.mode === "upcoming" && eventSpent <= 0 ? (
         <div className="mt-3">
           <div className="text-foreground text-2xl font-bold tabular-nums tracking-tight">
             {pick.days} {pick.days === 1 ? "day" : "days"}
           </div>
           <div className="text-muted-foreground/80 text-xs">
-            until {ev!.name} · {totalDays} {totalDays === 1 ? "day" : "days"} planned
+            until {ev!.eventName} · {totalDays} {totalDays === 1 ? "day" : "days"} planned
           </div>
         </div>
       ) : eventSpent > 0 ? (
@@ -295,8 +266,8 @@ export function EventsCard({
               <PrivacyAmount value={eventSpent} currency={currency} />
             </div>
             <div className="text-muted-foreground/80 text-xs">
-              {pick.mode === "recent" ? "total" : "spent so far"} · {eventActivities.length}{" "}
-              {eventActivities.length === 1 ? "transaction" : "transactions"}
+              {pick.mode === "recent" ? "total" : "spent so far"} · {ev!.transactionCount}{" "}
+              {ev!.transactionCount === 1 ? "transaction" : "transactions"}
               {subLine && (
                 <>
                   {" · "}
@@ -339,7 +310,7 @@ export function EventsCard({
         </div>
       )}
 
-      {pick.mode !== "upcoming" && topCategories.length > 0 && (
+      {eventSpent > 0 && topCategories.length > 0 && (
         <div className="mt-3 flex flex-wrap items-center gap-2">
           <span className="text-muted-foreground/60 text-[10px] font-semibold uppercase tracking-wide">
             Top
@@ -366,7 +337,7 @@ export function EventsCard({
         </div>
       )}
 
-      {pick.mode === "upcoming" ? (
+      {pick.mode === "upcoming" && eventSpent <= 0 ? (
         <button
           type="button"
           onClick={() => {

--- a/apps/frontend/src/features/spending/components/spending-period-toggle.tsx
+++ b/apps/frontend/src/features/spending/components/spending-period-toggle.tsx
@@ -1,6 +1,6 @@
 /**
  * Canonical period toggle for spending surfaces that need named comparison
- * periods (This month / 30D / 3M / 6M / YTD / 1Y). Used by the Insights page
+ * periods (This month / Last month / 3M / 6M / YTD / 1Y). Used by the Insights page
  * and any future page that compares period-over-period totals.
  *
  * Why this exists: prior to this primitive each surface inlined its own
@@ -11,14 +11,29 @@
  * - The Budget page (uses `MonthSwitcher` — budgets are inherently
  *   per-month with rollover, no useful "1Y" view).
  *
- * If we ever want cross-page period sync (e.g. picking 3M on the dashboard
- * propagating to insights), expose a `usePersistentSpendingPeriod` hook that
- * wraps a shared storage key. For now each surface owns its own key.
+ * Dashboard links use shared period-preference keys so the most recent explicit
+ * dashboard or insights period selection wins when moving between surfaces.
  */
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 
-import { AnimatedToggleGroup } from "@wealthfolio/ui";
+import { cn } from "@/lib/utils";
 
+import {
+  AnimatedToggleGroup,
+  Icons,
+  MonthYearPicker,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+  useIsMobile,
+} from "@wealthfolio/ui";
+
+import { compactMonthLabel } from "../lib/month-period";
 import { REPORTS_PERIODS, type ReportsPeriod } from "../lib/reports-period";
 
 export const SPENDING_PERIOD_LABELS: Record<ReportsPeriod, ReactNode> = {
@@ -28,7 +43,12 @@ export const SPENDING_PERIOD_LABELS: Record<ReportsPeriod, ReactNode> = {
       <span className="sm:hidden">MTD</span>
     </>
   ),
-  "30D": "30D",
+  LAST_MONTH: (
+    <>
+      <span className="hidden sm:inline">Last month</span>
+      <span className="sm:hidden">Prev</span>
+    </>
+  ),
   "3M": "3M",
   "6M": "6M",
   YTD: "YTD",
@@ -41,7 +61,8 @@ interface SpendingPeriodToggleProps {
   /** Visual variant on `AnimatedToggleGroup`. Default mirrors prior call sites. */
   variant?: "default" | "secondary";
   /** Size pass-through. Default "xs" matches the prior insights placement. */
-  size?: "xs" | "sm" | "md";
+  size?: "compact" | "xs" | "sm" | "md";
+  className?: string;
 }
 
 export function SpendingPeriodToggle({
@@ -49,6 +70,7 @@ export function SpendingPeriodToggle({
   onValueChange,
   variant = "secondary",
   size = "xs",
+  className,
 }: SpendingPeriodToggleProps) {
   return (
     <AnimatedToggleGroup
@@ -57,6 +79,146 @@ export function SpendingPeriodToggle({
       items={REPORTS_PERIODS.map((p) => ({ value: p, label: SPENDING_PERIOD_LABELS[p] }))}
       value={value}
       onValueChange={onValueChange}
+      className={className}
     />
+  );
+}
+
+interface SpendingPeriodSelectorProps {
+  value: ReportsPeriod | null;
+  onValueChange: (next: ReportsPeriod) => void;
+  customMonth: string | null;
+  maxMonth: string;
+  onCustomMonthChange: (monthKey: string | null) => void;
+  isLoading?: boolean;
+  className?: string;
+}
+
+export function SpendingPeriodSelector({
+  value,
+  onValueChange,
+  customMonth,
+  maxMonth,
+  onCustomMonthChange,
+  isLoading,
+  className,
+}: SpendingPeriodSelectorProps) {
+  const isMobile = useIsMobile();
+
+  return (
+    <div
+      className={cn("pointer-events-none relative w-full min-w-0 max-w-full overflow-hidden", className)}
+      aria-busy={isLoading ? "true" : undefined}
+    >
+      <div
+        className={cn(
+          "pointer-events-none relative z-30 flex w-full justify-start overflow-x-auto overflow-y-hidden sm:justify-center",
+          "touch-pan-x snap-x snap-mandatory overscroll-x-contain scroll-smooth",
+          "px-2 md:px-0",
+          "[&::-webkit-scrollbar]:hidden",
+          "[scrollbar-width:none]",
+          "[-webkit-overflow-scrolling:touch]",
+        )}
+      >
+        <div className="pointer-events-auto flex shrink-0 items-center gap-1.5">
+          <SpendingPeriodToggle
+            value={value}
+            onValueChange={onValueChange}
+            size={isMobile ? "compact" : "sm"}
+            variant="default"
+            className="bg-transparent"
+          />
+          <MonthPickerButton
+            value={customMonth}
+            defaultViewMonth={maxMonth}
+            maxDate={maxMonth}
+            onSelect={onCustomMonthChange}
+            onClear={customMonth ? () => onCustomMonthChange(null) : undefined}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MonthPickerButton({
+  value,
+  defaultViewMonth,
+  maxDate,
+  onSelect,
+  onClear,
+}: {
+  value: string | null;
+  defaultViewMonth: string;
+  maxDate: string;
+  onSelect: (monthKey: string) => void;
+  onClear?: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const isMobile = useIsMobile();
+  const label = value ? compactMonthLabel(value) : null;
+  const trigger = (
+    <button
+      type="button"
+      className={cn(
+        "flex h-8 items-center justify-center rounded-full transition-colors",
+        label
+          ? "bg-background/80 border-border/60 gap-1 border px-2.5 text-xs font-medium"
+          : "bg-muted text-foreground/90 hover:text-foreground w-8",
+      )}
+      aria-label={label ? `Viewing ${label}, click to change` : "Pick a specific month"}
+    >
+      {label ? <span>{label}</span> : <Icons.Calendar className="h-3.5 w-3.5" />}
+    </button>
+  );
+  const picker = (
+    <MonthYearPicker
+      value={value ?? defaultViewMonth}
+      maxDate={maxDate}
+      className={
+        isMobile
+          ? "w-full max-w-none p-0 [&>div:first-child]:mb-5 [&>div:first-child_button]:h-11 [&>div:first-child_button]:w-11 [&_.grid]:gap-3 [&_.grid_button]:h-12 [&_.grid_button]:text-base"
+          : undefined
+      }
+      onChange={(monthKey) => {
+        onSelect(monthKey);
+        setOpen(false);
+      }}
+    />
+  );
+
+  return (
+    <div className="flex items-center gap-1">
+      {isMobile ? (
+        <Sheet open={open} onOpenChange={setOpen}>
+          <SheetTrigger asChild>{trigger}</SheetTrigger>
+          <SheetContent side="bottom" className="rounded-t-4xl mx-1 p-0">
+            <SheetHeader className="border-border border-b px-6 py-4">
+              <SheetTitle>Select month</SheetTitle>
+            </SheetHeader>
+            <div className="px-5 py-5 pb-[calc(env(safe-area-inset-bottom,0px)+1.25rem)]">
+              {picker}
+            </div>
+          </SheetContent>
+        </Sheet>
+      ) : (
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+          <PopoverContent className="w-auto p-0" align="center">
+            {picker}
+          </PopoverContent>
+        </Popover>
+      )}
+      {label && onClear && (
+        <button
+          type="button"
+          onClick={onClear}
+          className="text-muted-foreground hover:text-foreground flex h-5 w-5 items-center justify-center rounded-full text-base leading-none transition-colors"
+          aria-label="Clear month selection"
+        >
+          ×
+        </button>
+      )}
+    </div>
   );
 }

--- a/apps/frontend/src/features/spending/components/spending-period-toggle.tsx
+++ b/apps/frontend/src/features/spending/components/spending-period-toggle.tsx
@@ -107,7 +107,10 @@ export function SpendingPeriodSelector({
 
   return (
     <div
-      className={cn("pointer-events-none relative w-full min-w-0 max-w-full overflow-hidden", className)}
+      className={cn(
+        "pointer-events-none relative w-full min-w-0 max-w-full overflow-hidden",
+        className,
+      )}
       aria-busy={isLoading ? "true" : undefined}
     >
       <div

--- a/apps/frontend/src/features/spending/components/spending-tab-content.tsx
+++ b/apps/frontend/src/features/spending/components/spending-tab-content.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type FC, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, useState, type FC } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import {
   Bar,
@@ -21,21 +21,10 @@ import { cn, formatAmount, formatDateISO } from "@/lib/utils";
 import Balance from "@/pages/dashboard/balance";
 
 import {
-  AnimatedToggleGroup,
   Icons,
-  MonthYearPicker,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
   PrivacyAmount,
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
   Skeleton,
   formatCompactAmount,
-  useIsMobile,
   usePersistentState,
 } from "@wealthfolio/ui";
 
@@ -45,6 +34,24 @@ import { useCashActivities, useUncategorizedCount } from "../hooks/use-cash-acti
 import { useSpendingReport } from "../hooks/use-spending-report";
 import { useSpendingSettings } from "../hooks/use-spending-settings";
 import { topCategoryId } from "../lib/category-rollup";
+import {
+  SPENDING_MONTH_PARAM,
+  SPENDING_MONTH_STORAGE_KEY,
+  addMonthsToMonthKey,
+  localDateFromParts,
+  monthKeyFromParts,
+  monthLabel,
+  monthRange,
+  parseMonthKey,
+} from "../lib/month-period";
+import {
+  DASHBOARD_PERIOD_UPDATED_AT_STORAGE_KEY,
+  INSIGHTS_PERIOD_STORAGE_KEY,
+  INSIGHTS_PERIOD_UPDATED_AT_STORAGE_KEY,
+  normalizeReportsPeriod,
+  periodPreferenceTimestamp,
+  shouldPreferDashboardPeriod,
+} from "../lib/period-preferences";
 import type { ReportsPeriod } from "../lib/reports-period";
 import { FOREST_THEME, themeBg, type Palette } from "../lib/theme";
 import {
@@ -57,32 +64,22 @@ import {
   localDateBoundaryToISOString,
   localDateParts,
   zonedCalendarDateBoundaryToDate,
-  type ZonedCalendarDate,
 } from "../lib/timezone";
 import { BudgetLineChartCard } from "./budget-line-chart-card";
 import { CashFlowStrip } from "./cash-flow-strip";
 import { EventsCard } from "./events-card";
 import { RecentActivityCard } from "./recent-activity-card";
+import { SpendingPeriodSelector } from "./spending-period-toggle";
 
 const FUTURE_BAR = "#E5E7EB";
 const SPENDING_TAXONOMY = "spending_categories";
-type SpendingDashboardPeriod = "MTD" | "LAST_MONTH" | "30D" | "3M" | "6M" | "YTD" | "1Y";
+type SpendingDashboardPeriod = "MTD" | "LAST_MONTH" | "3M" | "6M" | "YTD" | "1Y";
 
 type SpendingSelection =
   | { kind: "period"; code: SpendingDashboardPeriod }
   | { kind: "month"; monthKey: string; restoreCode: SpendingDashboardPeriod };
 
 const SPENDING_DASHBOARD_PERIODS: SpendingDashboardPeriod[] = [
-  "MTD",
-  "LAST_MONTH",
-  "30D",
-  "3M",
-  "6M",
-  "YTD",
-  "1Y",
-];
-
-const VISIBLE_SPENDING_DASHBOARD_PERIODS: SpendingDashboardPeriod[] = [
   "MTD",
   "LAST_MONTH",
   "3M",
@@ -93,35 +90,13 @@ const VISIBLE_SPENDING_DASHBOARD_PERIODS: SpendingDashboardPeriod[] = [
 
 const DEFAULT_INTERVAL: SpendingDashboardPeriod = "MTD";
 const INTERVAL_STORAGE_KEY = "spending-interval";
-const MONTH_STORAGE_KEY = "spending-month";
-const MONTH_PARAM = "spendingMonth";
 const INTERVAL_DESCRIPTIONS: Record<SpendingDashboardPeriod, string> = {
   MTD: "this month",
   LAST_MONTH: "last month",
-  "30D": "past 30 days",
   "3M": "past 3 months",
   "6M": "past 6 months",
   YTD: "year to date",
   "1Y": "past year",
-};
-const SPENDING_DASHBOARD_PERIOD_LABELS: Record<SpendingDashboardPeriod, ReactNode> = {
-  MTD: (
-    <>
-      <span className="hidden sm:inline">This month</span>
-      <span className="sm:hidden">MTD</span>
-    </>
-  ),
-  LAST_MONTH: (
-    <>
-      <span className="hidden sm:inline">Last month</span>
-      <span className="sm:hidden">Prev</span>
-    </>
-  ),
-  "30D": "30D",
-  "3M": "3M",
-  "6M": "6M",
-  YTD: "YTD",
-  "1Y": "1Y",
 };
 
 // The three insights stages, surfaced as a "Dig deeper" strip under Recent
@@ -156,56 +131,6 @@ function rangeToReportRequest(range: DateRange | undefined, timezone?: string | 
   };
 }
 
-function localDateFromParts(date: ZonedCalendarDate): Date {
-  return new Date(date.year, date.month - 1, date.day);
-}
-
-function monthKeyFromParts(date: Pick<ZonedCalendarDate, "year" | "month">): string {
-  return `${date.year}-${String(date.month).padStart(2, "0")}`;
-}
-
-function parseMonthKey(value: string | null | undefined): { year: number; month: number } | null {
-  if (!value || !/^\d{4}-(0[1-9]|1[0-2])$/.test(value)) return null;
-  const [year, month] = value.split("-").map(Number);
-  return { year, month };
-}
-
-function currentMonthKey(timezone?: string | null): string {
-  return monthKeyFromParts(getZonedDateParts(new Date(), timezone));
-}
-
-function addMonthsToMonthKey(monthKey: string, months: number): string {
-  const parts = parseMonthKey(monthKey);
-  if (!parts) return monthKey;
-  return monthKeyFromParts(addCalendarMonths({ ...parts, day: 1 }, months));
-}
-
-function monthRange(monthKey: string): DateRange {
-  const parts = parseMonthKey(monthKey) ?? parseMonthKey(currentMonthKey());
-  const month = parts ?? getZonedDateParts(new Date());
-  const start = { ...month, day: 1 };
-  const end = { ...month, day: daysInCalendarMonth(month.year, month.month) };
-  return { from: localDateFromParts(start), to: localDateFromParts(end) };
-}
-
-function monthLabel(monthKey: string, format: "long" | "short" = "long"): string {
-  const parts = parseMonthKey(monthKey);
-  if (!parts) return "";
-  return new Date(parts.year, parts.month - 1, 1).toLocaleString(undefined, {
-    month: format,
-    year: "numeric",
-  });
-}
-
-function compactMonthLabel(monthKey: string): string {
-  const parts = parseMonthKey(monthKey);
-  if (!parts) return "";
-  const month = new Date(parts.year, parts.month - 1, 1).toLocaleString(undefined, {
-    month: "short",
-  });
-  return `${month} '${String(parts.year).slice(2)}`;
-}
-
 function isSpendingDashboardPeriod(
   value: string | null | undefined,
 ): value is SpendingDashboardPeriod {
@@ -216,7 +141,6 @@ function normalizeSpendingDashboardPeriod(
   value: string | null | undefined,
 ): SpendingDashboardPeriod {
   if (isSpendingDashboardPeriod(value)) return value;
-  if (value === "1M") return "30D";
   if (value === "5Y" || value === "ALL") return "1Y";
   return DEFAULT_INTERVAL;
 }
@@ -238,8 +162,6 @@ function spendingIntervalData(code: SpendingDashboardPeriod, timezone?: string |
           },
         };
       }
-      case "30D":
-        return { start: addCalendarDays(today, -29), end: today };
       case "3M":
         return { start: addCalendarMonths(today, -3), end: today };
       case "6M":
@@ -262,7 +184,7 @@ function spendingIntervalData(code: SpendingDashboardPeriod, timezone?: string |
 }
 
 function insightPeriodForDashboardInterval(code: SpendingDashboardPeriod): ReportsPeriod {
-  if (code === "LAST_MONTH") return "MTD";
+  if (code === "LAST_MONTH") return "LAST_MONTH";
   return code;
 }
 
@@ -272,7 +194,7 @@ function selectionFromParams(
   persistedMonth: string | null,
 ): SpendingSelection {
   const intervalParam = params.get("spendingInterval");
-  const monthParam = params.get(MONTH_PARAM);
+  const monthParam = params.get(SPENDING_MONTH_PARAM);
   const restoreCode = normalizeSpendingDashboardPeriod(intervalParam ?? persistedInterval);
   const monthKey = monthParam ?? (intervalParam === null ? persistedMonth : null);
   if (monthKey && parseMonthKey(monthKey)) return { kind: "month", monthKey, restoreCode };
@@ -303,7 +225,7 @@ function selectionData(selection: SpendingSelection, timezone?: string | null) {
     return {
       range: monthRange(selection.monthKey),
       description: monthLabel(selection.monthKey),
-      insightPeriod: "MTD" as ReportsPeriod,
+      insightPeriod: "LAST_MONTH" as ReportsPeriod,
     };
   }
 
@@ -325,69 +247,6 @@ function previousFullMonthRange(range: DateRange): DateRange | undefined {
 function usesCalendarMonthComparison(selection: SpendingSelection) {
   return (
     selection.kind === "month" || (selection.kind === "period" && selection.code === "LAST_MONTH")
-  );
-}
-
-interface SpendingDashboardPeriodSelectorProps {
-  value: SpendingDashboardPeriod | null;
-  onValueChange: (next: SpendingDashboardPeriod) => void;
-  customMonth: string | null;
-  maxMonth: string;
-  onCustomMonthChange: (monthKey: string | null) => void;
-  isLoading?: boolean;
-  className?: string;
-}
-
-function SpendingDashboardPeriodSelector({
-  value,
-  onValueChange,
-  customMonth,
-  maxMonth,
-  onCustomMonthChange,
-  isLoading,
-  className,
-}: SpendingDashboardPeriodSelectorProps) {
-  const isMobile = useIsMobile();
-  const items = VISIBLE_SPENDING_DASHBOARD_PERIODS.map((period) => ({
-    value: period,
-    label: SPENDING_DASHBOARD_PERIOD_LABELS[period],
-    title: INTERVAL_DESCRIPTIONS[period],
-  }));
-
-  return (
-    <div
-      className={cn("pointer-events-none relative w-full min-w-0", className)}
-      aria-busy={isLoading ? "true" : undefined}
-    >
-      <div
-        className={cn(
-          "pointer-events-none relative z-30 flex w-full justify-center overflow-x-auto overflow-y-hidden",
-          "touch-pan-x snap-x snap-mandatory overscroll-x-contain scroll-smooth",
-          "px-2 md:px-0",
-          "[&::-webkit-scrollbar]:hidden",
-          "[scrollbar-width:none]",
-          "[-webkit-overflow-scrolling:touch]",
-        )}
-      >
-        <div className="pointer-events-auto flex items-center gap-1.5">
-          <AnimatedToggleGroup
-            items={items}
-            value={value}
-            onValueChange={onValueChange}
-            size={isMobile ? "compact" : "sm"}
-            variant="default"
-            className="bg-transparent"
-          />
-          <MonthPickerButton
-            value={customMonth}
-            defaultViewMonth={maxMonth}
-            maxDate={maxMonth}
-            onSelect={onCustomMonthChange}
-            onClear={customMonth ? () => onCustomMonthChange(null) : undefined}
-          />
-        </div>
-      </div>
-    </div>
   );
 }
 
@@ -451,8 +310,20 @@ export default function SpendingTabContent() {
     DEFAULT_INTERVAL,
   );
   const [persistedMonth, setPersistedMonth] = usePersistentState<string | null>(
-    MONTH_STORAGE_KEY,
+    SPENDING_MONTH_STORAGE_KEY,
     null,
+  );
+  const [persistedInsightPeriod] = usePersistentState<string | null>(
+    INSIGHTS_PERIOD_STORAGE_KEY,
+    null,
+  );
+  const [insightPeriodUpdatedAt] = usePersistentState<string>(
+    INSIGHTS_PERIOD_UPDATED_AT_STORAGE_KEY,
+    "0",
+  );
+  const [dashboardPeriodUpdatedAt, setDashboardPeriodUpdatedAt] = usePersistentState<string>(
+    DASHBOARD_PERIOD_UPDATED_AT_STORAGE_KEY,
+    "0",
   );
   const selection = useMemo(
     () => selectionFromParams(searchParams, persistedInterval, persistedMonth),
@@ -613,12 +484,20 @@ export default function SpendingTabContent() {
   // accounts. Single-currency users see the same number either way.
   const currency = baseCurrency;
   const dashboardInsightHref = useMemo(() => {
-    const rangeParams =
-      dateRange?.from && dateRange?.to
-        ? `&from=${formatDateISO(dateRange.from)}&to=${formatDateISO(dateRange.to)}`
+    const preferDashboardPeriod = shouldPreferDashboardPeriod({
+      persistedInsightPeriod,
+      dashboardUpdatedAt: dashboardPeriodUpdatedAt,
+      insightUpdatedAt: insightPeriodUpdatedAt,
+    });
+    const linkPeriod = preferDashboardPeriod
+      ? insightPeriod
+      : (normalizeReportsPeriod(persistedInsightPeriod) ?? insightPeriod);
+    const monthParams =
+      preferDashboardPeriod && selection.kind === "month"
+        ? `&${SPENDING_MONTH_PARAM}=${selection.monthKey}`
         : "";
     const href = (stage: (typeof INSIGHT_STAGES)[number]["stage"], hash = "") =>
-      `/spending/insights?stage=${stage}&period=${insightPeriod}${rangeParams}${hash}`;
+      `/spending/insights?stage=${stage}&period=${linkPeriod}${monthParams}${hash}`;
     const cashflow = href("where", "#cashflow");
     return {
       where: href("where"),
@@ -626,7 +505,13 @@ export default function SpendingTabContent() {
       when: href("when"),
       cashflow,
     };
-  }, [insightPeriod, dateRange]);
+  }, [
+    dashboardPeriodUpdatedAt,
+    insightPeriod,
+    insightPeriodUpdatedAt,
+    persistedInsightPeriod,
+    selection,
+  ]);
   const accountTypeById = useMemo(
     () => new Map(accounts.map((account) => [account.id, account.accountType])),
     [accounts],
@@ -652,11 +537,12 @@ export default function SpendingTabContent() {
   const handleIntervalSelect = (code: SpendingDashboardPeriod) => {
     setPersistedInterval(code);
     setPersistedMonth(null);
+    setDashboardPeriodUpdatedAt(periodPreferenceTimestamp());
     setSearchParams(
       (prev) => {
         const p = new URLSearchParams(prev);
         p.set("spendingInterval", code);
-        p.delete(MONTH_PARAM);
+        p.delete(SPENDING_MONTH_PARAM);
         return p;
       },
       { replace: true },
@@ -672,15 +558,16 @@ export default function SpendingTabContent() {
 
   const handleCustomMonthSelect = (monthKey: string | null) => {
     setPersistedMonth(monthKey);
+    setDashboardPeriodUpdatedAt(periodPreferenceTimestamp());
     setSearchParams(
       (prev) => {
         const p = new URLSearchParams(prev);
         if (monthKey) {
           p.set("spendingInterval", restoreCode);
-          p.set(MONTH_PARAM, monthKey);
+          p.set(SPENDING_MONTH_PARAM, monthKey);
         } else {
           p.set("spendingInterval", restoreCode);
-          p.delete(MONTH_PARAM);
+          p.delete(SPENDING_MONTH_PARAM);
         }
         return p;
       },
@@ -700,7 +587,6 @@ export default function SpendingTabContent() {
     switch (selection.code) {
       case "MTD":
       case "LAST_MONTH":
-      case "30D":
         return "day";
       case "3M":
       case "6M":
@@ -1109,7 +995,7 @@ export default function SpendingTabContent() {
             </ResponsiveContainer>
           )}
           <div className="flex w-full justify-center">
-            <SpendingDashboardPeriodSelector
+            <SpendingPeriodSelector
               className="pointer-events-auto relative z-20 w-full max-w-screen-sm sm:max-w-screen-md md:max-w-2xl lg:max-w-3xl"
               value={selectedPeriod}
               onValueChange={handleIntervalSelect}
@@ -1287,88 +1173,6 @@ export default function SpendingTabContent() {
 }
 
 // ─── small inline components ──────────────────────────────────────────────
-
-function MonthPickerButton({
-  value,
-  defaultViewMonth,
-  maxDate,
-  onSelect,
-  onClear,
-}: {
-  value: string | null;
-  defaultViewMonth: string;
-  maxDate: string;
-  onSelect: (monthKey: string) => void;
-  onClear?: () => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const isMobile = useIsMobile();
-  const label = value ? compactMonthLabel(value) : null;
-  const trigger = (
-    <button
-      type="button"
-      className={cn(
-        "flex h-8 items-center justify-center rounded-full transition-colors",
-        label
-          ? "bg-background/80 border-border/60 gap-1 border px-2.5 text-xs font-medium"
-          : "bg-muted text-foreground/90 hover:text-foreground w-8",
-      )}
-      aria-label={label ? `Viewing ${label}, click to change` : "Pick a specific month"}
-    >
-      {label ? <span>{label}</span> : <Icons.Calendar className="h-3.5 w-3.5" />}
-    </button>
-  );
-  const picker = (
-    <MonthYearPicker
-      value={value ?? defaultViewMonth}
-      maxDate={maxDate}
-      className={
-        isMobile
-          ? "w-full max-w-none p-0 [&>div:first-child]:mb-5 [&>div:first-child_button]:h-11 [&>div:first-child_button]:w-11 [&_.grid]:gap-3 [&_.grid_button]:h-12 [&_.grid_button]:text-base"
-          : undefined
-      }
-      onChange={(monthKey) => {
-        onSelect(monthKey);
-        setOpen(false);
-      }}
-    />
-  );
-
-  return (
-    <div className="flex items-center gap-1">
-      {isMobile ? (
-        <Sheet open={open} onOpenChange={setOpen}>
-          <SheetTrigger asChild>{trigger}</SheetTrigger>
-          <SheetContent side="bottom" className="rounded-t-4xl mx-1 p-0">
-            <SheetHeader className="border-border border-b px-6 py-4">
-              <SheetTitle>Select month</SheetTitle>
-            </SheetHeader>
-            <div className="px-5 py-5 pb-[calc(env(safe-area-inset-bottom,0px)+1.25rem)]">
-              {picker}
-            </div>
-          </SheetContent>
-        </Sheet>
-      ) : (
-        <Popover open={open} onOpenChange={setOpen}>
-          <PopoverTrigger asChild>{trigger}</PopoverTrigger>
-          <PopoverContent className="w-auto p-0" align="center">
-            {picker}
-          </PopoverContent>
-        </Popover>
-      )}
-      {label && onClear && (
-        <button
-          type="button"
-          onClick={onClear}
-          className="text-muted-foreground hover:text-foreground flex h-5 w-5 items-center justify-center rounded-full text-base leading-none transition-colors"
-          aria-label="Clear month selection"
-        >
-          ×
-        </button>
-      )}
-    </div>
-  );
-}
 
 function SegmentedToggle({
   items,

--- a/apps/frontend/src/features/spending/components/spending-tab-content.tsx
+++ b/apps/frontend/src/features/spending/components/spending-tab-content.tsx
@@ -1157,6 +1157,8 @@ export default function SpendingTabContent() {
                   activities={activities}
                   accountTypeById={accountTypeById}
                   categoriesMeta={categoriesMeta}
+                  eventSummaryEndDate={reportReq.endDate}
+                  eventSummaryStartDate={reportReq.startDate}
                   periodEndDate={dateRange?.to ? formatDateISO(dateRange.to) : reportReq.endDate}
                   periodStartDate={
                     dateRange?.from ? formatDateISO(dateRange.from) : reportReq.startDate

--- a/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
+++ b/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
@@ -37,6 +37,7 @@ import {
 
 import { CashActivityForm } from "./cash-activity-form";
 import { ActivityForm } from "@/pages/activity/components/activity-form";
+import { MobileActivityForm } from "@/pages/activity/components/mobile-forms/mobile-activity-form";
 import { TransferMatchDialog } from "@/pages/activity/components/transfer-match-dialog";
 import { getActivityRestrictionLevel } from "@/lib/activity-restrictions";
 import { ActivityType } from "@/lib/constants";
@@ -960,16 +961,26 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
           onTransferClick={handleTransferClick}
         />
 
-        {showTransferForm && (
-          <ActivityForm
-            accounts={transferFormAccounts}
-            transferAccounts={transferFormAccounts}
-            activity={transferFormActivity}
-            open={showTransferForm}
-            onClose={handleTransferFormClose}
-            hidePicker
-          />
-        )}
+        {showTransferForm &&
+          (isMobile ? (
+            <MobileActivityForm
+              accounts={transferFormAccounts}
+              transferAccounts={transferFormAccounts}
+              activity={transferFormActivity}
+              open={showTransferForm}
+              onClose={handleTransferFormClose}
+              startOnDetails
+            />
+          ) : (
+            <ActivityForm
+              accounts={transferFormAccounts}
+              transferAccounts={transferFormAccounts}
+              activity={transferFormActivity}
+              open={showTransferForm}
+              onClose={handleTransferFormClose}
+              hidePicker
+            />
+          ))}
 
         <DeleteTransactionsDialog
           open={!!deletingIds && deletingIds.length > 0}

--- a/apps/frontend/src/features/spending/hooks/use-spending-events.ts
+++ b/apps/frontend/src/features/spending/hooks/use-spending-events.ts
@@ -48,6 +48,7 @@ export function useEventSpendingSummaries(request: { startDate: string; endDate:
   return useQuery<EventSpendingSummary[], Error>({
     queryKey: [QueryKeys.SPENDING_EVENTS, "summaries", request],
     queryFn: () => getEventSpendingSummaries(request),
+    staleTime: STALE_TIME,
   });
 }
 

--- a/apps/frontend/src/features/spending/lib/month-period.test.ts
+++ b/apps/frontend/src/features/spending/lib/month-period.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  addMonthsToMonthKey,
+  currentMonthKey,
+  monthReportsRange,
+  parseMonthKey,
+} from "./month-period";
+
+describe("spending month periods", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("parses and shifts valid month keys", () => {
+    expect(parseMonthKey("2026-05")).toEqual({ year: 2026, month: 5 });
+    expect(parseMonthKey("2026-13")).toBeNull();
+    expect(addMonthsToMonthKey("2026-01", -1)).toBe("2025-12");
+  });
+
+  it("resolves a month key to a full calendar month report range", () => {
+    const range = monthReportsRange("2026-05", "UTC");
+
+    expect(range?.start.toISOString()).toBe("2026-05-01T00:00:00.000Z");
+    expect(range?.end.toISOString()).toBe("2026-05-31T23:59:59.999Z");
+    expect(range?.days).toBe(31);
+    expect(range?.months).toBe(1);
+  });
+
+  it("reads the current month in the requested timezone", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-01T03:00:00.000Z"));
+
+    expect(currentMonthKey("America/Toronto")).toBe("2026-05");
+  });
+});

--- a/apps/frontend/src/features/spending/lib/month-period.ts
+++ b/apps/frontend/src/features/spending/lib/month-period.ts
@@ -1,0 +1,83 @@
+import type { DateRange } from "@/lib/types";
+
+import type { ReportsRange } from "./reports-period";
+import {
+  addCalendarMonths,
+  calendarDaysBetweenInclusive,
+  calendarMonthsBetweenInclusive,
+  daysInCalendarMonth,
+  getZonedDateParts,
+  zonedCalendarDateBoundaryToDate,
+  type ZonedCalendarDate,
+} from "./timezone";
+
+export const SPENDING_MONTH_PARAM = "spendingMonth";
+export const SPENDING_MONTH_STORAGE_KEY = "spending-month";
+
+export function localDateFromParts(date: ZonedCalendarDate): Date {
+  return new Date(date.year, date.month - 1, date.day);
+}
+
+export function monthKeyFromParts(date: Pick<ZonedCalendarDate, "year" | "month">): string {
+  return `${date.year}-${String(date.month).padStart(2, "0")}`;
+}
+
+export function parseMonthKey(
+  value: string | null | undefined,
+): { year: number; month: number } | null {
+  if (!value || !/^\d{4}-(0[1-9]|1[0-2])$/.test(value)) return null;
+  const [year, month] = value.split("-").map(Number);
+  return { year, month };
+}
+
+export function currentMonthKey(timezone?: string | null): string {
+  return monthKeyFromParts(getZonedDateParts(new Date(), timezone));
+}
+
+export function addMonthsToMonthKey(monthKey: string, months: number): string {
+  const parts = parseMonthKey(monthKey);
+  if (!parts) return monthKey;
+  return monthKeyFromParts(addCalendarMonths({ ...parts, day: 1 }, months));
+}
+
+export function monthRange(monthKey: string): DateRange {
+  const parts = parseMonthKey(monthKey) ?? parseMonthKey(currentMonthKey());
+  const month = parts ?? getZonedDateParts(new Date());
+  const start = { ...month, day: 1 };
+  const end = { ...month, day: daysInCalendarMonth(month.year, month.month) };
+  return { from: localDateFromParts(start), to: localDateFromParts(end) };
+}
+
+export function monthReportsRange(
+  monthKey: string,
+  timezone?: string | null,
+): ReportsRange | null {
+  const month = parseMonthKey(monthKey);
+  if (!month) return null;
+  const start = { ...month, day: 1 };
+  const end = { ...month, day: daysInCalendarMonth(month.year, month.month) };
+  return {
+    start: zonedCalendarDateBoundaryToDate(start, "start", timezone),
+    end: zonedCalendarDateBoundaryToDate(end, "end", timezone),
+    days: calendarDaysBetweenInclusive(start, end),
+    months: calendarMonthsBetweenInclusive(start, end),
+  };
+}
+
+export function monthLabel(monthKey: string, format: "long" | "short" = "long"): string {
+  const parts = parseMonthKey(monthKey);
+  if (!parts) return "";
+  return new Date(parts.year, parts.month - 1, 1).toLocaleString(undefined, {
+    month: format,
+    year: "numeric",
+  });
+}
+
+export function compactMonthLabel(monthKey: string): string {
+  const parts = parseMonthKey(monthKey);
+  if (!parts) return "";
+  const month = new Date(parts.year, parts.month - 1, 1).toLocaleString(undefined, {
+    month: "short",
+  });
+  return `${month} '${String(parts.year).slice(2)}`;
+}

--- a/apps/frontend/src/features/spending/lib/month-period.ts
+++ b/apps/frontend/src/features/spending/lib/month-period.ts
@@ -48,10 +48,7 @@ export function monthRange(monthKey: string): DateRange {
   return { from: localDateFromParts(start), to: localDateFromParts(end) };
 }
 
-export function monthReportsRange(
-  monthKey: string,
-  timezone?: string | null,
-): ReportsRange | null {
+export function monthReportsRange(monthKey: string, timezone?: string | null): ReportsRange | null {
   const month = parseMonthKey(monthKey);
   if (!month) return null;
   const start = { ...month, day: 1 };

--- a/apps/frontend/src/features/spending/lib/period-preferences.test.ts
+++ b/apps/frontend/src/features/spending/lib/period-preferences.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { normalizeReportsPeriod, shouldPreferDashboardPeriod } from "./period-preferences";
+
+describe("spending period preferences", () => {
+  it("normalizes legacy dashboard month periods for insights", () => {
+    expect(normalizeReportsPeriod("3M")).toBe("3M");
+    expect(normalizeReportsPeriod("LAST_MONTH")).toBe("LAST_MONTH");
+    expect(normalizeReportsPeriod("1M")).toBeNull();
+  });
+
+  it("uses the dashboard period when no valid insight period is stored", () => {
+    expect(
+      shouldPreferDashboardPeriod({
+        persistedInsightPeriod: null,
+        dashboardUpdatedAt: "0",
+        insightUpdatedAt: "100",
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps a newer insight period when returning from the dashboard", () => {
+    expect(
+      shouldPreferDashboardPeriod({
+        persistedInsightPeriod: "6M",
+        dashboardUpdatedAt: "100",
+        insightUpdatedAt: "200",
+      }),
+    ).toBe(false);
+  });
+
+  it("uses the dashboard period after the dashboard selector changes", () => {
+    expect(
+      shouldPreferDashboardPeriod({
+        persistedInsightPeriod: "6M",
+        dashboardUpdatedAt: "300",
+        insightUpdatedAt: "200",
+      }),
+    ).toBe(true);
+  });
+});

--- a/apps/frontend/src/features/spending/lib/period-preferences.ts
+++ b/apps/frontend/src/features/spending/lib/period-preferences.ts
@@ -1,0 +1,29 @@
+import { REPORTS_PERIODS, type ReportsPeriod } from "./reports-period";
+
+export const INSIGHTS_PERIOD_STORAGE_KEY = "spending-insights-period";
+export const INSIGHTS_PERIOD_UPDATED_AT_STORAGE_KEY = "spending-insights-period-updated-at";
+export const DASHBOARD_PERIOD_UPDATED_AT_STORAGE_KEY = "spending-dashboard-period-updated-at";
+
+export function normalizeReportsPeriod(value: string | null | undefined): ReportsPeriod | null {
+  if (!value) return null;
+  if (REPORTS_PERIODS.includes(value as ReportsPeriod)) return value as ReportsPeriod;
+  return null;
+}
+
+export function periodPreferenceTimestamp(): string {
+  return String(Date.now());
+}
+
+export function shouldPreferDashboardPeriod(opts: {
+  persistedInsightPeriod: string | null | undefined;
+  dashboardUpdatedAt: string | null | undefined;
+  insightUpdatedAt: string | null | undefined;
+}): boolean {
+  if (!normalizeReportsPeriod(opts.persistedInsightPeriod)) return true;
+  return timestampValue(opts.dashboardUpdatedAt) > timestampValue(opts.insightUpdatedAt);
+}
+
+function timestampValue(value: string | null | undefined): number {
+  const timestamp = Number(value);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}

--- a/apps/frontend/src/features/spending/lib/reports-period.test.ts
+++ b/apps/frontend/src/features/spending/lib/reports-period.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { periodLabel, periodToReportsRange } from "./reports-period";
+
+describe("reports periods", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves LAST_MONTH to the previous full calendar month", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-10T12:00:00.000Z"));
+
+    const range = periodToReportsRange("LAST_MONTH", "UTC");
+
+    expect(range.start.toISOString()).toBe("2026-05-01T00:00:00.000Z");
+    expect(range.end.toISOString()).toBe("2026-05-31T23:59:59.999Z");
+    expect(range.days).toBe(31);
+    expect(range.months).toBe(1);
+    expect(periodLabel("LAST_MONTH")).toBe("Last month");
+  });
+});

--- a/apps/frontend/src/features/spending/lib/reports-period.ts
+++ b/apps/frontend/src/features/spending/lib/reports-period.ts
@@ -2,8 +2,7 @@
  * Period model for the Reports page.
  *
  * Distinct from the portfolio-wide `TimePeriod` because spending reports use
- * cashflow language: current month, trailing 30 days, and longer comparison
- * windows.
+ * cashflow language: current month, last month, and longer comparison windows.
  */
 
 import type { DateRange } from "@/lib/types";
@@ -19,9 +18,9 @@ import {
   type ZonedCalendarDate,
 } from "./timezone";
 
-export type ReportsPeriod = "MTD" | "30D" | "3M" | "6M" | "YTD" | "1Y";
+export type ReportsPeriod = "MTD" | "LAST_MONTH" | "3M" | "6M" | "YTD" | "1Y";
 
-export const REPORTS_PERIODS: ReportsPeriod[] = ["MTD", "30D", "3M", "6M", "YTD", "1Y"];
+export const REPORTS_PERIODS: ReportsPeriod[] = ["MTD", "LAST_MONTH", "3M", "6M", "YTD", "1Y"];
 
 export const DEFAULT_REPORTS_PERIOD: ReportsPeriod = "MTD";
 
@@ -47,8 +46,9 @@ export function periodToReportsRange(
   const today = getZonedDateParts(now, timezone);
 
   // For MTD/This month we span the full calendar month so "X days left in May"
-  // reads correctly and forecasts can project past today. Other periods stay
-  // "through today" since the current month is naturally the trailing edge.
+  // reads correctly and forecasts can project past today. Last month also uses
+  // a full calendar month. Longer periods stay "through today" since the
+  // current month is naturally the trailing edge.
   const { start, end } = (() => {
     switch (period) {
       case "MTD": {
@@ -61,11 +61,17 @@ export function periodToReportsRange(
           },
         };
       }
-      case "30D":
+      case "LAST_MONTH": {
+        const lastMonth = addCalendarMonths({ year: today.year, month: today.month, day: 1 }, -1);
         return {
-          start: addCalendarDays(today, -29),
-          end: today,
+          start: { year: lastMonth.year, month: lastMonth.month, day: 1 },
+          end: {
+            year: lastMonth.year,
+            month: lastMonth.month,
+            day: daysInCalendarMonth(lastMonth.year, lastMonth.month),
+          },
         };
+      }
       case "3M":
         return {
           start: addCalendarMonths({ year: today.year, month: today.month, day: 1 }, -2),
@@ -133,8 +139,8 @@ export function periodLabel(period: ReportsPeriod): string {
   switch (period) {
     case "MTD":
       return "This month";
-    case "30D":
-      return "Past 30 days";
+    case "LAST_MONTH":
+      return "Last month";
     case "3M":
       return "Past 3 months";
     case "6M":

--- a/apps/frontend/src/features/spending/pages/spending-insights-page.tsx
+++ b/apps/frontend/src/features/spending/pages/spending-insights-page.tsx
@@ -10,7 +10,7 @@ import { Page, PageContent, PageHeader, useIsMobile, usePersistentState } from "
 
 import { CategoryTransactionsSheet } from "../components/reports/category-transactions-sheet";
 import { HeatmapCellSheet } from "../components/reports/heatmap-cell-sheet";
-import { SpendingPeriodToggle } from "../components/spending-period-toggle";
+import { SpendingPeriodSelector } from "../components/spending-period-toggle";
 import { StageNav, type InsightsStage } from "../components/reports/insights/stage-nav";
 import { WhatChangedStage } from "../components/reports/insights/what-changed-stage";
 import { WhenWhereStage } from "../components/reports/insights/when-where-stage";
@@ -21,8 +21,21 @@ import { useSpendingInsight } from "../hooks/use-spending-insight";
 import { useSpendingSettings } from "../hooks/use-spending-settings";
 import { insightToReportProjection, UNCATEGORIZED_CATEGORY_ID } from "../lib/insight-projection";
 import {
+  SPENDING_MONTH_PARAM,
+  SPENDING_MONTH_STORAGE_KEY,
+  addMonthsToMonthKey,
+  currentMonthKey,
+  monthReportsRange,
+  parseMonthKey,
+} from "../lib/month-period";
+import {
+  INSIGHTS_PERIOD_STORAGE_KEY,
+  INSIGHTS_PERIOD_UPDATED_AT_STORAGE_KEY,
+  normalizeReportsPeriod,
+  periodPreferenceTimestamp,
+} from "../lib/period-preferences";
+import {
   DEFAULT_REPORTS_PERIOD,
-  REPORTS_PERIODS,
   periodToReportsRange,
   type ReportsPeriod,
   type ReportsRange,
@@ -41,36 +54,11 @@ import {
 const SPENDING_TAXONOMY = "spending_categories";
 const INCOME_TAXONOMY = "income_sources";
 const SAVINGS_TAXONOMY = "savings_categories";
-const PERIOD_STORAGE_KEY = "spending-insights-period";
 const STAGE_STORAGE_KEY = "spending-insights-stage";
 const EMPTY_TAXONOMY: never[] = [];
 /** Heatmap window — last 12 weeks regardless of selected period. */
 const HEATMAP_WEEKS = 12;
 const HEATMAP_DAY_NAMES = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
-
-function parseDateParam(value: string | null): { year: number; month: number; day: number } | null {
-  if (!value) return null;
-  const [year, month, day] = value.split("-").map(Number);
-  if (!year || !month || !day) return null;
-  return { year, month, day };
-}
-
-function customRangeFromParams(
-  params: URLSearchParams,
-  timezone?: string | null,
-): ReportsRange | null {
-  const startParts = parseDateParam(params.get("from"));
-  const endParts = parseDateParam(params.get("to"));
-  if (!startParts || !endParts) return null;
-  const days = calendarDaysBetweenInclusive(startParts, endParts);
-  if (days <= 0) return null;
-  return {
-    start: zonedCalendarDateBoundaryToDate(startParts, "start", timezone),
-    end: zonedCalendarDateBoundaryToDate(endParts, "end", timezone),
-    days,
-    months: calendarMonthsBetweenInclusive(startParts, endParts),
-  };
-}
 
 function monthToDateRange(timezone?: string | null): ReportsRange {
   const today = getZonedDateParts(new Date(), timezone);
@@ -117,13 +105,6 @@ function previousMonthMatchingRange(range: ReportsRange, timezone?: string | nul
  */
 const VALID_STAGES: InsightsStage[] = ["where", "changed", "when"];
 
-function normalizeReportsPeriod(value: string | null | undefined): ReportsPeriod | null {
-  if (!value) return null;
-  if (value === "1M") return "MTD";
-  if (REPORTS_PERIODS.includes(value as ReportsPeriod)) return value as ReportsPeriod;
-  return null;
-}
-
 export default function SpendingInsightsPage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -134,14 +115,27 @@ export default function SpendingInsightsPage() {
   const { isEnabled, isLoading: settingsLoading } = useSpendingSettings();
 
   const [persistedPeriod, setPersistedPeriod] = usePersistentState<string>(
-    PERIOD_STORAGE_KEY,
+    INSIGHTS_PERIOD_STORAGE_KEY,
     DEFAULT_REPORTS_PERIOD,
+  );
+  const [, setPeriodUpdatedAt] = usePersistentState<string>(
+    INSIGHTS_PERIOD_UPDATED_AT_STORAGE_KEY,
+    "0",
+  );
+  const [persistedMonth, setPersistedMonth] = usePersistentState<string | null>(
+    SPENDING_MONTH_STORAGE_KEY,
+    null,
   );
   const period = normalizeReportsPeriod(persistedPeriod) ?? DEFAULT_REPORTS_PERIOD;
   const [stage, setStage] = usePersistentState<InsightsStage>(STAGE_STORAGE_KEY, "where");
+  const urlMonth = parseMonthKey(searchParams.get(SPENDING_MONTH_PARAM))
+    ? searchParams.get(SPENDING_MONTH_PARAM)
+    : null;
+  const customMonth =
+    urlMonth ?? (!searchParams.has("period") && parseMonthKey(persistedMonth) ? persistedMonth : null);
 
   // ─── URL ↔ state sync ─────────────────────────────────────────────────────
-  // ?stage=where|changed|when and ?period=MTD|30D|3M|6M|YTD|1Y drive the page
+  // ?stage=where|changed|when and ?period=MTD|LAST_MONTH|3M|6M|YTD|1Y drive the page
   // when present, otherwise fall back to the persisted localStorage values.
   // Linking from the dashboard (`/spending/insights?stage=where`) and reload-
   // ability of the current view both rely on this.
@@ -153,6 +147,9 @@ export default function SpendingInsightsPage() {
     const urlPeriod = normalizeReportsPeriod(searchParams.get("period"));
     if (urlPeriod && urlPeriod !== period) {
       setPersistedPeriod(urlPeriod);
+    }
+    if (urlMonth && urlMonth !== persistedMonth) {
+      setPersistedMonth(urlMonth);
     }
     // Eslint disable: we intentionally run only on URL change, not on every
     // state change — the inverse direction (state → URL) is handled by the
@@ -178,18 +175,37 @@ export default function SpendingInsightsPage() {
   const setPeriodAndUrl = useCallback(
     (next: ReportsPeriod) => {
       setPersistedPeriod(next);
+      setPeriodUpdatedAt(periodPreferenceTimestamp());
+      setPersistedMonth(null);
       setSearchParams(
         (prev) => {
           const p = new URLSearchParams(prev);
           p.set("period", next);
-          p.delete("from");
-          p.delete("to");
+          p.delete(SPENDING_MONTH_PARAM);
           return p;
         },
         { replace: true },
       );
     },
-    [setPersistedPeriod, setSearchParams],
+    [setPersistedPeriod, setPeriodUpdatedAt, setPersistedMonth, setSearchParams],
+  );
+
+  const setCustomMonthAndUrl = useCallback(
+    (next: string | null) => {
+      setPersistedMonth(next);
+      setPeriodUpdatedAt(periodPreferenceTimestamp());
+      setSearchParams(
+        (prev) => {
+          const p = new URLSearchParams(prev);
+          p.set("period", period);
+          if (next) p.set(SPENDING_MONTH_PARAM, next);
+          else p.delete(SPENDING_MONTH_PARAM);
+          return p;
+        },
+        { replace: true },
+      );
+    },
+    [period, setPersistedMonth, setPeriodUpdatedAt, setSearchParams],
   );
 
   // Events-timeline pagination — independent from `period`. Stored alongside
@@ -205,22 +221,22 @@ export default function SpendingInsightsPage() {
     [period],
   );
 
-  const customRange = useMemo(
-    () => customRangeFromParams(searchParams, appTimezone),
-    [searchParams, appTimezone],
+  const monthRange = useMemo(
+    () => (customMonth ? monthReportsRange(customMonth, appTimezone) : null),
+    [customMonth, appTimezone],
   );
   const range = useMemo(
-    () => customRange ?? periodToReportsRange(period, appTimezone),
-    [customRange, period, appTimezone],
+    () => monthRange ?? periodToReportsRange(period, appTimezone),
+    [monthRange, period, appTimezone],
   );
   const whatChangedWindow = useMemo(() => {
-    if (customRange || period !== "MTD") return null;
+    if (customMonth || period !== "MTD") return null;
     const current = monthToDateRange(appTimezone);
     return {
       current,
       prior: previousMonthMatchingRange(current, appTimezone),
     };
-  }, [customRange, period, appTimezone]);
+  }, [customMonth, period, appTimezone]);
   const eventsRange = useMemo(
     () => shiftRangeBack(range, period, eventsWindowOffset, appTimezone),
     [range, period, eventsWindowOffset, appTimezone],
@@ -395,6 +411,10 @@ export default function SpendingInsightsPage() {
     () => new Map(accounts.map((account) => [account.id, account.accountType])),
     [accounts],
   );
+  const maxPickerMonth = useMemo(
+    () => addMonthsToMonthKey(currentMonthKey(appTimezone), -1),
+    [appTimezone],
+  );
 
   // Gate the entire page when tracking is disabled — mirrors spending-budget-page.
   // Without this, disabling tracking from ModuleCard leaves Insights live and
@@ -404,7 +424,14 @@ export default function SpendingInsightsPage() {
   }
 
   const periodToggle = (
-    <SpendingPeriodToggle value={customRange ? null : period} onValueChange={setPeriodAndUrl} />
+    <SpendingPeriodSelector
+      value={customMonth ? null : period}
+      onValueChange={setPeriodAndUrl}
+      customMonth={customMonth}
+      maxMonth={maxPickerMonth}
+      onCustomMonthChange={setCustomMonthAndUrl}
+      className="w-[calc(100vw-6rem)] max-w-[calc(100vw-6rem)] sm:w-full sm:max-w-screen-md md:max-w-2xl"
+    />
   );
 
   return (
@@ -537,7 +564,7 @@ export default function SpendingInsightsPage() {
  *  the prior year's window. */
 const MONTHS_PER_PERIOD: Record<ReportsPeriod, number> = {
   MTD: 1,
-  "30D": 1,
+  LAST_MONTH: 1,
   "3M": 3,
   "6M": 6,
   YTD: 12,
@@ -551,20 +578,6 @@ function shiftRangeBack(
   timezone?: string | null,
 ): ReportsRange {
   if (offset === 0) return range;
-  if (period === "30D") {
-    const days = 30 * offset;
-    const start = zonedCalendarDateBoundaryToDate(
-      addCalendarDays(getZonedDateParts(range.start, timezone), -days),
-      "start",
-      timezone,
-    );
-    const end = zonedCalendarDateBoundaryToDate(
-      addCalendarDays(getZonedDateParts(range.end, timezone), -days),
-      "end",
-      timezone,
-    );
-    return { ...range, start, end };
-  }
   const months = MONTHS_PER_PERIOD[period] * offset;
   const start = zonedCalendarDateBoundaryToDate(
     addCalendarMonths(getZonedDateParts(range.start, timezone), -months),

--- a/apps/frontend/src/features/spending/pages/spending-insights-page.tsx
+++ b/apps/frontend/src/features/spending/pages/spending-insights-page.tsx
@@ -132,7 +132,8 @@ export default function SpendingInsightsPage() {
     ? searchParams.get(SPENDING_MONTH_PARAM)
     : null;
   const customMonth =
-    urlMonth ?? (!searchParams.has("period") && parseMonthKey(persistedMonth) ? persistedMonth : null);
+    urlMonth ??
+    (!searchParams.has("period") && parseMonthKey(persistedMonth) ? persistedMonth : null);
 
   // ─── URL ↔ state sync ─────────────────────────────────────────────────────
   // ?stage=where|changed|when and ?period=MTD|LAST_MONTH|3M|6M|YTD|1Y drive the page

--- a/apps/frontend/src/features/wealthfolio-connect/components/broker-sync-state-card.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/components/broker-sync-state-card.tsx
@@ -4,6 +4,7 @@ import { Icons } from "@wealthfolio/ui/components/ui/icons";
 import { formatDistanceToNow } from "date-fns";
 import type { Account, Platform } from "@/lib/types";
 import type { BrokerSyncState, SyncStatus } from "../types";
+import { getBrokerSyncIssueMessage } from "../lib/broker-sync-messages";
 
 interface BrokerSyncStateCardProps {
   syncState: BrokerSyncState;
@@ -86,7 +87,9 @@ export function BrokerSyncStateCard({ syncState, account, platform }: BrokerSync
       {/* Show error message if failed */}
       {syncState.syncStatus === "FAILED" && syncState.lastError && (
         <div className="border-t px-4 py-3">
-          <p className="text-sm text-red-600 dark:text-red-400">{syncState.lastError}</p>
+          <p className="text-sm text-red-600 dark:text-red-400">
+            {getBrokerSyncIssueMessage(syncState.syncStatus, syncState.lastError)}
+          </p>
         </div>
       )}
     </Card>

--- a/apps/frontend/src/features/wealthfolio-connect/components/import-runs-list.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/components/import-runs-list.tsx
@@ -10,6 +10,7 @@ import { format } from "date-fns";
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import type { ImportRun, ImportRunStatus } from "../types";
+import { BROKER_SYNC_RUN_FAILED_MESSAGE } from "../lib/broker-sync-messages";
 
 interface ImportRunsListProps {
   runs: ImportRun[];
@@ -160,7 +161,9 @@ function ImportRunItem({ run }: { run: ImportRun }) {
             {/* Error */}
             {run.error && (
               <div className="rounded-md bg-red-50 p-2 dark:bg-red-900/20">
-                <p className="text-sm text-red-600 dark:text-red-400">{run.error}</p>
+                <p className="text-sm text-red-600 dark:text-red-400">
+                  {BROKER_SYNC_RUN_FAILED_MESSAGE}
+                </p>
               </div>
             )}
 

--- a/apps/frontend/src/features/wealthfolio-connect/components/sync-history.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/components/sync-history.tsx
@@ -8,6 +8,7 @@ import { useMemo } from "react";
 import { Link } from "react-router-dom";
 import { useImportRunsInfinite } from "../hooks";
 import type { ImportRun, ImportRunStatus } from "../types";
+import { BROKER_SYNC_RUN_FAILED_MESSAGE } from "../lib/broker-sync-messages";
 
 const statusConfig: Record<
   ImportRunStatus,
@@ -214,7 +215,7 @@ function SyncRunItem({ run }: { run: ImportRun }) {
       {/* Error message */}
       {run.error && (
         <div className="mt-2 rounded-md bg-red-50 p-2 dark:bg-red-900/20">
-          <p className="text-xs text-red-600 dark:text-red-400">{run.error}</p>
+          <p className="text-xs text-red-600 dark:text-red-400">{BROKER_SYNC_RUN_FAILED_MESSAGE}</p>
         </div>
       )}
 

--- a/apps/frontend/src/features/wealthfolio-connect/lib/broker-sync-messages.ts
+++ b/apps/frontend/src/features/wealthfolio-connect/lib/broker-sync-messages.ts
@@ -1,0 +1,38 @@
+import type { SyncStatus } from "../types";
+
+export const BROKER_SYNC_RUN_FAILED_MESSAGE =
+  "This sync run couldn't be completed. Please retry sync or manage your broker connection.";
+
+export const BROKER_SYNC_RUN_NEEDS_REVIEW_MESSAGE =
+  "Some synced items need your review before sync can continue.";
+
+const BROKER_SYNC_ACCOUNT_FAILED_MESSAGE =
+  "We couldn't sync this broker account. Please retry sync or manage your broker connection.";
+
+const BROKER_SYNC_ACCOUNT_NEEDS_REVIEW_MESSAGE =
+  "Some broker data needs review. Please retry sync or manage your broker connection.";
+
+const HOLDINGS_SYNCED_ACTIVITY_ATTENTION_MESSAGE =
+  "Holdings synced, but activity sync needs attention. Please retry sync or manage your broker connection.";
+
+const HOLDINGS_DEFERRED_ACTIVITY_ATTENTION_MESSAGE =
+  "Holdings sync needs attention. Please retry sync or manage your broker connection.";
+
+export function getBrokerSyncIssueMessage(
+  syncStatus: SyncStatus,
+  lastError?: string | null,
+): string {
+  const normalizedError = lastError?.toLowerCase() ?? "";
+
+  if (normalizedError.startsWith("holdings synced")) {
+    return HOLDINGS_SYNCED_ACTIVITY_ATTENTION_MESSAGE;
+  }
+
+  if (normalizedError.startsWith("holdings sync deferred")) {
+    return HOLDINGS_DEFERRED_ACTIVITY_ATTENTION_MESSAGE;
+  }
+
+  return syncStatus === "FAILED"
+    ? BROKER_SYNC_ACCOUNT_FAILED_MESSAGE
+    : BROKER_SYNC_ACCOUNT_NEEDS_REVIEW_MESSAGE;
+}

--- a/apps/frontend/src/features/wealthfolio-connect/pages/connect-page.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/pages/connect-page.tsx
@@ -37,6 +37,10 @@ import type { Device } from "@/features/devices-sync/types";
 import type { Account } from "@/lib/types";
 import { hasBrokerSync } from "../lib/plan-capabilities";
 import { hasReviewableActivityWarnings } from "../lib/import-run-review";
+import {
+  BROKER_SYNC_RUN_NEEDS_REVIEW_MESSAGE,
+  getBrokerSyncIssueMessage,
+} from "../lib/broker-sync-messages";
 import { NewAccountsFoundModal } from "../components/new-accounts-found-modal";
 
 export default function ConnectPage() {
@@ -737,11 +741,7 @@ function BrokerSyncAttentionSection({
             const account = accountById.get(issue.accountId);
             const accountName = account?.name || issue.accountId;
             const broker = account?.provider || issue.provider;
-            const message =
-              issue.lastError ||
-              (issue.syncStatus === "FAILED"
-                ? "Broker sync failed."
-                : "Broker sync needs review before the cursor can advance.");
+            const message = getBrokerSyncIssueMessage(issue.syncStatus, issue.lastError);
 
             return (
               <div key={`${issue.provider}:${issue.accountId}`} className="rounded-md border p-3">
@@ -799,7 +799,7 @@ function SyncHistoryItem({
     description =
       issueCount > 0
         ? `${issueCount} ${issueCount === 1 ? "item needs" : "items need"} your review`
-        : run.error || "Sync needs attention";
+        : BROKER_SYNC_RUN_NEEDS_REVIEW_MESSAGE;
   } else if (inserted > 0 || updated > 0 || removed > 0) {
     const parts: string[] = [];
     if (inserted > 0) {

--- a/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
@@ -45,6 +45,7 @@ interface MobileActivityFormProps {
   activity?: Partial<ActivityDetails>;
   open?: boolean;
   onClose?: () => void;
+  startOnDetails?: boolean;
 }
 
 export interface TransferValidationInput {
@@ -254,8 +255,11 @@ export function MobileActivityForm({
   activity,
   open,
   onClose,
+  startOnDetails,
 }: MobileActivityFormProps) {
-  const [currentStep, setCurrentStep] = useState(activity?.id ? 2 : 1);
+  const shouldStartOnDetails = Boolean(activity?.id || startOnDetails);
+  const initialStep = shouldStartOnDetails ? 2 : 1;
+  const [currentStep, setCurrentStep] = useState(initialStep);
   const {
     addActivityMutation,
     updateActivityMutation,
@@ -387,8 +391,8 @@ export function MobileActivityForm({
       : { ...defaultValues, activityDate: new Date() };
 
     reset(nextDefaultValues);
-    setCurrentStep(activity?.id ? 2 : 1);
-  }, [activity?.date, activity?.id, defaultValues, open, reset]);
+    setCurrentStep(shouldStartOnDetails ? 2 : 1);
+  }, [activity?.date, defaultValues, open, reset, shouldStartOnDetails]);
 
   // Transfers may target any account (incl. spending/saving accounts the Spending
   // split hides from `accounts`), so widen the list once the type is a transfer.
@@ -401,10 +405,7 @@ export function MobileActivityForm({
   // Handle sheet close - reset form and step
   const handleOpenChange = (isOpen: boolean) => {
     if (!isOpen) {
-      // Reset step when closing (unless editing)
-      if (!activity?.id) {
-        setCurrentStep(1);
-      }
+      setCurrentStep(shouldStartOnDetails ? 2 : 1);
       form.reset(defaultValues);
     }
     onClose?.();
@@ -560,7 +561,7 @@ export function MobileActivityForm({
           });
 
           form.reset(defaultValues);
-          setCurrentStep(1);
+          setCurrentStep(initialStep);
           return;
         }
 
@@ -642,7 +643,7 @@ export function MobileActivityForm({
           });
 
           form.reset(defaultValues);
-          setCurrentStep(1);
+          setCurrentStep(initialStep);
           return;
         }
 
@@ -672,7 +673,7 @@ export function MobileActivityForm({
         });
 
         form.reset(defaultValues);
-        setCurrentStep(1);
+        setCurrentStep(initialStep);
         return;
       }
 
@@ -720,7 +721,7 @@ export function MobileActivityForm({
 
       // Reset form and step after successful submission
       form.reset(defaultValues);
-      setCurrentStep(1);
+      setCurrentStep(initialStep);
     } catch (error) {
       toast.error("Failed to save activity", { description: extractErrorMessage(error) });
       logger.error(
@@ -801,7 +802,7 @@ export function MobileActivityForm({
         <SheetHeader className="border-b px-6 py-4">
           <div className="flex flex-col items-center space-y-2">
             <SheetTitle>{activity?.id ? "Update Activity" : "Add Activity"}</SheetTitle>
-            {!activity?.id && (
+            {!activity?.id && !startOnDetails && (
               <div className="flex gap-1.5">
                 {[1, 2].map((step) => (
                   <div
@@ -837,7 +838,7 @@ export function MobileActivityForm({
 
         <SheetFooter className="mt-auto border-t px-6 py-4 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)]">
           <div className="flex w-full gap-3">
-            {currentStep > 1 && !activity?.id && (
+            {currentStep > 1 && !activity?.id && !startOnDetails && (
               <Button
                 type="button"
                 variant="outline"

--- a/apps/frontend/src/pages/settings/addons/components/addon-store-card.tsx
+++ b/apps/frontend/src/pages/settings/addons/components/addon-store-card.tsx
@@ -40,6 +40,7 @@ export function AddonStoreCard({
   isRatingSubmitting: _isRatingSubmitting = false,
 }: AddonStoreCardProps) {
   const [ratingDialogOpen, setRatingDialogOpen] = React.useState(false);
+  const addonDetailUrl = `https://wealthfolio.app/addons/${encodeURIComponent(listing.id)}`;
 
   const formatDownloads = (downloads: number) => {
     if (downloads >= 1000000) {
@@ -220,9 +221,9 @@ export function AddonStoreCard({
 
                   {listing.changelogUrl && (
                     <Button variant="outline" asChild>
-                      <ExternalLink href={listing.changelogUrl}>
+                      <ExternalLink href={addonDetailUrl}>
                         <Icons.ExternalLink className="mr-2 h-4 w-4" />
-                        Changelog
+                        Add-on Page
                       </ExternalLink>
                     </Button>
                   )}
@@ -414,10 +415,10 @@ export function AddonStoreCard({
 
                 {listing.changelogUrl && (
                   <Button variant="outline" asChild>
-                    <a href={listing.changelogUrl} target="_blank" rel="noopener noreferrer">
+                    <ExternalLink href={addonDetailUrl}>
                       <Icons.ExternalLink className="mr-2 h-4 w-4" />
-                      Changelog
-                    </a>
+                      Add-on Page
+                    </ExternalLink>
                   </Button>
                 )}
               </div>

--- a/apps/frontend/src/pages/settings/addons/components/addon-update-card.tsx
+++ b/apps/frontend/src/pages/settings/addons/components/addon-update-card.tsx
@@ -1,18 +1,9 @@
 import { reloadAllAddons } from "@/addons/addons-core";
 import { updateAddon } from "@/adapters";
+import { ExternalLink } from "@/components/external-link";
 import { Badge } from "@wealthfolio/ui/components/ui/badge";
 import { Button } from "@wealthfolio/ui/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@wealthfolio/ui/components/ui/dialog";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
-import { ScrollArea } from "@wealthfolio/ui/components/ui/scroll-area";
-import { Separator } from "@wealthfolio/ui/components/ui/separator";
 import { useToast } from "@wealthfolio/ui/components/ui/use-toast";
 import type { AddonUpdateInfo } from "@wealthfolio/addon-sdk";
 import { useState } from "react";
@@ -33,8 +24,8 @@ export function AddonUpdateCard({
   disabled = false,
 }: AddonUpdateCardProps) {
   const [isUpdating, setIsUpdating] = useState(false);
-  const [showReleaseNotes, setShowReleaseNotes] = useState(false);
   const { toast } = useToast();
+  const addonDetailUrl = `https://wealthfolio.app/addons/${encodeURIComponent(addonId)}`;
 
   const handleUpdate = async () => {
     if (!updateInfo.downloadUrl) {
@@ -123,91 +114,14 @@ export function AddonUpdateCard({
 
         <div className="ml-4 flex items-center gap-2">
           {(updateInfo.releaseNotes || updateInfo.changelogUrl) && (
-            <Dialog open={showReleaseNotes} onOpenChange={setShowReleaseNotes}>
-              <DialogTrigger asChild>
-                <Button variant="ghost" size="sm">
+            <Button variant="ghost" size="sm" asChild>
+              <ExternalLink href={addonDetailUrl}>
+                <span className="inline-flex items-center">
                   <Icons.FileText className="mr-1 h-3 w-3" />
                   Release Notes
-                </Button>
-              </DialogTrigger>
-              <DialogContent className="max-w-2xl">
-                <DialogHeader>
-                  <DialogTitle>
-                    Release Notes - {addonName} v{updateInfo.latestVersion}
-                  </DialogTitle>
-                  <DialogDescription>What&apos;s new in this version</DialogDescription>
-                </DialogHeader>
-                <ScrollArea className="max-h-96">
-                  <div className="space-y-4">
-                    {updateInfo.releaseNotes && (
-                      <div className="space-y-2">
-                        <h4 className="font-medium">Release Notes</h4>
-                        <div className="text-muted-foreground whitespace-pre-wrap text-sm">
-                          {updateInfo.releaseNotes}
-                        </div>
-                      </div>
-                    )}
-
-                    {updateInfo.changelogUrl && (
-                      <>
-                        <Separator />
-                        <div className="space-y-2">
-                          <h4 className="font-medium">Full Changelog</h4>
-                          <a
-                            href={updateInfo.changelogUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="inline-flex items-center text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300"
-                          >
-                            View detailed changelog
-                            <Icons.Globe className="ml-1 h-3 w-3" />
-                          </a>
-                        </div>
-                      </>
-                    )}
-
-                    {updateInfo.hasBreakingChanges && (
-                      <>
-                        <Separator />
-                        <div className="border-destructive/50 bg-destructive/10 rounded-lg border p-3">
-                          <div className="flex items-start gap-2">
-                            <Icons.AlertTriangle className="text-destructive mt-0.5 h-4 w-4 shrink-0" />
-                            <div>
-                              <h5 className="text-destructive font-medium">Breaking Changes</h5>
-                              <p className="text-destructive/80 text-sm">
-                                This update includes breaking changes that may affect addon
-                                functionality. Please review the release notes carefully before
-                                updating.
-                              </p>
-                            </div>
-                          </div>
-                        </div>
-                      </>
-                    )}
-
-                    {updateInfo.isCritical && (
-                      <>
-                        <Separator />
-                        <div className="rounded-lg border border-red-500/50 bg-red-50 p-3 dark:bg-red-950/20">
-                          <div className="flex items-start gap-2">
-                            <Icons.AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-red-600 dark:text-red-400" />
-                            <div>
-                              <h5 className="font-medium text-red-800 dark:text-red-200">
-                                Critical Security Update
-                              </h5>
-                              <p className="text-sm text-red-700 dark:text-red-300">
-                                This is a critical security update. We strongly recommend updating
-                                as soon as possible.
-                              </p>
-                            </div>
-                          </div>
-                        </div>
-                      </>
-                    )}
-                  </div>
-                </ScrollArea>
-              </DialogContent>
-            </Dialog>
+                </span>
+              </ExternalLink>
+            </Button>
           )}
 
           <Button onClick={handleUpdate} disabled={isUpdating || disabled} size="sm">

--- a/apps/frontend/src/pages/settings/addons/hooks/use-addon-updates.test.tsx
+++ b/apps/frontend/src/pages/settings/addons/hooks/use-addon-updates.test.tsx
@@ -1,0 +1,80 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AddonUpdateCheckResult } from "@wealthfolio/addon-sdk";
+import type { InstalledAddon } from "@/adapters";
+import { QueryKeys } from "@/lib/query-keys";
+import { useAddonUpdates } from "./use-addon-updates";
+
+const mocks = vi.hoisted(() => ({
+  checkAddonUpdate: vi.fn(),
+  checkAllAddonUpdates: vi.fn(),
+  toast: vi.fn(),
+}));
+
+vi.mock("@/adapters", () => ({
+  checkAddonUpdate: mocks.checkAddonUpdate,
+  checkAllAddonUpdates: mocks.checkAllAddonUpdates,
+}));
+
+vi.mock("@wealthfolio/ui/components/ui/use-toast", () => ({
+  useToast: () => ({ toast: mocks.toast }),
+}));
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const installedAddon: InstalledAddon = {
+  metadata: {
+    id: "swingfolio",
+    name: "Swingfolio",
+    version: "3.1.0",
+    enabled: true,
+  },
+  filePath: "/addons/swingfolio",
+  isZipAddon: true,
+};
+
+const updateResult: AddonUpdateCheckResult = {
+  addonId: "swingfolio",
+  updateInfo: {
+    currentVersion: "3.1.0",
+    latestVersion: "3.5.1",
+    updateAvailable: true,
+  },
+};
+
+describe("useAddonUpdates", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses cached auto-check results for card update state", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    queryClient.setQueryData(
+      [QueryKeys.ADDON_AUTO_UPDATE_CHECK, ["swingfolio@3.1.0"]],
+      [updateResult],
+    );
+
+    const { result } = renderHook(
+      () =>
+        useAddonUpdates({
+          installedAddons: [installedAddon],
+          autoCheck: true,
+        }),
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    await waitFor(() => {
+      expect(result.current.getUpdateResult("swingfolio")).toEqual(updateResult);
+    });
+    expect(result.current.hasUpdates()).toBe(true);
+    expect(mocks.checkAllAddonUpdates).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/pages/settings/addons/hooks/use-addon-updates.ts
+++ b/apps/frontend/src/pages/settings/addons/hooks/use-addon-updates.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useToast } from "@wealthfolio/ui/components/ui/use-toast";
 import { checkAddonUpdate, checkAllAddonUpdates } from "@/adapters";
@@ -17,10 +17,14 @@ export function useAddonUpdates(options: UseAddonUpdatesOptions = {}) {
   const [isCheckingUpdates, setIsCheckingUpdates] = useState(false);
   const [lastUpdateCheck, setLastUpdateCheck] = useState<Date | null>(null);
   const { toast } = useToast();
+  const installedAddonVersions = useMemo(
+    () => installedAddons.map((addon) => `${addon.metadata.id}@${addon.metadata.version}`),
+    [installedAddons],
+  );
 
   // Auto-check query that runs when addons are loaded
-  const { isFetching: isAutoChecking } = useQuery({
-    queryKey: [QueryKeys.ADDON_AUTO_UPDATE_CHECK, installedAddons.map((a) => a.metadata.id)],
+  const { data: autoUpdateResults, isFetching: isAutoChecking } = useQuery({
+    queryKey: [QueryKeys.ADDON_AUTO_UPDATE_CHECK, installedAddonVersions],
     queryFn: async () => {
       const results = await checkAllAddonUpdates();
       setUpdateResults(results);
@@ -53,6 +57,12 @@ export function useAddonUpdates(options: UseAddonUpdatesOptions = {}) {
     refetchOnWindowFocus: false,
     refetchOnMount: true,
   });
+
+  useEffect(() => {
+    if (autoUpdateResults) {
+      setUpdateResults(autoUpdateResults);
+    }
+  }, [autoUpdateResults]);
 
   const checkSingleAddonUpdate = useCallback(
     async (addonId: string) => {

--- a/apps/frontend/src/use-global-event-listener.ts
+++ b/apps/frontend/src/use-global-event-listener.ts
@@ -29,6 +29,9 @@ const TOAST_IDS = {
   brokerSyncStart: "broker-sync-start",
 } as const;
 
+const BROKER_SYNC_FAILURE_DESCRIPTION =
+  "We couldn't sync your broker data. Please try again later.";
+
 interface MarketSyncCompletePayload {
   failed_syncs?: [string, string][];
   skipped_reasons?: [string, string][];
@@ -241,9 +244,10 @@ const useGlobalEventListener = () => {
         }
       } else {
         toast.error("Broker Sync Failed", {
-          description: message,
+          description: BROKER_SYNC_FAILURE_DESCRIPTION,
           duration: 10000,
         });
+        logger.error("Broker sync failed: " + message);
       }
     };
 
@@ -252,9 +256,10 @@ const useGlobalEventListener = () => {
       // Dismiss the loading toast
       toast.dismiss(TOAST_IDS.brokerSyncStart);
       toast.error("Broker Sync Failed", {
-        description: error,
+        description: BROKER_SYNC_FAILURE_DESCRIPTION,
         duration: 10000,
       });
+      logger.error("Broker sync error: " + error);
     };
 
     const setupListeners = async () => {

--- a/crates/connect/src/broker/orchestrator/holdings_phase.rs
+++ b/crates/connect/src/broker/orchestrator/holdings_phase.rs
@@ -7,6 +7,11 @@ use super::super::traits::BrokerApiClient;
 use super::{AccountSyncJob, HoldingsPhaseContext, SyncOrchestrator};
 use crate::broker_ingest::{ImportRunMode, ImportRunStatus, ImportRunSummary};
 
+const HOLDINGS_SYNCED_ACTIVITY_ATTENTION_MESSAGE: &str =
+    "Holdings synced, but activity sync needs attention. Please retry sync or manage your broker connection.";
+const HOLDINGS_DEFERRED_ACTIVITY_ATTENTION_MESSAGE: &str =
+    "Holdings sync needs attention. Please retry sync or manage your broker connection.";
+
 impl<P: SyncProgressReporter> SyncOrchestrator<P> {
     pub(super) async fn sync_holdings_phase(
         &self,
@@ -21,10 +26,11 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
             Ok(ProviderReadiness::Ready(_)) => {}
             Ok(ProviderReadiness::NotReady(reason)) => {
                 let warning = if let Some(activity_warning) = context.activity_warning.as_ref() {
-                    format!(
-                        "Holdings sync deferred: {}; activity reference sync needs review: {}",
-                        reason, activity_warning
-                    )
+                    warn!(
+                        "Holdings sync deferred for '{}' because activity reference sync needs review: {}; provider holdings status: {}",
+                        job.account_name, activity_warning, reason
+                    );
+                    HOLDINGS_DEFERRED_ACTIVITY_ATTENTION_MESSAGE.to_string()
                 } else {
                     format!("Holdings sync deferred: {}", reason)
                 };
@@ -143,10 +149,11 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
                 summary.new_asset_ids.extend(new_asset_ids);
 
                 if let Some(warning) = context.activity_warning {
-                    let warning_message = format!(
-                        "Holdings synced, but activity reference sync needs review: {}",
-                        warning
+                    warn!(
+                        "Holdings synced for '{}' but activity reference sync needs review: {}",
+                        job.account_name, warning
                     );
+                    let warning_message = HOLDINGS_SYNCED_ACTIVITY_ATTENTION_MESSAGE.to_string();
                     if let Err(e) = self
                         .sync_service
                         .finalize_activity_sync_needs_review(

--- a/crates/spending/src/activity_events/traits.rs
+++ b/crates/spending/src/activity_events/traits.rs
@@ -18,6 +18,18 @@ pub trait ActivityEventsRepositoryTrait: Send + Sync {
     /// Activity ids currently tagged to a given event.
     async fn list_for_event(&self, event_id: &str) -> Result<Vec<String>>;
 
+    /// Returns activity_id → event_id for the requested event ids.
+    /// Activities tagged to other events are absent from the map.
+    async fn list_for_events(&self, event_ids: &[String]) -> Result<HashMap<String, String>> {
+        let mut out = HashMap::new();
+        for event_id in event_ids {
+            for activity_id in self.list_for_event(event_id).await? {
+                out.entry(activity_id).or_insert_with(|| event_id.clone());
+            }
+        }
+        Ok(out)
+    }
+
     /// Tag or untag an activity with a spending event.
     ///
     /// The tag lives in the `activity_events` join table, not on the core

--- a/crates/spending/src/analytics/service.rs
+++ b/crates/spending/src/analytics/service.rs
@@ -834,12 +834,51 @@ impl AnalyticsService {
     }
 }
 
-fn activity_date_in_window(
-    activity_date: &DateTime<Utc>,
-    start: Option<&DateTime<Utc>>,
-    end: Option<&DateTime<Utc>>,
+fn event_overlaps_window(
+    event_start: &str,
+    event_end: &str,
+    window_start: Option<&DateTime<Utc>>,
+    window_end: Option<&DateTime<Utc>>,
 ) -> bool {
-    start.is_none_or(|start| activity_date >= start) && end.is_none_or(|end| activity_date <= end)
+    // Events have YYYY-MM-DD date strings; compare date keys lexicographically.
+    if let Some(ws) = window_start {
+        let window_start_key = format!("{}-{:02}-{:02}", ws.year(), ws.month(), ws.day());
+        if event_end < window_start_key.as_str() {
+            return false;
+        }
+    }
+    if let Some(we) = window_end {
+        let window_end_key = format!("{}-{:02}-{:02}", we.year(), we.month(), we.day());
+        if event_start > window_end_key.as_str() {
+            return false;
+        }
+    }
+    true
+}
+
+fn group_activities_by_visible_event(
+    activities: Vec<Activity>,
+    tag_map: HashMap<String, String>,
+    visible_event_ids: &HashSet<String>,
+    account_types: &HashMap<String, String>,
+) -> HashMap<String, Vec<Activity>> {
+    let mut by_event: HashMap<String, Vec<Activity>> = HashMap::new();
+    for activity in activities {
+        let Some(event_id) = tag_map.get(&activity.id).cloned() else {
+            continue;
+        };
+        if !visible_event_ids.contains(&event_id) {
+            continue;
+        }
+        let Some(classification) = classification_for(&activity, account_types) else {
+            continue;
+        };
+        if classification.spending_amount(activity_abs_amount(&activity)) == Decimal::ZERO {
+            continue;
+        }
+        by_event.entry(event_id).or_default().push(activity);
+    }
+    by_event
 }
 
 fn empty_summary(period: &str) -> SpendingSummary {
@@ -1171,22 +1210,25 @@ impl AnalyticsService {
             .map(|s| DateTime::parse_from_rfc3339(s).map(|d| d.with_timezone(&Utc)))
             .transpose()?;
 
-        let in_window = |event_start: &str, event_end: &str| -> bool {
-            // Events have YYYY-MM-DD date strings; compare lexicographically
-            if let Some(ws) = window_start {
-                let we_iso = format!("{}-{:02}-{:02}", ws.year(), ws.month(), ws.day());
-                if event_end < we_iso.as_str() {
-                    return false;
-                }
-            }
-            if let Some(we) = window_end {
-                let ws_iso = format!("{}-{:02}-{:02}", we.year(), we.month(), we.day());
-                if event_start > ws_iso.as_str() {
-                    return false;
-                }
-            }
-            true
-        };
+        let visible_events: Vec<_> = events
+            .into_iter()
+            .filter(|ev| {
+                event_overlaps_window(
+                    &ev.event.start_date,
+                    &ev.event.end_date,
+                    window_start.as_ref(),
+                    window_end.as_ref(),
+                )
+            })
+            .collect();
+        if visible_events.is_empty() {
+            return Ok(Vec::new());
+        }
+        let visible_event_ids: Vec<String> = visible_events
+            .iter()
+            .map(|ev| ev.event.id.clone())
+            .collect();
+        let visible_event_id_set: HashSet<String> = visible_event_ids.iter().cloned().collect();
 
         // Load category metadata for spending taxonomy
         let taxonomy_with_cats = self
@@ -1206,40 +1248,34 @@ impl AnalyticsService {
             })
             .collect();
 
-        // Load all activities once, then narrow to the date window *before*
-        // hitting the join table — preloading tags for activities we'll drop
-        // immediately would pull in junk ids on a wide history.
-        let activities = self
-            .activity_repo
-            .get_activities_by_account_ids(&target_accounts)
-            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
-        let activities_in_window: Vec<Activity> = activities
-            .into_iter()
-            .filter(|a| {
-                activity_date_in_window(
-                    &a.activity_date,
-                    window_start.as_ref(),
-                    window_end.as_ref(),
-                )
-            })
-            .collect();
-        let activity_ids: Vec<String> = activities_in_window.iter().map(|a| a.id.clone()).collect();
+        // Event reporting is tag-based: the request window chooses which
+        // events are visible, but every in-scope activity tagged to those
+        // events contributes to the event total, even when the activity date is
+        // before/after the event's own reporting window. Start from the
+        // visible event tags so this stays bounded by tagged activity count
+        // instead of scanning all spending history for the account set.
         let tag_map = self
             .activity_events
-            .list_for_activities(&activity_ids)
+            .list_for_events(&visible_event_ids)
             .await?;
-        let mut by_event: HashMap<String, Vec<Activity>> = HashMap::new();
-        for a in activities_in_window {
-            if let Some(eid) = tag_map.get(&a.id).cloned() {
-                let Some(classification) = classification_for(&a, &account_types) else {
-                    continue;
-                };
-                if classification.spending_amount(activity_abs_amount(&a)) == Decimal::ZERO {
-                    continue;
-                }
-                by_event.entry(eid).or_default().push(a);
-            }
-        }
+        let mut tagged_activity_ids: Vec<String> = tag_map.keys().cloned().collect();
+        tagged_activity_ids.sort();
+        tagged_activity_ids.dedup();
+        let target_account_ids: HashSet<&str> =
+            target_accounts.iter().map(String::as_str).collect();
+        let activities = self
+            .activity_repo
+            .get_activities_by_ids(&tagged_activity_ids)
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?
+            .into_iter()
+            .filter(|activity| target_account_ids.contains(activity.account_id.as_str()))
+            .collect();
+        let mut by_event = group_activities_by_visible_event(
+            activities,
+            tag_map,
+            &visible_event_id_set,
+            &account_types,
+        );
 
         let currency = req.currency.unwrap_or_else(|| "USD".to_string());
         // FX as-of: end of the requested window if provided; otherwise today.
@@ -1269,11 +1305,8 @@ impl AnalyticsService {
                 .push(asg);
         }
 
-        let mut out = Vec::with_capacity(events.len());
-        for ev in events {
-            if !in_window(&ev.event.start_date, &ev.event.end_date) {
-                continue;
-            }
+        let mut out = Vec::with_capacity(visible_events.len());
+        for ev in visible_events {
             let acts = by_event.remove(&ev.event.id).unwrap_or_default();
 
             let mut total = Decimal::ZERO;
@@ -1730,28 +1763,94 @@ mod tests {
     }
 
     #[test]
-    fn event_summary_window_filters_activity_dates() {
+    fn event_window_selects_events_by_event_dates() {
         let start = Utc.with_ymd_and_hms(2024, 2, 1, 0, 0, 0).unwrap();
         let end = Utc.with_ymd_and_hms(2024, 2, 29, 23, 59, 59).unwrap();
-        let in_window = Utc.with_ymd_and_hms(2024, 2, 10, 12, 0, 0).unwrap();
-        let before_window = Utc.with_ymd_and_hms(2024, 1, 31, 23, 59, 59).unwrap();
-        let after_window = Utc.with_ymd_and_hms(2024, 3, 1, 0, 0, 0).unwrap();
+        assert!(event_overlaps_window(
+            "2024-01-30",
+            "2024-02-02",
+            Some(&start),
+            Some(&end)
+        ));
+        assert!(event_overlaps_window(
+            "2024-02-10",
+            "2024-02-12",
+            Some(&start),
+            Some(&end)
+        ));
+        assert!(!event_overlaps_window(
+            "2024-01-01",
+            "2024-01-31",
+            Some(&start),
+            Some(&end)
+        ));
+        assert!(!event_overlaps_window(
+            "2024-03-01",
+            "2024-03-03",
+            Some(&start),
+            Some(&end)
+        ));
+    }
 
-        assert!(activity_date_in_window(
-            &in_window,
-            Some(&start),
-            Some(&end)
-        ));
-        assert!(!activity_date_in_window(
-            &before_window,
-            Some(&start),
-            Some(&end)
-        ));
-        assert!(!activity_date_in_window(
-            &after_window,
-            Some(&start),
-            Some(&end)
-        ));
+    #[test]
+    fn event_summary_groups_all_tagged_activities_for_visible_event() {
+        let (mut before, _) = spending_activity("flight", "WITHDRAWAL", 300, "travel", 5);
+        before.activity_date = Utc.with_ymd_and_hms(2024, 5, 20, 12, 0, 0).unwrap();
+        let (mut during, _) = spending_activity("meal", "WITHDRAWAL", 80, "travel", 6);
+        during.activity_date = Utc.with_ymd_and_hms(2024, 6, 12, 12, 0, 0).unwrap();
+        let (mut after, _) = spending_activity("deposit", "WITHDRAWAL", 120, "travel", 7);
+        after.activity_date = Utc.with_ymd_and_hms(2024, 7, 2, 12, 0, 0).unwrap();
+
+        let grouped = group_activities_by_visible_event(
+            vec![before, during, after],
+            HashMap::from([
+                ("flight".to_string(), "holiday".to_string()),
+                ("meal".to_string(), "holiday".to_string()),
+                ("deposit".to_string(), "holiday".to_string()),
+            ]),
+            &HashSet::from(["holiday".to_string()]),
+            &HashMap::from([(
+                "card-account".to_string(),
+                account_types::CREDIT_CARD.to_string(),
+            )]),
+        );
+
+        let mut ids = grouped
+            .get("holiday")
+            .unwrap()
+            .iter()
+            .map(|activity| activity.id.as_str())
+            .collect::<Vec<_>>();
+        ids.sort_unstable();
+        assert_eq!(ids, vec!["deposit", "flight", "meal"]);
+    }
+
+    #[test]
+    fn event_summary_ignores_tags_for_events_outside_requested_window() {
+        let (visible, _) = spending_activity("visible", "WITHDRAWAL", 100, "travel", 6);
+        let (hidden, _) = spending_activity("hidden", "WITHDRAWAL", 100, "travel", 6);
+
+        let grouped = group_activities_by_visible_event(
+            vec![visible, hidden],
+            HashMap::from([
+                ("visible".to_string(), "visible-event".to_string()),
+                ("hidden".to_string(), "hidden-event".to_string()),
+            ]),
+            &HashSet::from(["visible-event".to_string()]),
+            &HashMap::from([(
+                "card-account".to_string(),
+                account_types::CREDIT_CARD.to_string(),
+            )]),
+        );
+
+        let ids = grouped
+            .get("visible-event")
+            .unwrap()
+            .iter()
+            .map(|activity| activity.id.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(ids, vec!["visible"]);
+        assert!(!grouped.contains_key("hidden-event"));
     }
 
     #[test]

--- a/crates/spending/src/cash_activities/service.rs
+++ b/crates/spending/src/cash_activities/service.rs
@@ -488,6 +488,9 @@ impl CashActivityService {
     }
 
     /// Set or clear the spending-event tag on an activity. Pass `None` to clear.
+    /// Event date ranges describe reporting periods; they do not restrict
+    /// manual tagging. This allows pre-event spending like flights or deposits
+    /// to stay attached to the event they belong to.
     ///
     /// **Return contract**: returns the underlying `Activity` row, which does
     /// **not** carry the new tag — `event_id` lives on the `activity_events`
@@ -499,23 +502,13 @@ impl CashActivityService {
     pub async fn set_event(&self, activity_id: &str, event_id: Option<String>) -> Result<Activity> {
         let activity = self.ensure_activity_in_spending_scope(activity_id).await?;
         if let Some(ref event_id) = event_id {
-            let event =
-                self.events
-                    .get_event(event_id)
-                    .await?
-                    .ok_or_else(|| SpendingError::NotFound {
-                        entity: "Spending event",
-                        id: event_id.clone(),
-                    })?;
-            if !self
-                .events
-                .contains_activity_date(&event, &activity.activity_date)?
-            {
-                return Err(SpendingError::InvalidInput {
-                    message: "Activity date is outside the selected event date range".to_string(),
-                }
-                .into());
-            }
+            self.events
+                .get_event(event_id)
+                .await?
+                .ok_or_else(|| SpendingError::NotFound {
+                    entity: "Spending event",
+                    id: event_id.clone(),
+                })?;
         }
         self.activity_events
             .set_activity_event_tag(activity_id, event_id)

--- a/crates/spending/src/events/service.rs
+++ b/crates/spending/src/events/service.rs
@@ -110,10 +110,9 @@ impl EventsService {
         validate_event_range(&new_event.start_date, &new_event.end_date)?;
         self.events_repo.create(new_event).await
     }
-    /// Update an event. Validates the new (possibly partial) window. If the
-    /// window narrowed on either side, untags any activities that fell out of
-    /// range. On expansion, logs the count of newly in-range untagged
-    /// activities (we don't auto-tag — that's a UX decision).
+    /// Update an event. Validates the new (possibly partial) window. Existing
+    /// activity tags are preserved because event date ranges describe reporting
+    /// periods, not assignment validity.
     pub async fn update_event(&self, id: &str, patch: UpdateEvent) -> Result<Event> {
         let existing = self
             .events_repo
@@ -139,33 +138,12 @@ impl EventsService {
         let new_start_dt = parse_event_start_bound(&new_start)?;
         let new_end_dt = parse_event_end_bound(&new_end)?;
 
-        let narrowed_start = new_start_dt > old_start_dt;
-        let narrowed_end = new_end_dt < old_end_dt;
         let expanded_start = new_start_dt < old_start_dt;
         let expanded_end = new_end_dt > old_end_dt;
 
         let updated = self.events_repo.update(id, patch).await?;
 
-        // Untag activities that fell out of the new window on either narrowed
-        // side. Indexed lookup on activity_events gives us just the ids
-        // tagged to this event (typically small), and we fetch each by id
-        // instead of scanning the whole activities table.
-        if narrowed_start || narrowed_end {
-            let tagged_ids = self.activity_events.list_for_event(id).await?;
-            for activity_id in &tagged_ids {
-                let a = self
-                    .activity_repo
-                    .get_activity(activity_id)
-                    .map_err(|e| anyhow::anyhow!(e.to_string()))?;
-                if a.activity_date < new_start_dt || a.activity_date > new_end_dt {
-                    self.activity_events
-                        .set_activity_event_tag(&a.id, None)
-                        .await?;
-                }
-            }
-        }
-
-        // On expansion, surface count of newly-eligible (untagged) activities so
+        // On expansion, surface count of newly in-range untagged activities so
         // the frontend can offer a "tag these N activities" CTA. We do not
         // auto-tag.
         //
@@ -194,7 +172,7 @@ impl EventsService {
                 .count();
             if newly_eligible > 0 {
                 log::info!(
-                    "Event {} expanded — {} previously untagged in-range activities are now eligible for tagging",
+                    "Event {} expanded — {} previously untagged activities are now in the event date range",
                     id,
                     newly_eligible
                 );
@@ -257,7 +235,8 @@ fn parse_event_start_bound(s: &str) -> Result<DateTime<Utc>> {
 }
 
 /// Parse an event end boundary. Date-only end dates are inclusive for the full
-/// day so narrowing an event to `YYYY-MM-DD` does not untag same-day activity.
+/// day when checking whether an activity falls within an event's reporting
+/// window.
 fn parse_event_end_bound(s: &str) -> Result<DateTime<Utc>> {
     if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
         return Ok(dt.with_timezone(&Utc));
@@ -817,7 +796,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn shrinking_window_untags_out_of_range_activities() {
+    async fn shrinking_window_preserves_existing_activity_tags() {
         let in1 = Utc.with_ymd_and_hms(2024, 6, 5, 12, 0, 0).unwrap();
         let in2 = Utc.with_ymd_and_hms(2024, 6, 7, 12, 0, 0).unwrap();
         let out = Utc.with_ymd_and_hms(2024, 6, 9, 12, 0, 0).unwrap();
@@ -839,11 +818,11 @@ mod tests {
         let tags = tags.lock().unwrap();
         assert_eq!(tags.get("a1"), Some(&"ev1".to_string()));
         assert_eq!(tags.get("a2"), Some(&"ev1".to_string()));
-        assert_eq!(tags.get("a3"), None);
+        assert_eq!(tags.get("a3"), Some(&"ev1".to_string()));
     }
 
     #[tokio::test]
-    async fn date_only_end_date_keeps_same_day_activities() {
+    async fn date_only_end_date_update_preserves_existing_activity_tags() {
         let same_day = Utc.with_ymd_and_hms(2024, 6, 8, 14, 0, 0).unwrap();
         let next_day = Utc.with_ymd_and_hms(2024, 6, 9, 1, 0, 0).unwrap();
         let (svc, _, _, _, tags) = make_service(
@@ -859,7 +838,7 @@ mod tests {
 
         let tags = tags.lock().unwrap();
         assert_eq!(tags.get("a1"), Some(&"ev1".to_string()));
-        assert_eq!(tags.get("a2"), None);
+        assert_eq!(tags.get("a2"), Some(&"ev1".to_string()));
     }
 
     #[tokio::test]

--- a/crates/storage-sqlite/src/spending/activity_events.rs
+++ b/crates/storage-sqlite/src/spending/activity_events.rs
@@ -98,6 +98,25 @@ impl ActivityEventsRepositoryTrait for ActivityEventsRepository {
         Ok(rows)
     }
 
+    async fn list_for_events(&self, event_ids: &[String]) -> Result<HashMap<String, String>> {
+        if event_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let mut conn = get_connection(&self.pool).map_err(|e| anyhow::anyhow!(e))?;
+        const CHUNK: usize = 500;
+        let mut out = HashMap::new();
+        for chunk in event_ids.chunks(CHUNK) {
+            let rows: Vec<ActivityEventDB> = spending_activity_events::table
+                .filter(spending_activity_events::event_id.eq_any(chunk))
+                .select(ActivityEventDB::as_select())
+                .load(&mut conn)
+                .map_err(StorageError::from)
+                .map_err(|e| anyhow::anyhow!(e))?;
+            out.extend(rows.into_iter().map(|r| (r.activity_id, r.event_id)));
+        }
+        Ok(out)
+    }
+
     async fn set_activity_event_tag(
         &self,
         activity_id: &str,
@@ -253,23 +272,30 @@ mod tests {
         .expect("insert activity");
     }
 
-    fn insert_event(conn: &mut SqliteConnection) {
-        diesel::sql_query(
+    fn insert_event_with_id(conn: &mut SqliteConnection, id: &str) {
+        let event_type_id = format!("event-type-{id}");
+        diesel::sql_query(format!(
             "INSERT INTO spending_event_types (id, key, name, color, created_at, updated_at) \
-             VALUES ('event-type-test', NULL, 'Test Event Type', '#000000', \
+             VALUES ('{}', NULL, 'Test Event Type', '#000000', \
                      '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
-        )
+            event_type_id
+        ))
         .execute(conn)
         .expect("insert event type");
 
-        diesel::sql_query(
+        diesel::sql_query(format!(
             "INSERT INTO spending_events \
              (id, name, description, event_type_id, start_date, end_date, created_at, updated_at) \
-             VALUES ('event-test', 'Test Event', NULL, 'event-type-test', '2026-01-01', '2026-01-31', \
+             VALUES ('{}', 'Test Event', NULL, '{}', '2026-01-01', '2026-01-31', \
                      '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
-        )
+            id, event_type_id
+        ))
         .execute(conn)
         .expect("insert event");
+    }
+
+    fn insert_event(conn: &mut SqliteConnection) {
+        insert_event_with_id(conn, "event-test");
     }
 
     fn outbox_count(conn: &mut SqliteConnection) -> i64 {
@@ -321,5 +347,46 @@ mod tests {
             .load::<String>(&mut conn)
             .expect("load outbox entities");
         assert_eq!(entities, vec!["spending_activity_event".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn list_for_events_returns_tags_for_requested_events_only() {
+        let (pool, writer) = setup_db();
+        {
+            let mut conn = get_connection(&pool).expect("conn");
+            insert_account_and_activity(&mut conn, "activity-a", "MANUAL");
+            insert_account_and_activity(&mut conn, "activity-b", "MANUAL");
+            insert_account_and_activity(&mut conn, "activity-c", "MANUAL");
+            insert_event_with_id(&mut conn, "event-a");
+            insert_event_with_id(&mut conn, "event-b");
+            insert_event_with_id(&mut conn, "event-c");
+        }
+
+        let repo = ActivityEventsRepository::new(pool.clone(), writer);
+        repo.set_activity_event_tag("activity-a", Some("event-a".to_string()))
+            .await
+            .expect("tag activity a");
+        repo.set_activity_event_tag("activity-b", Some("event-b".to_string()))
+            .await
+            .expect("tag activity b");
+        repo.set_activity_event_tag("activity-c", Some("event-c".to_string()))
+            .await
+            .expect("tag activity c");
+
+        let tag_map = repo
+            .list_for_events(&["event-a".to_string(), "event-b".to_string()])
+            .await
+            .expect("list event tags");
+
+        assert_eq!(tag_map.len(), 2);
+        assert_eq!(
+            tag_map.get("activity-a").map(String::as_str),
+            Some("event-a")
+        );
+        assert_eq!(
+            tag_map.get("activity-b").map(String::as_str),
+            Some("event-b")
+        );
+        assert!(!tag_map.contains_key("activity-c"));
     }
 }


### PR DESCRIPTION
## Description

- Fix spending UI flows, including the mobile transaction form and spending period controls.
- Keep addon update callout state and changelog links aligned with addon detail pages.
- Update spending event summaries so visible events include all tagged in-scope activities, preserve tags when event date ranges change, and add repository support for loading tags by event ids.
- Replace raw broker sync errors in connect surfaces with stable user-facing review/failure messages.
- Apply Prettier formatting fixes required by the PR check.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run build:types`
- `pnpm format:check`
- `pnpm lint`
- `pnpm type-check`
- `pnpm test`
- `pnpm build`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `CONNECT_API_URL=http://test.local cargo test --workspace`
- `cargo check -p wealthfolio-server --release`

## Checklist

- [ ] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).