### PR TITLE
Raise symbol length cap to 100 chars (#1145)

### DIFF
--- a/apps/frontend/src/components/create-custom-asset-dialog.tsx
+++ b/apps/frontend/src/components/create-custom-asset-dialog.tsx
@@ -44,7 +44,7 @@ const customAssetSchema = z.object({
   symbol: z
     .string()
     .min(1, "Symbol is required")
-    .max(20, "Symbol must be 20 characters or less")
+    .max(100, "Symbol must be 100 characters or less")
     .transform((val) => val.toUpperCase().trim()),
   name: z.string().min(1, "Name is required").max(100, "Name must be 100 characters or less"),
   assetType: z.enum(["EQUITY", "CRYPTO", "BOND", "OPTION", "METAL", "OTHER"]),

--- a/apps/frontend/src/lib/schemas.ts
+++ b/apps/frontend/src/lib/schemas.ts
@@ -179,7 +179,7 @@ export const importActivitySchema = z
       .refine(
         (val) => {
           if (!val || val.trim() === "") return true;
-          return /^(CASH:[A-Z]{3}|[A-Z0-9]{1,21}([.-][A-Z0-9]+){0,2})$/.test(val.trim());
+          return /^(CASH:[A-Z]{3}|[A-Z0-9_]{1,100}([.-][A-Z0-9]+){0,2})$/.test(val.trim());
         },
         { message: "Invalid symbol format" },
       ),

--- a/apps/frontend/src/lib/schemas.ts
+++ b/apps/frontend/src/lib/schemas.ts
@@ -179,7 +179,7 @@ export const importActivitySchema = z
       .refine(
         (val) => {
           if (!val || val.trim() === "") return true;
-          return /^(CASH:[A-Z]{3}|[A-Z0-9_]{1,100}([.-][A-Z0-9]+){0,2})$/.test(val.trim());
+          return /^(?=.{1,100}$)(CASH:[A-Z]{3}|[A-Z0-9_]+([.-][A-Z0-9]+){0,2})$/.test(val.trim());
         },
         { message: "Invalid symbol format" },
       ),

--- a/apps/frontend/src/lib/schemas.ts
+++ b/apps/frontend/src/lib/schemas.ts
@@ -179,7 +179,7 @@ export const importActivitySchema = z
       .refine(
         (val) => {
           if (!val || val.trim() === "") return true;
-          return /^(?=.{1,100}$)(CASH:[A-Z]{3}|[A-Z0-9_]+([.-][A-Z0-9]+){0,2})$/.test(val.trim());
+          return /^(?=.{1,100}$)(CASH:[A-Z]{3}|[A-Z0-9_]+([.-][A-Z0-9_]+){0,2})$/.test(val.trim());
         },
         { message: "Invalid symbol format" },
       ),

--- a/apps/frontend/src/pages/activity/import/utils/validation-utils.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/validation-utils.test.ts
@@ -4,10 +4,39 @@ import {
   validateActivityImport,
   normalizeNumericValue,
   parseAndAbsoluteValue,
+  validateTickerSymbol,
 } from "./validation-utils";
 import { ImportFormat, ActivityType, ImportType } from "@/lib/types";
 
 describe("validation-utils", () => {
+  describe("validateTickerSymbol (length)", () => {
+    it("accepts common ticker formats", () => {
+      expect(validateTickerSymbol("AAPL")).toBe(true);
+      expect(validateTickerSymbol("CASH:USD")).toBe(true);
+      expect(validateTickerSymbol("BRK.B")).toBe(true);
+    });
+
+    it("accepts symbols longer than the old 20/21 cap (issue #1145)", () => {
+      expect(validateTickerSymbol("A".repeat(21))).toBe(true);
+      expect(validateTickerSymbol("A".repeat(50))).toBe(true);
+      expect(validateTickerSymbol("A".repeat(100))).toBe(true);
+    });
+
+    it("still rejects symbols beyond the 100-char bound", () => {
+      expect(validateTickerSymbol("A".repeat(101))).toBe(false);
+    });
+
+    it("accepts underscores used by custom-provider symbols", () => {
+      expect(validateTickerSymbol("GOLD_KRUGERRAND")).toBe(true);
+      expect(validateTickerSymbol("XAU_1OZ")).toBe(true);
+    });
+
+    it("still rejects free-text/whitespace garbage", () => {
+      expect(validateTickerSymbol("bad symbol")).toBe(false);
+      expect(validateTickerSymbol("Some Company Inc.")).toBe(false);
+    });
+  });
+
   describe("normalizeNumericValue", () => {
     it("should handle currency symbols", () => {
       expect(normalizeNumericValue("$48.945")).toBe(48.945);

--- a/apps/frontend/src/pages/activity/import/utils/validation-utils.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/validation-utils.test.ts
@@ -26,6 +26,12 @@ describe("validation-utils", () => {
       expect(validateTickerSymbol("A".repeat(101))).toBe(false);
     });
 
+    it("bounds the full symbol, not just the first segment", () => {
+      // The 100-char limit must apply to the whole symbol including suffixes.
+      expect(validateTickerSymbol("A".repeat(100) + ".B")).toBe(false);
+      expect(validateTickerSymbol("A".repeat(98) + "-" + "B".repeat(50))).toBe(false);
+    });
+
     it("accepts underscores used by custom-provider symbols", () => {
       expect(validateTickerSymbol("GOLD_KRUGERRAND")).toBe(true);
       expect(validateTickerSymbol("XAU_1OZ")).toBe(true);

--- a/apps/frontend/src/pages/activity/import/utils/validation-utils.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/validation-utils.test.ts
@@ -35,6 +35,9 @@ describe("validation-utils", () => {
     it("accepts underscores used by custom-provider symbols", () => {
       expect(validateTickerSymbol("GOLD_KRUGERRAND")).toBe(true);
       expect(validateTickerSymbol("XAU_1OZ")).toBe(true);
+      // underscores are allowed in suffix segments too, not just the first token
+      expect(validateTickerSymbol("FUND.CLASS_A")).toBe(true);
+      expect(validateTickerSymbol("ABC-DEF_GHI")).toBe(true);
     });
 
     it("still rejects free-text/whitespace garbage", () => {

--- a/apps/frontend/src/pages/activity/import/utils/validation-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/validation-utils.ts
@@ -16,7 +16,7 @@ import { findMappedActivityType } from "./activity-type-mapping";
 import { normalizeInstrumentType, splitInstrumentPrefixedSymbol } from "./instrument-type";
 
 // Ticker symbol validation regex
-const tickerRegex = /^(CASH:[A-Z]{3}|[A-Z0-9]{1,21}([.-][A-Z0-9]+){0,2})$/;
+const tickerRegex = /^(CASH:[A-Z]{3}|[A-Z0-9_]{1,100}([.-][A-Z0-9]+){0,2})$/;
 
 // CUSIP: 9 alphanumeric chars ending in a digit
 const cusipRegex = /^[A-Z0-9]{8}\d$/;

--- a/apps/frontend/src/pages/activity/import/utils/validation-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/validation-utils.ts
@@ -15,8 +15,8 @@ import { looksLikeIsin } from "@/lib/isin";
 import { findMappedActivityType } from "./activity-type-mapping";
 import { normalizeInstrumentType, splitInstrumentPrefixedSymbol } from "./instrument-type";
 
-// Ticker symbol validation regex
-const tickerRegex = /^(CASH:[A-Z]{3}|[A-Z0-9_]{1,100}([.-][A-Z0-9]+){0,2})$/;
+// Ticker symbol validation regex (full symbol bounded to 100 chars via the leading lookahead)
+const tickerRegex = /^(?=.{1,100}$)(CASH:[A-Z]{3}|[A-Z0-9_]+([.-][A-Z0-9]+){0,2})$/;
 
 // CUSIP: 9 alphanumeric chars ending in a digit
 const cusipRegex = /^[A-Z0-9]{8}\d$/;

--- a/apps/frontend/src/pages/activity/import/utils/validation-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/validation-utils.ts
@@ -16,7 +16,7 @@ import { findMappedActivityType } from "./activity-type-mapping";
 import { normalizeInstrumentType, splitInstrumentPrefixedSymbol } from "./instrument-type";
 
 // Ticker symbol validation regex (full symbol bounded to 100 chars via the leading lookahead)
-const tickerRegex = /^(?=.{1,100}$)(CASH:[A-Z]{3}|[A-Z0-9_]+([.-][A-Z0-9]+){0,2})$/;
+const tickerRegex = /^(?=.{1,100}$)(CASH:[A-Z]{3}|[A-Z0-9_]+([.-][A-Z0-9_]+){0,2})$/;
 
 // CUSIP: 9 alphanumeric chars ending in a digit
 const cusipRegex = /^[A-Z0-9]{8}\d$/;

--- a/apps/frontend/src/pages/asset/create-security-dialog.tsx
+++ b/apps/frontend/src/pages/asset/create-security-dialog.tsx
@@ -77,7 +77,7 @@ const createSecuritySchema = z.object({
   symbol: z
     .string()
     .min(1, "Symbol is required")
-    .max(20, "Symbol must be 20 characters or less")
+    .max(100, "Symbol must be 100 characters or less")
     .transform((val) => val.toUpperCase().trim()),
   name: z.string().min(1, "Name is required").max(100, "Name must be 100 characters or less"),
   instrumentType: z.string().min(1, "Instrument type is required"),


### PR DESCRIPTION
## Description

Fixes #1145.

The security/asset **symbol** field was capped at **20 characters** in the
create dialogs, which blocked users with custom data providers (e.g. tracking
metal coins) from entering longer symbols. The backend and SQLite schema are
unconstrained (`TEXT`), so this was a purely client-side restriction — and it
was applied inconsistently across the entry points.

### What changed
- **Raise the cap 20 → 100** in both `createSecuritySchema`
  (`create-security-dialog.tsx`) and `customAssetSchema`
  (`create-custom-asset-dialog.tsx`). The custom-asset dialog is also the one
  reused by the "Create custom (manual)" flow inside activity entry, so this
  covers that path too.
- **Raise the CSV import ticker bound `{1,21}` → `{1,100}`** in both copies of
  the regex (`importActivitySchema` refine in `lib/schemas.ts` and
  `tickerRegex` in `import/utils/validation-utils.ts`) so manual entry and CSV
  import stay consistent.
- **Allow underscore** (`[A-Z0-9]` → `[A-Z0-9_]`) in the import ticker regex so
  custom-provider symbols like `GOLD_KRUGERRAND` aren't needlessly flagged for
  mapping. Free-text/whitespace garbage (the column-misalignment guard) is
  still rejected.
- **Tests**: added boundary (21/50/100 accepted, 101 rejected) and char-set
  (underscore accepted, free-text rejected) cases for `validateTickerSymbol`.

### Notes for reviewers
- The import regex char-set stays a *guarded subset* on purpose — `validateTickerSymbol`
  is a routing heuristic that flags "doesn't look like a ticker → needs mapping",
  so it must keep rejecting misaligned-column garbage. The dialogs intentionally
  remain more permissive (explicit, single-asset, user-intended creation).
- Backend/DB remain unconstrained; 100 is a UI sanity bound, not a hard ceiling.
- Verified locally: `prettier --check`, `eslint`, `type-check`, and the
  `schemas` + `validation-utils` test suites (42 tests) all pass.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).