### PR TITLE
Fix dashboard showing base currency for foreign-currency accounts

### DIFF
--- a/apps/frontend/src/pages/dashboard/accounts-summary.test.tsx
+++ b/apps/frontend/src/pages/dashboard/accounts-summary.test.tsx
@@ -479,6 +479,38 @@ describe("AccountsSummary", () => {
     expect(within(row as HTMLElement).getByText("gain-percent:0.25")).toBeInTheDocument();
   });
 
+  it("displays a foreign-currency account in its own currency, not the base currency", () => {
+    renderAccountsSummary({
+      accounts: [createAccount({ id: "cad-account", name: "CAD Account", currency: "CAD" })],
+      valuations: [
+        createValuation({
+          accountId: "cad-account",
+          accountCurrency: "CAD",
+          baseCurrency: "USD",
+          totalValue: 150,
+          totalValueBase: 110,
+        }),
+      ],
+      performanceByAccountId: {
+        "cad-account": {
+          pnl: 10,
+          returnValue: 0.08,
+        },
+      },
+    });
+
+    const row = screen.getByText("CAD Account").closest("a");
+    expect(row).not.toBeNull();
+    // Value is shown in the account's own currency (CAD), not the USD base currency.
+    expect(within(row as HTMLElement).getByText("value:CAD:150")).toBeInTheDocument();
+    expect(within(row as HTMLElement).queryByText("value:USD:110")).not.toBeInTheDocument();
+    // Return percent is currency-agnostic and still shown.
+    expect(within(row as HTMLElement).getByText("gain-percent:0.08")).toBeInTheDocument();
+    // P&L amount is only computed in base currency for foreign accounts, so it is
+    // omitted here rather than mislabeled as CAD.
+    expect(within(row as HTMLElement).queryByText(/^gain-amount:/)).not.toBeInTheDocument();
+  });
+
   it("keeps the group header behavior unchanged when grouped totals have zero gain", async () => {
     const user = userEvent.setup();
 

--- a/apps/frontend/src/pages/dashboard/accounts-summary.test.tsx
+++ b/apps/frontend/src/pages/dashboard/accounts-summary.test.tsx
@@ -511,6 +511,37 @@ describe("AccountsSummary", () => {
     expect(within(row as HTMLElement).queryByText(/^gain-amount:/)).not.toBeInTheDocument();
   });
 
+  it("keeps bad-data warnings for foreign-currency accounts when only base P&L is available", () => {
+    renderAccountsSummary({
+      accounts: [createAccount({ id: "cad-account", name: "CAD Account", currency: "CAD" })],
+      valuations: [
+        createValuation({
+          accountId: "cad-account",
+          accountCurrency: "CAD",
+          baseCurrency: "USD",
+          totalValue: 150,
+          totalValueBase: 110,
+        }),
+      ],
+      performanceByAccountId: {
+        "cad-account": {
+          pnl: 10,
+          returnValue: null,
+        },
+      },
+    });
+
+    const row = screen.getByText("CAD Account").closest("a");
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).getByText("value:CAD:150")).toBeInTheDocument();
+    expect(within(row as HTMLElement).queryByText(/^gain-amount:/)).not.toBeInTheDocument();
+    expect(
+      within(row as HTMLElement).getByText(
+        "Return % unavailable - activity history may be inconsistent.",
+      ),
+    ).toBeInTheDocument();
+  });
+
   it("keeps the group header behavior unchanged when grouped totals have zero gain", async () => {
     const user = userEvent.setup();
 

--- a/apps/frontend/src/pages/dashboard/accounts-summary.tsx
+++ b/apps/frontend/src/pages/dashboard/accounts-summary.tsx
@@ -564,7 +564,7 @@ export const AccountsSummary = React.memo(
                               item={account}
                               isLoadingValuation={isLoadingPerformance}
                               displayInAccountCurrency={
-                                account.accountCurrency === account.baseCurrency
+                                account.accountCurrency !== account.baseCurrency
                               }
                               isNested
                             />
@@ -581,7 +581,7 @@ export const AccountsSummary = React.memo(
                 key={account.accountId}
                 item={account}
                 isLoadingValuation={isLoadingPerformance}
-                displayInAccountCurrency={account.accountCurrency === account.baseCurrency}
+                displayInAccountCurrency={account.accountCurrency !== account.baseCurrency}
               />
             ))}
           </>
@@ -596,7 +596,7 @@ export const AccountsSummary = React.memo(
             key={account.accountId}
             item={account}
             isLoadingValuation={isLoadingPerformance}
-            displayInAccountCurrency={account.accountCurrency === account.baseCurrency}
+            displayInAccountCurrency={account.accountCurrency !== account.baseCurrency}
           />
         ));
       }

--- a/apps/frontend/src/pages/dashboard/accounts-summary.tsx
+++ b/apps/frontend/src/pages/dashboard/accounts-summary.tsx
@@ -129,8 +129,8 @@ const AccountSummaryComponent = React.memo(
     const hasBadData =
       totalValue > 0 &&
       gainPercentToDisplay === null &&
-      gainAmountToDisplay !== null &&
-      gainAmountToDisplay !== 0;
+      item.totalGainLossAmountBaseCurrency !== null &&
+      item.totalGainLossAmountBaseCurrency !== 0;
     const warningMessages = hasBadData
       ? [
           item.trackingMode === "HOLDINGS"


### PR DESCRIPTION
## Summary

Fixes #1125 — the dashboard account list showed every account's currency and total in the **base currency** (e.g. USD) regardless of the account's actual currency. A CAD account with a USD base displayed as USD, while the Settings account view correctly showed CAD.

## Root cause

The dashboard rows pass `displayInAccountCurrency` with an **inverted condition**:

```tsx
displayInAccountCurrency={account.accountCurrency === account.baseCurrency}
```

For a CAD account with USD base, `"CAD" === "USD"` is `false`, so `AccountSummaryComponent` rendered `baseCurrency` / `totalValueBaseCurrency` (USD). The `===` makes the flag a no-op: it's only "true" when the two currencies are already identical (where native vs base display is the same anyway), and "false" for genuinely foreign accounts.

This is a regression from `f97c6a5b4` (2026-06-02), which replaced the previously always-on `displayInAccountCurrency` prop with this check. The underlying data was always correct — `accountCurrency` and the account-currency total are present on the valuation.

## Fix

Flip `===` → `!==` at all three call sites (nested grouped, standalone-under-group, and ungrouped list view) so each account renders in its own currency when it differs from base. Same-currency accounts are unchanged (both branches render identically). Group headers stay in base currency, since a group may mix currencies.

### P&L nuance

`totalGainLossAmountAccountCurrency` is `null` for foreign accounts (the performance pipeline only computes P&L in base currency). So a foreign-currency row now correctly shows its **value + return %**, and the P&L **amount** is omitted rather than mislabeled as the account currency. This is a pre-existing limitation, not introduced here; fully populating the account-currency P&L amount would need an FX conversion and is out of scope.

## Test plan

- Added a regression test: a CAD account with USD base asserts the row shows `value:CAD:150` (not `value:USD:110`), the return % renders, and no P&L amount is shown.
- `pnpm vitest run src/pages/dashboard/accounts-summary.test.tsx` → 8 passed
- `pnpm type-check` → clean