### PR TITLE
Add account activities tab and layout refinements

### DIFF
--- a/apps/frontend/src/pages/account/account-contribution-limit.tsx
+++ b/apps/frontend/src/pages/account/account-contribution-limit.tsx
@@ -1,12 +1,11 @@
 import { calculateDepositsForLimit, getContributionLimit } from "@/adapters";
-import { Card, CardContent, CardHeader } from "@wealthfolio/ui/components/ui/card";
+import { Card, CardContent } from "@wealthfolio/ui/components/ui/card";
 import { Progress } from "@wealthfolio/ui/components/ui/progress";
 import { Skeleton } from "@wealthfolio/ui/components/ui/skeleton";
 import { QueryKeys } from "@/lib/query-keys";
 import { ContributionLimit, DepositsCalculation } from "@/lib/types";
 import { useQuery } from "@tanstack/react-query";
-import { Icons, PrivacyAmount } from "@wealthfolio/ui";
-import { Link } from "react-router-dom";
+import { PrivacyAmount } from "@wealthfolio/ui";
 
 interface AccountContributionLimitProps {
   accountId: string;
@@ -23,11 +22,12 @@ export function AccountContributionLimit({ accountId }: AccountContributionLimit
   const limitForAccount = allLimits?.find(
     (limit) => limit.accountIds?.includes(accountId) && limit.contributionYear === currentYear,
   );
+  const limitForAccountId = limitForAccount?.id;
 
   const { data: deposits, isLoading: isDepositsLoading } = useQuery<DepositsCalculation, Error>({
-    queryKey: [QueryKeys.CONTRIBUTION_LIMIT_PROGRESS, accountId, currentYear],
-    queryFn: () => calculateDepositsForLimit(limitForAccount!.id),
-    enabled: !isLimitsLoading && !!limitForAccount,
+    queryKey: [QueryKeys.CONTRIBUTION_LIMIT_PROGRESS, accountId, currentYear, limitForAccountId],
+    queryFn: () => calculateDepositsForLimit(limitForAccountId!),
+    enabled: !isLimitsLoading && !!limitForAccountId,
   });
 
   if (isLimitsLoading) {
@@ -35,36 +35,18 @@ export function AccountContributionLimit({ accountId }: AccountContributionLimit
   }
 
   if (!limitForAccount) {
-    return (
-      <Card className="border-muted bg-muted/70 border-none p-6 shadow-none">
-        <div className="flex items-center justify-between text-sm">
-          <span>
-            No contribution limit set for this account.{" "}
-            <Link
-              to="/settings/contribution-limits"
-              className="text-primary inline-flex items-center gap-1 font-semibold"
-            >
-              Set limit
-              <Icons.ArrowRight className="h-3.5 w-3.5" />
-            </Link>
-          </span>
-        </div>
-      </Card>
-    );
+    return null;
   }
 
   if (isDepositsLoading) {
     return <AccountContributionLimit.Skeleton />;
   }
 
-  const accountDeposit = deposits?.byAccount[accountId];
-
   return (
     <div className="space-y-4">
       <AccountContributionLimitItem
         key={limitForAccount.id}
         limit={limitForAccount}
-        deposit={accountDeposit}
         totalDeposits={deposits?.total ?? 0}
         baseCurrency={deposits?.baseCurrency ?? "USD"}
       />
@@ -74,66 +56,58 @@ export function AccountContributionLimit({ accountId }: AccountContributionLimit
 
 function AccountContributionLimitItem({
   limit,
-  deposit,
   totalDeposits,
   baseCurrency,
 }: {
   limit: ContributionLimit;
-  deposit?: { amount: number; currency: string; convertedAmount: number };
   totalDeposits: number;
   baseCurrency: string;
 }) {
   const progressValue = totalDeposits ? totalDeposits : 0;
   const progressPercentageNumber =
     limit.limitAmount > 0 ? (progressValue / limit.limitAmount) * 100 : 0;
-  const isOverLimit = progressPercentageNumber > 100;
-  const isAtLimit = progressPercentageNumber === 100;
+  const remainingAmount = limit.limitAmount - progressValue;
+  const isOverLimit = remainingAmount < 0;
+  const isAtLimit = remainingAmount === 0;
+  const statusClassName = isOverLimit
+    ? "text-destructive"
+    : isAtLimit
+      ? "text-success"
+      : "text-muted-foreground";
+  const groupName = limit.groupName.replace(new RegExp(`^${limit.contributionYear}\\s+`, "i"), "");
 
   return (
     <Card
-      className={`border-none pt-6 shadow-sm ${
+      className={`border-none shadow-sm ${
         isOverLimit ? "border-destructive/20 bg-destructive/10" : isAtLimit ? "bg-success/10" : ""
       }`}
     >
-      <CardContent className="space-y-4">
-        <div className="flex items-center justify-between">
-          <div className="text-sm">
+      <CardContent className="space-y-3 p-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <p className="text-sm font-semibold">
+              {limit.contributionYear} {groupName} limit
+            </p>
+            <p className="text-muted-foreground text-xs">
+              <PrivacyAmount value={progressValue} currency={baseCurrency} /> of{" "}
+              <PrivacyAmount value={limit.limitAmount} currency={baseCurrency} /> used
+            </p>
+          </div>
+          <div className={`shrink-0 text-right text-xs font-semibold ${statusClassName}`}>
             {isOverLimit ? (
-              <span>
-                You&apos;ve contributed{" "}
-                <span className="font-semibold">
-                  <PrivacyAmount value={deposit?.convertedAmount ?? 0} currency={baseCurrency} />
-                </span>{" "}
-                to this account in {limit.contributionYear}. Your total is{" "}
-                <span className="text-destructive font-semibold">
-                  <PrivacyAmount value={totalDeposits} currency={baseCurrency} />
-                </span>{" "}
-                which is over the{" "}
-                <span className="font-semibold">
-                  <PrivacyAmount value={limit.limitAmount} currency={baseCurrency} />
-                </span>{" "}
-                limit.
-              </span>
+              <>
+                Over by <PrivacyAmount value={Math.abs(remainingAmount)} currency={baseCurrency} />
+              </>
+            ) : isAtLimit ? (
+              "Limit reached"
             ) : (
-              <span>
-                You&apos;ve contributed{" "}
-                <span className="font-semibold">
-                  <PrivacyAmount value={deposit?.convertedAmount ?? 0} currency={baseCurrency} />
-                </span>{" "}
-                to this account in {limit.contributionYear}. Your total contribution towards the{" "}
-                <span className="font-semibold">
-                  <PrivacyAmount value={limit.limitAmount} currency={baseCurrency} />
-                </span>{" "}
-                {limit.groupName} limit is{" "}
-                <span className="font-semibold">
-                  <PrivacyAmount value={totalDeposits} currency={baseCurrency} />
-                </span>
-                .
-              </span>
+              <>
+                <PrivacyAmount value={remainingAmount} currency={baseCurrency} /> left
+              </>
             )}
           </div>
         </div>
-        <Progress value={progressPercentageNumber} className="w-full" />
+        <Progress value={Math.min(progressPercentageNumber, 100)} className="w-full" />
       </CardContent>
     </Card>
   );
@@ -142,13 +116,16 @@ function AccountContributionLimitItem({
 AccountContributionLimit.Skeleton = function AccountContributionLimitSkeleton() {
   return (
     <div className="space-y-4">
-      <Card>
-        <CardHeader>
-          <Skeleton className="h-5 w-2/5" />
-          <Skeleton className="h-4 w-4/5" />
-        </CardHeader>
-        <CardContent>
-          <Skeleton className="h-4 w-full" />
+      <Card className="border-none shadow-sm">
+        <CardContent className="space-y-3 p-4">
+          <div className="flex items-start justify-between gap-4">
+            <div className="space-y-2">
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-3 w-40" />
+            </div>
+            <Skeleton className="h-3 w-20" />
+          </div>
+          <Skeleton className="h-2 w-full" />
         </CardContent>
       </Card>
     </div>

--- a/apps/frontend/src/pages/account/account-holdings.tsx
+++ b/apps/frontend/src/pages/account/account-holdings.tsx
@@ -23,12 +23,14 @@ import { useNavigate } from "react-router-dom";
 interface AccountHoldingsProps {
   accountId: string;
   showEmptyState?: boolean;
+  showTitle?: boolean;
   onAddHoldings?: () => void;
 }
 
 const AccountHoldings = ({
   accountId,
   showEmptyState = true,
+  showTitle = true,
   onAddHoldings,
 }: AccountHoldingsProps) => {
   const isMobile = useIsMobileViewport();
@@ -201,25 +203,29 @@ const AccountHoldings = ({
     );
   }
 
+  const showHeader = showTitle || (canEditHoldingsDirectly && onAddHoldings);
+
   return (
     <div>
-      <div className="flex items-center justify-between gap-3">
-        <h3 className="text-lg font-bold">Holdings</h3>
-        {canEditHoldingsDirectly && onAddHoldings && (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button variant="ghost" size="icon" onClick={onAddHoldings}>
-                  <Icons.Pencil className="h-4 w-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p>Update holdings</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        )}
-      </div>
+      {showHeader && (
+        <div className={`flex items-center gap-3 ${showTitle ? "justify-between" : "justify-end"}`}>
+          {showTitle && <h3 className="text-lg font-bold">Holdings</h3>}
+          {canEditHoldingsDirectly && onAddHoldings && (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button variant="ghost" size="icon" onClick={onAddHoldings}>
+                    <Icons.Pencil className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Update holdings</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+        </div>
+      )}
       {isMobile ? (
         <HoldingsTableMobile
           holdings={filteredHoldings ?? []}
@@ -227,7 +233,7 @@ const AccountHoldings = ({
           selectedTypes={selectedTypes}
           setSelectedTypes={setSelectedTypes}
           accountFilter={{ type: "account", accountId: selectedAccount?.id ?? "" }}
-          onAccountScopeChange={() => {}}
+          onAccountScopeChange={() => undefined}
           accounts={[]}
           portfolios={[]}
           showAccountScope={false}

--- a/apps/frontend/src/pages/account/account-metrics.tsx
+++ b/apps/frontend/src/pages/account/account-metrics.tsx
@@ -84,6 +84,7 @@ interface AccountMetricsProps {
   performance?: PerformanceResult | null;
   cashCurrencySplit?: CurrentValuationSplit[];
   className?: string;
+  compact?: boolean;
   isLoading?: boolean;
   isPerformanceLoading?: boolean;
   performanceError?: string;
@@ -140,6 +141,7 @@ const AccountMetrics: React.FC<AccountMetricsProps> = ({
   performance,
   cashCurrencySplit,
   className,
+  compact = false,
   isLoading,
   isPerformanceLoading,
   performanceError,
@@ -310,19 +312,21 @@ const AccountMetrics: React.FC<AccountMetricsProps> = ({
           )}
         </div>
       </CardHeader>
-      <CardContent className="space-y-4 pb-2">
-        <CashCurrencyBreakdown
-          cashCurrencySplit={cashCurrencySplit}
-          displayCurrency={displayCurrency}
-        />
-        <Separator />
-        <div className="space-y-2.5 text-sm">
-          {rows.map(({ label, value }, idx) => (
-            <div key={idx} className="flex justify-between">
-              <span className="text-muted-foreground">{label}</span>
-              <span className={`font-medium`}>{value}</span>
-            </div>
-          ))}
+      <CardContent className={cn(compact ? "space-y-4 pb-2" : "space-y-6 pb-4")}>
+        <div className="space-y-4">
+          <CashCurrencyBreakdown
+            cashCurrencySplit={cashCurrencySplit}
+            displayCurrency={displayCurrency}
+          />
+          <Separator />
+          <div className={cn(compact ? "space-y-2.5" : "space-y-4", "text-sm")}>
+            {rows.map(({ label, value }, idx) => (
+              <div key={idx} className="flex justify-between">
+                <span className="text-muted-foreground">{label}</span>
+                <span className={`font-medium`}>{value}</span>
+              </div>
+            ))}
+          </div>
         </div>
 
         <PerformanceGrid

--- a/apps/frontend/src/pages/account/account-page.test.tsx
+++ b/apps/frontend/src/pages/account/account-page.test.tsx
@@ -5,6 +5,7 @@ import { getHoldings } from "@/adapters";
 import { useAccounts } from "@/hooks/use-accounts";
 import { useRecalculatePortfolioMutation } from "@/hooks/use-calculate-portfolio";
 import { useCurrentValuation } from "@/hooks/use-current-account-valuations";
+import { useIsMobileViewport } from "@/hooks/use-platform";
 import { useValuationHistory } from "@/hooks/use-valuation-history";
 import { useSettingsContext } from "@/lib/settings-provider";
 import type {
@@ -20,6 +21,7 @@ import { useCalculatePerformanceHistory } from "@/pages/performance/hooks/use-pe
 import AccountPage from "./account-page";
 
 vi.mock("@/adapters", () => ({
+  getContributionLimit: vi.fn(),
   getHoldings: vi.fn(),
   getSnapshots: vi.fn(),
   searchActivities: vi.fn(),
@@ -49,6 +51,10 @@ vi.mock("@/hooks/use-current-account-valuations", () => ({
   useCurrentValuation: vi.fn(),
 }));
 
+vi.mock("@/hooks/use-platform", () => ({
+  useIsMobileViewport: vi.fn(),
+}));
+
 vi.mock("@/hooks/use-valuation-history", () => ({
   useValuationHistory: vi.fn(),
 }));
@@ -61,8 +67,43 @@ vi.mock("@/pages/activity/components/activity-date-sheet", () => ({
   ActivityDateSheet: () => <div>activity-date-sheet</div>,
 }));
 
+vi.mock("@/pages/activity/components/activity-delete-modal", () => ({
+  ActivityDeleteModal: () => <div>activity-delete-modal</div>,
+}));
+
+vi.mock("@/pages/activity/components/activity-form", () => ({
+  ActivityForm: () => <div>activity-form</div>,
+}));
+
+vi.mock("@/pages/activity/components/activity-table/activity-table", () => ({
+  default: () => <div>activity-table</div>,
+}));
+
+vi.mock("@/pages/activity/components/activity-table/activity-table-mobile", () => ({
+  default: () => <div>activity-table-mobile</div>,
+}));
+
 vi.mock("@/pages/activity/components/forms/bulk-holdings-modal", () => ({
   BulkHoldingsModal: () => <div>bulk-holdings-modal</div>,
+}));
+
+vi.mock("@/pages/activity/components/mobile-forms/mobile-activity-form", () => ({
+  MobileActivityForm: () => <div>mobile-activity-form</div>,
+}));
+
+vi.mock("@/pages/activity/hooks/use-activity-action-dialogs", () => ({
+  useActivityActionDialogs: () => ({
+    selectedActivity: undefined,
+    formOpen: false,
+    deleteDialogOpen: false,
+    isDeleting: false,
+    openForm: vi.fn(),
+    closeForm: vi.fn(),
+    requestDelete: vi.fn(),
+    cancelDelete: vi.fn(),
+    confirmDelete: vi.fn(),
+    duplicateActivity: vi.fn(),
+  }),
 }));
 
 vi.mock("@/pages/dashboard/portfolio-update-trigger", () => ({
@@ -100,7 +141,13 @@ vi.mock("@wealthfolio/ui", () => {
   const Passthrough = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
 
   return {
-    AnimatedToggleGroup: () => <div>toggle-group</div>,
+    AnimatedToggleGroup: ({ items }: { items?: { value: string; label: string }[] }) => (
+      <div>
+        {items?.map((item) => (
+          <span key={item.value}>{item.label}</span>
+        ))}
+      </div>
+    ),
     Card: Passthrough,
     CardContent: Passthrough,
     CardHeader: Passthrough,
@@ -109,6 +156,7 @@ vi.mock("@wealthfolio/ui", () => {
     GainPercent: ({ value }: { value: number }) => <span>{`gain-percent:${value}`}</span>,
     Icons: {
       Activity: Icon,
+      ArrowRight: Icon,
       Bitcoin: Icon,
       Briefcase: Icon,
       Check: Icon,
@@ -116,6 +164,7 @@ vi.mock("@wealthfolio/ui", () => {
       Clock: Icon,
       CreditCard: Icon,
       DollarSign: Icon,
+      ExternalLink: Icon,
       History: Icon,
       Holdings: Icon,
       Import: Icon,
@@ -140,10 +189,12 @@ vi.mock("@wealthfolio/ui", () => {
 vi.mock("@wealthfolio/ui/components/ui/button", () => ({
   Button: ({
     children,
+    asChild,
     ...props
-  }: React.ButtonHTMLAttributes<HTMLButtonElement> & { children?: React.ReactNode }) => (
-    <button {...props}>{children}</button>
-  ),
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    asChild?: boolean;
+    children?: React.ReactNode;
+  }) => (asChild ? <>{children}</> : <button {...props}>{children}</button>),
 }));
 
 vi.mock("@wealthfolio/ui/components/ui/command", () => ({
@@ -178,6 +229,18 @@ vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
   return {
     ...actual,
+    Link: ({
+      children,
+      to,
+      ...props
+    }: React.AnchorHTMLAttributes<HTMLAnchorElement> & {
+      children?: React.ReactNode;
+      to: string;
+    }) => (
+      <a href={to} {...props}>
+        {children}
+      </a>
+    ),
     useNavigate: () => vi.fn(),
     useParams: () => ({ id: "account-1" }),
   };
@@ -201,6 +264,7 @@ vi.mock("./account-snapshot-history", () => ({
 
 const mockUseAccounts = vi.mocked(useAccounts);
 const mockUseCurrentValuation = vi.mocked(useCurrentValuation);
+const mockUseIsMobileViewport = vi.mocked(useIsMobileViewport);
 const mockUseValuationHistory = vi.mocked(useValuationHistory);
 const mockUseSettingsContext = vi.mocked(useSettingsContext);
 const mockUseCalculatePerformanceHistory = vi.mocked(useCalculatePerformanceHistory);
@@ -219,6 +283,8 @@ describe("AccountPage", () => {
       accounts: [createAccount()],
       isLoading: false,
     } as unknown as ReturnType<typeof useAccounts>);
+
+    mockUseIsMobileViewport.mockReturnValue(false);
 
     mockUseRecalculatePortfolioMutation.mockReturnValue({
       mutate: vi.fn(),
@@ -329,6 +395,31 @@ describe("AccountPage", () => {
       "Some exchange rates are missing, so this value may be approximate.",
     );
     expect(screen.getByTestId("account-notices")).not.toHaveTextContent("Summary notice");
+  });
+
+  it("adds an activities tab to the account detail area", () => {
+    mockUseValuationHistory.mockReturnValue({
+      valuationHistory: [createHistoricalValuation({ totalValue: 100 })],
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useValuationHistory>);
+    mockUseCurrentValuation.mockReturnValue({
+      currentValuation: {
+        summary: createCurrentSummary({ totalValueBase: 125 }),
+        accounts: [createCurrentAccountValuation({ totalValue: 125 })],
+      },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+    } as unknown as ReturnType<typeof useCurrentValuation>);
+
+    render(<AccountPage />);
+
+    expect(screen.getByText("Activities")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Explore activities/i })).toHaveAttribute(
+      "href",
+      "/activities?account=account-1",
+    );
   });
 });
 

--- a/apps/frontend/src/pages/account/account-page.test.tsx
+++ b/apps/frontend/src/pages/account/account-page.test.tsx
@@ -17,6 +17,7 @@ import type {
   Settings,
 } from "@/lib/types";
 import { AccountType } from "@/lib/types";
+import { useActivitySearch } from "@/pages/activity/hooks/use-activity-search";
 import { useCalculatePerformanceHistory } from "@/pages/performance/hooks/use-performance-data";
 import AccountPage from "./account-page";
 
@@ -75,6 +76,10 @@ vi.mock("@/pages/activity/components/activity-form", () => ({
   ActivityForm: () => <div>activity-form</div>,
 }));
 
+vi.mock("@/pages/activity/components/activity-pagination", () => ({
+  ActivityPagination: () => <div>activity-pagination</div>,
+}));
+
 vi.mock("@/pages/activity/components/activity-table/activity-table", () => ({
   default: () => <div>activity-table</div>,
 }));
@@ -104,6 +109,20 @@ vi.mock("@/pages/activity/hooks/use-activity-action-dialogs", () => ({
     confirmDelete: vi.fn(),
     duplicateActivity: vi.fn(),
   }),
+}));
+
+vi.mock("@/pages/activity/hooks/use-activity-search", () => ({
+  useActivitySearch: vi.fn(() => ({
+    mode: "infinite",
+    data: [],
+    totalRowCount: 0,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetching: false,
+    isFetchingNextPage: false,
+    isLoading: false,
+    refetch: vi.fn(),
+  })),
 }));
 
 vi.mock("@/pages/dashboard/portfolio-update-trigger", () => ({
@@ -276,6 +295,7 @@ const mockUseIsMobileViewport = vi.mocked(useIsMobileViewport);
 const mockUseValuationHistory = vi.mocked(useValuationHistory);
 const mockUseSettingsContext = vi.mocked(useSettingsContext);
 const mockUseCalculatePerformanceHistory = vi.mocked(useCalculatePerformanceHistory);
+const mockUseActivitySearch = vi.mocked(useActivitySearch);
 const mockUseQuery = vi.mocked(useQuery);
 const mockUseRecalculatePortfolioMutation = vi.mocked(useRecalculatePortfolioMutation);
 
@@ -424,8 +444,17 @@ describe("AccountPage", () => {
     render(<AccountPage />);
 
     expect(screen.getByText("Activities")).toBeInTheDocument();
+    expect(mockUseActivitySearch.mock.calls.at(-1)?.[0]).toMatchObject({
+      mode: "infinite",
+      filters: { accountIds: [] },
+    });
+
     fireEvent.click(screen.getByRole("button", { name: "Activities" }));
 
+    expect(mockUseActivitySearch.mock.calls.at(-1)?.[0]).toMatchObject({
+      mode: "infinite",
+      filters: { accountIds: ["account-1"] },
+    });
     expect(screen.getByRole("link", { name: /Explore activities/i })).toHaveAttribute(
       "href",
       "/activities?account=account-1",

--- a/apps/frontend/src/pages/account/account-page.test.tsx
+++ b/apps/frontend/src/pages/account/account-page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useQuery } from "@tanstack/react-query";
 import { getHoldings } from "@/adapters";
@@ -141,10 +141,18 @@ vi.mock("@wealthfolio/ui", () => {
   const Passthrough = ({ children }: { children?: React.ReactNode }) => <>{children}</>;
 
   return {
-    AnimatedToggleGroup: ({ items }: { items?: { value: string; label: string }[] }) => (
+    AnimatedToggleGroup: ({
+      items,
+      onValueChange,
+    }: {
+      items?: { value: string; label: string }[];
+      onValueChange?: (value: string) => void;
+    }) => (
       <div>
         {items?.map((item) => (
-          <span key={item.value}>{item.label}</span>
+          <button key={item.value} type="button" onClick={() => onValueChange?.(item.value)}>
+            {item.label}
+          </button>
         ))}
       </div>
     ),
@@ -416,6 +424,8 @@ describe("AccountPage", () => {
     render(<AccountPage />);
 
     expect(screen.getByText("Activities")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Activities" }));
+
     expect(screen.getByRole("link", { name: /Explore activities/i })).toHaveAttribute(
       "href",
       "/activities?account=account-1",

--- a/apps/frontend/src/pages/account/account-page.tsx
+++ b/apps/frontend/src/pages/account/account-page.tsx
@@ -1,4 +1,4 @@
-import { getHoldings, getSnapshots, searchActivities } from "@/adapters";
+import { getContributionLimit, getHoldings, getSnapshots, searchActivities } from "@/adapters";
 import { HistoryChart } from "@/components/history-chart";
 import type { ActivityDetails } from "@/lib/types";
 import {
@@ -27,8 +27,9 @@ import { PrivacyToggle } from "@/components/privacy-toggle";
 import { useAccounts } from "@/hooks/use-accounts";
 import { useRecalculatePortfolioMutation } from "@/hooks/use-calculate-portfolio";
 import { useCurrentValuation } from "@/hooks/use-current-account-valuations";
+import { useIsMobileViewport } from "@/hooks/use-platform";
 import { useValuationHistory } from "@/hooks/use-valuation-history";
-import { canAddHoldings } from "@/lib/activity-restrictions";
+import { canAddHoldings, getActivityRestrictionLevel } from "@/lib/activity-restrictions";
 import {
   AccountPurpose,
   AccountType,
@@ -47,6 +48,7 @@ import { useSettingsContext } from "@/lib/settings-provider";
 import {
   Account,
   AccountValuation,
+  ContributionLimit,
   DateRange,
   Holding,
   SnapshotInfo,
@@ -55,7 +57,13 @@ import {
 } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { ActivityDateSheet } from "@/pages/activity/components/activity-date-sheet";
+import { ActivityDeleteModal } from "@/pages/activity/components/activity-delete-modal";
+import { ActivityForm, type AccountSelectOption } from "@/pages/activity/components/activity-form";
+import ActivityTable from "@/pages/activity/components/activity-table/activity-table";
+import ActivityTableMobile from "@/pages/activity/components/activity-table/activity-table-mobile";
 import { BulkHoldingsModal } from "@/pages/activity/components/forms/bulk-holdings-modal";
+import { MobileActivityForm } from "@/pages/activity/components/mobile-forms/mobile-activity-form";
+import { useActivityActionDialogs } from "@/pages/activity/hooks/use-activity-action-dialogs";
 import { PortfolioUpdateTrigger } from "@/pages/dashboard/portfolio-update-trigger";
 import { HoldingsEditMode } from "@/pages/holdings/components/holdings-edit-mode";
 import { useCalculatePerformanceHistory } from "@/pages/performance/hooks/use-performance-data";
@@ -81,7 +89,7 @@ import {
   SheetTrigger,
 } from "@wealthfolio/ui/components/ui/sheet";
 import { format, subMonths } from "date-fns";
-import { useNavigate, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { AccountContributionLimit } from "./account-contribution-limit";
 import AccountHoldings from "./account-holdings";
 import AccountMetrics from "./account-metrics";
@@ -100,7 +108,7 @@ interface HistoryChartData {
   currency: string;
 }
 
-type AccountDetailTab = "holdings" | "snapshots";
+type AccountDetailTab = "holdings" | "activities" | "snapshots";
 
 // Map account types to icons for visual distinction
 const accountTypeIcons: Record<AccountType, Icon> = {
@@ -119,6 +127,31 @@ const getInitialDateRange = (): DateRange => ({
 // Define the initial interval code (consistent with other pages)
 const INITIAL_INTERVAL_CODE: TimePeriod = "3M";
 const CASH_AUDIT_ACTIVITY_PAGE_SIZE = 500;
+const ACCOUNT_ACTIVITY_PAGE_SIZE = 500;
+
+async function getAccountActivities(accountId: string): Promise<ActivityDetails[]> {
+  const activities: ActivityDetails[] = [];
+  let page = 0;
+  let totalRowCount = Number.POSITIVE_INFINITY;
+
+  while (activities.length < totalRowCount) {
+    const response = await searchActivities(
+      page,
+      ACCOUNT_ACTIVITY_PAGE_SIZE,
+      { accountIds: [accountId] },
+      "",
+      { id: "date", desc: true },
+    );
+
+    activities.push(...response.data);
+    totalRowCount = response.meta.totalRowCount;
+
+    if (response.data.length < ACCOUNT_ACTIVITY_PAGE_SIZE) break;
+    page += 1;
+  }
+
+  return activities;
+}
 
 async function getCashAuditActivities(
   accountId: string,
@@ -154,6 +187,7 @@ const AccountPage = () => {
   const appTimezone = settings?.timezone?.trim() || undefined;
   const { id = "" } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const isMobile = useIsMobileViewport();
   const [dateRange, setDateRange] = useState<DateRange | undefined>(getInitialDateRange());
   const [selectedIntervalCode, setSelectedIntervalCode] =
     useState<TimePeriod>(INITIAL_INTERVAL_CODE);
@@ -167,16 +201,45 @@ const AccountPage = () => {
   const [isActivitySheetOpen, setIsActivitySheetOpen] = useState(false);
   const [showBulkHoldingsForm, setShowBulkHoldingsForm] = useState(false);
   const [accountDetailTab, setAccountDetailTab] = useState<AccountDetailTab>("holdings");
+  const {
+    selectedActivity,
+    formOpen: activityFormOpen,
+    deleteDialogOpen: showActivityDeleteAlert,
+    isDeleting: isActivityDeleting,
+    openForm: handleActivityEdit,
+    closeForm: handleActivityFormClose,
+    requestDelete: handleActivityDelete,
+    cancelDelete: handleActivityDeleteCancel,
+    confirmDelete: handleActivityDeleteConfirm,
+    duplicateActivity: handleActivityDuplicate,
+  } = useActivityActionDialogs();
 
   const recalculatePortfolioMutation = useRecalculatePortfolioMutation();
   const { accounts, isLoading: isAccountsLoading } = useAccounts();
   const account = useMemo(() => accounts?.find((acc) => acc.id === id), [accounts, id]);
   const isLiabilityAccount = isLiabilityAccountType(account?.accountType);
+  const isCashOnlyAccount = account?.accountType === AccountType.CASH || isLiabilityAccount;
   const supportsPerformance = accountSupportsPurpose(account, AccountPurpose.PERFORMANCE);
   const supportsContributionLimits = accountSupportsPurpose(
     account,
     AccountPurpose.CONTRIBUTION_LIMITS,
   );
+  const currentContributionYear = new Date().getFullYear();
+
+  const { data: contributionLimits, isLoading: isContributionLimitsLoading } = useQuery<
+    ContributionLimit[],
+    Error
+  >({
+    queryKey: [QueryKeys.CONTRIBUTION_LIMITS],
+    queryFn: getContributionLimit,
+    enabled: supportsContributionLimits,
+  });
+
+  const currentContributionLimit = contributionLimits?.find(
+    (limit) => limit.accountIds?.includes(id) && limit.contributionYear === currentContributionYear,
+  );
+  const showContributionLimitCard =
+    supportsContributionLimits && (isContributionLimitsLoading || !!currentContributionLimit);
 
   // Check if this account is in HOLDINGS tracking mode
   const isHoldingsMode = useMemo(() => {
@@ -209,19 +272,48 @@ const AccountPage = () => {
   const shouldShowSnapshotHistory = isHoldingsMode && hasHoldings && !isHoldingsLoading;
 
   const accountDetailTabs = useMemo(() => {
-    if (!shouldShowSnapshotHistory) return [];
-
+    if (!account) return [];
     const tabs: { value: AccountDetailTab; label: string }[] = [];
-    if (hasNonCashHoldings) {
+
+    if (!isCashOnlyAccount && (!shouldShowSnapshotHistory || hasNonCashHoldings)) {
       tabs.push({ value: "holdings", label: "Holdings" });
     }
-    tabs.push({ value: "snapshots", label: "Snapshots" });
+
+    tabs.push({ value: "activities", label: "Activities" });
+
+    if (shouldShowSnapshotHistory) {
+      tabs.push({ value: "snapshots", label: "Snapshots" });
+    }
+
     return tabs;
-  }, [shouldShowSnapshotHistory, hasNonCashHoldings]);
+  }, [account, hasNonCashHoldings, isCashOnlyAccount, shouldShowSnapshotHistory]);
 
   const activeAccountDetailTab = accountDetailTabs.some((tab) => tab.value === accountDetailTab)
     ? accountDetailTab
-    : (accountDetailTabs[0]?.value ?? "holdings");
+    : (accountDetailTabs[0]?.value ?? "activities");
+
+  const { data: accountActivities = [], isLoading: isAccountActivitiesLoading } = useQuery<
+    ActivityDetails[],
+    Error
+  >({
+    queryKey: [QueryKeys.ACTIVITIES, "byAccount", id],
+    queryFn: () => getAccountActivities(id),
+    enabled: !!account,
+  });
+
+  const activityFormAccounts = useMemo<AccountSelectOption[]>(
+    () =>
+      accounts
+        .filter((acc) => !acc.isArchived)
+        .map((acc) => ({
+          value: acc.id,
+          label: acc.name,
+          currency: acc.currency,
+          accountType: acc.accountType,
+          restrictionLevel: getActivityRestrictionLevel(acc),
+        })),
+    [accounts],
+  );
 
   // Format date range for snapshot query
   const snapshotDateFrom = dateRange?.from ? format(dateRange.from, "yyyy-MM-dd") : undefined;
@@ -521,6 +613,75 @@ const AccountPage = () => {
     setMobileSelectorOpen(false);
   };
 
+  const accountActivitiesContent = isMobile ? (
+    <ActivityTableMobile
+      activities={accountActivities}
+      isCompactView={true}
+      handleEdit={handleActivityEdit}
+      handleDelete={handleActivityDelete}
+      onDuplicate={handleActivityDuplicate}
+      onAdd={() => navigate(`/activities/manage?account=${id}`)}
+    />
+  ) : (
+    <ActivityTable
+      activities={accountActivities}
+      isLoading={isAccountActivitiesLoading}
+      sorting={[{ id: "date", desc: true }]}
+      onSortingChange={() => undefined}
+      handleEdit={handleActivityEdit}
+      handleDelete={handleActivityDelete}
+      onAdd={() => navigate(`/activities/manage?account=${id}`)}
+    />
+  );
+
+  const accountDetailsContent = (
+    <div className="space-y-4">
+      {(accountDetailTabs.length > 1 || activeAccountDetailTab === "activities") && (
+        <div className="flex items-center justify-between gap-3">
+          {accountDetailTabs.length > 1 ? (
+            <AnimatedToggleGroup<AccountDetailTab>
+              items={accountDetailTabs}
+              value={activeAccountDetailTab}
+              onValueChange={setAccountDetailTab}
+              className="text-sm"
+            />
+          ) : (
+            <div />
+          )}
+
+          {activeAccountDetailTab === "activities" && (
+            <Button variant="ghost" size="sm" className="shrink-0" asChild>
+              <Link to={`/activities?account=${id}`} className="inline-flex items-center gap-1.5">
+                Explore activities
+                <Icons.ArrowRight className="h-3.5 w-3.5" />
+              </Link>
+            </Button>
+          )}
+        </div>
+      )}
+
+      {activeAccountDetailTab === "holdings" ? (
+        <AccountHoldings
+          accountId={id}
+          showEmptyState={true}
+          showTitle={false}
+          onAddHoldings={() => setIsEditingHoldings(true)}
+        />
+      ) : activeAccountDetailTab === "activities" ? (
+        accountActivitiesContent
+      ) : account ? (
+        <AccountSnapshotHistory
+          account={account}
+          canEditSnapshots={canEditHoldingsDirectly}
+          onAddSnapshot={() => {
+            setEditingSnapshotDate(null);
+            setIsEditingHoldings(true);
+          }}
+        />
+      ) : null}
+    </div>
+  );
+
   return (
     <Page>
       <PageHeader
@@ -617,21 +778,32 @@ const AccountPage = () => {
             </div>
           )}
           <div className="flex min-w-0 flex-col justify-center">
-            <div className="flex items-center gap-1">
-              <h1 className="truncate text-base font-semibold leading-tight md:text-lg">
-                {account?.name ?? "Account"}
-              </h1>
+            <div className="flex min-w-0 items-center">
               {/* Desktop account selector */}
-              <div className="hidden sm:block">
+              <div className="hidden min-w-0 sm:block">
                 <Popover open={desktopSelectorOpen} onOpenChange={setDesktopSelectorOpen}>
                   <PopoverTrigger asChild>
                     <Button
                       variant="ghost"
-                      size="icon"
-                      className="h-8 w-8 rounded-full"
+                      className="-ml-2 h-auto min-w-0 justify-start rounded-md px-2 py-1 text-left"
                       aria-label="Switch account"
                     >
-                      <Icons.ChevronDown className="text-muted-foreground size-5" />
+                      <span className="flex min-w-0 items-center gap-1.5">
+                        {account?.group ? (
+                          <>
+                            <span className="text-muted-foreground truncate text-base font-semibold leading-tight md:text-lg">
+                              {account.group}
+                            </span>
+                            <span className="text-muted-foreground text-sm" aria-hidden="true">
+                              &gt;
+                            </span>
+                          </>
+                        ) : null}
+                        <span className="truncate text-base font-semibold leading-tight md:text-lg">
+                          {account?.name ?? "Account"}
+                        </span>
+                        <Icons.ChevronDown className="text-muted-foreground size-5 shrink-0" />
+                      </span>
                     </Button>
                   </PopoverTrigger>
                   <PopoverContent className="w-60 p-0" align="start">
@@ -673,16 +845,20 @@ const AccountPage = () => {
               </div>
 
               {/* Mobile account selector */}
-              <div className="block sm:hidden">
+              <div className="block min-w-0 sm:hidden">
                 <Sheet open={mobileSelectorOpen} onOpenChange={setMobileSelectorOpen}>
                   <SheetTrigger asChild>
                     <Button
                       variant="ghost"
-                      size="icon"
-                      className="h-8 w-8 rounded-full"
+                      className="-ml-2 h-auto min-w-0 justify-start rounded-md px-2 py-1 text-left"
                       aria-label="Switch account"
                     >
-                      <Icons.ChevronDown className="text-muted-foreground h-5 w-5" />
+                      <span className="flex min-w-0 items-center gap-1.5">
+                        <span className="truncate text-base font-semibold leading-tight">
+                          {account?.name ?? "Account"}
+                        </span>
+                        <Icons.ChevronDown className="text-muted-foreground h-5 w-5 shrink-0" />
+                      </span>
                     </Button>
                   </SheetTrigger>
                   <SheetContent side="bottom" className="rounded-t-4xl mx-1 h-[80vh] p-0">
@@ -738,9 +914,11 @@ const AccountPage = () => {
                 </Sheet>
               </div>
             </div>
-            <p className="text-muted-foreground text-xs leading-tight md:text-sm">
-              {account?.group ?? account?.currency}
-            </p>
+            {!account?.group && account?.currency && (
+              <p className="text-muted-foreground text-xs leading-tight md:text-sm">
+                {account?.currency}
+              </p>
+            )}
           </div>
         </div>
       </PageHeader>
@@ -857,12 +1035,13 @@ const AccountPage = () => {
                 </CardContent>
               </Card>
 
-              <div className="flex flex-col space-y-4">
+              <div className="flex min-h-0 flex-col gap-4">
                 <AccountMetrics
                   valuation={metricsValuation}
                   performance={accountPerformance}
                   cashCurrencySplit={liveCurrentValuation?.summary.cashCurrencySplit}
-                  className="grow"
+                  className="min-h-0 grow"
+                  compact={showContributionLimitCard}
                   isLoading={isLoading}
                   isPerformanceLoading={isPerformanceHistoryLoading}
                   performanceError={hasPerformanceError ? performanceErrorMessages[0] : undefined}
@@ -885,40 +1064,18 @@ const AccountPage = () => {
                       : undefined
                   }
                 />
-                {supportsContributionLimits && <AccountContributionLimit accountId={id} />}
+                {showContributionLimitCard && <AccountContributionLimit accountId={id} />}
               </div>
             </div>
 
-            {shouldShowSnapshotHistory && account ? (
-              <div className="space-y-4">
-                <AnimatedToggleGroup<AccountDetailTab>
-                  items={accountDetailTabs}
-                  value={activeAccountDetailTab}
-                  onValueChange={setAccountDetailTab}
-                  className="text-sm"
-                />
-
-                {activeAccountDetailTab === "holdings" ? (
-                  <AccountHoldings
-                    accountId={id}
-                    showEmptyState={false}
-                    onAddHoldings={() => setIsEditingHoldings(true)}
-                  />
-                ) : (
-                  <AccountSnapshotHistory
-                    account={account}
-                    canEditSnapshots={canEditHoldingsDirectly}
-                    onAddSnapshot={() => {
-                      setEditingSnapshotDate(null);
-                      setIsEditingHoldings(true);
-                    }}
-                  />
-                )}
-              </div>
+            {accountDetailTabs.length > 0 ? (
+              accountDetailsContent
             ) : (
               <AccountHoldings accountId={id} onAddHoldings={() => setIsEditingHoldings(true)} />
             )}
           </>
+        ) : accountDetailTabs.length > 0 ? (
+          accountDetailsContent
         ) : (
           <AccountHoldings
             accountId={id}
@@ -953,6 +1110,32 @@ const AccountPage = () => {
           </SheetContent>
         </Sheet>
       )}
+
+      {isMobile ? (
+        <MobileActivityForm
+          key={selectedActivity?.id ?? "new"}
+          accounts={activityFormAccounts}
+          transferAccounts={activityFormAccounts}
+          activity={selectedActivity}
+          open={activityFormOpen}
+          onClose={handleActivityFormClose}
+        />
+      ) : (
+        <ActivityForm
+          accounts={activityFormAccounts}
+          transferAccounts={activityFormAccounts}
+          activity={selectedActivity}
+          open={activityFormOpen}
+          onClose={handleActivityFormClose}
+        />
+      )}
+      <ActivityDeleteModal
+        isOpen={showActivityDeleteAlert}
+        isDeleting={isActivityDeleting}
+        linkedTransfer={!!selectedActivity?.sourceGroupId}
+        onConfirm={handleActivityDeleteConfirm}
+        onCancel={handleActivityDeleteCancel}
+      />
 
       <ActivityDateSheet
         open={isActivitySheetOpen}

--- a/apps/frontend/src/pages/account/account-page.tsx
+++ b/apps/frontend/src/pages/account/account-page.tsx
@@ -33,6 +33,7 @@ import { canAddHoldings, getActivityRestrictionLevel } from "@/lib/activity-rest
 import {
   AccountPurpose,
   AccountType,
+  type ActivityType,
   accountSupportsPurpose,
   HoldingType,
   isLiabilityAccountType,
@@ -59,15 +60,18 @@ import { cn } from "@/lib/utils";
 import { ActivityDateSheet } from "@/pages/activity/components/activity-date-sheet";
 import { ActivityDeleteModal } from "@/pages/activity/components/activity-delete-modal";
 import { ActivityForm, type AccountSelectOption } from "@/pages/activity/components/activity-form";
+import { ActivityPagination } from "@/pages/activity/components/activity-pagination";
 import ActivityTable from "@/pages/activity/components/activity-table/activity-table";
 import ActivityTableMobile from "@/pages/activity/components/activity-table/activity-table-mobile";
 import { BulkHoldingsModal } from "@/pages/activity/components/forms/bulk-holdings-modal";
 import { MobileActivityForm } from "@/pages/activity/components/mobile-forms/mobile-activity-form";
 import { useActivityActionDialogs } from "@/pages/activity/hooks/use-activity-action-dialogs";
+import { useActivitySearch } from "@/pages/activity/hooks/use-activity-search";
 import { PortfolioUpdateTrigger } from "@/pages/dashboard/portfolio-update-trigger";
 import { HoldingsEditMode } from "@/pages/holdings/components/holdings-edit-mode";
 import { useCalculatePerformanceHistory } from "@/pages/performance/hooks/use-performance-data";
 import { useQuery } from "@tanstack/react-query";
+import type { SortingState } from "@tanstack/react-table";
 import { Icons, type Icon } from "@wealthfolio/ui";
 import { Button } from "@wealthfolio/ui/components/ui/button";
 import {
@@ -127,31 +131,8 @@ const getInitialDateRange = (): DateRange => ({
 // Define the initial interval code (consistent with other pages)
 const INITIAL_INTERVAL_CODE: TimePeriod = "3M";
 const CASH_AUDIT_ACTIVITY_PAGE_SIZE = 500;
-const ACCOUNT_ACTIVITY_PAGE_SIZE = 500;
-
-async function getAccountActivities(accountId: string): Promise<ActivityDetails[]> {
-  const activities: ActivityDetails[] = [];
-  let page = 0;
-  let totalRowCount = Number.POSITIVE_INFINITY;
-
-  while (activities.length < totalRowCount) {
-    const response = await searchActivities(
-      page,
-      ACCOUNT_ACTIVITY_PAGE_SIZE,
-      { accountIds: [accountId] },
-      "",
-      { id: "date", desc: true },
-    );
-
-    activities.push(...response.data);
-    totalRowCount = response.meta.totalRowCount;
-
-    if (response.data.length < ACCOUNT_ACTIVITY_PAGE_SIZE) break;
-    page += 1;
-  }
-
-  return activities;
-}
+const EMPTY_ACCOUNT_IDS: string[] = [];
+const EMPTY_ACTIVITY_TYPES: ActivityType[] = [];
 
 async function getCashAuditActivities(
   accountId: string,
@@ -201,6 +182,9 @@ const AccountPage = () => {
   const [isActivitySheetOpen, setIsActivitySheetOpen] = useState(false);
   const [showBulkHoldingsForm, setShowBulkHoldingsForm] = useState(false);
   const [accountDetailTab, setAccountDetailTab] = useState<AccountDetailTab>("holdings");
+  const [accountActivitiesSorting, setAccountActivitiesSorting] = useState<SortingState>([
+    { id: "date", desc: true },
+  ]);
   const {
     selectedActivity,
     formOpen: activityFormOpen,
@@ -292,13 +276,19 @@ const AccountPage = () => {
     ? accountDetailTab
     : (accountDetailTabs[0]?.value ?? "activities");
 
-  const { data: accountActivities = [], isLoading: isAccountActivitiesLoading } = useQuery<
-    ActivityDetails[],
-    Error
-  >({
-    queryKey: [QueryKeys.ACTIVITIES, "byAccount", id],
-    queryFn: () => getAccountActivities(id),
-    enabled: !!account,
+  const isAccountActivitiesTabActive = activeAccountDetailTab === "activities";
+  const accountActivityAccountIds = useMemo(
+    () => (isAccountActivitiesTabActive && account ? [id] : EMPTY_ACCOUNT_IDS),
+    [account, id, isAccountActivitiesTabActive],
+  );
+  const accountActivitiesSearch = useActivitySearch({
+    mode: "infinite",
+    filters: {
+      accountIds: accountActivityAccountIds,
+      activityTypes: EMPTY_ACTIVITY_TYPES,
+    },
+    searchQuery: "",
+    sorting: accountActivitiesSorting,
   });
 
   const activityFormAccounts = useMemo<AccountSelectOption[]>(
@@ -614,24 +604,43 @@ const AccountPage = () => {
   };
 
   const accountActivitiesContent = isMobile ? (
-    <ActivityTableMobile
-      activities={accountActivities}
-      isCompactView={true}
-      handleEdit={handleActivityEdit}
-      handleDelete={handleActivityDelete}
-      onDuplicate={handleActivityDuplicate}
-      onAdd={() => navigate(`/activities/manage?account=${id}`)}
-    />
+    <>
+      <ActivityTableMobile
+        activities={accountActivitiesSearch.data}
+        isLoading={accountActivitiesSearch.isLoading}
+        isCompactView={true}
+        handleEdit={handleActivityEdit}
+        handleDelete={handleActivityDelete}
+        onDuplicate={handleActivityDuplicate}
+        onAdd={() => navigate(`/activities/manage?account=${id}`)}
+      />
+      <ActivityPagination
+        hasMore={accountActivitiesSearch.hasNextPage ?? false}
+        onLoadMore={accountActivitiesSearch.fetchNextPage}
+        isFetching={accountActivitiesSearch.isFetchingNextPage}
+        totalFetched={accountActivitiesSearch.data.length}
+        totalCount={accountActivitiesSearch.totalRowCount}
+      />
+    </>
   ) : (
-    <ActivityTable
-      activities={accountActivities}
-      isLoading={isAccountActivitiesLoading}
-      sorting={[{ id: "date", desc: true }]}
-      onSortingChange={() => undefined}
-      handleEdit={handleActivityEdit}
-      handleDelete={handleActivityDelete}
-      onAdd={() => navigate(`/activities/manage?account=${id}`)}
-    />
+    <>
+      <ActivityTable
+        activities={accountActivitiesSearch.data}
+        isLoading={accountActivitiesSearch.isLoading}
+        sorting={accountActivitiesSorting}
+        onSortingChange={setAccountActivitiesSorting}
+        handleEdit={handleActivityEdit}
+        handleDelete={handleActivityDelete}
+        onAdd={() => navigate(`/activities/manage?account=${id}`)}
+      />
+      <ActivityPagination
+        hasMore={accountActivitiesSearch.hasNextPage ?? false}
+        onLoadMore={accountActivitiesSearch.fetchNextPage}
+        isFetching={accountActivitiesSearch.isFetchingNextPage}
+        totalFetched={accountActivitiesSearch.data.length}
+        totalCount={accountActivitiesSearch.totalRowCount}
+      />
+    </>
   );
 
   const accountDetailsContent = (

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
@@ -23,6 +23,7 @@ import { ActivityTypeBadge } from "../activity-type-badge";
 
 interface ActivityTableMobileProps {
   activities: ActivityDetails[];
+  isLoading?: boolean;
   isCompactView: boolean;
   handleEdit: (activity?: ActivityDetails) => void;
   handleDelete: (activity: ActivityDetails) => void;
@@ -36,6 +37,7 @@ interface ActivityTableMobileProps {
 
 export const ActivityTableMobile = ({
   activities,
+  isLoading = false,
   isCompactView,
   handleEdit,
   handleDelete,
@@ -48,6 +50,14 @@ export const ActivityTableMobile = ({
 }: ActivityTableMobileProps) => {
   const { settings } = useSettingsContext();
   const appTimezone = settings?.timezone?.trim() || undefined;
+
+  if (isLoading) {
+    return (
+      <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
+        Loading...
+      </div>
+    );
+  }
 
   if (activities.length === 0) {
     return (


### PR DESCRIPTION
## Summary

- Add an Activities tab to account detail pages, reusing the existing activity tables and edit/delete flows.
- Add an account-filtered `Explore activities` link from the account Activities tab.
- Hide the redundant Holdings heading under tabs and keep cash/liability account detail tabs useful.
- Hide the contribution-limit prompt when no current-year limit is configured, and compact the configured-limit card copy.
- Refine the account header selector so desktop shows `Group > Account` and the account name opens the selector; mobile shows only the account name.

## Validation

- `pnpm exec prettier --check apps/frontend/src/pages/account/account-contribution-limit.tsx apps/frontend/src/pages/account/account-holdings.tsx apps/frontend/src/pages/account/account-metrics.tsx apps/frontend/src/pages/account/account-page.test.tsx apps/frontend/src/pages/account/account-page.tsx`
- `pnpm --filter frontend exec eslint src/pages/account/account-contribution-limit.tsx src/pages/account/account-holdings.tsx src/pages/account/account-metrics.tsx src/pages/account/account-page.test.tsx src/pages/account/account-page.tsx`
- `pnpm --filter frontend exec tsc --noEmit --pretty false --incremental false`
- `git diff --check`

Focused Vitest command was attempted but blocked before tests loaded by the existing `ERR_REQUIRE_ESM` worker-startup issue in `html-encoding-sniffer` requiring `@exodus/bytes/encoding-lite.js`:

`pnpm --filter frontend exec vitest run src/pages/account/account-page.test.tsx src/pages/account/account-metrics.test.tsx --pool=threads --maxWorkers=1`