### PR TITLE
[codex] Prefer import currency during asset resolution

### DIFF
--- a/apps/frontend/src/pages/activity/import/utils/draft-utils.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/draft-utils.test.ts
@@ -151,6 +151,42 @@ describe("createDraftActivities explicit activity mapping", () => {
     expect(draft.amount).toBe("1000.00");
   });
 
+  it("preserves signed amounts for cash adjustment rows", () => {
+    const [draft] = createDraftActivities(
+      [["2025-12-18T14:25:15", "ADJUSTMENT", "$CASH-CAD", "1", "1", "-2034.0743927", "CAD"]],
+      [
+        ImportFormat.DATE,
+        ImportFormat.ACTIVITY_TYPE,
+        ImportFormat.SYMBOL,
+        ImportFormat.QUANTITY,
+        ImportFormat.UNIT_PRICE,
+        ImportFormat.AMOUNT,
+        ImportFormat.CURRENCY,
+      ],
+      {
+        ...baseMapping,
+        fieldMappings: {
+          [ImportFormat.DATE]: ImportFormat.DATE,
+          [ImportFormat.ACTIVITY_TYPE]: ImportFormat.ACTIVITY_TYPE,
+          [ImportFormat.SYMBOL]: ImportFormat.SYMBOL,
+          [ImportFormat.QUANTITY]: ImportFormat.QUANTITY,
+          [ImportFormat.UNIT_PRICE]: ImportFormat.UNIT_PRICE,
+          [ImportFormat.AMOUNT]: ImportFormat.AMOUNT,
+          [ImportFormat.CURRENCY]: ImportFormat.CURRENCY,
+        },
+        activityMappings: {
+          [ActivityType.ADJUSTMENT]: ["ADJUSTMENT"],
+        },
+      },
+      parseConfig,
+      "account-1",
+    );
+
+    expect(draft.activityType).toBe(ActivityType.ADJUSTMENT);
+    expect(draft.amount).toBe("-2034.0743927");
+    expect(draftToActivityImport(draft).amount).toBe("-2034.0743927");
+  });
+
   it("does not infer transfer direction from sign", () => {
     const draft = createSingleDraftWithMapping(["2024-03-15", "TRANSFER", "-250.00", "USD"], {
       [ActivityType.TRANSFER_IN]: ["TRANSFER"],

--- a/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
@@ -11,6 +11,7 @@ import {
   hasPositiveValue,
   hasNonZeroValue,
   resolveCashActivityFields,
+  isCashAdjustmentActivity,
 } from "./review-draft-utils";
 import type { DraftActivity, DraftActivityStatus } from "../context";
 import {
@@ -464,16 +465,19 @@ export function createDraftActivities(
     const normalizedCsvInstrumentType = normalizeInstrumentType(rawInstrumentType);
     const resolvedInstrumentType =
       normalizedCsvInstrumentType || prefixInstrumentType || mappedInstrumentType;
-    const quantity = parseNumericValue(rawQuantity, decimalSeparator, thousandsSeparator);
-    const unitPrice = parseNumericValue(rawUnitPrice, decimalSeparator, thousandsSeparator);
-    const amount = parseNumericValue(rawAmount, decimalSeparator, thousandsSeparator);
     const currency = rawCurrency?.trim() || defaultCurrency;
-    const fee = parseNumericValue(rawFee, decimalSeparator, thousandsSeparator);
     const comment = rawComment?.trim();
-    const fxRate = parseNumericValue(rawFxRate, decimalSeparator, thousandsSeparator);
     const normalizedSubtype = rawSubtype?.trim().toUpperCase();
     const subtype =
       normalizedSubtype && normalizedSubtype !== activityType ? normalizedSubtype : undefined;
+    const preserveAmountSign = isCashAdjustmentActivity(activityType, symbol);
+    const quantity = parseNumericValue(rawQuantity, decimalSeparator, thousandsSeparator);
+    const unitPrice = parseNumericValue(rawUnitPrice, decimalSeparator, thousandsSeparator);
+    const amount = parseNumericValue(rawAmount, decimalSeparator, thousandsSeparator, {
+      preserveSign: preserveAmountSign,
+    });
+    const fee = parseNumericValue(rawFee, decimalSeparator, thousandsSeparator);
+    const fxRate = parseNumericValue(rawFxRate, decimalSeparator, thousandsSeparator);
 
     // Resolve account ID: use CSV account mapping, or fall back to default
     let accountId = accountMappings[""] || defaultAccountId;

--- a/apps/frontend/src/pages/activity/import/utils/review-draft-utils.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/review-draft-utils.test.ts
@@ -19,6 +19,14 @@ describe("parseNumericValue", () => {
       expect(parseNumericValue("-0.5", auto, none)).toBe("0.5");
     });
 
+    it("should preserve signs when requested", () => {
+      expect(parseNumericValue("-58.22", auto, none, { preserveSign: true })).toBe("-58.22");
+      expect(parseNumericValue("($1,234.56)", auto, none, { preserveSign: true })).toBe(
+        "-1234.56",
+      );
+      expect(parseNumericValue("+1000", auto, none, { preserveSign: true })).toBe("1000");
+    });
+
     it("should return absolute value for negative currency amounts", () => {
       expect(parseNumericValue("-$58.22", auto, none)).toBe("58.22");
       expect(parseNumericValue("-$1,234.56", auto, none)).toBe("1234.56");

--- a/apps/frontend/src/pages/activity/import/utils/review-draft-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/review-draft-utils.ts
@@ -3,12 +3,13 @@ import { isAssetBackedIncomeSubtype } from "@/lib/activity-utils";
 
 /**
  * Parse a numeric value from a string, handling various formats.
- * Always returns absolute values — brokers often use negative values to indicate direction.
+ * Returns absolute values by default — brokers often use negative values to indicate direction.
  */
 export function parseNumericValue(
   value: string | undefined,
   decimalSeparator: string,
   thousandsSeparator: string,
+  options: { preserveSign?: boolean } = {},
 ): string | undefined {
   if (!value || value.trim() === "") return undefined;
 
@@ -79,7 +80,9 @@ export function parseNumericValue(
 
   const numericCheck = Number(candidate);
   if (!Number.isFinite(numericCheck)) return undefined;
-  // Return absolute value — brokers often use negative values to indicate direction
+  if (options.preserveSign) {
+    return candidate.startsWith("+") ? candidate.slice(1) : candidate;
+  }
   return candidate.startsWith("-") ? candidate.slice(1) : candidate;
 }
 
@@ -111,6 +114,21 @@ const CASH_LIKE_TYPES: string[] = [
   ActivityType.WITHDRAWAL,
   ActivityType.CREDIT,
 ];
+
+function isCashLikeSymbol(symbol: string | undefined): boolean {
+  const normalized = symbol?.trim();
+  if (!normalized) return true;
+  if (/^\$?CASH[-_:][A-Z]{3}$/i.test(normalized)) return true;
+  if (/^-+$/.test(normalized)) return true;
+  return normalized.startsWith("$");
+}
+
+export function isCashAdjustmentActivity(
+  activityType: string | undefined,
+  symbol: string | undefined,
+): boolean {
+  return activityType?.trim().toUpperCase() === ActivityType.ADJUSTMENT && isCashLikeSymbol(symbol);
+}
 
 /**
  * For cash-like activities, some brokers (e.g. Schwab) put the dollar value

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -1292,6 +1292,7 @@ impl ActivityService {
                     ccy,
                 )
             };
+        let time_discriminator = preserves_signed_amount.then(|| date.to_rfc3339());
 
         Some(compute_idempotency_key(
             account_id,
@@ -1302,7 +1303,7 @@ impl ActivityService {
             unit_price,
             amount,
             currency,
-            None,
+            time_discriminator.as_deref(),
             activity.comment.as_deref(),
         ))
     }

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -426,11 +426,11 @@ impl ActivityService {
 
     fn normalize_quote_ccy(value: Option<&str>) -> Option<String> {
         let trimmed = value.map(str::trim).filter(|s| !s.is_empty())?;
-        if trimmed.eq_ignore_ascii_case("GBP") {
-            return Some("GBP".to_string());
-        }
         if trimmed == "GBp" {
             return Some("GBp".to_string());
+        }
+        if trimmed.eq_ignore_ascii_case("GBP") {
+            return Some("GBP".to_string());
         }
         if trimmed.eq_ignore_ascii_case("GBX") {
             return Some("GBX".to_string());
@@ -3362,6 +3362,11 @@ impl ActivityService {
                     activity.currency.as_str()
                 };
                 let explicit_quote_ccy = Self::normalize_quote_ccy(activity.quote_ccy.as_deref());
+                let activity_quote_ccy = if activity.currency.trim().is_empty() {
+                    None
+                } else {
+                    Self::normalize_quote_ccy(Some(activity.currency.as_str()))
+                };
 
                 let (resolved_quote_ccy, resolution_source) = if matches!(
                     effective_instrument_type,
@@ -3384,42 +3389,56 @@ impl ActivityService {
                 } else {
                     let has_deterministic = normalize_quote_ccy_code(explicit_quote_ccy.as_deref())
                         .is_some()
-                        || normalize_quote_ccy_code(asset_currency.as_deref()).is_some();
-                    let provider_ccy = if resolution_quote_ccy_source
-                        == Some(QuoteCcyResolutionSource::ProviderQuote)
+                        || normalize_quote_ccy_code(asset_currency.as_deref()).is_some()
+                        || normalize_quote_ccy_code(activity_quote_ccy.as_deref()).is_some();
+                    if let Some(quote_ccy) = normalize_quote_ccy_code(explicit_quote_ccy.as_deref())
                     {
-                        resolution_quote_ccy.clone()
-                    } else if has_deterministic {
-                        None
-                    } else {
-                        self.fetch_provider_quote_ccy(
-                            &normalized_symbol,
-                            resolved_mic.as_deref(),
-                            effective_instrument_type.as_ref(),
-                            &mut quote_ccy_cache,
-                        )
-                        .await
-                    };
-                    let mic_fallback_ccy = if resolution_quote_ccy_source
-                        == Some(QuoteCcyResolutionSource::MicFallback)
+                        (quote_ccy, QuoteCcyResolutionSource::ExplicitInput)
+                    } else if let Some(quote_ccy) =
+                        normalize_quote_ccy_code(asset_currency.as_deref())
                     {
-                        resolution_quote_ccy.as_deref()
+                        (quote_ccy, QuoteCcyResolutionSource::ExistingAsset)
+                    } else if let Some(quote_ccy) =
+                        normalize_quote_ccy_code(activity_quote_ccy.as_deref())
+                    {
+                        (quote_ccy, QuoteCcyResolutionSource::ExplicitInput)
                     } else {
-                        resolved_mic.as_deref().and_then(mic_to_currency)
-                    };
-                    resolve_quote_ccy_precedence(
-                        explicit_quote_ccy.as_deref(),
-                        asset_currency.as_deref(),
-                        provider_ccy.as_deref(),
-                        mic_fallback_ccy,
-                        Some(terminal_fallback),
-                    )
-                    .unwrap_or_else(|| {
-                        (
-                            terminal_fallback.to_string(),
-                            QuoteCcyResolutionSource::TerminalFallback,
+                        let provider_ccy = if resolution_quote_ccy_source
+                            == Some(QuoteCcyResolutionSource::ProviderQuote)
+                        {
+                            resolution_quote_ccy.clone()
+                        } else if has_deterministic {
+                            None
+                        } else {
+                            self.fetch_provider_quote_ccy(
+                                &normalized_symbol,
+                                resolved_mic.as_deref(),
+                                effective_instrument_type.as_ref(),
+                                &mut quote_ccy_cache,
+                            )
+                            .await
+                        };
+                        let mic_fallback_ccy = if resolution_quote_ccy_source
+                            == Some(QuoteCcyResolutionSource::MicFallback)
+                        {
+                            resolution_quote_ccy.as_deref()
+                        } else {
+                            resolved_mic.as_deref().and_then(mic_to_currency)
+                        };
+                        resolve_quote_ccy_precedence(
+                            None,
+                            None,
+                            provider_ccy.as_deref(),
+                            mic_fallback_ccy,
+                            Some(terminal_fallback),
                         )
-                    })
+                        .unwrap_or_else(|| {
+                            (
+                                terminal_fallback.to_string(),
+                                QuoteCcyResolutionSource::TerminalFallback,
+                            )
+                        })
+                    }
                 };
 
                 activity.quote_ccy = Some(resolved_quote_ccy);

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -149,6 +149,25 @@ impl ActivityService {
         !has_asset_id && !has_real_symbol
     }
 
+    fn is_cash_adjustment_import(activity: &ActivityImport) -> bool {
+        if !activity
+            .activity_type
+            .eq_ignore_ascii_case(ACTIVITY_TYPE_ADJUSTMENT)
+        {
+            return false;
+        }
+        let has_asset_id = activity
+            .asset_id
+            .as_deref()
+            .map(str::trim)
+            .is_some_and(|asset_id| !asset_id.is_empty());
+        let symbol = activity.symbol.trim();
+        let has_real_symbol =
+            !symbol.is_empty() && !is_cash_symbol(symbol) && !is_garbage_symbol(symbol);
+
+        !has_asset_id && !has_real_symbol
+    }
+
     fn normalize_new_activity_economic_signs(activity: &mut NewActivity) {
         let preserves_signed_amount = Self::is_cash_adjustment_activity(activity);
         activity.quantity = activity.quantity.map(|v| v.abs());
@@ -1245,15 +1264,19 @@ impl ActivityService {
 
         // Normalize to absolute values and major currencies, matching what
         // prepare_activities_internal does before the apply-step key computation.
+        // Cash adjustments are the exception: their signed amount is the
+        // economic direction, so it must remain part of the duplicate key.
+        let preserves_signed_amount = Self::is_cash_adjustment_import(activity);
         let quantity = activity.quantity.map(|v| v.abs());
         let (unit_price, amount, currency) =
             if let Some(rule) = get_normalization_rule(activity.currency.as_str()) {
                 let unit_price = activity
                     .unit_price
                     .map(|v| normalize_amount(v.abs(), activity.currency.as_str()).0);
-                let amount = activity
-                    .amount
-                    .map(|v| normalize_amount(v.abs(), activity.currency.as_str()).0);
+                let amount = activity.amount.map(|v| {
+                    let normalized_input = if preserves_signed_amount { v } else { v.abs() };
+                    normalize_amount(normalized_input, activity.currency.as_str()).0
+                });
                 (unit_price, amount, rule.major_code)
             } else {
                 let ccy = if activity.currency.trim().is_empty() {
@@ -1263,7 +1286,9 @@ impl ActivityService {
                 };
                 (
                     activity.unit_price.map(|v| v.abs()),
-                    activity.amount.map(|v| v.abs()),
+                    activity
+                        .amount
+                        .map(|v| if preserves_signed_amount { v } else { v.abs() }),
                     ccy,
                 )
             };

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -7,9 +7,9 @@ use std::sync::Arc;
 use crate::accounts::{account_types, Account, AccountServiceTrait};
 use crate::activities::activities_constants::{
     classify_import_activity, is_cash_symbol, is_garbage_symbol, requires_symbol,
-    ImportSymbolDisposition, ACTIVITY_TYPE_CREDIT, ACTIVITY_TYPE_FEE, ACTIVITY_TYPE_INTEREST,
-    ACTIVITY_TYPE_SPLIT, ACTIVITY_TYPE_TRANSFER_IN, ACTIVITY_TYPE_TRANSFER_OUT,
-    ACTIVITY_TYPE_WITHDRAWAL, PRICE_BEARING_ACTIVITY_TYPES,
+    ImportSymbolDisposition, ACTIVITY_TYPE_ADJUSTMENT, ACTIVITY_TYPE_CREDIT, ACTIVITY_TYPE_FEE,
+    ACTIVITY_TYPE_INTEREST, ACTIVITY_TYPE_SPLIT, ACTIVITY_TYPE_TRANSFER_IN,
+    ACTIVITY_TYPE_TRANSFER_OUT, ACTIVITY_TYPE_WITHDRAWAL, PRICE_BEARING_ACTIVITY_TYPES,
 };
 use crate::activities::activities_errors::ActivityError;
 use crate::activities::activities_model::*;
@@ -129,10 +129,33 @@ impl PreparationMode {
 }
 
 impl ActivityService {
+    fn is_cash_adjustment_activity(activity: &NewActivity) -> bool {
+        if !activity
+            .activity_type
+            .eq_ignore_ascii_case(ACTIVITY_TYPE_ADJUSTMENT)
+        {
+            return false;
+        }
+        let has_asset_id = activity
+            .get_symbol_id()
+            .map(str::trim)
+            .is_some_and(|asset_id| !asset_id.is_empty());
+        let has_real_symbol = activity
+            .get_symbol_code()
+            .map(str::trim)
+            .filter(|symbol| !symbol.is_empty())
+            .is_some_and(|symbol| !is_cash_symbol(symbol));
+
+        !has_asset_id && !has_real_symbol
+    }
+
     fn normalize_new_activity_economic_signs(activity: &mut NewActivity) {
+        let preserves_signed_amount = Self::is_cash_adjustment_activity(activity);
         activity.quantity = activity.quantity.map(|v| v.abs());
         activity.unit_price = activity.unit_price.map(|v| v.abs());
-        activity.amount = activity.amount.map(|v| v.abs());
+        if !preserves_signed_amount {
+            activity.amount = activity.amount.map(|v| v.abs());
+        }
         activity.fee = activity.fee.map(|v| v.abs());
     }
 
@@ -2177,11 +2200,7 @@ impl ActivityService {
             }
         }
 
-        // Normalize amounts to absolute values (direction is determined by activity type)
-        activity.quantity = activity.quantity.map(|v| v.abs());
-        activity.unit_price = activity.unit_price.map(|v| v.abs());
-        activity.amount = activity.amount.map(|v| v.abs());
-        activity.fee = activity.fee.map(|v| v.abs());
+        Self::normalize_new_activity_economic_signs(&mut activity);
 
         // Securities transfers derive monetary value from quantity × unit_price at
         // read time. Any inbound `amount` is redundant and has historically been
@@ -5680,11 +5699,7 @@ impl ActivityService {
                 }
             }
 
-            // Normalize amounts to absolute values (direction is determined by activity type)
-            activity.quantity = activity.quantity.map(|v| v.abs());
-            activity.unit_price = activity.unit_price.map(|v| v.abs());
-            activity.amount = activity.amount.map(|v| v.abs());
-            activity.fee = activity.fee.map(|v| v.abs());
+            Self::normalize_new_activity_economic_signs(&mut activity);
 
             if let Err(e) = Self::validate_split_ratio(&activity.activity_type, activity.amount) {
                 if mode.is_sync() {

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -799,6 +799,14 @@ mod tests {
             _quote_ccy: Option<&str>,
             _preferred_provider: Option<&str>,
         ) -> Result<ResolvedQuote> {
+            if symbol.eq_ignore_ascii_case("IUES") {
+                return Ok(ResolvedQuote {
+                    currency: Some("EUR".to_string()),
+                    price: Some(dec!(10)),
+                    resolved_provider_id: Some("YAHOO".to_string()),
+                });
+            }
+
             let is_uk_vwrp = (exchange_mic == Some("XLON") || exchange_mic == Some("CXE"))
                 && (symbol.eq_ignore_ascii_case("VWRPL")
                     || symbol.eq_ignore_ascii_case("VWRPL.XC"));
@@ -5232,7 +5240,10 @@ mod tests {
         );
         assert_eq!(preview[0].review_symbol.as_deref(), Some("VOD.L"));
         assert_eq!(
-            preview[0].draft.as_ref().map(|draft| draft.quote_ccy.as_str()),
+            preview[0]
+                .draft
+                .as_ref()
+                .map(|draft| draft.quote_ccy.as_str()),
             Some("USD")
         );
         assert!(preview[0].errors.is_none());
@@ -5284,7 +5295,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_check_import_uses_mic_currency_as_quote_ccy_fallback() {
+    async fn test_check_import_uses_activity_currency_before_mic_currency_fallback() {
         let account_service = Arc::new(MockAccountService::new());
         let asset_service = Arc::new(MockAssetService::new());
         let fx_service = Arc::new(MockFxService::new());
@@ -5345,14 +5356,14 @@ mod tests {
         assert_eq!(result.len(), 1);
         let checked = &result[0];
         assert_eq!(checked.instrument_type.as_deref(), Some("EQUITY"));
-        assert_eq!(checked.quote_ccy.as_deref(), Some("GBp"));
+        assert_eq!(checked.quote_ccy.as_deref(), Some("CAD"));
         assert!(
             checked
                 .warnings
                 .as_ref()
                 .and_then(|w| w.get("_quote_ccy_fallback"))
-                .is_some(),
-            "Expected MIC fallback warning when quote_ccy is inferred from exchange"
+                .is_none(),
+            "activity currency should not be reported as a MIC fallback"
         );
     }
 
@@ -5629,6 +5640,73 @@ mod tests {
         assert_eq!(checked.instrument_type.as_deref(), Some("EQUITY"));
         assert_eq!(checked.exchange_mic.as_deref(), Some("XLON"));
         assert_eq!(checked.quote_ccy.as_deref(), Some("GBP"));
+    }
+
+    #[tokio::test]
+    async fn test_check_import_uses_activity_currency_before_provider_quote_for_new_asset() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let account = create_test_account("acc-1", "USD");
+        account_service.add_account(account);
+
+        let quote_service = Arc::new(MockQuoteService);
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            quote_service,
+        );
+
+        let import = ActivityImport {
+            id: None,
+            date: "2025-12-30".to_string(),
+            symbol: "IUES".to_string(),
+            activity_type: "BUY".to_string(),
+            quantity: Some(dec!(778)),
+            unit_price: Some(dec!(9.4075)),
+            currency: "USD".to_string(),
+            fee: Some(dec!(0)),
+            amount: Some(dec!(7318.035)),
+            comment: None,
+            account_id: Some("acc-1".to_string()),
+            account_name: None,
+            symbol_name: None,
+            exchange_mic: Some("XAMS".to_string()),
+            quote_ccy: None,
+            instrument_type: Some("EQUITY".to_string()),
+            quote_mode: Some("MARKET".to_string()),
+            provider_id: None,
+            provider_symbol: None,
+            errors: None,
+            warnings: None,
+            duplicate_of_id: None,
+            duplicate_of_line_number: None,
+            is_draft: false,
+            is_valid: true,
+            line_number: Some(1),
+            fx_rate: None,
+            subtype: None,
+            asset_id: None,
+            isin: None,
+            force_import: false,
+            is_external: None,
+        };
+
+        let result = activity_service
+            .check_activities_import(vec![import])
+            .await
+            .expect("import check should succeed");
+
+        assert_eq!(result.len(), 1);
+        let checked = &result[0];
+        assert_eq!(checked.symbol, "IUES");
+        assert_eq!(checked.exchange_mic.as_deref(), Some("XAMS"));
+        assert_eq!(checked.quote_ccy.as_deref(), Some("USD"));
+        assert!(checked.is_valid);
     }
 
     #[tokio::test]

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -6757,6 +6757,82 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_import_keeps_same_day_cash_adjustments_with_distinct_times() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let account = create_test_account("acc-1", "USD");
+        account_service.add_account(account);
+
+        let quote_service = Arc::new(MockQuoteService);
+        let activity_service = ActivityService::new(
+            activity_repository.clone(),
+            account_service,
+            asset_service,
+            fx_service,
+            quote_service,
+        );
+
+        let base_adjustment = ActivityImport {
+            id: None,
+            date: "2025-12-30T10:30:03Z".to_string(),
+            symbol: "$CASH-USD".to_string(),
+            activity_type: "ADJUSTMENT".to_string(),
+            quantity: Some(dec!(1)),
+            unit_price: Some(dec!(1)),
+            currency: "USD".to_string(),
+            fee: Some(dec!(0)),
+            amount: Some(dec!(0.36)),
+            comment: None,
+            account_id: Some("acc-1".to_string()),
+            account_name: None,
+            symbol_name: None,
+            exchange_mic: None,
+            quote_ccy: None,
+            instrument_type: None,
+            quote_mode: None,
+            provider_id: None,
+            provider_symbol: None,
+            errors: None,
+            warnings: None,
+            duplicate_of_id: None,
+            duplicate_of_line_number: None,
+            is_draft: false,
+            is_valid: true,
+            line_number: Some(1),
+            fx_rate: None,
+            subtype: Some("FX_CONVERSION".to_string()),
+            asset_id: None,
+            isin: None,
+            force_import: false,
+            is_external: None,
+        };
+
+        let result = activity_service
+            .import_activities(vec![
+                base_adjustment.clone(),
+                ActivityImport {
+                    date: "2025-12-30T12:00:09Z".to_string(),
+                    line_number: Some(2),
+                    ..base_adjustment
+                },
+            ])
+            .await
+            .expect("cash adjustment import should succeed");
+
+        assert!(result.summary.success);
+        assert_eq!(result.summary.imported, 2);
+        assert_eq!(result.summary.duplicates, 0);
+
+        let stored = activity_repository
+            .get_activities()
+            .expect("stored activities should be readable");
+        assert_eq!(stored.len(), 2);
+    }
+
+    #[tokio::test]
     async fn test_import_accepts_resolved_symbol_rows_without_rechecking() {
         let account_service = Arc::new(MockAccountService::new());
         let asset_service = Arc::new(MockAssetService::new());

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -387,8 +387,16 @@ mod tests {
                         }
                     }
 
-                    let explicit_quote_ccy = normalize_quote_ccy_code(input.quote_ccy.as_deref());
-                    let existing_quote_ccy = existing_asset.map(|asset| asset.quote_ccy.clone());
+                    let explicit_quote_ccy = normalize_quote_ccy_code(input.quote_ccy.as_deref())
+                        .or_else(|| {
+                            pair_quote
+                                .as_deref()
+                                .and_then(|quote| normalize_quote_ccy_code(Some(quote)))
+                        });
+                    let existing_quote_ccy = existing_asset
+                        .and_then(|asset| normalize_quote_ccy_code(Some(asset.quote_ccy.as_str())));
+                    let activity_quote_ccy =
+                        normalize_quote_ccy_code(input.activity_currency.as_deref());
                     let provider_quote_ccy = provider_resolution
                         .as_ref()
                         .map(|(_, _, quote, _, _)| quote.clone());
@@ -396,22 +404,16 @@ mod tests {
                         .as_deref()
                         .and_then(wealthfolio_market_data::mic_to_currency)
                         .map(str::to_string);
-                    let activity_quote_ccy = input
-                        .activity_currency
-                        .clone()
-                        .filter(|currency| !currency.trim().is_empty());
                     let (quote_ccy, quote_ccy_source) = if let Some(quote) = explicit_quote_ccy {
                         (quote, QuoteCcyResolutionSource::ExplicitInput)
                     } else if let Some(quote) = existing_quote_ccy {
                         (quote, QuoteCcyResolutionSource::ExistingAsset)
+                    } else if let Some(quote) = activity_quote_ccy {
+                        (quote, QuoteCcyResolutionSource::ExplicitInput)
                     } else if let Some(quote) = provider_quote_ccy {
                         (quote, QuoteCcyResolutionSource::ProviderQuote)
-                    } else if let Some(quote) = pair_quote {
-                        (quote, QuoteCcyResolutionSource::ExplicitInput)
                     } else if let Some(quote) = mic_quote_ccy {
                         (quote, QuoteCcyResolutionSource::MicFallback)
-                    } else if let Some(quote) = activity_quote_ccy {
-                        (quote, QuoteCcyResolutionSource::TerminalFallback)
                     } else {
                         (
                             input.account_currency.clone(),
@@ -5185,6 +5187,55 @@ mod tests {
         assert_eq!(draft.display_code.as_deref(), Some("MSF"));
         assert_eq!(draft.instrument_symbol.as_deref(), Some("MSF"));
         assert_eq!(draft.instrument_exchange_mic.as_deref(), Some("XETR"));
+    }
+
+    #[tokio::test]
+    async fn test_preview_import_assets_uses_csv_currency_before_provider_currency() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let account = create_test_account("acc-1", "USD");
+        account_service.add_account(account);
+
+        let quote_service = Arc::new(MockQuoteService);
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            quote_service,
+        );
+
+        let preview = activity_service
+            .preview_import_assets(vec![ImportAssetCandidate {
+                key: "vod-usd".to_string(),
+                account_id: "acc-1".to_string(),
+                symbol: "VOD.L".to_string(),
+                currency: Some("USD".to_string()),
+                instrument_type: None,
+                quote_ccy: None,
+                quote_mode: None,
+                exchange_mic: None,
+                isin: None,
+                provider_id: None,
+                provider_symbol: None,
+            }])
+            .await
+            .expect("preview should succeed");
+
+        assert_eq!(preview.len(), 1);
+        assert_eq!(
+            preview[0].status,
+            ImportAssetPreviewStatus::AutoResolvedNewAsset
+        );
+        assert_eq!(preview[0].review_symbol.as_deref(), Some("VOD.L"));
+        assert_eq!(
+            preview[0].draft.as_ref().map(|draft| draft.quote_ccy.as_str()),
+            Some("USD")
+        );
+        assert!(preview[0].errors.is_none());
     }
 
     #[tokio::test]

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -6605,6 +6605,158 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_import_preserves_negative_cash_adjustment_amount() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let account = create_test_account("acc-1", "USD");
+        account_service.add_account(account);
+
+        let quote_service = Arc::new(MockQuoteService);
+        let activity_service = ActivityService::new(
+            activity_repository.clone(),
+            account_service,
+            asset_service,
+            fx_service,
+            quote_service,
+        );
+
+        let cash_adjustment = ActivityImport {
+            id: None,
+            date: "2025-12-18T14:25:15Z".to_string(),
+            symbol: "$CASH-CAD".to_string(),
+            activity_type: "ADJUSTMENT".to_string(),
+            quantity: Some(dec!(1)),
+            unit_price: Some(dec!(1)),
+            currency: "CAD".to_string(),
+            fee: Some(dec!(0)),
+            amount: Some(dec!(-2034.0743927)),
+            comment: None,
+            account_id: Some("acc-1".to_string()),
+            account_name: None,
+            symbol_name: None,
+            exchange_mic: None,
+            quote_ccy: None,
+            instrument_type: None,
+            quote_mode: None,
+            provider_id: None,
+            provider_symbol: None,
+            errors: None,
+            warnings: None,
+            duplicate_of_id: None,
+            duplicate_of_line_number: None,
+            is_draft: false,
+            is_valid: true,
+            line_number: Some(1),
+            fx_rate: None,
+            subtype: Some("FX_CONVERSION".to_string()),
+            asset_id: None,
+            isin: None,
+            force_import: false,
+            is_external: None,
+        };
+
+        let result = activity_service
+            .import_activities(vec![cash_adjustment])
+            .await
+            .expect("cash adjustment import should succeed");
+
+        assert!(result.summary.success);
+        assert_eq!(result.summary.imported, 1);
+
+        let stored = activity_repository
+            .get_activities()
+            .expect("stored activities should be readable");
+        assert_eq!(stored.len(), 1);
+        assert_eq!(stored[0].activity_type, "ADJUSTMENT");
+        assert_eq!(stored[0].asset_id, None);
+        assert_eq!(stored[0].amount, Some(dec!(-2034.0743927)));
+    }
+
+    #[tokio::test]
+    async fn test_import_keeps_opposite_signed_cash_adjustments_distinct() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let account = create_test_account("acc-1", "USD");
+        account_service.add_account(account);
+
+        let quote_service = Arc::new(MockQuoteService);
+        let activity_service = ActivityService::new(
+            activity_repository.clone(),
+            account_service,
+            asset_service,
+            fx_service,
+            quote_service,
+        );
+
+        let base_adjustment = ActivityImport {
+            id: None,
+            date: "2025-12-18T14:25:15Z".to_string(),
+            symbol: "$CASH-CAD".to_string(),
+            activity_type: "ADJUSTMENT".to_string(),
+            quantity: Some(dec!(1)),
+            unit_price: Some(dec!(1)),
+            currency: "CAD".to_string(),
+            fee: Some(dec!(0)),
+            amount: Some(dec!(-100)),
+            comment: None,
+            account_id: Some("acc-1".to_string()),
+            account_name: None,
+            symbol_name: None,
+            exchange_mic: None,
+            quote_ccy: None,
+            instrument_type: None,
+            quote_mode: None,
+            provider_id: None,
+            provider_symbol: None,
+            errors: None,
+            warnings: None,
+            duplicate_of_id: None,
+            duplicate_of_line_number: None,
+            is_draft: false,
+            is_valid: true,
+            line_number: Some(1),
+            fx_rate: None,
+            subtype: Some("FX_CONVERSION".to_string()),
+            asset_id: None,
+            isin: None,
+            force_import: false,
+            is_external: None,
+        };
+
+        let result = activity_service
+            .import_activities(vec![
+                base_adjustment.clone(),
+                ActivityImport {
+                    amount: Some(dec!(100)),
+                    line_number: Some(2),
+                    ..base_adjustment
+                },
+            ])
+            .await
+            .expect("cash adjustment import should succeed");
+
+        assert!(result.summary.success);
+        assert_eq!(result.summary.imported, 2);
+        assert_eq!(result.summary.duplicates, 0);
+
+        let mut amounts: Vec<Decimal> = activity_repository
+            .get_activities()
+            .expect("stored activities should be readable")
+            .into_iter()
+            .filter_map(|activity| activity.amount)
+            .collect();
+        amounts.sort();
+
+        assert_eq!(amounts, vec![dec!(-100), dec!(100)]);
+    }
+
+    #[tokio::test]
     async fn test_import_accepts_resolved_symbol_rows_without_rechecking() {
         let account_service = Arc::new(MockAccountService::new());
         let asset_service = Arc::new(MockAssetService::new());

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -2324,6 +2324,58 @@ mod tests {
         assert_eq!(prepared.status, Some(ActivityStatus::Draft));
     }
 
+    #[tokio::test]
+    async fn prepare_cash_adjustment_preserves_signed_amount() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let account = create_test_account("acc-1", "USD");
+        account_service.add_account(account.clone());
+
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            Arc::new(MockQuoteService),
+        );
+
+        let result = activity_service
+            .prepare_activities_for_sync(
+                vec![NewActivity {
+                    id: Some("cash-adjustment-out".to_string()),
+                    account_id: "acc-1".to_string(),
+                    asset: None,
+                    activity_type: "ADJUSTMENT".to_string(),
+                    subtype: Some("FX_CONVERSION".to_string()),
+                    activity_date: "2025-06-01".to_string(),
+                    quantity: Some(dec!(1)),
+                    unit_price: Some(dec!(1)),
+                    currency: "USD".to_string(),
+                    fee: Some(dec!(0)),
+                    amount: Some(dec!(-200.35)),
+                    status: Some(ActivityStatus::Posted),
+                    notes: None,
+                    fx_rate: None,
+                    metadata: None,
+                    needs_review: Some(false),
+                    source_system: Some("CSV".to_string()),
+                    source_record_id: None,
+                    source_group_id: None,
+                    idempotency_key: None,
+                }],
+                &account,
+            )
+            .await
+            .expect("cash adjustment should prepare");
+
+        assert!(result.errors.is_empty());
+        assert_eq!(result.prepared.len(), 1);
+        assert_eq!(result.prepared[0].activity.amount, Some(dec!(-200.35)));
+    }
+
     /// Test: When creating an activity where the activity currency matches the account currency,
     /// but the asset has a different currency, we should still register the FX pair for the asset currency.
     ///

--- a/crates/core/src/assets/assets_service.rs
+++ b/crates/core/src/assets/assets_service.rs
@@ -3482,7 +3482,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_resolve_import_asset_inputs_falls_back_to_raw_unsuffixed_symbol() {
+    async fn test_raw_symbol_fallback_prefers_activity_currency() {
         let nyse = yahoo_search_result("SHOP", "SHOP", "XNYS", "Shopify Inc.", "USD", "SHOP");
         let quote_service = TestQuoteService::default().with_result("SHOP", vec![nyse]);
         let search_calls = Arc::clone(&quote_service.search_calls);
@@ -3498,7 +3498,11 @@ mod tests {
         assert_eq!(search_calls.lock().unwrap().as_slice(), ["SHOP.TO", "SHOP"]);
         assert_eq!(output.canonical_symbol.as_deref(), Some("SHOP"));
         assert_eq!(output.exchange_mic.as_deref(), Some("XNYS"));
-        assert_eq!(output.quote_ccy.as_deref(), Some("USD"));
+        assert_eq!(output.quote_ccy.as_deref(), Some("CAD"));
+        assert_eq!(
+            output.quote_ccy_source,
+            Some(QuoteCcyResolutionSource::ExplicitInput)
+        );
         assert_eq!(output.provider_symbol.as_deref(), Some("SHOP"));
         assert_eq!(output.review_symbol.as_deref(), Some("SHOP"));
     }

--- a/crates/core/src/assets/assets_service.rs
+++ b/crates/core/src/assets/assets_service.rs
@@ -1394,22 +1394,36 @@ impl AssetServiceTrait for AssetService {
                 .map(|asset| asset.quote_ccy.as_str());
 
             let explicit_quote_ccy = input.quote_ccy.as_deref().or(pair_quote_ccy.as_deref());
+            let activity_quote_ccy = input
+                .activity_currency
+                .as_deref()
+                .map(str::trim)
+                .filter(|currency| !currency.is_empty());
             let provider_quote_ccy = provider_result
                 .as_ref()
                 .and_then(|result| result.currency.as_deref());
-            let (quote_ccy, quote_ccy_source) = resolve_quote_ccy_precedence(
-                explicit_quote_ccy,
-                existing_quote_ccy,
-                provider_quote_ccy,
-                exchange_mic.as_deref().and_then(mic_to_currency),
-                Some(&terminal_currency),
-            )
-            .unwrap_or_else(|| {
-                (
-                    terminal_currency.clone(),
-                    QuoteCcyResolutionSource::TerminalFallback,
-                )
-            });
+            let (quote_ccy, quote_ccy_source) =
+                if let Some(quote_ccy) = normalize_quote_ccy_code(explicit_quote_ccy) {
+                    (quote_ccy, QuoteCcyResolutionSource::ExplicitInput)
+                } else if let Some(quote_ccy) = normalize_quote_ccy_code(existing_quote_ccy) {
+                    (quote_ccy, QuoteCcyResolutionSource::ExistingAsset)
+                } else if let Some(quote_ccy) = normalize_quote_ccy_code(activity_quote_ccy) {
+                    (quote_ccy, QuoteCcyResolutionSource::ExplicitInput)
+                } else {
+                    resolve_quote_ccy_precedence(
+                        None,
+                        None,
+                        provider_quote_ccy,
+                        exchange_mic.as_deref().and_then(mic_to_currency),
+                        Some(&terminal_currency),
+                    )
+                    .unwrap_or_else(|| {
+                        (
+                            terminal_currency.clone(),
+                            QuoteCcyResolutionSource::TerminalFallback,
+                        )
+                    })
+                };
 
             let quote_mode = input.quote_mode.unwrap_or(QuoteMode::Market);
             let provider_id = input.provider_id.clone().or_else(|| {
@@ -2612,7 +2626,8 @@ impl AssetServiceTrait for AssetService {
 #[cfg(test)]
 mod tests {
     use super::super::assets_model::{
-        Asset, AssetKind, InstrumentType, NewAsset, ProviderProfile, UpdateAssetProfile,
+        Asset, AssetKind, InstrumentType, NewAsset, ProviderProfile, QuoteCcyResolutionSource,
+        UpdateAssetProfile,
     };
     use super::{AssetRepositoryTrait, AssetService, AssetServiceTrait, QuoteMode};
     use crate::assets::AssetResolutionInput;
@@ -3141,6 +3156,45 @@ mod tests {
         assert_eq!(draft.instrument_exchange_mic.as_deref(), Some("XLON"));
         assert_eq!(draft.provider_config, None);
         assert_eq!(draft.provider_id.as_deref(), Some("YAHOO"));
+        assert_eq!(draft.provider_symbol.as_deref(), Some("VOD.L"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_import_asset_inputs_uses_activity_currency_before_provider_quote() {
+        let service = test_asset_service(
+            Vec::new(),
+            TestQuoteService::default().with_result(
+                "VOD.L",
+                vec![yahoo_search_result(
+                    "VOD.L",
+                    "VOD",
+                    "XLON",
+                    "Vodafone Group Public Limited Company",
+                    "GBp",
+                    "VOD.L",
+                )],
+            ),
+        );
+
+        let output = service
+            .resolve_import_asset_inputs(vec![import_input("VOD.L", "USD")])
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
+
+        assert_eq!(output.canonical_symbol.as_deref(), Some("VOD"));
+        assert_eq!(output.exchange_mic.as_deref(), Some("XLON"));
+        assert_eq!(output.quote_ccy.as_deref(), Some("USD"));
+        assert_eq!(
+            output.quote_ccy_source,
+            Some(QuoteCcyResolutionSource::ExplicitInput)
+        );
+        assert_eq!(output.provider_id.as_deref(), Some("YAHOO"));
+        assert_eq!(output.provider_symbol.as_deref(), Some("VOD.L"));
+
+        let draft = output.draft.expect("new LSE asset draft");
+        assert_eq!(draft.quote_ccy, "USD");
         assert_eq!(draft.provider_symbol.as_deref(), Some("VOD.L"));
     }
 

--- a/crates/core/src/portfolio/snapshot/holdings_calculator.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator.rs
@@ -1339,7 +1339,8 @@ impl HoldingsCalculator {
     /// Handle ADJUSTMENT activity.
     /// Dispatches on subtype:
     /// - OPTION_EXPIRY: removes option lots via FIFO, no cash effect
-    /// - Other/None: no-op (future: RoC basis adjustment, merger/spinoff, etc.)
+    /// - Cash-only: applies signed amount as a cash correction
+    /// - Other/None with asset: no-op (future: RoC basis adjustment, merger/spinoff, etc.)
     fn handle_adjustment(
         &self,
         activity: &Activity,
@@ -1392,7 +1393,17 @@ impl HoldingsCalculator {
                 Ok(())
             }
             _ => {
-                // Other adjustments: no-op for now
+                if activity
+                    .asset_id
+                    .as_deref()
+                    .is_none_or(|asset_id| asset_id.trim().is_empty())
+                {
+                    add_cash(
+                        state,
+                        &activity.currency,
+                        activity.amount.unwrap_or(Decimal::ZERO),
+                    );
+                }
                 Ok(())
             }
         }

--- a/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
@@ -4905,6 +4905,65 @@ mod tests {
     }
 
     #[test]
+    fn cash_adjustment_increases_cash_without_net_contribution() {
+        let date_str = "2025-06-01";
+        let target_date = NaiveDate::from_str(date_str).unwrap();
+        let mock_fx_service = MockFxService::new();
+        let base_currency = Arc::new(RwLock::new("USD".to_string()));
+        let calculator = create_calculator(Arc::new(mock_fx_service), base_currency);
+        let previous_snapshot = create_initial_snapshot("acc_1", "USD", "2025-05-31");
+        let mut adjustment = create_cash_activity(
+            "cash_adjustment_in",
+            ActivityType::Adjustment,
+            dec!(125.50),
+            Decimal::ZERO,
+            "USD",
+            date_str,
+        );
+        adjustment.subtype = Some("FX_CONVERSION".to_string());
+
+        let next_state = calculator
+            .calculate_next_holdings(&previous_snapshot, &[adjustment], target_date)
+            .unwrap()
+            .snapshot;
+
+        assert_eq!(next_state.cash_balances.get("USD"), Some(&dec!(125.50)));
+        assert_eq!(next_state.net_contribution, Decimal::ZERO);
+        assert_eq!(next_state.net_contribution_base, Decimal::ZERO);
+    }
+
+    #[test]
+    fn cash_adjustment_decreases_cash_without_net_contribution() {
+        let date_str = "2025-06-01";
+        let target_date = NaiveDate::from_str(date_str).unwrap();
+        let mock_fx_service = MockFxService::new();
+        let base_currency = Arc::new(RwLock::new("USD".to_string()));
+        let calculator = create_calculator(Arc::new(mock_fx_service), base_currency);
+        let mut previous_snapshot = create_initial_snapshot("acc_1", "USD", "2025-05-31");
+        previous_snapshot
+            .cash_balances
+            .insert("USD".to_string(), dec!(500));
+        let mut adjustment = create_cash_activity(
+            "cash_adjustment_out",
+            ActivityType::Adjustment,
+            dec!(-200.35),
+            Decimal::ZERO,
+            "USD",
+            date_str,
+        );
+        adjustment.subtype = Some("FX_CONVERSION".to_string());
+
+        let next_state = calculator
+            .calculate_next_holdings(&previous_snapshot, &[adjustment], target_date)
+            .unwrap()
+            .snapshot;
+
+        assert_eq!(next_state.cash_balances.get("USD"), Some(&dec!(299.65)));
+        assert_eq!(next_state.net_contribution, Decimal::ZERO);
+        assert_eq!(next_state.net_contribution_base, Decimal::ZERO);
+    }
+
+    #[test]
     fn test_buy_without_fx_rate_still_books_in_activity_currency() {
         // When no fx_rate is provided, cash should still be booked in
         // activity currency (multi-currency account behavior is preserved).


### PR DESCRIPTION
## Summary

- Prefer the CSV/import activity currency when resolving quote currency for newly imported assets.
- Keep explicit quoteCcy, existing asset quote currency, provider currency, MIC fallback, and terminal fallback in a deterministic order.
- Add resolver and activity import preview coverage for a USD import where the provider reports GBp.

## Root Cause

Import asset resolution selected provider-inferred quote currency before the CSV activity currency. For ambiguous London-listed symbols, a USD-denominated import could therefore create a GBp asset even though the import row specified USD.

## Validation

- `git diff --check`
- `openspec validate prevent-import-currency-mismatch-autoresolve`
- Not run: `cargo test -p wealthfolio-core test_resolve_import_asset_inputs_uses_activity_currency_before_provider_quote test_preview_import_assets_uses_csv_currency_before_provider_currency` because `cargo`/`rustc` are not installed in this local environment.
