### PR TITLE
Fix split-adjusted valuation history

### DIFF
--- a/crates/core/src/portfolio/net_worth/net_worth_service.rs
+++ b/crates/core/src/portfolio/net_worth/net_worth_service.rs
@@ -371,8 +371,15 @@ impl NetWorthServiceTrait for NetWorthService {
         // Get all assets for lookup
         let all_assets = self.asset_repository.list()?;
         let asset_map: HashMap<String, _> = all_assets.iter().map(|a| (a.id.clone(), a)).collect();
+        let stored_valuations_by_account: HashMap<String, DailyAccountValuation> = self
+            .valuation_repository
+            .get_valuations_on_date(&account_ids, date)?
+            .into_iter()
+            .map(|valuation| (valuation.account_id.clone(), valuation))
+            .collect();
 
         let mut valuations: Vec<ValuationInfo> = Vec::new();
+        let mut account_position_asset_ids: HashSet<String> = HashSet::new();
 
         // Process each account's snapshot
         for (account_id, snapshot) in &snapshots {
@@ -386,6 +393,46 @@ impl NetWorthServiceTrait for NetWorthService {
 
             let account_category = Self::categorize_by_account_type(&account.account_type);
             let is_liability_account = is_liability_account_type(&account.account_type);
+            let stored_account_valuation = if is_liability_account {
+                None
+            } else {
+                stored_valuations_by_account.get(account_id)
+            };
+            if !is_liability_account {
+                for (asset_id, position) in &snapshot.positions {
+                    if !position.quantity.is_zero() {
+                        account_position_asset_ids.insert(asset_id.clone());
+                    }
+                }
+            }
+
+            if let Some(account_valuation) = stored_account_valuation {
+                if !account_valuation.investment_market_value_base.is_zero() {
+                    valuations.push(ValuationInfo {
+                        asset_id: format!("INVESTMENTS:{}", account.id),
+                        name: Some(account.name.clone()),
+                        market_value_base: account_valuation
+                            .investment_market_value_base
+                            .round_dp(DECIMAL_PRECISION),
+                        valuation_date: account_valuation.valuation_date,
+                        category: AssetCategory::Investment,
+                        is_cash_like: false,
+                    });
+                }
+
+                if !account_valuation.cash_balance_base.is_zero() {
+                    valuations.push(ValuationInfo {
+                        asset_id: format!("CASH:{}", account.id),
+                        name: Some(account.name.clone()),
+                        market_value_base: account_valuation
+                            .cash_balance_base
+                            .round_dp(DECIMAL_PRECISION),
+                        valuation_date: account_valuation.valuation_date,
+                        category: AssetCategory::Cash,
+                        is_cash_like: true,
+                    });
+                }
+            }
 
             // Process positions (securities, alternative assets)
             if is_liability_account {
@@ -396,7 +443,7 @@ impl NetWorthServiceTrait for NetWorthService {
                         account.id
                     );
                 }
-            } else {
+            } else if stored_account_valuation.is_none() {
                 for (asset_id, position) in &snapshot.positions {
                     if position.quantity.is_zero() {
                         continue;
@@ -527,6 +574,9 @@ impl NetWorthServiceTrait for NetWorthService {
             }
 
             // Process cash balances
+            if stored_account_valuation.is_some() {
+                continue;
+            }
             for (currency, &amount) in &snapshot.cash_balances {
                 if amount.is_zero() {
                     continue;
@@ -567,7 +617,9 @@ impl NetWorthServiceTrait for NetWorthService {
         for asset in alternative_assets {
             // Skip if this asset was already processed via a snapshot position
             // (in case there's overlap)
-            if valuations.iter().any(|v| v.asset_id == asset.id) {
+            if account_position_asset_ids.contains(&asset.id)
+                || valuations.iter().any(|v| v.asset_id == asset.id)
+            {
                 continue;
             }
 

--- a/crates/core/src/portfolio/net_worth/net_worth_service.rs
+++ b/crates/core/src/portfolio/net_worth/net_worth_service.rs
@@ -379,7 +379,6 @@ impl NetWorthServiceTrait for NetWorthService {
             .collect();
 
         let mut valuations: Vec<ValuationInfo> = Vec::new();
-        let mut account_position_asset_ids: HashSet<String> = HashSet::new();
 
         // Process each account's snapshot
         for (account_id, snapshot) in &snapshots {
@@ -398,13 +397,6 @@ impl NetWorthServiceTrait for NetWorthService {
             } else {
                 stored_valuations_by_account.get(account_id)
             };
-            if !is_liability_account {
-                for (asset_id, position) in &snapshot.positions {
-                    if !position.quantity.is_zero() {
-                        account_position_asset_ids.insert(asset_id.clone());
-                    }
-                }
-            }
 
             if let Some(account_valuation) = stored_account_valuation {
                 if !account_valuation.investment_market_value_base.is_zero() {
@@ -617,9 +609,7 @@ impl NetWorthServiceTrait for NetWorthService {
         for asset in alternative_assets {
             // Skip if this asset was already processed via a snapshot position
             // (in case there's overlap)
-            if account_position_asset_ids.contains(&asset.id)
-                || valuations.iter().any(|v| v.asset_id == asset.id)
-            {
+            if valuations.iter().any(|v| v.asset_id == asset.id) {
                 continue;
             }
 

--- a/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
+++ b/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
@@ -1141,6 +1141,38 @@ async fn test_single_investment_account() {
 }
 
 #[tokio::test]
+async fn test_net_worth_uses_stored_investment_valuation_when_available() {
+    let date = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
+    let account = create_test_account("account-1", "SECURITIES", "USD");
+    let asset = create_test_asset("NFLX", AssetKind::Investment, "USD");
+    let property_asset = create_test_asset("PROP-1", AssetKind::Property, "USD");
+    let position = create_test_position("account-1", "NFLX", dec!(20), dec!(200), "USD");
+    let property_position = create_test_position("account-1", "PROP-1", dec!(1), dec!(5000), "USD");
+    let snapshot = create_test_snapshot(
+        "account-1",
+        vec![position, property_position],
+        HashMap::new(),
+    );
+    let quote = create_test_quote("NFLX", dec!(100), date, "USD");
+    let property_quote = create_test_quote("PROP-1", dec!(5000), date, "USD");
+
+    let service = create_net_worth_service_with_valuations(
+        vec![account],
+        vec![asset, property_asset],
+        vec![snapshot],
+        vec![quote, property_quote],
+        vec![create_total_valuation(date, dec!(20000), Decimal::ZERO)],
+    );
+
+    let result = service.get_net_worth(date).await.unwrap();
+
+    assert_eq!(result.net_worth, dec!(20000));
+    assert_eq!(result.assets.total, dec!(20000));
+    assert_eq!(get_category_value(&result, "investments"), dec!(20000));
+    assert_eq!(get_category_value(&result, "properties"), Decimal::ZERO);
+}
+
+#[tokio::test]
 async fn test_net_worth_with_liability() {
     // Investment account
     let inv_account = create_test_account("inv1", "SECURITIES", "USD");

--- a/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
+++ b/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
@@ -1141,7 +1141,7 @@ async fn test_single_investment_account() {
 }
 
 #[tokio::test]
-async fn test_net_worth_uses_stored_investment_valuation_when_available() {
+async fn test_net_worth_uses_stored_investment_valuation_and_keeps_alternatives() {
     let date = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
     let account = create_test_account("account-1", "SECURITIES", "USD");
     let asset = create_test_asset("NFLX", AssetKind::Investment, "USD");
@@ -1166,10 +1166,10 @@ async fn test_net_worth_uses_stored_investment_valuation_when_available() {
 
     let result = service.get_net_worth(date).await.unwrap();
 
-    assert_eq!(result.net_worth, dec!(20000));
-    assert_eq!(result.assets.total, dec!(20000));
+    assert_eq!(result.net_worth, dec!(25000));
+    assert_eq!(result.assets.total, dec!(25000));
     assert_eq!(get_category_value(&result, "investments"), dec!(20000));
-    assert_eq!(get_category_value(&result, "properties"), Decimal::ZERO);
+    assert_eq!(get_category_value(&result, "properties"), dec!(5000));
 }
 
 #[tokio::test]

--- a/crates/core/src/portfolio/valuation/valuation_calculator.rs
+++ b/crates/core/src/portfolio/valuation/valuation_calculator.rs
@@ -35,6 +35,28 @@ pub fn calculate_valuation(
     target_date: NaiveDate,
     base_currency: &str, // Pass base currency directly
 ) -> Result<DailyAccountValuation> {
+    calculate_valuation_with_price_factors(
+        holdings_snapshot,
+        quotes_today,
+        fx_rates_today,
+        fx_rates_by_date,
+        target_date,
+        base_currency,
+        &HashMap::new(),
+    )
+}
+
+/// Calculates valuation metrics with per-asset price factors for quote series
+/// whose historical closes are already split-adjusted.
+pub fn calculate_valuation_with_price_factors(
+    holdings_snapshot: &AccountStateSnapshot, // Holdings for target_date
+    quotes_today: &HashMap<String, Quote>,    // Market quotes for target_date
+    fx_rates_today: &DailyFxRateMap,
+    fx_rates_by_date: &HashMap<NaiveDate, DailyFxRateMap>,
+    target_date: NaiveDate,
+    base_currency: &str, // Pass base currency directly
+    split_price_factors: &HashMap<String, Decimal>,
+) -> Result<DailyAccountValuation> {
     let account_currency = &holdings_snapshot.currency;
     let normalized_account_currency = normalize_currency_code(account_currency);
     let normalized_base_currency = normalize_currency_code(base_currency);
@@ -46,6 +68,7 @@ pub fn calculate_valuation(
         fx_rates_today,
         target_date,
         normalized_account_currency,
+        split_price_factors,
     )?;
 
     let total_cash_value_acct_ccy = calculate_cash_value_acct(
@@ -260,6 +283,7 @@ fn calculate_investment_market_value_acct(
     fx_rates_today: &DailyFxRateMap,
     target_date: NaiveDate,
     account_currency: &str,
+    split_price_factors: &HashMap<String, Decimal>,
 ) -> Result<InvestmentValuation> {
     let mut total_position_market_value = Decimal::ZERO;
     let mut performance_eligible_market_value = Decimal::ZERO;
@@ -289,8 +313,13 @@ fn calculate_investment_market_value_acct(
                 )? // Propagate error if FX rate is missing
             };
 
+            let price_factor = split_price_factors
+                .get(asset_id)
+                .copied()
+                .unwrap_or(Decimal::ONE);
+            let valuation_price = normalized_price * price_factor;
             let market_value =
-                position.quantity * normalized_price * position.contract_multiplier * quote_fx_rate;
+                position.quantity * valuation_price * position.contract_multiplier * quote_fx_rate;
             total_position_market_value += market_value;
             priced_positions += 1;
             if position.basis_status() == BasisStatus::Complete {
@@ -483,6 +512,34 @@ mod tests {
         assert_eq!(result.total_value, dec!(185));
         assert_eq!(result.value_status, ValuationStatus::PartialUnpriced);
         assert_eq!(result.basis_status, BasisStatus::Complete);
+    }
+
+    #[test]
+    fn split_price_factor_adjusts_quote_basis_without_changing_quantity() {
+        let target_date = NaiveDate::from_ymd_opt(2025, 11, 14).unwrap();
+        let positions = HashMap::from([(
+            "NFLX".to_string(),
+            test_position("NFLX", dec!(20), dec!(200)),
+        )]);
+        let snapshot = test_snapshot(positions, Decimal::ZERO);
+        let quotes_today = HashMap::from([("NFLX".to_string(), test_quote("NFLX", dec!(100)))]);
+        let split_price_factors = HashMap::from([("NFLX".to_string(), dec!(10))]);
+
+        let result = calculate_valuation_with_price_factors(
+            &snapshot,
+            &quotes_today,
+            &HashMap::new(),
+            &HashMap::new(),
+            target_date,
+            "USD",
+            &split_price_factors,
+        )
+        .unwrap();
+
+        assert_eq!(snapshot.positions.get("NFLX").unwrap().quantity, dec!(20));
+        assert_eq!(result.investment_market_value, dec!(20000));
+        assert_eq!(result.total_value, dec!(20000));
+        assert_eq!(result.performance_eligible_value_base, dec!(20000));
     }
 
     #[test]

--- a/crates/core/src/portfolio/valuation/valuation_service.rs
+++ b/crates/core/src/portfolio/valuation/valuation_service.rs
@@ -14,7 +14,7 @@ use crate::portfolio::performance::{
     FlowType, PerformanceScope,
 };
 use crate::portfolio::snapshot::{AccountStateSnapshot, Position, SnapshotServiceTrait};
-use crate::portfolio::valuation::valuation_calculator::calculate_valuation;
+use crate::portfolio::valuation::valuation_calculator::calculate_valuation_with_price_factors;
 use crate::portfolio::valuation::valuation_model::{
     DailyAccountValuation, ExternalFlowSource, NegativeBalanceInfo, ValuationStatus,
 };
@@ -941,6 +941,7 @@ impl ValuationService {
         )?;
 
         let mut events = Vec::new();
+        let mut seen_events: HashSet<(String, NaiveDate)> = HashSet::new();
         for activity in activities {
             if !activity.is_posted() || activity.effective_type() != ACTIVITY_TYPE_SPLIT {
                 continue;
@@ -967,7 +968,8 @@ impl ValuationService {
                 asset_id,
                 split_date,
                 ratio,
-            ) {
+            ) && seen_events.insert((asset_id.clone(), split_date))
+            {
                 events.push(QuoteAdjustedSplitEvent {
                     asset_id: asset_id.clone(),
                     split_date,
@@ -980,27 +982,21 @@ impl ValuationService {
         Ok(events)
     }
 
-    fn apply_quote_adjusted_split_events(
-        snapshot: &mut AccountStateSnapshot,
+    fn split_price_factors_for_date(
+        valuation_date: NaiveDate,
         events: &[QuoteAdjustedSplitEvent],
-    ) {
+    ) -> HashMap<String, Decimal> {
+        let mut factors = HashMap::new();
         for event in events {
-            if snapshot.snapshot_date >= event.split_date {
+            if valuation_date >= event.split_date {
                 continue;
             }
 
-            let Some(position) = snapshot.positions.get_mut(&event.asset_id) else {
-                continue;
-            };
-            if position.quantity.is_zero() {
-                continue;
-            }
-
-            position.quantity *= event.ratio;
-            if !position.quantity.is_zero() {
-                position.average_cost = position.total_cost_basis / position.quantity;
-            }
+            *factors
+                .entry(event.asset_id.clone())
+                .or_insert(Decimal::ONE) *= event.ratio;
         }
+        factors
     }
 
     fn disposal_cost_basis_base(
@@ -1645,14 +1641,11 @@ impl ValuationServiceTrait for ValuationService {
         let mut newly_calculated_valuations: Vec<DailyAccountValuation> = snapshots_to_process
             .into_iter()
             .filter_map(|holdings_snapshot| {
-                let mut holdings_snapshot = holdings_snapshot;
                 let current_date = holdings_snapshot.snapshot_date;
                 let account_id_clone = account_id.to_string();
                 let base_curr_clone = base_curr.clone();
-                Self::apply_quote_adjusted_split_events(
-                    &mut holdings_snapshot,
-                    &quote_adjusted_split_events,
-                );
+                let split_price_factors =
+                    Self::split_price_factors_for_date(current_date, &quote_adjusted_split_events);
 
                 let quotes_for_current_date =
                     quotes_by_date.get(&current_date).cloned().unwrap_or_default();
@@ -1718,13 +1711,14 @@ impl ValuationServiceTrait for ValuationService {
                     return None;
                 }
 
-                match calculate_valuation(
+                match calculate_valuation_with_price_factors(
                     &holdings_snapshot,
                     &quotes_for_current_date,
                     &fx_for_current_date,
                     &fx_rates_by_date,
                     current_date,
                     &base_curr_clone,
+                    &split_price_factors,
                 ) {
                     Ok(valuation_result) => Some(valuation_result),
                     Err(e) => {
@@ -2458,31 +2452,66 @@ mod tests {
     }
 
     #[test]
-    fn quote_adjusted_split_event_adjusts_pre_split_snapshot_quantity_only() {
-        let mut before_split = snapshot_with_position("2025-11-14", "NFLX", dec!(20));
-        let mut split_day = snapshot_with_position("2025-11-17", "NFLX", dec!(200));
+    fn quote_adjusted_split_event_builds_pre_split_price_factor_only() {
+        let before_split = snapshot_with_position("2025-11-14", "NFLX", dec!(20));
+        let split_day = snapshot_with_position("2025-11-17", "NFLX", dec!(200));
         let events = vec![QuoteAdjustedSplitEvent {
             asset_id: "NFLX".to_string(),
             split_date: date("2025-11-17"),
             ratio: dec!(10),
         }];
 
-        ValuationService::apply_quote_adjusted_split_events(&mut before_split, &events);
-        ValuationService::apply_quote_adjusted_split_events(&mut split_day, &events);
+        let before_factors =
+            ValuationService::split_price_factors_for_date(date("2025-11-14"), &events);
+        let split_day_factors =
+            ValuationService::split_price_factors_for_date(date("2025-11-17"), &events);
 
+        assert_eq!(before_factors.get("NFLX"), Some(&dec!(10)));
+        assert!(split_day_factors.is_empty());
         assert_eq!(
             before_split.positions.get("NFLX").unwrap().quantity,
-            dec!(200)
+            dec!(20)
         );
         assert_eq!(
             before_split.positions.get("NFLX").unwrap().average_cost,
-            dec!(1)
+            dec!(10)
         );
         assert_eq!(split_day.positions.get("NFLX").unwrap().quantity, dec!(200));
         assert_eq!(
             split_day.positions.get("NFLX").unwrap().average_cost,
             dec!(10)
         );
+    }
+
+    #[test]
+    fn split_price_factors_multiply_future_splits_and_exclude_split_day() {
+        let events = vec![
+            QuoteAdjustedSplitEvent {
+                asset_id: "AAPL".to_string(),
+                split_date: date("2025-01-10"),
+                ratio: dec!(2),
+            },
+            QuoteAdjustedSplitEvent {
+                asset_id: "AAPL".to_string(),
+                split_date: date("2025-01-20"),
+                ratio: dec!(3),
+            },
+            QuoteAdjustedSplitEvent {
+                asset_id: "REV".to_string(),
+                split_date: date("2025-01-20"),
+                ratio: dec!(0.02),
+            },
+        ];
+
+        let before_all =
+            ValuationService::split_price_factors_for_date(date("2025-01-01"), &events);
+        let on_first_split =
+            ValuationService::split_price_factors_for_date(date("2025-01-10"), &events);
+
+        assert_eq!(before_all.get("AAPL"), Some(&dec!(6)));
+        assert_eq!(before_all.get("REV"), Some(&dec!(0.02)));
+        assert_eq!(on_first_split.get("AAPL"), Some(&dec!(3)));
+        assert_eq!(on_first_split.get("REV"), Some(&dec!(0.02)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1140.

- value split-adjusted historical quote series by applying split factors to price instead of mutating historical quantities
- keep split activity quantities as the source of truth for displayed/current quantities
- make point-in-time net worth use stored daily account valuations when available, avoiding drift from raw historical quotes
- prevent account-held assets from being double-counted as standalone alternatives when stored account valuations are used

## Root Cause

Yahoo historical closes are split-adjusted. For dates before a split, multiplying the pre-split activity quantity by the adjusted close understates market value by the split ratio. The earlier mitigation adjusted quantities in valuation snapshots, which fixed totals but polluted the quantity basis.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `CONNECT_API_URL=http://test.local cargo test --workspace`
- `cargo check -p wealthfolio-server --release`
- `pnpm install --frozen-lockfile`
- `pnpm run build:types`
- `pnpm format:check`
- `pnpm lint`
- `pnpm type-check`
- `pnpm test`
- `pnpm build`

## Notes

`pnpm lint` and `pnpm build` pass with existing warning output. No new warnings are from this Rust-only change.