### PR TITLE
Fix FX rate of "1" when adding a provider-sourced pair on weekends (#1143)

### DIFF
--- a/apps/frontend/src/pages/settings/general/exchange-rates/add-exchange-rate-form.tsx
+++ b/apps/frontend/src/pages/settings/general/exchange-rates/add-exchange-rate-form.tsx
@@ -98,8 +98,10 @@ export function AddExchangeRateForm({ onSubmit, onCancel }: AddExchangeRateFormP
       fromCurrency: data.fromCurrency,
       toCurrency: data.toCurrency,
       source: data.source,
-      // Only include rate for manual sources
-      rate: isManualSource ? data.rate! : 1,
+      // Only manual sources carry a user-entered rate. Provider-backed sources
+      // are fetched by the market-data sync; the backend ignores this value for
+      // them, so send a neutral 0 rather than a fake rate (#1143).
+      rate: isManualSource ? data.rate! : 0,
       timestamp: new Date().toISOString(),
     });
   };

--- a/apps/server/src/api/exchange_rates.rs
+++ b/apps/server/src/api/exchange_rates.rs
@@ -1,6 +1,10 @@
 use std::sync::Arc;
 
-use crate::{api::shared::trigger_full_portfolio_recalc, error::ApiResult, main_lib::AppState};
+use crate::{
+    api::shared::{trigger_full_portfolio_recalc, trigger_portfolio_recalc_with_asset_sync},
+    error::ApiResult,
+    main_lib::AppState,
+};
 use axum::{
     extract::{Path, State},
     http::StatusCode,
@@ -8,6 +12,7 @@ use axum::{
     Json, Router,
 };
 use wealthfolio_core::fx::{ExchangeRate, NewExchangeRate};
+use wealthfolio_core::quotes::DATA_SOURCE_MANUAL;
 
 async fn get_latest_exchange_rates(
     State(state): State<Arc<AppState>>,
@@ -33,7 +38,14 @@ async fn add_exchange_rate(
     Json(new_rate): Json<NewExchangeRate>,
 ) -> ApiResult<Json<ExchangeRate>> {
     let added = state.fx_service.add_exchange_rate(new_rate).await?;
-    trigger_full_portfolio_recalc(state.clone());
+    // Manual rates are saved as-is and need no market sync. Provider-backed
+    // pairs store no quote on add (#1143); sync their real rate now so the pair
+    // populates immediately instead of waiting for the next periodic sync.
+    if added.source == DATA_SOURCE_MANUAL {
+        trigger_full_portfolio_recalc(state.clone());
+    } else {
+        trigger_portfolio_recalc_with_asset_sync(state.clone(), vec![added.id.clone()]);
+    }
     Ok(Json(added))
 }
 

--- a/apps/server/src/api/shared.rs
+++ b/apps/server/src/api/shared.rs
@@ -123,6 +123,24 @@ pub fn trigger_full_portfolio_recalc(state: Arc<AppState>) {
     );
 }
 
+/// Trigger a full portfolio recalculation that also syncs the given assets'
+/// market data. Used when a provider-backed FX pair is added so its real rate
+/// is fetched immediately instead of waiting for the periodic sync (#1143).
+pub fn trigger_portfolio_recalc_with_asset_sync(state: Arc<AppState>, asset_ids: Vec<String>) {
+    enqueue_portfolio_job(
+        state,
+        PortfolioJobConfig {
+            account_ids: None,
+            market_sync_mode: MarketSyncMode::Incremental {
+                asset_ids: Some(asset_ids),
+            },
+            snapshot_mode: SnapshotRecalcMode::Full,
+            valuation_mode: ValuationRecalcMode::Full,
+            since_date: None,
+        },
+    );
+}
+
 pub async fn process_portfolio_job(
     state: Arc<AppState>,
     config: PortfolioJobConfig,

--- a/apps/tauri/src/commands/settings.rs
+++ b/apps/tauri/src/commands/settings.rs
@@ -6,7 +6,7 @@ use log::debug;
 use tauri::{AppHandle, State};
 use wealthfolio_core::fx::{ExchangeRate, NewExchangeRate};
 use wealthfolio_core::health::HealthServiceTrait;
-use wealthfolio_core::quotes::MarketSyncMode;
+use wealthfolio_core::quotes::{MarketSyncMode, DATA_SOURCE_MANUAL};
 use wealthfolio_core::settings::{Settings, SettingsUpdate};
 
 fn recalculate_mode_for_settings_change(
@@ -178,12 +178,21 @@ pub async fn add_exchange_rate(
         .await
         .map_err(|e| format!("Failed to add exchange rate: {}", e))?;
 
+    // Manual rates are saved as-is and need no market sync. Provider-backed
+    // pairs store no quote on add (#1143); sync their real rate now so the pair
+    // populates immediately instead of waiting for the next periodic sync.
+    let market_sync_mode = if result.source == DATA_SOURCE_MANUAL {
+        MarketSyncMode::None
+    } else {
+        MarketSyncMode::Incremental {
+            asset_ids: Some(vec![result.id.clone()]),
+        }
+    };
+
     let handle = handle.clone();
     tauri::async_runtime::spawn(async move {
-        // Emit event to trigger portfolio recalculation only - no market sync needed
-        // for manual exchange rate additions
         let payload = PortfolioRequestPayload::builder()
-            .market_sync_mode(MarketSyncMode::None)
+            .market_sync_mode(market_sync_mode)
             .build();
         emit_portfolio_trigger_recalculate(&handle, payload);
     });

--- a/crates/core/src/fx/fx_service.rs
+++ b/crates/core/src/fx/fx_service.rs
@@ -204,7 +204,16 @@ impl FxServiceTrait for FxService {
             timestamp: Utc::now(),
         };
 
-        self.repository.save_exchange_rate(rate).await
+        // Only MANUAL rates carry a user-supplied value worth persisting. For
+        // provider-backed sources the rate is fetched by the market-data sync;
+        // persisting the request's placeholder here would write a fake quote
+        // (e.g. "1") stamped on a non-trading day that the sync can never
+        // overwrite, since providers only return quotes for trading days (#1143).
+        if rate.source == DATA_SOURCE_MANUAL {
+            self.repository.save_exchange_rate(rate).await
+        } else {
+            Ok(rate)
+        }
     }
 
     fn get_historical_rates(&self, from: &str, to: &str, days: i64) -> Result<Vec<ExchangeRate>> {
@@ -446,6 +455,7 @@ mod tests {
     #[derive(Default)]
     struct MockFxRepository {
         created_pairs: Mutex<Vec<(String, String, String)>>,
+        saved_rates: Mutex<Vec<ExchangeRate>>,
     }
 
     #[async_trait]
@@ -489,6 +499,7 @@ mod tests {
         }
 
         async fn save_exchange_rate(&self, rate: ExchangeRate) -> Result<ExchangeRate> {
+            self.saved_rates.lock().unwrap().push(rate.clone());
             Ok(rate)
         }
 
@@ -555,5 +566,53 @@ mod tests {
         assert_eq!(created.len(), 1);
         assert_eq!(created[0].0, "USD");
         assert_eq!(created[0].1, "CAD");
+    }
+
+    #[tokio::test]
+    async fn add_exchange_rate_manual_persists_quote() {
+        let repo = Arc::new(MockFxRepository::default());
+        let service = FxService::new(repo.clone());
+
+        service
+            .add_exchange_rate(NewExchangeRate {
+                from_currency: "EUR".to_string(),
+                to_currency: "USD".to_string(),
+                rate: Decimal::new(11, 1), // 1.1
+                source: DATA_SOURCE_MANUAL.to_string(),
+            })
+            .await
+            .unwrap();
+
+        let saved = repo.saved_rates.lock().unwrap();
+        assert_eq!(saved.len(), 1, "manual rate should be persisted as a quote");
+        assert_eq!(saved[0].rate, Decimal::new(11, 1));
+    }
+
+    #[tokio::test]
+    async fn add_exchange_rate_provider_does_not_persist_placeholder_quote() {
+        let repo = Arc::new(MockFxRepository::default());
+        let service = FxService::new(repo.clone());
+
+        // Provider-backed add with the frontend placeholder rate. The real rate
+        // is fetched by the market-data sync, so no quote should be stored (#1143).
+        service
+            .add_exchange_rate(NewExchangeRate {
+                from_currency: "EUR".to_string(),
+                to_currency: "USD".to_string(),
+                rate: Decimal::ONE,
+                source: DATA_SOURCE_YAHOO.to_string(),
+            })
+            .await
+            .unwrap();
+
+        assert!(
+            repo.saved_rates.lock().unwrap().is_empty(),
+            "provider-backed add must not persist a placeholder quote"
+        );
+        assert_eq!(
+            repo.created_pairs.lock().unwrap().len(),
+            1,
+            "provider-backed add should still register the FX asset for syncing"
+        );
     }
 }


### PR DESCRIPTION
## Description

Fixes #1143 — adding a new FX rate on a weekend produced a rate of **"1"** in the pair's quote history.

### Root cause

When a user adds an exchange rate with a **provider** source (Yahoo, custom scraper), the form doesn't show a rate field and the frontend sent a placeholder `rate: 1`. `FxService::add_exchange_rate` then persisted that placeholder as a real quote, stamped on the add date.

Quotes are keyed by day (`{asset}_{YYYY-MM-DD}_{source}`) and the market-data sync upserts **per trading day**. So:

- **Weekday add** → the placeholder lands on a trading day → the next sync overwrites it with the real rate (self-heals).
- **Weekend add** → the placeholder lands on a Saturday/Sunday → providers never return weekend bars, so no sync can ever overwrite it. The fake `"1"` sticks forever.

Changing `MarketSyncMode` alone wouldn't fix it (a sync on Saturday still fetches no Saturday data) — the real fix is to never persist the placeholder.

### Changes

- **core** (`fx_service.rs`): `add_exchange_rate` only persists a quote for `MANUAL` sources. Provider-backed sources just register the FX asset and let the market-data sync populate the real rate. Added two regression tests.
- **desktop + web** (`settings.rs`, `exchange_rates.rs`, `shared.rs`): on a provider-source add, trigger a targeted `Incremental` market sync of the new FX asset so its real rate is fetched immediately instead of waiting for the next periodic sync. `MANUAL` adds keep the existing no-sync recalc.
- **frontend** (`add-exchange-rate-form.tsx`): stop sending a placeholder rate of `1` for provider sources (the backend now ignores the value for them).

### Behavior after the fix

Adding a provider FX pair on a weekend now shows the latest trading-day rate (e.g. Friday's close) instead of `"1"`. The pair briefly drops from the list while the targeted sync runs, then reappears with the real rate (the portfolio-update-complete invalidation refreshes it automatically — no manual refresh needed).

### Reviewer notes

- Desktop (Tauri) and web (Axum) paths were checked for parity: both sync only for non-MANUAL sources with the single new asset id, and both end in a full recalc.
- Verified a brand-new provider pair **with no related holdings** is still fetched by the targeted sync (a `Closed` FX asset under targeted-Incremental is promoted to `RecentlyClosed` and fetched over a recent window).
- Pre-existing, out of scope: re-adding an existing pair with a different source does not change the asset's stored source (`create_fx_asset` is match-or-insert). This fix doesn't worsen that case — it improves it (the old code corrupted such a pair's rate to `"1"`).
- Existing databases may still contain bogus `"1"` rows from past weekend adds; the clean remediation is to delete and re-add the affected pair (delete removes all its quotes, re-add syncs real rates). No automatic migration is included.

### Verification

- `cargo check` passes for `wealthfolio-core`, `wealthfolio-server`, and `wealthfolio-app`.
- `cargo test -p wealthfolio-core fx::` — 13 passed, including the two new regression tests.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
