### PR TITLE
Refactor post-login sync bootstrap and activity fixes

### DIFF
--- a/apps/frontend/src/adapters/shared/connect.ts
+++ b/apps/frontend/src/adapters/shared/connect.ts
@@ -31,6 +31,7 @@ import type {
   BackendSyncSnapshotUploadResult,
   BackendSyncStateResult,
   ImportRunsRequest,
+  PostLoginBootstrapResult,
 } from "../types";
 
 import { invoke } from "./platform";
@@ -41,6 +42,10 @@ import { invoke } from "./platform";
 
 export async function syncBrokerData(): Promise<void> {
   return invoke<void>("broker_ingest_run");
+}
+
+export async function postLoginBootstrap(): Promise<PostLoginBootstrapResult> {
+  return invoke<PostLoginBootstrapResult>("post_login_bootstrap");
 }
 
 export async function getSyncedAccounts(): Promise<Account[]> {

--- a/apps/frontend/src/adapters/types.ts
+++ b/apps/frontend/src/adapters/types.ts
@@ -39,6 +39,27 @@ export interface DataExportResult {
   filename?: string;
 }
 
+export type PostLoginBootstrapStatus = "started" | "skipped";
+
+export type PostLoginBootstrapReason =
+  | "feature_disabled"
+  | "not_entitled"
+  | "no_connections"
+  | "already_running"
+  | "error"
+  | "not_enrolled"
+  | "not_ready";
+
+export interface PostLoginBootstrapSyncResult {
+  status: PostLoginBootstrapStatus;
+  reason?: PostLoginBootstrapReason;
+}
+
+export interface PostLoginBootstrapResult {
+  brokerSync: PostLoginBootstrapSyncResult;
+  deviceSync: PostLoginBootstrapSyncResult;
+}
+
 // Addon types from SDK, re-exported with Tauri serialization adjustments
 import type {
   AddonInstallResult,

--- a/apps/frontend/src/adapters/web/core.ts
+++ b/apps/frontend/src/adapters/web/core.ts
@@ -290,6 +290,7 @@ export const COMMANDS: CommandMap = {
   cancel_pairing_flow: { method: "POST", path: "/sync/pairing/flow/cancel" },
   // Wealthfolio Connect (Broker Sync)
   store_sync_session: { method: "POST", path: "/connect/session" },
+  post_login_bootstrap: { method: "POST", path: "/connect/post-login-bootstrap" },
   clear_sync_session: { method: "DELETE", path: "/connect/session" },
   get_sync_session_status: { method: "GET", path: "/connect/session/status" },
   restore_sync_session: { method: "GET", path: "/connect/session/restore" },
@@ -1703,6 +1704,7 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
     case "list_devices":
     case "initialize_team_keys":
     case "rotate_team_keys":
+    case "post_login_bootstrap":
     case "clear_sync_session":
     case "get_sync_session_status":
     case "restore_sync_session":

--- a/apps/frontend/src/adapters/web/index.ts
+++ b/apps/frontend/src/adapters/web/index.ts
@@ -283,6 +283,7 @@ export {
   getUserInfo,
   listBrokerAccounts,
   listBrokerConnections,
+  postLoginBootstrap,
   listDevices,
   reinitializeDeviceSync,
   resetTeamSync,

--- a/apps/frontend/src/features/wealthfolio-connect/hooks/index.ts
+++ b/apps/frontend/src/features/wealthfolio-connect/hooks/index.ts
@@ -3,3 +3,4 @@ export { useImportRuns, useImportRunsInfinite } from "./use-import-runs";
 export { useAggregatedSyncStatus } from "./use-aggregated-sync-status";
 export { useSyncBrokerData } from "./use-sync-broker-data";
 export { useBrokerAccounts } from "./use-broker-accounts";
+export { usePostLoginConnectSync } from "./use-post-login-connect-sync";

--- a/apps/frontend/src/features/wealthfolio-connect/hooks/use-post-login-connect-sync.test.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/hooks/use-post-login-connect-sync.test.tsx
@@ -1,0 +1,185 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { usePostLoginConnectSync } from "./use-post-login-connect-sync";
+
+const adapterMocks = vi.hoisted(() => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+const connectMocks = vi.hoisted(() => ({
+  useWealthfolioConnect: vi.fn(),
+}));
+
+const authServiceMocks = vi.hoisted(() => ({
+  postLoginBootstrap: vi.fn(),
+}));
+
+const toastMocks = vi.hoisted(() => ({
+  toast: {
+    loading: vi.fn(),
+  },
+}));
+
+vi.mock("@/adapters", () => adapterMocks);
+vi.mock("../providers/wealthfolio-connect-provider", () => connectMocks);
+vi.mock("../services/auth-service", () => authServiceMocks);
+vi.mock("@wealthfolio/ui/components/ui/use-toast", () => toastMocks);
+
+const brokerStartedResult = {
+  brokerSync: { status: "started" },
+  deviceSync: { status: "skipped", reason: "not_enrolled" },
+};
+
+const skippedResult = {
+  brokerSync: { status: "skipped", reason: "no_connections" },
+  deviceSync: { status: "skipped", reason: "not_enrolled" },
+};
+
+function mockConnectContext(overrides: Record<string, unknown> = {}) {
+  connectMocks.useWealthfolioConnect.mockReturnValue({
+    isConnected: true,
+    isInitializing: false,
+    postLoginSyncRequest: {
+      id: "request-1",
+      userId: "user-1",
+      createdAt: Date.now(),
+      source: "auth-callback",
+    },
+    session: {
+      user: {
+        id: "user-1",
+      },
+    },
+    user: {
+      id: "user-1",
+    },
+    consumePostLoginSyncRequest: vi.fn(),
+    ...overrides,
+  });
+}
+
+describe("usePostLoginConnectSync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authServiceMocks.postLoginBootstrap.mockResolvedValue(brokerStartedResult);
+    mockConnectContext();
+  });
+
+  it("does not call bootstrap while disabled or not ready", () => {
+    const { rerender } = renderHook(({ enabled }) => usePostLoginConnectSync({ enabled }), {
+      initialProps: { enabled: false },
+    });
+
+    expect(authServiceMocks.postLoginBootstrap).not.toHaveBeenCalled();
+
+    mockConnectContext({ isInitializing: true });
+    rerender({ enabled: true });
+
+    expect(authServiceMocks.postLoginBootstrap).not.toHaveBeenCalled();
+
+    mockConnectContext({ isInitializing: false, isConnected: false });
+    rerender({ enabled: true });
+
+    expect(authServiceMocks.postLoginBootstrap).not.toHaveBeenCalled();
+  });
+
+  it("consumes a matching login request and calls bootstrap once", async () => {
+    const consumePostLoginSyncRequest = vi.fn();
+    mockConnectContext({ consumePostLoginSyncRequest });
+
+    renderHook(() => usePostLoginConnectSync({ enabled: true }));
+
+    expect(consumePostLoginSyncRequest).toHaveBeenCalledWith("request-1");
+    await waitFor(() => {
+      expect(authServiceMocks.postLoginBootstrap).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not start the same request twice across rerenders", async () => {
+    const { rerender } = renderHook(() => usePostLoginConnectSync({ enabled: true }));
+
+    await waitFor(() => {
+      expect(authServiceMocks.postLoginBootstrap).toHaveBeenCalledTimes(1);
+    });
+    rerender();
+
+    expect(authServiceMocks.postLoginBootstrap).toHaveBeenCalledTimes(1);
+  });
+
+  it("consumes stale requests from a different user without bootstrapping", () => {
+    const consumePostLoginSyncRequest = vi.fn();
+    mockConnectContext({
+      consumePostLoginSyncRequest,
+      user: { id: "user-2" },
+      session: { user: { id: "user-2" } },
+    });
+
+    renderHook(() => usePostLoginConnectSync({ enabled: true }));
+
+    expect(consumePostLoginSyncRequest).toHaveBeenCalledWith("request-1");
+    expect(authServiceMocks.postLoginBootstrap).not.toHaveBeenCalled();
+    expect(adapterMocks.logger.debug).toHaveBeenCalledWith(
+      "Discarded stale post-login sync request",
+    );
+  });
+
+  it("shows a broker sync toast only when broker bootstrap starts", async () => {
+    renderHook(() => usePostLoginConnectSync({ enabled: true }));
+
+    await waitFor(() => {
+      expect(toastMocks.toast.loading).toHaveBeenCalledWith("Syncing broker data...", {
+        id: "broker-sync-start",
+      });
+    });
+  });
+
+  it("does not show a broker sync toast for skipped broker and device bootstrap", async () => {
+    authServiceMocks.postLoginBootstrap.mockResolvedValue(skippedResult);
+
+    renderHook(() => usePostLoginConnectSync({ enabled: true }));
+
+    await waitFor(() => {
+      expect(authServiceMocks.postLoginBootstrap).toHaveBeenCalledTimes(1);
+    });
+    expect(toastMocks.toast.loading).not.toHaveBeenCalled();
+    expect(adapterMocks.logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("logs unexpected skipped errors without showing a broker sync toast", async () => {
+    authServiceMocks.postLoginBootstrap.mockResolvedValue({
+      brokerSync: { status: "skipped", reason: "error" },
+      deviceSync: { status: "skipped", reason: "error" },
+    });
+
+    renderHook(() => usePostLoginConnectSync({ enabled: true }));
+
+    await waitFor(() => {
+      expect(adapterMocks.logger.warn).toHaveBeenCalledWith(
+        "Post-login broker sync bootstrap skipped due to an unexpected error",
+      );
+    });
+    expect(adapterMocks.logger.warn).toHaveBeenCalledWith(
+      "Post-login device sync bootstrap skipped due to an unexpected error",
+    );
+    expect(toastMocks.toast.loading).not.toHaveBeenCalled();
+  });
+
+  it("logs bootstrap rejection and consumes the request", async () => {
+    const consumePostLoginSyncRequest = vi.fn();
+    authServiceMocks.postLoginBootstrap.mockRejectedValue(new Error("network down"));
+    mockConnectContext({ consumePostLoginSyncRequest });
+
+    renderHook(() => usePostLoginConnectSync({ enabled: true }));
+
+    expect(consumePostLoginSyncRequest).toHaveBeenCalledWith("request-1");
+    await waitFor(() => {
+      expect(adapterMocks.logger.warn).toHaveBeenCalledWith(
+        "Post-login sync bootstrap failed: network down",
+      );
+    });
+  });
+});

--- a/apps/frontend/src/features/wealthfolio-connect/hooks/use-post-login-connect-sync.ts
+++ b/apps/frontend/src/features/wealthfolio-connect/hooks/use-post-login-connect-sync.ts
@@ -1,0 +1,85 @@
+import { logger } from "@/adapters";
+import { toast } from "@wealthfolio/ui/components/ui/use-toast";
+import { useEffect, useRef } from "react";
+import { useWealthfolioConnect } from "../providers/wealthfolio-connect-provider";
+import { postLoginBootstrap } from "../services/auth-service";
+
+const BROKER_SYNC_START_TOAST_ID = "broker-sync-start";
+const MAX_ATTEMPTED_REQUEST_IDS = 20;
+
+interface UsePostLoginConnectSyncOptions {
+  enabled: boolean;
+}
+
+export function usePostLoginConnectSync({ enabled }: UsePostLoginConnectSyncOptions) {
+  const {
+    isConnected,
+    isInitializing,
+    postLoginSyncRequest,
+    session,
+    user,
+    consumePostLoginSyncRequest,
+  } = useWealthfolioConnect();
+  const attemptedRequestIdsRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!enabled || isInitializing || !isConnected || !postLoginSyncRequest) {
+      return;
+    }
+
+    const request = postLoginSyncRequest;
+    const currentUserId = user?.id ?? session?.user.id ?? null;
+
+    if (currentUserId !== request.userId) {
+      consumePostLoginSyncRequest(request.id);
+      logger.debug("Discarded stale post-login sync request");
+      return;
+    }
+
+    if (attemptedRequestIdsRef.current.has(request.id)) {
+      consumePostLoginSyncRequest(request.id);
+      return;
+    }
+
+    attemptedRequestIdsRef.current.add(request.id);
+    while (attemptedRequestIdsRef.current.size > MAX_ATTEMPTED_REQUEST_IDS) {
+      const oldestRequestId = attemptedRequestIdsRef.current.keys().next().value;
+      if (!oldestRequestId) break;
+      attemptedRequestIdsRef.current.delete(oldestRequestId);
+    }
+
+    consumePostLoginSyncRequest(request.id);
+
+    void postLoginBootstrap()
+      .then((result) => {
+        if (result.brokerSync.status === "started") {
+          toast.loading("Syncing broker data...", { id: BROKER_SYNC_START_TOAST_ID });
+          logger.info(`Post-login broker sync started after ${request.source}`);
+        }
+
+        if (result.brokerSync.status === "skipped" && result.brokerSync.reason === "error") {
+          logger.warn("Post-login broker sync bootstrap skipped due to an unexpected error");
+        }
+
+        if (result.deviceSync.status === "skipped" && result.deviceSync.reason === "error") {
+          logger.warn("Post-login device sync bootstrap skipped due to an unexpected error");
+        }
+
+        if (result.deviceSync.status === "started") {
+          logger.info(`Post-login device sync started after ${request.source}`);
+        }
+      })
+      .catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        logger.warn(`Post-login sync bootstrap failed: ${message}`);
+      });
+  }, [
+    enabled,
+    isConnected,
+    isInitializing,
+    postLoginSyncRequest,
+    session?.user.id,
+    user?.id,
+    consumePostLoginSyncRequest,
+  ]);
+}

--- a/apps/frontend/src/features/wealthfolio-connect/lib/auth-callback.ts
+++ b/apps/frontend/src/features/wealthfolio-connect/lib/auth-callback.ts
@@ -67,7 +67,7 @@ export function parseAuthCallbackUrl(
     }
 
     const hasAccessToken =
-      hashParams.has("access_token") || urlObj.searchParams.has("access_token") || false;
+      hashParams.has("access_token") || urlObj.searchParams.has("access_token");
     if (hasAccessToken) {
       return {
         type: "error",

--- a/apps/frontend/src/features/wealthfolio-connect/providers/wealthfolio-connect-provider.tsx
+++ b/apps/frontend/src/features/wealthfolio-connect/providers/wealthfolio-connect-provider.tsx
@@ -56,6 +56,18 @@ const HOSTED_OAUTH_CALLBACK_URL =
 const parseConfiguredAuthCallbackUrl = (url: string) =>
   parseAuthCallbackUrl(url, { hostedCallbackUrl: HOSTED_OAUTH_CALLBACK_URL });
 
+const PROCESSED_AUTH_CODE_TTL_MS = 10 * 60 * 1000;
+const MAX_PROCESSED_AUTH_CODES = 20;
+
+type PostLoginSyncSource = "auth-callback" | "email-sign-in" | "email-sign-up" | "otp";
+
+interface PostLoginSyncRequest {
+  id: string;
+  userId: string;
+  createdAt: number;
+  source: PostLoginSyncSource;
+}
+
 interface WealthfolioConnectContextValue {
   isEnabled: boolean;
   isConnected: boolean;
@@ -66,6 +78,7 @@ interface WealthfolioConnectContextValue {
   session: Session | null;
   teamId: string | null;
   userInfo: UserInfo | null;
+  postLoginSyncRequest: PostLoginSyncRequest | null;
   error: string | null;
   signInWithEmail: (email: string, password: string) => Promise<void>;
   signUpWithEmail: (email: string, password: string) => Promise<void>;
@@ -75,6 +88,7 @@ interface WealthfolioConnectContextValue {
   signOut: () => Promise<void>;
   clearError: () => void;
   refetchUserInfo: () => Promise<void>;
+  consumePostLoginSyncRequest: (requestId: string) => void;
 }
 
 const WealthfolioConnectContext = createContext<WealthfolioConnectContextValue | undefined>(
@@ -93,6 +107,7 @@ const disabledContextValue: WealthfolioConnectContextValue = {
   session: null,
   teamId: null,
   userInfo: null,
+  postLoginSyncRequest: null,
   error: null,
   signInWithEmail: async () => {},
   signUpWithEmail: async () => {},
@@ -102,6 +117,7 @@ const disabledContextValue: WealthfolioConnectContextValue = {
   signOut: async () => {},
   clearError: () => {},
   refetchUserInfo: async () => {},
+  consumePostLoginSyncRequest: () => {},
 };
 
 function getAuthStorageKey(supabaseUrl: string): string {
@@ -191,10 +207,14 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
   const [user, setUser] = useState<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);
   const [userInfo, setUserInfo] = useState<UserInfo | null>(null);
+  const [postLoginSyncRequest, setPostLoginSyncRequest] = useState<PostLoginSyncRequest | null>(
+    null,
+  );
   const [error, setError] = useState<string | null>(null);
 
   const supabaseRef = useRef<SupabaseClient | null>(null);
-  const processedAuthCodesRef = useRef<Set<string>>(new Set());
+  const processedAuthCodesRef = useRef<Map<string, number>>(new Map());
+  const postLoginSyncRequestSequenceRef = useRef(0);
 
   // Initialize Supabase client
   supabaseRef.current ??= createSupabaseClient();
@@ -203,6 +223,47 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
 
   const clearProcessedAuthCodes = useCallback(() => {
     processedAuthCodesRef.current.clear();
+  }, []);
+
+  const rememberAuthCodeIfNew = useCallback((code: string) => {
+    const now = Date.now();
+    const processedAuthCodes = processedAuthCodesRef.current;
+
+    for (const [processedCode, processedAt] of processedAuthCodes) {
+      if (now - processedAt > PROCESSED_AUTH_CODE_TTL_MS) {
+        processedAuthCodes.delete(processedCode);
+      }
+    }
+
+    if (processedAuthCodes.has(code)) {
+      return false;
+    }
+
+    processedAuthCodes.set(code, now);
+    while (processedAuthCodes.size > MAX_PROCESSED_AUTH_CODES) {
+      const oldestCode = processedAuthCodes.keys().next().value;
+      if (!oldestCode) break;
+      processedAuthCodes.delete(oldestCode);
+    }
+
+    return true;
+  }, []);
+
+  const requestPostLoginSync = useCallback((source: PostLoginSyncSource, session: Session) => {
+    const now = Date.now();
+    const sequence = postLoginSyncRequestSequenceRef.current + 1;
+    postLoginSyncRequestSequenceRef.current = sequence;
+
+    setPostLoginSyncRequest({
+      id: `${session.user.id}:${now}:${sequence}`,
+      userId: session.user.id,
+      createdAt: now,
+      source,
+    });
+  }, []);
+
+  const consumePostLoginSyncRequest = useCallback((requestId: string) => {
+    setPostLoginSyncRequest((current) => (current?.id === requestId ? null : current));
   }, []);
 
   // Store tokens: refresh token goes to backend (for cloud API calls) and locally (for session restoration)
@@ -260,11 +321,12 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
         return;
       }
 
-      if (processedAuthCodesRef.current.has(payload.code)) {
+      if (!rememberAuthCodeIfNew(payload.code)) {
         logger.debug("Skipping duplicate auth callback code");
         return;
       }
-      processedAuthCodesRef.current.add(payload.code);
+
+      let didExchangeSession = false;
 
       try {
         const { data, error: exchangeError } = await supabase.auth.exchangeCodeForSession(
@@ -272,29 +334,35 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
         );
 
         if (exchangeError) {
+          processedAuthCodesRef.current.delete(payload.code);
           logger.error(`Failed to exchange auth code: ${exchangeError.message}`);
           setError(exchangeError.message);
           return;
         }
 
         if (!data.session) {
+          processedAuthCodesRef.current.delete(payload.code);
           logger.error("No session returned after code exchange");
           setError("No session returned after completing sign-in.");
           return;
         }
 
+        didExchangeSession = true;
         // Store tokens BEFORE setting session to avoid race condition
         await storeTokens(data.session);
         setSession(data.session);
         setUser(data.session.user);
-        clearProcessedAuthCodes();
+        requestPostLoginSync("auth-callback", data.session);
         logger.info("Auth callback completed successfully");
       } catch (err) {
+        if (!didExchangeSession) {
+          processedAuthCodesRef.current.delete(payload.code);
+        }
         logger.error(`Error in handleAuthCallback: ${err instanceof Error ? err.message : err}`);
         setError(err instanceof Error ? err.message : "Failed to complete sign in");
       }
     },
-    [supabase, storeTokens, clearProcessedAuthCodes],
+    [supabase, storeTokens, rememberAuthCodeIfNew, requestPostLoginSync],
   );
 
   // Restore session from stored tokens on mount
@@ -350,6 +418,8 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
       } else if (event === "SIGNED_OUT") {
         setSession(null);
         setUser(null);
+        setPostLoginSyncRequest(null);
+        clearProcessedAuthCodes();
         await storeTokens(null);
       }
     });
@@ -435,6 +505,7 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
           await storeTokens(data.session);
           setSession(data.session);
           setUser(data.session.user);
+          requestPostLoginSync("email-sign-in", data.session);
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : "Sign in failed";
@@ -444,7 +515,7 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
         setIsLoading(false);
       }
     },
-    [supabase, storeTokens],
+    [supabase, storeTokens, requestPostLoginSync],
   );
 
   const signUpWithEmail = useCallback(
@@ -468,6 +539,7 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
           await storeTokens(data.session);
           setSession(data.session);
           setUser(data.session.user);
+          requestPostLoginSync("email-sign-up", data.session);
         } else if (data.user && !data.session) {
           // Email confirmation required
           setError("Please check your email to confirm your account.");
@@ -480,14 +552,13 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
         setIsLoading(false);
       }
     },
