### PR TITLE
Optimize dashboard performance loading

### DIFF
--- a/apps/frontend/src/components/metric-display.test.tsx
+++ b/apps/frontend/src/components/metric-display.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it } from "vitest";
+
+import { MetricDisplay } from "./metric-display";
+
+describe("MetricDisplay", () => {
+  it("links unavailable metric reasons to the Health Center", () => {
+    const reason =
+      "TWR unavailable for 2025-11-02 because an external flow amount or transfer boundary is unknown.";
+
+    render(
+      <MemoryRouter>
+        <MetricDisplay
+          label="Time Weighted Return"
+          infoText="Time-weighted return"
+          emptyReason={reason}
+        />
+      </MemoryRouter>,
+    );
+
+    const link = screen.getByRole("link", {
+      name: "Open Health Center for Time Weighted Return issue",
+    });
+
+    expect(link).toHaveAttribute("href", "/health");
+    expect(link).toHaveAttribute("title", reason);
+    expect(link).toHaveTextContent(reason);
+  });
+});

--- a/apps/frontend/src/components/metric-display.tsx
+++ b/apps/frontend/src/components/metric-display.tsx
@@ -10,6 +10,7 @@ import {
 import { cn } from "@/lib/utils";
 import { formatPercent, GainAmount, GainPercent } from "@wealthfolio/ui";
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 
 // Explanatory texts for info popovers
 export const TIME_WEIGHTED_RETURN_INFO =
@@ -157,9 +158,16 @@ export const MetricDisplay: React.FC<MetricDisplayProps> = ({
       )}
 
       {value === undefined && emptyReason && (
-        <div className="text-muted-foreground line-clamp-2 max-w-[11rem] text-center text-[10px] leading-tight">
+        <Link
+          to="/health"
+          title={emptyReason}
+          aria-label={`Open Health Center for ${label} issue`}
+          className="text-muted-foreground hover:text-foreground focus-visible:ring-ring line-clamp-2 max-w-[11rem] rounded-sm text-center text-[10px] leading-tight underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+          onClick={(event) => event.stopPropagation()}
+          onPointerDown={(event) => event.stopPropagation()}
+        >
           {emptyReason}
-        </div>
+        </Link>
       )}
     </>
   );

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -1146,7 +1146,7 @@ export interface PerformanceResult {
   isMixedTrackingMode?: boolean;
 }
 
