### PR TITLE
feat(allocations): hybrid drift bands with per-sleeve tolerance

### DIFF
--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -2400,6 +2400,8 @@ export type ScenarioMode = "cash_flow_only" | "sell_to_rebalance" | "hybrid";
 export type DriftStatus = "in_band" | "underweight" | "overweight" | "not_targeted";
 export type RebalanceTo = "nearest_band" | "exact_target";
 
+export type BandType = "absolute" | "hybrid";
+
 export interface AllocationTarget {
   id: string;
   name: string;
@@ -2408,6 +2410,8 @@ export interface AllocationTarget {
   taxonomyId: string;
   triggerType: TriggerType;
   driftBandBps: number;
+  bandType: BandType;
+  relativeFactorBps: number;
   rebalanceGoal: RebalanceGoal;
   minTradeAmount: string;
   wholeSharesOnly: boolean;
@@ -2424,6 +2428,8 @@ export interface NewAllocationTarget {
   taxonomyId: string;
   triggerType: TriggerType;
   driftBandBps: number;
+  bandType?: BandType;
+  relativeFactorBps?: number;
   rebalanceGoal?: RebalanceGoal;
   minTradeAmount?: string;
   wholeSharesOnly?: boolean;
@@ -2464,6 +2470,7 @@ export interface DriftRow {
   currentValue: number;
   targetValue: number;
   valueDelta: number;
+  effectiveBandBps: number;
   status: DriftStatus;
   isRequired: boolean;
   isZeroCurrent: boolean;

--- a/apps/frontend/src/pages/allocation-targets/components/allocation-donut.test.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/allocation-donut.test.tsx
@@ -19,6 +19,7 @@ function row(
     currentValue: 0,
     targetValue: 0,
     valueDelta: 0,
+    effectiveBandBps: 0,
     status: "in_band",
     isRequired: true,
     isZeroCurrent: false,

--- a/apps/frontend/src/pages/allocation-targets/components/drift-band-slider.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/drift-band-slider.tsx
@@ -1,59 +1,125 @@
+import { AnimatedToggleGroup } from "@wealthfolio/ui";
+
+import type { BandType } from "@/lib/types";
+
 interface DriftBandSliderProps {
-  value: number;
-  onChange: (value: number) => void;
+  driftBandPct: number;
+  onDriftBandChange: (value: number) => void;
+  bandType: BandType;
+  onBandTypeChange: (bandType: BandType) => void;
+  relativeFactorPct: number;
+  onRelativeFactorChange: (value: number) => void;
   className?: string;
-  label?: string;
-  description?: string;
-  compact?: boolean;
 }
 
 const MIN_DRIFT_BAND = 0.5;
 const MAX_DRIFT_BAND = 10;
+const MIN_RELATIVE_FACTOR = 5;
+const MAX_RELATIVE_FACTOR = 50;
+
+const DEFAULT_ABSOLUTE_PCT = 5;
+const DEFAULT_HYBRID_FLOOR_PCT = 1;
+const DEFAULT_RELATIVE_FACTOR_PCT = 20;
 
 export function DriftBandSlider({
-  value,
-  onChange,
+  driftBandPct,
+  onDriftBandChange,
+  bandType,
+  onBandTypeChange,
+  relativeFactorPct,
+  onRelativeFactorChange,
   className,
-  label = "Drift tolerance",
-  description,
-  compact = false,
 }: DriftBandSliderProps) {
-  const pct = ((value - MIN_DRIFT_BAND) / (MAX_DRIFT_BAND - MIN_DRIFT_BAND)) * 100;
+  const isHybrid = bandType === "hybrid";
+  const floorPct = ((driftBandPct - MIN_DRIFT_BAND) / (MAX_DRIFT_BAND - MIN_DRIFT_BAND)) * 100;
+  const relativePct =
+    ((relativeFactorPct - MIN_RELATIVE_FACTOR) / (MAX_RELATIVE_FACTOR - MIN_RELATIVE_FACTOR)) * 100;
+
+  function handleBandTypeChange(next: BandType) {
+    if (next === bandType) return;
+    onBandTypeChange(next);
+    if (next === "hybrid") {
+      onRelativeFactorChange(DEFAULT_RELATIVE_FACTOR_PCT);
+      onDriftBandChange(DEFAULT_HYBRID_FLOOR_PCT);
+    } else {
+      onDriftBandChange(DEFAULT_ABSOLUTE_PCT);
+    }
+  }
 
   return (
     <div className={className}>
-      <div
-        className={
-          compact
-            ? "mb-1.5 flex items-center justify-between gap-3"
-            : "mb-2 flex items-center justify-between gap-3"
-        }
-      >
-        <span className="text-foreground text-[12px] font-semibold">{label}</span>
-        <span className="bg-muted text-foreground rounded-md px-2.5 py-1 text-[12px] font-semibold tabular-nums">
-          ±{value.toFixed(1)}%
-        </span>
-      </div>
-      {description && !compact && (
-        <p className="text-muted-foreground mb-2 text-[11px] leading-relaxed">{description}</p>
-      )}
-      <input
-        type="range"
-        min={MIN_DRIFT_BAND}
-        max={MAX_DRIFT_BAND}
-        step={0.5}
-        value={value}
-        onChange={(event) => onChange(parseFloat(event.target.value))}
-        className="lever-slider block w-full"
-        style={{ ["--lever-pct" as string]: `${pct}%` }}
+      <AnimatedToggleGroup<BandType>
+        value={bandType}
+        onValueChange={handleBandTypeChange}
+        items={[
+          { value: "hybrid", label: "Hybrid" },
+          { value: "absolute", label: "Absolute" },
+        ]}
+        rounded="lg"
+        className="bg-muted/30 [&_button:has(>div)]:text-primary-foreground [&_button:not(:has(>div))]:text-muted-foreground [&_button>div]:bg-primary w-full border [&_button]:flex-1 [&_button]:py-2 [&_button]:text-[12px]"
       />
-      {!compact && (
-        <div className="text-muted-foreground mt-2 flex justify-between text-[10px]">
+      <p className="text-muted-foreground mt-2 text-[11px] leading-relaxed">
+        {isHybrid
+          ? "Each sleeve's band scales with its target weight. Small sleeves get tighter bands; the absolute floor prevents micro-trades."
+          : "Same fixed band applied to every sleeve regardless of its target weight."}
+      </p>
+
+      {isHybrid && (
+        <div className="mt-4">
+          <div className="mb-1.5 flex items-center justify-between">
+            <span className="text-foreground text-[12px] font-medium">Relative factor</span>
+            <span className="bg-muted text-foreground rounded-md px-2 py-0.5 text-[12px] font-semibold tabular-nums">
+              ±{relativeFactorPct}% of target
+            </span>
+          </div>
+          <input
+            type="range"
+            min={MIN_RELATIVE_FACTOR}
+            max={MAX_RELATIVE_FACTOR}
+            step={5}
+            value={relativeFactorPct}
+            onChange={(event) => onRelativeFactorChange(parseFloat(event.target.value))}
+            className="lever-slider block w-full"
+            style={{ ["--lever-pct" as string]: `${relativePct}%` }}
+          />
+          <div className="text-muted-foreground mt-1.5 flex justify-between text-[10px]">
+            <span>Tight</span>
+            <span>Standard</span>
+            <span>Loose</span>
+          </div>
+        </div>
+      )}
+
+      <div className="mt-4">
+        <div className="mb-1.5 flex items-center justify-between">
+          <span className="text-foreground text-[12px] font-medium">
+            {isHybrid ? "Absolute floor" : "Band width"}
+          </span>
+          <span className="bg-muted text-foreground rounded-md px-2 py-0.5 text-[12px] font-semibold tabular-nums">
+            ±{driftBandPct.toFixed(1)}%
+          </span>
+        </div>
+        <input
+          type="range"
+          min={MIN_DRIFT_BAND}
+          max={MAX_DRIFT_BAND}
+          step={0.5}
+          value={driftBandPct}
+          onChange={(event) => onDriftBandChange(parseFloat(event.target.value))}
+          className="lever-slider block w-full"
+          style={{ ["--lever-pct" as string]: `${floorPct}%` }}
+        />
+        <div className="text-muted-foreground mt-1.5 flex justify-between text-[10px]">
           <span>Tight</span>
           <span>Standard</span>
           <span>Loose</span>
         </div>
-      )}
+        {isHybrid && (
+          <p className="text-muted-foreground mt-1.5 text-[11px] leading-relaxed">
+            Minimum band for any sleeve, regardless of its target weight.
+          </p>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/frontend/src/pages/allocation-targets/components/drift-copy.ts
+++ b/apps/frontend/src/pages/allocation-targets/components/drift-copy.ts
@@ -22,13 +22,13 @@ export function targetLabel(targetName: string | undefined) {
 
 export function formatPp(bps: number, decimals = 1) {
   const pp = bps / 100;
-  return `${pp > 0 ? "+" : ""}${pp.toFixed(decimals)} pp`;
+  return `${pp > 0 ? "+" : ""}${pp.toFixed(decimals)}%`;
 }
 
 export function formatTolerance(bps: number) {
   const pp = bps / 100;
   const value = Number.isInteger(pp) ? pp.toFixed(0) : pp.toFixed(1);
-  return `±${value} pp`;
+  return `±${value}%`;
 }
 
 export function formatRoundedCurrency(amount: number, currency: string) {

--- a/apps/frontend/src/pages/allocation-targets/components/drift-drivers-card.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/drift-drivers-card.tsx
@@ -12,6 +12,7 @@ import { isOutOfBand } from "./drift-row-utils";
 interface DriftDriversCardProps {
   report: DriftReport;
   statusDescription: string;
+  bandLabel?: string | null;
   onRebalanceClick?: () => void;
 }
 
@@ -64,6 +65,7 @@ function markerTextColor(color: string): string {
 export function DriftDriversCard({
   report,
   statusDescription,
+  bandLabel,
   onRebalanceClick,
 }: DriftDriversCardProps) {
   const colorByCategory = useMemo(() => buildAllocationTargetColorMap(report.rows), [report.rows]);
@@ -78,7 +80,15 @@ export function DriftDriversCard({
     <Card className="flex h-full flex-col">
       <CardHeader className="pb-4">
         <CardTitle className="text-base">Largest gaps</CardTitle>
-        <CardDescription>{statusDescription}</CardDescription>
+        <CardDescription>
+          {statusDescription}
+          {bandLabel && (
+            <>
+              {" · "}
+              <span className="text-muted-foreground">{bandLabel}</span>
+            </>
+          )}
+        </CardDescription>
       </CardHeader>
       <CardContent className="flex flex-1 flex-col">
         {oobRows.length === 0 ? (

--- a/apps/frontend/src/pages/allocation-targets/components/drift-report-resolver.test.ts
+++ b/apps/frontend/src/pages/allocation-targets/components/drift-report-resolver.test.ts
@@ -15,6 +15,7 @@ function driftRow(overrides: Partial<DriftRow> & Pick<DriftRow, "categoryId">): 
     currentValue: 50_000,
     targetValue: 50_000,
     valueDelta: 0,
+    effectiveBandBps: 0,
     status: "in_band",
     isRequired: true,
     isZeroCurrent: false,

--- a/apps/frontend/src/pages/allocation-targets/components/overview-tab.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/overview-tab.tsx
@@ -1,15 +1,16 @@
-import type { DriftReport } from "@/lib/types";
+import type { AllocationTarget, DriftReport } from "@/lib/types";
 import { useTaxonomy } from "@/hooks/use-taxonomies";
 import { CurrentVsTargetCard } from "./current-vs-target-card";
 import { DriftDriversCard } from "./drift-drivers-card";
 import { HoldingsTable } from "./holdings-table";
 import { resolveDriftReportCategories } from "./drift-report-resolver";
-import { categoryNoun, taxonomyLabel, targetLabel } from "./drift-copy";
+import { categoryNoun, formatTolerance, taxonomyLabel, targetLabel } from "./drift-copy";
 
 interface OverviewTabProps {
   report: DriftReport;
   taxonomyId: string;
   targetName?: string;
+  target?: AllocationTarget | null;
   onRebalanceClick?: () => void;
 }
 
@@ -17,6 +18,7 @@ export function OverviewTab({
   report,
   taxonomyId,
   targetName,
+  target,
   onRebalanceClick,
 }: OverviewTabProps) {
   const { data: taxonomy } = useTaxonomy(taxonomyId);
@@ -30,6 +32,22 @@ export function OverviewTab({
       ? `All ${pluralCategoryLabel} inside target`
       : `${report.outOfBandCount} ${categoryLabel} outside target`;
 
+  const bandLabel = (() => {
+    if (!target) return null;
+    const isHybrid = target.bandType === "hybrid";
+    const typeName = isHybrid ? "Hybrid" : "Absolute";
+    const requiredRows = resolvedReport.rows.filter((r) => r.isRequired && r.targetBps > 0);
+    if (!requiredRows.length) return `${typeName} · ${formatTolerance(target.driftBandBps)}`;
+    const bands = requiredRows.map((r) => r.effectiveBandBps);
+    const minBand = Math.min(...bands);
+    const maxBand = Math.max(...bands);
+    const range =
+      minBand === maxBand
+        ? formatTolerance(minBand)
+        : `±${(minBand / 100).toFixed(1)}–${(maxBand / 100).toFixed(1)} pp`;
+    return `${typeName} · ${range}`;
+  })();
+
   return (
     <div className="space-y-5">
       <div className="grid grid-cols-1 gap-5 lg:grid-cols-[minmax(0,1.7fr)_minmax(340px,0.75fr)]">
@@ -41,6 +59,7 @@ export function OverviewTab({
         <DriftDriversCard
           report={resolvedReport}
           statusDescription={gapStatus}
+          bandLabel={bandLabel}
           onRebalanceClick={onRebalanceClick}
         />
       </div>

--- a/apps/frontend/src/pages/allocation-targets/components/overview-tab.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/overview-tab.tsx
@@ -44,7 +44,7 @@ export function OverviewTab({
     const range =
       minBand === maxBand
         ? formatTolerance(minBand)
-        : `±${(minBand / 100).toFixed(1)}–${(maxBand / 100).toFixed(1)} pp`;
+        : `±${(minBand / 100).toFixed(1)}–${(maxBand / 100).toFixed(1)}%`;
     return `${typeName} · ${range}`;
   })();
 

--- a/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
@@ -1237,7 +1237,13 @@ export function RebalanceTab({
         ? "Invest your cash first, then sell overweight sleeves only if cash alone can't close the gap. Cash can add to a holding but can't shrink one you already own too much of. Tax impact is not estimated."
         : "Put your new cash to work in the sleeves you're light on. Buys only — nothing is sold.";
 
-  const bandBps = profile.driftBandBps;
+  const bandBps = (() => {
+    if (!driftReport?.rows.length) return profile.driftBandBps;
+    const maxRow = driftReport.rows
+      .filter((r) => r.isRequired)
+      .reduce((best, r) => (Math.abs(r.driftBps) > Math.abs(best.driftBps) ? r : best));
+    return maxRow.effectiveBandBps;
+  })();
   const baseDrift = driftReport?.maxDriftBps ?? 0;
   const beforeDrift = plan?.maxDriftBpsBefore ?? baseDrift;
   const scaleMaxBps = driftScaleMaxBps(Math.max(beforeDrift, baseDrift), bandBps);

--- a/apps/frontend/src/pages/allocation-targets/components/target-weight-editor.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/target-weight-editor.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { Icons } from "@wealthfolio/ui";
-import type { TaxonomyCategory } from "@/lib/types";
+import type { BandType, TaxonomyCategory } from "@/lib/types";
 import { allocationTargetColor } from "./allocation-target-colors";
 
 export interface WeightDraft {
@@ -16,6 +16,9 @@ interface TargetWeightEditorProps {
   weights: WeightDraft[];
   currentAllocation?: Record<string, number>; // categoryId → pct 0-100
   categoryLabel?: string;
+  bandType: BandType;
+  driftBandBps: number;
+  relativeFactorBps: number;
   onChange: (weights: WeightDraft[]) => void;
 }
 
@@ -78,8 +81,19 @@ function redistribute(weights: WeightDraft[], changedId: string, newBps: number)
   return result;
 }
 
-function driftTone(drift: number): { label: string; className: string } {
-  if (Math.abs(drift) < 0.05) {
+function effectiveBandPct(
+  targetBps: number,
+  bandType: BandType,
+  driftBandBps: number,
+  relativeFactorBps: number,
+): number {
+  if (bandType === "absolute") return driftBandBps / 100;
+  const relative = (targetBps * relativeFactorBps) / 10_000 / 100;
+  return Math.max(relative, driftBandBps / 100);
+}
+
+function driftTone(drift: number, bandPct: number): { label: string; className: string } {
+  if (Math.abs(drift) <= bandPct) {
     return {
       label: "On target",
       className: "bg-muted text-muted-foreground",
@@ -102,6 +116,9 @@ export function TargetWeightEditor({
   weights,
   currentAllocation = {},
   categoryLabel = "Asset class",
+  bandType,
+  driftBandBps,
+  relativeFactorBps,
   onChange,
 }: TargetWeightEditorProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -151,12 +168,14 @@ export function TargetWeightEditor({
     const currentPct = currentAllocation[cat.id] ?? 0;
     const targetPct = bps / 100;
     const drift = currentPct - targetPct;
+    const bandPct = effectiveBandPct(bps, bandType, driftBandBps, relativeFactorBps);
     return {
       cat,
       bps,
       currentPct,
       targetPct,
       drift,
+      bandPct,
       color: allocationTargetColor(cat.id, cat.name, index),
       isLocked: getIsLocked(cat.id),
       isEditing: editingId === cat.id,
@@ -164,7 +183,7 @@ export function TargetWeightEditor({
   });
 
   const biggestMove = [...rows]
-    .filter((row) => Math.abs(row.drift) >= 0.05)
+    .filter((row) => Math.abs(row.drift) > row.bandPct)
     .sort((a, b) => Math.abs(b.drift) - Math.abs(a.drift))[0];
 
   return (
@@ -183,7 +202,7 @@ export function TargetWeightEditor({
         {/* Category rows */}
         <div className="divide-y">
           {rows.map((row) => {
-            const tone = driftTone(row.drift);
+            const tone = driftTone(row.drift, row.bandPct);
             return (
               <div
                 key={row.cat.id}

--- a/apps/frontend/src/pages/allocation-targets/components/targets-tab.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/targets-tab.tsx
@@ -25,6 +25,7 @@ import {
   useSaveAllocationTargetWithWeights,
 } from "../hooks/use-allocation-target-mutations";
 import type {
+  BandType,
   CategoryAllocation,
   PortfolioAllocations,
   AllocationTarget,
@@ -271,7 +272,11 @@ function TargetEditor({
   const [startId, setStartId] = useState<string>(target ? "saved" : "current");
   const [targetName, setTargetName] = useState(target?.name ?? "");
   const [nameTouched, setNameTouched] = useState(!!target);
-  const [driftBandPct, setDriftBandPct] = useState(target ? target.driftBandBps / 100 : 5);
+  const [driftBandPct, setDriftBandPct] = useState(target ? target.driftBandBps / 100 : 1);
+  const [bandType, setBandType] = useState<BandType>(target?.bandType ?? "hybrid");
+  const [relativeFactorPct, setRelativeFactorPct] = useState(
+    target ? target.relativeFactorBps / 100 : 20,
+  );
   const [allowSells, setAllowSells] = useState(target?.allowSells ?? true);
   const [rebalanceGoal, setRebalanceGoal] = useState<RebalanceGoal>(
     target?.rebalanceGoal ?? "nearest_band",
@@ -286,7 +291,9 @@ function TargetEditor({
   const resetTargetId = target?.id ?? null;
   const resetTargetTaxonomyId = target?.taxonomyId ?? "asset_classes";
   const resetTargetName = target?.name ?? "";
-  const resetTargetDriftBandBps = target?.driftBandBps ?? 500;
+  const resetTargetDriftBandBps = target?.driftBandBps ?? 100;
+  const resetTargetBandType = target?.bandType ?? "hybrid";
+  const resetTargetRelativeFactorBps = target?.relativeFactorBps ?? 2000;
 
   const { data: taxonomy, isLoading: taxonomyLoading } = useTaxonomy(taxonomyId);
   const targetCategories = React.useMemo(
@@ -350,6 +357,8 @@ function TargetEditor({
       setTargetName(resetTargetName);
       setNameTouched(true);
       setDriftBandPct(resetTargetDriftBandBps / 100);
+      setBandType(resetTargetBandType);
+      setRelativeFactorPct(resetTargetRelativeFactorBps / 100);
       setAllowSells(target?.allowSells ?? false);
       setRebalanceGoal(target?.rebalanceGoal ?? "nearest_band");
       setMinTradeAmount(target?.minTradeAmount ?? "0");
@@ -359,7 +368,9 @@ function TargetEditor({
       setStartId("current");
       setTargetName("");
       setNameTouched(false);
-      setDriftBandPct(5);
+      setDriftBandPct(1);
+      setBandType("hybrid");
+      setRelativeFactorPct(20);
       setAllowSells(true);
       setRebalanceGoal("nearest_band");
       setMinTradeAmount("0");
@@ -373,6 +384,8 @@ function TargetEditor({
     onUnsavedChange?.(false);
   }, [
     resetTargetDriftBandBps,
+    resetTargetBandType,
+    resetTargetRelativeFactorBps,
     resetTargetId,
     resetTargetName,
     resetTargetTaxonomyId,
@@ -450,6 +463,8 @@ function TargetEditor({
         taxonomyId,
         triggerType: "threshold",
         driftBandBps: Math.round(driftBandPct * 100),
+        bandType,
+        relativeFactorBps: Math.round(relativeFactorPct * 100),
         allowSells,
         rebalanceGoal,
         minTradeAmount: minTradeAmount === "" ? "0" : minTradeAmount,
@@ -484,6 +499,8 @@ function TargetEditor({
       setTargetName(target.name);
       setNameTouched(true);
       setDriftBandPct(target.driftBandBps / 100);
+      setBandType(target.bandType ?? "absolute");
+      setRelativeFactorPct((target.relativeFactorBps ?? 2000) / 100);
       setAllowSells(target.allowSells ?? false);
       setRebalanceGoal(target.rebalanceGoal ?? "nearest_band");
       setMinTradeAmount(target.minTradeAmount ?? "0");
@@ -494,7 +511,9 @@ function TargetEditor({
       setStartId("current");
       setTargetName("");
       setNameTouched(false);
-      setDriftBandPct(5);
+      setDriftBandPct(1);
+      setBandType("hybrid");
+      setRelativeFactorPct(20);
       setRebalanceGoal("nearest_band");
       setMinTradeAmount("0");
       setWholeSharesOnly(false);
@@ -648,6 +667,29 @@ function TargetEditor({
           </section>
 
           <section className="bg-card/80 rounded-lg border p-5 shadow-sm">
+            <StepHeader number={3} className="mb-3">
+              Drift tolerance
+            </StepHeader>
+            <DriftBandSlider
+              driftBandPct={driftBandPct}
+              onDriftBandChange={(value) => {
+                setDriftBandPct(value);
+                markDirty();
+              }}
+              bandType={bandType}
+              onBandTypeChange={(value) => {
+                setBandType(value);
+                markDirty();
+              }}
+              relativeFactorPct={relativeFactorPct}
+              onRelativeFactorChange={(value) => {
+                setRelativeFactorPct(value);
+                markDirty();
+              }}
+            />
+          </section>
+
+          <section className="bg-card/80 rounded-lg border p-5 shadow-sm">
             <div className="text-muted-foreground mb-4 text-[11px] font-medium uppercase tracking-wider">
               Rebalance settings
             </div>
@@ -748,7 +790,7 @@ function TargetEditor({
         <div className="space-y-4">
           <section className="bg-card/80 rounded-lg border p-5 shadow-sm">
             <div className="mb-3">
-              <StepHeader number={3}>Starting point</StepHeader>
+              <StepHeader number={4}>Starting point</StepHeader>
             </div>
 
             <ModelPresetPicker
@@ -766,35 +808,23 @@ function TargetEditor({
           </section>
 
           <section className="bg-card/80 rounded-lg border p-5 shadow-sm">
-            <div className="mb-7 flex flex-col gap-3 xl:flex-row xl:items-start xl:justify-between">
-              <div className="min-w-0">
-                <h3 className="text-foreground text-[15px] font-semibold">
-                  Target weights · {selectedStartName}
-                </h3>
-                <p className="text-muted-foreground mt-1 text-[12px]">
-                  Set the intended mix. The total must equal 100%.
+            <div className="mb-7">
+              <h3 className="text-foreground text-[15px] font-semibold">
+                Target weights · {selectedStartName}
+              </h3>
+              <p className="text-muted-foreground mt-1 text-[12px]">
+                Set the intended mix. The total must equal 100%.
+              </p>
+              {cannotTargetScope && (
+                <p className="text-destructive mt-2 text-[11px] leading-relaxed">
+                  Select all accounts, one portfolio, or one account before saving.
                 </p>
-                {cannotTargetScope && (
-                  <p className="text-destructive mt-2 text-[11px] leading-relaxed">
-                    Select all accounts, one portfolio, or one account before saving.
-                  </p>
-                )}
-                {targetName.trim().length === 0 && (
-                  <p className="text-destructive mt-2 text-[11px] leading-relaxed">
-                    Add a target name before saving.
-                  </p>
-                )}
-              </div>
-              <DriftBandSlider
-                value={driftBandPct}
-                label="Drift tolerance"
-                compact
-                className="w-full xl:w-[300px]"
-                onChange={(value) => {
-                  setDriftBandPct(value);
-                  markDirty();
-                }}
-              />
+              )}
+              {targetName.trim().length === 0 && (
+                <p className="text-destructive mt-2 text-[11px] leading-relaxed">
+                  Add a target name before saving.
+                </p>
+              )}
             </div>
 
             {showEditorSkeleton ? (

--- a/apps/frontend/src/pages/allocation-targets/components/targets-tab.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/targets-tab.tsx
@@ -273,7 +273,9 @@ function TargetEditor({
   const [targetName, setTargetName] = useState(target?.name ?? "");
   const [nameTouched, setNameTouched] = useState(!!target);
   const [driftBandPct, setDriftBandPct] = useState(target ? target.driftBandBps / 100 : 1);
-  const [bandType, setBandType] = useState<BandType>(target?.bandType ?? "hybrid");
+  const [bandType, setBandType] = useState<BandType>(
+    target ? (target.bandType ?? "absolute") : "hybrid",
+  );
   const [relativeFactorPct, setRelativeFactorPct] = useState(
     target ? target.relativeFactorBps / 100 : 20,
   );
@@ -292,7 +294,7 @@ function TargetEditor({
   const resetTargetTaxonomyId = target?.taxonomyId ?? "asset_classes";
   const resetTargetName = target?.name ?? "";
   const resetTargetDriftBandBps = target?.driftBandBps ?? 100;
-  const resetTargetBandType = target?.bandType ?? "hybrid";
+  const resetTargetBandType = target?.bandType ?? "absolute";
   const resetTargetRelativeFactorBps = target?.relativeFactorBps ?? 2000;
 
   const { data: taxonomy, isLoading: taxonomyLoading } = useTaxonomy(taxonomyId);
@@ -835,6 +837,9 @@ function TargetEditor({
                 weights={weights}
                 currentAllocation={currentAllocation}
                 categoryLabel={categoryLabelForTaxonomy(selectedTaxonomy?.name)}
+                bandType={bandType}
+                driftBandBps={Math.round(driftBandPct * 100)}
+                relativeFactorBps={Math.round(relativeFactorPct * 100)}
                 onChange={(nextWeights) => {
                   setWeights(nextWeights);
                   markDirty();

--- a/apps/frontend/src/pages/insights/overview/overview-page.tsx
+++ b/apps/frontend/src/pages/insights/overview/overview-page.tsx
@@ -370,6 +370,7 @@ export function OverviewPage({
             report={driftReport}
             taxonomyId={effectiveTarget?.taxonomyId ?? "asset_classes"}
             targetName={effectiveTarget?.name}
+            target={effectiveTarget}
             onRebalanceClick={() => setWorkspaceView("rebalance")}
           />
         ) : targetLoading ? (
@@ -446,7 +447,6 @@ export function OverviewPage({
             selectedTargetId={effectiveTargetId}
             onTargetChange={requestTargetChange}
             driftReport={driftReport}
-            driftBandBps={effectiveTarget?.driftBandBps ?? 0}
             isLoading={driftLoading && !driftReport}
             onCreateTarget={handleCreateTarget}
             onViewDetails={() => setWorkspaceView("details")}

--- a/apps/frontend/src/pages/insights/overview/target-rails-card.tsx
+++ b/apps/frontend/src/pages/insights/overview/target-rails-card.tsx
@@ -22,7 +22,6 @@ interface TargetRailsCardProps {
   selectedTargetId: string | null;
   onTargetChange: (id: string) => void;
   driftReport: DriftReport | null;
-  driftBandBps: number;
   isLoading?: boolean;
   onCreateTarget?: () => void;
   /** Opens the full current-vs-target analysis. */
@@ -40,7 +39,6 @@ export function TargetRailsCard({
   selectedTargetId,
   onTargetChange,
   driftReport,
-  driftBandBps,
   isLoading,
   onCreateTarget,
   onViewDetails,
@@ -68,6 +66,20 @@ export function TargetRailsCard({
   const hasTarget = !!resolvedDriftReport;
   const currency = resolvedDriftReport?.baseCurrency ?? "USD";
   const rows = resolvedDriftReport?.rows.filter(hasVisibleAllocation) ?? [];
+
+  const toleranceLabel = (() => {
+    const requiredRows = rows.filter((r) => r.isRequired && r.targetBps > 0);
+    if (!requiredRows.length) return formatTolerance(selectedTarget?.driftBandBps ?? 0);
+    const bands = requiredRows.map((r) => r.effectiveBandBps);
+    const minBand = Math.min(...bands);
+    const maxBand = Math.max(...bands);
+    if (minBand === maxBand) return formatTolerance(minBand);
+    const fmt = (bps: number) => {
+      const pp = bps / 100;
+      return Number.isInteger(pp) ? pp.toFixed(0) : pp.toFixed(1);
+    };
+    return `±${fmt(minBand)}–${fmt(maxBand)} pp`;
+  })();
   const maxScale =
     Math.max(1, ...rows.flatMap((r) => [r.currentBps / 100, r.targetBps / 100])) * 1.08;
   const withinTolerance = resolvedDriftReport ? resolvedDriftReport.outOfBandCount === 0 : false;
@@ -241,7 +253,7 @@ export function TargetRailsCard({
                 ? "Inside target range"
                 : `${resolvedDriftReport?.outOfBandCount} outside range · largest gap ${largestGapLabel}`}
             </span>
-            <span className="shrink-0 tabular-nums">tolerance {formatTolerance(driftBandBps)}</span>
+            <span className="shrink-0 tabular-nums">tolerance {toleranceLabel}</span>
           </div>
         </>
       ) : (

--- a/apps/frontend/src/pages/insights/overview/target-rails-card.tsx
+++ b/apps/frontend/src/pages/insights/overview/target-rails-card.tsx
@@ -78,7 +78,7 @@ export function TargetRailsCard({
       const pp = bps / 100;
       return Number.isInteger(pp) ? pp.toFixed(0) : pp.toFixed(1);
     };
-    return `±${fmt(minBand)}–${fmt(maxBand)} pp`;
+    return `±${fmt(minBand)}–${fmt(maxBand)}%`;
   })();
   const maxScale =
     Math.max(1, ...rows.flatMap((r) => [r.currentBps / 100, r.targetBps / 100])) * 1.08;

--- a/crates/core/src/portfolio/allocation_targets/drift_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/drift_service.rs
@@ -183,7 +183,12 @@ impl DriftService {
                 };
                 let value_delta = current_value - target_value;
 
-                let status = if drift_bps.abs() <= target.drift_band_bps {
+                let effective_band = target.band_type.effective_band_bps(
+                    target_bps,
+                    target.drift_band_bps,
+                    target.relative_factor_bps,
+                );
+                let status = if drift_bps.abs() <= effective_band {
                     DriftStatus::InBand
                 } else if drift_bps < 0 {
                     DriftStatus::Underweight
@@ -215,6 +220,7 @@ impl DriftService {
                     current_value,
                     target_value,
                     value_delta,
+                    effective_band_bps: effective_band,
                     status,
                     is_required: weight.is_required,
                     is_zero_current: current_value == Decimal::ZERO,
@@ -246,6 +252,7 @@ impl DriftService {
                 current_value: current.value,
                 target_value: Decimal::ZERO,
                 value_delta: current.value,
+                effective_band_bps: 0,
                 status: DriftStatus::NotTargeted,
                 is_required: false,
                 is_zero_current: current.value == Decimal::ZERO,
@@ -445,8 +452,9 @@ mod tests {
         PortfolioAllocations, TaxonomyAllocation, TaxonomyHoldingContributions,
     };
     use crate::portfolio::allocation_targets::model::{
-        AllocationTarget, AllocationTargetWeight, NewAllocationTarget, NewAllocationTargetWeight,
-        RebalanceGoal, SaveAllocationTargetResult, ScopeType, TriggerType,
+        AllocationTarget, AllocationTargetWeight, BandType, NewAllocationTarget,
+        NewAllocationTargetWeight, RebalanceGoal, SaveAllocationTargetResult, ScopeType,
+        TriggerType,
     };
     use crate::portfolio::holdings::HoldingType;
     use async_trait::async_trait;
@@ -463,6 +471,8 @@ mod tests {
             taxonomy_id: "asset_classes".to_string(),
             trigger_type: TriggerType::Threshold,
             drift_band_bps,
+            band_type: BandType::Absolute,
+            relative_factor_bps: 2000,
             rebalance_goal: RebalanceGoal::NearestBand,
             min_trade_amount: "0".to_string(),
             whole_shares_only: false,
@@ -1257,5 +1267,99 @@ mod tests {
         assert_eq!(unknown.current_bps, 10000);
         assert_eq!(target.status, DriftStatus::Underweight);
         assert_eq!(target.current_bps, 0);
+    }
+
+    // ── Hybrid band tests ──────────────────────────────────────────────────
+
+    fn hybrid_target(drift_band_bps: i32, relative_factor_bps: i32) -> AllocationTarget {
+        AllocationTarget {
+            band_type: BandType::Hybrid,
+            relative_factor_bps,
+            ..base_target(drift_band_bps)
+        }
+    }
+
+    #[tokio::test]
+    async fn hybrid_band_large_sleeve_in_band_where_absolute_would_flag() {
+        // EQUITY: target=50% (5000 bps), current=56% (5600 bps), drift=+600.
+        // Absolute band 500 → 600 > 500 → Overweight.
+        // Hybrid 20%: effective = max(5000*2000/10000, 500) = max(1000, 500) = 1000 → 600 ≤ 1000 → InBand.
+        let svc = make_service(
+            hybrid_target(500, 2000),
+            vec![weight("EQUITY", 5000), weight("BONDS", 5000)],
+            alloc_with(
+                vec![cat("EQUITY", dec!(5600)), cat("BONDS", dec!(4400))],
+                dec!(10000),
+            ),
+        );
+        let report = svc
+            .get_drift_report_for_target("p1", &[], "USD", "agg")
+            .await
+            .unwrap();
+
+        let equity = report
+            .rows
+            .iter()
+            .find(|r| r.category_id == "EQUITY")
+            .unwrap();
+        assert_eq!(equity.drift_bps, 600);
+        assert_eq!(equity.status, DriftStatus::InBand);
+        assert_eq!(equity.effective_band_bps, 1000);
+    }
+
+    #[tokio::test]
+    async fn hybrid_band_small_sleeve_uses_floor() {
+        // SMALL: target=5% (500 bps), current=8% (800 bps), drift=+300.
+        // Hybrid 20%: effective = max(500*2000/10000, 100) = max(100, 100) = 100 → 300 > 100 → Overweight.
+        // With absolute 500: 300 ≤ 500 → InBand.
+        let svc = make_service(
+            hybrid_target(100, 2000),
+            vec![weight("SMALL", 500), weight("OTHER", 9500)],
+            alloc_with(
+                vec![cat("SMALL", dec!(800)), cat("OTHER", dec!(9200))],
+                dec!(10000),
+            ),
+        );
+        let report = svc
+            .get_drift_report_for_target("p1", &[], "USD", "agg")
+            .await
+            .unwrap();
+
+        let small = report
+            .rows
+            .iter()
+            .find(|r| r.category_id == "SMALL")
+            .unwrap();
+        assert_eq!(small.drift_bps, 300);
+        assert_eq!(small.status, DriftStatus::Overweight);
+        assert_eq!(small.effective_band_bps, 100);
+    }
+
+    #[tokio::test]
+    async fn hybrid_effective_band_bps_varies_per_sleeve() {
+        // Two sleeves with different targets should get different effective bands.
+        let svc = make_service(
+            hybrid_target(100, 2000),
+            vec![weight("BIG", 6000), weight("SMALL", 4000)],
+            alloc_with(
+                vec![cat("BIG", dec!(6000)), cat("SMALL", dec!(4000))],
+                dec!(10000),
+            ),
+        );
+        let report = svc
+            .get_drift_report_for_target("p1", &[], "USD", "agg")
+            .await
+            .unwrap();
+
+        let big = report.rows.iter().find(|r| r.category_id == "BIG").unwrap();
+        let small = report
+            .rows
+            .iter()
+            .find(|r| r.category_id == "SMALL")
+            .unwrap();
+        // BIG: 6000 * 2000 / 10000 = 1200; max(1200, 100) = 1200
+        assert_eq!(big.effective_band_bps, 1200);
+        // SMALL: 4000 * 2000 / 10000 = 800; max(800, 100) = 800
+        assert_eq!(small.effective_band_bps, 800);
     }
 }

--- a/crates/core/src/portfolio/allocation_targets/model.rs
+++ b/crates/core/src/portfolio/allocation_targets/model.rs
@@ -69,6 +69,49 @@ pub enum ScenarioMode {
     Hybrid,
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BandType {
+    #[default]
+    Absolute,
+    Hybrid,
+}
+
+impl BandType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Absolute => "absolute",
+            Self::Hybrid => "hybrid",
+        }
+    }
+
+    pub fn effective_band_bps(
+        &self,
+        target_bps: i32,
+        drift_band_bps: i32,
+        relative_factor_bps: i32,
+    ) -> i32 {
+        match self {
+            Self::Absolute => drift_band_bps,
+            Self::Hybrid => {
+                let relative = target_bps as i64 * relative_factor_bps as i64 / 10_000;
+                (relative as i32).max(drift_band_bps)
+            }
+        }
+    }
+}
+
+impl TryFrom<&str> for BandType {
+    type Error = String;
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s {
+            "absolute" => Ok(Self::Absolute),
+            "hybrid" => Ok(Self::Hybrid),
+            _ => Err(format!("unknown band type: {s}")),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RebalanceGoal {
@@ -108,6 +151,8 @@ pub struct AllocationTarget {
     pub taxonomy_id: String,
     pub trigger_type: TriggerType,
     pub drift_band_bps: i32,
+    pub band_type: BandType,
+    pub relative_factor_bps: i32,
     pub rebalance_goal: RebalanceGoal,
     pub min_trade_amount: String,
     pub whole_shares_only: bool,
@@ -126,6 +171,8 @@ pub struct NewAllocationTarget {
     pub taxonomy_id: String,
     pub trigger_type: TriggerType,
     pub drift_band_bps: i32,
+    pub band_type: Option<BandType>,
+    pub relative_factor_bps: Option<i32>,
     pub rebalance_goal: Option<RebalanceGoal>,
     pub min_trade_amount: Option<String>,
     pub whole_shares_only: Option<bool>,
@@ -185,11 +232,10 @@ pub struct DriftRow {
     pub current_value: Decimal,
     pub target_value: Decimal,
     pub value_delta: Decimal,
+    pub effective_band_bps: i32,
     pub status: DriftStatus,
     pub is_required: bool,
     pub is_zero_current: bool,
-    /// True when this category holds only cash. The rebalance planner reduces
-    /// this row by the deployed cash when estimating after-drift.
     #[serde(default)]
     pub is_cash: bool,
 }
@@ -304,4 +350,57 @@ pub struct RebalancePlan {
     /// instead of re-deriving from trades (which only carry the primary category).
     #[serde(default)]
     pub after_bps_by_category: std::collections::HashMap<String, i32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn absolute_band_ignores_target_bps() {
+        let band = BandType::Absolute;
+        assert_eq!(band.effective_band_bps(5000, 500, 2000), 500);
+        assert_eq!(band.effective_band_bps(100, 500, 2000), 500);
+        assert_eq!(band.effective_band_bps(0, 500, 2000), 500);
+    }
+
+    #[test]
+    fn hybrid_band_large_sleeve_uses_relative() {
+        let band = BandType::Hybrid;
+        // 50% target, 20% factor → relative = 5000 * 2000 / 10000 = 1000 bps
+        // floor = 100 bps → max(1000, 100) = 1000
+        assert_eq!(band.effective_band_bps(5000, 100, 2000), 1000);
+    }
+
+    #[test]
+    fn hybrid_band_small_sleeve_uses_floor() {
+        let band = BandType::Hybrid;
+        // 1% target, 20% factor → relative = 100 * 2000 / 10000 = 20 bps
+        // floor = 100 bps → max(20, 100) = 100
+        assert_eq!(band.effective_band_bps(100, 100, 2000), 100);
+    }
+
+    #[test]
+    fn hybrid_band_zero_target_uses_floor() {
+        let band = BandType::Hybrid;
+        // 0% target → relative = 0, floor = 100
+        assert_eq!(band.effective_band_bps(0, 100, 2000), 100);
+    }
+
+    #[test]
+    fn hybrid_band_mid_sleeve() {
+        let band = BandType::Hybrid;
+        // 10% target, 20% factor → relative = 1000 * 2000 / 10000 = 200 bps
+        // floor = 100 → max(200, 100) = 200
+        assert_eq!(band.effective_band_bps(1000, 100, 2000), 200);
+    }
+
+    #[test]
+    fn band_type_round_trip() {
+        assert_eq!(BandType::try_from("absolute"), Ok(BandType::Absolute));
+        assert_eq!(BandType::try_from("hybrid"), Ok(BandType::Hybrid));
+        assert!(BandType::try_from("invalid").is_err());
+        assert_eq!(BandType::Absolute.as_str(), "absolute");
+        assert_eq!(BandType::Hybrid.as_str(), "hybrid");
+    }
 }

--- a/crates/core/src/portfolio/allocation_targets/optimizer.rs
+++ b/crates/core/src/portfolio/allocation_targets/optimizer.rs
@@ -6,7 +6,7 @@ use rust_decimal_macros::dec;
 use crate::errors::Result as CoreResult;
 
 use super::model::{
-    RebalanceGoal, RebalancePlan, RebalanceWarning, RebalanceWarningKind, ScenarioMode,
+    BandType, RebalanceGoal, RebalancePlan, RebalanceWarning, RebalanceWarningKind, ScenarioMode,
     SuggestedManualTrade,
 };
 
@@ -15,9 +15,18 @@ use super::model::{
 pub struct RebalanceProfile {
     pub target_id: String,
     pub drift_band_bps: i32,
+    pub band_type: BandType,
+    pub relative_factor_bps: i32,
     pub rebalance_goal: RebalanceGoal,
     pub min_trade_amount: Decimal,
     pub whole_shares_only: bool,
+}
+
+impl RebalanceProfile {
+    pub fn effective_band_bps(&self, target_bps: i32) -> i32 {
+        self.band_type
+            .effective_band_bps(target_bps, self.drift_band_bps, self.relative_factor_bps)
+    }
 }
 
 pub struct CategoryState {
@@ -76,10 +85,12 @@ pub trait RebalanceOptimizer: Send + Sync {
 pub struct DriftPriorityOptimizer;
 
 impl DriftPriorityOptimizer {
-    fn desired_bps_for_goal(target_bps: i32, goal: &RebalanceGoal, band: Decimal) -> Decimal {
+    fn desired_bps_for_goal(target_bps: i32, goal: &RebalanceGoal, band_bps: i32) -> Decimal {
         match goal {
             RebalanceGoal::ExactTarget => Decimal::from(target_bps),
-            RebalanceGoal::NearestBand => (Decimal::from(target_bps) - band).max(Decimal::ZERO),
+            RebalanceGoal::NearestBand => {
+                (Decimal::from(target_bps) - Decimal::from(band_bps)).max(Decimal::ZERO)
+            }
         }
     }
 
@@ -89,8 +100,7 @@ impl DriftPriorityOptimizer {
         values: &HashMap<String, Decimal>,
         categories: &[CategoryState],
         total_value: Decimal,
-        goal: &RebalanceGoal,
-        band: Decimal,
+        profile: &RebalanceProfile,
     ) -> Decimal {
         if candidate.price <= Decimal::ZERO || cash <= Decimal::ZERO {
             return Decimal::ZERO;
@@ -107,7 +117,9 @@ impl DriftPriorityOptimizer {
                 continue;
             }
 
-            let desired_bps = Self::desired_bps_for_goal(cat.target_bps, goal, band);
+            let band_bps = profile.effective_band_bps(cat.target_bps);
+            let desired_bps =
+                Self::desired_bps_for_goal(cat.target_bps, &profile.rebalance_goal, band_bps);
             let desired_value = desired_bps / scale * total_value;
             let base = values.get(&cat.category_id).copied().unwrap_or_default();
             if base < desired_value {
@@ -162,7 +174,6 @@ impl DriftPriorityOptimizer {
         categories: &[CategoryState],
         total_value: Decimal,
         profile: &RebalanceProfile,
-        drift_band: Decimal,
         sell_proceeds: Decimal,
         buy_amount: Decimal,
     ) -> Option<Decimal> {
@@ -179,40 +190,34 @@ impl DriftPriorityOptimizer {
 
         let current_cash: Decimal = required_cash.iter().map(|c| c.current_value).sum();
         let target_bps: i32 = required_cash.iter().map(|c| c.target_bps).sum();
+        let cash_band = Decimal::from(profile.effective_band_bps(target_bps));
         let stop_bps = match profile.rebalance_goal {
             RebalanceGoal::ExactTarget => Decimal::from(target_bps),
-            RebalanceGoal::NearestBand => (Decimal::from(target_bps) + drift_band).min(dec!(10000)),
+            RebalanceGoal::NearestBand => (Decimal::from(target_bps) + cash_band).min(dec!(10000)),
         };
         let stop_value = stop_bps / dec!(10000) * total_value;
 
         Some((current_cash + sell_proceeds - stop_value - buy_amount).max(Decimal::ZERO))
     }
 
-    /// Per-category drift the planner tries to minimise.
-    ///
-    /// `ExactTarget` measures distance to the exact target. `NearestBand` only counts
-    /// the distance *outside* the [target ± band] tolerance, so once a category is
-    /// inside its band it contributes zero and the greedy stops deploying into it.
     fn category_drift(
         bps: Decimal,
         target_bps: i32,
         goal: &RebalanceGoal,
-        band: Decimal,
+        band_bps: i32,
     ) -> Decimal {
         let dist = (bps - Decimal::from(target_bps)).abs();
         match goal {
             RebalanceGoal::ExactTarget => dist,
-            RebalanceGoal::NearestBand => (dist - band).max(Decimal::ZERO),
+            RebalanceGoal::NearestBand => (dist - Decimal::from(band_bps)).max(Decimal::ZERO),
         }
     }
 
-    /// Σ drift for required non-cash categories (band-aware via `category_drift`).
     fn total_drift(
         values: &HashMap<String, Decimal>,
         categories: &[CategoryState],
         total_value: Decimal,
-        goal: &RebalanceGoal,
-        band: Decimal,
+        profile: &RebalanceProfile,
     ) -> Decimal {
         if total_value == Decimal::ZERO {
             return Decimal::ZERO;
@@ -224,19 +229,18 @@ impl DriftPriorityOptimizer {
             .map(|c| {
                 let v = values.get(&c.category_id).copied().unwrap_or_default();
                 let bps = v / total_value * scale;
-                Self::category_drift(bps, c.target_bps, goal, band)
+                let band_bps = profile.effective_band_bps(c.target_bps);
+                Self::category_drift(bps, c.target_bps, &profile.rebalance_goal, band_bps)
             })
             .sum()
     }
 
-    /// Same as `total_drift` but adds `exposure` delta without mutating state.
     fn total_drift_with_buy(
         values: &HashMap<String, Decimal>,
         categories: &[CategoryState],
         total_value: Decimal,
         exposure: &HashMap<String, Decimal>,
-        goal: &RebalanceGoal,
-        band: Decimal,
+        profile: &RebalanceProfile,
     ) -> Decimal {
         if total_value == Decimal::ZERO {
             return Decimal::ZERO;
@@ -249,7 +253,8 @@ impl DriftPriorityOptimizer {
                 let base = values.get(&c.category_id).copied().unwrap_or_default();
                 let delta = exposure.get(&c.category_id).copied().unwrap_or_default();
                 let bps = (base + delta) / total_value * scale;
-                Self::category_drift(bps, c.target_bps, goal, band)
+                let band_bps = profile.effective_band_bps(c.target_bps);
+                Self::category_drift(bps, c.target_bps, &profile.rebalance_goal, band_bps)
             })
             .sum()
     }
@@ -262,10 +267,7 @@ impl DriftPriorityOptimizer {
         total_value: Decimal,
         categories: &[CategoryState],
         sell_candidates: &[SellCandidate],
-        goal: &RebalanceGoal,
-        drift_band: Decimal,
-        whole_shares_only: bool,
-        min_trade_amount: Decimal,
+        profile: &RebalanceProfile,
     ) -> (HashMap<String, Decimal>, Decimal, Vec<SuggestedManualTrade>) {
         if total_value == Decimal::ZERO || sell_candidates.is_empty() {
             return (values.clone(), Decimal::ZERO, vec![]);
@@ -279,8 +281,7 @@ impl DriftPriorityOptimizer {
         let mut shares_sold: Vec<Decimal> = vec![Decimal::ZERO; sell_candidates.len()];
 
         loop {
-            let drift_before =
-                Self::total_drift(&values, categories, total_value, goal, drift_band);
+            let drift_before = Self::total_drift(&values, categories, total_value, profile);
             if drift_before == Decimal::ZERO {
                 break;
             }
@@ -297,13 +298,12 @@ impl DriftPriorityOptimizer {
                     continue;
                 }
 
-                let sell_qty = if whole_shares_only {
+                let sell_qty = if profile.whole_shares_only {
                     if qty_remaining[idx] < Decimal::ONE {
                         continue;
                     }
                     Decimal::ONE
                 } else {
-                    // Cap fractional sell at the band edge for each exposed category
                     let mut max_shares = qty_remaining[idx];
                     for cat in categories.iter().filter(|c| c.is_required && !c.is_cash) {
                         let Some(expo) = candidate.exposure_per_share.get(&cat.category_id) else {
@@ -314,17 +314,14 @@ impl DriftPriorityOptimizer {
                         }
                         let current_v = values.get(&cat.category_id).copied().unwrap_or_default();
                         let current_bps = current_v / total_value * scale;
-                        // For NearestBand: stop at target + band (overweight edge)
-                        // For ExactTarget: stop at exact target
-                        let stop_bps = match goal {
+                        let cat_band = Decimal::from(profile.effective_band_bps(cat.target_bps));
+                        let stop_bps = match profile.rebalance_goal {
                             RebalanceGoal::ExactTarget => Decimal::from(cat.target_bps),
                             RebalanceGoal::NearestBand => {
-                                (Decimal::from(cat.target_bps) + drift_band).min(dec!(10000))
+                                (Decimal::from(cat.target_bps) + cat_band).min(dec!(10000))
                             }
                         };
                         if current_bps <= stop_bps {
-                            // This sleeve is not overweight — skip cap for it.
-                            // Let drift_before - drift_after reject net-bad sells.
                             continue;
                         }
                         let stop_value = stop_bps / scale * total_value;
@@ -340,7 +337,6 @@ impl DriftPriorityOptimizer {
                     continue;
                 }
 
-                // Simulate sell: subtract exposure from values
                 let neg_exposure: HashMap<String, Decimal> = candidate
                     .exposure_per_share
                     .iter()
@@ -351,8 +347,7 @@ impl DriftPriorityOptimizer {
                     categories,
                     total_value,
                     &neg_exposure,
-                    goal,
-                    drift_band,
+                    profile,
                 );
                 let improvement = drift_before - drift_after;
                 if improvement <= Decimal::ZERO {
@@ -375,8 +370,7 @@ impl DriftPriorityOptimizer {
             };
 
             let candidate = &sell_candidates[idx];
-            let batch = if whole_shares_only {
-                // Batch only when sole improving candidate
+            let batch = if profile.whole_shares_only {
                 let improving_count = sell_candidates
                     .iter()
                     .enumerate()
@@ -394,8 +388,7 @@ impl DriftPriorityOptimizer {
                             categories,
                             total_value,
                             &neg,
-                            goal,
-                            drift_band,
+                            profile,
                         );
                         (drift_before - da) > Decimal::ZERO
                     })
@@ -411,10 +404,11 @@ impl DriftPriorityOptimizer {
                             continue;
                         }
                         let current_v = values.get(&cat.category_id).copied().unwrap_or_default();
-                        let stop_bps = match goal {
+                        let cat_band = Decimal::from(profile.effective_band_bps(cat.target_bps));
+                        let stop_bps = match profile.rebalance_goal {
                             RebalanceGoal::ExactTarget => Decimal::from(cat.target_bps),
                             RebalanceGoal::NearestBand => {
-                                (Decimal::from(cat.target_bps) + drift_band).min(dec!(10000))
+                                (Decimal::from(cat.target_bps) + cat_band).min(dec!(10000))
                             }
                         };
                         let stop_value = stop_bps / dec!(10000) * total_value;
@@ -457,7 +451,9 @@ impl DriftPriorityOptimizer {
             }
 
             let estimated_amount = shares * candidate.price;
-            if min_trade_amount > Decimal::ZERO && estimated_amount < min_trade_amount {
+            if profile.min_trade_amount > Decimal::ZERO
+                && estimated_amount < profile.min_trade_amount
+            {
                 continue;
             }
 
@@ -598,15 +594,12 @@ impl DriftPriorityOptimizer {
         }
     }
 
-    /// Greedy buy loop. Mutates `values` and returns shares bought per candidate index.
-    #[allow(clippy::too_many_arguments)]
     fn run_buy_greedy(
         values: &mut HashMap<String, Decimal>,
         candidates: &[AssetCandidate],
         cash_pool: Decimal,
         categories: &[CategoryState],
         profile: &RebalanceProfile,
-        drift_band: Decimal,
         total_value: Decimal,
         scale: Decimal,
     ) -> Vec<Decimal> {
@@ -617,13 +610,7 @@ impl DriftPriorityOptimizer {
             if cash <= Decimal::ZERO {
                 break;
             }
-            let drift_before = Self::total_drift(
-                values,
-                categories,
-                total_value,
-                &profile.rebalance_goal,
-                drift_band,
-            );
+            let drift_before = Self::total_drift(values, categories, total_value, profile);
 
             let mut best_score = Decimal::ZERO;
             let mut best_idx: Option<usize> = None;
@@ -648,8 +635,7 @@ impl DriftPriorityOptimizer {
                             values,
                             categories,
                             total_value,
-                            &profile.rebalance_goal,
-                            drift_band,
+                            profile,
                         );
                         if shares <= Decimal::ZERO {
                             continue;
@@ -666,8 +652,7 @@ impl DriftPriorityOptimizer {
                     categories,
                     total_value,
                     &exposure_to_score,
-                    &profile.rebalance_goal,
-                    drift_band,
+                    profile,
                 );
                 let improvement = drift_before - drift_after;
                 if improvement <= Decimal::ZERO {
@@ -706,10 +691,11 @@ impl DriftPriorityOptimizer {
                     if *expo <= Decimal::ZERO {
                         continue;
                     }
+                    let cat_band_bps = profile.effective_band_bps(cat.target_bps);
                     let desired_bps = Self::desired_bps_for_goal(
                         cat.target_bps,
                         &profile.rebalance_goal,
-                        drift_band,
+                        cat_band_bps,
                     );
                     let desired_value = desired_bps / scale * total_value;
                     let base = values.get(&cat.category_id).copied().unwrap_or_default();
@@ -787,7 +773,6 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
         }
 
         let scale = dec!(10000);
-        let drift_band = Decimal::from(profile.drift_band_bps);
 
         let mut values: HashMap<String, Decimal> = categories
             .iter()
@@ -816,10 +801,7 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
                     total_value,
                     &categories,
                     &sell_candidates,
-                    &profile.rebalance_goal,
-                    drift_band,
-                    profile.whole_shares_only,
-                    profile.min_trade_amount,
+                    &profile,
                 );
                 values = updated_values;
                 (trades, proceeds)
@@ -840,12 +822,9 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
         // Track them so sleeve-level dollar trades can be added after the greedy.
         let mut no_candidate_categories: Vec<&CategoryState> = Vec::new();
         for cat in categories.iter().filter(|c| c.is_required && !c.is_cash) {
-            let desired_bps = match profile.rebalance_goal {
-                RebalanceGoal::ExactTarget => Decimal::from(cat.target_bps),
-                RebalanceGoal::NearestBand => {
-                    (Decimal::from(cat.target_bps) - drift_band).max(Decimal::ZERO)
-                }
-            };
+            let cat_band_bps = profile.effective_band_bps(cat.target_bps);
+            let desired_bps =
+                Self::desired_bps_for_goal(cat.target_bps, &profile.rebalance_goal, cat_band_bps);
             let desired_value = desired_bps / scale * total_value;
             if cat.current_value >= desired_value {
                 continue;
@@ -888,21 +867,16 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
 
         let shares_bought: Vec<Decimal> = match &scenario_mode {
             ScenarioMode::Hybrid => {
-                // Pass 1: buy with available_cash only.
                 let mut sb = Self::run_buy_greedy(
                     &mut values,
                     &candidates,
                     available_cash,
                     &categories,
                     &profile,
-                    drift_band,
                     total_value,
                     scale,
                 );
 
-                // Check if any required category is still overweight outside band
-                // in the post-cash-buy state. Cash cannot reduce overweight (only
-                // selling can), so this check is authoritative.
                 let still_overweight = categories
                     .iter()
                     .filter(|c| c.is_required && !c.is_cash)
@@ -912,46 +886,37 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
                         }
                         let v = values.get(&c.category_id).copied().unwrap_or_default();
                         let bps = v / total_value * scale;
+                        let cat_band = Decimal::from(profile.effective_band_bps(c.target_bps));
                         let threshold = match profile.rebalance_goal {
                             RebalanceGoal::ExactTarget => Decimal::from(c.target_bps),
                             RebalanceGoal::NearestBand => {
-                                (Decimal::from(c.target_bps) + drift_band).min(dec!(10000))
+                                (Decimal::from(c.target_bps) + cat_band).min(dec!(10000))
                             }
                         };
                         bps > threshold
                     });
 
                 if still_overweight && !sell_candidates.is_empty() {
-                    // Pass 2a: sell overweight on the post-cash-buy values.
                     let (updated_values, proceeds, extra_sell_trades) = Self::run_sell_phase(
                         &values,
                         total_value,
                         &categories,
                         &sell_candidates,
-                        &profile.rebalance_goal,
-                        drift_band,
-                        profile.whole_shares_only,
-                        profile.min_trade_amount,
+                        &profile,
                     );
                     values = updated_values;
-                    // Merge sell trades into sell_trades (already empty for Hybrid first pass).
-                    // We reassign the outer sell_trades/sell_proceeds below by reconstructing.
-                    // Pass 2b: buy with proceeds from the hybrid sell.
                     let sb2 = Self::run_buy_greedy(
                         &mut values,
                         &candidates,
                         proceeds,
                         &categories,
                         &profile,
-                        drift_band,
                         total_value,
                         scale,
                     );
-                    // Accumulate shares and merge sell trades.
                     for (i, s) in sb2.into_iter().enumerate() {
                         sb[i] += s;
                     }
-                    // Prepend the hybrid sell trades (before buy trades at output).
                     sell_trades = extra_sell_trades;
                     sell_proceeds = proceeds;
                 }
@@ -964,15 +929,11 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
                 buy_pool,
                 &categories,
                 &profile,
-                drift_band,
                 total_value,
                 scale,
             ),
         };
 
-        // Proportional top-up: deploy remaining cash proportionally to target_bps.
-        // Skipped for SellToRebalance (proceeds left over stay as cash_remaining to avoid
-        // circular sell→rebuy patterns).
         let mut shares_bought = shares_bought;
         if !matches!(scenario_mode, ScenarioMode::SellToRebalance) {
             let topup_pool = match &scenario_mode {
@@ -989,7 +950,6 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
                 &categories,
                 total_value,
                 &profile,
-                drift_band,
                 sell_proceeds,
                 greedy_used,
             ) {
@@ -1068,8 +1028,9 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
             if manual_cash <= Decimal::ZERO {
                 break;
             }
+            let cat_band_bps = profile.effective_band_bps(cat.target_bps);
             let desired_bps =
-                Self::desired_bps_for_goal(cat.target_bps, &profile.rebalance_goal, drift_band);
+                Self::desired_bps_for_goal(cat.target_bps, &profile.rebalance_goal, cat_band_bps);
             let shortfall =
                 ((desired_bps / scale * total_value) - cat.current_value).max(Decimal::ZERO);
             let amount = shortfall.min(manual_cash);
@@ -1212,15 +1173,21 @@ mod tests {
             exposure_per_share: HashMap::from([("bond".to_string(), dec!(100))]),
         }];
 
+        let profile = RebalanceProfile {
+            target_id: "test".to_string(),
+            drift_band_bps: 500,
+            band_type: BandType::Absolute,
+            relative_factor_bps: 2000,
+            rebalance_goal: RebalanceGoal::ExactTarget,
+            min_trade_amount: dec!(500),
+            whole_shares_only: false,
+        };
         let (updated_values, proceeds, trades) = DriftPriorityOptimizer::run_sell_phase(
             &values,
             dec!(10000),
             &categories,
             &sell_candidates,
-            &RebalanceGoal::ExactTarget,
-            dec!(500),
-            false,
-            dec!(500),
+            &profile,
         );
 
         assert!(trades.is_empty(), "sub-minimum sell should be filtered");

--- a/crates/core/src/portfolio/allocation_targets/optimizer.rs
+++ b/crates/core/src/portfolio/allocation_targets/optimizer.rs
@@ -1198,4 +1198,112 @@ mod tests {
             "filtered sells must not alter the state used by the buy phase"
         );
     }
+
+    fn make_two_sleeve_input(band_type: BandType) -> RebalanceInput {
+        // EQUITY 60% target, currently 68% (overweight +800 bps)
+        // BOND   40% target, currently 32% (underweight -800 bps)
+        // Cash: $500. Band floor: 500 bps. Relative factor: 20%.
+        //
+        // Absolute effective bands: EQUITY=500, BOND=500
+        //   → BOND desired = 4000-500 = 3500 bps, current 3200 → greedy buys BOND first
+        //
+        // Hybrid effective bands: EQUITY=max(6000*20%,500)=1200, BOND=max(4000*20%,500)=800
+        //   → BOND desired = 4000-800 = 3200 bps, current 3200 → already at desired
+        //   → greedy has nothing to do, all cash goes to proportional top-up
+        RebalanceInput {
+            profile: RebalanceProfile {
+                target_id: "test".to_string(),
+                drift_band_bps: 500,
+                band_type,
+                relative_factor_bps: 2000,
+                rebalance_goal: RebalanceGoal::NearestBand,
+                min_trade_amount: Decimal::ZERO,
+                whole_shares_only: false,
+            },
+            scenario_mode: ScenarioMode::CashFlowOnly,
+            available_cash: dec!(500),
+            total_value: dec!(10000),
+            categories: vec![
+                CategoryState {
+                    category_id: "equity".to_string(),
+                    category_name: "Equity".to_string(),
+                    target_bps: 6000,
+                    current_value: dec!(6800),
+                    is_cash: false,
+                    is_required: true,
+                },
+                CategoryState {
+                    category_id: "bond".to_string(),
+                    category_name: "Bond".to_string(),
+                    target_bps: 4000,
+                    current_value: dec!(3200),
+                    is_cash: false,
+                    is_required: true,
+                },
+            ],
+            candidates: vec![
+                AssetCandidate {
+                    holding_id: "h-vti".to_string(),
+                    asset_id: "a-vti".to_string(),
+                    symbol: "VTI".to_string(),
+                    name: Some("Vanguard Total Stock".to_string()),
+                    price: dec!(50),
+                    exposure_per_share: HashMap::from([("equity".to_string(), dec!(50))]),
+                },
+                AssetCandidate {
+                    holding_id: "h-bnd".to_string(),
+                    asset_id: "a-bnd".to_string(),
+                    symbol: "BND".to_string(),
+                    name: Some("Vanguard Total Bond".to_string()),
+                    price: dec!(50),
+                    exposure_per_share: HashMap::from([("bond".to_string(), dec!(50))]),
+                },
+            ],
+            sell_candidates: vec![],
+            warnings: vec![],
+        }
+    }
+
+    fn buy_amount_for(plan: &RebalancePlan, symbol: &str) -> Decimal {
+        plan.trades
+            .iter()
+            .filter(|t| t.action == "buy" && t.symbol.as_deref() == Some(symbol))
+            .map(|t| t.estimated_amount)
+            .sum()
+    }
+
+    #[test]
+    fn hybrid_vs_absolute_produces_different_trade_allocation() {
+        let optimizer = DriftPriorityOptimizer;
+
+        let abs_plan = optimizer
+            .plan(make_two_sleeve_input(BandType::Absolute))
+            .unwrap();
+        let hyb_plan = optimizer
+            .plan(make_two_sleeve_input(BandType::Hybrid))
+            .unwrap();
+
+        let abs_bnd = buy_amount_for(&abs_plan, "BND");
+        let abs_vti = buy_amount_for(&abs_plan, "VTI");
+        let hyb_bnd = buy_amount_for(&hyb_plan, "BND");
+        let hyb_vti = buy_amount_for(&hyb_plan, "VTI");
+
+        // Absolute: BOND is underweight outside band → greedy prioritizes BND
+        assert!(
+            abs_bnd > abs_vti,
+            "absolute should buy more BND ({abs_bnd}) than VTI ({abs_vti})"
+        );
+
+        // Hybrid: BOND is at desired level → proportional top-up favors larger-weight EQUITY
+        assert!(
+            hyb_vti > hyb_bnd,
+            "hybrid should buy more VTI ({hyb_vti}) than BND ({hyb_bnd})"
+        );
+
+        // Both use all available cash
+        let abs_total = abs_bnd + abs_vti;
+        let hyb_total = hyb_bnd + hyb_vti;
+        assert!(abs_total > Decimal::ZERO);
+        assert!(hyb_total > Decimal::ZERO);
+    }
 }

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -410,6 +410,8 @@ impl RebalanceServiceTrait for RebalanceService {
             profile: RebalanceProfile {
                 target_id: input.target_id.clone(),
                 drift_band_bps: profile.drift_band_bps,
+                band_type: profile.band_type.clone(),
+                relative_factor_bps: profile.relative_factor_bps,
                 rebalance_goal: profile.rebalance_goal.clone(),
                 min_trade_amount: Decimal::from_str(&profile.min_trade_amount)
                     .unwrap_or(Decimal::ZERO),
@@ -438,7 +440,7 @@ mod tests {
         TaxonomyHoldingContributions,
     };
     use crate::portfolio::allocation_targets::{
-        AllocationTarget, AllocationTargetWeight, DriftReport, DriftRow, DriftStatus,
+        AllocationTarget, AllocationTargetWeight, BandType, DriftReport, DriftRow, DriftStatus,
         NewAllocationTarget, NewAllocationTargetWeight, RebalanceGoal, ScenarioMode, ScopeType,
         TriggerType,
     };
@@ -456,6 +458,8 @@ mod tests {
             taxonomy_id: "asset_classes".to_string(),
             trigger_type: TriggerType::Threshold,
             drift_band_bps: 500,
+            band_type: BandType::Absolute,
+            relative_factor_bps: 2000,
             rebalance_goal,
             min_trade_amount: "0".to_string(),
             whole_shares_only,
@@ -493,6 +497,7 @@ mod tests {
             current_value,
             target_value,
             value_delta,
+            effective_band_bps: 500,
             status,
             is_required: true,
             is_zero_current: current_bps == 0,

--- a/crates/core/src/portfolio/allocation_targets/target_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/target_service.rs
@@ -8,8 +8,8 @@ use crate::errors::{Error as CoreError, Result as CoreResult, ValidationError};
 use crate::taxonomies::{Category, TaxonomyServiceTrait};
 
 use super::model::{
-    AllocationTarget, AllocationTargetWeight, NewAllocationTarget, NewAllocationTargetWeight,
-    RebalanceGoal, SaveAllocationTargetResult,
+    AllocationTarget, AllocationTargetWeight, BandType, NewAllocationTarget,
+    NewAllocationTargetWeight, RebalanceGoal, SaveAllocationTargetResult,
 };
 use super::validation::{validate_new_target, validate_weights_sum};
 
@@ -188,6 +188,14 @@ impl AllocationTargetService {
             taxonomy_id: input.taxonomy_id,
             trigger_type: input.trigger_type,
             drift_band_bps: input.drift_band_bps,
+            band_type: input
+                .band_type
+                .or_else(|| existing.as_ref().map(|target| target.band_type.clone()))
+                .unwrap_or(BandType::Absolute),
+            relative_factor_bps: input
+                .relative_factor_bps
+                .or_else(|| existing.as_ref().map(|target| target.relative_factor_bps))
+                .unwrap_or(2000),
             rebalance_goal: input
                 .rebalance_goal
                 .or_else(|| {
@@ -271,6 +279,8 @@ impl AllocationTargetServiceTrait for AllocationTargetService {
             taxonomy_id: input.taxonomy_id,
             trigger_type: input.trigger_type,
             drift_band_bps: input.drift_band_bps,
+            band_type: input.band_type.unwrap_or(BandType::Absolute),
+            relative_factor_bps: input.relative_factor_bps.unwrap_or(2000),
             rebalance_goal: input.rebalance_goal.unwrap_or(RebalanceGoal::NearestBand),
             min_trade_amount: input.min_trade_amount.unwrap_or_else(|| "0".to_string()),
             whole_shares_only: input.whole_shares_only.unwrap_or(false),
@@ -311,6 +321,10 @@ impl AllocationTargetServiceTrait for AllocationTargetService {
             taxonomy_id: input.taxonomy_id,
             trigger_type: input.trigger_type,
             drift_band_bps: input.drift_band_bps,
+            band_type: input.band_type.unwrap_or(existing.band_type),
+            relative_factor_bps: input
+                .relative_factor_bps
+                .unwrap_or(existing.relative_factor_bps),
             rebalance_goal: input.rebalance_goal.unwrap_or(existing.rebalance_goal),
             min_trade_amount: input.min_trade_amount.unwrap_or(existing.min_trade_amount),
             whole_shares_only: input
@@ -460,6 +474,8 @@ mod tests {
             taxonomy_id: taxonomy_id.to_string(),
             trigger_type: TriggerType::Threshold,
             drift_band_bps: 500,
+            band_type: BandType::Absolute,
+            relative_factor_bps: 2000,
             rebalance_goal: RebalanceGoal::NearestBand,
             min_trade_amount: "0".to_string(),
             whole_shares_only: false,
@@ -478,6 +494,8 @@ mod tests {
             taxonomy_id: taxonomy_id.to_string(),
             trigger_type: TriggerType::Threshold,
             drift_band_bps: 500,
+            band_type: None,
+            relative_factor_bps: None,
             rebalance_goal: Some(RebalanceGoal::NearestBand),
             min_trade_amount: Some("0".to_string()),
             whole_shares_only: Some(false),

--- a/crates/core/src/portfolio/allocation_targets/target_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/target_service.rs
@@ -191,7 +191,7 @@ impl AllocationTargetService {
             band_type: input
                 .band_type
                 .or_else(|| existing.as_ref().map(|target| target.band_type.clone()))
-                .unwrap_or(BandType::Absolute),
+                .unwrap_or(BandType::Hybrid),
             relative_factor_bps: input
                 .relative_factor_bps
                 .or_else(|| existing.as_ref().map(|target| target.relative_factor_bps))
@@ -279,7 +279,9 @@ impl AllocationTargetServiceTrait for AllocationTargetService {
             taxonomy_id: input.taxonomy_id,
             trigger_type: input.trigger_type,
             drift_band_bps: input.drift_band_bps,
-            band_type: input.band_type.unwrap_or(BandType::Absolute),
+            // New targets default to Hybrid (#1070). Existing DB rows
+            // keep Absolute via migration; updates preserve the saved value.
+            band_type: input.band_type.unwrap_or(BandType::Hybrid),
             relative_factor_bps: input.relative_factor_bps.unwrap_or(2000),
             rebalance_goal: input.rebalance_goal.unwrap_or(RebalanceGoal::NearestBand),
             min_trade_amount: input.min_trade_amount.unwrap_or_else(|| "0".to_string()),
@@ -802,5 +804,42 @@ mod tests {
 
         assert_eq!(updated.taxonomy_id, "asset_classes");
         assert_eq!(updated.name, "Updated target");
+    }
+
+    #[tokio::test]
+    async fn create_target_defaults_band_type_to_hybrid_when_omitted() {
+        let service = AllocationTargetService::new(
+            Arc::new(MockAllocationTargetRepository {
+                target: target("asset_classes"),
+                weights: vec![saved_weight("asset_classes")],
+            }),
+            Arc::new(MockTaxonomyService),
+        );
+
+        let mut input = target_input("asset_classes");
+        input.band_type = None;
+
+        let created = service.create_target(input).await.unwrap();
+        assert_eq!(created.band_type, BandType::Hybrid);
+    }
+
+    #[tokio::test]
+    async fn update_target_preserves_existing_band_type_when_omitted() {
+        let mut existing = target("asset_classes");
+        existing.band_type = BandType::Hybrid;
+
+        let service = AllocationTargetService::new(
+            Arc::new(MockAllocationTargetRepository {
+                target: existing,
+                weights: vec![saved_weight("asset_classes")],
+            }),
+            Arc::new(MockTaxonomyService),
+        );
+
+        let mut input = target_input("asset_classes");
+        input.band_type = None;
+
+        let updated = service.update_target("target-1", input).await.unwrap();
+        assert_eq!(updated.band_type, BandType::Hybrid);
     }
 }

--- a/crates/core/src/portfolio/allocation_targets/validation.rs
+++ b/crates/core/src/portfolio/allocation_targets/validation.rs
@@ -22,6 +22,11 @@ pub fn validate_new_target(input: &NewAllocationTarget) -> CoreResult<()> {
     if input.drift_band_bps < 0 || input.drift_band_bps > 10000 {
         return Err(invalid("drift_band_bps must be between 0 and 10000"));
     }
+    if let Some(factor) = input.relative_factor_bps {
+        if factor < 0 || factor > 10000 {
+            return Err(invalid("relative_factor_bps must be between 0 and 10000"));
+        }
+    }
     if let Some(min_trade_amount) = &input.min_trade_amount {
         let amount = min_trade_amount
             .parse::<Decimal>()
@@ -71,6 +76,8 @@ mod tests {
             taxonomy_id: "asset_classes".to_string(),
             trigger_type: TriggerType::Threshold,
             drift_band_bps: 500,
+            band_type: None,
+            relative_factor_bps: None,
             rebalance_goal: None,
             min_trade_amount: None,
             whole_shares_only: None,
@@ -171,6 +178,38 @@ mod tests {
     fn weights_negative_bps_rejected() {
         let weights = vec![weight("EQUITY", -100), weight("FIXED_INCOME", 10100)];
         assert!(validate_weights_sum(&weights).is_err());
+    }
+
+    #[test]
+    fn relative_factor_bps_out_of_range_rejected() {
+        let p = NewAllocationTarget {
+            relative_factor_bps: Some(10001),
+            ..base_target("p")
+        };
+        assert!(validate_new_target(&p).is_err());
+    }
+
+    #[test]
+    fn relative_factor_bps_negative_rejected() {
+        let p = NewAllocationTarget {
+            relative_factor_bps: Some(-1),
+            ..base_target("p")
+        };
+        assert!(validate_new_target(&p).is_err());
+    }
+
+    #[test]
+    fn relative_factor_bps_valid_passes() {
+        let p = NewAllocationTarget {
+            relative_factor_bps: Some(2000),
+            ..base_target("p")
+        };
+        assert!(validate_new_target(&p).is_ok());
+    }
+
+    #[test]
+    fn relative_factor_bps_none_passes() {
+        assert!(validate_new_target(&base_target("p")).is_ok());
     }
 
     #[test]

--- a/crates/core/src/portfolio/allocation_targets/validation.rs
+++ b/crates/core/src/portfolio/allocation_targets/validation.rs
@@ -23,7 +23,7 @@ pub fn validate_new_target(input: &NewAllocationTarget) -> CoreResult<()> {
         return Err(invalid("drift_band_bps must be between 0 and 10000"));
     }
     if let Some(factor) = input.relative_factor_bps {
-        if factor < 0 || factor > 10000 {
+        if !(0..=10000).contains(&factor) {
             return Err(invalid("relative_factor_bps must be between 0 and 10000"));
         }
     }

--- a/crates/storage-sqlite/migrations/2026-06-22-000001_hybrid_drift_bands/down.sql
+++ b/crates/storage-sqlite/migrations/2026-06-22-000001_hybrid_drift_bands/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE allocation_targets DROP COLUMN band_type;
+ALTER TABLE allocation_targets DROP COLUMN relative_factor_bps;

--- a/crates/storage-sqlite/migrations/2026-06-22-000001_hybrid_drift_bands/up.sql
+++ b/crates/storage-sqlite/migrations/2026-06-22-000001_hybrid_drift_bands/up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE allocation_targets
+  ADD COLUMN band_type TEXT NOT NULL DEFAULT 'absolute'
+      CHECK (band_type IN ('absolute', 'hybrid'));
+
+ALTER TABLE allocation_targets
+  ADD COLUMN relative_factor_bps INTEGER NOT NULL DEFAULT 2000
+      CHECK (relative_factor_bps >= 0 AND relative_factor_bps <= 10000);

--- a/crates/storage-sqlite/src/portfolio/allocation_targets/model.rs
+++ b/crates/storage-sqlite/src/portfolio/allocation_targets/model.rs
@@ -1,7 +1,7 @@
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
 use wealthfolio_core::portfolio::allocation_targets::{
-    AllocationTarget, AllocationTargetWeight, RebalanceGoal, ScopeType, TriggerType,
+    AllocationTarget, AllocationTargetWeight, BandType, RebalanceGoal, ScopeType, TriggerType,
 };
 
 #[derive(Debug, Clone, Queryable, Insertable, AsChangeset, Serialize, Deserialize)]
@@ -14,6 +14,8 @@ pub struct AllocationTargetDB {
     pub taxonomy_id: String,
     pub trigger_type: String,
     pub drift_band_bps: i32,
+    pub band_type: String,
+    pub relative_factor_bps: i32,
     pub rebalance_goal: String,
     pub min_trade_amount: String,
     pub whole_shares_only: i32,
@@ -33,6 +35,8 @@ impl From<AllocationTarget> for AllocationTargetDB {
             taxonomy_id: target.taxonomy_id,
             trigger_type: target.trigger_type.as_str().to_string(),
             drift_band_bps: target.drift_band_bps,
+            band_type: target.band_type.as_str().to_string(),
+            relative_factor_bps: target.relative_factor_bps,
             rebalance_goal: target.rebalance_goal.as_str().to_string(),
             min_trade_amount: target.min_trade_amount,
             whole_shares_only: target.whole_shares_only as i32,
@@ -55,6 +59,8 @@ impl TryFrom<AllocationTargetDB> for AllocationTarget {
             taxonomy_id: db.taxonomy_id,
             trigger_type: TriggerType::try_from(db.trigger_type.as_str())?,
             drift_band_bps: db.drift_band_bps,
+            band_type: BandType::try_from(db.band_type.as_str())?,
+            relative_factor_bps: db.relative_factor_bps,
             rebalance_goal: RebalanceGoal::try_from(db.rebalance_goal.as_str())?,
             min_trade_amount: db.min_trade_amount,
             whole_shares_only: db.whole_shares_only != 0,

--- a/crates/storage-sqlite/src/portfolio/allocation_targets/repository.rs
+++ b/crates/storage-sqlite/src/portfolio/allocation_targets/repository.rs
@@ -311,7 +311,9 @@ mod tests {
     use crate::taxonomies::TaxonomyRepository;
     use diesel::dsl::count_star;
     use tempfile::tempdir;
-    use wealthfolio_core::portfolio::allocation_targets::{RebalanceGoal, ScopeType, TriggerType};
+    use wealthfolio_core::portfolio::allocation_targets::{
+        BandType, RebalanceGoal, ScopeType, TriggerType,
+    };
     use wealthfolio_core::taxonomies::TaxonomyRepositoryTrait;
 
     fn setup_repos() -> (AllocationTargetRepository, TaxonomyRepository) {
@@ -344,6 +346,8 @@ mod tests {
             taxonomy_id: taxonomy_id.to_string(),
             trigger_type: TriggerType::Threshold,
             drift_band_bps: 500,
+            band_type: BandType::Absolute,
+            relative_factor_bps: 2000,
             rebalance_goal: RebalanceGoal::NearestBand,
             min_trade_amount: "0".to_string(),
             whole_shares_only: false,

--- a/crates/storage-sqlite/src/schema.rs
+++ b/crates/storage-sqlite/src/schema.rs
@@ -725,6 +725,8 @@ diesel::table! {
         taxonomy_id -> Text,
         trigger_type -> Text,
         drift_band_bps -> Integer,
+        band_type -> Text,
+        relative_factor_bps -> Integer,
         rebalance_goal -> Text,
         min_trade_amount -> Text,
         whole_shares_only -> Integer,


### PR DESCRIPTION
Hey @afadil 👋

Following up on the agreed direction from PR #1070 — this implements hybrid drift bands as discussed.

## What this does

Absolute bands apply the same fixed tolerance to every sleeve, which under-corrects small sleeves and over-corrects large ones (a 5% target sleeve under a ±5% band can double to 10% without triggering). Hybrid bands scale tolerance to each sleeve's target weight with an absolute floor.

**Per-sleeve effective band:**
```
band = max(target_bps × relative_factor, absolute_floor)
```

**Defaults (from our discussion):** 20% relative factor + 100 bps (1%) absolute floor. Existing targets keep absolute behavior unchanged — no silent migration.

### Example with hybrid 20% / 1% floor

| Sleeve target | Relative term | Floor | Effective band | In-band range |
|---|---|---|---|---|
| 50% | ±10% | 1% | ±10% | 40–60% |
| 10% | ±2% | 1% | ±2% | 8–12% |
| 1% | ±0.2% | 1% | ±1% | 0–2% |

## Changes

**Backend (Rust):**
- Migration: `band_type` (absolute/hybrid) + `relative_factor_bps` on `allocation_targets`
- `BandType` enum with `effective_band_bps()` — central computation, used everywhere
- DriftService: per-sleeve band for status (InBand/Overweight/Underweight) + `effective_band_bps` on DriftRow
- Optimizer: refactored from a single global band to per-category band through `RebalanceProfile`
- Validation: `relative_factor_bps` bounded 0–10000
- 13 new tests covering BandType unit, drift service hybrid scenarios, validation

**Frontend (React):**
- `BandType` + `relativeFactorBps` + `effectiveBandBps` in TS types
- New "Drift tolerance" section (step 3) with hybrid/absolute toggle using `AnimatedToggleGroup`
- Smart defaults on toggle: absolute→hybrid resets to 20%+1%, hybrid→absolute resets to 5%
- Separate from rebalance settings (drift tolerance is about monitoring, not rebalancing)

## Test plan

- [ ] Existing targets load as `absolute` with unchanged band values
- [ ] New targets default to `hybrid` (20% relative, 1% floor)
- [ ] Toggle between absolute↔hybrid applies smart defaults
- [ ] Save hybrid target, reload → values persist
- [ ] Drift status changes correctly between modes (small sleeve more sensitive in hybrid)
- [ ] Rebalance plan output differs between absolute and hybrid for same portfolio
- [ ] 84 Rust tests pass (`cargo test -p wealthfolio-core -- allocation_targets`)


## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).