-    [supabase, storeTokens],
+    [supabase, storeTokens, requestPostLoginSync],
   );
 
   const signInWithOAuth = useCallback(
     async (provider: "google" | "apple" | "github") => {
       setIsLoading(true);
       setError(null);
-      clearProcessedAuthCodes();
 
       try {
         const isTauri = isDesktop;
@@ -574,14 +645,13 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
         setIsLoading(false);
       }
     },
-    [supabase, handleAuthCallback, clearProcessedAuthCodes],
+    [supabase, handleAuthCallback],
   );
 
   const signInWithMagicLink = useCallback(
     async (email: string) => {
       setIsLoading(true);
       setError(null);
-      clearProcessedAuthCodes();
 
       try {
         const isTauri = isDesktop;
@@ -617,7 +687,7 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
         setIsLoading(false);
       }
     },
-    [supabase, clearProcessedAuthCodes],
+    [supabase],
   );
 
   const verifyOtp = useCallback(
@@ -641,6 +711,7 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
           await storeTokens(data.session);
           setSession(data.session);
           setUser(data.session.user);
+          requestPostLoginSync("otp", data.session);
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : "Invalid verification code";
@@ -650,7 +721,7 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
         setIsLoading(false);
       }
     },
-    [supabase, storeTokens],
+    [supabase, storeTokens, requestPostLoginSync],
   );
 
   const signOut = useCallback(async () => {
@@ -668,11 +739,15 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
 
       setSession(null);
       setUser(null);
+      setPostLoginSyncRequest(null);
+      clearProcessedAuthCodes();
       await storeTokens(null);
     } catch (err) {
       // Still clear local state even on unexpected errors
       setSession(null);
       setUser(null);
+      setPostLoginSyncRequest(null);
+      clearProcessedAuthCodes();
       await storeTokens(null).catch(() => {});
       const message = err instanceof Error ? err.message : "Sign out failed";
       setError(message);
@@ -680,7 +755,7 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
     } finally {
       setIsLoading(false);
     }
-  }, [supabase, storeTokens]);
+  }, [supabase, storeTokens, clearProcessedAuthCodes]);
 
   const clearError = useCallback(() => setError(null), []);
 
@@ -733,6 +808,7 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
       session,
       teamId,
       userInfo,
+      postLoginSyncRequest,
       error,
       signInWithEmail,
       signUpWithEmail,
@@ -742,6 +818,7 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
       signOut,
       clearError,
       refetchUserInfo,
+      consumePostLoginSyncRequest,
     }),
     [
       session,
@@ -751,6 +828,7 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
       user,
       teamId,
       userInfo,
+      postLoginSyncRequest,
       error,
       signInWithEmail,
       signUpWithEmail,
@@ -760,6 +838,7 @@ function EnabledWealthfolioConnectProvider({ children }: { children: ReactNode }
       signOut,
       clearError,
       refetchUserInfo,
+      consumePostLoginSyncRequest,
     ],
   );
 

--- a/apps/frontend/src/features/wealthfolio-connect/services/auth-service.ts
+++ b/apps/frontend/src/features/wealthfolio-connect/services/auth-service.ts
@@ -2,8 +2,10 @@ import {
   logger,
   storeSyncSession as storeSyncSessionApi,
   clearSyncSession as clearSyncSessionApi,
+  postLoginBootstrap as postLoginBootstrapApi,
   restoreSyncSession as restoreSyncSessionApi,
 } from "@/adapters";
+import type { PostLoginBootstrapResult } from "@/adapters/types";
 
 /**
  * Store Wealthfolio Connect tokens in the backend's encrypted secret store.
@@ -33,6 +35,10 @@ export const restoreSyncSession = async (): Promise<{
   refreshToken: string;
 }> => {
   return restoreSyncSessionApi();
+};
+
+export const postLoginBootstrap = async (): Promise<PostLoginBootstrapResult> => {
+  return postLoginBootstrapApi();
 };
 
 export const clearSyncSession = async (): Promise<void> => {

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -548,6 +548,7 @@ const ActivityPage = () => {
     displayedSearchInput.trim().length > 0;
 
   const clearInvestmentsFilters = useCallback(() => {
+    debouncedUpdateSearch.cancel();
     setPersistedAccountScope({ type: "all" });
     setSelectedActivityTypes([]);
     setSelectedInstrumentTypes([]);
@@ -558,6 +559,7 @@ const ActivityPage = () => {
     clearActivityUrlFilterParams();
   }, [
     clearActivityUrlFilterParams,
+    debouncedUpdateSearch,
     setPersistedAccountScope,
     setSelectedActivityTypes,
     setSelectedInstrumentTypes,
@@ -728,6 +730,7 @@ const ActivityPage = () => {
           onStatusFilterChange={setStatusFilter}
           dateRange={effectiveDateRange}
           onDateRangeChange={setInvestmentDateRange}
+          onResetFilters={clearInvestmentsFilters}
           viewMode={viewMode}
           onViewModeChange={setViewMode}
           totalFetched={shouldUseDatagridView ? undefined : totalFetched}

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -1,4 +1,4 @@
-import { getAccounts, getTransferPairForActivity } from "@/adapters";
+import { getAccounts } from "@/adapters";
 import { ActionPalette, type ActionPaletteGroup } from "@/components/action-palette";
 import { SwipablePage, type SwipablePageView } from "@/components/page";
 import {
@@ -34,7 +34,7 @@ import { ActivityViewControls, type ActivityViewMode } from "./components/activi
 import { BulkHoldingsModal } from "./components/forms/bulk-holdings-modal";
 import { MobileActivityForm } from "./components/mobile-forms/mobile-activity-form";
 import { TransferMatchDialog } from "./components/transfer-match-dialog";
-import { useActivityMutations } from "./hooks/use-activity-mutations";
+import { useActivityActionDialogs } from "./hooks/use-activity-action-dialogs";
 import { useActivitySearch, type ActivityStatusFilter } from "./hooks/use-activity-search";
 import {
   clearActivityUrlFilters,
@@ -81,9 +81,6 @@ function fromDateRange(range: DateRange | undefined): ActivityDateRangeFilter {
 }
 
 const ActivityPage = () => {
-  const [showForm, setShowForm] = useState(false);
-  const [selectedActivity, setSelectedActivity] = useState<Partial<ActivityDetails> | undefined>();
-  const [showDeleteAlert, setShowDeleteAlert] = useState(false);
   const [showBulkHoldingsForm, setShowBulkHoldingsForm] = useState(false);
   const [showAlternativeAssetModal, setShowAlternativeAssetModal] = useState(false);
   const [transferMatchDialog, setTransferMatchDialog] = useState<{
@@ -95,6 +92,18 @@ const ActivityPage = () => {
   const [showSpendingActionPalette, setShowSpendingActionPalette] = useState(false);
   const isMobileViewport = useIsMobileViewport();
   const isCompactTableViewport = useIsCompactTableViewport();
+  const {
+    selectedActivity,
+    formOpen: showForm,
+    deleteDialogOpen: showDeleteAlert,
+    isDeleting,
+    openForm: handleEdit,
+    closeForm: handleFormClose,
+    requestDelete: handleDelete,
+    cancelDelete: handleDeleteCancel,
+    confirmDelete: handleDeleteConfirm,
+    duplicateActivity: handleDuplicate,
+  } = useActivityActionDialogs();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const activityUrlFilterKey = searchParams.toString();
@@ -329,8 +338,6 @@ const ActivityPage = () => {
     queryFn: () => getAccounts(),
   });
 
-  const { deleteActivityMutation, duplicateActivityMutation } = useActivityMutations();
-
   const isDatagridView = viewMode === "datagrid";
   const shouldUseDatagridView = isDatagridView && !isCompactTableViewport;
 
@@ -466,76 +473,12 @@ const ActivityPage = () => {
     ? paginatedSearch.totalRowCount
     : infiniteSearch.totalRowCount;
 
-  const handleEdit = useCallback(
-    async (activity?: ActivityDetails, activityType?: ActivityType) => {
-      if (
-        activity?.id &&
-        (activity.activityType === ActivityType.TRANSFER_IN ||
-          activity.activityType === ActivityType.TRANSFER_OUT) &&
-        activity.sourceGroupId &&
-        ((activity.metadata?.flow as { is_external?: boolean } | undefined)?.is_external ??
-          false) !== true
-      ) {
-        try {
-          const pair = await getTransferPairForActivity(activity.id);
-          const counterpart =
-            activity.activityType === ActivityType.TRANSFER_IN ? pair.transferOut : pair.transferIn;
-          setSelectedActivity({
-            ...activity,
-            transferOutId: pair.transferOut.id,
-            transferInId: pair.transferIn.id,
-            counterpartActivityId: counterpart.id,
-            counterpartAccountId: counterpart.accountId,
-            counterpartAmount: counterpart.amount ?? null,
-            counterpartCurrency: counterpart.currency,
-            counterpartFxRate: pair.transferIn.fxRate ?? null,
-          });
-          setShowForm(true);
-          return;
-        } catch {
-          // Fall back to single-leg editing for invalid groups that are not valid internal pairs.
-          setSelectedActivity(activity);
-          setShowForm(true);
-          return;
-        }
-      }
-
-      setSelectedActivity(activity ?? { activityType });
-      setShowForm(true);
-    },
-    [],
-  );
-
-  const handleDelete = useCallback((activity: ActivityDetails) => {
-    setSelectedActivity(activity);
-    setShowDeleteAlert(true);
-  }, []);
-
-  const handleDuplicate = useCallback(
-    async (activity: ActivityDetails) => {
-      await duplicateActivityMutation.mutateAsync(activity);
-    },
-    [duplicateActivityMutation],
-  );
-
   const handleLinkTransfer = useCallback((activity: ActivityDetails) => {
     setTransferMatchDialog({ open: true, mode: "link", activity });
   }, []);
 
   const handleUnlinkTransfer = useCallback((activity: ActivityDetails) => {
     setTransferMatchDialog({ open: true, mode: "unlink", activity });
-  }, []);
-
-  const handleDeleteConfirm = async () => {
-    if (!selectedActivity?.id) return;
-    await deleteActivityMutation.mutateAsync(selectedActivity.id);
-    setShowDeleteAlert(false);
-    setSelectedActivity(undefined);
-  };
-
-  const handleFormClose = useCallback(() => {
-    setShowForm(false);
-    setSelectedActivity(undefined);
   }, []);
 
   const investmentsFiltersActive =
@@ -821,13 +764,10 @@ const ActivityPage = () => {
       )}
       <ActivityDeleteModal
         isOpen={showDeleteAlert}
-        isDeleting={deleteActivityMutation.isPending}
+        isDeleting={isDeleting}
         linkedTransfer={!!selectedActivity?.sourceGroupId}
         onConfirm={handleDeleteConfirm}
-        onCancel={() => {
-          setShowDeleteAlert(false);
-          setSelectedActivity(undefined);
-        }}
+        onCancel={handleDeleteCancel}
       />
       <BulkHoldingsModal
         open={showBulkHoldingsForm}

--- a/apps/frontend/src/pages/activity/components/activity-view-controls.test.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-view-controls.test.tsx
@@ -1,0 +1,94 @@
+import type { Account, AccountScope, PortfolioWithAccounts } from "@/lib/types";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { ActivityViewControls } from "./activity-view-controls";
+
+vi.mock("@/features/spending/components/date-range-filter", () => ({
+  DateRangeFilter: () => <div data-testid="date-range-filter" />,
+}));
+
+vi.mock("@wealthfolio/ui", () => ({
+  AnimatedToggleGroup: () => <div data-testid="view-toggle" />,
+  Button: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+    className?: string;
+    size?: string;
+    variant?: string;
+  }) => <button onClick={onClick}>{children}</button>,
+  FacetedFilter: ({ title }: { title?: string }) => <button>{title}</button>,
+  FacetedSearchInput: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+  }) => (
+    <input aria-label="Search" value={value} onChange={(event) => onChange(event.target.value)} />
+  ),
+  Icons: {
+    Close: () => <span data-testid="close-icon" />,
+  },
+}));
+
+const accounts = [
+  {
+    id: "acc_1",
+    name: "Brokerage",
+    currency: "USD",
+  } as Account,
+];
+
+const accountScope: AccountScope = { type: "all" };
+const portfolios: PortfolioWithAccounts[] = [];
+
+describe("ActivityViewControls", () => {
+  it("resets filters through the parent reset handler", async () => {
+    const user = userEvent.setup();
+    const onSearchQueryChange = vi.fn();
+    const onAccountScopeChange = vi.fn();
+    const onActivityTypesChange = vi.fn();
+    const onInstrumentTypesChange = vi.fn();
+    const onStatusFilterChange = vi.fn();
+    const onDateRangeChange = vi.fn();
+    const onResetFilters = vi.fn();
+
+    render(
+      <ActivityViewControls
+        accounts={accounts}
+        portfolios={portfolios}
+        searchQuery=""
+        onSearchQueryChange={onSearchQueryChange}
+        accountScope={accountScope}
+        onAccountScopeChange={onAccountScopeChange}
+        selectedActivityTypes={[]}
+        onActivityTypesChange={onActivityTypesChange}
+        selectedInstrumentTypes={[]}
+        onInstrumentTypesChange={onInstrumentTypesChange}
+        statusFilter="pending"
+        onStatusFilterChange={onStatusFilterChange}
+        dateRange={undefined}
+        onDateRangeChange={onDateRangeChange}
+        onResetFilters={onResetFilters}
+        viewMode="table"
+        onViewModeChange={vi.fn()}
+        isFetching={false}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /reset/i }));
+
+    expect(onResetFilters).toHaveBeenCalledTimes(1);
+    expect(onSearchQueryChange).not.toHaveBeenCalled();
+    expect(onAccountScopeChange).not.toHaveBeenCalled();
+    expect(onActivityTypesChange).not.toHaveBeenCalled();
+    expect(onInstrumentTypesChange).not.toHaveBeenCalled();
+    expect(onStatusFilterChange).not.toHaveBeenCalled();
+    expect(onDateRangeChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/pages/activity/components/activity-view-controls.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-view-controls.tsx
@@ -31,6 +31,7 @@ interface ActivityViewControlsProps {
   onStatusFilterChange: (status: ActivityStatusFilter) => void;
   dateRange: DateRange | undefined;
   onDateRangeChange: (range: DateRange | undefined) => void;
+  onResetFilters: () => void;
   viewMode: ActivityViewMode;
   onViewModeChange: (mode: ActivityViewMode) => void;
   /** Shown only in table view - number of activities fetched so far */
