### PR TITLE
fix: mobile activity filters not applying

### DIFF
--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -261,6 +261,18 @@ const ActivityPage = () => {
     [materializeInvestmentFilters],
   );
 
+  // handle filter changes in mobile form
+  const setMobileFilters = useCallback(
+    (types: ActivityType[], range: DateRange | undefined, scope: AccountScope) => {
+      materializeInvestmentFilters({
+        accountScope: scope,
+        activityTypes: types,
+        dateRange: fromDateRange(range),
+      });
+    },
+    [materializeInvestmentFilters],
+  );
+
   // Coerce "spending" URL state back to investments when the module is disabled.
   const urlTab = searchParams.get("tab");
   useEffect(() => {
@@ -704,13 +716,11 @@ const ActivityPage = () => {
           searchQuery={displayedSearchInput}
           onSearchQueryChange={handleSearchChange}
           accountScope={accountScope}
-          onAccountScopeChange={setAccountScope}
           selectedActivityTypes={effectiveActivityTypes}
-          onActivityTypesChange={setInvestmentActivityTypes}
           dateRange={effectiveDateRange}
-          onDateRangeChange={setInvestmentDateRange}
           isCompactView={isCompactView}
           onCompactViewChange={setIsCompactView}
+          onFilterChange={setMobileFilters}
         />
       ) : (
         <ActivityViewControls

--- a/apps/frontend/src/pages/activity/components/activity-mobile-controls.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-mobile-controls.tsx
@@ -11,13 +11,15 @@ interface ActivityMobileControlsProps {
   searchQuery: string;
   onSearchQueryChange: (value: string) => void;
   accountScope: AccountScope;
-  onAccountScopeChange: (accountScope: AccountScope) => void;
   selectedActivityTypes: ActivityType[];
-  onActivityTypesChange: (types: ActivityType[]) => void;
   dateRange: DateRange | undefined;
-  onDateRangeChange: (dateRange: DateRange | undefined) => void;
   isCompactView: boolean;
   onCompactViewChange: (isCompact: boolean) => void;
+  onFilterChange: (
+    types: ActivityType[],
+    range: DateRange | undefined,
+    scope: AccountScope,
+  ) => void;
 }
 
 export function ActivityMobileControls({
@@ -26,13 +28,11 @@ export function ActivityMobileControls({
   searchQuery,
   onSearchQueryChange,
   accountScope,
-  onAccountScopeChange,
   selectedActivityTypes,
-  onActivityTypesChange,
   dateRange,
-  onDateRangeChange,
   isCompactView,
   onCompactViewChange,
+  onFilterChange,
 }: ActivityMobileControlsProps) {
   const [isFilterSheetOpen, setIsFilterSheetOpen] = useState(false);
 
@@ -86,11 +86,9 @@ export function ActivityMobileControls({
         accountScope={accountScope}
         accounts={accounts}
         portfolios={portfolios}
-        setAccountScope={onAccountScopeChange}
         selectedActivityTypes={selectedActivityTypes}
-        setSelectedActivityTypes={onActivityTypesChange}
         dateRange={dateRange}
-        setDateRange={onDateRangeChange}
+        setFilters={onFilterChange}
       />
     </>
   );

--- a/apps/frontend/src/pages/activity/components/activity-mobile-filter-sheet.test.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-mobile-filter-sheet.test.tsx
@@ -93,7 +93,7 @@ describe("ActivityMobileFilterSheet", () => {
   it("preserves portfolio scope when applying without changing account selection", async () => {
     const user = userEvent.setup();
     const accountScope: AccountScope = { type: "portfolio", portfolioId: "pf_1" };
-    const setAccountScope = vi.fn();
+    const setFilters = vi.fn();
 
     render(
       <ActivityMobileFilterSheet
@@ -102,16 +102,14 @@ describe("ActivityMobileFilterSheet", () => {
         accountScope={accountScope}
         accounts={accounts}
         portfolios={portfolios}
-        setAccountScope={setAccountScope}
         selectedActivityTypes={[]}
-        setSelectedActivityTypes={vi.fn()}
         dateRange={undefined}
-        setDateRange={vi.fn()}
+        setFilters={setFilters}
       />,
     );
 
     await user.click(screen.getByRole("button", { name: "Done" }));
 
-    expect(setAccountScope).toHaveBeenCalledWith(accountScope);
+    expect(setFilters).toHaveBeenCalledWith([], undefined, accountScope);
   });
 });

--- a/apps/frontend/src/pages/activity/components/activity-mobile-filter-sheet.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-mobile-filter-sheet.tsx
@@ -21,11 +21,9 @@ interface ActivityMobileFilterSheetProps {
   accountScope: AccountScope;
   accounts: Account[];
   portfolios: PortfolioWithAccounts[];
-  setAccountScope: (accountScope: AccountScope) => void;
   selectedActivityTypes: ActivityType[];
-  setSelectedActivityTypes: (types: ActivityType[]) => void;
   dateRange: DateRange | undefined;
-  setDateRange: (dateRange: DateRange | undefined) => void;
+  setFilters: (types: ActivityType[], range: DateRange | undefined, scope: AccountScope) => void;
 }
 
 function accountIdsForScope(scope: AccountScope, portfolios: PortfolioWithAccounts[]) {
@@ -49,11 +47,9 @@ export const ActivityMobileFilterSheet = ({
   accountScope,
   accounts,
   portfolios,
-  setAccountScope,
   selectedActivityTypes,
-  setSelectedActivityTypes,
   dateRange,
-  setDateRange,
+  setFilters,
 }: ActivityMobileFilterSheetProps) => {
   // Local state for temporary selections
   const [localAccountScope, setLocalAccountScope] = useState<AccountScope>(accountScope);
@@ -76,9 +72,7 @@ export const ActivityMobileFilterSheet = ({
   }, [open, accountScope, selectedActivityTypes, dateRange]);
 
   const handleApply = () => {
-    setAccountScope(localAccountScope);
-    setSelectedActivityTypes(localActivityTypes);
-    setDateRange(localDateRange);
+    setFilters(localActivityTypes, localDateRange, localAccountScope);
     onOpenChange(false);
   };
 


### PR DESCRIPTION
## Description

### Issue (mobile: activity filter not working)
On mobile, the activity filters are not being applied after selecting in the filter modal.

Before:

https://github.com/user-attachments/assets/e8341038-1a39-4767-9ded-04055ca8ac42

## Fix
- Added `setMobileFilters` function that calls `materializeInvestmentFilters` once with all selected filters (account scope, activity types, date range), instead of calling the individual setters sequentially, removing the issue of each call reading stale/outdated states from the previous one.

After:

https://github.com/user-attachments/assets/8d982003-bd5a-48a7-b81b-60b73d51cb5f

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
