### PR TITLE
fix: invalid UTF-8 multi-byte character boundary error for custom pro…

### DIFF
--- a/crates/core/src/custom_provider/service.rs
+++ b/crates/core/src/custom_provider/service.rs
@@ -863,10 +863,7 @@ fn truncate_str(s: &str, max_bytes: usize) -> String {
         return s.to_string();
     }
     // Walk backward from max_bytes to find a char boundary
-    let end = s[..=max_bytes.min(s.len() - 1)]
-        .char_indices()
-        .next_back()
-        .map_or(0, |(i, _)| i);
+    let end = s.floor_char_boundary(max_bytes);
     format!("{}...", &s[..end])
 }
 


### PR DESCRIPTION
## Description

The commit fixes a UTF-8 character boundary bug in the truncate_str helper in custom_provider.

Problem: The old code walked backward through char_indices to find a safe UTF-8 boundary before truncating a string. This was both verbose and prone to off-by-one errors when max_bytes landed in the middle of a multi-byte character (e.g., CJK characters, emoji), which would panic with an "invalid UTF-8 boundary" error. This makes the custom_provider not work with pages from countries that uses CJK character.

Fix: Replaced the 4-line workaround with a single call to str::floor_char_boundary(max_bytes), a stable Rust standard library method (stabilized in 1.86) that correctly rounds down to the nearest valid UTF-8 character boundary.

Note: While this PR content and description was made with the help of AI, I have built the code locally and tested the changes myself.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
