### PR TITLE
fix: activity filter reset button not clearing

### DIFF
--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -735,6 +735,7 @@ const ActivityPage = () => {
           isFetching={
             shouldUseDatagridView ? paginatedSearch.isFetching : infiniteSearch.isFetching
           }
+          onClearFilters={clearInvestmentsFilters}
         />
       )}
 

--- a/apps/frontend/src/pages/activity/components/activity-view-controls.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-view-controls.tsx
@@ -38,6 +38,7 @@ interface ActivityViewControlsProps {
   /** Shown only in table view - total number of activities matching filters */
   totalRowCount?: number;
   isFetching: boolean;
+  onClearFilters?: () => void;
 }
 
 function accountIdsForScope(scope: AccountScope, portfolios: PortfolioWithAccounts[]): string[] {
@@ -75,6 +76,7 @@ export function ActivityViewControls({
   totalFetched,
   totalRowCount,
   isFetching,
+  onClearFilters,
 }: ActivityViewControlsProps) {
   const [localSearch, setLocalSearch] = useState(searchQuery);
 
@@ -205,20 +207,7 @@ export function ActivityViewControls({
         />
 
         {hasActiveFilters ? (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-8 px-2 text-xs"
-            onClick={() => {
-              setLocalSearch("");
-              onSearchQueryChange("");
-              onAccountScopeChange({ type: "all" });
-              onActivityTypesChange([]);
-              onInstrumentTypesChange([]);
-              onStatusFilterChange("all");
-              onDateRangeChange(undefined);
-            }}
-          >
+          <Button variant="ghost" size="sm" className="h-8 px-2 text-xs" onClick={onClearFilters}>
             Reset
             <Icons.Close className="ml-2 h-4 w-4" />
           </Button>


### PR DESCRIPTION
## Description

### Issue (desktop: activity filter reset button)
On desktop, the reset button on the activity filter tab is not clearing all filters; instead, it only clears the date filter.

Before:

https://github.com/user-attachments/assets/adfb38a7-9783-41c6-8502-818882579335


## Fix
- Switched to use ```clearInvestmentsFilters```  useCallback function used by all other reset buttons

After:

https://github.com/user-attachments/assets/9315138c-2f4f-47a7-b98f-69bc2c564620


## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