@@ -70,6 +71,7 @@ export function ActivityViewControls({
   onStatusFilterChange,
   dateRange,
   onDateRangeChange,
+  onResetFilters,
   viewMode,
   onViewModeChange,
   totalFetched,
@@ -210,13 +212,9 @@ export function ActivityViewControls({
             size="sm"
             className="h-8 px-2 text-xs"
             onClick={() => {
+              debouncedSearch.cancel();
               setLocalSearch("");
-              onSearchQueryChange("");
-              onAccountScopeChange({ type: "all" });
-              onActivityTypesChange([]);
-              onInstrumentTypesChange([]);
-              onStatusFilterChange("all");
-              onDateRangeChange(undefined);
+              onResetFilters();
             }}
           >
             Reset

--- a/apps/frontend/src/pages/activity/hooks/use-activity-action-dialogs.ts
+++ b/apps/frontend/src/pages/activity/hooks/use-activity-action-dialogs.ts
@@ -1,0 +1,94 @@
+import { getTransferPairForActivity } from "@/adapters";
+import { ActivityType } from "@/lib/constants";
+import type { ActivityDetails } from "@/lib/types";
+import { useCallback, useState } from "react";
+import { useActivityMutations } from "./use-activity-mutations";
+
+function isInternalTransfer(activity: ActivityDetails): boolean {
+  return (
+    (activity.activityType === ActivityType.TRANSFER_IN ||
+      activity.activityType === ActivityType.TRANSFER_OUT) &&
+    !!activity.sourceGroupId &&
+    ((activity.metadata?.flow as { is_external?: boolean } | undefined)?.is_external ?? false) !==
+      true
+  );
+}
+
+export function useActivityActionDialogs() {
+  const [selectedActivity, setSelectedActivity] = useState<Partial<ActivityDetails> | undefined>();
+  const [formOpen, setFormOpen] = useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const { deleteActivityMutation, duplicateActivityMutation } = useActivityMutations();
+  const { mutateAsync: deleteActivity, isPending: isDeleting } = deleteActivityMutation;
+  const { mutateAsync: duplicateActivityAsync } = duplicateActivityMutation;
+
+  const openForm = useCallback(async (activity?: ActivityDetails, activityType?: ActivityType) => {
+    if (activity?.id && isInternalTransfer(activity)) {
+      try {
+        const pair = await getTransferPairForActivity(activity.id);
+        const counterpart =
+          activity.activityType === ActivityType.TRANSFER_IN ? pair.transferOut : pair.transferIn;
+
+        setSelectedActivity({
+          ...activity,
+          transferOutId: pair.transferOut.id,
+          transferInId: pair.transferIn.id,
+          counterpartActivityId: counterpart.id,
+          counterpartAccountId: counterpart.accountId,
+          counterpartAmount: counterpart.amount ?? null,
+          counterpartCurrency: counterpart.currency,
+          counterpartFxRate: pair.transferIn.fxRate ?? null,
+        });
+        setFormOpen(true);
+        return;
+      } catch {
+        // Fall back to single-leg editing for invalid groups.
+      }
+    }
+
+    setSelectedActivity(activity ?? { activityType });
+    setFormOpen(true);
+  }, []);
+
+  const closeForm = useCallback(() => {
+    setFormOpen(false);
+    setSelectedActivity(undefined);
+  }, []);
+
+  const requestDelete = useCallback((activity: ActivityDetails) => {
+    setSelectedActivity(activity);
+    setDeleteDialogOpen(true);
+  }, []);
+
+  const cancelDelete = useCallback(() => {
+    setDeleteDialogOpen(false);
+    setSelectedActivity(undefined);
+  }, []);
+
+  const confirmDelete = useCallback(async () => {
+    if (!selectedActivity?.id) return;
+    await deleteActivity(selectedActivity.id);
+    setDeleteDialogOpen(false);
+    setSelectedActivity(undefined);
+  }, [deleteActivity, selectedActivity?.id]);
+
+  const duplicateActivity = useCallback(
+    async (activity: ActivityDetails) => {
+      await duplicateActivityAsync(activity);
+    },
+    [duplicateActivityAsync],
+  );
+
+  return {
+    selectedActivity,
+    formOpen,
+    deleteDialogOpen,
+    isDeleting,
+    openForm,
+    closeForm,
+    requestDelete,
+    cancelDelete,
+    confirmDelete,
+    duplicateActivity,
+  };
+}

--- a/apps/frontend/src/pages/asset/asset-profile-page.tsx
+++ b/apps/frontend/src/pages/asset/asset-profile-page.tsx
@@ -8,11 +8,13 @@ import {
 import { ActionPalette, type ActionPaletteGroup } from "@/components/action-palette";
 import { TickerAvatar } from "@/components/ticker-avatar";
 import { useHapticFeedback } from "@/hooks";
+import { useAccounts } from "@/hooks/use-accounts";
 import { useAlternativeAssetHolding, useAlternativeHoldings } from "@/hooks/use-alternative-assets";
 import { useIsMobileViewport } from "@/hooks/use-platform";
 import { useQuoteHistory } from "@/hooks/use-quote-history";
 import { useSyncMarketDataMutation } from "@/hooks/use-sync-market-data";
 import { useAssetTaxonomyAssignments, useTaxonomy } from "@/hooks/use-taxonomies";
+import { getActivityRestrictionLevel } from "@/lib/activity-restrictions";
 import { ActivityStatus, ActivityType } from "@/lib/constants";
 import { generateId } from "@/lib/id";
 import { QueryKeys } from "@/lib/query-keys";
@@ -44,8 +46,12 @@ import { AssetEditSheet } from "./asset-edit-sheet";
 import AssetHistoryCard from "./asset-history-card";
 import { AssetSnapshotHistory, useHasManualSnapshots } from "./asset-account-holdings";
 import AssetLotsTable from "./asset-lots-table";
+import { ActivityDeleteModal } from "@/pages/activity/components/activity-delete-modal";
+import { ActivityForm, type AccountSelectOption } from "@/pages/activity/components/activity-form";
 import ActivityTable from "@/pages/activity/components/activity-table/activity-table";
 import ActivityTableMobile from "@/pages/activity/components/activity-table/activity-table-mobile";
+import { MobileActivityForm } from "@/pages/activity/components/mobile-forms/mobile-activity-form";
+import { useActivityActionDialogs } from "@/pages/activity/hooks/use-activity-action-dialogs";
 import { useAssetProfile } from "./hooks/use-asset-profile";
 import { useAssetProfileMutations } from "./hooks/use-asset-profile-mutations";
 import { RefreshQuotesConfirmDialog } from "./refresh-quotes-confirm-dialog";
@@ -164,6 +170,18 @@ export const AssetProfilePage = () => {
   >("general");
   const { triggerHaptic } = useHapticFeedback();
   const isMobile = useIsMobileViewport();
+  const {
+    selectedActivity,
+    formOpen: activityFormOpen,
+    deleteDialogOpen: showActivityDeleteAlert,
+    isDeleting: isActivityDeleting,
+    openForm: handleActivityEdit,
+    closeForm: handleActivityFormClose,
+    requestDelete: handleActivityDelete,
+    cancelDelete: handleActivityDeleteCancel,
+    confirmDelete: handleActivityDeleteConfirm,
+    duplicateActivity: handleActivityDuplicate,
+  } = useActivityActionDialogs();
 
   const fxTabs = useMemo(() => {
     const items: { value: "overview" | "quotes"; label: string }[] = [
@@ -460,6 +478,22 @@ export const AssetProfilePage = () => {
     },
     enabled: !!assetId && !isAssetProfileLoading,
   });
+
+  const { accounts } = useAccounts({ filterActive: false });
+
+  const activityFormAccounts = useMemo<AccountSelectOption[]>(
+    () =>
+      accounts
+        .filter((account) => !account.isArchived)
+        .map((account) => ({
+          value: account.id,
+          label: account.name,
+          currency: account.currency,
+          accountType: account.accountType,
+          restrictionLevel: getActivityRestrictionLevel(account),
+        })),
+    [accounts],
+  );
 
   const overviewSubTabs = useMemo(() => {
     const items: { value: OverviewSubTab; label: string }[] = [{ value: "about", label: "About" }];
@@ -820,17 +854,13 @@ export const AssetProfilePage = () => {
       />
     );
 
-    const noopEdit = () => undefined;
-    const noopDelete = () => undefined;
-    const noopDuplicate = () => Promise.resolve();
-
     const activitiesContent = isMobile ? (
       <ActivityTableMobile
         activities={assetActivities}
         isCompactView={true}
-        handleEdit={noopEdit}
-        handleDelete={noopDelete}
-        onDuplicate={noopDuplicate}
+        handleEdit={handleActivityEdit}
+        handleDelete={handleActivityDelete}
+        onDuplicate={handleActivityDuplicate}
       />
     ) : (
       <ActivityTable
@@ -838,8 +868,8 @@ export const AssetProfilePage = () => {
         isLoading={isActivitiesLoading}
         sorting={[{ id: "date", desc: true }]}
         onSortingChange={() => undefined}
-        handleEdit={noopEdit}
-        handleDelete={noopDelete}
+        handleEdit={handleActivityEdit}
+        handleDelete={handleActivityDelete}
       />
     );
 
@@ -869,6 +899,9 @@ export const AssetProfilePage = () => {
     assetActivities,
     isActivitiesLoading,
     isMobile,
+    handleActivityEdit,
+    handleActivityDelete,
+    handleActivityDuplicate,
   ]);
 
   // Build swipable tabs for mobile from sub-tabs.
@@ -1403,6 +1436,32 @@ export const AssetProfilePage = () => {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {isMobile ? (
+        <MobileActivityForm
+          key={selectedActivity?.id ?? "new"}
+          accounts={activityFormAccounts}
+          transferAccounts={activityFormAccounts}
+          activity={selectedActivity}
+          open={activityFormOpen}
+          onClose={handleActivityFormClose}
+        />
+      ) : (
+        <ActivityForm
+          accounts={activityFormAccounts}
+          transferAccounts={activityFormAccounts}
+          activity={selectedActivity}
+          open={activityFormOpen}
+          onClose={handleActivityFormClose}
+        />
+      )}
+      <ActivityDeleteModal
+        isOpen={showActivityDeleteAlert}
+        isDeleting={isActivityDeleting}
+        linkedTransfer={!!selectedActivity?.sourceGroupId}
+        onConfirm={handleActivityDeleteConfirm}
+        onCancel={handleActivityDeleteCancel}
+      />
 
       {/* Edit Sheet (for regular assets) */}
       <AssetEditSheet

--- a/apps/frontend/src/pages/layouts/app-layout.tsx
+++ b/apps/frontend/src/pages/layouts/app-layout.tsx
@@ -5,6 +5,7 @@ import { StartupError } from "@/components/startup-error";
 import { UpdateDialog } from "@/components/update-dialog";
 import { PortfolioSyncProvider } from "@/context/portfolio-sync-context";
 import { useActiveAppSyncTrigger } from "@/features/devices-sync/hooks/use-active-app-sync-trigger";
+import { usePostLoginConnectSync } from "@/features/wealthfolio-connect/hooks";
 import useNavigationEventListener from "@/hooks/use-navigation-event-listener";
 import { useIsMobileViewport, usePlatform } from "@/hooks/use-platform";
 import { useSettings } from "@/hooks/use-settings";
@@ -42,10 +43,12 @@ const AppLayoutContent = () => {
   const isDesktopFocusMode = !shouldUseMobileNavigation && isFocusMode;
   const launchBarHeight =
     !shouldUseMobileNavigation && isLaunchBar && !isFocusMode ? "56px" : undefined;
+  const isAppShellReady = isSettingsReady && !!settings?.onboardingCompleted;
 
-  useGlobalEventListener();
+  const areGlobalEventsReady = useGlobalEventListener();
   useNavigationEventListener();
   useActiveAppSyncTrigger({ enabled: isTauri, requireWindowFocusForInterval: !isMobile });
+  usePostLoginConnectSync({ enabled: areGlobalEventsReady && isAppShellReady });
 
   if (isSettingsError) {
     return (

--- a/apps/frontend/src/use-global-event-listener.ts
+++ b/apps/frontend/src/use-global-event-listener.ts
@@ -32,6 +32,8 @@ const TOAST_IDS = {
 const BROKER_SYNC_FAILURE_DESCRIPTION =
   "We couldn't sync your broker data. Please try again later.";
 
+const POST_LOGIN_REQUIRED_LISTENERS = new Set(["broker-sync-complete", "broker-sync-error"]);
+
 interface MarketSyncCompletePayload {
   failed_syncs?: [string, string][];
   skipped_reasons?: [string, string][];
@@ -284,11 +286,13 @@ const useGlobalEventListener = () => {
 
       const results = await Promise.allSettled(listenerSetups.map(([, setup]) => setup));
       const cleanupFns: (() => void)[] = [];
+      const readyListeners = new Set<string>();
 
       results.forEach((result, index) => {
         const name = listenerSetups[index]?.[0] ?? "unknown";
         if (result.status === "fulfilled") {
           cleanupFns.push(result.value);
+          readyListeners.add(name);
         } else {
           logger.error(`Failed to setup ${name} listener: ${String(result.reason)}`);
         }
@@ -307,7 +311,9 @@ const useGlobalEventListener = () => {
       }
 
       cleanupFn = cleanup;
-      setAreListenersReady(cleanupFns.length > 0);
+      setAreListenersReady(
+        Array.from(POST_LOGIN_REQUIRED_LISTENERS).every((name) => readyListeners.has(name)),
+      );
 
       // Trigger initial portfolio update after listeners are set up
       if (!hasTriggeredInitialUpdate.current) {

--- a/apps/frontend/src/use-global-event-listener.ts
+++ b/apps/frontend/src/use-global-event-listener.ts
@@ -17,7 +17,7 @@ import { usePortfolioSyncOptional } from "@/context/portfolio-sync-context";
 import { useIsMobileViewport } from "@/hooks/use-platform";
 import { shouldInvalidateAfterPortfolioUpdate } from "@/lib/query-invalidation";
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 
@@ -44,6 +44,7 @@ function getSyncFailures(payload?: MarketSyncCompletePayload | null): [string, s
 const useGlobalEventListener = () => {
   const queryClient = useQueryClient();
   const navigate = useNavigate();
+  const [areListenersReady, setAreListenersReady] = useState(false);
   const hasTriggeredInitialUpdate = useRef(false);
   const isDesktopEnv = isDesktop;
   const isMobileViewport = useIsMobileViewport();
@@ -66,6 +67,7 @@ const useGlobalEventListener = () => {
   useEffect(() => {
     let isMounted = true;
     let cleanupFn: (() => void) | undefined;
+    setAreListenersReady(false);
 
     const handleMarketSyncStart = () => {
       if (isMobileViewportRef.current && syncContextRef.current) {
@@ -263,33 +265,39 @@ const useGlobalEventListener = () => {
     };
 
     const setupListeners = async () => {
-      const unlistenPortfolioSyncStart = await listenPortfolioUpdateStart(
-        handlePortfolioUpdateStart,
-      );
-      const unlistenPortfolioSyncComplete = await listenPortfolioUpdateComplete(
-        handlePortfolioUpdateComplete,
-      );
-      const unlistenPortfolioSyncError = await listenPortfolioUpdateError((event) => {
-        handlePortfolioUpdateError(event.payload as string);
+      const listenerSetups: [name: string, setup: Promise<() => void>][] = [
+        ["portfolio-update-start", listenPortfolioUpdateStart(handlePortfolioUpdateStart)],
+        ["portfolio-update-complete", listenPortfolioUpdateComplete(handlePortfolioUpdateComplete)],
+        [
+          "portfolio-update-error",
+          listenPortfolioUpdateError((event) => {
+            handlePortfolioUpdateError(event.payload as string);
+          }),
+        ],
+        ["market-sync-start", listenMarketSyncStart(handleMarketSyncStart)],
+        ["market-sync-complete", listenMarketSyncComplete(handleMarketSyncComplete)],
+        ["market-sync-error", listenMarketSyncError(handleMarketSyncError)],
+        ["database-restored", listenDatabaseRestored(handleDatabaseRestored)],
+        ["broker-sync-complete", listenBrokerSyncComplete(handleBrokerSyncComplete)],
+        ["broker-sync-error", listenBrokerSyncError(handleBrokerSyncError)],
+      ];
+
+      const results = await Promise.allSettled(listenerSetups.map(([, setup]) => setup));
+      const cleanupFns: (() => void)[] = [];
+
+      results.forEach((result, index) => {
+        const name = listenerSetups[index]?.[0] ?? "unknown";
+        if (result.status === "fulfilled") {
+          cleanupFns.push(result.value);
+        } else {
+          logger.error(`Failed to setup ${name} listener: ${String(result.reason)}`);
+        }
       });
-      const unlistenMarketStart = await listenMarketSyncStart(handleMarketSyncStart);
-      const unlistenMarketComplete = await listenMarketSyncComplete(handleMarketSyncComplete);
-      const unlistenMarketError = await listenMarketSyncError(handleMarketSyncError);
-      const unlistenDatabaseRestored = await listenDatabaseRestored(handleDatabaseRestored);
-      const unlistenBrokerSyncComplete = await listenBrokerSyncComplete(handleBrokerSyncComplete);
-      const unlistenBrokerSyncError = await listenBrokerSyncError(handleBrokerSyncError);
 
       const cleanup = () => {
-        unlistenPortfolioSyncStart();
-        unlistenPortfolioSyncComplete();
-        unlistenPortfolioSyncError();
-        unlistenMarketStart();
-        unlistenMarketComplete();
-        unlistenMarketError();
-
-        unlistenDatabaseRestored();
-        unlistenBrokerSyncComplete();
-        unlistenBrokerSyncError();
+        for (const unlisten of cleanupFns) {
+          unlisten();
+        }
       };
 
       // If unmounted while setting up, clean up immediately
@@ -299,6 +307,7 @@ const useGlobalEventListener = () => {
       }
 
       cleanupFn = cleanup;
+      setAreListenersReady(cleanupFns.length > 0);
 
       // Trigger initial portfolio update after listeners are set up
       if (!hasTriggeredInitialUpdate.current) {
@@ -314,16 +323,17 @@ const useGlobalEventListener = () => {
     };
 
     setupListeners().catch((error) => {
-      console.error("Failed to setup global event listeners:", error);
+      logger.error("Failed to setup global event listeners: " + String(error));
     });
 
     return () => {
       isMounted = false;
+      setAreListenersReady(false);
       cleanupFn?.();
     };
   }, [isDesktopEnv]); // Only re-run if isDesktopEnv changes (which it won't)
 
-  return null;
+  return areListenersReady;
 };
 
 export default useGlobalEventListener;

--- a/apps/server/src/api/connect.rs
+++ b/apps/server/src/api/connect.rs
@@ -4,10 +4,7 @@
 //! from the Wealthfolio Connect cloud service.
 
 use std::future::Future;
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-};
+use std::sync::Arc;
 
 use axum::{
     extract::{Query, State},
@@ -25,13 +22,17 @@ use crate::events::{
 };
 use crate::main_lib::AppState;
 use axum::http::StatusCode;
+use wealthfolio_connect::prepare_post_login_broker_bootstrap;
 use wealthfolio_connect::{
+    acquire_broker_sync_guard,
     broker::{
         BrokerApiClient, PlansResponse, SyncAccountsResponse, SyncActivitiesResponse,
         SyncConnectionsResponse, UserInfo,
     },
-    ensure_valid_access_token, fetch_subscription_plans_public, ConnectApiClient, SyncConfig,
-    SyncOrchestrator, SyncProgressPayload, SyncProgressReporter, SyncResult, TokenLifecycleConfig,
+    ensure_valid_access_token, fetch_subscription_plans_public, BrokerSyncRunGuard,
+    ConnectApiClient, PostLoginBootstrapReason, PostLoginBootstrapResult,
+    PostLoginBootstrapSyncResult, PostLoginBrokerBootstrapDecision, SyncConfig, SyncOrchestrator,
+    SyncProgressPayload, SyncProgressReporter, SyncResult, TokenLifecycleConfig,
     TokenLifecycleError, CLOUD_ACCESS_TOKEN_KEY, CLOUD_REFRESH_TOKEN_KEY,
 };
 #[cfg(feature = "device-sync")]
@@ -39,122 +40,6 @@ use wealthfolio_device_sync::{EnableSyncResult, SyncState, SyncStateResult};
 
 #[cfg(feature = "device-sync")]
 const DEVICE_ID_KEY: &str = "sync_device_id";
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-enum PostLoginBootstrapStatus {
-    Started,
-    Skipped,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-#[allow(dead_code)]
-enum PostLoginBootstrapReason {
-    FeatureDisabled,
-    NotEntitled,
-    NoConnections,
-    AlreadyRunning,
-    NotEnrolled,
-    NotReady,
-    Error,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct PostLoginBootstrapSyncResult {
-    status: PostLoginBootstrapStatus,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    reason: Option<PostLoginBootstrapReason>,
-}
-
-impl PostLoginBootstrapSyncResult {
-    fn started() -> Self {
-        Self {
-            status: PostLoginBootstrapStatus::Started,
-            reason: None,
-        }
-    }
-
-    fn skipped(reason: PostLoginBootstrapReason) -> Self {
-        Self {
-            status: PostLoginBootstrapStatus::Skipped,
-            reason: Some(reason),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct PostLoginBootstrapResult {
-    broker_sync: PostLoginBootstrapSyncResult,
-    device_sync: PostLoginBootstrapSyncResult,
-}
-
-enum PostLoginBrokerBootstrapDecision<Guard> {
-    Start(Guard),
-    Skip(PostLoginBootstrapReason),
-}
-
-async fn prepare_post_login_broker_bootstrap<
-    CheckEntitlement,
-    CheckEntitlementFuture,
-    ListConnections,
-    ListConnectionsFuture,
-    TryStart,
-    Guard,
->(
-    feature_enabled: bool,
-    check_entitlement: CheckEntitlement,
-    list_connections: ListConnections,
-    try_start: TryStart,
-) -> PostLoginBrokerBootstrapDecision<Guard>
-where
-    CheckEntitlement: FnOnce() -> CheckEntitlementFuture,
-    CheckEntitlementFuture: Future<Output = Result<bool, String>>,
-    ListConnections: FnOnce() -> ListConnectionsFuture,
-    ListConnectionsFuture:
-        Future<Output = Result<Vec<wealthfolio_connect::broker::BrokerConnection>, String>>,
-    TryStart: FnOnce() -> Option<Guard>,
-{
-    if !feature_enabled {
-        return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::FeatureDisabled);
-    }
-
-    match check_entitlement().await {
-        Ok(true) => {}
-        Ok(false) => {
-            return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::NotEntitled);
-        }
-        Err(err) => {
-            debug!(
-                "[Connect] Post-login broker sync skipped: could not verify entitlement ({})",
-                err
-            );
-            return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::Error);
-        }
-    }
-
-    let connections = match list_connections().await {
-        Ok(connections) => connections,
-        Err(err) => {
-            debug!(
-                "[Connect] Post-login broker sync skipped: failed to inspect connections ({})",
-                err
-            );
-            return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::Error);
-        }
-    };
-
-    if !connections.iter().any(is_active_broker_connection) {
-        return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::NoConnections);
-    }
-
-    match try_start() {
-        Some(guard) => PostLoginBrokerBootstrapDecision::Start(guard),
-        None => PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::AlreadyRunning),
-    }
-}
 
 #[cfg(feature = "device-sync")]
 enum PostLoginDeviceBootstrapDecision {
@@ -202,32 +87,8 @@ where
     PostLoginDeviceBootstrapDecision::StartBackground
 }
 
-struct BrokerSyncRunGuard {
-    running: Arc<AtomicBool>,
-}
-
-impl Drop for BrokerSyncRunGuard {
-    fn drop(&mut self) {
-        self.running.store(false, Ordering::Release);
-    }
-}
-
 fn try_acquire_broker_sync_guard(state: &AppState) -> Option<BrokerSyncRunGuard> {
-    state
-        .broker_sync_running
-        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-        .ok()
-        .map(|_| BrokerSyncRunGuard {
-            running: Arc::clone(&state.broker_sync_running),
-        })
-}
-
-fn is_active_broker_connection(connection: &wealthfolio_connect::broker::BrokerConnection) -> bool {
-    !connection.disabled
-        && connection
-            .status
-            .as_deref()
-            .is_some_and(|status| status.eq_ignore_ascii_case("connected"))
+    acquire_broker_sync_guard(&state.broker_sync_running)
 }
 
 fn ensure_cloud_sync_enabled() -> ApiResult<()> {
@@ -851,9 +712,17 @@ async fn perform_broker_sync_with_guard(
 ) -> Result<SyncResult, String> {
     ensure_connect_sync_enabled().map_err(|e| e.to_string())?;
     // Create API client
-    let client = create_connect_client(state)
-        .await
-        .map_err(|e| e.to_string())?;
+    let client = match create_connect_client(state).await {
+        Ok(client) => client,
+        Err(err) => {
+            let message = err.to_string();
+            state.event_bus.publish(ServerEvent::with_payload(
+                BROKER_SYNC_ERROR,
+                serde_json::json!({ "error": message }),
+            ));
+            return Err(message);
+        }
+    };
 
     // Create progress reporter and orchestrator
     let reporter = Arc::new(EventBusProgressReporter::new(state.event_bus.clone()));

--- a/apps/server/src/api/connect.rs
+++ b/apps/server/src/api/connect.rs
@@ -3,7 +3,11 @@
 //! This module provides REST endpoints for syncing broker accounts and activities
 //! from the Wealthfolio Connect cloud service.
 
-use std::sync::Arc;
+use std::future::Future;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 
 use axum::{
     extract::{Query, State},
@@ -13,6 +17,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info};
 
+#[cfg(feature = "device-sync")]
 use super::device_sync_engine;
 use crate::error::{ApiError, ApiResult};
 use crate::events::{
@@ -29,9 +34,201 @@ use wealthfolio_connect::{
     SyncOrchestrator, SyncProgressPayload, SyncProgressReporter, SyncResult, TokenLifecycleConfig,
     TokenLifecycleError, CLOUD_ACCESS_TOKEN_KEY, CLOUD_REFRESH_TOKEN_KEY,
 };
+#[cfg(feature = "device-sync")]
 use wealthfolio_device_sync::{EnableSyncResult, SyncState, SyncStateResult};
 
+#[cfg(feature = "device-sync")]
 const DEVICE_ID_KEY: &str = "sync_device_id";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum PostLoginBootstrapStatus {
+    Started,
+    Skipped,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[allow(dead_code)]
+enum PostLoginBootstrapReason {
+    FeatureDisabled,
+    NotEntitled,
+    NoConnections,
+    AlreadyRunning,
+    NotEnrolled,
+    NotReady,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PostLoginBootstrapSyncResult {
+    status: PostLoginBootstrapStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<PostLoginBootstrapReason>,
+}
+
+impl PostLoginBootstrapSyncResult {
+    fn started() -> Self {
+        Self {
+            status: PostLoginBootstrapStatus::Started,
+            reason: None,
+        }
+    }
+
+    fn skipped(reason: PostLoginBootstrapReason) -> Self {
+        Self {
+            status: PostLoginBootstrapStatus::Skipped,
+            reason: Some(reason),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PostLoginBootstrapResult {
+    broker_sync: PostLoginBootstrapSyncResult,
+    device_sync: PostLoginBootstrapSyncResult,
+}
+
+enum PostLoginBrokerBootstrapDecision<Guard> {
+    Start(Guard),
+    Skip(PostLoginBootstrapReason),
+}
+
+async fn prepare_post_login_broker_bootstrap<
+    CheckEntitlement,
+    CheckEntitlementFuture,
+    ListConnections,
+    ListConnectionsFuture,
+    TryStart,
+    Guard,
+>(
+    feature_enabled: bool,
+    check_entitlement: CheckEntitlement,
+    list_connections: ListConnections,
+    try_start: TryStart,
+) -> PostLoginBrokerBootstrapDecision<Guard>
+where
+    CheckEntitlement: FnOnce() -> CheckEntitlementFuture,
+    CheckEntitlementFuture: Future<Output = Result<bool, String>>,
+    ListConnections: FnOnce() -> ListConnectionsFuture,
+    ListConnectionsFuture:
+        Future<Output = Result<Vec<wealthfolio_connect::broker::BrokerConnection>, String>>,
+    TryStart: FnOnce() -> Option<Guard>,
+{
+    if !feature_enabled {
+        return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::FeatureDisabled);
+    }
+
+    match check_entitlement().await {
+        Ok(true) => {}
+        Ok(false) => {
+            return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::NotEntitled);
+        }
+        Err(err) => {
+            debug!(
+                "[Connect] Post-login broker sync skipped: could not verify entitlement ({})",
+                err
+            );
+            return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::Error);
+        }
+    }
+
+    let connections = match list_connections().await {
+        Ok(connections) => connections,
+        Err(err) => {
+            debug!(
+                "[Connect] Post-login broker sync skipped: failed to inspect connections ({})",
+                err
+            );
+            return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::Error);
+        }
+    };
+
+    if !connections.iter().any(is_active_broker_connection) {
+        return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::NoConnections);
+    }
+
+    match try_start() {
+        Some(guard) => PostLoginBrokerBootstrapDecision::Start(guard),
+        None => PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::AlreadyRunning),
+    }
+}
+
+#[cfg(feature = "device-sync")]
+enum PostLoginDeviceBootstrapDecision {
+    StartBackground,
+    Skip(PostLoginBootstrapReason),
+}
+
+#[cfg(feature = "device-sync")]
+async fn prepare_post_login_device_bootstrap<
+    CheckBackgroundRunning,
+    CheckBackgroundRunningFuture,
+    LoadSyncState,
+    LoadSyncStateFuture,
+>(
+    can_run_background: bool,
+    check_background_running: CheckBackgroundRunning,
+    load_sync_state: LoadSyncState,
+) -> PostLoginDeviceBootstrapDecision
+where
+    CheckBackgroundRunning: FnOnce() -> CheckBackgroundRunningFuture,
+    CheckBackgroundRunningFuture: Future<Output = bool>,
+    LoadSyncState: FnOnce() -> LoadSyncStateFuture,
+    LoadSyncStateFuture: Future<Output = Result<SyncState, String>>,
+{
+    if !can_run_background {
+        return PostLoginDeviceBootstrapDecision::Skip(PostLoginBootstrapReason::NotEnrolled);
+    }
+
+    if check_background_running().await {
+        return PostLoginDeviceBootstrapDecision::Skip(PostLoginBootstrapReason::AlreadyRunning);
+    }
+
+    let sync_state = match load_sync_state().await {
+        Ok(sync_state) => sync_state,
+        Err(err) => {
+            debug!("[Connect] Post-login device sync skipped: {}", err);
+            return PostLoginDeviceBootstrapDecision::Skip(PostLoginBootstrapReason::Error);
+        }
+    };
+
+    if sync_state != SyncState::Ready {
+        return PostLoginDeviceBootstrapDecision::Skip(PostLoginBootstrapReason::NotReady);
+    }
+
+    PostLoginDeviceBootstrapDecision::StartBackground
+}
+
+struct BrokerSyncRunGuard {
+    running: Arc<AtomicBool>,
+}
+
+impl Drop for BrokerSyncRunGuard {
+    fn drop(&mut self) {
+        self.running.store(false, Ordering::Release);
+    }
+}
+
+fn try_acquire_broker_sync_guard(state: &AppState) -> Option<BrokerSyncRunGuard> {
+    state
+        .broker_sync_running
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .ok()
+        .map(|_| BrokerSyncRunGuard {
+            running: Arc::clone(&state.broker_sync_running),
+        })
+}
+
+fn is_active_broker_connection(connection: &wealthfolio_connect::broker::BrokerConnection) -> bool {
+    !connection.disabled
+        && connection
+            .status
+            .as_deref()
+            .is_some_and(|status| status.eq_ignore_ascii_case("connected"))
+}
 
 fn ensure_cloud_sync_enabled() -> ApiResult<()> {
     if crate::features::cloud_sync_enabled() {
@@ -53,6 +250,7 @@ fn ensure_connect_sync_enabled() -> ApiResult<()> {
     }
 }
 
+#[cfg(feature = "device-sync")]
 fn ensure_device_sync_enabled() -> ApiResult<()> {
     if crate::features::device_sync_enabled() {
         Ok(())
@@ -125,6 +323,7 @@ pub struct RestoreSyncSessionResponse {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg(feature = "device-sync")]
 struct DeviceSyncEngineStatusResponse {
     cursor: i64,
     last_push_at: Option<String>,
@@ -140,6 +339,7 @@ struct DeviceSyncEngineStatusResponse {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg(feature = "device-sync")]
 struct DeviceSyncPairingSourceStatusResponse {
     status: String,
     message: String,
@@ -149,6 +349,7 @@ struct DeviceSyncPairingSourceStatusResponse {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg(feature = "device-sync")]
 struct DeviceSyncBootstrapOverwriteCheckTableResponse {
     table: String,
     rows: i64,
@@ -156,6 +357,7 @@ struct DeviceSyncBootstrapOverwriteCheckTableResponse {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg(feature = "device-sync")]
 struct DeviceSyncBootstrapOverwriteCheckResponse {
     bootstrap_required: bool,
     has_local_data: bool,
@@ -165,6 +367,7 @@ struct DeviceSyncBootstrapOverwriteCheckResponse {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg(feature = "device-sync")]
 struct DeviceSyncBootstrapResponse {
     status: String,
     message: String,
@@ -174,6 +377,7 @@ struct DeviceSyncBootstrapResponse {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg(feature = "device-sync")]
 struct DeviceSyncCycleResponse {
     status: String,
     lock_version: i64,
@@ -188,6 +392,7 @@ struct DeviceSyncCycleResponse {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg(feature = "device-sync")]
 struct DeviceSyncBackgroundResponse {
     status: String,
     message: String,
@@ -195,6 +400,7 @@ struct DeviceSyncBackgroundResponse {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg(feature = "device-sync")]
 struct DeviceSyncReconcileReadyResponse {
     status: String,
     message: String,
@@ -209,6 +415,7 @@ struct DeviceSyncReconcileReadyResponse {
     background_status: String,
 }
 
+#[cfg(feature = "device-sync")]
 fn to_device_sync_reconcile_ready_response(
     result: device_sync_engine::SyncReconcileReadyStateResult,
 ) -> DeviceSyncReconcileReadyResponse {
@@ -229,6 +436,7 @@ fn to_device_sync_reconcile_ready_response(
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg(feature = "device-sync")]
 struct DeviceSyncReconcileReadyRequest {
     #[serde(default)]
     allow_overwrite: bool,
@@ -236,6 +444,7 @@ struct DeviceSyncReconcileReadyRequest {
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[cfg(feature = "device-sync")]
 struct DeviceSyncSnapshotUploadResponse {
     status: String,
     snapshot_id: Option<String>,
@@ -302,47 +511,112 @@ async fn store_sync_session(
     let _ = state.secret_store.delete_secret(CLOUD_ACCESS_TOKEN_KEY);
     state.token_lifecycle.clear_cache().await;
 
-    if crate::features::device_sync_enabled() {
-        let engine_state = Arc::clone(&state);
-        tokio::spawn(async move {
-            let token = match mint_access_token(&engine_state).await {
-                Ok(token) => token,
-                Err(err) => {
-                    debug!(
-                        "[Connect] Skipping post-login device sync background start: {}",
-                        err
-                    );
-                    return;
-                }
-            };
+    Ok(Json(()))
+}
 
-            match engine_state
+async fn post_login_bootstrap(
+    State(state): State<Arc<AppState>>,
+) -> ApiResult<Json<PostLoginBootstrapResult>> {
+    let broker_sync = run_post_login_broker_bootstrap(Arc::clone(&state)).await;
+    let device_sync = run_post_login_device_bootstrap(state).await;
+
+    Ok(Json(PostLoginBootstrapResult {
+        broker_sync,
+        device_sync,
+    }))
+}
+
+async fn run_post_login_broker_bootstrap(state: Arc<AppState>) -> PostLoginBootstrapSyncResult {
+    let entitlement_state = Arc::clone(&state);
+    let connections_state = Arc::clone(&state);
+    let guard_state = Arc::clone(&state);
+
+    let decision = prepare_post_login_broker_bootstrap(
+        crate::features::connect_sync_enabled(),
+        move || async move { has_broker_sync(&entitlement_state).await },
+        move || async move {
+            let client = create_connect_client(&connections_state)
+                .await
+                .map_err(|e| e.to_string())?;
+            client.list_connections().await.map_err(|e| e.to_string())
+        },
+        move || try_acquire_broker_sync_guard(&guard_state),
+    )
+    .await;
+
+    let guard = match decision {
+        PostLoginBrokerBootstrapDecision::Start(guard) => guard,
+        PostLoginBrokerBootstrapDecision::Skip(reason) => {
+            return PostLoginBootstrapSyncResult::skipped(reason);
+        }
+    };
+
+    tokio::spawn(async move {
+        match perform_broker_sync_with_guard(&state, guard).await {
+            Ok(_result) => {
+                info!("[Connect] Post-login broker sync completed successfully");
+            }
+            Err(err) => {
+                error!("[Connect] Post-login broker sync failed: {}", err);
+            }
+        }
+    });
+
+    PostLoginBootstrapSyncResult::started()
+}
+
+#[cfg(feature = "device-sync")]
+async fn run_post_login_device_bootstrap(state: Arc<AppState>) -> PostLoginBootstrapSyncResult {
+    let Some(identity) = device_sync_engine::get_sync_identity_from_store(&state) else {
+        return PostLoginBootstrapSyncResult::skipped(PostLoginBootstrapReason::NotEnrolled);
+    };
+
+    let background_state = Arc::clone(&state);
+    let sync_state_state = Arc::clone(&state);
+    let decision = prepare_post_login_device_bootstrap(
+        device_sync_engine::sync_identity_can_run_background(&identity),
+        move || async move {
+            background_state
+                .device_sync_runtime
+                .is_background_running()
+                .await
+        },
+        move || async move {
+            let token = mint_access_token(&sync_state_state)
+                .await
+                .map_err(|err| format!("failed to mint token ({})", err))?;
+            sync_state_state
                 .device_enroll_service
                 .get_sync_state(&token)
                 .await
-            {
-                Ok(sync_state) if sync_state.state == SyncState::Ready => {
-                    if let Err(err) =
-                        device_sync_engine::ensure_background_engine_started(engine_state).await
-                    {
-                        debug!(
-                            "[Connect] Failed to start device sync background engine after login: {}",
-                            err
-                        );
-                    }
-                }
-                Ok(_) => {}
-                Err(err) => {
-                    debug!(
-                        "[Connect] Skipping post-login device sync background start: {}",
-                        err.message
-                    );
-                }
-            }
-        });
+                .map(|sync_state| sync_state.state)
+                .map_err(|err| format!("failed to get sync state ({})", err.message))
+        },
+    )
+    .await;
+
+    match decision {
+        PostLoginDeviceBootstrapDecision::StartBackground => {}
+        PostLoginDeviceBootstrapDecision::Skip(reason) => {
+            return PostLoginBootstrapSyncResult::skipped(reason);
+        }
     }
 
-    Ok(Json(()))
+    match device_sync_engine::ensure_background_engine_started(Arc::clone(&state)).await {
+        Ok(()) => PostLoginBootstrapSyncResult::started(),
+        Err(err) => {
+            debug!(
+                "[Connect] Post-login device sync background start failed: {}",
+                err
+            );
+            PostLoginBootstrapSyncResult::skipped(PostLoginBootstrapReason::Error)
+        }
+    }
+}
+
+#[cfg(not(feature = "device-sync"))]
+async fn run_post_login_device_bootstrap(_state: Arc<AppState>) -> PostLoginBootstrapSyncResult {
+    PostLoginBootstrapSyncResult::skipped(PostLoginBootstrapReason::FeatureDisabled)
 }
 
 async fn clear_sync_session(State(state): State<Arc<AppState>>) -> ApiResult<Json<()>> {
@@ -353,6 +627,7 @@ async fn clear_sync_session(State(state): State<Arc<AppState>>) -> ApiResult<Jso
     let _ = state.secret_store.delete_secret(CLOUD_ACCESS_TOKEN_KEY);
 
     state.token_lifecycle.clear_cache().await;
+    #[cfg(feature = "device-sync")]
     device_sync_engine::clear_min_snapshot_created_at_from_store();
     let _ = state
         .app_sync_repository
@@ -527,11 +802,16 @@ async fn sync_broker_data(State(state): State<Arc<AppState>>) -> StatusCode {
         }
     }
 
+    let Some(guard) = try_acquire_broker_sync_guard(&state) else {
+        info!("[Connect] Broker sync skipped: sync already running");
+        return StatusCode::CONFLICT;
+    };
+
     info!("[Connect] Starting broker data sync (non-blocking)...");
 
     // Spawn background task to perform the sync
     tokio::spawn(async move {
-        match perform_broker_sync(&state).await {
+        match perform_broker_sync_with_guard(&state, guard).await {
             Ok(_result) => {
                 info!("[Connect] Broker sync completed successfully");
                 // Events are emitted by the orchestrator via EventBusProgressReporter
@@ -560,6 +840,15 @@ pub async fn has_broker_sync(state: &AppState) -> Result<bool, String> {
 /// Uses the centralized SyncOrchestrator for full pagination support.
 /// Also used by the background scheduler for periodic syncs.
 pub async fn perform_broker_sync(state: &AppState) -> Result<SyncResult, String> {
+    let guard = try_acquire_broker_sync_guard(state)
+        .ok_or_else(|| "Broker sync already running".to_string())?;
+    perform_broker_sync_with_guard(state, guard).await
+}
+
+async fn perform_broker_sync_with_guard(
+    state: &AppState,
+    _guard: BrokerSyncRunGuard,
+) -> Result<SyncResult, String> {
     ensure_connect_sync_enabled().map_err(|e| e.to_string())?;
     // Create API client
     let client = create_connect_client(state)
@@ -810,6 +1099,7 @@ async fn save_broker_sync_profile_rules(
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Get the current device sync state (FRESH, REGISTERED, READY, STALE, RECOVERY, ORPHANED)
+#[cfg(feature = "device-sync")]
 async fn get_device_sync_state(
     State(state): State<Arc<AppState>>,
 ) -> ApiResult<Json<SyncStateResult>> {
@@ -827,6 +1117,7 @@ async fn get_device_sync_state(
 }
 
 /// Enable device sync - enrolls the device and initializes E2EE if first device
+#[cfg(feature = "device-sync")]
 async fn enable_device_sync(
     State(state): State<Arc<AppState>>,
 ) -> ApiResult<Json<EnableSyncResult>> {
@@ -867,6 +1158,7 @@ async fn enable_device_sync(
 }
 
 /// Clear all device sync data and return to FRESH state
+#[cfg(feature = "device-sync")]
 async fn clear_device_sync_data(State(state): State<Arc<AppState>>) -> ApiResult<Json<()>> {
     ensure_device_sync_enabled()?;
     info!("[Connect] Clearing device sync data...");
@@ -892,6 +1184,7 @@ async fn clear_device_sync_data(State(state): State<Arc<AppState>>) -> ApiResult
 }
 
 /// Reinitialize device sync - resets server data and enables sync in one operation
+#[cfg(feature = "device-sync")]
 async fn reinitialize_device_sync(
     State(state): State<Arc<AppState>>,
 ) -> ApiResult<Json<EnableSyncResult>> {
@@ -929,6 +1222,7 @@ async fn reinitialize_device_sync(
     Ok(Json(result))
 }
 
+#[cfg(feature = "device-sync")]
 async fn get_device_sync_engine_status(
     State(state): State<Arc<AppState>>,
 ) -> ApiResult<Json<DeviceSyncEngineStatusResponse>> {
@@ -950,6 +1244,7 @@ async fn get_device_sync_engine_status(
     }))
 }
 
+#[cfg(feature = "device-sync")]
 async fn get_device_sync_pairing_source_status(
     State(state): State<Arc<AppState>>,
 ) -> ApiResult<Json<DeviceSyncPairingSourceStatusResponse>> {
@@ -965,6 +1260,7 @@ async fn get_device_sync_pairing_source_status(
     }))
 }
 
+#[cfg(feature = "device-sync")]
 async fn get_device_sync_bootstrap_overwrite_check(
     State(state): State<Arc<AppState>>,
 ) -> ApiResult<Json<DeviceSyncBootstrapOverwriteCheckResponse>> {
@@ -988,6 +1284,7 @@ async fn get_device_sync_bootstrap_overwrite_check(
     }))
 }
 
+#[cfg(feature = "device-sync")]
 async fn bootstrap_device_snapshot(
     State(state): State<Arc<AppState>>,
 ) -> ApiResult<Json<DeviceSyncBootstrapResponse>> {
@@ -1019,6 +1316,7 @@ async fn bootstrap_device_snapshot(
     }))
 }
 
+#[cfg(feature = "device-sync")]
 async fn trigger_device_sync_cycle(
     State(state): State<Arc<AppState>>,
 ) -> ApiResult<Json<DeviceSyncCycleResponse>> {
@@ -1039,6 +1337,7 @@ async fn trigger_device_sync_cycle(
     }))
 }
 
+#[cfg(feature = "device-sync")]
 async fn start_device_sync_background_engine(
     State(state): State<Arc<AppState>>,
 ) -> ApiResult<Json<DeviceSyncBackgroundResponse>> {
@@ -1061,6 +1360,7 @@ async fn start_device_sync_background_engine(
     }))
 }
 
+#[cfg(feature = "device-sync")]
 async fn reconcile_device_sync_ready_state(
     State(state): State<Arc<AppState>>,
     Json(body): Json<DeviceSyncReconcileReadyRequest>,
@@ -1072,6 +1372,7 @@ async fn reconcile_device_sync_ready_state(
     Ok(Json(to_device_sync_reconcile_ready_response(result)))
 }
 
+#[cfg(feature = "device-sync")]
 async fn stop_device_sync_background_engine(
     State(state): State<Arc<AppState>>,
 ) -> ApiResult<Json<DeviceSyncBackgroundResponse>> {
@@ -1085,6 +1386,7 @@ async fn stop_device_sync_background_engine(
     }))
 }
 
+#[cfg(feature = "device-sync")]
 async fn generate_device_snapshot_now(
     State(state): State<Arc<AppState>>,
 ) -> ApiResult<Json<DeviceSyncSnapshotUploadResponse>> {
@@ -1100,6 +1402,7 @@ async fn generate_device_snapshot_now(
     }))
 }
 
+#[cfg(feature = "device-sync")]
 async fn cancel_device_snapshot_upload(
     State(state): State<Arc<AppState>>,
 ) -> ApiResult<Json<DeviceSyncBackgroundResponse>> {
@@ -1116,9 +1419,10 @@ async fn cancel_device_snapshot_upload(
 // ─────────────────────────────────────────────────────────────────────────────
 
 pub fn router() -> Router<Arc<AppState>> {
-    Router::new()
+    let router = Router::new()
         // Session management
         .route("/connect/session", post(store_sync_session))
+        .route("/connect/post-login-bootstrap", post(post_login_bootstrap))
         .route("/connect/session", delete(clear_sync_session))
         .route("/connect/session/status", get(get_sync_session_status))
         .route("/connect/session/restore", get(restore_sync_session))
@@ -1144,8 +1448,10 @@ pub fn router() -> Router<Arc<AppState>> {
         // User & Subscription
         .route("/connect/plans", get(get_subscription_plans))
         .route("/connect/plans/public", get(get_subscription_plans_public))
-        .route("/connect/user", get(get_user_info))
-        // Device Sync / Enrollment
+        .route("/connect/user", get(get_user_info));
+
+    #[cfg(feature = "device-sync")]
+    let router = router
         .route("/connect/device/sync-state", get(get_device_sync_state))
         .route("/connect/device/enable", post(enable_device_sync))
         .route("/connect/device/sync-data", delete(clear_device_sync_data))
@@ -1192,18 +1498,253 @@ pub fn router() -> Router<Arc<AppState>> {
         .route(
             "/connect/device/cancel-snapshot",
             post(cancel_device_snapshot_upload),
-        )
+        );
+
+    router
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
 
+    fn broker_connection(
+        status: Option<&str>,
+        disabled: bool,
+    ) -> wealthfolio_connect::broker::BrokerConnection {
+        wealthfolio_connect::broker::BrokerConnection {
+            id: "connection-1".to_string(),
+            brokerage: None,
+            connection_type: None,
+            status: status.map(str::to_string),
+            disabled,
+            disabled_date: None,
+            updated_at: None,
+            name: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn broker_preflight_feature_disabled_skips_without_checks() {
+        let entitlement_calls = Arc::new(AtomicUsize::new(0));
+        let list_calls = Arc::new(AtomicUsize::new(0));
+
+        let decision = prepare_post_login_broker_bootstrap(
+            false,
+            {
+                let entitlement_calls = Arc::clone(&entitlement_calls);
+                move || async move {
+                    entitlement_calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(true)
+                }
+            },
+            {
+                let list_calls = Arc::clone(&list_calls);
+                move || async move {
+                    list_calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(vec![broker_connection(Some("connected"), false)])
+                }
+            },
+            || Some(()),
+        )
+        .await;
+
+        assert!(matches!(
+            decision,
+            PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::FeatureDisabled)
+        ));
+        assert_eq!(entitlement_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(list_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn broker_preflight_no_entitlement_skips_without_listing_connections() {
+        let list_calls = Arc::new(AtomicUsize::new(0));
+
+        let decision = prepare_post_login_broker_bootstrap(
+            true,
+            || async { Ok(false) },
+            {
+                let list_calls = Arc::clone(&list_calls);
+                move || async move {
+                    list_calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(vec![broker_connection(Some("connected"), false)])
+                }
+            },
+            || Some(()),
+        )
+        .await;
+
+        assert!(matches!(
+            decision,
+            PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::NotEntitled)
+        ));
+        assert_eq!(list_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn broker_preflight_zero_connections_skips_without_starting() {
+        let start_calls = Arc::new(AtomicUsize::new(0));
+
+        let decision = prepare_post_login_broker_bootstrap(
+            true,
+            || async { Ok(true) },
+            || async { Ok(vec![]) },
+            {
+                let start_calls = Arc::clone(&start_calls);
+                move || {
+                    start_calls.fetch_add(1, Ordering::SeqCst);
+                    Some(())
+                }
+            },
+        )
+        .await;
+
+        assert!(matches!(
+            decision,
+            PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::NoConnections)
+        ));
+        assert_eq!(start_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn broker_preflight_requires_active_usable_connection() {
+        let decision = prepare_post_login_broker_bootstrap(
+            true,
+            || async { Ok(true) },
+            || async {
+                Ok(vec![
+                    broker_connection(Some("disconnected"), false),
+                    broker_connection(Some("connected"), true),
+                    broker_connection(None, false),
+                ])
+            },
+            || Some(()),
+        )
+        .await;
+
+        assert!(matches!(
+            decision,
+            PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::NoConnections)
+        ));
+    }
+
+    #[tokio::test]
+    async fn broker_preflight_active_connection_starts() {
+        let decision = prepare_post_login_broker_bootstrap(
+            true,
+            || async { Ok(true) },
+            || async { Ok(vec![broker_connection(Some("connected"), false)]) },
+            || Some("guard"),
+        )
+        .await;
+
+        assert!(matches!(
+            decision,
+            PostLoginBrokerBootstrapDecision::Start("guard")
+        ));
+    }
+
+    #[tokio::test]
+    async fn broker_preflight_already_running_skips() {
+        let decision = prepare_post_login_broker_bootstrap(
+            true,
+            || async { Ok(true) },
+            || async { Ok(vec![broker_connection(Some("connected"), false)]) },
+            || None::<()>,
+        )
+        .await;
+
+        assert!(matches!(
+            decision,
+            PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::AlreadyRunning)
+        ));
+    }
+
+    #[cfg(feature = "device-sync")]
+    #[tokio::test]
+    async fn device_preflight_not_enrolled_skips_without_remote_state() {
+        let remote_calls = Arc::new(AtomicUsize::new(0));
+
+        let decision = prepare_post_login_device_bootstrap(false, || async { false }, {
+            let remote_calls = Arc::clone(&remote_calls);
+            move || async move {
+                remote_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(SyncState::Ready)
+            }
+        })
+        .await;
+
+        assert!(matches!(
+            decision,
+            PostLoginDeviceBootstrapDecision::Skip(PostLoginBootstrapReason::NotEnrolled)
+        ));
+        assert_eq!(remote_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[cfg(feature = "device-sync")]
+    #[tokio::test]
+    async fn device_preflight_already_running_skips_without_remote_state() {
+        let remote_calls = Arc::new(AtomicUsize::new(0));
+
+        let decision = prepare_post_login_device_bootstrap(true, || async { true }, {
+            let remote_calls = Arc::clone(&remote_calls);
+            move || async move {
+                remote_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(SyncState::Ready)
+            }
+        })
+        .await;
+
+        assert!(matches!(
+            decision,
+            PostLoginDeviceBootstrapDecision::Skip(PostLoginBootstrapReason::AlreadyRunning)
+        ));
+        assert_eq!(remote_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[cfg(feature = "device-sync")]
+    #[tokio::test]
+    async fn device_preflight_not_ready_skips() {
+        let decision = prepare_post_login_device_bootstrap(
+            true,
+            || async { false },
+            || async { Ok(SyncState::Registered) },
+        )
+        .await;
+
+        assert!(matches!(
+            decision,
+            PostLoginDeviceBootstrapDecision::Skip(PostLoginBootstrapReason::NotReady)
+        ));
+    }
+
+    #[cfg(feature = "device-sync")]
+    #[tokio::test]
+    async fn device_preflight_ready_starts_background() {
+        let decision = prepare_post_login_device_bootstrap(
+            true,
+            || async { false },
+            || async { Ok(SyncState::Ready) },
+        )
+        .await;
+
+        assert!(matches!(
+            decision,
+            PostLoginDeviceBootstrapDecision::StartBackground
+        ));
+    }
+
+    #[cfg(feature = "device-sync")]
     #[test]
     fn connect_router_includes_device_engine_routes() {
         let _router = router();
     }
 
+    #[cfg(feature = "device-sync")]
     #[test]
     fn reconcile_response_mapping_preserves_fields() {
         let source = device_sync_engine::SyncReconcileReadyStateResult {

--- a/apps/server/src/api/device_sync_engine.rs
+++ b/apps/server/src/api/device_sync_engine.rs
@@ -181,7 +181,7 @@ fn create_client() -> DeviceSyncClient {
     DeviceSyncClient::new(&cloud_api_base_url())
 }
 
-fn get_sync_identity_from_store(state: &AppState) -> Option<SyncIdentity> {
+pub(crate) fn get_sync_identity_from_store(state: &AppState) -> Option<SyncIdentity> {
     let raw = state
         .secret_store
         .get_secret(SYNC_IDENTITY_KEY)
@@ -195,7 +195,7 @@ fn get_sync_identity_from_store(state: &AppState) -> Option<SyncIdentity> {
     })
 }
 
-fn sync_identity_can_run_background(identity: &SyncIdentity) -> bool {
+pub(crate) fn sync_identity_can_run_background(identity: &SyncIdentity) -> bool {
     identity.device_id.is_some() && identity.root_key.is_some()
 }
 

--- a/apps/server/src/domain_events/queue_worker.rs
+++ b/apps/server/src/domain_events/queue_worker.rs
@@ -10,7 +10,8 @@ use std::time::Duration;
 
 use tokio::sync::mpsc;
 use wealthfolio_connect::{
-    ensure_valid_access_token, BrokerSyncServiceTrait, TokenLifecycleConfig, TokenLifecycleState,
+    acquire_broker_sync_guard, ensure_valid_access_token, BrokerSyncServiceTrait,
+    TokenLifecycleConfig, TokenLifecycleState,
 };
 use wealthfolio_core::{
     assets::AssetServiceTrait,
@@ -61,25 +62,6 @@ pub struct QueueWorkerDeps {
     /// Categorization rules service — auto-runs rules against newly-changed activities.
     pub categorization_rules_service:
         Arc<wealthfolio_spending::categorization_rules::CategorizationRulesService>,
-}
-
-struct BrokerSyncRunGuard {
-    running: Arc<AtomicBool>,
-}
-
-impl Drop for BrokerSyncRunGuard {
-    fn drop(&mut self) {
-        self.running.store(false, Ordering::Release);
-    }
-}
-
-fn try_acquire_broker_sync_guard(running: &Arc<AtomicBool>) -> Option<BrokerSyncRunGuard> {
-    running
-        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-        .ok()
-        .map(|_| BrokerSyncRunGuard {
-            running: Arc::clone(running),
-        })
 }
 
 /// Runs the event queue worker.
@@ -269,7 +251,7 @@ async fn process_event_batch(events: &[DomainEvent], deps: Arc<QueueWorkerDeps>)
         let broker_sync_running = deps.broker_sync_running.clone();
 
         tokio::spawn(async move {
-            let Some(_guard) = try_acquire_broker_sync_guard(&broker_sync_running) else {
+            let Some(_guard) = acquire_broker_sync_guard(&broker_sync_running) else {
                 tracing::info!(
                     "Broker sync skipped after tracking mode change: sync already running"
                 );

--- a/apps/server/src/domain_events/queue_worker.rs
+++ b/apps/server/src/domain_events/queue_worker.rs
@@ -34,6 +34,7 @@ pub struct QueueWorkerDeps {
     pub asset_service: Arc<dyn AssetServiceTrait + Send + Sync>,
     pub connect_sync_service: Arc<dyn BrokerSyncServiceTrait + Send + Sync>,
     pub event_bus: EventBus,
+    pub broker_sync_running: Arc<AtomicBool>,
     pub health_service: Arc<dyn wealthfolio_core::health::HealthServiceTrait + Send + Sync>,
     // We need a way to enqueue portfolio jobs. Since AppState is not easily cloneable,
     // we pass what we need for enqueue_portfolio_job (which spawns its own async task).
@@ -60,6 +61,25 @@ pub struct QueueWorkerDeps {
     /// Categorization rules service — auto-runs rules against newly-changed activities.
     pub categorization_rules_service:
         Arc<wealthfolio_spending::categorization_rules::CategorizationRulesService>,
+}
+
+struct BrokerSyncRunGuard {
+    running: Arc<AtomicBool>,
+}
+
+impl Drop for BrokerSyncRunGuard {
+    fn drop(&mut self) {
+        self.running.store(false, Ordering::Release);
+    }
+}
+
+fn try_acquire_broker_sync_guard(running: &Arc<AtomicBool>) -> Option<BrokerSyncRunGuard> {
+    running
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .ok()
+        .map(|_| BrokerSyncRunGuard {
+            running: Arc::clone(running),
+        })
 }
 
 /// Runs the event queue worker.
@@ -246,8 +266,16 @@ async fn process_event_batch(events: &[DomainEvent], deps: Arc<QueueWorkerDeps>)
         let event_bus = deps.event_bus.clone();
         let secret_store = deps.secret_store.clone();
         let token_lifecycle = deps.token_lifecycle.clone();
+        let broker_sync_running = deps.broker_sync_running.clone();
 
         tokio::spawn(async move {
+            let Some(_guard) = try_acquire_broker_sync_guard(&broker_sync_running) else {
+                tracing::info!(
+                    "Broker sync skipped after tracking mode change: sync already running"
+                );
+                return;
+            };
+
             match perform_broker_sync(
                 connect_sync_service,
                 event_bus,

--- a/apps/server/src/domain_events/sink.rs
+++ b/apps/server/src/domain_events/sink.rs
@@ -3,7 +3,7 @@
 //! Receives domain events and sends them to a background queue worker
 //! for debounced processing.
 
-use std::sync::{Arc, RwLock};
+use std::sync::{atomic::AtomicBool, Arc, RwLock};
 
 use tokio::sync::mpsc;
 use wealthfolio_connect::{BrokerSyncServiceTrait, TokenLifecycleState};
@@ -60,6 +60,7 @@ impl WebDomainEventSink {
         asset_service: Arc<dyn AssetServiceTrait + Send + Sync>,
         connect_sync_service: Arc<dyn BrokerSyncServiceTrait + Send + Sync>,
         event_bus: EventBus,
+        broker_sync_running: Arc<AtomicBool>,
         health_service: Arc<dyn wealthfolio_core::health::HealthServiceTrait + Send + Sync>,
         snapshot_service: Arc<
             dyn wealthfolio_core::portfolio::snapshot::SnapshotServiceTrait + Send + Sync,
@@ -94,6 +95,7 @@ impl WebDomainEventSink {
             asset_service,
             connect_sync_service,
             event_bus,
+            broker_sync_running,
             health_service,
             snapshot_service,
             snapshot_repository,

--- a/apps/server/src/main_lib.rs
+++ b/apps/server/src/main_lib.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use std::sync::{Arc, RwLock};
+use std::sync::{atomic::AtomicBool, Arc, RwLock};
 
 use crate::{
     ai_environment::ServerAiEnvironment, auth::AuthManager, config::Config,
@@ -107,6 +107,7 @@ pub struct AppState {
     pub device_enroll_service: Arc<DeviceEnrollService>,
     pub app_sync_repository: Arc<AppSyncRepository>,
     pub device_sync_runtime: Arc<DeviceSyncRuntimeState>,
+    pub broker_sync_running: Arc<AtomicBool>,
     pub health_service: Arc<dyn HealthServiceTrait + Send + Sync>,
     pub token_lifecycle: Arc<TokenLifecycleState>,
     pub custom_provider_service: Arc<wealthfolio_core::custom_provider::CustomProviderService>,
@@ -732,6 +733,7 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
 
     let event_bus = EventBus::new(256);
     let device_sync_runtime = Arc::new(DeviceSyncRuntimeState::new());
+    let broker_sync_running = Arc::new(AtomicBool::new(false));
     let token_lifecycle = Arc::new(TokenLifecycleState::new());
     let now = chrono::Utc::now();
     if let Err(err) = app_sync_repository
@@ -749,6 +751,7 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
         asset_service.clone(),
         connect_sync_service.clone(),
         event_bus.clone(),
+        broker_sync_running.clone(),
         health_service.clone(),
         snapshot_service.clone(),
         snapshot_repository.clone(),
@@ -813,6 +816,7 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
         device_enroll_service,
         app_sync_repository,
         device_sync_runtime,
+        broker_sync_running,
         health_service,
         token_lifecycle,
         custom_provider_service,

--- a/apps/server/src/scheduler.rs
+++ b/apps/server/src/scheduler.rs
@@ -103,8 +103,9 @@ async fn run_scheduled_sync(state: &Arc<AppState>) {
             if e.contains("No refresh token")
                 || e.contains("not authenticated")
                 || e.contains("Session expired")
+                || e.contains("Broker sync already running")
             {
-                debug!("Scheduled sync skipped: user not authenticated");
+                debug!("Scheduled sync skipped: {}", e);
             } else {
                 warn!("Scheduled broker sync failed: {}", e);
             }

--- a/apps/tauri/src/commands/brokers_sync.rs
+++ b/apps/tauri/src/commands/brokers_sync.rs
@@ -1,48 +1,32 @@
 //! Commands for syncing broker data from the cloud API.
 
 use log::{debug, error, info};
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-};
+use std::sync::Arc;
 use tauri::{AppHandle, Emitter, State};
 
 use crate::context::ServiceContext;
 use crate::events::{BROKER_SYNC_COMPLETE, BROKER_SYNC_ERROR, BROKER_SYNC_START};
 use wealthfolio_connect::{
-    broker::BrokerApiClient, fetch_subscription_plans_public, BrokerAccount, BrokerConnection,
-    PlansResponse, Platform, SyncConfig, SyncOrchestrator, SyncProgressPayload,
-    SyncProgressReporter, SyncResult, UserInfo,
+    acquire_broker_sync_guard, broker::BrokerApiClient, fetch_subscription_plans_public,
+    BrokerAccount, BrokerConnection, BrokerSyncRunGuard, PlansResponse, Platform, SyncConfig,
+    SyncOrchestrator, SyncProgressPayload, SyncProgressReporter, SyncResult, UserInfo,
 };
-
-pub(crate) struct BrokerSyncRunGuard {
-    running: Arc<AtomicBool>,
-}
-
-impl Drop for BrokerSyncRunGuard {
-    fn drop(&mut self) {
-        self.running.store(false, Ordering::Release);
-    }
-}
 
 pub(crate) fn try_acquire_broker_sync_guard(
     context: &ServiceContext,
 ) -> Option<BrokerSyncRunGuard> {
-    context
-        .broker_sync_running()
-        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-        .ok()
-        .map(|_| BrokerSyncRunGuard {
-            running: context.broker_sync_running(),
-        })
+    acquire_broker_sync_guard(&context.broker_sync_running())
 }
 
-pub(crate) fn is_active_broker_connection(connection: &BrokerConnection) -> bool {
-    !connection.disabled
-        && connection
-            .status
-            .as_deref()
-            .is_some_and(|status| status.eq_ignore_ascii_case("connected"))
+pub(crate) fn emit_broker_sync_error(app_handle: &AppHandle, error_message: &str) {
+    app_handle
+        .emit(
+            BROKER_SYNC_ERROR,
+            serde_json::json!({ "error": error_message }),
+        )
+        .unwrap_or_else(|e| {
+            error!("Failed to emit broker:sync-error event: {}", e);
+        });
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -83,14 +67,7 @@ impl SyncProgressReporter for TauriProgressReporter {
                     error!("Failed to emit broker:sync-complete event: {}", e);
                 });
         } else {
-            self.app_handle
-                .emit(
-                    BROKER_SYNC_ERROR,
-                    serde_json::json!({ "error": result.message }),
-                )
-                .unwrap_or_else(|e| {
-                    error!("Failed to emit broker:sync-error event: {}", e);
-                });
+            emit_broker_sync_error(&self.app_handle, &result.message);
         }
     }
 }
@@ -183,7 +160,15 @@ pub(crate) async fn perform_broker_sync_with_guard(
 ) -> Result<SyncResult, String> {
     info!("Starting broker data sync...");
 
-    let client = context.connect_service().get_api_client().await?;
+    let client = match context.connect_service().get_api_client().await {
+        Ok(client) => client,
+        Err(err) => {
+            if let Some(app_handle) = app {
+                emit_broker_sync_error(app_handle, &err);
+            }
+            return Err(err);
+        }
+    };
 
     // Create progress reporter and orchestrator
     // Use TauriProgressReporter if we have an AppHandle, otherwise use NoOp

--- a/apps/tauri/src/commands/brokers_sync.rs
+++ b/apps/tauri/src/commands/brokers_sync.rs
@@ -1,7 +1,10 @@
 //! Commands for syncing broker data from the cloud API.
 
 use log::{debug, error, info};
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
 use tauri::{AppHandle, Emitter, State};
 
 use crate::context::ServiceContext;
@@ -11,6 +14,36 @@ use wealthfolio_connect::{
     PlansResponse, Platform, SyncConfig, SyncOrchestrator, SyncProgressPayload,
     SyncProgressReporter, SyncResult, UserInfo,
 };
+
+pub(crate) struct BrokerSyncRunGuard {
+    running: Arc<AtomicBool>,
+}
+
+impl Drop for BrokerSyncRunGuard {
+    fn drop(&mut self) {
+        self.running.store(false, Ordering::Release);
+    }
+}
+
+pub(crate) fn try_acquire_broker_sync_guard(
+    context: &ServiceContext,
+) -> Option<BrokerSyncRunGuard> {
+    context
+        .broker_sync_running()
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .ok()
+        .map(|_| BrokerSyncRunGuard {
+            running: context.broker_sync_running(),
+        })
+}
+
+pub(crate) fn is_active_broker_connection(connection: &BrokerConnection) -> bool {
+    !connection.disabled
+        && connection
+            .status
+            .as_deref()
+            .is_some_and(|status| status.eq_ignore_ascii_case("connected"))
+}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Tauri Progress Reporter
@@ -88,6 +121,11 @@ pub async fn sync_broker_data(
         }
     }
 
+    let Some(guard) = try_acquire_broker_sync_guard(state.inner().as_ref()) else {
+        info!("[Connect] Broker sync skipped: sync already running");
+        return Err("Broker sync already running".to_string());
+    };
+
     info!("[Connect] Starting broker data sync ...");
 
     // Clone what we need for the spawned task
@@ -96,7 +134,7 @@ pub async fn sync_broker_data(
 
     // Spawn background task
     tauri::async_runtime::spawn(async move {
-        match perform_broker_sync(&context, Some(&app_handle)).await {
+        match perform_broker_sync_with_guard(&context, Some(&app_handle), guard).await {
             Ok(_result) => {
                 info!("[Connect] Broker sync completed successfully");
                 // Events are emitted by the orchestrator via TauriProgressReporter
@@ -132,6 +170,16 @@ pub async fn broker_ingest_run(
 pub async fn perform_broker_sync(
     context: &Arc<ServiceContext>,
     app: Option<&AppHandle>,
+) -> Result<SyncResult, String> {
+    let guard = try_acquire_broker_sync_guard(context)
+        .ok_or_else(|| "Broker sync already running".to_string())?;
+    perform_broker_sync_with_guard(context, app, guard).await
+}
+
+pub(crate) async fn perform_broker_sync_with_guard(
+    context: &Arc<ServiceContext>,
+    app: Option<&AppHandle>,
+    _guard: BrokerSyncRunGuard,
 ) -> Result<SyncResult, String> {
     info!("Starting broker data sync...");
 

--- a/apps/tauri/src/commands/device_sync/mod.rs
+++ b/apps/tauri/src/commands/device_sync/mod.rs
@@ -54,7 +54,7 @@ pub(crate) struct SyncIdentity {
     key_version: Option<i32>,
 }
 
-fn get_sync_identity_from_store() -> Option<SyncIdentity> {
+pub(crate) fn get_sync_identity_from_store() -> Option<SyncIdentity> {
     const SYNC_IDENTITY_KEY: &str = "sync_identity";
 
     match KeyringSecretStore.get_secret(SYNC_IDENTITY_KEY) {
@@ -92,7 +92,7 @@ fn get_sync_identity_from_store() -> Option<SyncIdentity> {
     }
 }
 
-fn sync_identity_can_run_background(identity: &SyncIdentity) -> bool {
+pub(crate) fn sync_identity_can_run_background(identity: &SyncIdentity) -> bool {
     identity.device_id.is_some() && identity.root_key.is_some()
 }
 

--- a/apps/tauri/src/commands/wealthfolio_connect.rs
+++ b/apps/tauri/src/commands/wealthfolio_connect.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "connect-sync")]
 use crate::commands::brokers_sync::{
-    is_active_broker_connection, perform_broker_sync_with_guard, try_acquire_broker_sync_guard,
+    perform_broker_sync_with_guard, try_acquire_broker_sync_guard,
 };
 #[cfg(feature = "device-sync")]
 use crate::commands::device_sync::{
@@ -15,7 +15,12 @@ use std::future::Future;
 use std::sync::Arc;
 use tauri::{AppHandle, State};
 #[cfg(feature = "connect-sync")]
-use wealthfolio_connect::broker::{BrokerApiClient, BrokerConnection};
+use wealthfolio_connect::{
+    prepare_post_login_broker_bootstrap, BrokerApiClient, PostLoginBrokerBootstrapDecision,
+};
+use wealthfolio_connect::{
+    PostLoginBootstrapReason, PostLoginBootstrapResult, PostLoginBootstrapSyncResult,
+};
 use wealthfolio_core::secrets::SecretStore;
 #[cfg(feature = "device-sync")]
 use wealthfolio_device_sync::SyncState;
@@ -23,118 +28,6 @@ use wealthfolio_device_sync::SyncState;
 // Storage keys (without prefix - the SecretStore adds "wealthfolio_" prefix)
 const SYNC_ACCESS_TOKEN_KEY: &str = "sync_access_token";
 const SYNC_REFRESH_TOKEN_KEY: &str = "sync_refresh_token";
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub enum PostLoginBootstrapStatus {
-    Started,
-    Skipped,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "snake_case")]
-#[allow(dead_code)]
-pub enum PostLoginBootstrapReason {
-    FeatureDisabled,
-    NotEntitled,
-    NoConnections,
-    AlreadyRunning,
-    NotEnrolled,
-    NotReady,
-    Error,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PostLoginBootstrapSyncResult {
-    status: PostLoginBootstrapStatus,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    reason: Option<PostLoginBootstrapReason>,
-}
-
-impl PostLoginBootstrapSyncResult {
-    fn started() -> Self {
-        Self {
-            status: PostLoginBootstrapStatus::Started,
-            reason: None,
-        }
-    }
-
-    fn skipped(reason: PostLoginBootstrapReason) -> Self {
-        Self {
-            status: PostLoginBootstrapStatus::Skipped,
-            reason: Some(reason),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct PostLoginBootstrapResult {
-    broker_sync: PostLoginBootstrapSyncResult,
-    device_sync: PostLoginBootstrapSyncResult,
-}
-
-#[cfg(feature = "connect-sync")]
-enum PostLoginBrokerBootstrapDecision<Guard> {
-    Start(Guard),
-    Skip(PostLoginBootstrapReason),
-}
-
-#[cfg(feature = "connect-sync")]
-async fn prepare_post_login_broker_bootstrap<
-    CheckEntitlement,
-    CheckEntitlementFuture,
-    ListConnections,
-    ListConnectionsFuture,
-    TryStart,
-    Guard,
->(
-    check_entitlement: CheckEntitlement,
-    list_connections: ListConnections,
-    try_start: TryStart,
-) -> PostLoginBrokerBootstrapDecision<Guard>
-where
-    CheckEntitlement: FnOnce() -> CheckEntitlementFuture,
-    CheckEntitlementFuture: Future<Output = Result<bool, String>>,
-    ListConnections: FnOnce() -> ListConnectionsFuture,
-    ListConnectionsFuture: Future<Output = Result<Vec<BrokerConnection>, String>>,
-    TryStart: FnOnce() -> Option<Guard>,
-{
-    match check_entitlement().await {
-        Ok(true) => {}
-        Ok(false) => {
-            return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::NotEntitled);
-        }
-        Err(err) => {
-            debug!(
-                "[Connect] Post-login broker sync skipped: could not verify entitlement ({})",
-                err
-            );
-            return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::Error);
-        }
-    }
-
-    let connections = match list_connections().await {
-        Ok(connections) => connections,
-        Err(err) => {
-            debug!(
-                "[Connect] Post-login broker sync skipped: failed to inspect connections ({})",
-                err
-            );
-            return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::Error);
-        }
-    };
-
-    if !connections.iter().any(is_active_broker_connection) {
-        return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::NoConnections);
-    }
-
-    match try_start() {
-        Some(guard) => PostLoginBrokerBootstrapDecision::Start(guard),
-        None => PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::AlreadyRunning),
-    }
-}
 
 #[cfg(feature = "device-sync")]
 enum PostLoginDeviceBootstrapDecision {
@@ -234,6 +127,7 @@ async fn run_post_login_broker_bootstrap(
     let guard_context = Arc::clone(&context);
 
     let decision = prepare_post_login_broker_bootstrap(
+        true,
         move || async move {
             entitlement_context
                 .connect_service()
@@ -406,6 +300,9 @@ mod tests {
     };
 
     #[cfg(feature = "connect-sync")]
+    use wealthfolio_connect::BrokerConnection;
+
+    #[cfg(feature = "connect-sync")]
     fn broker_connection(status: Option<&str>, disabled: bool) -> BrokerConnection {
         BrokerConnection {
             id: "connection-1".to_string(),
@@ -425,6 +322,7 @@ mod tests {
         let list_calls = Arc::new(AtomicUsize::new(0));
 
         let decision = prepare_post_login_broker_bootstrap(
+            true,
             || async { Ok(false) },
             {
                 let list_calls = Arc::clone(&list_calls);
@@ -449,15 +347,19 @@ mod tests {
     async fn broker_preflight_zero_connections_skips_without_starting() {
         let start_calls = Arc::new(AtomicUsize::new(0));
 
-        let decision =
-            prepare_post_login_broker_bootstrap(|| async { Ok(true) }, || async { Ok(vec![]) }, {
+        let decision = prepare_post_login_broker_bootstrap(
+            true,
+            || async { Ok(true) },
+            || async { Ok(vec![]) },
+            {
                 let start_calls = Arc::clone(&start_calls);
                 move || {
                     start_calls.fetch_add(1, Ordering::SeqCst);
                     Some(())
                 }
-            })
-            .await;
+            },
+        )
+        .await;
 
         assert!(matches!(
             decision,
@@ -470,6 +372,7 @@ mod tests {
     #[tokio::test]
     async fn broker_preflight_requires_active_usable_connection() {
         let decision = prepare_post_login_broker_bootstrap(
+            true,
             || async { Ok(true) },
             || async {
                 Ok(vec![
@@ -492,6 +395,7 @@ mod tests {
     #[tokio::test]
     async fn broker_preflight_active_connection_starts() {
         let decision = prepare_post_login_broker_bootstrap(
+            true,
             || async { Ok(true) },
             || async { Ok(vec![broker_connection(Some("connected"), false)]) },
             || Some("guard"),
@@ -508,6 +412,7 @@ mod tests {
     #[tokio::test]
     async fn broker_preflight_already_running_skips() {
         let decision = prepare_post_login_broker_bootstrap(
+            true,
             || async { Ok(true) },
             || async { Ok(vec![broker_connection(Some("connected"), false)]) },
             || None::<()>,

--- a/apps/tauri/src/commands/wealthfolio_connect.rs
+++ b/apps/tauri/src/commands/wealthfolio_connect.rs
@@ -1,15 +1,186 @@
-use crate::commands::device_sync::clear_min_snapshot_created_at_from_store;
+#[cfg(feature = "connect-sync")]
+use crate::commands::brokers_sync::{
+    is_active_broker_connection, perform_broker_sync_with_guard, try_acquire_broker_sync_guard,
+};
+#[cfg(feature = "device-sync")]
+use crate::commands::device_sync::{
+    clear_min_snapshot_created_at_from_store, ensure_background_engine_started,
+    get_sync_identity_from_store, sync_identity_can_run_background,
+};
 use crate::context::ServiceContext;
 use crate::secret_store::KeyringSecretStore;
 use log::{debug, error};
 use serde::Serialize;
+use std::future::Future;
 use std::sync::Arc;
-use tauri::State;
+use tauri::{AppHandle, State};
+#[cfg(feature = "connect-sync")]
+use wealthfolio_connect::broker::{BrokerApiClient, BrokerConnection};
 use wealthfolio_core::secrets::SecretStore;
+#[cfg(feature = "device-sync")]
+use wealthfolio_device_sync::SyncState;
 
 // Storage keys (without prefix - the SecretStore adds "wealthfolio_" prefix)
 const SYNC_ACCESS_TOKEN_KEY: &str = "sync_access_token";
 const SYNC_REFRESH_TOKEN_KEY: &str = "sync_refresh_token";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PostLoginBootstrapStatus {
+    Started,
+    Skipped,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+#[allow(dead_code)]
+pub enum PostLoginBootstrapReason {
+    FeatureDisabled,
+    NotEntitled,
+    NoConnections,
+    AlreadyRunning,
+    NotEnrolled,
+    NotReady,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PostLoginBootstrapSyncResult {
+    status: PostLoginBootstrapStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<PostLoginBootstrapReason>,
+}
+
+impl PostLoginBootstrapSyncResult {
+    fn started() -> Self {
+        Self {
+            status: PostLoginBootstrapStatus::Started,
+            reason: None,
+        }
+    }
+
+    fn skipped(reason: PostLoginBootstrapReason) -> Self {
+        Self {
+            status: PostLoginBootstrapStatus::Skipped,
+            reason: Some(reason),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PostLoginBootstrapResult {
+    broker_sync: PostLoginBootstrapSyncResult,
+    device_sync: PostLoginBootstrapSyncResult,
+}
+
+#[cfg(feature = "connect-sync")]
+enum PostLoginBrokerBootstrapDecision<Guard> {
+    Start(Guard),
+    Skip(PostLoginBootstrapReason),
+}
+
+#[cfg(feature = "connect-sync")]
+async fn prepare_post_login_broker_bootstrap<
+    CheckEntitlement,
+    CheckEntitlementFuture,
+    ListConnections,
+    ListConnectionsFuture,
+    TryStart,
+    Guard,
+>(
+    check_entitlement: CheckEntitlement,
+    list_connections: ListConnections,
+    try_start: TryStart,
+) -> PostLoginBrokerBootstrapDecision<Guard>
+where
+    CheckEntitlement: FnOnce() -> CheckEntitlementFuture,
+    CheckEntitlementFuture: Future<Output = Result<bool, String>>,
+    ListConnections: FnOnce() -> ListConnectionsFuture,
+    ListConnectionsFuture: Future<Output = Result<Vec<BrokerConnection>, String>>,
+    TryStart: FnOnce() -> Option<Guard>,
+{
+    match check_entitlement().await {
+        Ok(true) => {}
+        Ok(false) => {
+            return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::NotEntitled);
+        }
+        Err(err) => {
+            debug!(
+                "[Connect] Post-login broker sync skipped: could not verify entitlement ({})",
+                err
+            );
+            return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::Error);
+        }
+    }
+
+    let connections = match list_connections().await {
+        Ok(connections) => connections,
+        Err(err) => {
+            debug!(
+                "[Connect] Post-login broker sync skipped: failed to inspect connections ({})",
+                err
+            );
+            return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::Error);
+        }
+    };
+
+    if !connections.iter().any(is_active_broker_connection) {
+        return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::NoConnections);
+    }
+
+    match try_start() {
+        Some(guard) => PostLoginBrokerBootstrapDecision::Start(guard),
+        None => PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::AlreadyRunning),
+    }
+}
+
+#[cfg(feature = "device-sync")]
+enum PostLoginDeviceBootstrapDecision {
+    StartBackground,
+    Skip(PostLoginBootstrapReason),
+}
+
+#[cfg(feature = "device-sync")]
+async fn prepare_post_login_device_bootstrap<
+    CheckBackgroundRunning,
+    CheckBackgroundRunningFuture,
+    LoadSyncState,
+    LoadSyncStateFuture,
+>(
+    can_run_background: bool,
+    check_background_running: CheckBackgroundRunning,
+    load_sync_state: LoadSyncState,
+) -> PostLoginDeviceBootstrapDecision
+where
+    CheckBackgroundRunning: FnOnce() -> CheckBackgroundRunningFuture,
+    CheckBackgroundRunningFuture: Future<Output = bool>,
+    LoadSyncState: FnOnce() -> LoadSyncStateFuture,
+    LoadSyncStateFuture: Future<Output = Result<SyncState, String>>,
+{
+    if !can_run_background {
+        return PostLoginDeviceBootstrapDecision::Skip(PostLoginBootstrapReason::NotEnrolled);
+    }
+
+    if check_background_running().await {
+        return PostLoginDeviceBootstrapDecision::Skip(PostLoginBootstrapReason::AlreadyRunning);
+    }
+
+    let sync_state = match load_sync_state().await {
+        Ok(sync_state) => sync_state,
+        Err(err) => {
+            debug!("[Connect] Post-login device sync skipped: {}", err);
+            return PostLoginDeviceBootstrapDecision::Skip(PostLoginBootstrapReason::Error);
+        }
+    };
+
+    if sync_state != SyncState::Ready {
+        return PostLoginDeviceBootstrapDecision::Skip(PostLoginBootstrapReason::NotReady);
+    }
+
+    PostLoginDeviceBootstrapDecision::StartBackground
+}
 
 #[tauri::command]
 pub async fn store_sync_session(
@@ -39,6 +210,138 @@ pub async fn store_sync_session(
 }
 
 #[tauri::command]
+pub async fn post_login_bootstrap(
+    app: AppHandle,
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<PostLoginBootstrapResult, String> {
+    let context = state.inner().clone();
+    let broker_sync = run_post_login_broker_bootstrap(app, Arc::clone(&context)).await;
+    let device_sync = run_post_login_device_bootstrap(context).await;
+
+    Ok(PostLoginBootstrapResult {
+        broker_sync,
+        device_sync,
+    })
+}
+
+#[cfg(feature = "connect-sync")]
+async fn run_post_login_broker_bootstrap(
+    app: AppHandle,
+    context: Arc<ServiceContext>,
+) -> PostLoginBootstrapSyncResult {
+    let entitlement_context = Arc::clone(&context);
+    let connections_context = Arc::clone(&context);
+    let guard_context = Arc::clone(&context);
+
+    let decision = prepare_post_login_broker_bootstrap(
+        move || async move {
+            entitlement_context
+                .connect_service()
+                .has_broker_sync()
+                .await
+        },
+        move || async move {
+            let client = connections_context
+                .connect_service()
+                .get_api_client()
+                .await?;
+            client.list_connections().await.map_err(|e| e.to_string())
+        },
+        move || try_acquire_broker_sync_guard(guard_context.as_ref()),
+    )
+    .await;
+
+    let guard = match decision {
+        PostLoginBrokerBootstrapDecision::Start(guard) => guard,
+        PostLoginBrokerBootstrapDecision::Skip(reason) => {
+            return PostLoginBootstrapSyncResult::skipped(reason);
+        }
+    };
+
+    let app_handle = app.clone();
+    tauri::async_runtime::spawn(async move {
+        match perform_broker_sync_with_guard(&context, Some(&app_handle), guard).await {
+            Ok(_result) => {
+                debug!("[Connect] Post-login broker sync completed successfully");
+            }
+            Err(err) => {
+                error!("[Connect] Post-login broker sync failed: {}", err);
+            }
+        }
+    });
+
+    PostLoginBootstrapSyncResult::started()
+}
+
+#[cfg(not(feature = "connect-sync"))]
+async fn run_post_login_broker_bootstrap(
+    _app: AppHandle,
+    _context: Arc<ServiceContext>,
+) -> PostLoginBootstrapSyncResult {
+    PostLoginBootstrapSyncResult::skipped(PostLoginBootstrapReason::FeatureDisabled)
+}
+
+#[cfg(feature = "device-sync")]
+async fn run_post_login_device_bootstrap(
+    context: Arc<ServiceContext>,
+) -> PostLoginBootstrapSyncResult {
+    let Some(identity) = get_sync_identity_from_store() else {
+        return PostLoginBootstrapSyncResult::skipped(PostLoginBootstrapReason::NotEnrolled);
+    };
+
+    let background_context = Arc::clone(&context);
+    let sync_state_context = Arc::clone(&context);
+    let decision = prepare_post_login_device_bootstrap(
+        sync_identity_can_run_background(&identity),
+        move || async move {
+            background_context
+                .device_sync_runtime()
+                .is_background_running()
+                .await
+        },
+        move || async move {
+            let token = sync_state_context
+                .connect_service()
+                .get_valid_access_token()
+                .await
+                .map_err(|err| format!("failed to mint token ({})", err))?;
+            sync_state_context
+                .device_enroll_service()
+                .get_sync_state(&token)
+                .await
+                .map(|sync_state| sync_state.state)
+                .map_err(|err| format!("failed to get sync state ({})", err.message))
+        },
+    )
+    .await;
+
+    match decision {
+        PostLoginDeviceBootstrapDecision::StartBackground => {}
+        PostLoginDeviceBootstrapDecision::Skip(reason) => {
+            return PostLoginBootstrapSyncResult::skipped(reason);
+        }
+    }
+
+    match ensure_background_engine_started(Arc::clone(&context)).await {
+        Ok(()) => PostLoginBootstrapSyncResult::started(),
+        Err(err) => {
+            debug!(
+                "[Connect] Post-login device sync background start failed: {}",
+                err
+            );
+            PostLoginBootstrapSyncResult::skipped(PostLoginBootstrapReason::Error)
+        }
+    }
+}
+
+#[cfg(not(feature = "device-sync"))]
+async fn run_post_login_device_bootstrap(
+    _context: Arc<ServiceContext>,
+) -> PostLoginBootstrapSyncResult {
+    PostLoginBootstrapSyncResult::skipped(PostLoginBootstrapReason::FeatureDisabled)
+}
+
+#[tauri::command]
 pub async fn clear_sync_session(state: State<'_, Arc<ServiceContext>>) -> Result<(), String> {
     // Best-effort cleanup for legacy installs that persisted the access token.
     let _ = KeyringSecretStore.delete_secret(SYNC_ACCESS_TOKEN_KEY);
@@ -52,6 +355,7 @@ pub async fn clear_sync_session(state: State<'_, Arc<ServiceContext>>) -> Result
     }
 
     state.connect_service().clear_cached_token().await;
+    #[cfg(feature = "device-sync")]
     clear_min_snapshot_created_at_from_store();
     let _ = state
         .app_sync_repository()
@@ -91,4 +395,202 @@ pub async fn restore_sync_session(
         access_token,
         refresh_token,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    };
+
+    #[cfg(feature = "connect-sync")]
+    fn broker_connection(status: Option<&str>, disabled: bool) -> BrokerConnection {
+        BrokerConnection {
+            id: "connection-1".to_string(),
+            brokerage: None,
+            connection_type: None,
+            status: status.map(str::to_string),
+            disabled,
+            disabled_date: None,
+            updated_at: None,
+            name: None,
+        }
+    }
+
+    #[cfg(feature = "connect-sync")]
+    #[tokio::test]
+    async fn broker_preflight_no_entitlement_skips_without_listing_connections() {
+        let list_calls = Arc::new(AtomicUsize::new(0));
+
+        let decision = prepare_post_login_broker_bootstrap(
+            || async { Ok(false) },
+            {
+                let list_calls = Arc::clone(&list_calls);
+                move || async move {
+                    list_calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(vec![broker_connection(Some("connected"), false)])
+                }
+            },
+            || Some(()),
+        )
+        .await;
+
+        assert!(matches!(
+            decision,
+            PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::NotEntitled)
+        ));
+        assert_eq!(list_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[cfg(feature = "connect-sync")]
+    #[tokio::test]
+    async fn broker_preflight_zero_connections_skips_without_starting() {
+        let start_calls = Arc::new(AtomicUsize::new(0));
+
+        let decision =
+            prepare_post_login_broker_bootstrap(|| async { Ok(true) }, || async { Ok(vec![]) }, {
+                let start_calls = Arc::clone(&start_calls);
+                move || {
+                    start_calls.fetch_add(1, Ordering::SeqCst);
+                    Some(())
+                }
+            })
+            .await;
+
+        assert!(matches!(
+            decision,
+            PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::NoConnections)
+        ));
+        assert_eq!(start_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[cfg(feature = "connect-sync")]
+    #[tokio::test]
+    async fn broker_preflight_requires_active_usable_connection() {
+        let decision = prepare_post_login_broker_bootstrap(
+            || async { Ok(true) },
+            || async {
+                Ok(vec![
+                    broker_connection(Some("disconnected"), false),
+                    broker_connection(Some("connected"), true),
+                    broker_connection(None, false),
+                ])
+            },
+            || Some(()),
+        )
+        .await;
+
+        assert!(matches!(
+            decision,
+            PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::NoConnections)
+        ));
+    }
+
+    #[cfg(feature = "connect-sync")]
+    #[tokio::test]
+    async fn broker_preflight_active_connection_starts() {
+        let decision = prepare_post_login_broker_bootstrap(
+            || async { Ok(true) },
+            || async { Ok(vec![broker_connection(Some("connected"), false)]) },
+            || Some("guard"),
+        )
+        .await;
+
+        assert!(matches!(
+            decision,
+            PostLoginBrokerBootstrapDecision::Start("guard")
+        ));
+    }
+
+    #[cfg(feature = "connect-sync")]
+    #[tokio::test]
+    async fn broker_preflight_already_running_skips() {
+        let decision = prepare_post_login_broker_bootstrap(
+            || async { Ok(true) },
+            || async { Ok(vec![broker_connection(Some("connected"), false)]) },
+            || None::<()>,
+        )
+        .await;
+
+        assert!(matches!(
+            decision,
+            PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::AlreadyRunning)
+        ));
+    }
+
+    #[cfg(feature = "device-sync")]
+    #[tokio::test]
+    async fn device_preflight_not_enrolled_skips_without_remote_state() {
+        let remote_calls = Arc::new(AtomicUsize::new(0));
+
+        let decision = prepare_post_login_device_bootstrap(false, || async { false }, {
+            let remote_calls = Arc::clone(&remote_calls);
+            move || async move {
+                remote_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(SyncState::Ready)
+            }
+        })
+        .await;
+
+        assert!(matches!(
+            decision,
+            PostLoginDeviceBootstrapDecision::Skip(PostLoginBootstrapReason::NotEnrolled)
+        ));
+        assert_eq!(remote_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[cfg(feature = "device-sync")]
+    #[tokio::test]
+    async fn device_preflight_already_running_skips_without_remote_state() {
+        let remote_calls = Arc::new(AtomicUsize::new(0));
+
+        let decision = prepare_post_login_device_bootstrap(true, || async { true }, {
+            let remote_calls = Arc::clone(&remote_calls);
+            move || async move {
+                remote_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(SyncState::Ready)
+            }
+        })
+        .await;
+
+        assert!(matches!(
+            decision,
+            PostLoginDeviceBootstrapDecision::Skip(PostLoginBootstrapReason::AlreadyRunning)
+        ));
+        assert_eq!(remote_calls.load(Ordering::SeqCst), 0);
+    }
+
+    #[cfg(feature = "device-sync")]
+    #[tokio::test]
+    async fn device_preflight_not_ready_skips() {
+        let decision = prepare_post_login_device_bootstrap(
+            true,
+            || async { false },
+            || async { Ok(SyncState::Registered) },
+        )
+        .await;
+
+        assert!(matches!(
+            decision,
+            PostLoginDeviceBootstrapDecision::Skip(PostLoginBootstrapReason::NotReady)
+        ));
+    }
+
+    #[cfg(feature = "device-sync")]
+    #[tokio::test]
+    async fn device_preflight_ready_starts_background() {
+        let decision = prepare_post_login_device_bootstrap(
+            true,
+            || async { false },
+            || async { Ok(SyncState::Ready) },
+        )
+        .await;
+
+        assert!(matches!(
+            decision,
+            PostLoginDeviceBootstrapDecision::StartBackground
+        ));
+    }
 }

--- a/apps/tauri/src/context/providers.rs
+++ b/apps/tauri/src/context/providers.rs
@@ -547,6 +547,7 @@ pub async fn initialize_context(
         app_version,
     ));
     let device_sync_runtime = Arc::new(DeviceSyncRuntimeState::new());
+    let broker_sync_running = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let now = chrono::Utc::now();
     if let Err(err) = app_sync_repository
         .prune_sync_outbox(
@@ -593,6 +594,7 @@ pub async fn initialize_context(
             ai_chat_service,
             device_enroll_service,
             device_sync_runtime,
+            broker_sync_running,
             health_service,
             custom_provider_service,
             portfolio_service,

--- a/apps/tauri/src/context/registry.rs
+++ b/apps/tauri/src/context/registry.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, RwLock};
+use std::sync::{atomic::AtomicBool, Arc, RwLock};
 use wealthfolio_ai::{AiProviderServiceTrait, ChatService};
 use wealthfolio_connect::BrokerSyncServiceTrait;
 use wealthfolio_core::{
@@ -68,6 +68,7 @@ pub struct ServiceContext {
     pub ai_chat_service: Arc<ChatService<TauriAiEnvironment>>,
     pub device_enroll_service: Arc<DeviceEnrollService>,
     pub device_sync_runtime: Arc<DeviceSyncRuntimeState>,
+    pub broker_sync_running: Arc<AtomicBool>,
     pub health_service: Arc<health::HealthService>,
     pub custom_provider_service: Arc<wealthfolio_core::custom_provider::CustomProviderService>,
     pub portfolio_service: Arc<dyn portfolios::PortfolioServiceTrait>,
@@ -243,6 +244,10 @@ impl ServiceContext {
 
     pub fn device_sync_runtime(&self) -> Arc<DeviceSyncRuntimeState> {
         Arc::clone(&self.device_sync_runtime)
+    }
+
+    pub fn broker_sync_running(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.broker_sync_running)
     }
 
     pub fn health_service(&self) -> Arc<health::HealthService> {

--- a/apps/tauri/src/lib.rs
+++ b/apps/tauri/src/lib.rs
@@ -639,6 +639,8 @@ pub fn run() {
             #[cfg(any(feature = "connect-sync", feature = "device-sync"))]
             commands::wealthfolio_connect::store_sync_session,
             #[cfg(any(feature = "connect-sync", feature = "device-sync"))]
+            commands::wealthfolio_connect::post_login_bootstrap,
+            #[cfg(any(feature = "connect-sync", feature = "device-sync"))]
             commands::wealthfolio_connect::clear_sync_session,
             #[cfg(any(feature = "connect-sync", feature = "device-sync"))]
             commands::wealthfolio_connect::restore_sync_session,

--- a/apps/tauri/src/scheduler.rs
+++ b/apps/tauri/src/scheduler.rs
@@ -94,8 +94,11 @@ pub async fn run_startup_sync(handle: &AppHandle, context: &Arc<ServiceContext>)
         }
         Err(e) => {
             // Check if this is an auth error (user not logged in)
-            if e.contains("No access token") || e.contains("not authenticated") {
-                debug!("Startup sync skipped: user not authenticated");
+            if e.contains("No access token")
+                || e.contains("not authenticated")
+                || e.contains("Broker sync already running")
+            {
+                debug!("Startup sync skipped: {}", e);
             } else {
                 warn!("Startup sync failed: {}", e);
                 // Note: broker:sync-error event is emitted by the orchestrator via TauriProgressReporter

--- a/crates/connect/src/lib.rs
+++ b/crates/connect/src/lib.rs
@@ -8,6 +8,7 @@ pub mod broker;
 pub mod broker_ingest;
 pub mod client;
 pub mod platform;
+pub mod post_login_bootstrap;
 mod request_metadata;
 pub mod token_lifecycle;
 
@@ -24,9 +25,19 @@ pub use broker::{
 
 // Re-export the HTTP client and public functions
 pub use client::{fetch_subscription_plans_public, ConnectApiClient, DEFAULT_CLOUD_API_URL};
+pub use post_login_bootstrap::{
+    acquire_broker_sync_guard, BrokerSyncRunGuard, PostLoginBootstrapReason,
+    PostLoginBootstrapResult, PostLoginBootstrapStatus, PostLoginBootstrapSyncResult,
+};
 pub use token_lifecycle::{
     ensure_valid_access_token, TokenLifecycleConfig, TokenLifecycleError, TokenLifecycleState,
     CLOUD_ACCESS_TOKEN_KEY, CLOUD_REFRESH_TOKEN_KEY,
+};
+
+#[cfg(feature = "broker")]
+pub use post_login_bootstrap::{
+    is_active_broker_connection, prepare_post_login_broker_bootstrap,
+    PostLoginBrokerBootstrapDecision,
 };
 
 pub use broker_ingest::{

--- a/crates/connect/src/post_login_bootstrap.rs
+++ b/crates/connect/src/post_login_bootstrap.rs
@@ -1,0 +1,152 @@
+#[cfg(feature = "broker")]
+use std::future::Future;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PostLoginBootstrapStatus {
+    Started,
+    Skipped,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PostLoginBootstrapReason {
+    FeatureDisabled,
+    NotEntitled,
+    NoConnections,
+    AlreadyRunning,
+    NotEnrolled,
+    NotReady,
+    Error,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PostLoginBootstrapSyncResult {
+    pub status: PostLoginBootstrapStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<PostLoginBootstrapReason>,
+}
+
+impl PostLoginBootstrapSyncResult {
+    pub fn started() -> Self {
+        Self {
+            status: PostLoginBootstrapStatus::Started,
+            reason: None,
+        }
+    }
+
+    pub fn skipped(reason: PostLoginBootstrapReason) -> Self {
+        Self {
+            status: PostLoginBootstrapStatus::Skipped,
+            reason: Some(reason),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PostLoginBootstrapResult {
+    pub broker_sync: PostLoginBootstrapSyncResult,
+    pub device_sync: PostLoginBootstrapSyncResult,
+}
+
+pub struct BrokerSyncRunGuard {
+    running: Arc<AtomicBool>,
+}
+
+impl Drop for BrokerSyncRunGuard {
+    fn drop(&mut self) {
+        self.running.store(false, Ordering::Release);
+    }
+}
+
+pub fn acquire_broker_sync_guard(running: &Arc<AtomicBool>) -> Option<BrokerSyncRunGuard> {
+    running
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .ok()
+        .map(|_| BrokerSyncRunGuard {
+            running: Arc::clone(running),
+        })
+}
+
+#[cfg(feature = "broker")]
+pub enum PostLoginBrokerBootstrapDecision<Guard> {
+    Start(Guard),
+    Skip(PostLoginBootstrapReason),
+}
+
+#[cfg(feature = "broker")]
+pub fn is_active_broker_connection(connection: &crate::broker::BrokerConnection) -> bool {
+    !connection.disabled
+        && connection
+            .status
+            .as_deref()
+            .is_some_and(|status| status.eq_ignore_ascii_case("connected"))
+}
+
+#[cfg(feature = "broker")]
+pub async fn prepare_post_login_broker_bootstrap<
+    CheckEntitlement,
+    CheckEntitlementFuture,
+    ListConnections,
+    ListConnectionsFuture,
+    TryStart,
+    Guard,
+>(
+    feature_enabled: bool,
+    check_entitlement: CheckEntitlement,
+    list_connections: ListConnections,
+    try_start: TryStart,
+) -> PostLoginBrokerBootstrapDecision<Guard>
+where
+    CheckEntitlement: FnOnce() -> CheckEntitlementFuture,
+    CheckEntitlementFuture: Future<Output = Result<bool, String>>,
+    ListConnections: FnOnce() -> ListConnectionsFuture,
+    ListConnectionsFuture: Future<Output = Result<Vec<crate::broker::BrokerConnection>, String>>,
+    TryStart: FnOnce() -> Option<Guard>,
+{
+    if !feature_enabled {
+        return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::FeatureDisabled);
+    }
+
+    match check_entitlement().await {
+        Ok(true) => {}
+        Ok(false) => {
+            return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::NotEntitled);
+        }
+        Err(err) => {
+            log::debug!(
+                "[Connect] Post-login broker sync skipped: could not verify entitlement ({})",
+                err
+            );
+            return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::Error);
+        }
+    }
+
+    let connections = match list_connections().await {
+        Ok(connections) => connections,
+        Err(err) => {
+            log::debug!(
+                "[Connect] Post-login broker sync skipped: failed to inspect connections ({})",
+                err
+            );
+            return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::Error);
+        }
+    };
+
+    if !connections.iter().any(is_active_broker_connection) {
+        return PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::NoConnections);
+    }
+
+    match try_start() {
+        Some(guard) => PostLoginBrokerBootstrapDecision::Start(guard),
+        None => PostLoginBrokerBootstrapDecision::Skip(PostLoginBootstrapReason::AlreadyRunning),
+    }
+}


### PR DESCRIPTION
## Summary
- Refactor post-login sync so the frontend calls one bootstrap command and web/Tauri own broker/device sync decisions.
- Keep sync session storage pure, add broker in-flight guards, and make global event listener readiness resilient.
- Add focused post-login hook tests and backend/Tauri bootstrap coverage.
- Include the activity action/filter reset fixes already on this branch.

## Validation
- pnpm lint (passes; existing warnings only)
- pnpm type-check
- pnpm test -- --runInBand
- cargo fmt --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features
- git diff --check
- Targeted Prettier check passed for intended PR files. Root pnpm format:check currently reports only docs/features/performance-semantics-design.md, which is intentionally untracked and excluded from this PR.