### PR TITLE
Fix hidden accounts in portfolio history

### DIFF
--- a/apps/frontend/src/pages/settings/market-data/custom-provider-form.test.tsx
+++ b/apps/frontend/src/pages/settings/market-data/custom-provider-form.test.tsx
@@ -80,7 +80,8 @@ describe("CustomProviderForm", () => {
     expect(urlInput()).toHaveValue("https://history.example.com/prices/{SYMBOL}");
     expect(pricePathInput()).toHaveValue("$[*].adj_close");
 
-    await user.click(screen.getByRole("button", { name: /create provider/i }));
+    const createButton = screen.getByRole("button", { name: /create provider/i });
+    fireEvent.submit(createButton.closest("form")!);
 
     await waitFor(() => expect(createProvider).toHaveBeenCalledTimes(1));
     const payload = createProvider.mock.calls[0][0] as NewCustomProvider;

--- a/apps/server/src/api/performance.rs
+++ b/apps/server/src/api/performance.rs
@@ -11,7 +11,8 @@ use axum::{
 };
 use wealthfolio_core::{
     accounts::{
-        account_supports_purpose, Account, AccountPurpose, AccountServiceTrait, TrackingMode,
+        account_supports_portfolio_scope, account_supports_purpose, Account, AccountPurpose,
+        AccountServiceTrait, TrackingMode,
     },
     portfolio::{
         economic_events::BasisStatus,
@@ -191,11 +192,7 @@ fn performance_account_ids(
         .account_service
         .get_accounts_by_ids(account_ids)?
         .into_iter()
-        .filter(|account| {
-            account.is_active
-                && !account.is_archived
-                && account_supports_purpose(&account.account_type, AccountPurpose::Performance)
-        })
+        .filter(|account| account_supports_portfolio_scope(account, AccountPurpose::Performance))
         .map(|account| account.id)
         .collect())
 }
@@ -228,11 +225,7 @@ fn performance_account_ids_from_map(
     account_ids
         .iter()
         .filter_map(|account_id| accounts_by_id.get(account_id))
-        .filter(|account| {
-            account.is_active
-                && !account.is_archived
-                && account_supports_purpose(&account.account_type, AccountPurpose::Performance)
-        })
+        .filter(|account| account_supports_portfolio_scope(account, AccountPurpose::Performance))
         .filter_map(|account| {
             if seen.insert(account.id.clone()) {
                 Some(account.id.clone())
@@ -296,7 +289,7 @@ async fn calculate_performance_history(
             );
             if !resolved.account_ids.is_empty() {
                 result.data_quality.warnings.push(
-                    "Requested accounts were excluded because they are inactive, archived, or not eligible for performance."
+                    "Requested accounts were excluded because they are archived or not eligible for performance."
                         .to_string(),
                 );
                 sync_performance_summary_quality(&mut result);
@@ -319,7 +312,7 @@ async fn calculate_performance_history(
             .await?;
         if account_ids.len() != resolved.account_ids.len() {
             result.data_quality.warnings.push(
-                "Some requested accounts were excluded because they are inactive, archived, or not eligible for performance."
+                "Some requested accounts were excluded because they are archived or not eligible for performance."
                     .to_string(),
             );
             result.data_quality.status = DataQualityStatus::Partial;
@@ -330,10 +323,7 @@ async fn calculate_performance_history(
         let (authoritative_tracking_mode, authoritative_account_type) =
             if body.item_type == "account" {
                 let account = state.account_service.get_account(&body.item_id)?;
-                if !account.is_active
-                    || account.is_archived
-                    || !account_supports_purpose(&account.account_type, AccountPurpose::Performance)
-                {
+                if !account_supports_portfolio_scope(&account, AccountPurpose::Performance) {
                     return Ok(Json(empty_performance_metrics(
                         &body.item_id,
                         account.currency,
@@ -386,7 +376,7 @@ async fn calculate_performance_summary(
             );
             if !resolved.account_ids.is_empty() {
                 result.data_quality.warnings.push(
-                    "Requested accounts were excluded because they are inactive, archived, or not eligible for performance."
+                    "Requested accounts were excluded because they are archived or not eligible for performance."
                         .to_string(),
                 );
                 sync_performance_summary_quality(&mut result);
@@ -410,7 +400,7 @@ async fn calculate_performance_summary(
             .await?;
         if account_ids.len() != resolved.account_ids.len() {
             result.data_quality.warnings.push(
-                "Some requested accounts were excluded because they are inactive, archived, or not eligible for performance."
+                "Some requested accounts were excluded because they are archived or not eligible for performance."
                     .to_string(),
             );
             result.data_quality.status = DataQualityStatus::Partial;
@@ -421,10 +411,7 @@ async fn calculate_performance_summary(
         let (authoritative_tracking_mode, authoritative_account_type) =
             if body.item_type == "account" {
                 let account = state.account_service.get_account(&body.item_id)?;
-                if !account.is_active
-                    || account.is_archived
-                    || !account_supports_purpose(&account.account_type, AccountPurpose::Performance)
-                {
+                if !account_supports_portfolio_scope(&account, AccountPurpose::Performance) {
                     return Ok(Json(empty_performance_metrics(
                         &body.item_id,
                         account.currency,
@@ -476,7 +463,7 @@ async fn get_performance_summaries(
             let mut result = empty_performance_metrics(&key, base.clone(), start, end);
             if !scope.account_ids.is_empty() {
                 result.data_quality.warnings.push(
-                    "Requested accounts were excluded because they are inactive, archived, or not eligible for performance."
+                    "Requested accounts were excluded because they are archived or not eligible for performance."
                         .to_string(),
                 );
                 sync_performance_summary_quality(&mut result);
@@ -501,7 +488,7 @@ async fn get_performance_summaries(
 
         if account_ids.len() != scope.account_ids.len() {
             result.data_quality.warnings.push(
-                "Some requested accounts were excluded because they are inactive, archived, or not eligible for performance."
+                "Some requested accounts were excluded because they are archived or not eligible for performance."
                     .to_string(),
             );
             result.data_quality.status = DataQualityStatus::Partial;
@@ -596,4 +583,65 @@ pub fn router() -> Router<Arc<AppState>> {
         .route("/performance/summaries", post(get_performance_summaries))
         .route("/income/summary", get(get_income_summary_for_account))
         .route("/income/summary/query", post(get_income_summary))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDateTime;
+    use wealthfolio_core::accounts::account_types;
+
+    fn account(id: &str, account_type: &str) -> Account {
+        Account {
+            id: id.to_string(),
+            name: id.to_string(),
+            account_type: account_type.to_string(),
+            group: None,
+            currency: "USD".to_string(),
+            is_default: false,
+            is_active: true,
+            created_at: NaiveDateTime::default(),
+            updated_at: NaiveDateTime::default(),
+            platform_id: None,
+            account_number: None,
+            meta: None,
+            provider: None,
+            provider_account_id: None,
+            is_archived: false,
+            tracking_mode: TrackingMode::Transactions,
+        }
+    }
+
+    #[test]
+    fn performance_account_ids_keep_hidden_and_exclude_archived_accounts() {
+        let mut hidden = account("hidden", account_types::SECURITIES);
+        hidden.is_active = false;
+        let mut archived = account("archived", account_types::SECURITIES);
+        archived.is_archived = true;
+        let accounts_by_id = HashMap::from([
+            (
+                "active".to_string(),
+                account("active", account_types::SECURITIES),
+            ),
+            ("hidden".to_string(), hidden),
+            ("archived".to_string(), archived),
+            (
+                "card".to_string(),
+                account("card", account_types::CREDIT_CARD),
+            ),
+        ]);
+
+        let ids = performance_account_ids_from_map(
+            &accounts_by_id,
+            &[
+                "hidden".to_string(),
+                "archived".to_string(),
+                "active".to_string(),
+                "card".to_string(),
+                "hidden".to_string(),
+            ],
+        );
+
+        assert_eq!(ids, vec!["hidden", "active"]);
+    }
 }

--- a/apps/server/src/api/shared.rs
+++ b/apps/server/src/api/shared.rs
@@ -12,7 +12,7 @@ use anyhow::anyhow;
 use chrono::NaiveDate;
 use serde_json::json;
 use wealthfolio_core::{
-    accounts::{account_supports_purpose, AccountPurpose, AccountServiceTrait},
+    accounts::{account_supports_portfolio_scope, AccountPurpose, AccountServiceTrait},
     portfolio::{
         snapshot::{reconcile_quote_sync_from_latest_account_snapshots, SnapshotRecalcMode},
         valuation::ValuationRecalcMode,
@@ -43,7 +43,7 @@ pub fn holdings_account_ids(state: &AppState, account_ids: &[String]) -> ApiResu
         .account_service
         .get_accounts_by_ids(account_ids)?
         .into_iter()
-        .filter(|account| account_supports_purpose(&account.account_type, AccountPurpose::Holdings))
+        .filter(|account| account_supports_portfolio_scope(account, AccountPurpose::Holdings))
         .map(|account| account.id)
         .collect())
 }

--- a/apps/tauri/src/commands/portfolio.rs
+++ b/apps/tauri/src/commands/portfolio.rs
@@ -14,7 +14,10 @@ use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, State};
 use wealthfolio_core::{
-    accounts::{account_supports_purpose, Account, AccountPurpose, TrackingMode},
+    accounts::{
+        account_supports_portfolio_scope, account_supports_purpose, Account, AccountPurpose,
+        TrackingMode,
+    },
     allocation::{AllocationHoldings, PortfolioAllocations},
     holdings::Holding,
     income::IncomeSummary,
@@ -105,7 +108,7 @@ pub(super) fn holdings_account_ids(
         .get_accounts_by_ids(account_ids)
         .map_err(|e| e.to_string())?
         .into_iter()
-        .filter(|account| account_supports_purpose(&account.account_type, AccountPurpose::Holdings))
+        .filter(|account| account_supports_portfolio_scope(account, AccountPurpose::Holdings))
         .map(|account| account.id)
         .collect())
 }
@@ -139,11 +142,7 @@ fn performance_account_ids_from_map(
     account_ids
         .iter()
         .filter_map(|account_id| accounts_by_id.get(account_id))
-        .filter(|account| {
-            account.is_active
-                && !account.is_archived
-                && account_supports_purpose(&account.account_type, AccountPurpose::Performance)
-        })
+        .filter(|account| account_supports_portfolio_scope(account, AccountPurpose::Performance))
         .filter_map(|account| {
             if seen.insert(account.id.clone()) {
                 Some(account.id.clone())
@@ -636,10 +635,8 @@ pub async fn calculate_accounts_simple_performance(
             .map_err(|e| format!("Failed to fetch accounts: {}", e))?;
         requested
             .into_iter()
-            .filter(|acc| {
-                acc.is_active
-                    && !acc.is_archived
-                    && account_supports_purpose(&acc.account_type, AccountPurpose::Performance)
+            .filter(|account| {
+                account_supports_portfolio_scope(account, AccountPurpose::Performance)
             })
             .map(|acc| acc.id)
             .collect()
@@ -713,7 +710,7 @@ pub async fn calculate_performance_history(
             );
             if !resolved.account_ids.is_empty() {
                 result.data_quality.warnings.push(
-                    "Requested accounts were excluded because they are inactive, archived, or not eligible for performance."
+                    "Requested accounts were excluded because they are archived or not eligible for performance."
                         .to_string(),
                 );
                 sync_performance_summary_quality(&mut result);
@@ -737,7 +734,7 @@ pub async fn calculate_performance_history(
             .map_err(|e| format!("Failed to calculate performance: {}", e))?;
         if account_ids.len() != resolved.account_ids.len() {
             result.data_quality.warnings.push(
-                "Some requested accounts were excluded because they are inactive, archived, or not eligible for performance."
+                "Some requested accounts were excluded because they are archived or not eligible for performance."
                     .to_string(),
             );
             result.data_quality.status = DataQualityStatus::Partial;
@@ -750,10 +747,7 @@ pub async fn calculate_performance_history(
                 .account_service()
                 .get_account(&item_id)
                 .map_err(|e| format!("Failed to fetch account: {}", e))?;
-            if !account.is_active
-                || account.is_archived
-                || !account_supports_purpose(&account.account_type, AccountPurpose::Performance)
-            {
+            if !account_supports_portfolio_scope(&account, AccountPurpose::Performance) {
                 return Ok(empty_performance_metrics(
                     &item_id,
                     account.currency,
@@ -906,7 +900,7 @@ pub async fn calculate_performance_summary(
             );
             if !resolved.account_ids.is_empty() {
                 result.data_quality.warnings.push(
-                    "Requested accounts were excluded because they are inactive, archived, or not eligible for performance."
+                    "Requested accounts were excluded because they are archived or not eligible for performance."
                         .to_string(),
                 );
                 sync_performance_summary_quality(&mut result);
@@ -931,7 +925,7 @@ pub async fn calculate_performance_summary(
             .map_err(|e| format!("Failed to calculate performance: {}", e))?;
         if account_ids.len() != resolved.account_ids.len() {
             result.data_quality.warnings.push(
-                "Some requested accounts were excluded because they are inactive, archived, or not eligible for performance."
+                "Some requested accounts were excluded because they are archived or not eligible for performance."
                     .to_string(),
             );
             result.data_quality.status = DataQualityStatus::Partial;
@@ -944,10 +938,7 @@ pub async fn calculate_performance_summary(
                 .account_service()
                 .get_account(&item_id)
                 .map_err(|e| format!("Failed to fetch account: {}", e))?;
-            if !account.is_active
-                || account.is_archived
-                || !account_supports_purpose(&account.account_type, AccountPurpose::Performance)
-            {
+            if !account_supports_portfolio_scope(&account, AccountPurpose::Performance) {
                 return Ok(empty_performance_metrics(
                     &item_id,
                     account.currency,
@@ -1022,7 +1013,7 @@ pub async fn get_performance_summaries(
             );
             if !scope.account_ids.is_empty() {
                 result.data_quality.warnings.push(
-                    "Requested accounts were excluded because they are inactive, archived, or not eligible for performance."
+                    "Requested accounts were excluded because they are archived or not eligible for performance."
                         .to_string(),
                 );
                 sync_performance_summary_quality(&mut result);
@@ -1048,7 +1039,7 @@ pub async fn get_performance_summaries(
 
         if account_ids.len() != scope.account_ids.len() {
             result.data_quality.warnings.push(
-                "Some requested accounts were excluded because they are inactive, archived, or not eligible for performance."
+                "Some requested accounts were excluded because they are archived or not eligible for performance."
                     .to_string(),
             );
             result.data_quality.status = DataQualityStatus::Partial;
@@ -1916,4 +1907,65 @@ pub async fn delete_snapshot(
     emit_portfolio_trigger_recalculate(&handle, payload);
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDateTime;
+    use wealthfolio_core::accounts::account_types;
+
+    fn account(id: &str, account_type: &str) -> Account {
+        Account {
+            id: id.to_string(),
+            name: id.to_string(),
+            account_type: account_type.to_string(),
+            group: None,
+            currency: "USD".to_string(),
+            is_default: false,
+            is_active: true,
+            created_at: NaiveDateTime::default(),
+            updated_at: NaiveDateTime::default(),
+            platform_id: None,
+            account_number: None,
+            meta: None,
+            provider: None,
+            provider_account_id: None,
+            is_archived: false,
+            tracking_mode: TrackingMode::Transactions,
+        }
+    }
+
+    #[test]
+    fn performance_account_ids_keep_hidden_and_exclude_archived_accounts() {
+        let mut hidden = account("hidden", account_types::SECURITIES);
+        hidden.is_active = false;
+        let mut archived = account("archived", account_types::SECURITIES);
+        archived.is_archived = true;
+        let accounts_by_id = HashMap::from([
+            (
+                "active".to_string(),
+                account("active", account_types::SECURITIES),
+            ),
+            ("hidden".to_string(), hidden),
+            ("archived".to_string(), archived),
+            (
+                "card".to_string(),
+                account("card", account_types::CREDIT_CARD),
+            ),
+        ]);
+
+        let ids = performance_account_ids_from_map(
+            &accounts_by_id,
+            &[
+                "hidden".to_string(),
+                "archived".to_string(),
+                "active".to_string(),
+                "card".to_string(),
+                "hidden".to_string(),
+            ],
+        );
+
+        assert_eq!(ids, vec!["hidden", "active"]);
+    }
 }

--- a/crates/ai/src/tools/performance.rs
+++ b/crates/ai/src/tools/performance.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 
 use crate::env::AiEnvironment;
 use crate::error::AiError;
-use wealthfolio_core::accounts::{account_supports_purpose, AccountPurpose};
+use wealthfolio_core::accounts::{account_supports_portfolio_scope, AccountPurpose};
 use wealthfolio_core::portfolio::performance::PerformanceResult as CorePerformanceResult;
 
 // ============================================================================
@@ -243,10 +243,7 @@ impl<E: AiEnvironment + 'static> Tool for GetPerformanceTool<E> {
                 .account_service()
                 .get_account(account_id)
                 .map_err(|e| AiError::ToolExecutionFailed(e.to_string()))?;
-            if !account.is_active
-                || account.is_archived
-                || !account_supports_purpose(&account.account_type, AccountPurpose::Performance)
-            {
+            if !account_supports_portfolio_scope(&account, AccountPurpose::Performance) {
                 let reason = "Performance unavailable for this account type.".to_string();
                 return Ok(GetPerformanceOutput {
                     id: account_id.to_string(),
@@ -280,14 +277,14 @@ impl<E: AiEnvironment + 'static> Tool for GetPerformanceTool<E> {
             let accounts = self
                 .env
                 .account_service()
-                .get_active_non_archived_accounts()
+                .get_non_archived_accounts()
                 .map_err(|e| AiError::ToolExecutionFailed(e.to_string()))?;
             let mut account_tracking_modes = std::collections::HashMap::new();
             let mut account_types = std::collections::HashMap::new();
             let account_ids: Vec<String> = accounts
                 .into_iter()
                 .filter(|account| {
-                    account_supports_purpose(&account.account_type, AccountPurpose::Performance)
+                    account_supports_portfolio_scope(account, AccountPurpose::Performance)
                 })
                 .map(|account| {
                     account_tracking_modes.insert(account.id.clone(), account.tracking_mode);

--- a/crates/core/src/accounts/mod.rs
+++ b/crates/core/src/accounts/mod.rs
@@ -14,5 +14,15 @@ pub use accounts_model::{
 pub use accounts_service::AccountService;
 pub use accounts_traits::{AccountRepositoryTrait, AccountServiceTrait};
 
+/// Returns true when an account belongs in portfolio totals/history.
+pub fn account_in_portfolio_scope(account: &Account) -> bool {
+    !account.is_archived
+}
+
+/// Returns true when an account belongs in a portfolio reporting scope for a purpose.
+pub fn account_supports_portfolio_scope(account: &Account, purpose: AccountPurpose) -> bool {
+    account_in_portfolio_scope(account) && account_supports_purpose(&account.account_type, purpose)
+}
+
 #[cfg(test)]
 mod accounts_model_tests;

--- a/crates/core/src/portfolio/snapshot/snapshot_service.rs
+++ b/crates/core/src/portfolio/snapshot/snapshot_service.rs
@@ -659,7 +659,7 @@ impl SnapshotService {
                 }
             }
             None => {
-                for acc in self.account_repository.list(Some(true), None, None)? {
+                for acc in self.account_repository.list(None, Some(false), None)? {
                     // Skip HOLDINGS mode accounts - they don't participate in transaction-based recalculation
                     if acc.tracking_mode == TrackingMode::Holdings {
                         debug!(

--- a/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
+++ b/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
@@ -3759,6 +3759,85 @@ mod tests {
         assert_eq!(count, 0);
     }
 
+    #[tokio::test]
+    async fn test_global_snapshot_recalc_keeps_hidden_and_excludes_archived_accounts() {
+        let base = Arc::new(RwLock::new("USD".to_string()));
+
+        let mut account_repo = MockAccountRepository::new();
+        let active = create_test_account("active", "USD", "Active Account");
+        let mut hidden = create_test_account("hidden", "USD", "Hidden Account");
+        hidden.is_active = false;
+        let mut archived = create_test_account("archived", "USD", "Archived Account");
+        archived.is_archived = true;
+        account_repo.add_account(active.clone());
+        account_repo.add_account(hidden.clone());
+        account_repo.add_account(archived.clone());
+
+        let d1 = NaiveDate::from_ymd_opt(2025, 1, 10).unwrap();
+        let activity_repo = Arc::new(MockActivityRepositoryWithData::new(vec![
+            create_test_activity(
+                "active-deposit",
+                &active.id,
+                Some("CASH:USD"),
+                "DEPOSIT",
+                d1,
+                None,
+                None,
+                Some(dec!(1000)),
+                "USD",
+            ),
+            create_test_activity(
+                "hidden-deposit",
+                &hidden.id,
+                Some("CASH:USD"),
+                "DEPOSIT",
+                d1,
+                None,
+                None,
+                Some(dec!(2000)),
+                "USD",
+            ),
+            create_test_activity(
+                "archived-deposit",
+                &archived.id,
+                Some("CASH:USD"),
+                "DEPOSIT",
+                d1,
+                None,
+                None,
+                Some(dec!(3000)),
+                "USD",
+            ),
+        ]));
+        let snapshot_repo = Arc::new(MockSnapshotRepository::new());
+
+        let svc = SnapshotService::new(
+            base,
+            Arc::new(account_repo),
+            activity_repo,
+            snapshot_repo.clone(),
+            Arc::new(MockAssetRepository::new()),
+            Arc::new(MockFxService::new()),
+        );
+
+        svc.recalculate_holdings_snapshots(None, SnapshotRecalcMode::IncrementalFromLast)
+            .await
+            .unwrap();
+
+        assert!(!snapshot_repo
+            .get_snapshots_by_account("active", None, None)
+            .unwrap()
+            .is_empty());
+        assert!(!snapshot_repo
+            .get_snapshots_by_account("hidden", None, None)
+            .unwrap()
+            .is_empty());
+        assert!(snapshot_repo
+            .get_snapshots_by_account("archived", None, None)
+            .unwrap()
+            .is_empty());
+    }
+
     // ==================== CASH AGGREGATION CALCULATION TESTS ====================
 
     #[tokio::test]

--- a/crates/core/src/portfolio/valuation/current_account_valuation.rs
+++ b/crates/core/src/portfolio/valuation/current_account_valuation.rs
@@ -4,7 +4,7 @@ use rust_decimal::Decimal;
 use std::collections::{HashMap, HashSet};
 
 use crate::{
-    accounts::{account_supports_purpose, Account, AccountPurpose, AccountServiceTrait},
+    accounts::{account_supports_portfolio_scope, Account, AccountPurpose, AccountServiceTrait},
     assets::{Asset, AssetServiceTrait, InstrumentType},
     errors::Result,
     fx::{currency::normalize_amount, FxServiceTrait},
@@ -309,10 +309,8 @@ pub fn filter_current_valuation_accounts(
         None => accounts
             .into_iter()
             .filter(|account| {
-                account.is_active
-                    && !account.is_archived
-                    && account_supports_purpose(&account.account_type, AccountPurpose::Performance)
-                    && account_supports_purpose(&account.account_type, AccountPurpose::Holdings)
+                account_supports_portfolio_scope(account, AccountPurpose::Performance)
+                    && account_supports_portfolio_scope(account, AccountPurpose::Holdings)
             })
             .collect(),
         Some(ids) => {
@@ -324,13 +322,8 @@ pub fn filter_current_valuation_accounts(
             ids.iter()
                 .filter_map(|account_id| accounts_by_id.get(account_id).cloned())
                 .filter(|account| {
-                    account.is_active
-                        && !account.is_archived
-                        && account_supports_purpose(
-                            &account.account_type,
-                            AccountPurpose::Performance,
-                        )
-                        && account_supports_purpose(&account.account_type, AccountPurpose::Holdings)
+                    account_supports_portfolio_scope(account, AccountPurpose::Performance)
+                        && account_supports_portfolio_scope(account, AccountPurpose::Holdings)
                 })
                 .collect()
         }

--- a/crates/core/src/portfolio/valuation/current_account_valuation_tests.rs
+++ b/crates/core/src/portfolio/valuation/current_account_valuation_tests.rs
@@ -592,7 +592,7 @@ fn current_account_valuation_preserves_requested_account_order() {
 }
 
 #[test]
-fn current_valuation_account_filter_excludes_inactive_and_archived_requested_accounts() {
+fn current_valuation_account_filter_keeps_hidden_and_excludes_archived_requested_accounts() {
     let requested = unique_account_ids(vec![
         "active".to_string(),
         "inactive".to_string(),
@@ -613,7 +613,7 @@ fn current_valuation_account_filter_excludes_inactive_and_archived_requested_acc
             .iter()
             .map(|account| account.id.as_str())
             .collect::<Vec<_>>(),
-        vec!["active"]
+        vec!["active", "inactive"]
     );
 }
 

--- a/crates/core/src/portfolios/portfolios_model.rs
+++ b/crates/core/src/portfolios/portfolios_model.rs
@@ -122,7 +122,7 @@ pub struct ResolvedAccountScope {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum AccountScope {
-    /// All active, non-archived accounts.
+    /// All non-archived accounts.
     All,
     /// A single specific account.
     #[serde(rename_all = "camelCase")]

--- a/crates/core/src/portfolios/portfolios_service.rs
+++ b/crates/core/src/portfolios/portfolios_service.rs
@@ -4,7 +4,10 @@ use super::portfolios_model::{
     AccountScope, NewPortfolio, PortfolioUpdate, PortfolioWithAccounts, ResolvedAccountScope,
 };
 use super::portfolios_traits::{PortfolioRepositoryTrait, PortfolioServiceTrait};
-use crate::accounts::{account_supports_purpose, AccountPurpose, AccountRepositoryTrait};
+use crate::accounts::{
+    account_in_portfolio_scope, account_supports_portfolio_scope, AccountPurpose,
+    AccountRepositoryTrait,
+};
 use crate::errors::{DatabaseError, Result, ValidationError};
 use crate::Error;
 
@@ -65,6 +68,24 @@ impl PortfolioService {
         }
         Ok(())
     }
+
+    fn retain_portfolio_scope_accounts(&self, ids: &mut Vec<String>) -> Result<()> {
+        if ids.is_empty() {
+            return Ok(());
+        }
+
+        let accounts = self
+            .account_repository
+            .list(None, None, Some(ids.as_slice()))?;
+        let eligible_ids: HashSet<String> = accounts
+            .into_iter()
+            .filter(account_in_portfolio_scope)
+            .map(|account| account.id)
+            .collect();
+
+        ids.retain(|account_id| eligible_ids.contains(account_id));
+        Ok(())
+    }
 }
 
 #[async_trait::async_trait]
@@ -120,6 +141,7 @@ impl PortfolioServiceTrait for PortfolioService {
         ids.sort();
         ids.dedup();
         self.validate_resolved_account_ids_exist(&ids)?;
+        self.retain_portfolio_scope_accounts(&mut ids)?;
 
         let scope_id = match filter {
             AccountScope::All => "all".to_string(),
@@ -156,7 +178,7 @@ impl PortfolioServiceTrait for PortfolioService {
             .list(None, None, Some(&resolved.account_ids))?;
         let eligible_ids: HashSet<String> = accounts
             .into_iter()
-            .filter(|account| account_supports_purpose(&account.account_type, purpose))
+            .filter(|account| account_supports_portfolio_scope(account, purpose))
             .map(|account| account.id)
             .collect();
 

--- a/crates/core/src/portfolios/portfolios_service_tests.rs
+++ b/crates/core/src/portfolios/portfolios_service_tests.rs
@@ -184,6 +184,16 @@ mod tests {
         )
     }
 
+    fn make_service_with_accounts(
+        repo: MockPortfolioRepo,
+        accounts: Vec<Account>,
+    ) -> PortfolioService {
+        PortfolioService::new(
+            Arc::new(repo),
+            Arc::new(MockAccountRepo::with_accounts(accounts)),
+        )
+    }
+
     fn valid_new(name: &str, account_ids: Vec<String>) -> NewPortfolio {
         NewPortfolio {
             name: name.to_string(),
@@ -321,6 +331,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn resolve_account_scope_keeps_hidden_and_excludes_archived_accounts() {
+        let mut hidden = mock_account(
+            "hidden",
+            account_types::SECURITIES,
+            TrackingMode::Transactions,
+        );
+        hidden.is_active = false;
+        let mut archived = mock_account(
+            "archived",
+            account_types::SECURITIES,
+            TrackingMode::Transactions,
+        );
+        archived.is_archived = true;
+        let svc = make_service_with_accounts(
+            MockPortfolioRepo::default(),
+            vec![
+                mock_account(
+                    "active",
+                    account_types::SECURITIES,
+                    TrackingMode::Transactions,
+                ),
+                hidden,
+                archived,
+            ],
+        );
+
+        let scope = svc
+            .resolve_account_scope(
+                &AccountScope::Accounts {
+                    account_ids: vec![
+                        "active".to_string(),
+                        "hidden".to_string(),
+                        "archived".to_string(),
+                    ],
+                },
+                "USD",
+            )
+            .unwrap();
+
+        assert_eq!(scope.account_ids, vec!["active", "hidden"]);
+    }
+
+    #[tokio::test]
     async fn resolve_account_scope_rejects_fake_account_id() {
         let svc = make_service_with(MockPortfolioRepo::default(), &["a1"]);
         let err = svc
@@ -352,6 +405,18 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_account_scope_for_purpose_filters_by_account_capability() {
+        let mut hidden = mock_account(
+            "hidden",
+            account_types::SECURITIES,
+            TrackingMode::Transactions,
+        );
+        hidden.is_active = false;
+        let mut archived = mock_account(
+            "archived",
+            account_types::SECURITIES,
+            TrackingMode::Transactions,
+        );
+        archived.is_archived = true;
         let svc = PortfolioService::new(
             Arc::new(MockPortfolioRepo::default()),
             Arc::new(MockAccountRepo::with_accounts(vec![
@@ -376,6 +441,8 @@ mod tests {
                     account_types::CREDIT_CARD,
                     TrackingMode::Transactions,
                 ),
+                hidden,
+                archived,
             ])),
         );
         let filter = AccountScope::Accounts {
@@ -386,6 +453,8 @@ mod tests {
                 "security-holdings".to_string(),
                 "cash".to_string(),
                 "security-transactions".to_string(),
+                "hidden".to_string(),
+                "archived".to_string(),
             ],
         };
 
@@ -401,6 +470,7 @@ mod tests {
             vec![
                 "cash".to_string(),
                 "crypto".to_string(),
+                "hidden".to_string(),
                 "security-holdings".to_string(),
                 "security-transactions".to_string(),
             ]

--- a/crates/storage-sqlite/src/portfolios/repository.rs
+++ b/crates/storage-sqlite/src/portfolios/repository.rs
@@ -230,7 +230,6 @@ impl PortfolioRepositoryTrait for PortfolioRepository {
             AccountScope::All => {
                 use crate::schema::accounts::dsl::*;
                 let ids = accounts
-                    .filter(is_active.eq(true))
                     .filter(is_archived.eq(false))
                     .order(name.asc())
                     .select(id)
@@ -251,5 +250,59 @@ impl PortfolioRepositoryTrait for PortfolioRepository {
             }
             AccountScope::Accounts { account_ids } => Ok(account_ids.clone()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{create_pool, get_connection, run_migrations, write_actor::spawn_writer};
+    use diesel::sql_query;
+    use diesel::sql_types::{Bool, Text};
+    use tempfile::tempdir;
+
+    fn setup() -> (PortfolioRepository, tempfile::TempDir) {
+        std::env::set_var("CONNECT_API_URL", "http://test.local");
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("test.db").to_string_lossy().to_string();
+        run_migrations(&db_path).unwrap();
+        let pool = create_pool(&db_path).unwrap();
+        let writer = spawn_writer((*pool).clone()).unwrap();
+        let repo = PortfolioRepository::new(pool, writer);
+        (repo, dir)
+    }
+
+    fn insert_account(
+        repo: &PortfolioRepository,
+        account_id: &str,
+        name: &str,
+        active: bool,
+        archived: bool,
+    ) {
+        let mut conn = get_connection(&repo.pool).unwrap();
+        sql_query(
+            "INSERT INTO accounts (
+                id, name, account_type, currency, is_default, is_active, created_at, updated_at,
+                is_archived, tracking_mode
+             ) VALUES (?, ?, 'SECURITIES', 'USD', 0, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, ?, 'TRANSACTIONS')",
+        )
+        .bind::<Text, _>(account_id)
+        .bind::<Text, _>(name)
+        .bind::<Bool, _>(active)
+        .bind::<Bool, _>(archived)
+        .execute(&mut conn)
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn resolve_all_keeps_hidden_and_excludes_archived_accounts() {
+        let (repo, _dir) = setup();
+        insert_account(&repo, "active", "Active", true, false);
+        insert_account(&repo, "hidden", "Hidden", false, false);
+        insert_account(&repo, "archived", "Archived", true, true);
+
+        let ids = repo.resolve_account_ids(&AccountScope::All).unwrap();
+
+        assert_eq!(ids, vec!["active", "hidden"]);
     }
 }


### PR DESCRIPTION
## Summary

- keep hidden, non-archived accounts in portfolio Total/history scopes
- centralize portfolio-scope account eligibility in core account helpers
- update performance, holdings, valuation, snapshot recalculation, and AI paths to use non-archived portfolio scope semantics
- add regressions for hidden-vs-archived account behavior across core, storage, web, and desktop boundaries
- fix a frontend market-data form test submit path that timed out in CI under jsdom

## Root Cause

`AccountScope::All` and several downstream reporting paths treated hidden accounts as inactive accounts and excluded them from aggregate/history calculations. That contradicted the UI promise that hiding an account keeps it in Total & history. Snapshot global recalculation also selected only active accounts, which could leave hidden account valuations stale once they were included in aggregate scopes.

## Validation

- `cargo fmt --all -- --check`
- `pnpm check`
- `pnpm test`
- `cargo test --workspace`
- `cargo check -p wealthfolio-server --release`
- `git diff --check`