### PR TITLE
Fix synthetic holdings history backfill

### DIFF
--- a/apps/frontend/src/components/history-chart.tsx
+++ b/apps/frontend/src/components/history-chart.tsx
@@ -215,6 +215,8 @@ export function HistoryChart({
     () => new Set(markerDataPoints.map((p) => p.date)),
     [markerDataPoints],
   );
+  const singleDataPoint =
+    data.length === 1 && !markerDateSet.has(data[0].date) ? data[0] : undefined;
 
   if (isLoading && data.length === 0) {
     return null;
@@ -397,6 +399,16 @@ export function HistoryChart({
               )}
             />
           ))}
+        {singleDataPoint && (
+          <ReferenceDot
+            x={singleDataPoint.date}
+            y={singleDataPoint.totalValue}
+            r={4}
+            fill={singleDataPoint.totalValue >= 0 ? "var(--success)" : "var(--destructive)"}
+            stroke="var(--background)"
+            strokeWidth={2}
+          />
+        )}
       </AreaChart>
     </ChartContainer>
   );

--- a/crates/connect/src/broker/service.rs
+++ b/crates/connect/src/broker/service.rs
@@ -16,7 +16,7 @@ use crate::broker_ingest::{
     ImportRunRepositoryTrait, ImportRunStatus, ImportRunSummary, ImportRunType, ReviewMode,
 };
 use crate::platform::Platform;
-use chrono::{DateTime, Months, NaiveDate, Utc};
+use chrono::{DateTime, NaiveDate, Utc};
 use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::Decimal;
 use std::collections::{HashMap, HashSet};
@@ -1092,8 +1092,6 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 account_ids: vec![account_id.clone()],
                 asset_ids: new_asset_ids.clone(),
             });
