### PR TITLE
fix(valuation): forward-fill per-position quotes to prevent zero-value spikes

### DIFF
--- a/crates/core/src/portfolio/valuation/valuation_calculator.rs
+++ b/crates/core/src/portfolio/valuation/valuation_calculator.rs
@@ -328,7 +328,7 @@ fn calculate_investment_market_value_acct(
         } else {
             unpriced_positions += 1;
             warn!(
-                "Missing quote for asset {} on date {}. Position market value treated as ZERO.",
+                "No quote (including forward-fill) for asset {} on date {}. Position market value treated as zero.",
                 asset_id, target_date
             );
         }

--- a/crates/core/src/portfolio/valuation/valuation_service.rs
+++ b/crates/core/src/portfolio/valuation/valuation_service.rs
@@ -1638,6 +1638,7 @@ impl ValuationServiceTrait for ValuationService {
         };
 
         let mut skipped_incomplete_dates: Vec<(NaiveDate, String)> = Vec::new();
+        let mut last_known_quotes: HashMap<String, Quote> = HashMap::new();
         let mut newly_calculated_valuations: Vec<DailyAccountValuation> = snapshots_to_process
             .into_iter()
             .filter_map(|holdings_snapshot| {
@@ -1683,15 +1684,37 @@ impl ValuationServiceTrait for ValuationService {
                     return None;
                 }
 
-                // Partial gap: some quotes present, some missing → proceed.
-                // Missing positions valued at ZERO by the calculator, which is
-                // better than dropping the entire day (see #683).
-                if !missing_quotes.is_empty() {
-                    debug!(
-                        "Partial quote gap for {:?} on {} (account '{}').",
-                        missing_quotes, current_date, account_id_clone
-                    );
+                // Forward-fill: use last known quote for positions missing today.
+                for (asset_id, quote) in &quotes_for_current_date {
+                    last_known_quotes.insert(asset_id.clone(), quote.clone());
                 }
+                let mut filled_quotes = quotes_for_current_date;
+                if !missing_quotes.is_empty() {
+                    let mut forward_filled = Vec::new();
+                    for symbol in &missing_quotes {
+                        if let Some(last_quote) = last_known_quotes.get(symbol) {
+                            filled_quotes.insert(symbol.clone(), last_quote.clone());
+                            forward_filled.push(symbol.as_str());
+                        }
+                    }
+                    if !forward_filled.is_empty() {
+                        debug!(
+                            "Forward-filled {:?} from last known quote on {} (account '{}').",
+                            forward_filled, current_date, account_id_clone
+                        );
+                    }
+                    let still_missing: Vec<_> = missing_quotes
+                        .iter()
+                        .filter(|s| !filled_quotes.contains_key(*s))
+                        .collect();
+                    if !still_missing.is_empty() {
+                        warn!(
+                            "No prior quote to forward-fill for {:?} on {} (account '{}').",
+                            still_missing, current_date, account_id_clone
+                        );
+                    }
+                }
+
                 let account_curr = &holdings_snapshot.currency;
                 if account_curr != &base_curr_clone
                     && !fx_for_current_date
@@ -1713,7 +1736,7 @@ impl ValuationServiceTrait for ValuationService {
 
                 match calculate_valuation_with_price_factors(
                     &holdings_snapshot,
-                    &quotes_for_current_date,
+                    &filled_quotes,
                     &fx_for_current_date,
                     &fx_rates_by_date,
                     current_date,


### PR DESCRIPTION
Hey @afadil ! 

This PR fixes a bug where a missing quote for a single asset on a given day would cause that position's market value to be treated as **zero**.
Even when other assets in the same account had valid quotes. 
This created dramatic vertical spikes (sudden drops) in portfolio charts that recovered after 1-2 days when the quote became available again.

This is different from [#1022](https://github.com/afadil/wealthfolio/pull/1022) which handles the case where *all* quotes for an account are missing on a day (full-gap skip at the aggregation level). 
This fix targets the **per-position** level within a single account.

## What changed

| File | Change |
|------|--------|
| `valuation_service.rs` | Maintain a `last_known_quotes` map across the daily valuation loop. When a position has a partial quote gap, forward-fill from the most recent known quote for that asset before passing quotes to the calculator. |
| `valuation_calculator.rs` | Updated the warn message to reflect that forward-fill was attempted (no longer "treated as ZERO" when the service layer already tried to fill). |

## How it works

The quotes service (`fill_missing_quotes`) already does carry-forward at the quote series level, which handles most gaps (weekends, holidays). This fix adds a **second layer of defense** in the valuation loop itself:

1. Each day, store all available quotes in `last_known_quotes`
2. For positions with a partial quote gap, fill from `last_known_quotes`
3. Log forward-filled assets at `debug` level, truly missing assets (no prior quote at all) at `warn` level
4. Pass the filled quote map to the calculator

The full-gap skip logic (all quotable positions missing → skip day) is unchanged and still operates on raw quotes.

## Test plan

- [x] All 1454 existing tests pass (`cargo test -p wealthfolio-core`)
- [ ] Manual: verify portfolio chart with an asset that has sporadic quote gaps no longer shows vertical spikes

---

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).