### PR TITLE
Surface budget group delete errors

### DIFF
--- a/apps/frontend/src/features/spending/adapters/budget.ts
+++ b/apps/frontend/src/features/spending/adapters/budget.ts
@@ -101,7 +101,7 @@ export const deleteBudgetGroup = async (
       periodKey,
     });
   } catch (e) {
-    logger.error("Error deleting budget group.");
+    logger.error("Error deleting budget group.", e);
     throw e;
   }
 };

--- a/apps/frontend/src/features/spending/hooks/use-budget.ts
+++ b/apps/frontend/src/features/spending/hooks/use-budget.ts
@@ -82,7 +82,10 @@ export function useBudgetMutations(periodKey?: string) {
     mutationFn: ({ id, reassignToGroupId }: { id: string; reassignToGroupId: string }) =>
       deleteBudgetGroup(id, reassignToGroupId, periodKey),
     onSuccess: invalidate,
-    onError: () => toast.error("Failed to delete budget group."),
+    onError: (error) =>
+      toast.error(
+        error instanceof Error && error.message ? error.message : "Failed to delete budget group.",
+      ),
   });
 
   const assignCategory = useMutation({


### PR DESCRIPTION
## Summary
- Log the caught error object when budget group deletion fails.
- Show the backend error message in the delete-group toast when available.

## Why
Issue #1130 was hard to diagnose because the UI and console only surfaced a generic failure message. This preserves the existing fallback while exposing the actual backend validation or request error.

## Validation
- pnpm --filter frontend exec eslint src/features/spending/adapters/budget.ts src/features/spending/hooks/use-budget.ts
- pnpm --filter frontend exec prettier --check src/features/spending/adapters/budget.ts src/features/spending/hooks/use-budget.ts
- pnpm --filter frontend type-check