-export type PerformanceSummaryProfile = "full" | "summary";
+export type PerformanceSummaryProfile = "full" | "summary" | "dashboard";
 
 export interface PerformanceScopeDescriptor {
   id: string;

--- a/apps/frontend/src/pages/dashboard/accounts-summary.test.tsx
+++ b/apps/frontend/src/pages/dashboard/accounts-summary.test.tsx
@@ -12,11 +12,12 @@ import type {
   AccountValuation,
   CurrentAccountValuation,
   PerformanceResult,
+  PerformanceSummaryScope,
   Settings,
   TrackingMode,
 } from "@/lib/types";
 import { AccountType } from "@/lib/types";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { AccountsSummary } from "./accounts-summary";
 
 vi.mock("@/adapters", () => ({
@@ -42,6 +43,7 @@ vi.mock("@/lib/settings-provider", () => ({
 }));
 
 vi.mock("@tanstack/react-query", () => ({
+  keepPreviousData: Symbol("keepPreviousData"),
   useQuery: vi.fn(),
 }));
 
@@ -265,12 +267,14 @@ function renderAccountsSummary({
   currentValuations,
   performanceByAccountId = {},
   performanceByScopeKey = {},
+  isPerformanceLoading = false,
 }: {
   accounts: Account[];
   valuations: AccountValuation[];
   currentValuations?: CurrentAccountValuation[];
   performanceByAccountId?: Record<string, PerformanceFixture>;
   performanceByScopeKey?: Record<string, PerformanceFixture>;
+  isPerformanceLoading?: boolean;
 }) {
   mockUseSettingsContext.mockReturnValue({
     settings: mockSettings,
@@ -357,7 +361,7 @@ function renderAccountsSummary({
   }
 
   mockUseQuery.mockReturnValue({
-    isLoading: false,
+    isLoading: isPerformanceLoading,
     data: performanceSummaries,
   } as unknown as ReturnType<typeof useQuery>);
 
@@ -370,9 +374,78 @@ function renderAccountsSummary({
   );
 }
 
+function getLastPerformanceScopes(): PerformanceSummaryScope[] {
+  const lastCall = mockUseQuery.mock.calls[mockUseQuery.mock.calls.length - 1];
+  const options = lastCall?.[0] as { queryKey?: unknown[] } | undefined;
+  return (options?.queryKey?.[2] ?? []) as PerformanceSummaryScope[];
+}
+
+function getLastPerformanceQueryPlaceholderData(): unknown {
+  const lastCall = mockUseQuery.mock.calls[mockUseQuery.mock.calls.length - 1];
+  const options = lastCall?.[0] as { placeholderData?: unknown } | undefined;
+  return options?.placeholderData;
+}
+
 describe("AccountsSummary", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("requests performance for visible grouped dashboard rows only", async () => {
+    const user = userEvent.setup();
+
+    renderAccountsSummary({
+      accounts: [
+        createAccount({ id: "group-a-1", name: "Group A One", group: "Group A" }),
+        createAccount({ id: "group-a-2", name: "Group A Two", group: "Group A" }),
+        createAccount({ id: "standalone", name: "Standalone" }),
+        createAccount({ id: "single-group", name: "Single Group", group: "Single Group" }),
+      ],
+      valuations: [
+        createValuation({ accountId: "group-a-1", totalValue: 100 }),
+        createValuation({ accountId: "group-a-2", totalValue: 200 }),
+        createValuation({ accountId: "standalone", totalValue: 300 }),
+        createValuation({ accountId: "single-group", totalValue: 400 }),
+      ],
+    });
+
+    expect(getLastPerformanceScopes()).toEqual([
+      { accountIds: ["group-a-1", "group-a-2"] },
+      { accountIds: ["standalone"] },
+      { accountIds: ["single-group"] },
+    ]);
+
+    await user.click(screen.getByText("Group A"));
+
+    expect(getLastPerformanceScopes()).toEqual([
+      { accountIds: ["group-a-1", "group-a-2"] },
+      { accountIds: ["group-a-1"] },
+      { accountIds: ["group-a-2"] },
+      { accountIds: ["standalone"] },
+      { accountIds: ["single-group"] },
+    ]);
+  });
+
+  it("keeps standalone account values visible while performance is loading", () => {
+    renderAccountsSummary({
+      accounts: [createAccount({ id: "live-account", name: "Live Account" })],
+      valuations: [
+        createValuation({
+          accountId: "live-account",
+          totalValue: 125,
+          totalValueBase: 125,
+        }),
+      ],
+      isPerformanceLoading: true,
+    });
+
+    const row = screen.getByText("Live Account").closest("a");
+    expect(row).not.toBeNull();
+    expect(within(row as HTMLElement).getByText("value:USD:125")).toBeInTheDocument();
+    expect(
+      within(row as HTMLElement).getByTestId("account-summary-performance-placeholder"),
+    ).toBeInTheDocument();
+    expect(getLastPerformanceQueryPlaceholderData()).toBe(keepPreviousData);
   });
 
   it("shows consistent secondary metrics for expanded grouped child rows", async () => {

--- a/apps/frontend/src/pages/dashboard/accounts-summary.tsx
+++ b/apps/frontend/src/pages/dashboard/accounts-summary.tsx
@@ -8,12 +8,13 @@ import { performanceSummaryReturn, performancePeriodPnl } from "@/lib/performanc
 import { QueryKeys } from "@/lib/query-keys";
 import { useSettingsContext } from "@/lib/settings-provider";
 import type {
+  Account,
   CurrentAccountValuation,
   DateRange,
   PerformanceSummaryScope,
   TrackingMode,
 } from "@/lib/types";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { GainAmount, GainPercent, PrivacyAmount } from "@wealthfolio/ui";
 import { Button } from "@wealthfolio/ui/components/ui/button";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
@@ -43,6 +44,67 @@ interface AccountSummaryDisplayData {
   displayInAccountCurrency?: boolean;
 }
 
+function addPerformanceScope(
+  scopes: PerformanceSummaryScope[],
+  seenScopeKeys: Set<string>,
+  accountIds: string[],
+) {
+  const uniqueAccountIds = [...new Set(accountIds)].filter(Boolean);
+  if (uniqueAccountIds.length === 0) return;
+
+  const key = performanceSummaryScopeKey(uniqueAccountIds);
+  if (seenScopeKeys.has(key)) return;
+
+  seenScopeKeys.add(key);
+  scopes.push({ accountIds: uniqueAccountIds });
+}
+
+function getDashboardAccountPerformanceScopes(
+  accounts: Account[],
+  accountsGrouped: boolean,
+  expandedGroups: Record<string, boolean>,
+): PerformanceSummaryScope[] {
+  const scopes: PerformanceSummaryScope[] = [];
+  const seenScopeKeys = new Set<string>();
+
+  if (!accountsGrouped) {
+    accounts.forEach((account) => addPerformanceScope(scopes, seenScopeKeys, [account.id]));
+    return scopes;
+  }
+
+  const groupedAccountIds = new Map<string, string[]>();
+  const standaloneAccountIds: string[] = [];
+
+  for (const account of accounts) {
+    const groupName = account.group ?? "Uncategorized";
+    if (groupName === "Uncategorized") {
+      standaloneAccountIds.push(account.id);
+      continue;
+    }
+
+    groupedAccountIds.set(groupName, [...(groupedAccountIds.get(groupName) ?? []), account.id]);
+  }
+
+  for (const [groupName, accountIds] of groupedAccountIds) {
+    if (accountIds.length === 1) {
+      standaloneAccountIds.push(accountIds[0]);
+      continue;
+    }
+
+    addPerformanceScope(scopes, seenScopeKeys, accountIds);
+
+    if (expandedGroups[groupName]) {
+      accountIds.forEach((accountId) => addPerformanceScope(scopes, seenScopeKeys, [accountId]));
+    }
+  }
+
+  standaloneAccountIds.forEach((accountId) =>
+    addPerformanceScope(scopes, seenScopeKeys, [accountId]),
+  );
+
+  return scopes;
+}
+
 const AccountSummarySkeleton = () => (
   <div className="flex w-full items-center justify-between gap-3">
     <div className="flex min-w-0 flex-1 flex-col gap-1 md:gap-1.5">
@@ -67,6 +129,7 @@ const AccountSummaryComponent = React.memo(
     isExpanded = false,
     onToggle,
     isLoadingValuation = false,
+    isLoadingPerformance = false,
     displayInAccountCurrency = false,
     isNested = false,
   }: {
@@ -74,6 +137,7 @@ const AccountSummaryComponent = React.memo(
     isExpanded?: boolean;
     onToggle?: () => void;
     isLoadingValuation?: boolean;
+    isLoadingPerformance?: boolean;
     displayInAccountCurrency?: boolean;
     isNested?: boolean;
   }) => {
@@ -81,12 +145,20 @@ const AccountSummaryComponent = React.memo(
     const useAccountCurrency =
       displayInAccountCurrency || (item.displayInAccountCurrency && Boolean(item.accountCurrency));
 
-    if (!isGroup && isLoadingValuation) {
+    if (isLoadingValuation) {
       const skeletonContent = <AccountSummarySkeleton />;
 
       if (isNested) {
         return (
           <div className="flex w-full items-center justify-between gap-3">{skeletonContent}</div>
+        );
+      }
+
+      if (isGroup) {
+        return (
+          <div className="flex w-full items-center justify-between gap-3 rounded-lg p-3 md:p-4">
+            {skeletonContent}
+          </div>
         );
       }
 
@@ -145,8 +217,18 @@ const AccountSummaryComponent = React.memo(
     const shouldRenderNestedPlaceholder = isNested && !shouldRenderGainMetrics;
 
     let secondaryMetricContent: React.ReactNode = null;
+    let shouldExposeSecondaryMetric = false;
 
-    if (shouldRenderNestedPlaceholder) {
+    if (isLoadingPerformance) {
+      secondaryMetricContent = (
+        <div
+          aria-hidden="true"
+          className="bg-muted/70 h-4 w-28 rounded"
+          data-testid="account-summary-performance-placeholder"
+        />
+      );
+      shouldExposeSecondaryMetric = true;
+    } else if (shouldRenderNestedPlaceholder) {
       secondaryMetricContent = (
         <div
           className="text-muted-foreground text-xs font-medium md:text-sm md:font-medium"
@@ -155,6 +237,7 @@ const AccountSummaryComponent = React.memo(
           -
         </div>
       );
+      shouldExposeSecondaryMetric = true;
     } else if (shouldRenderGainMetrics) {
       secondaryMetricContent = (
         <>
@@ -175,6 +258,9 @@ const AccountSummaryComponent = React.memo(
           />
         </>
       );
+      shouldExposeSecondaryMetric = true;
+    } else {
+      secondaryMetricContent = <span aria-hidden="true" className="block h-4 w-28 opacity-0" />;
     }
 
     const content = (
@@ -207,7 +293,9 @@ const AccountSummaryComponent = React.memo(
             {secondaryMetricContent && (
               <div
                 className="flex items-center gap-1.5 md:gap-2"
-                data-testid="account-summary-secondary-metric"
+                data-testid={
+                  shouldExposeSecondaryMetric ? "account-summary-secondary-metric" : undefined
+                }
               >
                 {secondaryMetricContent}
               </div>
@@ -318,27 +406,9 @@ export const AccountsSummary = React.memo(
     const datesReady = isAllTime || (!!startDate && !!endDate);
 
     const performanceScopes = useMemo((): PerformanceSummaryScope[] => {
-      const scopes = accounts.map((account) => ({ accountIds: [account.id] }));
-      if (!accountsGrouped) return scopes;
-
-      const groupedAccountIds = new Map<string, string[]>();
-
-      for (const account of accounts) {
-        const groupName = account.group ?? "Uncategorized";
-        if (groupName === "Uncategorized") continue;
-        const ids = groupedAccountIds.get(groupName) ?? [];
-        ids.push(account.id);
-        groupedAccountIds.set(groupName, ids);
-      }
-
-      for (const ids of groupedAccountIds.values()) {
-        if (ids.length > 1) {
-          scopes.push({ accountIds: ids });
-        }
-      }
-
-      return scopes;
-    }, [accounts, accountsGrouped]);
+      return getDashboardAccountPerformanceScopes(accounts, accountsGrouped, expandedGroups);
+    }, [accounts, accountsGrouped, expandedGroups]);
+    const shouldFetchPerformance = datesReady && performanceScopes.length > 0;
 
     const {
       data: performanceSummaries,
@@ -354,8 +424,9 @@ export const AccountsSummary = React.memo(
         endDate,
       ],
       queryFn: () =>
-        calculatePerformanceSummaries(performanceScopes, startDate, endDate, "summary"),
-      enabled: datesReady && performanceScopes.length > 0,
+        calculatePerformanceSummaries(performanceScopes, startDate, endDate, "dashboard"),
+      enabled: shouldFetchPerformance,
+      placeholderData: keepPreviousData,
       staleTime: 30 * 1000,
       retry: 1,
     });
@@ -553,6 +624,8 @@ export const AccountsSummary = React.memo(
                       item={group}
                       isExpanded={isExpanded}
                       onToggle={() => toggleGroup(group.accountName)}
+                      isLoadingValuation={isLoadingCurrentValuations}
+                      isLoadingPerformance={isLoadingPerformanceQueries}
                     />
                   </div>
                   {isExpanded && (
@@ -562,7 +635,8 @@ export const AccountsSummary = React.memo(
                           <div key={account.accountId} className="px-4 py-3 md:px-5 md:py-4">
                             <AccountSummaryComponent
                               item={account}
-                              isLoadingValuation={isLoadingPerformance}
+                              isLoadingValuation={isLoadingCurrentValuations}
+                              isLoadingPerformance={isLoadingPerformance}
                               displayInAccountCurrency={
                                 account.accountCurrency !== account.baseCurrency
                               }
@@ -580,7 +654,8 @@ export const AccountsSummary = React.memo(
               <AccountSummaryComponent
                 key={account.accountId}
                 item={account}
-                isLoadingValuation={isLoadingPerformance}
+                isLoadingValuation={isLoadingCurrentValuations}
+                isLoadingPerformance={isLoadingPerformance}
                 displayInAccountCurrency={account.accountCurrency !== account.baseCurrency}
               />
             ))}
@@ -595,7 +670,8 @@ export const AccountsSummary = React.memo(
           <AccountSummaryComponent
             key={account.accountId}
             item={account}
-            isLoadingValuation={isLoadingPerformance}
+            isLoadingValuation={isLoadingCurrentValuations}
+            isLoadingPerformance={isLoadingPerformance}
             displayInAccountCurrency={account.accountCurrency !== account.baseCurrency}
           />
         ));

--- a/apps/frontend/src/pages/dashboard/dashboard-content.test.tsx
+++ b/apps/frontend/src/pages/dashboard/dashboard-content.test.tsx
@@ -1,12 +1,16 @@
 import { render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { describe, expect, it, vi } from "vitest";
-import { useQuery } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { useCurrentValuation } from "@/hooks/use-current-account-valuations";
 import { useHoldings } from "@/hooks/use-holdings";
 import { useValuationHistory } from "@/hooks/use-valuation-history";
 import { useSettingsContext } from "@/lib/settings-provider";
 import { DashboardContent } from "./dashboard-content";
+
+const uiMocks = vi.hoisted(() => ({
+  intervalCode: "3M" as "3M" | "ALL",
+}));
 
 vi.mock("@/adapters", () => ({
   calculatePerformanceSummary: vi.fn(),
@@ -37,18 +41,25 @@ vi.mock("@/lib/settings-provider", () => ({
 }));
 
 vi.mock("@tanstack/react-query", () => ({
+  keepPreviousData: Symbol("keepPreviousData"),
   useQuery: vi.fn(),
 }));
 
 vi.mock("@wealthfolio/ui", () => ({
   GainAmount: ({ value }: { value: number }) => <span>{`gain-amount:${value}`}</span>,
   GainPercent: ({ value }: { value: number }) => <span>{`gain-percent:${value}`}</span>,
-  getInitialIntervalData: () => ({
-    range: { from: new Date("2026-03-01T00:00:00Z"), to: new Date("2026-06-01T00:00:00Z") },
-    description: "3M",
-  }),
+  getInitialIntervalData: (code?: string) =>
+    code === "ALL"
+      ? {
+          range: { from: new Date("1970-01-01T00:00:00Z"), to: new Date("2026-06-24T00:00:00Z") },
+          description: "All Time",
+        }
+      : {
+          range: { from: new Date("2026-03-01T00:00:00Z"), to: new Date("2026-06-01T00:00:00Z") },
+          description: "3M",
+        },
   IntervalSelector: () => <div>interval-selector</div>,
-  usePersistentState: () => ["3M", vi.fn()],
+  usePersistentState: () => [uiMocks.intervalCode, vi.fn()],
 }));
 
 vi.mock("@wealthfolio/ui/components/ui/skeleton", () => ({
@@ -98,6 +109,11 @@ const mockUseValuationHistory = vi.mocked(useValuationHistory);
 const mockUseSettingsContext = vi.mocked(useSettingsContext);
 
 describe("DashboardContent", () => {
+  beforeEach(() => {
+    uiMocks.intervalCode = "3M";
+    vi.clearAllMocks();
+  });
+
   function mockCurrentValuation(totalValueBase = 125) {
     mockUseCurrentValuation.mockReturnValue({
       currentValuation: {
@@ -223,6 +239,70 @@ describe("DashboardContent", () => {
     expect(screen.queryByText("balance:100")).not.toBeInTheDocument();
     expect(screen.getByTestId("portfolio-as-of")).toHaveTextContent("2026-06-01T12:30:00Z");
     expect(screen.getByTestId("portfolio-as-of")).not.toHaveTextContent("2026-06-01T13:00:00Z");
+  });
+
+  it("requests all-time valuation history without the 1970 sentinel range", () => {
+    uiMocks.intervalCode = "ALL";
+    mockCurrentValuation(125);
+    mockUseHoldings.mockReturnValue({
+      holdings: [],
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useHoldings>);
+    mockUseValuationHistory.mockReturnValue({
+      valuationHistory: [],
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useValuationHistory>);
+    mockUseSettingsContext.mockReturnValue({
+      settings: { baseCurrency: "USD" },
+    } as unknown as ReturnType<typeof useSettingsContext>);
+    mockUseQuery.mockReturnValue({
+      isLoading: false,
+      data: null,
+    } as unknown as ReturnType<typeof useQuery>);
+
+    render(<DashboardContent />);
+
+    expect(mockUseValuationHistory).toHaveBeenCalledWith(undefined);
+  });
+
+  it("starts dashboard performance queries while valuation history is loading", () => {
+    mockCurrentValuation(125);
+    mockUseHoldings.mockReturnValue({
+      holdings: [],
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useHoldings>);
+    mockUseValuationHistory.mockReturnValue({
+      valuationHistory: [
+        {
+          valuationDate: "2026-06-01",
+          totalValueBase: 1000,
+          netContributionBase: 900,
+          baseCurrency: "USD",
+          calculatedAt: "2026-06-01T12:00:00Z",
+        },
+      ],
+      isLoading: true,
+      error: null,
+    } as unknown as ReturnType<typeof useValuationHistory>);
+    mockUseSettingsContext.mockReturnValue({
+      settings: { baseCurrency: "USD" },
+    } as unknown as ReturnType<typeof useSettingsContext>);
+    mockUseQuery.mockReturnValue({
+      isLoading: false,
+      data: null,
+    } as unknown as ReturnType<typeof useQuery>);
+
+    render(<DashboardContent />);
+
+    const performanceQueryOptions = mockUseQuery.mock.calls[0]?.[0] as
+      | { enabled?: boolean; placeholderData?: unknown }
+      | undefined;
+    expect(performanceQueryOptions?.enabled).toBe(true);
+    expect(performanceQueryOptions?.placeholderData).toBe(keepPreviousData);
+    expect(screen.getByText("accounts-summary")).toBeInTheDocument();
   });
 
   it("does not render a failed current valuation as zero", () => {

--- a/apps/frontend/src/pages/dashboard/dashboard-content.tsx
+++ b/apps/frontend/src/pages/dashboard/dashboard-content.tsx
@@ -10,7 +10,7 @@ import { QueryKeys } from "@/lib/query-keys";
 import { useSettingsContext } from "@/lib/settings-provider";
 import { DateRange, TimePeriod } from "@/lib/types";
 import { PortfolioUpdateTrigger } from "@/pages/dashboard/portfolio-update-trigger";
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import type { TimePeriod as UITimePeriod } from "@wealthfolio/ui";
 import {
   GainAmount,
@@ -106,7 +106,9 @@ export function DashboardContent() {
 
   const totalValue = portfolioCurrentValuation?.summary.totalValueBase ?? 0;
 
-  const { valuationHistory, isLoading: isValuationHistoryLoading } = useValuationHistory(dateRange);
+  const valuationHistoryRange = isAllTime ? undefined : dateRange;
+  const { valuationHistory, isLoading: isValuationHistoryLoading } =
+    useValuationHistory(valuationHistoryRange);
 
   const { settings } = useSettingsContext();
   const baseCurrency = settings?.baseCurrency ?? "USD";
@@ -125,9 +127,10 @@ export function DashboardContent() {
         startDate,
         endDate,
         filter: { type: "all" },
-        profile: "summary",
+        profile: "dashboard",
       }),
     enabled: datesReady,
+    placeholderData: keepPreviousData,
     staleTime: 30 * 1000,
     retry: 1,
   });
@@ -192,9 +195,9 @@ export function DashboardContent() {
                 currency={baseCurrency}
                 displayCurrency={true}
               />
-              <div className="text-md flex space-x-3">
+              <div className="text-md flex min-h-5 items-center space-x-3">
                 {isPortfolioPerformanceLoading ? (
-                  <div className="flex items-center gap-3 pt-1">
+                  <div className="flex items-center gap-3">
                     <Skeleton className="h-4 w-24" />
                     <div className="border-secondary my-1 border-r pr-2" />
                     <Skeleton className="h-4 w-16" />

--- a/apps/server/src/api/holdings/handlers.rs
+++ b/apps/server/src/api/holdings/handlers.rs
@@ -272,7 +272,7 @@ pub async fn get_historical_valuations_for_scope(
     } else {
         state
             .valuation_service
-            .get_historical_valuations_for_accounts(
+            .get_historical_valuation_totals_for_accounts(
                 &resolved.scope_id,
                 &account_ids,
                 &resolved.base_currency,

--- a/apps/server/src/api/performance.rs
+++ b/apps/server/src/api/performance.rs
@@ -1,9 +1,9 @@
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc, time::Instant};
 
-use crate::{error::ApiResult, main_lib::AppState};
+use crate::{
+    error::{ApiError, ApiResult},
+    main_lib::AppState,
+};
 use axum::{
     extract::{Query, State},
     routing::{get, post},
@@ -15,12 +15,14 @@ use wealthfolio_core::{
         AccountServiceTrait, TrackingMode,
     },
     portfolio::{
-        economic_events::BasisStatus,
         income::IncomeSummary,
         performance::{
-            DataQualityStatus, PerformanceAttribution, PerformanceDataQuality, PerformancePeriod,
-            PerformanceResult, PerformanceReturns, PerformanceRisk, PerformanceScopeDescriptor,
-            PerformanceSummary, PerformanceSummaryProfile, ReturnMethod, SimplePerformanceMetrics,
+            calculate_performance_summary_batch_for_accounts, empty_performance_metrics,
+            performance_account_ids_from_map, performance_account_tracking_modes_from_map,
+            performance_account_types_from_map, performance_tracking_composition,
+            sync_performance_summary_quality, unique_account_ids, DataQualityStatus,
+            PerformanceResult, PerformanceSummaryBatchScope, PerformanceSummaryProfile,
+            SimplePerformanceMetrics, PERFORMANCE_SUMMARY_BATCH_PARALLELISM,
         },
     },
     portfolios::AccountScope,
@@ -92,13 +94,6 @@ struct PerformanceSummariesBody {
     profile: Option<PerformanceSummaryProfile>,
 }
 
-fn performance_summary_scope_key(account_ids: &[String]) -> String {
-    let mut sorted = account_ids.to_vec();
-    sorted.sort();
-    sorted.dedup();
-    format!("accounts:{}", sorted.join(","))
-}
-
 fn parse_tracking_mode(mode: Option<String>) -> Option<TrackingMode> {
     mode.and_then(|m| match m.as_str() {
         "HOLDINGS" => Some(TrackingMode::Holdings),
@@ -121,69 +116,6 @@ fn account_ids_for_purpose(
         .collect())
 }
 
-fn empty_performance_metrics(
-    id: &str,
-    currency: String,
-    start_date: Option<chrono::NaiveDate>,
-    end_date: Option<chrono::NaiveDate>,
-) -> PerformanceResult {
-    let reason = "Performance unavailable for this account type.".to_string();
-    PerformanceResult {
-        scope: PerformanceScopeDescriptor {
-            id: id.to_string(),
-            currency,
-        },
-        period: PerformancePeriod {
-            start_date,
-            end_date,
-        },
-        mode: ReturnMethod::NotApplicable,
-        returns: PerformanceReturns {
-            twr: None,
-            annualized_twr: None,
-            irr: None,
-            annualized_irr: None,
-            value_return: None,
-            annualized_value_return: None,
-        },
-        attribution: PerformanceAttribution::default(),
-        risk: PerformanceRisk {
-            volatility: None,
-            max_drawdown: None,
-            peak_date: None,
-            trough_date: None,
-            recovery_date: None,
-            drawdown_duration_days: None,
-        },
-        data_quality: PerformanceDataQuality {
-            status: DataQualityStatus::NoData,
-            warnings: Vec::new(),
-            not_applicable_reasons: vec![reason.clone()],
-        },
-        basis_status: BasisStatus::NotApplicable,
-        summary: PerformanceSummary {
-            quality: DataQualityStatus::NoData,
-            basis_status: BasisStatus::NotApplicable,
-            reasons: vec![reason],
-            ..PerformanceSummary::default()
-        },
-        series: Vec::new(),
-        is_holdings_mode: false,
-        is_mixed_tracking_mode: false,
-    }
-}
-
-fn sync_performance_summary_quality(result: &mut PerformanceResult) {
-    result.summary.quality = result.data_quality.status.clone();
-    result.summary.reasons = result
-        .data_quality
-        .warnings
-        .iter()
-        .chain(result.data_quality.not_applicable_reasons.iter())
-        .cloned()
-        .collect();
-}
-
 fn performance_account_ids(
     state: &AppState,
     account_ids: &[String],
@@ -197,14 +129,6 @@ fn performance_account_ids(
         .collect())
 }
 
-fn unique_account_ids(account_ids: impl IntoIterator<Item = String>) -> Vec<String> {
-    let mut seen = HashSet::new();
-    account_ids
-        .into_iter()
-        .filter(|account_id| seen.insert(account_id.clone()))
-        .collect()
-}
-
 fn performance_accounts_by_id(
     state: &AppState,
     account_ids: &[String],
@@ -215,53 +139,6 @@ fn performance_accounts_by_id(
         .into_iter()
         .map(|account| (account.id.clone(), account))
         .collect())
-}
-
-fn performance_account_ids_from_map(
-    accounts_by_id: &HashMap<String, Account>,
-    account_ids: &[String],
-) -> Vec<String> {
-    let mut seen = HashSet::new();
-    account_ids
-        .iter()
-        .filter_map(|account_id| accounts_by_id.get(account_id))
-        .filter(|account| account_supports_portfolio_scope(account, AccountPurpose::Performance))
-        .filter_map(|account| {
-            if seen.insert(account.id.clone()) {
-                Some(account.id.clone())
-            } else {
-                None
-            }
-        })
-        .collect()
-}
-
-fn account_tracking_modes_from_map(
-    accounts_by_id: &HashMap<String, Account>,
-    account_ids: &[String],
-) -> HashMap<String, TrackingMode> {
-    account_ids
-        .iter()
-        .filter_map(|account_id| {
-            accounts_by_id
-                .get(account_id)
-                .map(|account| (account.id.clone(), account.tracking_mode))
-        })
-        .collect()
-}
-
-fn account_types_from_map(
-    accounts_by_id: &HashMap<String, Account>,
-    account_ids: &[String],
-) -> HashMap<String, String> {
-    account_ids
-        .iter()
-        .filter_map(|account_id| {
-            accounts_by_id
-                .get(account_id)
-                .map(|account| (account.id.clone(), account.account_type.clone()))
-        })
-        .collect()
 }
 
 async fn calculate_performance_history(
@@ -296,8 +173,9 @@ async fn calculate_performance_history(
             }
             return Ok(Json(result));
         }
-        let tracking_modes = account_tracking_modes_from_map(&accounts_by_id, &account_ids);
-        let account_types = account_types_from_map(&accounts_by_id, &account_ids);
+        let tracking_modes =
+            performance_account_tracking_modes_from_map(&accounts_by_id, &account_ids);
+        let account_types = performance_account_types_from_map(&accounts_by_id, &account_ids);
         let mut result = state
             .performance_service
             .calculate_performance_history_for_accounts(
@@ -358,6 +236,7 @@ async fn calculate_performance_summary(
     let end = parse_date_optional(body.end_date, "endDate")?;
     let tracking_mode = parse_tracking_mode(body.tracking_mode);
     let profile = body.profile.unwrap_or_default();
+    let summary_start = Instant::now();
     let metrics = if let (true, Some(filter)) = (body.item_type == "account", body.filter.as_ref())
     {
         let base = state.base_currency.read().unwrap().clone();
@@ -383,21 +262,51 @@ async fn calculate_performance_summary(
             }
             return Ok(Json(result));
         }
-        let tracking_modes = account_tracking_modes_from_map(&accounts_by_id, &account_ids);
-        let account_types = account_types_from_map(&accounts_by_id, &account_ids);
-        let mut result = state
-            .performance_service
-            .calculate_performance_summary_for_accounts(
-                &resolved.scope_id,
-                &account_ids,
-                &resolved.base_currency,
-                &tracking_modes,
-                &account_types,
-                start,
-                end,
-                profile,
-            )
-            .await?;
+        let tracking_modes =
+            performance_account_tracking_modes_from_map(&accounts_by_id, &account_ids);
+        let account_types = performance_account_types_from_map(&accounts_by_id, &account_ids);
+        let tracking_composition = performance_tracking_composition(&tracking_modes, &account_ids);
+        let performance_service = Arc::clone(&state.performance_service);
+        let handle = tokio::runtime::Handle::current();
+        let scope_id_for_task = resolved.scope_id.clone();
+        let base_for_task = resolved.base_currency.clone();
+        let account_ids_for_task = account_ids.clone();
+        let tracking_modes_for_task = tracking_modes.clone();
+        let account_types_for_task = account_types.clone();
+        let mut result = tokio::task::spawn_blocking(move || {
+            handle.block_on(async move {
+                performance_service
+                    .calculate_performance_summary_for_accounts(
+                        &scope_id_for_task,
+                        &account_ids_for_task,
+                        &base_for_task,
+                        &tracking_modes_for_task,
+                        &account_types_for_task,
+                        start,
+                        end,
+                        profile,
+                    )
+                    .await
+            })
+        })
+        .await
+        .map_err(|e| {
+            ApiError::Internal(format!(
+                "Failed to join performance summary calculation for {}: {}",
+                resolved.scope_id, e
+            ))
+        })??;
+        tracing::debug!(
+            item_type = %body.item_type,
+            scope_id = %resolved.scope_id,
+            ?profile,
+            account_count = account_ids.len(),
+            tracking_composition = %tracking_composition,
+            ?start,
+            ?end,
+            elapsed_ms = summary_start.elapsed().as_secs_f64() * 1000.0,
+            "Performance summary timing"
+        );
         if account_ids.len() != resolved.account_ids.len() {
             result.data_quality.warnings.push(
                 "Some requested accounts were excluded because they are archived or not eligible for performance."
@@ -423,7 +332,7 @@ async fn calculate_performance_summary(
             } else {
                 (tracking_mode, None)
             };
-        state
+        let result = state
             .performance_service
             .calculate_performance_summary(
                 &body.item_type,
@@ -434,7 +343,18 @@ async fn calculate_performance_summary(
                 authoritative_account_type.as_deref(),
                 profile,
             )
-            .await?
+            .await?;
+        tracing::debug!(
+            item_type = %body.item_type,
+            item_id = %body.item_id,
+            ?profile,
+            ?authoritative_tracking_mode,
+            ?start,
+            ?end,
+            elapsed_ms = summary_start.elapsed().as_secs_f64() * 1000.0,
+            "Performance summary timing"
+        );
+        result
     };
     Ok(Json(metrics))
 }
@@ -453,52 +373,81 @@ async fn get_performance_summaries(
             .flat_map(|scope| scope.account_ids.iter().cloned()),
     );
     let accounts_by_id = performance_accounts_by_id(&state, &requested_account_ids)?;
-    let mut results = HashMap::new();
+    let batch_scopes = body
+        .scopes
+        .into_iter()
+        .map(|scope| PerformanceSummaryBatchScope {
+            account_ids: scope.account_ids,
+        })
+        .collect();
+    let batch = calculate_performance_summary_batch_for_accounts(
+        Arc::clone(&state.performance_service),
+        batch_scopes,
+        accounts_by_id,
+        base,
+        start,
+        end,
+        profile,
+    )
+    .await;
 
-    for scope in body.scopes {
-        let key = performance_summary_scope_key(&scope.account_ids);
-        let account_ids = performance_account_ids_from_map(&accounts_by_id, &scope.account_ids);
-
-        if account_ids.is_empty() {
-            let mut result = empty_performance_metrics(&key, base.clone(), start, end);
-            if !scope.account_ids.is_empty() {
-                result.data_quality.warnings.push(
-                    "Requested accounts were excluded because they are archived or not eligible for performance."
-                        .to_string(),
-                );
-                sync_performance_summary_quality(&mut result);
-            }
-            results.insert(key.clone(), result);
-            continue;
-        }
-
-        let mut result = state
-            .performance_service
-            .calculate_performance_summary_for_accounts(
-                &key,
-                &account_ids,
-                &base,
-                &account_tracking_modes_from_map(&accounts_by_id, &account_ids),
-                &account_types_from_map(&accounts_by_id, &account_ids),
-                start,
-                end,
-                profile,
-            )
-            .await?;
-
-        if account_ids.len() != scope.account_ids.len() {
-            result.data_quality.warnings.push(
-                "Some requested accounts were excluded because they are archived or not eligible for performance."
-                    .to_string(),
+    for timing in &batch.scope_timings {
+        if timing.skipped {
+            tracing::debug!(
+                index = timing.index,
+                total = timing.total,
+                key = %timing.key,
+                ?profile,
+                requested_accounts = timing.requested_accounts,
+                eligible_accounts = 0,
+                tracking_composition = "none",
+                skipped = true,
+                elapsed_ms = timing.elapsed_ms,
+                "Performance summaries scope timing"
             );
-            result.data_quality.status = DataQualityStatus::Partial;
-            sync_performance_summary_quality(&mut result);
+        } else if timing.failed {
+            tracing::debug!(
+                index = timing.index,
+                total = timing.total,
+                key = %timing.key,
+                ?profile,
+                requested_accounts = timing.requested_accounts,
+                eligible_accounts = timing.eligible_accounts,
+                tracking_composition = %timing.tracking_composition,
+                failed = true,
+                elapsed_ms = timing.elapsed_ms,
+                "Performance summaries scope timing"
+            );
+        } else {
+            tracing::debug!(
+                index = timing.index,
+                total = timing.total,
+                key = %timing.key,
+                ?profile,
+                requested_accounts = timing.requested_accounts,
+                eligible_accounts = timing.eligible_accounts,
+                tracking_composition = %timing.tracking_composition,
+                warnings = timing.warnings,
+                elapsed_ms = timing.elapsed_ms,
+                "Performance summaries scope timing"
+            );
         }
-
-        results.insert(key, result);
     }
 
-    Ok(Json(results))
+    tracing::debug!(
+        ?profile,
+        scopes = batch.scope_timings.len(),
+        parallelism = PERFORMANCE_SUMMARY_BATCH_PARALLELISM,
+        unique_requested_accounts = requested_account_ids.len(),
+        result_count = batch.results.len(),
+        failed_scopes = batch.failed_scope_count,
+        ?start,
+        ?end,
+        elapsed_ms = batch.elapsed_ms,
+        "Performance summaries batch timing"
+    );
+
+    Ok(Json(batch.results))
 }
 
 #[derive(serde::Deserialize)]

--- a/apps/tauri/src/commands/portfolio.rs
+++ b/apps/tauri/src/commands/portfolio.rs
@@ -1,5 +1,6 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Instant;
 
 use crate::{
     context::ServiceContext,
@@ -23,11 +24,13 @@ use wealthfolio_core::{
     income::IncomeSummary,
     lots::AssetLotView,
     performance::{
-        DataQualityStatus, PerformanceAttribution, PerformanceDataQuality, PerformancePeriod,
-        PerformanceResult, PerformanceReturns, PerformanceRisk, PerformanceScopeDescriptor,
-        PerformanceSummary, PerformanceSummaryProfile, ReturnMethod, SimplePerformanceMetrics,
+        calculate_performance_summary_batch_for_accounts, empty_performance_metrics,
+        performance_account_ids_from_map, performance_account_tracking_modes_from_map,
+        performance_account_types_from_map, performance_tracking_composition,
+        sync_performance_summary_quality, unique_account_ids, DataQualityStatus, PerformanceResult,
+        PerformanceSummaryBatchScope, PerformanceSummaryProfile, SimplePerformanceMetrics,
+        PERFORMANCE_SUMMARY_BATCH_PARALLELISM,
     },
-    portfolio::economic_events::BasisStatus,
     portfolio::snapshot::{
         CashBalanceInput, ManualHoldingInput, ManualSnapshotRequest, ManualSnapshotService,
         SnapshotSource,
@@ -92,13 +95,6 @@ impl AccountScopeInput {
     }
 }
 
-fn performance_summary_scope_key(account_ids: &[String]) -> String {
-    let mut sorted = account_ids.to_vec();
-    sorted.sort();
-    sorted.dedup();
-    format!("accounts:{}", sorted.join(","))
-}
-
 pub(super) fn holdings_account_ids(
     state: &ServiceContext,
     account_ids: &[String],
@@ -113,14 +109,6 @@ pub(super) fn holdings_account_ids(
         .collect())
 }
 
-fn unique_account_ids(account_ids: impl IntoIterator<Item = String>) -> Vec<String> {
-    let mut seen = HashSet::new();
-    account_ids
-        .into_iter()
-        .filter(|account_id| seen.insert(account_id.clone()))
-        .collect()
-}
-
 fn performance_accounts_by_id(
     state: &ServiceContext,
     account_ids: &[String],
@@ -132,53 +120,6 @@ fn performance_accounts_by_id(
         .into_iter()
         .map(|account| (account.id.clone(), account))
         .collect())
-}
-
-fn performance_account_ids_from_map(
-    accounts_by_id: &HashMap<String, Account>,
-    account_ids: &[String],
-) -> Vec<String> {
-    let mut seen = HashSet::new();
-    account_ids
-        .iter()
-        .filter_map(|account_id| accounts_by_id.get(account_id))
-        .filter(|account| account_supports_portfolio_scope(account, AccountPurpose::Performance))
-        .filter_map(|account| {
-            if seen.insert(account.id.clone()) {
-                Some(account.id.clone())
-            } else {
-                None
-            }
-        })
-        .collect()
-}
-
-fn account_tracking_modes_from_map(
-    accounts_by_id: &HashMap<String, Account>,
-    account_ids: &[String],
-) -> HashMap<String, TrackingMode> {
-    account_ids
-        .iter()
-        .filter_map(|account_id| {
-            accounts_by_id
-                .get(account_id)
-                .map(|account| (account.id.clone(), account.tracking_mode))
-        })
-        .collect()
-}
-
-fn account_types_from_map(
-    accounts_by_id: &HashMap<String, Account>,
-    account_ids: &[String],
-) -> HashMap<String, String> {
-    account_ids
-        .iter()
-        .filter_map(|account_id| {
-            accounts_by_id
-                .get(account_id)
-                .map(|account| (account.id.clone(), account.account_type.clone()))
-        })
-        .collect()
 }
 
 fn income_account_ids(
@@ -437,6 +378,9 @@ pub async fn get_historical_valuations(
     start_date: Option<String>,
     end_date: Option<String>,
 ) -> Result<Vec<DailyAccountValuation>, String> {
+    let started_at = Instant::now();
+    let debug_scope = log::log_enabled!(log::Level::Debug)
+        .then(|| (format!("{:?}", account_id), format!("{:?}", filter)));
     debug!(
         "Get historical valuations for account: {:?}, filter: {:?}",
         account_id, filter
@@ -456,7 +400,7 @@ pub async fn get_historical_valuations(
         })
         .transpose()?;
 
-    if let Some(input) = filter {
+    let result = if let Some(input) = filter {
         let base_currency = state.get_base_currency();
         let account_filter = input.into_account_filter()?;
         let resolved = state
@@ -474,7 +418,7 @@ pub async fn get_historical_valuations(
         } else {
             state
                 .valuation_service()
-                .get_historical_valuations_for_accounts(
+                .get_historical_valuation_totals_for_accounts(
                     &resolved.scope_id,
                     &account_ids,
                     &resolved.base_currency,
@@ -505,7 +449,7 @@ pub async fn get_historical_valuations(
         }
         state
             .valuation_service()
-            .get_historical_valuations_for_accounts(
+            .get_historical_valuation_totals_for_accounts(
                 &resolved.scope_id,
                 &account_ids,
                 &resolved.base_currency,
@@ -513,7 +457,18 @@ pub async fn get_historical_valuations(
                 to_date_opt,
             )
             .map_err(|e| e.to_string())
+    };
+
+    if let Some((account_debug, filter_debug)) = debug_scope {
+        debug!(
+            "Historical valuations timing: account={}, filter={}, rows={}, elapsed_ms={:.1}",
+            account_debug,
+            filter_debug,
+            result.as_ref().map(Vec::len).unwrap_or_default(),
+            started_at.elapsed().as_secs_f64() * 1000.0,
+        );
     }
+    result
 }
 
 #[tauri::command]
@@ -717,8 +672,9 @@ pub async fn calculate_performance_history(
             }
             return Ok(result);
         }
-        let tracking_modes = account_tracking_modes_from_map(&accounts_by_id, &account_ids);
-        let account_types = account_types_from_map(&accounts_by_id, &account_ids);
+        let tracking_modes =
+            performance_account_tracking_modes_from_map(&accounts_by_id, &account_ids);
+        let account_types = performance_account_types_from_map(&accounts_by_id, &account_ids);
         let mut result = state
             .performance_service()
             .calculate_performance_history_for_accounts(
@@ -775,69 +731,6 @@ pub async fn calculate_performance_history(
     }
 }
 
-fn empty_performance_metrics(
-    id: &str,
-    currency: String,
-    start_date: Option<NaiveDate>,
-    end_date: Option<NaiveDate>,
-) -> PerformanceResult {
-    let reason = "Performance unavailable for this account type.".to_string();
-    PerformanceResult {
-        scope: PerformanceScopeDescriptor {
-            id: id.to_string(),
-            currency,
-        },
-        period: PerformancePeriod {
-            start_date,
-            end_date,
-        },
-        mode: ReturnMethod::NotApplicable,
-        returns: PerformanceReturns {
-            twr: None,
-            annualized_twr: None,
-            irr: None,
-            annualized_irr: None,
-            value_return: None,
-            annualized_value_return: None,
-        },
-        attribution: PerformanceAttribution::default(),
-        risk: PerformanceRisk {
-            volatility: None,
-            max_drawdown: None,
-            peak_date: None,
-            trough_date: None,
-            recovery_date: None,
-            drawdown_duration_days: None,
-        },
-        data_quality: PerformanceDataQuality {
-            status: DataQualityStatus::NoData,
-            warnings: Vec::new(),
-            not_applicable_reasons: vec![reason.clone()],
-        },
-        basis_status: BasisStatus::NotApplicable,
-        summary: PerformanceSummary {
-            quality: DataQualityStatus::NoData,
-            basis_status: BasisStatus::NotApplicable,
-            reasons: vec![reason],
-            ..PerformanceSummary::default()
-        },
-        series: Vec::new(),
-        is_holdings_mode: false,
-        is_mixed_tracking_mode: false,
-    }
-}
-
-fn sync_performance_summary_quality(result: &mut PerformanceResult) {
-    result.summary.quality = result.data_quality.status.clone();
-    result.summary.reasons = result
-        .data_quality
-        .warnings
-        .iter()
-        .chain(result.data_quality.not_applicable_reasons.iter())
-        .cloned()
-        .collect();
-}
-
 /// Calculates performance summary for a given item (account or symbol) over a given date range.
 /// return performance metrics for the item.
 /// tracking_mode: Optional tracking mode for the account ("HOLDINGS" or "TRANSACTIONS")
@@ -880,6 +773,7 @@ pub async fn calculate_performance_summary(
         _ => None,
     });
     let profile = profile.unwrap_or_default();
+    let summary_start = Instant::now();
 
     if let (true, Some(filter)) = (item_type == "account", filter) {
         let base_currency = state.get_base_currency();
@@ -907,22 +801,52 @@ pub async fn calculate_performance_summary(
             }
             return Ok(result);
         }
-        let tracking_modes = account_tracking_modes_from_map(&accounts_by_id, &account_ids);
-        let account_types = account_types_from_map(&accounts_by_id, &account_ids);
-        let mut result = state
-            .performance_service()
-            .calculate_performance_summary_for_accounts(
-                &resolved.scope_id,
-                &account_ids,
-                &resolved.base_currency,
-                &tracking_modes,
-                &account_types,
-                start_date_opt,
-                end_date_opt,
-                profile,
+        let tracking_modes =
+            performance_account_tracking_modes_from_map(&accounts_by_id, &account_ids);
+        let account_types = performance_account_types_from_map(&accounts_by_id, &account_ids);
+        let tracking_composition = performance_tracking_composition(&tracking_modes, &account_ids);
+        let performance_service = state.performance_service();
+        let handle = tokio::runtime::Handle::current();
+        let scope_id_for_task = resolved.scope_id.clone();
+        let base_currency_for_task = resolved.base_currency.clone();
+        let account_ids_for_task = account_ids.clone();
+        let tracking_modes_for_task = tracking_modes.clone();
+        let account_types_for_task = account_types.clone();
+        let mut result = tokio::task::spawn_blocking(move || {
+            handle.block_on(async move {
+                performance_service
+                    .calculate_performance_summary_for_accounts(
+                        &scope_id_for_task,
+                        &account_ids_for_task,
+                        &base_currency_for_task,
+                        &tracking_modes_for_task,
+                        &account_types_for_task,
+                        start_date_opt,
+                        end_date_opt,
+                        profile,
+                    )
+                    .await
+            })
+        })
+        .await
+        .map_err(|e| {
+            format!(
+                "Failed to join performance summary calculation for {}: {}",
+                resolved.scope_id, e
             )
-            .await
-            .map_err(|e| format!("Failed to calculate performance: {}", e))?;
+        })?
+        .map_err(|e| format!("Failed to calculate performance: {}", e))?;
+        debug!(
+            "Performance summary timing: item_type={}, scope_id={}, profile={:?}, account_count={}, tracking_composition={}, start={:?}, end={:?}, elapsed_ms={:.1}",
+            item_type,
+            resolved.scope_id,
+            profile,
+            account_ids.len(),
+            tracking_composition,
+            start_date_opt,
+            end_date_opt,
+            summary_start.elapsed().as_secs_f64() * 1000.0
+        );
         if account_ids.len() != resolved.account_ids.len() {
             result.data_quality.warnings.push(
                 "Some requested accounts were excluded because they are archived or not eligible for performance."
@@ -951,7 +875,7 @@ pub async fn calculate_performance_summary(
             (tracking_mode_opt, None)
         };
 
-        state
+        let result = state
             .performance_service()
             .calculate_performance_summary(
                 &item_type,
@@ -963,7 +887,18 @@ pub async fn calculate_performance_summary(
                 profile,
             )
             .await
-            .map_err(|e| format!("Failed to calculate performance: {}", e))
+            .map_err(|e| format!("Failed to calculate performance: {}", e))?;
+        debug!(
+            "Performance summary timing: item_type={}, item_id={}, profile={:?}, tracking_mode={:?}, start={:?}, end={:?}, elapsed_ms={:.1}",
+            item_type,
+            item_id,
+            profile,
+            authoritative_tracking_mode,
+            start_date_opt,
+            end_date_opt,
+            summary_start.elapsed().as_secs_f64() * 1000.0
+        );
+        Ok(result)
     }
 }
 
@@ -998,58 +933,77 @@ pub async fn get_performance_summaries(
     );
     let accounts_by_id =
         performance_accounts_by_id(state.inner().as_ref(), &requested_account_ids)?;
-    let mut results = HashMap::new();
+    let batch_scopes = scopes
+        .into_iter()
+        .map(|scope| PerformanceSummaryBatchScope {
+            account_ids: scope.account_ids,
+        })
+        .collect();
+    let performance_service = state.performance_service();
+    let batch = calculate_performance_summary_batch_for_accounts(
+        performance_service,
+        batch_scopes,
+        accounts_by_id,
+        base_currency,
+        start_date_opt,
+        end_date_opt,
+        profile,
+    )
+    .await;
 
-    for scope in scopes {
-        let key = performance_summary_scope_key(&scope.account_ids);
-        let account_ids = performance_account_ids_from_map(&accounts_by_id, &scope.account_ids);
-
-        if account_ids.is_empty() {
-            let mut result = empty_performance_metrics(
-                &key,
-                base_currency.clone(),
-                start_date_opt,
-                end_date_opt,
-            );
-            if !scope.account_ids.is_empty() {
-                result.data_quality.warnings.push(
-                    "Requested accounts were excluded because they are archived or not eligible for performance."
-                        .to_string(),
-                );
-                sync_performance_summary_quality(&mut result);
-            }
-            results.insert(key.clone(), result);
-            continue;
-        }
-
-        let mut result = state
-            .performance_service()
-            .calculate_performance_summary_for_accounts(
-                &key,
-                &account_ids,
-                &base_currency,
-                &account_tracking_modes_from_map(&accounts_by_id, &account_ids),
-                &account_types_from_map(&accounts_by_id, &account_ids),
-                start_date_opt,
-                end_date_opt,
+    for timing in &batch.scope_timings {
+        if timing.skipped {
+            debug!(
+                "Performance summaries scope timing: index={}/{}, key={}, profile={:?}, requested_accounts={}, eligible_accounts=0, tracking_composition=none, skipped=true, elapsed_ms={:.1}",
+                timing.index,
+                timing.total,
+                timing.key,
                 profile,
-            )
-            .await
-            .map_err(|e| format!("Failed to calculate performance summary: {}", e))?;
-
-        if account_ids.len() != scope.account_ids.len() {
-            result.data_quality.warnings.push(
-                "Some requested accounts were excluded because they are archived or not eligible for performance."
-                    .to_string(),
+                timing.requested_accounts,
+                timing.elapsed_ms
             );
-            result.data_quality.status = DataQualityStatus::Partial;
-            sync_performance_summary_quality(&mut result);
+        } else if timing.failed {
+            debug!(
+                "Performance summaries scope timing: index={}/{}, key={}, profile={:?}, requested_accounts={}, eligible_accounts={}, tracking_composition={}, failed=true, elapsed_ms={:.1}",
+                timing.index,
+                timing.total,
+                timing.key,
+                profile,
+                timing.requested_accounts,
+                timing.eligible_accounts,
+                timing.tracking_composition,
+                timing.elapsed_ms
+            );
+        } else {
+            debug!(
+                "Performance summaries scope timing: index={}/{}, key={}, profile={:?}, requested_accounts={}, eligible_accounts={}, tracking_composition={}, warnings={}, elapsed_ms={:.1}",
+                timing.index,
+                timing.total,
+                timing.key,
+                profile,
+                timing.requested_accounts,
+                timing.eligible_accounts,
+                timing.tracking_composition,
+                timing.warnings,
+                timing.elapsed_ms
+            );
         }
-
-        results.insert(key, result);
     }
 
-    Ok(results)
+    debug!(
+        "Performance summaries batch timing: profile={:?}, scopes={}, parallelism={}, unique_requested_accounts={}, result_count={}, failed_scopes={}, start={:?}, end={:?}, elapsed_ms={:.1}",
+        profile,
+        batch.scope_timings.len(),
+        PERFORMANCE_SUMMARY_BATCH_PARALLELISM,
+        requested_account_ids.len(),
+        batch.results.len(),
+        batch.failed_scope_count,
+        start_date_opt,
+        end_date_opt,
+        batch.elapsed_ms
+    );
+
+    Ok(batch.results)
 }
 
 /// Input for a single holding when saving manual holdings

--- a/crates/core/src/portfolio/performance/performance_model.rs
+++ b/crates/core/src/portfolio/performance/performance_model.rs
@@ -1,7 +1,11 @@
-use crate::portfolio::economic_events::BasisStatus;
+use crate::{
+    accounts::{account_supports_portfolio_scope, Account, AccountPurpose, TrackingMode},
+    portfolio::economic_events::BasisStatus,
+};
 use chrono::NaiveDate;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CumulativeReturn {
@@ -67,6 +71,197 @@ pub enum PerformanceSummaryProfile {
     Full,
     #[serde(alias = "headline")]
     Summary,
+    Dashboard,
+}
+
+pub fn performance_tracking_composition(
+    tracking_modes: &HashMap<String, TrackingMode>,
+    account_ids: &[String],
+) -> String {
+    let mut holdings_count = 0;
+    let mut transaction_count = 0;
+
+    for account_id in account_ids {
+        if matches!(tracking_modes.get(account_id), Some(TrackingMode::Holdings)) {
+            holdings_count += 1;
+        } else {
+            transaction_count += 1;
+        }
+    }
+
+    match (holdings_count, transaction_count) {
+        (0, _) => format!("transactions({transaction_count})"),
+        (_, 0) => format!("holdings({holdings_count})"),
+        _ => format!("mixed(holdings={holdings_count}, transactions={transaction_count})"),
+    }
+}
+
+pub fn performance_summary_scope_key(account_ids: &[String]) -> String {
+    let mut sorted = account_ids.to_vec();
+    sorted.sort();
+    sorted.dedup();
+    format!("accounts:{}", sorted.join(","))
+}
+
+pub fn unique_account_ids(account_ids: impl IntoIterator<Item = String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    account_ids
+        .into_iter()
+        .filter(|account_id| seen.insert(account_id.clone()))
+        .collect()
+}
+
+pub fn performance_account_ids_from_map(
+    accounts_by_id: &HashMap<String, Account>,
+    account_ids: &[String],
+) -> Vec<String> {
+    let mut seen = HashSet::new();
+    account_ids
+        .iter()
+        .filter_map(|account_id| accounts_by_id.get(account_id))
+        .filter(|account| account_supports_portfolio_scope(account, AccountPurpose::Performance))
+        .filter_map(|account| {
+            if seen.insert(account.id.clone()) {
+                Some(account.id.clone())
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+pub fn performance_account_tracking_modes_from_map(
+    accounts_by_id: &HashMap<String, Account>,
+    account_ids: &[String],
+) -> HashMap<String, TrackingMode> {
+    account_ids
+        .iter()
+        .filter_map(|account_id| {
+            accounts_by_id
+                .get(account_id)
+                .map(|account| (account.id.clone(), account.tracking_mode))
+        })
+        .collect()
+}
+
+pub fn performance_account_types_from_map(
+    accounts_by_id: &HashMap<String, Account>,
+    account_ids: &[String],
+) -> HashMap<String, String> {
+    account_ids
+        .iter()
+        .filter_map(|account_id| {
+            accounts_by_id
+                .get(account_id)
+                .map(|account| (account.id.clone(), account.account_type.clone()))
+        })
+        .collect()
+}
+
+pub fn empty_performance_metrics(
+    id: &str,
+    currency: String,
+    start_date: Option<NaiveDate>,
+    end_date: Option<NaiveDate>,
+) -> PerformanceResult {
+    unavailable_performance_metrics(
+        id,
+        currency,
+        start_date,
+        end_date,
+        "Performance unavailable for this account type.",
+    )
+}
+
+pub fn unavailable_performance_metrics(
+    id: &str,
+    currency: String,
+    start_date: Option<NaiveDate>,
+    end_date: Option<NaiveDate>,
+    reason: impl Into<String>,
+) -> PerformanceResult {
+    let reason = reason.into();
+    PerformanceResult {
+        scope: PerformanceScopeDescriptor {
+            id: id.to_string(),
+            currency,
+        },
+        period: PerformancePeriod {
+            start_date,
+            end_date,
+        },
+        mode: ReturnMethod::NotApplicable,
+        returns: PerformanceReturns {
+            twr: None,
+            annualized_twr: None,
+            irr: None,
+            annualized_irr: None,
+            value_return: None,
+            annualized_value_return: None,
+        },
+        attribution: PerformanceAttribution::default(),
+        risk: PerformanceRisk {
+            volatility: None,
+            max_drawdown: None,
+            peak_date: None,
+            trough_date: None,
+            recovery_date: None,
+            drawdown_duration_days: None,
+        },
+        data_quality: PerformanceDataQuality {
+            status: DataQualityStatus::NoData,
+            warnings: Vec::new(),
+            not_applicable_reasons: vec![reason.clone()],
+        },
+        basis_status: BasisStatus::NotApplicable,
+        summary: PerformanceSummary {
+            quality: DataQualityStatus::NoData,
+            basis_status: BasisStatus::NotApplicable,
+            reasons: vec![reason],
+            ..PerformanceSummary::default()
+        },
+        series: Vec::new(),
+        is_holdings_mode: false,
+        is_mixed_tracking_mode: false,
+    }
+}
+
+pub fn sync_performance_summary_quality(result: &mut PerformanceResult) {
+    result.summary.quality = result.data_quality.status.clone();
+    result.summary.reasons = result
+        .data_quality
+        .warnings
+        .iter()
+        .chain(result.data_quality.not_applicable_reasons.iter())
+        .cloned()
+        .collect();
+}
+
+#[derive(Debug, Clone)]
+pub struct PerformanceSummaryBatchScope {
+    pub account_ids: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PerformanceSummaryScopeTiming {
+    pub index: usize,
+    pub total: usize,
+    pub key: String,
+    pub requested_accounts: usize,
+    pub eligible_accounts: usize,
+    pub tracking_composition: String,
+    pub warnings: usize,
+    pub skipped: bool,
+    pub failed: bool,
+    pub elapsed_ms: f64,
+}
+
+#[derive(Debug)]
+pub struct PerformanceSummaryBatchResult {
+    pub results: HashMap<String, PerformanceResult>,
+    pub failed_scope_count: usize,
+    pub scope_timings: Vec<PerformanceSummaryScopeTiming>,
+    pub elapsed_ms: f64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/core/src/portfolio/performance/performance_service.rs
+++ b/crates/core/src/portfolio/performance/performance_service.rs
@@ -1,4 +1,4 @@
-use crate::accounts::{account_types, TrackingMode};
+use crate::accounts::{account_types, Account, TrackingMode};
 use crate::activities::{Activity, ActivityRepositoryTrait, ActivityType, TransferPairResolution};
 use crate::constants::DECIMAL_PRECISION;
 use crate::errors::{self, Result, ValidationError};
@@ -16,10 +16,12 @@ use crate::valuation::ValuationServiceTrait;
 
 use async_trait::async_trait;
 use chrono::{DateTime, Duration, NaiveDate, Utc};
+use futures::stream::{self, StreamExt};
 use num_traits::ToPrimitive;
 use std::collections::{HashMap, HashSet};
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
+use std::time::Instant;
 
 use log::{debug, warn};
 use rust_decimal::prelude::FromPrimitive;
@@ -28,10 +30,15 @@ use rust_decimal::MathematicalOps;
 use rust_decimal_macros::dec;
 
 use super::{
-    is_external_transfer, DataQualityStatus, PerformanceAttribution, PerformanceDataQuality,
-    PerformancePeriod, PerformanceResult, PerformanceReturns, PerformanceRisk,
-    PerformanceScopeDescriptor, PerformanceSummary, PerformanceSummaryBasis,
-    PerformanceSummaryProfile, PerformanceSummaryStatus, ReturnMethod, SimplePerformanceMetrics,
+    empty_performance_metrics, is_external_transfer, performance_account_ids_from_map,
+    performance_account_tracking_modes_from_map, performance_account_types_from_map,
+    performance_summary_scope_key, performance_tracking_composition,
+    sync_performance_summary_quality, unavailable_performance_metrics, DataQualityStatus,
+    PerformanceAttribution, PerformanceDataQuality, PerformancePeriod, PerformanceResult,
+    PerformanceReturns, PerformanceRisk, PerformanceScopeDescriptor, PerformanceSummary,
+    PerformanceSummaryBasis, PerformanceSummaryBatchResult, PerformanceSummaryBatchScope,
+    PerformanceSummaryProfile, PerformanceSummaryScopeTiming, PerformanceSummaryStatus,
+    ReturnMethod, SimplePerformanceMetrics,
 };
 use crate::portfolio::valuation::{
     DailyAccountValuation, ExternalFlowSource as ValuationExternalFlowSource,
@@ -92,6 +99,192 @@ pub trait PerformanceServiceTrait: Send + Sync {
         &self,
         account_ids: &[String],
     ) -> Result<Vec<SimplePerformanceMetrics>>;
+}
+
+pub const PERFORMANCE_SUMMARY_BATCH_PARALLELISM: usize = 4;
+
+struct PerformanceSummaryBatchScopeResult {
+    key: String,
+    result: PerformanceResult,
+    timing: PerformanceSummaryScopeTiming,
+}
+
+pub async fn calculate_performance_summary_batch_for_accounts<T>(
+    performance_service: Arc<T>,
+    scopes: Vec<PerformanceSummaryBatchScope>,
+    accounts_by_id: HashMap<String, Account>,
+    base_currency: String,
+    start_date: Option<NaiveDate>,
+    end_date: Option<NaiveDate>,
+    profile: PerformanceSummaryProfile,
+) -> PerformanceSummaryBatchResult
+where
+    T: PerformanceServiceTrait + ?Sized + 'static,
+{
+    let total_scope_count = scopes.len();
+    let batch_start = Instant::now();
+    let mut results = HashMap::new();
+    let mut scope_results = stream::iter(scopes.into_iter().enumerate())
+        .map(|(scope_index, scope)| {
+            let performance_service = Arc::clone(&performance_service);
+            let accounts_by_id = accounts_by_id.clone();
+            let base_currency = base_currency.clone();
+            async move {
+                let key = performance_summary_scope_key(&scope.account_ids);
+                let account_ids =
+                    performance_account_ids_from_map(&accounts_by_id, &scope.account_ids);
+                let scope_start = Instant::now();
+
+                if account_ids.is_empty() {
+                    let mut result = empty_performance_metrics(
+                        &key,
+                        base_currency.clone(),
+                        start_date,
+                        end_date,
+                    );
+                    if !scope.account_ids.is_empty() {
+                        result.data_quality.warnings.push(
+                            "Requested accounts were excluded because they are archived or not eligible for performance."
+                                .to_string(),
+                        );
+                        sync_performance_summary_quality(&mut result);
+                    }
+                    let timing = PerformanceSummaryScopeTiming {
+                        index: scope_index + 1,
+                        total: total_scope_count,
+                        key: key.clone(),
+                        requested_accounts: scope.account_ids.len(),
+                        eligible_accounts: 0,
+                        tracking_composition: "none".to_string(),
+                        warnings: result.data_quality.warnings.len(),
+                        skipped: true,
+                        failed: false,
+                        elapsed_ms: scope_start.elapsed().as_secs_f64() * 1000.0,
+                    };
+                    return PerformanceSummaryBatchScopeResult {
+                        key,
+                        result,
+                        timing,
+                    };
+                }
+
+                let tracking_modes =
+                    performance_account_tracking_modes_from_map(&accounts_by_id, &account_ids);
+                let account_types =
+                    performance_account_types_from_map(&accounts_by_id, &account_ids);
+                let tracking_composition =
+                    performance_tracking_composition(&tracking_modes, &account_ids);
+                let requested_account_count = scope.account_ids.len();
+                let handle = tokio::runtime::Handle::current();
+                let key_for_task = key.clone();
+                let account_ids_for_task = account_ids.clone();
+                let base_currency_for_task = base_currency.clone();
+                let tracking_modes_for_task = tracking_modes.clone();
+                let account_types_for_task = account_types.clone();
+                let calculation = match tokio::task::spawn_blocking(move || {
+                    handle.block_on(async move {
+                        performance_service
+                            .calculate_performance_summary_for_accounts(
+                                &key_for_task,
+                                &account_ids_for_task,
+                                &base_currency_for_task,
+                                &tracking_modes_for_task,
+                                &account_types_for_task,
+                                start_date,
+                                end_date,
+                                profile,
+                            )
+                            .await
+                    })
+                })
+                .await
+                {
+                    Ok(result) => result
+                        .map_err(|e| format!("Failed to calculate performance summary: {}", e)),
+                    Err(error) => Err(format!(
+                        "Failed to join performance summary calculation for {}: {}",
+                        key, error
+                    )),
+                };
+
+                let mut result = match calculation {
+                    Ok(result) => result,
+                    Err(error) => {
+                        let mut result = unavailable_performance_metrics(
+                            &key,
+                            base_currency.clone(),
+                            start_date,
+                            end_date,
+                            format!("Performance unavailable for this scope: {error}"),
+                        );
+                        result.data_quality.status = DataQualityStatus::Partial;
+                        sync_performance_summary_quality(&mut result);
+                        let timing = PerformanceSummaryScopeTiming {
+                            index: scope_index + 1,
+                            total: total_scope_count,
+                            key: key.clone(),
+                            requested_accounts: requested_account_count,
+                            eligible_accounts: account_ids.len(),
+                            tracking_composition,
+                            warnings: result.data_quality.warnings.len(),
+                            skipped: false,
+                            failed: true,
+                            elapsed_ms: scope_start.elapsed().as_secs_f64() * 1000.0,
+                        };
+                        return PerformanceSummaryBatchScopeResult {
+                            key,
+                            result,
+                            timing,
+                        };
+                    }
+                };
+
+                if account_ids.len() != requested_account_count {
+                    result.data_quality.warnings.push(
+                        "Some requested accounts were excluded because they are archived or not eligible for performance."
+                            .to_string(),
+                    );
+                    result.data_quality.status = DataQualityStatus::Partial;
+                    sync_performance_summary_quality(&mut result);
+                }
+
+                let timing = PerformanceSummaryScopeTiming {
+                    index: scope_index + 1,
+                    total: total_scope_count,
+                    key: key.clone(),
+                    requested_accounts: requested_account_count,
+                    eligible_accounts: account_ids.len(),
+                    tracking_composition,
+                    warnings: result.data_quality.warnings.len(),
+                    skipped: false,
+                    failed: false,
+                    elapsed_ms: scope_start.elapsed().as_secs_f64() * 1000.0,
+                };
+                PerformanceSummaryBatchScopeResult {
+                    key,
+                    result,
+                    timing,
+                }
+            }
+        })
+        .buffer_unordered(PERFORMANCE_SUMMARY_BATCH_PARALLELISM);
+
+    let mut failed_scope_count = 0usize;
+    let mut scope_timings = Vec::new();
+    while let Some(scope_result) = scope_results.next().await {
+        if scope_result.timing.failed {
+            failed_scope_count += 1;
+        }
+        scope_timings.push(scope_result.timing);
+        results.insert(scope_result.key, scope_result.result);
+    }
+
+    PerformanceSummaryBatchResult {
+        results,
+        failed_scope_count,
+        scope_timings,
+        elapsed_ms: batch_start.elapsed().as_secs_f64() * 1000.0,
+    }
 }
 
 pub struct PerformanceService {
@@ -766,16 +959,29 @@ impl PerformanceService {
         flow_basis: ExternalFlowBasis,
     ) -> Option<Decimal> {
         let start_point = full_history.first()?;
-        let end_point = full_history.last()?;
         let start_value = Self::return_total_value(start_point, flow_basis);
         if start_value <= Decimal::ZERO {
             return None;
         }
 
-        let net_cash_flow: Decimal = daily_flows.iter().map(|flow| flow.net()).sum();
-        let end_value = Self::return_total_value(end_point, flow_basis);
+        Self::compute_simple_value_return_amount(full_history, daily_flows, flow_basis)
+            .map(|amount| amount / start_value)
+    }
 
-        Some((end_value - start_value - net_cash_flow) / start_value)
+    fn compute_simple_value_return_amount(
+        full_history: &[DailyAccountValuation],
+        daily_flows: &[DailyExternalFlow],
+        flow_basis: ExternalFlowBasis,
+    ) -> Option<Decimal> {
+        let start_point = full_history.first()?;
+        let end_point = full_history.last()?;
+        let net_cash_flow: Decimal = daily_flows.iter().map(|flow| flow.net()).sum();
+
+        Some(
+            Self::return_total_value(end_point, flow_basis)
+                - Self::return_total_value(start_point, flow_basis)
+                - net_cash_flow,
+        )
     }
 
     fn total_external_flows(daily_flows: &[DailyExternalFlow]) -> (Decimal, Decimal) {
@@ -2637,6 +2843,10 @@ impl PerformanceService {
             Self::is_cash_account_type(account_type),
         )?;
         metrics.scope.id = account_id.to_string();
+        if profile == PerformanceSummaryProfile::Dashboard {
+            return Ok(metrics);
+        }
+
         let attribution_baseline = Self::attribution_baseline(
             matches!(tracking_mode, Some(TrackingMode::Holdings)),
             start_date_opt,
@@ -2815,6 +3025,10 @@ impl PerformanceService {
         };
 
         metrics.scope.id = scope_id.to_string();
+        if profile == PerformanceSummaryProfile::Dashboard {
+            return Ok(metrics);
+        }
+
         // Transaction-only all-time scopes can use inception attribution; holdings-only
         // scopes stay period-based because holdings snapshots do not carry cash-flow history.
         let attribution_baseline = if scoped_tracking_composition
@@ -3122,6 +3336,19 @@ impl PerformanceService {
                     holdings_amount
                         .unwrap_or(Decimal::ZERO)
                         .round_dp(DECIMAL_PRECISION),
+                    Decimal::ZERO,
+                )
+            } else if profile == PerformanceSummaryProfile::Dashboard {
+                (
+                    Decimal::ZERO,
+                    Decimal::ZERO,
+                    Self::compute_simple_value_return_amount(
+                        full_history,
+                        &daily_flows,
+                        flow_basis,
+                    )
+                    .unwrap_or(Decimal::ZERO)
+                    .round_dp(DECIMAL_PRECISION),
                     Decimal::ZERO,
                 )
             } else {
@@ -3779,15 +4006,22 @@ impl PerformanceService {
                 continue;
             }
 
+            let component_profile = if profile == PerformanceSummaryProfile::Dashboard {
+                PerformanceSummaryProfile::Dashboard
+            } else {
+                PerformanceSummaryProfile::Summary
+            };
             let mut metrics = Self::compute_mixed_scope_component_metrics(
                 component,
                 start_date_opt,
-                PerformanceSummaryProfile::Summary,
+                component_profile,
                 flow_basis,
                 is_all_time,
             )?;
 
-            if matches!(component.tracking_mode, TrackingMode::Transactions) {
+            if profile != PerformanceSummaryProfile::Dashboard
+                && matches!(component.tracking_mode, TrackingMode::Transactions)
+            {
                 let mut component_result = Self::compute_mixed_scope_transaction_component_result(
                     component,
                     start_date_opt,
@@ -9425,6 +9659,144 @@ mod tests {
         assert_eq!(
             result.returns.value_return.unwrap().round_dp(4),
             dec!(0.0667)
+        );
+    }
+
+    #[tokio::test]
+    async fn mixed_scope_dashboard_skips_transaction_component_attribution() {
+        let transaction = [
+            account_valuation(
+                "transaction",
+                "2026-06-12",
+                dec!(1000),
+                dec!(1000),
+                dec!(1000),
+                dec!(1000),
+            ),
+            account_valuation(
+                "transaction",
+                "2026-06-19",
+                dec!(1050),
+                dec!(1000),
+                dec!(1000),
+                dec!(1000),
+            ),
+        ];
+        let holdings = [
+            account_valuation(
+                "holdings",
+                "2026-06-12",
+                dec!(500),
+                dec!(500),
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            account_valuation(
+                "holdings",
+                "2026-06-19",
+                dec!(550),
+                dec!(500),
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+        ];
+        let history = vec![
+            transaction[0].clone(),
+            transaction[1].clone(),
+            holdings[0].clone(),
+            holdings[1].clone(),
+        ];
+        let valuation_service = Arc::new(TestValuationService::new_with_aggregate_failure(history));
+        let mut dividend = income_activity_on(
+            "dividend-1",
+            "transaction",
+            "2026-06-19",
+            ActivityType::Dividend,
+            dec!(50),
+        );
+        dividend.currency = "CAD".to_string();
+        let activity_repo = Arc::new(TestActivityRepository::new(vec![dividend]));
+        let service = PerformanceService::new(valuation_service, Arc::new(TestQuoteService))
+            .with_activity_repository(activity_repo, Arc::new(TestFxService));
+        let account_ids = vec!["transaction".to_string(), "holdings".to_string()];
+        let mut modes = HashMap::new();
+        modes.insert("transaction".to_string(), TrackingMode::Transactions);
+        modes.insert("holdings".to_string(), TrackingMode::Holdings);
+        let account_types = HashMap::new();
+
+        let result = service
+            .calculate_performance_summary_for_accounts(
+                "mixed-scope",
+                &account_ids,
+                "CAD",
+                &modes,
+                &account_types,
+                Some(date("2026-06-12")),
+                Some(date("2026-06-19")),
+                PerformanceSummaryProfile::Dashboard,
+            )
+            .await
+            .expect("mixed dashboard summary should skip detailed attribution");
+
+        assert_eq!(result.attribution.income, Decimal::ZERO);
+        assert_eq!(result.attribution.unrealized_pnl_change, dec!(100));
+        assert_eq!(attribution_pnl(&result), dec!(100));
+        assert_eq!(
+            result.returns.value_return.unwrap().round_dp(4),
+            dec!(0.0667)
+        );
+    }
+
+    #[tokio::test]
+    async fn dashboard_scope_preserves_time_weighted_return_percent() {
+        let mut history = vec![
+            account_valuation(
+                "transaction",
+                "2026-06-12",
+                dec!(1000),
+                dec!(1000),
+                dec!(1000),
+                dec!(1000),
+            ),
+            account_valuation(
+                "transaction",
+                "2026-06-19",
+                dec!(1200),
+                dec!(1100),
+                dec!(1200),
+                dec!(1100),
+            ),
+        ];
+        history[1].external_inflow_base = dec!(100);
+        history[1].external_flow_source = ValuationExternalFlowSource::StoredGross;
+        let valuation_service = Arc::new(TestValuationService::new(history));
+        let service = PerformanceService::new(valuation_service, Arc::new(TestQuoteService));
+        let account_ids = vec!["transaction".to_string()];
+        let mut modes = HashMap::new();
+        modes.insert("transaction".to_string(), TrackingMode::Transactions);
+        let account_types = HashMap::new();
+
+        let result = service
+            .calculate_performance_summary_for_accounts(
+                "dashboard-scope",
+                &account_ids,
+                "CAD",
+                &modes,
+                &account_types,
+                Some(date("2026-06-12")),
+                Some(date("2026-06-19")),
+                PerformanceSummaryProfile::Dashboard,
+            )
+            .await
+            .expect("dashboard summary should preserve return semantics");
+
+        assert_eq!(result.summary.amount, Some(dec!(100)));
+        assert_eq!(result.summary.method, ReturnMethod::TimeWeighted);
+        assert_eq!(result.returns.value_return.unwrap().round_dp(4), dec!(0.1));
+        assert_eq!(result.returns.twr.unwrap().round_dp(4), dec!(0.0909));
+        assert_eq!(
+            result.summary.percent.unwrap().round_dp(4),
+            result.returns.twr.unwrap().round_dp(4)
         );
     }
 

--- a/crates/core/src/portfolio/valuation/valuation_service.rs
+++ b/crates/core/src/portfolio/valuation/valuation_service.rs
@@ -35,6 +35,7 @@ use std::time::Instant;
 use super::DailyFxRateMap;
 
 static VALUATION_SERVICE_INSTANCE_COUNTER: AtomicU64 = AtomicU64::new(1);
+const SCOPED_HISTORY_CACHE_LIMIT_PER_MODE: usize = 128;
 
 fn parse_decimal_lossy(value: &str) -> Decimal {
     Decimal::from_str(value).unwrap_or(Decimal::ZERO)
@@ -94,6 +95,28 @@ pub trait ValuationServiceTrait: Send + Sync {
         start_date_opt: Option<NaiveDate>,
         end_date_opt: Option<NaiveDate>,
     ) -> CoreResult<Vec<DailyAccountValuation>>;
+
+    /// Loads and aggregates scoped valuation totals without activity-flow enrichment.
+    ///
+    /// Use this for chart/read paths that only need stored valuation totals and
+    /// net contribution history. Performance calculations should use
+    /// `get_historical_valuations_for_accounts`.
+    fn get_historical_valuation_totals_for_accounts(
+        &self,
+        scope_id: &str,
+        account_ids: &[String],
+        base_currency: &str,
+        start_date_opt: Option<NaiveDate>,
+        end_date_opt: Option<NaiveDate>,
+    ) -> CoreResult<Vec<DailyAccountValuation>> {
+        self.get_historical_valuations_for_accounts(
+            scope_id,
+            account_ids,
+            base_currency,
+            start_date_opt,
+            end_date_opt,
+        )
+    }
 
     /// Loads real-account valuation histories in an account-keyed shape.
     fn get_historical_valuations_by_account(
@@ -167,12 +190,19 @@ pub struct ValuationService {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct ScopedValuationCacheKey {
     service_instance_id: u64,
+    mode: ScopedValuationHistoryMode,
     scope_id: String,
     membership_hash: String,
     base_currency: String,
     start_date: Option<NaiveDate>,
     end_date: Option<NaiveDate>,
     max_calculated_at: String,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+enum ScopedValuationHistoryMode {
+    TotalsOnly,
+    PerformanceFlows,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -285,6 +315,20 @@ impl ValuationService {
         ids.dedup();
         let digest = Sha256::digest(ids.join("\n").as_bytes());
         hex::encode(&digest[..8])
+    }
+
+    fn insert_scoped_history_cache(
+        &self,
+        cache_key: ScopedValuationCacheKey,
+        aggregate: &[DailyAccountValuation],
+    ) {
+        let mode = cache_key.mode;
+        let mut cache = self.scoped_history_cache.write().unwrap();
+        let mode_entry_count = cache.keys().filter(|key| key.mode == mode).count();
+        if mode_entry_count >= SCOPED_HISTORY_CACHE_LIMIT_PER_MODE {
+            cache.retain(|key, _| key.mode != mode);
+        }
+        cache.insert(cache_key, aggregate.to_vec());
     }
 
     fn position_requires_price_quote(position: &Position) -> bool {
@@ -466,6 +510,22 @@ impl ValuationService {
             );
         }
         Ok(values)
+    }
+
+    fn aggregate_scoped_valuation_totals(
+        scope_id: &str,
+        account_ids: &[String],
+        base_currency: &str,
+        histories: Vec<Vec<DailyAccountValuation>>,
+    ) -> CoreResult<Vec<DailyAccountValuation>> {
+        Self::aggregate_scoped_valuations(
+            scope_id,
+            account_ids,
+            base_currency,
+            histories,
+            None,
+            None,
+        )
     }
 
     fn validate_scoped_history_completeness(
@@ -753,6 +813,21 @@ impl ValuationService {
 
     fn transfer_multiplier_snapshot_start(start_date_opt: Option<NaiveDate>) -> Option<NaiveDate> {
         start_date_opt.map(|start_date| start_date - Duration::days(1))
+    }
+
+    fn has_posted_security_transfer_in_range(
+        activities: &[Activity],
+        timezone: chrono_tz::Tz,
+        start_date_opt: Option<NaiveDate>,
+        end_date_opt: Option<NaiveDate>,
+    ) -> bool {
+        activities.iter().any(|activity| {
+            if !activity.is_posted() || !Self::is_security_transfer_activity(activity) {
+                return false;
+            }
+            let activity_date = time_utils::activity_date_in_tz(activity.activity_date, timezone);
+            Self::activity_date_in_range(activity_date, start_date_opt, end_date_opt)
+        })
     }
 
     fn activity_flow_amount_base(
@@ -1248,11 +1323,20 @@ impl ValuationService {
             start_date_opt,
             end_date_opt,
         )?;
-        let transfer_multiplier_context = self.transfer_multiplier_context_for_accounts(
-            account_ids,
+        let transfer_multiplier_context = if Self::has_posted_security_transfer_in_range(
+            &all_activities,
+            timezone,
             start_date_opt,
             end_date_opt,
-        )?;
+        ) {
+            self.transfer_multiplier_context_for_accounts(
+                account_ids,
+                start_date_opt,
+                end_date_opt,
+            )?
+        } else {
+            TransferMultiplierContext::default()
+        };
         let removed_lot_basis_by_activity = match Self::disposal_query_bounds_from_activities(
             &all_activities,
             timezone,
@@ -1424,11 +1508,20 @@ impl ValuationService {
             start_date_opt,
             end_date_opt,
         )?;
-        let transfer_multiplier_context = self.transfer_multiplier_context_for_accounts(
-            account_ids,
+        let transfer_multiplier_context = if Self::has_posted_security_transfer_in_range(
+            &transfer_activities,
+            timezone,
             start_date_opt,
             end_date_opt,
-        )?;
+        ) {
+            self.transfer_multiplier_context_for_accounts(
+                account_ids,
+                start_date_opt,
+                end_date_opt,
+            )?
+        } else {
+            TransferMultiplierContext::default()
+        };
 
         let mut adjustments_by_date: HashMap<NaiveDate, (Decimal, Decimal)> = HashMap::new();
         for pair in transfer_resolution.pairs() {
@@ -1822,6 +1915,7 @@ impl ValuationServiceTrait for ValuationService {
             .unwrap_or_default();
         let mut cache_key = ScopedValuationCacheKey {
             service_instance_id: self.service_instance_id,
+            mode: ScopedValuationHistoryMode::PerformanceFlows,
             scope_id: scope_id.to_string(),
             membership_hash: Self::membership_hash(account_ids),
             base_currency: base_currency.to_string(),
@@ -1898,13 +1992,87 @@ impl ValuationServiceTrait for ValuationService {
             internal_transfer_flow_adjustments_by_date.as_ref(),
         )?;
 
+        self.insert_scoped_history_cache(cache_key, &aggregate);
+
+        Ok(aggregate)
+    }
+
+    fn get_historical_valuation_totals_for_accounts(
+        &self,
+        scope_id: &str,
+        account_ids: &[String],
+        base_currency: &str,
+        start_date_opt: Option<NaiveDate>,
+        end_date_opt: Option<NaiveDate>,
+    ) -> CoreResult<Vec<DailyAccountValuation>> {
+        let max_calculated_at = self
+            .valuation_repository
+            .get_max_calculated_at_for_accounts(account_ids, start_date_opt, end_date_opt)?
+            .unwrap_or_default();
+        let mut cache_key = ScopedValuationCacheKey {
+            service_instance_id: self.service_instance_id,
+            mode: ScopedValuationHistoryMode::TotalsOnly,
+            scope_id: scope_id.to_string(),
+            membership_hash: Self::membership_hash(account_ids),
+            base_currency: base_currency.to_string(),
+            start_date: start_date_opt,
+            end_date: end_date_opt,
+            max_calculated_at,
+        };
+
+        if let Some(cached) = self
+            .scoped_history_cache
+            .read()
+            .unwrap()
+            .get(&cache_key)
+            .cloned()
         {
-            let mut cache = self.scoped_history_cache.write().unwrap();
-            if cache.len() > 128 {
-                cache.clear();
-            }
-            cache.insert(cache_key, aggregate.clone());
+            return Ok(cached);
         }
+
+        let records = self
+            .valuation_repository
+            .get_historical_valuations_for_accounts(account_ids, start_date_opt, end_date_opt)?;
+
+        let loaded_max_calculated_at = records
+            .iter()
+            .map(|valuation| valuation.calculated_at.to_rfc3339())
+            .max()
+            .unwrap_or_default();
+        if loaded_max_calculated_at != cache_key.max_calculated_at {
+            cache_key.max_calculated_at = loaded_max_calculated_at;
+            if let Some(cached) = self
+                .scoped_history_cache
+                .read()
+                .unwrap()
+                .get(&cache_key)
+                .cloned()
+            {
+                return Ok(cached);
+            }
+        }
+
+        let mut histories_by_account: HashMap<String, Vec<DailyAccountValuation>> =
+            HashMap::with_capacity(account_ids.len());
+        for record in records {
+            histories_by_account
+                .entry(record.account_id.clone())
+                .or_default()
+                .push(record);
+        }
+        let histories = account_ids
+            .iter()
+            .map(|account_id| histories_by_account.remove(account_id).unwrap_or_default())
+            .collect();
+
+        let aggregate = Self::aggregate_scoped_valuation_totals(
+            scope_id,
+            account_ids,
+            base_currency,
+            histories,
+        )?;
+
+        self.insert_scoped_history_cache(cache_key, &aggregate);
 
         Ok(aggregate)
     }
@@ -2160,6 +2328,101 @@ mod tests {
             "an unvaluable flow in one account must keep the aggregated scope unavailable",
         );
         assert!(day2.external_flow_source.is_unavailable_for_returns());
+    }
+
+    #[test]
+    fn scoped_history_cache_keys_separate_totals_from_performance_flows() {
+        let totals_key = ScopedValuationCacheKey {
+            service_instance_id: 1,
+            mode: ScopedValuationHistoryMode::TotalsOnly,
+            scope_id: "all".to_string(),
+            membership_hash: "members".to_string(),
+            base_currency: "CAD".to_string(),
+            start_date: Some(date("2026-01-01")),
+            end_date: Some(date("2026-06-25")),
+            max_calculated_at: "2026-06-25T00:00:00Z".to_string(),
+        };
+        let performance_key = ScopedValuationCacheKey {
+            mode: ScopedValuationHistoryMode::PerformanceFlows,
+            ..totals_key.clone()
+        };
+
+        assert_ne!(totals_key, performance_key);
+    }
+
+    #[test]
+    fn valuation_totals_aggregation_skips_internal_transfer_flow_adjustments() {
+        let acct_a = vec![
+            valuation(
+                "acct_a",
+                "2026-04-01",
+                dec!(100),
+                dec!(100),
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            valuation(
+                "acct_a",
+                "2026-04-02",
+                dec!(150),
+                dec!(150),
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+        ];
+        let acct_b = vec![
+            valuation(
+                "acct_b",
+                "2026-04-01",
+                dec!(50),
+                dec!(50),
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+            valuation(
+                "acct_b",
+                "2026-04-02",
+                dec!(70),
+                dec!(70),
+                Decimal::ZERO,
+                Decimal::ZERO,
+            ),
+        ];
+        let histories = vec![acct_a, acct_b];
+        let account_ids = ["acct_a".to_string(), "acct_b".to_string()];
+        let mut internal_transfer_adjustments = HashMap::new();
+        internal_transfer_adjustments.insert(date("2026-04-02"), (dec!(70), Decimal::ZERO));
+
+        let totals = ValuationService::aggregate_scoped_valuation_totals(
+            "scope",
+            &account_ids,
+            "CAD",
+            histories.clone(),
+        )
+        .expect("totals aggregation should succeed");
+        let adjusted = ValuationService::aggregate_scoped_valuations(
+            "scope",
+            &account_ids,
+            "CAD",
+            histories,
+            None,
+            Some(&internal_transfer_adjustments),
+        )
+        .expect("adjusted aggregation should succeed");
+
+        let totals_day2 = totals
+            .iter()
+            .find(|valuation| valuation.valuation_date == date("2026-04-02"))
+            .expect("totals day 2 present");
+        let adjusted_day2 = adjusted
+            .iter()
+            .find(|valuation| valuation.valuation_date == date("2026-04-02"))
+            .expect("adjusted day 2 present");
+
+        assert_eq!(totals_day2.total_value_base, dec!(220));
+        assert_eq!(totals_day2.net_contribution_base, dec!(220));
+        assert_eq!(totals_day2.external_inflow_base, dec!(70));
+        assert_eq!(adjusted_day2.external_inflow_base, Decimal::ZERO);
     }
 
     // Core availability contract: merging two provenances must never upgrade
@@ -2813,6 +3076,38 @@ mod tests {
             ValuationService::transfer_multiplier_snapshot_start(None),
             None
         );
+    }
+
+    #[test]
+    fn transfer_multiplier_context_is_needed_only_for_security_transfers_in_range() {
+        let cash_transfer =
+            transfer_activity(ACTIVITY_TYPE_TRANSFER_IN, None, None, None, Some(dec!(250)));
+        let security_transfer = transfer_activity(
+            ACTIVITY_TYPE_TRANSFER_IN,
+            Some("AAPL"),
+            Some(dec!(10)),
+            Some(dec!(8)),
+            None,
+        );
+
+        assert!(!ValuationService::has_posted_security_transfer_in_range(
+            &[cash_transfer],
+            chrono_tz::UTC,
+            None,
+            None,
+        ));
+        assert!(ValuationService::has_posted_security_transfer_in_range(
+            std::slice::from_ref(&security_transfer),
+            chrono_tz::UTC,
+            None,
+            None,
+        ));
+        assert!(!ValuationService::has_posted_security_transfer_in_range(
+            &[security_transfer],
+            chrono_tz::UTC,
+            Some(date("2026-06-02")),
+            None,
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a dashboard performance profile for lightweight account/group rows while preserving TWR for transaction-mode summaries
- load dashboard valuation chart totals through the stored valuation totals path instead of performance-flow enrichment
- run dashboard performance summaries with bounded parallelism and keep prior UI data to reduce flicker
- link unavailable metric reasons to the Health Center

## Validation
- pnpm check
- cargo fmt --check
- cargo check -p wealthfolio-core
- cargo check -p wealthfolio-app
- cargo check -p wealthfolio-server
- cargo test -p wealthfolio-core mixed_scope_dashboard_skips_transaction_component_attribution
- cargo test -p wealthfolio-core mixed_scope_summary_enriches_transaction_component_attribution
- cargo test -p wealthfolio-core dashboard_scope_preserves_time_weighted_return_percent
- git diff --check