-
-            self.ensure_holdings_history(&account_id).await?;
         }
 
         info!(
@@ -1234,88 +1232,6 @@ impl BrokerSyncService {
             .or_else(|| api_parsed.as_ref().and_then(|(_, mic)| mic.clone()));
 
         Some((symbol, exchange_mic))
-    }
-
-    /// Ensures HOLDINGS mode accounts have at least 2 snapshots for proper history.
-    /// If only 1 non-calculated snapshot exists, creates a synthetic snapshot 3 months prior.
-    async fn ensure_holdings_history(&self, account_id: &str) -> Result<()> {
-        // Get count of non-calculated snapshots
-        let count = self
-            .snapshot_repository
-            .get_non_calculated_snapshot_count(account_id)?;
-
-        if count >= 2 {
-            debug!(
-                "Account {} already has {} non-calculated snapshots, no synthetic needed",
-                account_id, count
-            );
-            return Ok(());
-        }
-
-        if count == 0 {
-            debug!(
-                "Account {} has no non-calculated snapshots, nothing to backfill from",
-                account_id
-            );
-            return Ok(());
-        }
-
-        // count == 1: Create synthetic snapshot 3 months before the earliest
-        let earliest = self
-            .snapshot_repository
-            .get_earliest_non_calculated_snapshot(account_id)?;
-
-        let earliest = match earliest {
-            Some(s) => s,
-            None => {
-                debug!("No earliest snapshot found for account {}", account_id);
-                return Ok(());
-            }
-        };
-
-        // Calculate synthetic date: 3 months before earliest
-        let synthetic_date = earliest
-            .snapshot_date
-            .checked_sub_months(Months::new(3))
-            .unwrap_or(earliest.snapshot_date);
-
-        // Don't create if synthetic date equals earliest (edge case)
-        if synthetic_date == earliest.snapshot_date {
-            debug!(
-                "Synthetic date equals earliest date for account {}, skipping",
-                account_id
-            );
-            return Ok(());
-        }
-
-        // Clone the earliest snapshot with new date and source
-        let synthetic = AccountStateSnapshot {
-            id: AccountStateSnapshot::stable_id(account_id, synthetic_date),
-            account_id: account_id.to_string(),
-            snapshot_date: synthetic_date,
-            source: SnapshotSource::Synthetic,
-            calculated_at: chrono::Utc::now().naive_utc(),
-            // Clone all holdings data from earliest
-            currency: earliest.currency,
-            positions: earliest.positions,
-            cash_balances: earliest.cash_balances,
-            cost_basis: earliest.cost_basis,
-            net_contribution: earliest.net_contribution,
-            net_contribution_base: earliest.net_contribution_base,
-            cash_total_account_currency: earliest.cash_total_account_currency,
-            cash_total_base_currency: earliest.cash_total_base_currency,
-        };
-
-        self.snapshot_repository
-            .save_or_update_snapshot(&synthetic)
-            .await?;
-
-        info!(
-            "Created synthetic snapshot for account {} at {} (3 months before {})",
-            account_id, synthetic_date, earliest.snapshot_date
-        );
-
-        Ok(())
     }
 
     /// Find the platform ID for a broker account using institution/broker metadata.

--- a/crates/core/src/portfolio/snapshot/snapshot_model.rs
+++ b/crates/core/src/portfolio/snapshot/snapshot_model.rs
@@ -22,7 +22,7 @@ pub enum SnapshotSource {
     BrokerImported,
     /// Imported from CSV file
     CsvImport,
-    /// Synthetic backfill snapshot (cloned from earliest for history)
+    /// Legacy synthetic backfill snapshot.
     Synthetic,
 }
 

--- a/crates/core/src/portfolio/snapshot/snapshot_service.rs
+++ b/crates/core/src/portfolio/snapshot/snapshot_service.rs
@@ -19,7 +19,7 @@ use crate::utils::time_utils::{
 };
 
 use async_trait::async_trait;
-use chrono::{Months, NaiveDate, Utc};
+use chrono::{NaiveDate, Utc};
 use log::{debug, error, info, warn};
 use rust_decimal::Decimal;
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
@@ -98,9 +98,9 @@ pub trait SnapshotServiceTrait: Send + Sync {
     /// Returns the number of snapshots updated.
     async fn update_snapshots_source(&self, account_id: &str, new_source: &str) -> Result<usize>;
 
-    /// Ensures HOLDINGS mode accounts have at least 2 snapshots for proper history.
-    /// If only 1 non-calculated snapshot exists, creates a synthetic snapshot 3 months prior.
-    /// This enables history charting, valuation engines, and provides an inception boundary.
+    /// Legacy compatibility hook for holdings-history setup.
+    /// Synthetic backfill snapshots are no longer created because they make
+    /// charts and valuation history show holdings before they existed.
     async fn ensure_holdings_history(&self, account_id: &str) -> Result<()>;
 
     /// Delete snapshot(s) on the given dates.
@@ -1112,6 +1112,42 @@ impl SnapshotService {
 
     // --- Helpers ---
 
+    fn get_non_synthetic_snapshots_by_account(
+        &self,
+        account_id: &str,
+        start_date_opt: Option<NaiveDate>,
+        end_date_opt: Option<NaiveDate>,
+    ) -> Result<Vec<AccountStateSnapshot>> {
+        Ok(self
+            .snapshot_repository
+            .get_snapshots_by_account(account_id, start_date_opt, end_date_opt)?
+            .into_iter()
+            .filter(|snapshot| snapshot.source != SnapshotSource::Synthetic)
+            .collect())
+    }
+
+    fn get_earliest_non_synthetic_snapshot_date(
+        &self,
+        account_id: &str,
+    ) -> Result<Option<NaiveDate>> {
+        Ok(self
+            .get_non_synthetic_snapshots_by_account(account_id, None, None)?
+            .into_iter()
+            .map(|snapshot| snapshot.snapshot_date)
+            .min())
+    }
+
+    fn get_latest_non_synthetic_snapshot_before_date(
+        &self,
+        account_id: &str,
+        target_date: NaiveDate,
+    ) -> Result<Option<AccountStateSnapshot>> {
+        Ok(self
+            .get_non_synthetic_snapshots_by_account(account_id, None, Some(target_date))?
+            .into_iter()
+            .max_by_key(|snapshot| snapshot.snapshot_date))
+    }
+
     // create_initial_snapshot creates a snapshot with default values
     fn create_initial_snapshot(account: &Account, date: NaiveDate) -> AccountStateSnapshot {
         AccountStateSnapshot {
@@ -1178,10 +1214,8 @@ impl SnapshotServiceTrait for SnapshotService {
             account_id, start_date_opt, end_date_opt
         );
 
-        // Determine start date: Use provided, else earliest snapshot date
-        let earliest_snapshot_date = self
-            .snapshot_repository
-            .get_earliest_snapshot_date(account_id)?;
+        // Determine start date: Use provided, else earliest non-synthetic snapshot date.
+        let earliest_snapshot_date = self.get_earliest_non_synthetic_snapshot_date(account_id)?;
 
         let start_date = match start_date_opt {
             Some(date) => date,
@@ -1205,10 +1239,7 @@ impl SnapshotServiceTrait for SnapshotService {
                 // Use a far future date to get the absolute latest snapshot
                 let today = self.user_today();
                 let far_future = today + chrono::Duration::days(365);
-                match self
-                    .snapshot_repository
-                    .get_latest_snapshot_before_date(account_id, far_future)?
-                {
+                match self.get_latest_non_synthetic_snapshot_before_date(account_id, far_future)? {
                     Some(latest_snapshot) => latest_snapshot.snapshot_date.max(today),
                     None => today,
                 }
@@ -1224,10 +1255,10 @@ impl SnapshotServiceTrait for SnapshotService {
         }
 
         // Fetch keyframes within the actual range first, as we might need them to determine the initial state.
-        let keyframes_in_range = self.snapshot_repository.get_snapshots_by_account(
+        let keyframes_in_range = self.get_non_synthetic_snapshots_by_account(
             account_id,
-            Some(start_date), // Fetch keyframes from start_date...
-            Some(end_date),   // ...to end_date inclusive
+            Some(start_date),
+            Some(end_date),
         )?;
         let keyframes_map: BTreeMap<NaiveDate, AccountStateSnapshot> = keyframes_in_range
             .into_iter()
@@ -1235,9 +1266,8 @@ impl SnapshotServiceTrait for SnapshotService {
             .collect();
 
         // Try to get the state from the day before the loop starts.
-        let initial_state_result = self
-            .snapshot_repository
-            .get_latest_snapshot_before_date(account_id, start_date);
+        let initial_state_result =
+            self.get_latest_non_synthetic_snapshot_before_date(account_id, start_date);
 
         let mut current_state = match initial_state_result? {
             Some(initial_snapshot) => initial_snapshot,
@@ -1371,9 +1401,6 @@ impl SnapshotServiceTrait for SnapshotService {
             .collect();
         self.emit_holdings_changed(vec![account_id.to_string()], asset_ids);
 
-        // Ensure holdings history has at least 2 snapshots
-        self.ensure_holdings_history(account_id).await?;
-
         Ok(())
     }
 
@@ -1397,82 +1424,10 @@ impl SnapshotServiceTrait for SnapshotService {
     }
 
     async fn ensure_holdings_history(&self, account_id: &str) -> Result<()> {
-        // Get count of non-calculated snapshots
-        let count = self
-            .snapshot_repository
-            .get_non_calculated_snapshot_count(account_id)?;
-
-        if count >= 2 {
-            debug!(
-                "Account {} already has {} non-calculated snapshots, no synthetic needed",
-                account_id, count
-            );
-            return Ok(());
-        }
-
-        if count == 0 {
-            debug!(
-                "Account {} has no non-calculated snapshots, nothing to backfill from",
-                account_id
-            );
-            return Ok(());
-        }
-
-        // count == 1: Create synthetic snapshot 3 months before the earliest
-        let earliest = self
-            .snapshot_repository
-            .get_earliest_non_calculated_snapshot(account_id)?;
-
-        let earliest = match earliest {
-            Some(s) => s,
-            None => {
-                debug!("No earliest snapshot found for account {}", account_id);
-                return Ok(());
-            }
-        };
-
-        // Calculate synthetic date: 3 months before earliest
-        let synthetic_date = earliest
-            .snapshot_date
-            .checked_sub_months(Months::new(3))
-            .unwrap_or(earliest.snapshot_date);
-
-        // Don't create if synthetic date equals earliest (edge case)
-        if synthetic_date == earliest.snapshot_date {
-            debug!(
-                "Synthetic date equals earliest date for account {}, skipping",
-                account_id
-            );
-            return Ok(());
-        }
-
-        // Clone the earliest snapshot with new date and source
-        let synthetic = AccountStateSnapshot {
-            id: AccountStateSnapshot::stable_id(account_id, synthetic_date),
-            account_id: account_id.to_string(),
-            snapshot_date: synthetic_date,
-            source: SnapshotSource::Synthetic,
-            calculated_at: Utc::now().naive_utc(),
-            // Clone all holdings data from earliest
-            currency: earliest.currency,
-            positions: earliest.positions,
-            cash_balances: earliest.cash_balances,
-            cost_basis: earliest.cost_basis,
-            net_contribution: earliest.net_contribution,
-            net_contribution_base: earliest.net_contribution_base,
-            cash_total_account_currency: earliest.cash_total_account_currency,
-            cash_total_base_currency: earliest.cash_total_base_currency,
-        };
-
-        self.snapshot_repository
-            .save_or_update_snapshot(&synthetic)
-            .await?;
-
-        info!(
-            "Created synthetic snapshot for account {} at {} (3 months before {})",
-            account_id, synthetic_date, earliest.snapshot_date
+        debug!(
+            "Skipping synthetic holdings-history backfill for account {}",
+            account_id
         );
-
         Ok(())
     }
 

--- a/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
+++ b/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
@@ -4188,14 +4188,14 @@ mod tests {
             .await;
         assert!(result.is_ok(), "save_manual_snapshot should succeed");
 
-        // Verify snapshots were saved (manual + synthetic for performance history)
+        // Verify only the user-authored snapshot was saved.
         let saved = snapshot_repo
             .get_snapshots_by_account("acc1", None, None)
             .unwrap();
         assert_eq!(
             saved.len(),
-            2,
-            "Should have two snapshots: manual + synthetic for holdings history"
+            1,
+            "Should have one manual snapshot without synthetic backfill"
         );
 
         // Find and verify the manual snapshot
@@ -4209,19 +4209,6 @@ mod tests {
             "Source should be ManualEntry"
         );
         assert_eq!(saved_snapshot.cash_balances.get("USD"), Some(&dec!(5000)));
-
-        // Verify synthetic snapshot was created 3 months before
-        let synthetic = saved
-            .iter()
-            .find(|s| s.source == SnapshotSource::Synthetic)
-            .unwrap();
-        let expected_synthetic_date = snapshot_date
-            .checked_sub_months(chrono::Months::new(3))
-            .unwrap();
-        assert_eq!(
-            synthetic.snapshot_date, expected_synthetic_date,
-            "Synthetic should be 3 months before"
-        );
     }
 
     #[tokio::test]
@@ -4268,17 +4255,11 @@ mod tests {
             "save_manual_snapshot should succeed for update"
         );
 
-        // Verify: 1 updated manual snapshot + 1 synthetic for holdings history
-        // Note: Pre-existing snapshot had count=1, but after first save synthetic is created.
-        // After update on same date, still 2 total (synthetic + updated manual).
+        // Verify: the same-date manual snapshot was updated without synthetic backfill.
         let saved = snapshot_repo
             .get_snapshots_by_account("acc1", None, None)
             .unwrap();
-        assert_eq!(
-            saved.len(),
-            2,
-            "Should have 2 snapshots: updated manual + synthetic"
-        );
+        assert_eq!(saved.len(), 1, "Should have 1 updated manual snapshot");
 
         // Find and verify the manual snapshot was updated
         let manual_date = NaiveDate::from_ymd_opt(2025, 1, 15).unwrap();
@@ -4393,14 +4374,14 @@ mod tests {
         let result = svc.save_manual_snapshot("acc1", snapshot).await;
         assert!(result.is_ok());
 
-        // Verify: CsvImport snapshot + synthetic for holdings history
+        // Verify: CsvImport snapshot only.
         let saved = snapshot_repo
             .get_snapshots_by_account("acc1", None, None)
             .unwrap();
         assert_eq!(
             saved.len(),
-            2,
-            "Should have 2 snapshots: CSV import + synthetic"
+            1,
+            "Should have 1 CSV import snapshot without synthetic backfill"
         );
 
         // Find and verify the CSV import snapshot preserves source
@@ -4413,7 +4394,7 @@ mod tests {
         );
     }
 
-    // ==================== ensure_holdings_history Tests ====================
+    // ==================== Synthetic Backfill Regression Tests ====================
 
     #[tokio::test]
     async fn test_ensure_holdings_history_no_synthetic_when_two_snapshots_exist() {
@@ -4473,8 +4454,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_synthetic_snapshot_copies_holdings_from_earliest() {
-        // Synthetic snapshot should copy all holdings data from the earliest manual snapshot
+    async fn test_single_manual_snapshot_does_not_create_synthetic_backfill() {
         let base = Arc::new(RwLock::new("USD".to_string()));
 
         let mut account_repo = MockAccountRepository::new();
@@ -4496,7 +4476,6 @@ mod tests {
         );
 
         // Create snapshot with specific holdings data
-        let manual_date = NaiveDate::from_ymd_opt(2025, 6, 15).unwrap();
         let mut manual_snapshot = create_blank_snapshot("acc1", "USD", "2025-06-15");
         manual_snapshot.source = SnapshotSource::ManualEntry;
         manual_snapshot
@@ -4528,35 +4507,78 @@ mod tests {
         let result = svc.save_manual_snapshot("acc1", manual_snapshot).await;
         assert!(result.is_ok());
 
-        // Verify synthetic was created with same holdings data
+        // Verify no synthetic row was created and the manual data is intact.
         let saved = snapshot_repo
             .get_snapshots_by_account("acc1", None, None)
             .unwrap();
-        let synthetic = saved
+        assert_eq!(saved.len(), 1);
+        let saved_snapshot = saved
             .iter()
-            .find(|s| s.source == SnapshotSource::Synthetic)
+            .find(|s| s.source == SnapshotSource::ManualEntry)
             .unwrap();
-
-        // Synthetic should be 3 months before manual
-        let expected_synthetic_date = manual_date
-            .checked_sub_months(chrono::Months::new(3))
-            .unwrap();
-        assert_eq!(synthetic.snapshot_date, expected_synthetic_date);
-
-        // Synthetic should have same holdings data
-        assert_eq!(synthetic.cash_balances.get("USD"), Some(&dec!(5000)));
-        assert_eq!(synthetic.cost_basis, dec!(10000));
-        assert_eq!(synthetic.net_contribution, dec!(15000));
-        assert!(synthetic.positions.contains_key("asset1"));
+        assert_eq!(saved_snapshot.cash_balances.get("USD"), Some(&dec!(5000)));
+        assert_eq!(saved_snapshot.cost_basis, dec!(10000));
+        assert_eq!(saved_snapshot.net_contribution, dec!(15000));
+        assert!(saved_snapshot.positions.contains_key("asset1"));
         assert_eq!(
-            synthetic.positions.get("asset1").unwrap().quantity,
+            saved_snapshot.positions.get("asset1").unwrap().quantity,
             dec!(100)
         );
+        assert!(saved.iter().all(|s| s.source != SnapshotSource::Synthetic));
     }
 
     #[tokio::test]
-    async fn test_broker_imported_snapshot_also_triggers_synthetic() {
-        // Broker imported snapshots should also trigger synthetic creation
+    async fn test_daily_holdings_snapshots_ignore_legacy_synthetic_keyframes() {
+        let base = Arc::new(RwLock::new("USD".to_string()));
+
+        let mut account_repo = MockAccountRepository::new();
+        let acc = create_test_account("acc1", "USD", "Test Account");
+        account_repo.add_account(acc.clone());
+
+        let activity_repo = Arc::new(MockActivityRepository::new());
+        let fx = Arc::new(MockFxService::new());
+        let snapshot_repo = Arc::new(MockSnapshotRepository::new());
+        let asset_repo = Arc::new(MockAssetRepository::new());
+
+        let mut synthetic = create_blank_snapshot("acc1", "USD", "2025-01-01");
+        synthetic.source = SnapshotSource::Synthetic;
+        synthetic
+            .cash_balances
+            .insert("USD".to_string(), dec!(1000));
+
+        let mut manual = create_blank_snapshot("acc1", "USD", "2025-04-01");
+        manual.source = SnapshotSource::ManualEntry;
+        manual.cash_balances.insert("USD".to_string(), dec!(5000));
+
+        snapshot_repo.add_snapshots(vec![synthetic, manual]);
+
+        let svc = SnapshotService::new(
+            base,
+            Arc::new(account_repo),
+            activity_repo,
+            snapshot_repo,
+            asset_repo,
+            fx,
+        );
+
+        let frames = svc
+            .get_daily_holdings_snapshots(
+                "acc1",
+                None,
+                Some(NaiveDate::from_ymd_opt(2025, 4, 1).unwrap()),
+            )
+            .unwrap();
+
+        assert_eq!(frames.len(), 1);
+        assert_eq!(
+            frames[0].snapshot_date,
+            NaiveDate::from_ymd_opt(2025, 4, 1).unwrap()
+        );
+        assert_eq!(frames[0].cash_balances.get("USD"), Some(&dec!(5000)));
+    }
+
+    #[tokio::test]
+    async fn test_broker_imported_snapshot_does_not_create_synthetic_backfill() {
         let base = Arc::new(RwLock::new("USD".to_string()));
 
         let mut account_repo = MockAccountRepository::new();
@@ -4587,11 +4609,11 @@ mod tests {
         let result = svc.save_manual_snapshot("acc1", broker_snapshot).await;
         assert!(result.is_ok());
 
-        // Should have 2 snapshots: broker + synthetic
+        // Should have only the broker snapshot.
         let saved = snapshot_repo
             .get_snapshots_by_account("acc1", None, None)
             .unwrap();
-        assert_eq!(saved.len(), 2);
+        assert_eq!(saved.len(), 1);
 
         let broker = saved
             .iter()
@@ -4599,14 +4621,13 @@ mod tests {
         let synthetic = saved.iter().find(|s| s.source == SnapshotSource::Synthetic);
 
         assert!(broker.is_some(), "Broker snapshot should exist");
-        assert!(synthetic.is_some(), "Synthetic snapshot should exist");
+        assert!(synthetic.is_none(), "Synthetic snapshot should not exist");
     }
 
     // ==================== Snapshot Source Filtering Tests ====================
 
     #[tokio::test]
-    async fn test_calculated_snapshots_not_counted_for_holdings_history() {
-        // Only non-calculated snapshots should count for ensure_holdings_history
+    async fn test_calculated_snapshots_do_not_trigger_synthetic_backfill() {
         let base = Arc::new(RwLock::new("USD".to_string()));
 
         let mut account_repo = MockAccountRepository::new();
@@ -4642,20 +4663,19 @@ mod tests {
         let result = svc.save_manual_snapshot("acc1", manual).await;
         assert!(result.is_ok());
 
-        // Should have: 2 calculated + 1 manual + 1 synthetic = 4 total
+        // Should have: 2 calculated + 1 manual. Synthetic backfill is not created.
         let saved = snapshot_repo
             .get_snapshots_by_account("acc1", None, None)
             .unwrap();
-        assert_eq!(saved.len(), 4);
+        assert_eq!(saved.len(), 3);
 
-        // Synthetic should be created because only 1 non-calculated existed before
         let synthetic_count = saved
             .iter()
             .filter(|s| s.source == SnapshotSource::Synthetic)
             .count();
         assert_eq!(
-            synthetic_count, 1,
-            "Synthetic should be created when only 1 non-calculated exists"
+            synthetic_count, 0,
+            "Synthetic backfill should not be created"
         );
     }
 

--- a/crates/core/src/portfolio/snapshot/snapshot_traits.rs
+++ b/crates/core/src/portfolio/snapshot/snapshot_traits.rs
@@ -102,11 +102,11 @@ pub trait SnapshotRepositoryTrait: Send + Sync {
     async fn save_or_update_snapshot(&self, snapshot: &AccountStateSnapshot) -> Result<()>;
 
     /// Get the count of non-calculated snapshots for an account.
-    /// Non-calculated sources include: ManualEntry, BrokerImported, CsvImport, Synthetic.
+    /// Non-calculated sources include user/imported snapshots and legacy Synthetic rows.
     fn get_non_calculated_snapshot_count(&self, account_id: &str) -> Result<usize>;
 
     /// Get the earliest non-calculated snapshot for an account.
-    /// Used for creating synthetic backfill snapshots.
+    /// Retained for legacy callers.
     fn get_earliest_non_calculated_snapshot(
         &self,
         account_id: &str,

--- a/crates/storage-sqlite/migrations/2026-06-21-000001_valuation_quality/up.sql
+++ b/crates/storage-sqlite/migrations/2026-06-21-000001_valuation_quality/up.sql
@@ -4,6 +4,29 @@ ADD COLUMN value_status TEXT NOT NULL DEFAULT 'COMPLETE';
 ALTER TABLE daily_account_valuation
 ADD COLUMN basis_status TEXT NOT NULL DEFAULT 'NOT_APPLICABLE';
 
+-- Synthetic holdings snapshots were a chart backfill workaround. They clone real
+-- holdings into dates before the account actually held them, so remove them
+-- before rebuilding valuation history.
+DELETE FROM snapshot_positions
+WHERE snapshot_id IN (
+    SELECT id FROM holdings_snapshots WHERE source = 'SYNTHETIC'
+);
+
+DELETE FROM sync_outbox
+WHERE entity = 'snapshot'
+  AND entity_id IN (
+      SELECT id FROM holdings_snapshots WHERE source = 'SYNTHETIC'
+  );
+
+DELETE FROM sync_entity_metadata
+WHERE entity = 'snapshot'
+  AND entity_id IN (
+      SELECT id FROM holdings_snapshots WHERE source = 'SYNTHETIC'
+  );
+
+DELETE FROM holdings_snapshots
+WHERE source = 'SYNTHETIC';
+
 -- Daily valuations are generated read models. Rebuild them with explicit value
 -- and basis coverage instead of relying on implicit zero-valued missing quotes.
 DELETE FROM daily_account_valuation;

--- a/crates/storage-sqlite/src/portfolio/snapshot/repository.rs
+++ b/crates/storage-sqlite/src/portfolio/snapshot/repository.rs
@@ -1829,8 +1829,8 @@ mod tests {
 
         assert_eq!(
             count_pending_outbox(&pool),
-            3,
-            "Only manual/csv/synthetic snapshots should be enqueued"
+            2,
+            "Only manual/csv snapshots should be enqueued"
         );
     }
 }

--- a/crates/storage-sqlite/src/sync/app_sync/repository.rs
+++ b/crates/storage-sqlite/src/sync/app_sync/repository.rs
@@ -175,13 +175,13 @@ impl SyncRowFilter {
     fn sql(self) -> &'static str {
         match self {
             Self::UserSyncableHoldingsSnapshots => {
-                "account_id IN (SELECT id FROM accounts) AND source IN ('MANUAL_ENTRY', 'CSV_IMPORT', 'SYNTHETIC')"
+                "account_id IN (SELECT id FROM accounts) AND source IN ('MANUAL_ENTRY', 'CSV_IMPORT')"
             }
             Self::UserSyncableSnapshotPositions => {
                 "snapshot_id IN (
                     SELECT id FROM holdings_snapshots
                     WHERE account_id IN (SELECT id FROM accounts)
-                      AND source IN ('MANUAL_ENTRY', 'CSV_IMPORT', 'SYNTHETIC')
+                      AND source IN ('MANUAL_ENTRY', 'CSV_IMPORT')
                 )"
             }
             Self::ManualQuotes => "source = 'MANUAL'",

--- a/crates/storage-sqlite/src/sync/mod.rs
+++ b/crates/storage-sqlite/src/sync/mod.rs
@@ -72,7 +72,7 @@ pub fn should_sync_outbox_for_import_run(run_type: &str, source_system: &str) ->
 pub fn should_sync_outbox_for_snapshot_source(source: SnapshotSource) -> bool {
     matches!(
         source,
-        SnapshotSource::ManualEntry | SnapshotSource::CsvImport | SnapshotSource::Synthetic
+        SnapshotSource::ManualEntry | SnapshotSource::CsvImport
     )
 }
 
@@ -167,14 +167,14 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_outbox_rules_include_user_and_synthetic_sources() {
+    fn snapshot_outbox_rules_include_only_user_authored_sources() {
         assert!(should_sync_outbox_for_snapshot_source(
             SnapshotSource::ManualEntry
         ));
         assert!(should_sync_outbox_for_snapshot_source(
             SnapshotSource::CsvImport
         ));
-        assert!(should_sync_outbox_for_snapshot_source(
+        assert!(!should_sync_outbox_for_snapshot_source(
             SnapshotSource::Synthetic
         ));
         assert!(!should_sync_outbox_for_snapshot_source(


### PR DESCRIPTION
## Summary
- stop creating synthetic holdings snapshots for manual, CSV, and broker-imported holdings snapshots
- ignore legacy `SYNTHETIC` snapshots when building daily holdings history
- delete legacy synthetic snapshots and generated valuations in the existing valuation-quality migration
- render single-point history charts with a real chart dot instead of backend fake history
- exclude synthetic snapshots from local sync outbox/export policy

Closes #1105.

## Validation
- `git diff --check`
- `cargo fmt --check`
- `pnpm --filter frontend exec eslint src/components/history-chart.tsx`
- `pnpm --filter frontend type-check`
- `cargo test -p wealthfolio-core snapshot_service_tests::tests:: -- --nocapture`
- `cargo test -p wealthfolio-storage-sqlite db::migration_tests -- --nocapture`
- `cargo test -p wealthfolio-storage-sqlite snapshot -- --nocapture`
- earlier full touched-crate run: `cargo test -p wealthfolio-core -p wealthfolio-storage-sqlite -p wealthfolio-connect -- --nocapture`

## Notes
- Per maintainer direction, the cleanup stays in `2026-06-21-000001_valuation_quality` rather than adding a follow-up migration. DBs that already recorded that migration need a one-time direct cleanup; the local dev DB was cleaned manually.