### PR TITLE
Prepare 5.5.3

### DIFF
--- a/apps/frontend/src/adapters/adapter-command-parity.test.ts
+++ b/apps/frontend/src/adapters/adapter-command-parity.test.ts
@@ -249,6 +249,49 @@ describe("scope-based routing — get_holdings", () => {
   });
 });
 
+describe("scope-based routing — get_holdings_list", () => {
+  it("all → POST /holdings/list/query", async () => {
+    const mock = stubFetch();
+    await invoke("get_holdings_list", { filter: { type: "all" } });
+    const { url, method, body } = lastCall(mock);
+    expect(url).toBe("/api/v1/holdings/list/query");
+    expect(method).toBe("POST");
+    expect(JSON.parse(body as string)).toEqual({ filter: { type: "all" } });
+  });
+
+  it("account → GET /holdings/list?accountId=...", async () => {
+    const mock = stubFetch();
+    await invoke("get_holdings_list", { filter: { type: "account", accountId: "acc_1" } });
+    const { url, method } = lastCall(mock);
+    expect(url).toBe("/api/v1/holdings/list?accountId=acc_1");
+    expect(method).toBe("GET");
+  });
+
+  it("portfolio → POST /holdings/list/query", async () => {
+    const mock = stubFetch();
+    await invoke("get_holdings_list", { filter: { type: "portfolio", portfolioId: "pf_1" } });
+    const { url, method, body } = lastCall(mock);
+    expect(url).toBe("/api/v1/holdings/list/query");
+    expect(method).toBe("POST");
+    expect(JSON.parse(body as string)).toEqual({
+      filter: { type: "portfolio", portfolioId: "pf_1" },
+    });
+  });
+
+  it("accounts → POST /holdings/list/query", async () => {
+    const mock = stubFetch();
+    await invoke("get_holdings_list", {
+      filter: { type: "accounts", accountIds: ["acc_1", "acc_2"] },
+    });
+    const { url, method, body } = lastCall(mock);
+    expect(url).toBe("/api/v1/holdings/list/query");
+    expect(method).toBe("POST");
+    expect(JSON.parse(body as string)).toEqual({
+      filter: { type: "accounts", accountIds: ["acc_1", "acc_2"] },
+    });
+  });
+});
+
 describe("scope-based routing — get_portfolio_allocations", () => {
   it("all → POST /allocations/query", async () => {
     const mock = stubFetch();

--- a/apps/frontend/src/adapters/shared/portfolio.ts
+++ b/apps/frontend/src/adapters/shared/portfolio.ts
@@ -33,6 +33,10 @@ export const getHoldings = async (filter: AccountScope): Promise<Holding[]> => {
   return invoke<Holding[]>("get_holdings", { filter });
 };
 
+export const getHoldingsList = async (filter: AccountScope): Promise<Holding[]> => {
+  return invoke<Holding[]>("get_holdings_list", { filter });
+};
+
 export const getIncomeSummary = async (filter?: AccountScope): Promise<IncomeSummary[]> => {
   return invoke<IncomeSummary[]>("get_income_summary", { filter });
 };

--- a/apps/frontend/src/adapters/web/core.ts
+++ b/apps/frontend/src/adapters/web/core.ts
@@ -44,6 +44,7 @@ export const COMMANDS: CommandMap = {
   list_database_backups: { method: "GET", path: "/utilities/database/backups" },
   delete_database_backup: { method: "DELETE", path: "/utilities/database/backups" },
   get_holdings: { method: "POST", path: "/holdings/query" },
+  get_holdings_list: { method: "POST", path: "/holdings/list/query" },
   get_holding: { method: "GET", path: "/holdings/item" },
   get_asset_holdings: { method: "GET", path: "/holdings/by-asset" },
   get_asset_lots: { method: "GET", path: "/holdings/lots" },
@@ -481,10 +482,12 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
       body = JSON.stringify(data.settingsUpdate);
       break;
     }
-    case "get_holdings": {
+    case "get_holdings":
+    case "get_holdings_list": {
       const p = payload as { filter: { type: string; accountId?: string } };
       if (p.filter?.type === "account" && p.filter.accountId) {
-        url = `${API_PREFIX}/holdings?accountId=${encodeURIComponent(p.filter.accountId)}`;
+        const path = command === "get_holdings_list" ? "/holdings/list" : "/holdings";
+        url = `${API_PREFIX}${path}?accountId=${encodeURIComponent(p.filter.accountId)}`;
         method = "GET";
       } else {
         body = JSON.stringify({ filter: p.filter });

--- a/apps/frontend/src/adapters/web/index.ts
+++ b/apps/frontend/src/adapters/web/index.ts
@@ -166,6 +166,7 @@ export {
   getHistoricalValuations,
   getHolding,
   getHoldings,
+  getHoldingsList,
   getHoldingsByAllocation,
   getIncomeSummary,
   getCurrentValuation,

--- a/apps/frontend/src/features/goals/retirement-planner/hooks/use-portfolio.ts
+++ b/apps/frontend/src/features/goals/retirement-planner/hooks/use-portfolio.ts
@@ -1,5 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
-import { getAccounts, getCurrentValuation, getHoldings } from "@/adapters";
+import { useMemo } from "react";
+import { getAccounts, getCurrentValuation } from "@/adapters";
+import { useHoldings } from "@/hooks/use-holdings";
 import { QueryKeys } from "@/lib/query-keys";
 import type { Holding } from "@/lib/types";
 
@@ -28,48 +30,42 @@ export function usePortfolioData(accountIds?: string[]) {
     staleTime: 5 * 60 * 1000,
   });
 
-  const holdingsQuery = useQuery({
-    queryKey: [QueryKeys.HOLDINGS, activeAccountIds],
-    queryFn: async (): Promise<Holding[]> => {
-      if (activeAccountIds.length === 0) return [];
-      const perAccount = await Promise.all(
-        activeAccountIds.map((id) => getHoldings({ type: "account", accountId: id })),
-      );
-      // Aggregate by symbol so drift analysis sees combined weights across all FIRE accounts.
-      const bySymbol = new Map<string, Holding>();
-      for (const holdings of perAccount) {
-        for (const h of holdings) {
-          const key = h.instrument?.symbol ?? h.id;
-          const existing = bySymbol.get(key);
-          if (existing) {
-            existing.marketValue = {
-              local: existing.marketValue.local + h.marketValue.local,
-              base: existing.marketValue.base + h.marketValue.base,
-            };
-            existing.quantity = existing.quantity + h.quantity;
-          } else {
-            bySymbol.set(key, { ...h });
-          }
-        }
+  const {
+    holdings: holdingsForAccounts,
+    isLoading: isHoldingsLoading,
+    error: holdingsError,
+  } = useHoldings({ type: "accounts", accountIds: activeAccountIds });
+
+  const holdings = useMemo((): Holding[] => {
+    const bySymbol = new Map<string, Holding>();
+    for (const h of holdingsForAccounts) {
+      const key = h.instrument?.symbol ?? h.id;
+      const existing = bySymbol.get(key);
+      if (existing) {
+        existing.marketValue = {
+          local: existing.marketValue.local + h.marketValue.local,
+          base: existing.marketValue.base + h.marketValue.base,
+        };
+        existing.quantity = existing.quantity + h.quantity;
+      } else {
+        bySymbol.set(key, { ...h });
       }
-      return Array.from(bySymbol.values());
-    },
-    enabled: activeAccountIds.length > 0,
-    staleTime: 5 * 60 * 1000,
-  });
+    }
+    return Array.from(bySymbol.values());
+  }, [holdingsForAccounts]);
 
   const totalValue = currentValuationQuery.data?.summary.totalValueBase ?? 0;
 
   const activeAccounts = accounts.filter((a) => activeAccountIds.includes(a.id));
 
   return {
-    holdings: holdingsQuery.data ?? [],
+    holdings,
     activeAccountIds,
     accounts,
     activeAccounts,
     totalValue,
     isLoading:
-      accountsQuery.isLoading || currentValuationQuery.isLoading || holdingsQuery.isLoading,
-    error: currentValuationQuery.error || holdingsQuery.error,
+      accountsQuery.isLoading || currentValuationQuery.isLoading || isHoldingsLoading,
+    error: currentValuationQuery.error || holdingsError,
   };
 }

--- a/apps/frontend/src/features/goals/retirement-planner/hooks/use-portfolio.ts
+++ b/apps/frontend/src/features/goals/retirement-planner/hooks/use-portfolio.ts
@@ -64,8 +64,7 @@ export function usePortfolioData(accountIds?: string[]) {
     accounts,
     activeAccounts,
     totalValue,
-    isLoading:
-      accountsQuery.isLoading || currentValuationQuery.isLoading || isHoldingsLoading,
+    isLoading: accountsQuery.isLoading || currentValuationQuery.isLoading || isHoldingsLoading,
     error: currentValuationQuery.error || holdingsError,
   };
 }

--- a/apps/frontend/src/globals.css
+++ b/apps/frontend/src/globals.css
@@ -456,7 +456,9 @@
 
   --mobile-nav-ui-height: 64px; /* nav bar height */
   --mobile-nav-gap: 12px; /* space between nav and bottom */
-  --mobile-nav-bottom-offset: max(var(--mobile-nav-gap), env(safe-area-inset-bottom));
+  /* iOS WKWebView can report an oversized bottom inset after relaunch. */
+  --mobile-safe-area-bottom: min(env(safe-area-inset-bottom, 0px), 44px);
+  --mobile-nav-bottom-offset: max(var(--mobile-nav-gap), var(--mobile-safe-area-bottom));
   --mobile-nav-total-offset: calc(var(--mobile-nav-ui-height) + var(--mobile-nav-bottom-offset));
 
   /* Sonner toast overrides - solid backgrounds for better readability */

--- a/apps/frontend/src/hooks/use-holdings.ts
+++ b/apps/frontend/src/hooks/use-holdings.ts
@@ -1,10 +1,23 @@
 import { useQuery } from "@tanstack/react-query";
 import { AccountScope, Holding } from "@/lib/types";
-import { getHoldings } from "@/adapters";
+import { getHoldingsList } from "@/adapters";
 import { QueryKeys } from "@/lib/query-keys";
 
 export function useHoldings(accountFilter: AccountScope) {
-  const isEnabled = accountFilter.type !== "account" || accountFilter.accountId.trim().length > 0;
+  const isEnabled = (() => {
+    switch (accountFilter.type) {
+      case "account":
+        return accountFilter.accountId.trim().length > 0;
+      case "accounts":
+        return accountFilter.accountIds.length > 0;
+      case "portfolio":
+        return accountFilter.portfolioId.trim().length > 0;
+      case "all":
+        return true;
+      default:
+        return false;
+    }
+  })();
 
   const {
     data: holdings = [],
@@ -14,7 +27,7 @@ export function useHoldings(accountFilter: AccountScope) {
     error,
   } = useQuery<Holding[], Error>({
     queryKey: [QueryKeys.HOLDINGS, accountFilter],
-    queryFn: () => getHoldings(accountFilter),
+    queryFn: () => getHoldingsList(accountFilter),
     enabled: isEnabled,
   });
 

--- a/apps/frontend/src/lib/constants.ts
+++ b/apps/frontend/src/lib/constants.ts
@@ -276,6 +276,7 @@ export type ImportRequiredField = (typeof IMPORT_REQUIRED_FIELDS)[number];
 export const ExportDataType = {
   ACCOUNTS: "accounts",
   ACTIVITIES: "activities",
+  HOLDINGS: "holdings",
   GOALS: "goals",
   PORTFOLIO_HISTORY: "portfolio-history",
 } as const;
@@ -285,6 +286,7 @@ export type ExportDataType = (typeof ExportDataType)[keyof typeof ExportDataType
 export const exportDataTypeSchema = z.enum([
   ExportDataType.ACCOUNTS,
   ExportDataType.ACTIVITIES,
+  ExportDataType.HOLDINGS,
   ExportDataType.GOALS,
   ExportDataType.PORTFOLIO_HISTORY,
 ]);

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -615,6 +615,8 @@ export interface Instrument {
   notes?: string | null;
   quoteMode: QuoteMode;
   preferredProvider?: string | null;
+  isin?: string | null;
+  exchangeMic?: string | null;
 
   // Taxonomy-based classifications
   classifications?: AssetClassifications | null;

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -727,6 +727,7 @@ export interface HoldingSummary {
   id: string;
   symbol: string;
   name?: string | null;
+  accountName?: string | null;
   holdingType: HoldingType;
   quantity: number;
   marketValue: number; // Base currency value

--- a/apps/frontend/src/pages/account/account-holdings.tsx
+++ b/apps/frontend/src/pages/account/account-holdings.tsx
@@ -1,8 +1,7 @@
-import { getHoldings } from "@/adapters";
 import { useAccounts } from "@/hooks/use-accounts";
+import { useHoldings } from "@/hooks/use-holdings";
 import { useIsMobileViewport } from "@/hooks/use-platform";
-import { QueryKeys } from "@/lib/query-keys";
-import { Holding, HoldingType } from "@/lib/types";
+import { HoldingType } from "@/lib/types";
 import { AccountType, isLiabilityAccountType } from "@/lib/constants";
 import { canAddHoldings } from "@/lib/activity-restrictions";
 import { HoldingsTable } from "@/pages/holdings/components/holdings-table";
@@ -16,7 +15,6 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@wealthfolio/ui";
-import { useQuery } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -37,9 +35,9 @@ const AccountHoldings = ({
   const navigate = useNavigate();
   const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
 
-  const { data: holdings, isLoading } = useQuery<Holding[], Error>({
-    queryKey: [QueryKeys.HOLDINGS, accountId],
-    queryFn: () => getHoldings({ type: "account", accountId }),
+  const { holdings, isLoading } = useHoldings({
+    type: "account",
+    accountId,
   });
 
   const { accounts } = useAccounts();

--- a/apps/frontend/src/pages/account/account-page.test.tsx
+++ b/apps/frontend/src/pages/account/account-page.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useQuery } from "@tanstack/react-query";
-import { getHoldings } from "@/adapters";
+import { getHoldingsList } from "@/adapters";
 import { useAccounts } from "@/hooks/use-accounts";
 import { useRecalculatePortfolioMutation } from "@/hooks/use-calculate-portfolio";
 import { useCurrentValuation } from "@/hooks/use-current-account-valuations";
@@ -23,7 +23,7 @@ import AccountPage from "./account-page";
 
 vi.mock("@/adapters", () => ({
   getContributionLimit: vi.fn(),
-  getHoldings: vi.fn(),
+  getHoldingsList: vi.fn(),
   getSnapshots: vi.fn(),
   searchActivities: vi.fn(),
 }));
@@ -342,7 +342,7 @@ describe("AccountPage", () => {
       } as ReturnType<typeof useQuery>;
     });
 
-    vi.mocked(getHoldings).mockResolvedValue([createCashHolding()]);
+    vi.mocked(getHoldingsList).mockResolvedValue([createCashHolding()]);
   });
 
   it("displays live current account valuation instead of stale historical valuation", () => {

--- a/apps/frontend/src/pages/account/account-page.tsx
+++ b/apps/frontend/src/pages/account/account-page.tsx
@@ -1,4 +1,4 @@
-import { getContributionLimit, getHoldings, getSnapshots, searchActivities } from "@/adapters";
+import { getContributionLimit, getSnapshots, searchActivities } from "@/adapters";
 import { HistoryChart } from "@/components/history-chart";
 import type { ActivityDetails } from "@/lib/types";
 import {
@@ -27,6 +27,7 @@ import { PrivacyToggle } from "@/components/privacy-toggle";
 import { useAccounts } from "@/hooks/use-accounts";
 import { useRecalculatePortfolioMutation } from "@/hooks/use-calculate-portfolio";
 import { useCurrentValuation } from "@/hooks/use-current-account-valuations";
+import { useHoldings } from "@/hooks/use-holdings";
 import { useIsMobileViewport } from "@/hooks/use-platform";
 import { useValuationHistory } from "@/hooks/use-valuation-history";
 import { canAddHoldings, getActivityRestrictionLevel } from "@/lib/activity-restrictions";
@@ -51,7 +52,6 @@ import {
   AccountValuation,
   ContributionLimit,
   DateRange,
-  Holding,
   SnapshotInfo,
   TimePeriod,
   TrackedItem,
@@ -236,10 +236,9 @@ const AccountPage = () => {
     return canAddHoldings(account);
   }, [account]);
 
-  // Query holdings to check if account has any assets
-  const { data: holdings, isLoading: isHoldingsLoading } = useQuery<Holding[], Error>({
-    queryKey: [QueryKeys.HOLDINGS, id],
-    queryFn: () => getHoldings({ type: "account", accountId: id }),
+  const { holdings, isLoading: isHoldingsLoading } = useHoldings({
+    type: "account",
+    accountId: id,
   });
 
   // Check if account has any holdings (including cash)

--- a/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
@@ -88,10 +88,49 @@ function parseCashValue(value: string): number {
   return parseFloat(value.replace(/,/g, "")) || 0;
 }
 
-/** Round drift-bar scale up to a clean ceiling (nearest 5pp), always covering the band. */
-function driftScaleMaxBps(maxDriftBps: number, bandBps: number): number {
-  const ceiling = Math.ceil(Math.max(maxDriftBps, bandBps * 1.4, 100) / 500) * 500;
+/** Round drift-bar scale up to a clean ceiling, always covering the tolerance range. */
+function driftScaleMaxBps(maxDriftBps: number, toleranceMaxBps: number): number {
+  const ceiling = Math.ceil(Math.max(maxDriftBps, toleranceMaxBps * 1.4, 100) / 500) * 500;
   return Math.max(ceiling, 500);
+}
+
+interface DriftToleranceRange {
+  minBps: number;
+  maxBps: number;
+  label: string;
+}
+
+function formatTolerancePct(bps: number): string {
+  const pct = bps / 100;
+  return Number.isInteger(pct) ? pct.toFixed(0) : pct.toFixed(1);
+}
+
+function driftToleranceRange(
+  profile: AllocationTarget,
+  driftReport: DriftReport | null,
+): DriftToleranceRange {
+  const bands =
+    driftReport?.rows
+      .filter((row) => row.isRequired && row.targetBps > 0)
+      .map((row) => row.effectiveBandBps) ?? [];
+
+  if (bands.length === 0) {
+    const bps = profile.driftBandBps;
+    return {
+      minBps: bps,
+      maxBps: bps,
+      label: `tolerance ±${formatTolerancePct(bps)}%`,
+    };
+  }
+
+  const minBps = Math.min(...bands);
+  const maxBps = Math.max(...bands);
+  const label =
+    minBps === maxBps
+      ? `tolerance ±${formatTolerancePct(maxBps)}%`
+      : `tolerance range ±${formatTolerancePct(minBps)}-${formatTolerancePct(maxBps)}%`;
+
+  return { minBps, maxBps, label };
 }
 
 interface SleeveSummaryRow {
@@ -512,18 +551,19 @@ function PlannerInput({
 function DriftBar({
   beforeBps,
   afterBps,
-  bandBps,
+  tolerance,
   scaleMaxBps,
 }: {
   beforeBps: number;
   afterBps: number | null;
-  bandBps: number;
+  tolerance: DriftToleranceRange;
   scaleMaxBps: number;
 }) {
   const clamp = (bps: number) => Math.min(100, Math.max(0, (bps / scaleMaxBps) * 100));
   const beforePos = clamp(beforeBps);
   const afterPos = afterBps != null ? clamp(afterBps) : 0;
-  const bandPos = clamp(bandBps);
+  const toleranceMinPos = clamp(tolerance.minBps);
+  const toleranceMaxPos = clamp(tolerance.maxBps);
   const isAfter = afterBps != null;
   const primaryLabel = driftLabelPlacement(isAfter ? afterPos : beforePos);
   const beforeLabel = driftLabelPlacement(beforePos);
@@ -551,11 +591,21 @@ function DriftBar({
           </>
         ) : (
           <>
-            {/* tolerance band: 0 → band */}
+            {/* tolerance band: solid to the tightest sleeve, soft to the widest sleeve */}
             <div
               className="absolute inset-y-0 left-0 rounded-full"
-              style={{ width: `${bandPos}%`, background: "#9db8a8" }}
+              style={{ width: `${toleranceMinPos}%`, background: "#9db8a8" }}
             />
+            {toleranceMaxPos > toleranceMinPos && (
+              <div
+                className="absolute inset-y-0 rounded-full opacity-45"
+                style={{
+                  left: `${toleranceMinPos}%`,
+                  width: `${toleranceMaxPos - toleranceMinPos}%`,
+                  background: "#9db8a8",
+                }}
+              />
+            )}
           </>
         )}
         {/* NOW / AFTER marker */}
@@ -596,7 +646,7 @@ function DriftBar({
       {/* scale */}
       <div className="text-muted-foreground mt-1 flex justify-between font-mono text-xs tabular-nums">
         <span>0%</span>
-        <span>tolerance ±{(bandBps / 100).toFixed(0)}%</span>
+        <span>{tolerance.label}</span>
         <span>{(scaleMaxBps / 100).toFixed(0)}%</span>
       </div>
     </div>
@@ -618,7 +668,7 @@ function PlannerResult({
   driftReport,
   plan,
   currency,
-  bandBps,
+  tolerance,
   scaleMaxBps,
   mode,
   onReview,
@@ -626,7 +676,7 @@ function PlannerResult({
   driftReport: DriftReport;
   plan: RebalancePlan | null;
   currency: string;
-  bandBps: number;
+  tolerance: DriftToleranceRange;
   scaleMaxBps: number;
   mode: ScenarioMode;
   onReview: () => void;
@@ -646,7 +696,7 @@ function PlannerResult({
           <DriftBar
             beforeBps={driftReport.maxDriftBps}
             afterBps={null}
-            bandBps={bandBps}
+            tolerance={tolerance}
             scaleMaxBps={scaleMaxBps}
           />
         </div>
@@ -700,7 +750,7 @@ function PlannerResult({
                 : "bg-[#f0e0da] text-[#b4664a] dark:bg-red-950/40 dark:text-red-400",
             )}
           >
-            {improved ? "↓" : "↑"} {Math.abs(improvedBps / 100).toFixed(1)} pts
+            {improved ? "↓" : "↑"} {Math.abs(improvedBps / 100).toFixed(1)}%
           </span>
         )}
       </div>
@@ -717,7 +767,7 @@ function PlannerResult({
         <DriftBar
           beforeBps={plan.maxDriftBpsBefore}
           afterBps={plan.maxDriftBpsAfter}
-          bandBps={bandBps}
+          tolerance={tolerance}
           scaleMaxBps={scaleMaxBps}
         />
       </div>
@@ -1237,16 +1287,10 @@ export function RebalanceTab({
         ? "Invest your cash first, then sell overweight sleeves only if cash alone can't close the gap. Cash can add to a holding but can't shrink one you already own too much of. Tax impact is not estimated."
         : "Put your new cash to work in the sleeves you're light on. Buys only — nothing is sold.";
 
-  const bandBps = (() => {
-    if (!driftReport?.rows.length) return profile.driftBandBps;
-    const maxRow = driftReport.rows
-      .filter((r) => r.isRequired)
-      .reduce((best, r) => (Math.abs(r.driftBps) > Math.abs(best.driftBps) ? r : best));
-    return maxRow.effectiveBandBps;
-  })();
+  const tolerance = driftToleranceRange(profile, driftReport);
   const baseDrift = driftReport?.maxDriftBps ?? 0;
   const beforeDrift = plan?.maxDriftBpsBefore ?? baseDrift;
-  const scaleMaxBps = driftScaleMaxBps(Math.max(beforeDrift, baseDrift), bandBps);
+  const scaleMaxBps = driftScaleMaxBps(Math.max(beforeDrift, baseDrift), tolerance.maxBps);
 
   const sleeveSummary = plan && driftReport ? computeSleeveSummary(driftReport, plan) : [];
   const isCalculating = planQuery.isFetching;
@@ -1300,7 +1344,7 @@ export function RebalanceTab({
                   driftReport={driftReport}
                   plan={plan}
                   currency={currency}
-                  bandBps={bandBps}
+                  tolerance={tolerance}
                   scaleMaxBps={scaleMaxBps}
                   mode={scenarioMode}
                   onReview={reviewTrades}

--- a/apps/frontend/src/pages/allocation-targets/components/target-weight-editor.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/target-weight-editor.tsx
@@ -357,7 +357,7 @@ export function TargetWeightEditor({
             Biggest move:{" "}
             <span className="text-foreground font-medium">
               {biggestMove.drift > 0 ? "trim" : "add"} {biggestMove.cat.name}{" "}
-              {Math.abs(biggestMove.drift).toFixed(1)} pts
+              {Math.abs(biggestMove.drift).toFixed(1)}%
             </span>
             .
           </p>

--- a/apps/frontend/src/pages/asset/asset-profile-page.tsx
+++ b/apps/frontend/src/pages/asset/asset-profile-page.tsx
@@ -2,7 +2,6 @@ import {
   createActivity,
   getAssetHoldings,
   getAssetLots,
-  getHoldings,
   searchActivities,
 } from "@/adapters";
 import { ActionPalette, type ActionPaletteGroup } from "@/components/action-palette";
@@ -10,6 +9,7 @@ import { TickerAvatar } from "@/components/ticker-avatar";
 import { useHapticFeedback } from "@/hooks";
 import { useAccounts } from "@/hooks/use-accounts";
 import { useAlternativeAssetHolding, useAlternativeHoldings } from "@/hooks/use-alternative-assets";
+import { useHoldings } from "@/hooks/use-holdings";
 import { useIsMobileViewport } from "@/hooks/use-platform";
 import { useQuoteHistory } from "@/hooks/use-quote-history";
 import { useSyncMarketDataMutation } from "@/hooks/use-sync-market-data";
@@ -202,24 +202,22 @@ export const AssetProfilePage = () => {
   } = useAssetProfile(assetId);
 
   const {
-    data: holding,
+    holdings: allHoldings,
     isLoading: isHoldingLoading,
     isError: isHoldingError,
-  } = useQuery<Holding | null, Error>({
-    queryKey: [QueryKeys.HOLDING, { type: "all" }, assetId],
-    queryFn: async () => {
-      const holdings = await getHoldings({ type: "all" });
-      return (
-        holdings.find(
-          (item) =>
-            item.id === assetId ||
-            item.instrument?.id === assetId ||
-            item.instrument?.symbol === assetId,
-        ) ?? null
-      );
-    },
-    enabled: !!assetId,
-  });
+  } = useHoldings({ type: "all" });
+
+  const holding = useMemo<Holding | null>(() => {
+    if (!assetId) return null;
+    return (
+      allHoldings.find(
+        (item) =>
+          item.id === assetId ||
+          item.instrument?.id === assetId ||
+          item.instrument?.symbol === assetId,
+      ) ?? null
+    );
+  }, [allHoldings, assetId]);
 
   const {
     data: quoteHistory,

--- a/apps/frontend/src/pages/asset/asset-profile-page.tsx
+++ b/apps/frontend/src/pages/asset/asset-profile-page.tsx
@@ -1,9 +1,4 @@
-import {
-  createActivity,
-  getAssetHoldings,
-  getAssetLots,
-  searchActivities,
-} from "@/adapters";
+import { createActivity, getAssetHoldings, getAssetLots, searchActivities } from "@/adapters";
 import { ActionPalette, type ActionPaletteGroup } from "@/components/action-palette";
 import { TickerAvatar } from "@/components/ticker-avatar";
 import { useHapticFeedback } from "@/hooks";

--- a/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
+++ b/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
@@ -35,6 +35,8 @@ interface AllocationDetailSheetProps {
   initialCategoryId?: string | null;
 }
 
+type HoldingsByAllocationQueryKey = readonly [string, AccountScope, string, string];
+
 export function AllocationDetailSheet({
   isOpen,
   onOpenChange,
@@ -88,6 +90,15 @@ export function AllocationDetailSheet({
     }
   }, [isOpen, initialCategoryId, allocation?.categories]);
 
+  const taxonomyId = allocation?.taxonomyId ?? "";
+  const categoryId = selectedCategoryId ?? "";
+  const holdingsQueryKey: HoldingsByAllocationQueryKey = [
+    QueryKeys.HOLDINGS_BY_ALLOCATION,
+    accountFilter,
+    taxonomyId,
+    categoryId,
+  ];
+
   // Fetch holdings for the selected category
   const {
     data: allocationHoldings,
@@ -96,23 +107,22 @@ export function AllocationDetailSheet({
     error: holdingsQueryError,
     refetch: refetchAllocationHoldings,
   } = useQuery({
-    queryKey: [
-      QueryKeys.HOLDINGS_BY_ALLOCATION,
-      accountFilter,
-      allocation?.taxonomyId,
-      selectedCategoryId,
-    ],
-    queryFn: () =>
-      getHoldingsByAllocation(
-        accountFilter,
-        allocation?.taxonomyId ?? "",
-        selectedCategoryId ?? "",
-      ),
-    enabled: !!selectedCategoryId && !!allocation?.taxonomyId,
+    queryKey: holdingsQueryKey,
+    queryFn: ({ queryKey }) => {
+      const [, filter, selectedTaxonomyId, selectedCategoryId] = queryKey;
+      return getHoldingsByAllocation(filter, selectedTaxonomyId, selectedCategoryId);
+    },
+    enabled: !!categoryId && !!taxonomyId,
     staleTime: 30000,
   });
 
-  const holdings = allocationHoldings?.holdings;
+  const hasRequestedCategory = !!categoryId && !!taxonomyId;
+  const holdingsMatchSelection =
+    allocationHoldings?.taxonomyId === taxonomyId && allocationHoldings?.categoryId === categoryId;
+  const holdings = holdingsMatchSelection ? allocationHoldings?.holdings : undefined;
+  const holdingsLoadingForSelection =
+    holdingsLoading ||
+    (hasRequestedCategory && !holdingsError && !!allocationHoldings && !holdingsMatchSelection);
 
   const handleSegmentClick = useCallback(
     (categoryId: string, categoryName: string) => {
@@ -325,7 +335,7 @@ export function AllocationDetailSheet({
                 </Button>
               </div>
 
-              {holdingsLoading ? (
+              {holdingsLoadingForSelection ? (
                 <div className="space-y-2">
                   {[1, 2, 3].map((i) => (
                     <div key={i} className="flex items-center gap-3 py-3">
@@ -361,7 +371,7 @@ export function AllocationDetailSheet({
                 </div>
               ) : holdings && holdings.length > 0 ? (
                 <div className="divide-y">
-                  {holdings.map((holding) => {
+                  {holdings.map((holding, index) => {
                     const canNavigate = holding.holdingType !== HoldingType.CASH;
                     const isCash = holding.holdingType === HoldingType.CASH;
                     const avatarSymbol =
@@ -372,9 +382,19 @@ export function AllocationDetailSheet({
                     const secondaryLabel = isCash
                       ? (holding.name ?? `Cash (${holding.currency})`)
                       : (holding.name ?? holding.symbol);
+                    const rowKey = isCash
+                      ? [
+                          categoryId,
+                          holding.id,
+                          holding.accountName ?? "",
+                          holding.symbol,
+                          holding.currency,
+                          index,
+                        ].join(":")
+                      : `${categoryId}:${holding.id}`;
                     return (
                       <div
-                        key={holding.id}
+                        key={rowKey}
                         className={cn(
                           "flex items-center gap-3 py-3 transition-colors",
                           canNavigate ? "hover:bg-muted/30 cursor-pointer" : "cursor-default",

--- a/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
+++ b/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
@@ -363,10 +363,15 @@ export function AllocationDetailSheet({
                 <div className="divide-y">
                   {holdings.map((holding) => {
                     const canNavigate = holding.holdingType !== HoldingType.CASH;
+                    const isCash = holding.holdingType === HoldingType.CASH;
                     const avatarSymbol =
-                      holding.holdingType === HoldingType.CASH
-                        ? `CASH:${holding.currency}`
-                        : holding.symbol;
+                      isCash ? `CASH:${holding.currency}` : holding.symbol;
+                    const primaryLabel = isCash
+                      ? (holding.accountName ?? holding.symbol)
+                      : holding.symbol;
+                    const secondaryLabel = isCash
+                      ? (holding.name ?? `Cash (${holding.currency})`)
+                      : (holding.name ?? holding.symbol);
                     return (
                       <div
                         key={holding.id}
@@ -378,9 +383,9 @@ export function AllocationDetailSheet({
                       >
                         <TickerAvatar symbol={avatarSymbol} className="h-9 w-9" />
                         <div className="min-w-0 flex-1">
-                          <p className="truncate text-sm font-semibold">{holding.symbol}</p>
+                          <p className="truncate text-sm font-semibold">{primaryLabel}</p>
                           <p className="text-muted-foreground truncate text-xs">
-                            {holding.name ?? holding.symbol}
+                            {secondaryLabel}
                           </p>
                         </div>
                         <div className="text-right">

--- a/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
+++ b/apps/frontend/src/pages/holdings/components/allocation-detail-sheet.tsx
@@ -374,8 +374,7 @@ export function AllocationDetailSheet({
                   {holdings.map((holding, index) => {
                     const canNavigate = holding.holdingType !== HoldingType.CASH;
                     const isCash = holding.holdingType === HoldingType.CASH;
-                    const avatarSymbol =
-                      isCash ? `CASH:${holding.currency}` : holding.symbol;
+                    const avatarSymbol = isCash ? `CASH:${holding.currency}` : holding.symbol;
                     const primaryLabel = isCash
                       ? (holding.accountName ?? holding.symbol)
                       : holding.symbol;
@@ -404,9 +403,7 @@ export function AllocationDetailSheet({
                         <TickerAvatar symbol={avatarSymbol} className="h-9 w-9" />
                         <div className="min-w-0 flex-1">
                           <p className="truncate text-sm font-semibold">{primaryLabel}</p>
-                          <p className="text-muted-foreground truncate text-xs">
-                            {secondaryLabel}
-                          </p>
+                          <p className="text-muted-foreground truncate text-xs">{secondaryLabel}</p>
                         </div>
                         <div className="text-right">
                           <AmountDisplay

--- a/apps/frontend/src/pages/holdings/components/holdings-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table.tsx
@@ -20,7 +20,7 @@ import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
 import { HoldingType } from "@/lib/constants";
 import { useSettingsContext } from "@/lib/settings-provider";
 import { Holding } from "@/lib/types";
-import { AmountDisplay, QuantityDisplay } from "@wealthfolio/ui";
+import { AmountDisplay, QuantityDisplay, formatPercent } from "@wealthfolio/ui";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -46,6 +46,21 @@ const getDisplayValueAndCurrency = (
       currency: holding.localCurrency, // Use localCurrency from Holding
     };
   }
+};
+
+const getAveragePrice = (holding: Holding): number | null => {
+  const costBasis = holding.costBasis?.local;
+  if (costBasis == null || holding.quantity === 0) {
+    return null;
+  }
+
+  const symbol = holding.instrument?.symbol ?? holding.id;
+  const isOption = !!parseOccSymbol(symbol);
+  const contractMultiplier = holding.contractMultiplier ?? 1;
+  const costUnits =
+    isOption && contractMultiplier > 0 ? holding.quantity * contractMultiplier : holding.quantity;
+
+  return costUnits !== 0 ? costBasis / costUnits : null;
 };
 
 export const HoldingsTable = ({
@@ -116,6 +131,8 @@ export const HoldingsTable = ({
           currency: false,
           symbolName: false,
           holdingType: false,
+          avgPrice: false,
+          weight: false,
           bookValue: false,
           totalPnl: false,
           unrealizedPnl: false,
@@ -304,6 +321,41 @@ const getColumns = (
     },
   },
   {
+    id: "avgPrice",
+    accessorFn: (row) => getAveragePrice(row) ?? 0,
+    enableHiding: true,
+    enableSorting: true,
+    header: ({ column }) => (
+      <DataTableColumnHeader className="justify-end text-right" column={column} title="Avg Price" />
+    ),
+    meta: {
+      label: "Avg Price",
+    },
+    cell: ({ row }) => {
+      const averagePrice = getAveragePrice(row.original);
+
+      return (
+        <div className="flex min-h-[40px] flex-col items-end justify-center px-4">
+          {averagePrice == null ? (
+            <span className="text-muted-foreground">-</span>
+          ) : (
+            <AmountDisplay
+              value={averagePrice}
+              currency={row.original.localCurrency}
+              isHidden={isHidden}
+            />
+          )}
+          <div className="text-xs text-transparent">-</div>
+        </div>
+      );
+    },
+    sortingFn: (rowA, rowB) => {
+      const valueA = getAveragePrice(rowA.original) ?? 0;
+      const valueB = getAveragePrice(rowB.original) ?? 0;
+      return valueA - valueB;
+    },
+  },
+  {
     id: "bookValue",
     accessorFn: (row) => row.costBasis?.local ?? 0,
     enableHiding: true,
@@ -366,6 +418,25 @@ const getColumns = (
 
       return valueA - valueB;
     },
+  },
+  {
+    id: "weight",
+    accessorFn: (row) => row.weight ?? 0,
+    enableHiding: true,
+    enableSorting: true,
+    header: ({ column }) => (
+      <DataTableColumnHeader className="justify-end text-right" column={column} title="Weight" />
+    ),
+    meta: {
+      label: "Weight",
+    },
+    cell: ({ row }) => (
+      <div className="flex min-h-[40px] flex-col items-end justify-center px-4">
+        <span className="font-medium tabular-nums">{formatPercent(row.original.weight ?? 0)}</span>
+        <div className="text-xs text-transparent">-</div>
+      </div>
+    ),
+    sortingFn: (rowA, rowB) => (rowA.original.weight ?? 0) - (rowB.original.weight ?? 0),
   },
   {
     id: "totalPnl",

--- a/apps/frontend/src/pages/layouts/app-layout.tsx
+++ b/apps/frontend/src/pages/layouts/app-layout.tsx
@@ -63,7 +63,7 @@ const AppLayoutContent = () => {
   if (!isSettingsReady) {
     return (
       <div
-        className="flex h-screen items-center justify-center supports-[height:100dvh]:h-dvh"
+        className="flex h-screen items-center justify-center"
         style={{ backgroundColor: "#09090b" }}
       >
         <img src="/logo-gold.png" alt="Wealthfolio" className="h-[100px] w-auto" />
@@ -78,7 +78,7 @@ const AppLayoutContent = () => {
   return (
     <ErrorBoundary>
       <ApplicationShell
-        className="app-shell h-screen overflow-x-hidden supports-[height:100dvh]:h-dvh"
+        className="app-shell h-screen overflow-x-hidden"
         style={
           launchBarHeight ? { ["--mobile-nav-ui-height" as string]: launchBarHeight } : undefined
         }

--- a/apps/frontend/src/pages/settings/accounts/components/account-edit-modal.tsx
+++ b/apps/frontend/src/pages/settings/accounts/components/account-edit-modal.tsx
@@ -33,7 +33,7 @@ export function AccountEditModal({ account, open, onClose }: AccountEditModalPro
 
   return (
     <Dialog open={open} onOpenChange={onClose} useIsMobile={useIsMobileViewport}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[625px]">
+      <DialogContent className="max-h-[90vh] overflow-y-auto p-0 sm:max-w-[920px]">
         <AccountForm defaultValues={defaultValues} onSuccess={onClose} />
       </DialogContent>
     </Dialog>

--- a/apps/frontend/src/pages/settings/accounts/components/account-form.tsx
+++ b/apps/frontend/src/pages/settings/accounts/components/account-form.tsx
@@ -4,16 +4,19 @@ import { useForm } from "react-hook-form";
 import * as z from "zod";
 
 import { Button } from "@wealthfolio/ui/components/ui/button";
-import { Checkbox } from "@wealthfolio/ui/components/ui/checkbox";
+import { Switch } from "@wealthfolio/ui/components/ui/switch";
 
 import { newAccountSchema } from "@/lib/schemas";
 import { AccountType } from "@/lib/constants";
 import { useTaxonomy } from "@/hooks/use-taxonomies";
+import { cn } from "@/lib/utils";
 import {
   CurrencyInput,
   RadioGroup,
   RadioGroupItem,
   ResponsiveSelect,
+  ToggleGroup,
+  ToggleGroupItem,
   type ResponsiveSelectOption,
 } from "@wealthfolio/ui";
 import { Alert, AlertDescription } from "@wealthfolio/ui/components/ui/alert";
@@ -27,11 +30,11 @@ import {
   AlertDialogTitle,
 } from "@wealthfolio/ui/components/ui/alert-dialog";
 import {
+  DialogClose,
   DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@wealthfolio/ui/components/ui/dialog";
 import {
   Form,
@@ -97,6 +100,22 @@ const accountTypes: ResponsiveSelectOption[] = [
   { label: "Crypto", value: "CRYPTOCURRENCY" },
 ];
 
+const accountTypeIcons = {
+  [AccountType.SECURITIES]: Icons.Briefcase,
+  [AccountType.CASH]: Icons.DollarSign,
+  [AccountType.CREDIT_CARD]: Icons.CreditCard,
+  [AccountType.CRYPTOCURRENCY]: Icons.Bitcoin,
+} as const;
+
+const formCardClassName =
+  "rounded-xl border border-border bg-background p-4 sm:p-5 dark:border-border/70 dark:bg-muted/20";
+const formSectionLabelClassName =
+  "text-muted-foreground text-xs font-semibold uppercase tracking-[0.18em]";
+const trackingOptionClassName =
+  "hover:bg-accent/50 relative flex cursor-pointer gap-3 rounded-xl border bg-card p-4 transition-colors dark:bg-muted/20 dark:hover:bg-muted/30";
+const cashClassificationItemClassName =
+  "data-[state=on]:bg-primary data-[state=on]:text-primary-foreground h-9 rounded-md text-sm data-[state=on]:shadow-sm dark:data-[state=on]:bg-secondary dark:data-[state=on]:text-foreground";
+
 // Input type (what the form receives)
 type AccountFormInput = z.input<typeof newAccountSchema>;
 // Output type after zod parsing (with defaults applied)
@@ -133,17 +152,12 @@ export function AccountForm({ defaultValues, onSuccess = () => undefined }: Acco
   const isCashAccount = currentAccountType === AccountType.CASH;
 
   const { data: assetClassesTaxonomy } = useTaxonomy(isCashAccount ? "asset_classes" : null);
-  const assetClassOptions = useMemo<ResponsiveSelectOption[]>(() => {
-    const fixedIncomeCategory = assetClassesTaxonomy?.categories.find(
-      (c) => !c.parentId && c.id === CASH_FIXED_INCOME_CATEGORY_ID,
+  const fixedIncomeCategoryName = useMemo(() => {
+    return (
+      assetClassesTaxonomy?.categories.find(
+        (c) => !c.parentId && c.id === CASH_FIXED_INCOME_CATEGORY_ID,
+      )?.name ?? "Fixed Income"
     );
-    return [
-      { label: "Cash (default)", value: CASH_ALLOCATION_DEFAULT_VALUE },
-      {
-        label: fixedIncomeCategory?.name ?? "Fixed Income",
-        value: CASH_FIXED_INCOME_CATEGORY_ID,
-      },
-    ];
   }, [assetClassesTaxonomy]);
 
   useEffect(() => {
@@ -217,243 +231,289 @@ export function AccountForm({ defaultValues, onSuccess = () => undefined }: Acco
     form.setValue("trackingMode", initialTrackingMode);
   };
 
+  const formTitle = defaultValues?.id ? "Update Account" : "Add Account";
+  const formDescription = defaultValues?.id
+    ? "Update account information"
+    : "Add an investment account to track.";
+  const AccountTypeIcon = accountTypeIcons[currentAccountType] ?? Icons.Wallet;
+
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
-        <DialogHeader>
-          <DialogTitle> {defaultValues?.id ? "Update Account" : "Add Account"}</DialogTitle>
-          <DialogDescription>
-            {defaultValues?.id
-              ? "Update account information"
-              : " Add an investment account to track."}
-          </DialogDescription>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col gap-6 p-5 sm:p-6">
+        <DialogHeader className="pr-10 text-left">
+          <div className="flex items-start gap-3">
+            <div className="bg-muted flex h-11 w-11 shrink-0 items-center justify-center rounded-xl">
+              <AccountTypeIcon className="text-muted-foreground h-5 w-5" />
+            </div>
+            <div className="min-w-0 space-y-1">
+              <DialogTitle>{formTitle}</DialogTitle>
+              <DialogDescription>{formDescription}</DialogDescription>
+            </div>
+          </div>
         </DialogHeader>
 
-        <div className="grid gap-4 p-4">
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(320px,0.9fr)]">
           <input type="hidden" name="id" />
-          <FormField
-            control={form.control}
-            name="name"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Account Name</FormLabel>
-                <FormControl>
-                  <Input placeholder="Account display name" {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="group"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Account Group</FormLabel>
-                <FormControl>
-                  <Input placeholder="Retirement, 401K, RRSP, TFSA,..." {...field} />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+          <section className={formCardClassName}>
+            <h3 className={formSectionLabelClassName}>Identity</h3>
+            <div className="mt-4 grid gap-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Account Name</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Account display name" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="group"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Account Group</FormLabel>
+                    <FormControl>
+                      <Input placeholder="Retirement, 401K, RRSP, TFSA,..." {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
 
-          <FormField
-            control={form.control}
-            name="accountType"
-            render={({ field }) => (
-              <FormItem className="flex flex-col">
-                <FormLabel>Account Type</FormLabel>
-                <FormControl>
-                  <ResponsiveSelect
-                    value={field.value}
-                    onValueChange={field.onChange}
-                    options={accountTypes}
-                    placeholder="Select an account type"
-                    sheetTitle="Select Account Type"
-                    sheetDescription="Choose the account type that best matches."
-                    triggerClassName="h-11"
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          {!defaultValues?.id ? (
+              <FormField
+                control={form.control}
+                name="accountType"
+                render={({ field }) => (
+                  <FormItem className="flex flex-col">
+                    <FormLabel>Account Type</FormLabel>
+                    <FormControl>
+                      <ResponsiveSelect
+                        value={field.value}
+                        onValueChange={field.onChange}
+                        options={accountTypes}
+                        placeholder="Select an account type"
+                        sheetTitle="Select Account Type"
+                        sheetDescription="Choose the account type that best matches."
+                        triggerClassName="h-11"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              {!defaultValues?.id ? (
+                <FormField
+                  control={form.control}
+                  name="currency"
+                  render={({ field }) => (
+                    <FormItem className="flex flex-col">
+                      <FormLabel>Currency</FormLabel>
+                      <FormControl>
+                        <CurrencyInput
+                          value={field.value}
+                          onChange={(value: string) => field.onChange(value)}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              ) : null}
+
+              {isCashAccount && (
+                <div className="flex flex-col gap-2">
+                  <div>
+                    <label className="text-sm font-medium">Cash Classification</label>
+                    <p className="text-muted-foreground text-xs">
+                      How this cash is counted in allocation reports
+                    </p>
+                  </div>
+                  <ToggleGroup
+                    type="single"
+                    aria-label="Cash Classification"
+                    value={getSelectableCashCategoryFromMeta(form.watch("meta"))}
+                    onValueChange={(v) => {
+                      if (!v) return;
+                      const categoryId = v === CASH_ALLOCATION_DEFAULT_VALUE ? null : v;
+                      const updatedMeta = setCashCategoryInMeta(form.getValues("meta"), categoryId);
+                      form.setValue("meta", updatedMeta, { shouldDirty: true });
+                    }}
+                    className="bg-muted grid h-11 grid-cols-2 rounded-lg p-1"
+                  >
+                    <ToggleGroupItem
+                      value={CASH_ALLOCATION_DEFAULT_VALUE}
+                      className={cashClassificationItemClassName}
+                    >
+                      Cash
+                    </ToggleGroupItem>
+                    <ToggleGroupItem
+                      value={CASH_FIXED_INCOME_CATEGORY_ID}
+                      className={cashClassificationItemClassName}
+                    >
+                      {fixedIncomeCategoryName}
+                    </ToggleGroupItem>
+                  </ToggleGroup>
+                </div>
+              )}
+            </div>
+          </section>
+
+          <div className="grid content-start gap-4">
             <FormField
               control={form.control}
-              name="currency"
+              name="trackingMode"
               render={({ field }) => (
-                <FormItem className="flex flex-col">
-                  <FormLabel>Currency</FormLabel>
-                  <FormControl>
-                    <CurrencyInput
-                      value={field.value}
-                      onChange={(value: string) => field.onChange(value)}
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          ) : null}
-
-          <FormField
-            control={form.control}
-            name="trackingMode"
-            render={({ field }) => (
-              <FormItem className="space-y-2">
-                <FormLabel>Tracking Mode</FormLabel>
-                {needsSetup && !currentTrackingMode && (
-                  <Alert
-                    variant="warning"
-                    className="px-3 py-2.5 [&>svg]:left-3 [&>svg]:top-2.5 [&>svg~*]:pl-6"
-                  >
-                    <Icons.AlertTriangle className="h-4 w-4" />
-                    <AlertDescription className="text-xs">
-                      Choose how to track this account. This affects what data you enter and what
-                      metrics are available.{" "}
-                      <a
-                        href="https://wealthfolio.app/docs/concepts/activity-types"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="hover:text-foreground underline"
-                      >
-                        Learn more
-                      </a>
-                    </AlertDescription>
-                  </Alert>
-                )}
-                <FormControl>
-                  <RadioGroup
-                    onValueChange={field.onChange}
-                    value={field.value}
-                    className="grid grid-cols-1 gap-3 sm:grid-cols-2"
-                  >
-                    <label
-                      className={`hover:bg-accent relative flex cursor-pointer gap-3 rounded-lg border p-3 transition-colors ${
-                        field.value === "TRANSACTIONS"
-                          ? "border-primary bg-primary/5"
-                          : "border-muted"
-                      }`}
+                <FormItem className={cn(formCardClassName, "space-y-4")}>
+                  <FormLabel className={formSectionLabelClassName}>Tracking Mode</FormLabel>
+                  {needsSetup && !currentTrackingMode && (
+                    <Alert
+                      variant="warning"
+                      className="px-3 py-2.5 [&>svg]:left-3 [&>svg]:top-2.5 [&>svg~*]:pl-6"
                     >
-                      <RadioGroupItem value="TRANSACTIONS" className="mt-0.5" />
-                      <div className="flex flex-col">
-                        <span className="text-sm font-medium">Transactions</span>
-                        <span className="text-muted-foreground text-xs">
-                          Track every trade for performance analytics
-                        </span>
-                      </div>
-                    </label>
-                    {!isCreditCardAccount && (
+                      <Icons.AlertTriangle className="h-4 w-4" />
+                      <AlertDescription className="text-xs">
+                        Choose how to track this account. This affects what data you enter and what
+                        metrics are available.{" "}
+                        <a
+                          href="https://wealthfolio.app/docs/concepts/activity-types"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="hover:text-foreground underline"
+                        >
+                          Learn more
+                        </a>
+                      </AlertDescription>
+                    </Alert>
+                  )}
+                  <FormControl>
+                    <RadioGroup
+                      onValueChange={field.onChange}
+                      value={field.value}
+                      className="grid gap-3"
+                    >
                       <label
-                        className={`hover:bg-accent relative flex cursor-pointer gap-3 rounded-lg border p-3 transition-colors ${
-                          field.value === "HOLDINGS"
-                            ? "border-primary bg-primary/5"
-                            : "border-muted"
-                        }`}
+                        className={cn(
+                          trackingOptionClassName,
+                          field.value === "TRANSACTIONS"
+                            ? "border-primary bg-primary/5 dark:border-foreground/60 dark:bg-secondary/30"
+                            : "border-border",
+                        )}
                       >
-                        <RadioGroupItem value="HOLDINGS" className="mt-0.5" />
+                        <RadioGroupItem value="TRANSACTIONS" className="mt-0.5" />
                         <div className="flex flex-col">
-                          <span className="text-sm font-medium">Holdings</span>
+                          <span className="text-sm font-medium">Transactions</span>
                           <span className="text-muted-foreground text-xs">
-                            Add holdings directly as snapshots
+                            Track every trade for performance analytics
                           </span>
                         </div>
                       </label>
-                    )}
-                  </RadioGroup>
-                </FormControl>
-                {field.value === "HOLDINGS" && (
-                  <Alert
-                    variant="warning"
-                    className="px-3 py-2.5 [&>svg]:left-3 [&>svg]:top-2.5 [&>svg~*]:pl-6"
-                  >
-                    <Icons.AlertTriangle className="h-4 w-4" />
-                    <AlertDescription className="text-xs">
-                      Performance metrics will be limited without transaction history.{" "}
-                      <a
-                        href="https://wealthfolio.app/docs/concepts/activity-types"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="hover:text-foreground underline"
-                      >
-                        Learn more
-                      </a>
-                    </AlertDescription>
-                  </Alert>
-                )}
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          {isCashAccount && (
-            <div className="flex flex-col gap-2">
-              <label className="text-sm font-medium">Allocation category</label>
-              <ResponsiveSelect
-                value={getSelectableCashCategoryFromMeta(form.watch("meta"))}
-                onValueChange={(v) => {
-                  const categoryId = v === CASH_ALLOCATION_DEFAULT_VALUE ? null : v;
-                  const updatedMeta = setCashCategoryInMeta(form.getValues("meta"), categoryId);
-                  form.setValue("meta", updatedMeta, { shouldDirty: true });
-                }}
-                options={assetClassOptions}
-                placeholder="Cash (default)"
-                sheetTitle="Allocation Category"
-                sheetDescription="Override how this account appears in allocation charts."
-                triggerClassName="h-11"
-              />
-            </div>
-          )}
-
-          <FormField
-            control={form.control}
-            name="isActive"
-            render={({ field }) => (
-              <FormItem className="flex items-center space-x-3 space-y-0 rounded-lg border p-3">
-                <FormControl>
-                  <Checkbox
-                    checked={!field.value}
-                    onCheckedChange={(checked) => field.onChange(!checked)}
-                  />
-                </FormControl>
-                <FormLabel className="text-sm font-normal">
-                  Hide this account
-                  <span className="text-muted-foreground ml-1 text-xs font-normal">
-                    — keeps in Total & history
-                  </span>
-                </FormLabel>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-
-          {defaultValues?.id && (
-            <FormField
-              control={form.control}
-              name="isArchived"
-              render={({ field }) => (
-                <FormItem className="border-destructive/30 flex items-center space-x-3 space-y-0 rounded-lg border p-3">
-                  <FormControl>
-                    <Checkbox checked={field.value} onCheckedChange={field.onChange} />
+                      {!isCreditCardAccount && (
+                        <label
+                          className={cn(
+                            trackingOptionClassName,
+                            field.value === "HOLDINGS"
+                              ? "border-primary bg-primary/5 dark:border-foreground/60 dark:bg-secondary/30"
+                              : "border-border",
+                          )}
+                        >
+                          <RadioGroupItem value="HOLDINGS" className="mt-0.5" />
+                          <div className="flex flex-col">
+                            <span className="text-sm font-medium">Holdings</span>
+                            <span className="text-muted-foreground text-xs">
+                              Add holdings directly as snapshots
+                            </span>
+                          </div>
+                        </label>
+                      )}
+                    </RadioGroup>
                   </FormControl>
-                  <FormLabel className="text-sm font-normal">
-                    Archive this account
-                    <span className="text-muted-foreground ml-1 text-xs font-normal">
-                      — removes from portfolio, can restore later
-                    </span>
-                  </FormLabel>
+                  {field.value === "HOLDINGS" && (
+                    <Alert
+                      variant="warning"
+                      className="px-3 py-2.5 [&>svg]:left-3 [&>svg]:top-2.5 [&>svg~*]:pl-6"
+                    >
+                      <Icons.AlertTriangle className="h-4 w-4" />
+                      <AlertDescription className="text-xs">
+                        Performance metrics will be limited without transaction history.{" "}
+                        <a
+                          href="https://wealthfolio.app/docs/concepts/activity-types"
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="hover:text-foreground underline"
+                        >
+                          Learn more
+                        </a>
+                      </AlertDescription>
+                    </Alert>
+                  )}
                   <FormMessage />
                 </FormItem>
               )}
             />
-          )}
+
+            <section className={formCardClassName}>
+              <h3 className={formSectionLabelClassName}>Visibility</h3>
+              <div className="mt-4 grid gap-4">
+                <FormField
+                  control={form.control}
+                  name="isActive"
+                  render={({ field }) => (
+                    <FormItem className="flex items-center justify-between gap-4 space-y-0">
+                      <div className="min-w-0">
+                        <FormLabel className="text-sm font-normal">
+                          Hide this account
+                          <span className="text-muted-foreground ml-1 text-xs font-normal">
+                            — keeps in Total & history
+                          </span>
+                        </FormLabel>
+                        <FormMessage />
+                      </div>
+                      <FormControl>
+                        <Switch
+                          checked={!field.value}
+                          onCheckedChange={(checked) => field.onChange(!checked)}
+                        />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+
+                {defaultValues?.id && (
+                  <FormField
+                    control={form.control}
+                    name="isArchived"
+                    render={({ field }) => (
+                      <FormItem className="flex items-center justify-between gap-4 space-y-0">
+                        <div className="min-w-0">
+                          <FormLabel className="text-sm font-normal">
+                            Archive this account
+                            <span className="text-muted-foreground ml-1 text-xs font-normal">
+                              — removes from portfolio, can restore later
+                            </span>
+                          </FormLabel>
+                          <FormMessage />
+                        </div>
+                        <FormControl>
+                          <Switch checked={field.value} onCheckedChange={field.onChange} />
+                        </FormControl>
+                      </FormItem>
+                    )}
+                  />
+                )}
+              </div>
+            </section>
+          </div>
         </div>
         <DialogFooter className="gap-2">
-          <DialogTrigger asChild>
-            <Button variant="outline">Cancel</Button>
-          </DialogTrigger>
+          <DialogClose asChild>
+            <Button type="button" variant="outline">
+              Cancel
+            </Button>
+          </DialogClose>
           <Button type="submit" disabled={needsSetup && !currentTrackingMode}>
             {defaultValues?.id ? (
               <Icons.Save className="h-4 w-4" />

--- a/apps/frontend/src/pages/settings/accounts/components/account-form.tsx
+++ b/apps/frontend/src/pages/settings/accounts/components/account-form.tsx
@@ -87,12 +87,6 @@ function getSelectableCashCategoryFromMeta(meta?: string | null): string {
     : CASH_ALLOCATION_DEFAULT_VALUE;
 }
 
-function normalizeCashCategoryInMeta(meta: string | null | undefined): string | null | undefined {
-  const categoryId = getCashCategoryFromMeta(meta);
-  if (!categoryId || categoryId === CASH_FIXED_INCOME_CATEGORY_ID) return meta;
-  return setCashCategoryInMeta(meta, null);
-}
-
 const accountTypes: ResponsiveSelectOption[] = [
   { label: "Securities", value: "SECURITIES" },
   { label: "Cash", value: "CASH" },
@@ -188,27 +182,20 @@ export function AccountForm({ defaultValues, onSuccess = () => undefined }: Acco
   );
 
   function onSubmit(data: AccountFormOutput) {
-    const submitData =
-      data.accountType === AccountType.CASH
-        ? { ...data, meta: normalizeCashCategoryInMeta(data.meta) }
-        : data;
-
     // Check if this is an existing account (update) and mode is switching from HOLDINGS to TRANSACTIONS
-    const isExistingAccount = !!submitData.id;
+    const isExistingAccount = !!data.id;
     const isSwitchingFromHoldingsToTransactions =
-      !needsSetup &&
-      initialTrackingMode === "HOLDINGS" &&
-      submitData.trackingMode === "TRANSACTIONS";
+      !needsSetup && initialTrackingMode === "HOLDINGS" && data.trackingMode === "TRANSACTIONS";
 
     if (isExistingAccount && isSwitchingFromHoldingsToTransactions) {
       // Show confirmation dialog
-      setPendingFormData(submitData);
+      setPendingFormData(data);
       setShowModeConfirmation(true);
       return;
     }
 
     // Otherwise, submit directly
-    doSubmit(submitData);
+    doSubmit(data);
   }
 
   // Handle confirmation dialog actions

--- a/apps/frontend/src/pages/settings/accounts/components/account-form.tsx
+++ b/apps/frontend/src/pages/settings/accounts/components/account-form.tsx
@@ -46,6 +46,9 @@ import { Input } from "@wealthfolio/ui/components/ui/input";
 
 import { useAccountMutations } from "./use-account-mutations";
 
+const CASH_ALLOCATION_DEFAULT_VALUE = "__default__";
+const CASH_FIXED_INCOME_CATEGORY_ID = "FIXED_INCOME";
+
 function getCashCategoryFromMeta(meta?: string | null): string | null {
   if (!meta) return null;
   try {
@@ -72,6 +75,19 @@ function setCashCategoryInMeta(meta: string | null | undefined, categoryId: stri
     delete parsed.allocation;
   }
   return JSON.stringify(parsed);
+}
+
+function getSelectableCashCategoryFromMeta(meta?: string | null): string {
+  const categoryId = getCashCategoryFromMeta(meta);
+  return categoryId === CASH_FIXED_INCOME_CATEGORY_ID
+    ? CASH_FIXED_INCOME_CATEGORY_ID
+    : CASH_ALLOCATION_DEFAULT_VALUE;
+}
+
+function normalizeCashCategoryInMeta(meta: string | null | undefined): string | null | undefined {
+  const categoryId = getCashCategoryFromMeta(meta);
+  if (!categoryId || categoryId === CASH_FIXED_INCOME_CATEGORY_ID) return meta;
+  return setCashCategoryInMeta(meta, null);
 }
 
 const accountTypes: ResponsiveSelectOption[] = [
@@ -118,12 +134,16 @@ export function AccountForm({ defaultValues, onSuccess = () => undefined }: Acco
 
   const { data: assetClassesTaxonomy } = useTaxonomy(isCashAccount ? "asset_classes" : null);
   const assetClassOptions = useMemo<ResponsiveSelectOption[]>(() => {
-    const defaultOption: ResponsiveSelectOption = { label: "Cash (default)", value: "__default__" };
-    if (!assetClassesTaxonomy) return [defaultOption];
-    const categories = assetClassesTaxonomy.categories
-      .filter((c) => !c.parentId && c.id !== "CASH")
-      .map((c) => ({ label: c.name, value: c.id }));
-    return [defaultOption, ...categories];
+    const fixedIncomeCategory = assetClassesTaxonomy?.categories.find(
+      (c) => !c.parentId && c.id === CASH_FIXED_INCOME_CATEGORY_ID,
+    );
+    return [
+      { label: "Cash (default)", value: CASH_ALLOCATION_DEFAULT_VALUE },
+      {
+        label: fixedIncomeCategory?.name ?? "Fixed Income",
+        value: CASH_FIXED_INCOME_CATEGORY_ID,
+      },
+    ];
   }, [assetClassesTaxonomy]);
 
   useEffect(() => {
@@ -154,20 +174,27 @@ export function AccountForm({ defaultValues, onSuccess = () => undefined }: Acco
   );
 
   function onSubmit(data: AccountFormOutput) {
+    const submitData =
+      data.accountType === AccountType.CASH
+        ? { ...data, meta: normalizeCashCategoryInMeta(data.meta) }
+        : data;
+
     // Check if this is an existing account (update) and mode is switching from HOLDINGS to TRANSACTIONS
-    const isExistingAccount = !!data.id;
+    const isExistingAccount = !!submitData.id;
     const isSwitchingFromHoldingsToTransactions =
-      !needsSetup && initialTrackingMode === "HOLDINGS" && data.trackingMode === "TRANSACTIONS";
+      !needsSetup &&
+      initialTrackingMode === "HOLDINGS" &&
+      submitData.trackingMode === "TRANSACTIONS";
 
     if (isExistingAccount && isSwitchingFromHoldingsToTransactions) {
       // Show confirmation dialog
-      setPendingFormData(data);
+      setPendingFormData(submitData);
       setShowModeConfirmation(true);
       return;
     }
 
     // Otherwise, submit directly
-    doSubmit(data);
+    doSubmit(submitData);
   }
 
   // Handle confirmation dialog actions
@@ -365,9 +392,9 @@ export function AccountForm({ defaultValues, onSuccess = () => undefined }: Acco
             <div className="flex flex-col gap-2">
               <label className="text-sm font-medium">Allocation category</label>
               <ResponsiveSelect
-                value={getCashCategoryFromMeta(form.watch("meta")) ?? "__default__"}
+                value={getSelectableCashCategoryFromMeta(form.watch("meta"))}
                 onValueChange={(v) => {
-                  const categoryId = v === "__default__" ? null : v;
+                  const categoryId = v === CASH_ALLOCATION_DEFAULT_VALUE ? null : v;
                   const updatedMeta = setCashCategoryInMeta(form.getValues("meta"), categoryId);
                   form.setValue("meta", updatedMeta, { shouldDirty: true });
                 }}

--- a/apps/frontend/src/pages/settings/exports/exports-form.tsx
+++ b/apps/frontend/src/pages/settings/exports/exports-form.tsx
@@ -40,6 +40,12 @@ const dataTypes = {
       description: "Detailed transaction history and logs",
     },
     {
+      key: "holdings",
+      name: "Holdings",
+      icon: Icons.Holdings,
+      description: "Current holdings with valuation, performance, allocation, and instrument data",
+    },
+    {
       key: "goals",
       name: "Goals",
       icon: Icons.Goals,
@@ -65,6 +71,12 @@ const dataTypes = {
       name: "Activities",
       icon: Icons.Activity,
       description: "Detailed transaction history and logs",
+    },
+    {
+      key: "holdings",
+      name: "Holdings",
+      icon: Icons.Holdings,
+      description: "Current holdings with valuation, performance, allocation, and instrument data",
     },
     {
       key: "goals",

--- a/apps/frontend/src/pages/settings/exports/use-export-data.ts
+++ b/apps/frontend/src/pages/settings/exports/use-export-data.ts
@@ -34,6 +34,7 @@ type ExportMutationResult = SQLiteBackupResult | FileExportResult | null;
 const datasetLabels: Record<ExportDataType, string> = {
   accounts: "accounts",
   activities: "activities",
+  holdings: "holdings",
   goals: "goals",
   "portfolio-history": "portfolio history records",
 };

--- a/apps/frontend/src/pages/settings/settings-layout.tsx
+++ b/apps/frontend/src/pages/settings/settings-layout.tsx
@@ -133,7 +133,7 @@ export default function SettingsLayout() {
 
   // Mobile-first: show list view on main page, detail view on specific pages
   return (
-    <ApplicationShell className="settings-root app-shell h-screen overflow-x-hidden supports-[height:100dvh]:h-dvh">
+    <ApplicationShell className="settings-root app-shell h-screen overflow-x-hidden">
       {/* Mobile Layout */}
       <div className="w-full lg:hidden">
         {isMainSettingsPage ? (

--- a/apps/server/src/api/data_exports.rs
+++ b/apps/server/src/api/data_exports.rs
@@ -11,18 +11,23 @@ use axum::{
 use wealthfolio_core::{
     accounts::AccountServiceTrait,
     activities::Sort,
-    exports::{export_file_name, format_records, ExportDataType, ExportFileFormat},
+    exports::{
+        export_file_name, format_holding_list_records, format_records, ExportDataType,
+        ExportFileFormat,
+    },
+    portfolio::holdings::HoldingListItem,
     portfolios::AccountScope,
 };
 
 use crate::{
+    api::shared::holdings_account_ids,
     error::{ApiError, ApiResult},
     main_lib::AppState,
 };
 
 const EXPORT_ACTIVITY_PAGE_SIZE: i64 = 9_007_199_254_740_991;
 
-fn build_data_export_content(
+async fn build_data_export_content(
     state: &AppState,
     data_type: ExportDataType,
     format: ExportFileFormat,
@@ -53,6 +58,33 @@ fn build_data_export_content(
                 .data;
             Ok(format_records(&records, format)?)
         }
+        ExportDataType::Holdings => {
+            let base = state.base_currency.read().unwrap().clone();
+            let resolved = state
+                .portfolio_service
+                .resolve_account_scope(&AccountScope::All, &base)?;
+            let account_ids = holdings_account_ids(state, &resolved.account_ids)?;
+            if account_ids.is_empty() {
+                return Ok(None);
+            }
+
+            let holdings = if account_ids.len() == 1 {
+                state
+                    .holdings_service
+                    .get_holdings(&account_ids[0], &base)
+                    .await?
+            } else {
+                state
+                    .holdings_service
+                    .get_holdings_for_accounts(&account_ids, &base, &resolved.scope_id)
+                    .await?
+            };
+            let records = holdings
+                .into_iter()
+                .map(HoldingListItem::from)
+                .collect::<Vec<_>>();
+            Ok(format_holding_list_records(&records, format)?)
+        }
         ExportDataType::Goals => {
             let records = state.goal_service.get_goals()?;
             Ok(format_records(&records, format)?)
@@ -82,7 +114,7 @@ async fn export_data_route(
 ) -> ApiResult<Response<Body>> {
     let data_type = ExportDataType::parse(&data_type)?;
     let format = ExportFileFormat::parse(&format)?;
-    let Some(content) = build_data_export_content(&state, data_type, format)? else {
+    let Some(content) = build_data_export_content(&state, data_type, format).await? else {
         return Ok(StatusCode::NO_CONTENT.into_response());
     };
 

--- a/apps/server/src/api/holdings/handlers.rs
+++ b/apps/server/src/api/holdings/handlers.rs
@@ -13,7 +13,7 @@ use wealthfolio_core::{
     lots::AssetLotView,
     portfolio::{
         allocation::{AllocationHoldings, PortfolioAllocations},
-        holdings::Holding,
+        holdings::{Holding, HoldingListItem},
         snapshot::{
             reconcile_quote_sync_from_latest_account_snapshots, CashBalanceInput,
             ManualHoldingInput, ManualSnapshotRequest, ManualSnapshotService, SnapshotSource,
@@ -88,9 +88,27 @@ pub async fn get_holdings(
     State(state): State<Arc<AppState>>,
     Json(body): Json<FilterBody>,
 ) -> ApiResult<Json<Vec<Holding>>> {
+    let holdings = load_holdings_for_filter(state.as_ref(), &body.filter).await?;
+    Ok(Json(holdings))
+}
+
+pub async fn get_holdings_list(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<FilterBody>,
+) -> ApiResult<Json<Vec<HoldingListItem>>> {
+    let holdings = load_holdings_for_filter(state.as_ref(), &body.filter).await?;
+    Ok(Json(
+        holdings.into_iter().map(HoldingListItem::from).collect(),
+    ))
+}
+
+async fn load_holdings_for_filter(
+    state: &AppState,
+    filter: &AccountScope,
+) -> ApiResult<Vec<Holding>> {
     let base = state.base_currency.read().unwrap().clone();
-    let resolved = resolve_scope(&body.filter, &state)?;
-    let account_ids = holdings_account_ids(&state, &resolved.account_ids)?;
+    let resolved = resolve_scope(filter, state)?;
+    let account_ids = holdings_account_ids(state, &resolved.account_ids)?;
     let holdings = if account_ids.is_empty() {
         Vec::new()
     } else if account_ids.len() == 1 {
@@ -104,7 +122,7 @@ pub async fn get_holdings(
             .get_holdings_for_accounts(&account_ids, &base, &resolved.scope_id)
             .await?
     };
-    Ok(Json(holdings))
+    Ok(holdings)
 }
 
 /// GET /holdings?accountId=... — simple single-account scope
@@ -122,6 +140,25 @@ pub async fn get_holdings_for_account(
         .get_holdings(&account_ids[0], &base)
         .await?;
     Ok(Json(holdings))
+}
+
+/// GET /holdings/list?accountId=... — single-account lightweight list scope
+pub async fn get_holdings_list_for_account(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<AccountIdQuery>,
+) -> ApiResult<Json<Vec<HoldingListItem>>> {
+    let base = state.base_currency.read().unwrap().clone();
+    let account_ids = holdings_account_ids(&state, std::slice::from_ref(&q.account_id))?;
+    if account_ids.is_empty() {
+        return Ok(Json(Vec::new()));
+    }
+    let holdings = state
+        .holdings_service
+        .get_holdings(&account_ids[0], &base)
+        .await?;
+    Ok(Json(
+        holdings.into_iter().map(HoldingListItem::from).collect(),
+    ))
 }
 
 /// GET /allocations?accountId=... — simple single-account scope

--- a/apps/server/src/api/holdings/mod.rs
+++ b/apps/server/src/api/holdings/mod.rs
@@ -15,6 +15,11 @@ pub fn router() -> Router<Arc<AppState>> {
     Router::new()
         .route("/holdings", get(handlers::get_holdings_for_account))
         .route("/holdings/query", post(handlers::get_holdings))
+        .route(
+            "/holdings/list",
+            get(handlers::get_holdings_list_for_account),
+        )
+        .route("/holdings/list/query", post(handlers::get_holdings_list))
         .route("/holdings/item", get(handlers::get_holding))
         .route("/holdings/by-asset", get(handlers::get_asset_holdings))
         .route("/holdings/lots", get(handlers::get_asset_lots))

--- a/apps/tauri/gen/apple/wealthfolio-app_iOS/Info.plist
+++ b/apps/tauri/gen/apple/wealthfolio-app_iOS/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundleShortVersionString</key>
 	<string>3.5.3</string>
 	<key>CFBundleVersion</key>
-	<string>3.5.2</string>
+	<string>3.5.3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/apps/tauri/src/commands/portfolio.rs
+++ b/apps/tauri/src/commands/portfolio.rs
@@ -20,7 +20,7 @@ use wealthfolio_core::{
         TrackingMode,
     },
     allocation::{AllocationHoldings, PortfolioAllocations},
-    holdings::Holding,
+    holdings::{Holding, HoldingListItem},
     income::IncomeSummary,
     lots::AssetLotView,
     performance::{
@@ -228,10 +228,28 @@ pub async fn get_holdings(
     filter: AccountScopeInput,
 ) -> Result<Vec<Holding>, String> {
     debug!("Get holdings...");
-    let base_currency = state.get_base_currency();
     let filter = filter.into_account_filter()?;
-    let resolved = resolve_scope(&filter, &state).await?;
-    let account_ids = holdings_account_ids(&state, &resolved.account_ids)?;
+    get_holdings_for_filter(state.inner().as_ref(), filter).await
+}
+
+#[tauri::command]
+pub async fn get_holdings_list(
+    state: State<'_, Arc<ServiceContext>>,
+    filter: AccountScopeInput,
+) -> Result<Vec<HoldingListItem>, String> {
+    debug!("Get holdings list...");
+    let filter = filter.into_account_filter()?;
+    let holdings = get_holdings_for_filter(state.inner().as_ref(), filter).await?;
+    Ok(holdings.into_iter().map(HoldingListItem::from).collect())
+}
+
+async fn get_holdings_for_filter(
+    state: &ServiceContext,
+    filter: AccountScope,
+) -> Result<Vec<Holding>, String> {
+    let base_currency = state.get_base_currency();
+    let resolved = resolve_scope(&filter, state).await?;
+    let account_ids = holdings_account_ids(state, &resolved.account_ids)?;
     if account_ids.is_empty() {
         return Ok(Vec::new());
     }

--- a/apps/tauri/src/commands/utilities.rs
+++ b/apps/tauri/src/commands/utilities.rs
@@ -13,11 +13,16 @@ use tauri_plugin_shell::ShellExt;
 use uuid::Uuid;
 use wealthfolio_core::{
     activities::Sort,
-    exports::{export_file_name, format_records, ExportDataType, ExportFileFormat},
+    exports::{
+        export_file_name, format_holding_list_records, format_records, ExportDataType,
+        ExportFileFormat,
+    },
+    portfolio::holdings::HoldingListItem,
     portfolios::AccountScope,
 };
 use wealthfolio_storage_sqlite::db;
 
+use crate::commands::portfolio::holdings_account_ids;
 use crate::context::ServiceContext;
 #[cfg(desktop)]
 use crate::updater::{check_for_update, install_update};
@@ -248,7 +253,7 @@ fn write_pending_export_content(
     })
 }
 
-fn build_data_export_content(
+async fn build_data_export_content(
     state: &ServiceContext,
     data_type: ExportDataType,
     format: ExportFileFormat,
@@ -282,6 +287,36 @@ fn build_data_export_content(
                 .map_err(|e| format!("Failed to load activities for export: {}", e))?
                 .data;
             format_records(&records, format).map_err(|e| e.to_string())
+        }
+        ExportDataType::Holdings => {
+            let base_currency = state.get_base_currency();
+            let resolved = state
+                .portfolio_service()
+                .resolve_account_scope(&AccountScope::All, &base_currency)
+                .map_err(|e| format!("Failed to resolve portfolio scope: {}", e))?;
+            let account_ids = holdings_account_ids(state, &resolved.account_ids)?;
+            if account_ids.is_empty() {
+                return Ok(None);
+            }
+
+            let holdings = if account_ids.len() == 1 {
+                state
+                    .holdings_service()
+                    .get_holdings(&account_ids[0], &base_currency)
+                    .await
+                    .map_err(|e| format!("Failed to load holdings for export: {}", e))?
+            } else {
+                state
+                    .holdings_service()
+                    .get_holdings_for_accounts(&account_ids, &base_currency, &resolved.scope_id)
+                    .await
+                    .map_err(|e| format!("Failed to load holdings for export: {}", e))?
+            };
+            let records = holdings
+                .into_iter()
+                .map(HoldingListItem::from)
+                .collect::<Vec<_>>();
+            format_holding_list_records(&records, format).map_err(|e| e.to_string())
         }
         ExportDataType::Goals => {
             let records = state
@@ -380,7 +415,8 @@ pub async fn export_data_file(
 ) -> Result<DataExportResult, String> {
     let data_type = ExportDataType::parse(&data_type).map_err(|e| e.to_string())?;
     let format = ExportFileFormat::parse(&format).map_err(|e| e.to_string())?;
-    let Some(content) = build_data_export_content(state.inner().as_ref(), data_type, format)?
+    let Some(content) =
+        build_data_export_content(state.inner().as_ref(), data_type, format).await?
     else {
         return Ok(DataExportResult::empty());
     };

--- a/apps/tauri/src/lib.rs
+++ b/apps/tauri/src/lib.rs
@@ -501,6 +501,7 @@ pub fn run() {
             commands::portfolios::delete_portfolio_entry,
             // Portfolio commands
             commands::portfolio::get_holdings,
+            commands::portfolio::get_holdings_list,
             commands::portfolio::get_holding,
             commands::portfolio::get_asset_holdings,
             commands::portfolio::get_asset_lots,

--- a/crates/core/src/exports.rs
+++ b/crates/core/src/exports.rs
@@ -1,16 +1,21 @@
 use chrono::NaiveDate;
+use rust_decimal::Decimal;
 use serde::de::{MapAccess, Visitor};
 use serde::Deserializer;
 use serde::Serialize;
 use serde_json::Value;
 use std::fmt;
 
+use crate::assets::AssetKind;
 use crate::errors::{Error, Result, ValidationError};
+use crate::portfolio::holdings::{HoldingListItem, HoldingType, MonetaryValue};
+use crate::utils::occ_symbol::parse_occ_symbol;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ExportDataType {
     Accounts,
     Activities,
+    Holdings,
     Goals,
     PortfolioHistory,
 }
@@ -20,6 +25,7 @@ impl ExportDataType {
         match value {
             "accounts" => Ok(Self::Accounts),
             "activities" => Ok(Self::Activities),
+            "holdings" => Ok(Self::Holdings),
             "goals" => Ok(Self::Goals),
             "portfolio-history" => Ok(Self::PortfolioHistory),
             _ => Err(Error::Validation(ValidationError::InvalidInput(format!(
@@ -33,9 +39,188 @@ impl ExportDataType {
         match self {
             Self::Accounts => "accounts",
             Self::Activities => "activities",
+            Self::Holdings => "holdings",
             Self::Goals => "goals",
             Self::PortfolioHistory => "portfolio-history",
         }
+    }
+}
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct HoldingExportRow {
+    pub id: String,
+    pub account_id: String,
+    pub holding_type: HoldingType,
+    pub instrument_id: Option<String>,
+    pub symbol: Option<String>,
+    pub name: Option<String>,
+    pub instrument_currency: Option<String>,
+    pub quote_mode: Option<String>,
+    pub isin: Option<String>,
+    pub exchange_mic: Option<String>,
+    pub asset_type_id: Option<String>,
+    pub asset_type_name: Option<String>,
+    pub asset_type_key: Option<String>,
+    pub asset_kind: Option<AssetKind>,
+    pub quantity: Decimal,
+    pub open_date: Option<chrono::DateTime<chrono::Utc>>,
+    pub contract_multiplier: Decimal,
+    pub local_currency: String,
+    pub base_currency: String,
+    pub fx_rate: Option<Decimal>,
+    pub market_value_local: Decimal,
+    pub market_value_base: Decimal,
+    pub cost_basis_local: Option<Decimal>,
+    pub cost_basis_base: Option<Decimal>,
+    pub average_price: Option<Decimal>,
+    pub price: Option<Decimal>,
+    pub unrealized_gain_local: Option<Decimal>,
+    pub unrealized_gain_base: Option<Decimal>,
+    pub unrealized_gain_pct: Option<Decimal>,
+    pub realized_gain_local: Option<Decimal>,
+    pub realized_gain_base: Option<Decimal>,
+    pub realized_gain_pct: Option<Decimal>,
+    pub total_gain_local: Option<Decimal>,
+    pub total_gain_base: Option<Decimal>,
+    pub total_gain_pct: Option<Decimal>,
+    pub income_local: Option<Decimal>,
+    pub income_base: Option<Decimal>,
+    pub total_return_local: Option<Decimal>,
+    pub total_return_base: Option<Decimal>,
+    pub total_return_pct: Option<Decimal>,
+    pub return_basis_local: Option<Decimal>,
+    pub return_basis_base: Option<Decimal>,
+    pub day_change_local: Option<Decimal>,
+    pub day_change_base: Option<Decimal>,
+    pub day_change_pct: Option<Decimal>,
+    pub prev_close_value_local: Option<Decimal>,
+    pub prev_close_value_base: Option<Decimal>,
+    pub weight: Decimal,
+    pub as_of_date: NaiveDate,
+    pub source_account_ids: Vec<String>,
+}
+
+impl From<HoldingListItem> for HoldingExportRow {
+    fn from(holding: HoldingListItem) -> Self {
+        let (
+            instrument_id,
+            symbol,
+            name,
+            instrument_currency,
+            quote_mode,
+            isin,
+            exchange_mic,
+            asset_type_id,
+            asset_type_name,
+            asset_type_key,
+        ) = if let Some(instrument) = holding.instrument {
+            let asset_type = instrument
+                .classifications
+                .and_then(|classifications| classifications.asset_type);
+
+            (
+                Some(instrument.id),
+                Some(instrument.symbol),
+                instrument.name,
+                Some(instrument.currency),
+                Some(instrument.quote_mode),
+                instrument.isin,
+                instrument.exchange_mic,
+                asset_type.as_ref().map(|category| category.id.clone()),
+                asset_type.as_ref().map(|category| category.name.clone()),
+                asset_type.as_ref().map(|category| category.key.clone()),
+            )
+        } else {
+            (None, None, None, None, None, None, None, None, None, None)
+        };
+
+        let average_price = average_price(
+            holding.cost_basis.as_ref(),
+            holding.quantity,
+            holding.contract_multiplier,
+            symbol.as_deref(),
+        );
+
+        Self {
+            id: holding.id,
+            account_id: holding.account_id,
+            holding_type: holding.holding_type,
+            instrument_id,
+            symbol,
+            name,
+            instrument_currency,
+            quote_mode,
+            isin,
+            exchange_mic,
+            asset_type_id,
+            asset_type_name,
+            asset_type_key,
+            asset_kind: holding.asset_kind,
+            quantity: holding.quantity,
+            open_date: holding.open_date,
+            contract_multiplier: holding.contract_multiplier,
+            local_currency: holding.local_currency,
+            base_currency: holding.base_currency,
+            fx_rate: holding.fx_rate,
+            market_value_local: holding.market_value.local,
+            market_value_base: holding.market_value.base,
+            cost_basis_local: holding.cost_basis.as_ref().map(|value| value.local),
+            cost_basis_base: holding.cost_basis.as_ref().map(|value| value.base),
+            average_price,
+            price: holding.price,
+            unrealized_gain_local: holding.unrealized_gain.as_ref().map(|value| value.local),
+            unrealized_gain_base: holding.unrealized_gain.as_ref().map(|value| value.base),
+            unrealized_gain_pct: holding.unrealized_gain_pct,
+            realized_gain_local: holding.realized_gain.as_ref().map(|value| value.local),
+            realized_gain_base: holding.realized_gain.as_ref().map(|value| value.base),
+            realized_gain_pct: holding.realized_gain_pct,
+            total_gain_local: holding.total_gain.as_ref().map(|value| value.local),
+            total_gain_base: holding.total_gain.as_ref().map(|value| value.base),
+            total_gain_pct: holding.total_gain_pct,
+            income_local: holding.income.as_ref().map(|value| value.local),
+            income_base: holding.income.as_ref().map(|value| value.base),
+            total_return_local: holding.total_return.as_ref().map(|value| value.local),
+            total_return_base: holding.total_return.as_ref().map(|value| value.base),
+            total_return_pct: holding.total_return_pct,
+            return_basis_local: holding.return_basis.as_ref().map(|value| value.local),
+            return_basis_base: holding.return_basis.as_ref().map(|value| value.base),
+            day_change_local: holding.day_change.as_ref().map(|value| value.local),
+            day_change_base: holding.day_change.as_ref().map(|value| value.base),
+            day_change_pct: holding.day_change_pct,
+            prev_close_value_local: holding.prev_close_value.as_ref().map(|value| value.local),
+            prev_close_value_base: holding.prev_close_value.as_ref().map(|value| value.base),
+            weight: holding.weight,
+            as_of_date: holding.as_of_date,
+            source_account_ids: holding.source_account_ids,
+        }
+    }
+}
+
+fn average_price(
+    cost_basis: Option<&MonetaryValue>,
+    quantity: Decimal,
+    contract_multiplier: Decimal,
+    symbol: Option<&str>,
+) -> Option<Decimal> {
+    let cost_basis = cost_basis?.local;
+    if quantity == Decimal::ZERO {
+        return None;
+    }
+
+    let is_option = symbol
+        .map(|symbol| parse_occ_symbol(symbol).is_ok())
+        .unwrap_or(false);
+    let units = if is_option && contract_multiplier > Decimal::ZERO {
+        quantity * contract_multiplier
+    } else {
+        quantity
+    };
+
+    if units == Decimal::ZERO {
+        None
+    } else {
+        Some(cost_basis / units)
     }
 }
 
@@ -100,6 +285,23 @@ pub fn format_records<T: Serialize>(
     };
 
     Ok(Some(content.into_bytes()))
+}
+
+pub fn format_holding_list_records(
+    records: &[HoldingListItem],
+    format: ExportFileFormat,
+) -> Result<Option<Vec<u8>>> {
+    match format {
+        ExportFileFormat::Csv => {
+            let export_rows = records
+                .iter()
+                .cloned()
+                .map(HoldingExportRow::from)
+                .collect::<Vec<_>>();
+            format_records(&export_rows, format)
+        }
+        ExportFileFormat::Json => format_records(records, format),
+    }
 }
 
 fn records_to_csv<T: Serialize>(records: &[T]) -> Result<String> {
@@ -225,6 +427,7 @@ fn json_string(value: &str) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rust_decimal_macros::dec;
 
     #[derive(Serialize)]
     #[serde(rename_all = "camelCase")]
@@ -240,6 +443,116 @@ mod tests {
         id: u32,
         description: String,
         notes: String,
+    }
+
+    fn sample_holding_list_item() -> HoldingListItem {
+        HoldingListItem {
+            id: "AGG-AAPL".to_string(),
+            account_id: "all".to_string(),
+            holding_type: HoldingType::Security,
+            instrument: Some(crate::portfolio::holdings::HoldingListInstrument {
+                id: "asset-aapl".to_string(),
+                symbol: "AAPL".to_string(),
+                name: Some("Apple Inc.".to_string()),
+                currency: "USD".to_string(),
+                quote_mode: "MARKET".to_string(),
+                isin: Some("US0378331005".to_string()),
+                exchange_mic: Some("XNAS".to_string()),
+                classifications: None,
+            }),
+            asset_kind: Some(AssetKind::Investment),
+            quantity: dec!(10),
+            open_date: None,
+            contract_multiplier: dec!(1),
+            local_currency: "USD".to_string(),
+            base_currency: "USD".to_string(),
+            fx_rate: Some(dec!(1)),
+            market_value: MonetaryValue {
+                local: dec!(2000),
+                base: dec!(2000),
+            },
+            cost_basis: Some(MonetaryValue {
+                local: dec!(1000),
+                base: dec!(1000),
+            }),
+            price: Some(dec!(200)),
+            unrealized_gain: None,
+            unrealized_gain_pct: None,
+            realized_gain: None,
+            realized_gain_pct: None,
+            total_gain: None,
+            total_gain_pct: None,
+            income: None,
+            total_return: None,
+            total_return_pct: None,
+            return_basis: None,
+            day_change: None,
+            day_change_pct: None,
+            prev_close_value: None,
+            weight: dec!(1),
+            as_of_date: NaiveDate::from_ymd_opt(2026, 6, 25).unwrap(),
+            source_account_ids: vec!["account-1".to_string()],
+        }
+    }
+
+    #[test]
+    fn holdings_export_type_parses_and_names_file() {
+        let data_type = ExportDataType::parse("holdings").unwrap();
+
+        assert_eq!(data_type, ExportDataType::Holdings);
+        assert_eq!(
+            export_file_name(
+                data_type,
+                ExportFileFormat::Csv,
+                NaiveDate::from_ymd_opt(2026, 6, 25).unwrap()
+            ),
+            "holdings_2026-06-25.csv"
+        );
+    }
+
+    #[test]
+    fn average_price_uses_option_contract_multiplier() {
+        let cost_basis = MonetaryValue {
+            local: dec!(1000),
+            base: dec!(1000),
+        };
+
+        assert_eq!(
+            average_price(
+                Some(&cost_basis),
+                dec!(2),
+                dec!(100),
+                Some("AAPL250321C00150000")
+            ),
+            Some(dec!(5))
+        );
+        assert_eq!(
+            average_price(Some(&cost_basis), dec!(10), dec!(100), Some("AAPL")),
+            Some(dec!(100))
+        );
+    }
+
+    #[test]
+    fn holding_list_json_keeps_list_shape_while_csv_flattens_rows() {
+        let records = vec![sample_holding_list_item()];
+
+        let json = String::from_utf8(
+            format_holding_list_records(&records, ExportFileFormat::Json)
+                .unwrap()
+                .unwrap(),
+        )
+        .unwrap();
+        let csv = String::from_utf8(
+            format_holding_list_records(&records, ExportFileFormat::Csv)
+                .unwrap()
+                .unwrap(),
+        )
+        .unwrap();
+
+        assert!(json.contains("\"marketValue\""));
+        assert!(!json.contains("\"marketValueLocal\""));
+        assert!(csv.contains("\"marketValueLocal\""));
+        assert!(csv.contains("\"averagePrice\""));
     }
 
     #[test]

--- a/crates/core/src/portfolio/allocation/allocation_service.rs
+++ b/crates/core/src/portfolio/allocation/allocation_service.rs
@@ -1995,6 +1995,108 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn holdings_by_allocation_excludes_default_cash_from_fixed_income() {
+        let default_cash_account_id = "checking";
+        let fixed_income_cash_account_id = "business-cash";
+        let holdings = vec![
+            make_cash_holding_for_account("CAD", dec!(1000), default_cash_account_id),
+            make_cash_holding_for_account("USD", dec!(2000), fixed_income_cash_account_id),
+        ];
+        let taxonomies = StaticTaxonomies {
+            taxonomies: vec![TaxonomyWithCategories {
+                taxonomy: make_taxonomy("asset_classes", "Asset Classes", true),
+                categories: vec![
+                    make_category_for_taxonomy("asset_classes", "CASH", None),
+                    make_category_for_taxonomy("asset_classes", "CASH_BANK_DEPOSITS", Some("CASH")),
+                    make_category_for_taxonomy("asset_classes", "FIXED_INCOME", None),
+                ],
+            }],
+            assignments_by_asset: HashMap::new(),
+        };
+        let svc = AllocationService::new(Arc::new(NoopHoldings), Arc::new(taxonomies));
+        let overrides = HashMap::from([(
+            fixed_income_cash_account_id.to_string(),
+            "FIXED_INCOME".to_string(),
+        )]);
+
+        let fixed_income = svc
+            .compute_holdings_by_allocation_from_holdings(
+                &holdings,
+                "USD",
+                "asset_classes",
+                "FIXED_INCOME",
+                &overrides,
+            )
+            .await
+            .unwrap();
+        let bank_deposits = svc
+            .compute_holdings_by_allocation_from_holdings(
+                &holdings,
+                "USD",
+                "asset_classes",
+                "CASH_BANK_DEPOSITS",
+                &overrides,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(fixed_income.total_value, dec!(2000));
+        assert_eq!(fixed_income.holdings.len(), 1);
+        assert_eq!(fixed_income.holdings[0].symbol, "USD");
+
+        assert_eq!(bank_deposits.total_value, dec!(1000));
+        assert_eq!(bank_deposits.holdings.len(), 1);
+        assert_eq!(bank_deposits.holdings[0].symbol, "CAD");
+    }
+
+    #[tokio::test]
+    async fn holdings_by_allocation_excludes_cash_from_equity_when_overrides_exist() {
+        let default_cash_account_id = "checking";
+        let fixed_income_cash_account_id = "business-cash";
+        let holdings = vec![
+            make_holding("AAPL", dec!(3000)),
+            make_cash_holding_for_account("CAD", dec!(1000), default_cash_account_id),
+            make_cash_holding_for_account("USD", dec!(2000), fixed_income_cash_account_id),
+        ];
+        let taxonomies = StaticTaxonomies {
+            taxonomies: vec![TaxonomyWithCategories {
+                taxonomy: make_taxonomy("asset_classes", "Asset Classes", true),
+                categories: vec![
+                    make_category_for_taxonomy("asset_classes", "EQUITY", None),
+                    make_category_for_taxonomy("asset_classes", "CASH", None),
+                    make_category_for_taxonomy("asset_classes", "CASH_BANK_DEPOSITS", Some("CASH")),
+                    make_category_for_taxonomy("asset_classes", "FIXED_INCOME", None),
+                ],
+            }],
+            assignments_by_asset: HashMap::from([(
+                "AAPL".to_string(),
+                vec![make_assignment("AAPL", "asset_classes", "EQUITY", 10000)],
+            )]),
+        };
+        let svc = AllocationService::new(Arc::new(NoopHoldings), Arc::new(taxonomies));
+        let overrides = HashMap::from([(
+            fixed_income_cash_account_id.to_string(),
+            "FIXED_INCOME".to_string(),
+        )]);
+
+        let equity = svc
+            .compute_holdings_by_allocation_from_holdings(
+                &holdings,
+                "USD",
+                "asset_classes",
+                "EQUITY",
+                &overrides,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(equity.total_value, dec!(3000));
+        assert_eq!(equity.holdings.len(), 1);
+        assert_eq!(equity.holdings[0].symbol, "AAPL");
+        assert_ne!(equity.holdings[0].holding_type, HoldingType::Cash);
+    }
+
+    #[tokio::test]
     async fn holdings_by_allocation_merges_duplicate_non_cash_rows() {
         let holdings = vec![
             Holding {

--- a/crates/core/src/portfolio/allocation/allocation_service.rs
+++ b/crates/core/src/portfolio/allocation/allocation_service.rs
@@ -111,6 +111,106 @@ impl AllocationService {
             .collect()
     }
 
+    fn load_account_names(&self, account_ids: &[String]) -> HashMap<String, String> {
+        let Some(account_service) = &self.account_service else {
+            return HashMap::new();
+        };
+        let Ok(accounts) = account_service.get_accounts_by_ids(account_ids) else {
+            return HashMap::new();
+        };
+        accounts
+            .into_iter()
+            .map(|account| (account.id, account.name))
+            .collect()
+    }
+
+    fn account_ids_for_holdings(holdings: &[Holding]) -> Vec<String> {
+        let mut account_ids = Vec::new();
+        for holding in holdings {
+            if holding.source_account_ids.is_empty() {
+                account_ids.push(holding.account_id.clone());
+            } else {
+                account_ids.extend(holding.source_account_ids.iter().cloned());
+            }
+        }
+        account_ids.sort();
+        account_ids.dedup();
+        account_ids
+    }
+
+    fn single_source_account_id(holding: &Holding) -> Option<&str> {
+        if holding.source_account_ids.is_empty() {
+            return Some(holding.account_id.as_str());
+        }
+        if holding.source_account_ids.len() == 1 {
+            return holding.source_account_ids.first().map(String::as_str);
+        }
+        None
+    }
+
+    fn cash_account_name(
+        holding: &Holding,
+        account_names: &HashMap<String, String>,
+    ) -> Option<String> {
+        if holding.holding_type != HoldingType::Cash {
+            return None;
+        }
+        Self::single_source_account_id(holding).and_then(|id| account_names.get(id).cloned())
+    }
+
+    fn merge_non_cash_detail_rows(
+        matched_values: Vec<(HoldingSummary, Decimal)>,
+    ) -> Vec<(HoldingSummary, Decimal)> {
+        let mut merged: Vec<(HoldingSummary, Decimal)> = Vec::new();
+        let mut non_cash_index_by_id: HashMap<String, usize> = HashMap::new();
+
+        for (summary, value) in matched_values {
+            if summary.holding_type == HoldingType::Cash {
+                merged.push((summary, value));
+                continue;
+            }
+
+            if let Some(&index) = non_cash_index_by_id.get(&summary.id) {
+                let (existing_summary, existing_value) = &mut merged[index];
+                existing_summary.quantity += summary.quantity;
+                existing_summary.market_value += summary.market_value;
+                if existing_summary.name.is_none() {
+                    existing_summary.name = summary.name;
+                }
+                if existing_summary.unit_price.is_none() {
+                    existing_summary.unit_price = summary.unit_price;
+                }
+                *existing_value += value;
+            } else {
+                non_cash_index_by_id.insert(summary.id.clone(), merged.len());
+                merged.push((summary, value));
+            }
+        }
+
+        merged
+    }
+
+    fn should_load_cash_detail_by_account(taxonomy_id: &str, category_id: &str) -> bool {
+        taxonomy_id == "asset_classes"
+            && (category_id == "CASH" || category_id.starts_with("CASH_"))
+    }
+
+    async fn get_unmerged_holdings_for_accounts(
+        &self,
+        account_ids: &[String],
+        base_currency: &str,
+    ) -> Result<Vec<Holding>> {
+        let mut all_holdings: Vec<Holding> = Vec::new();
+        for account_id in account_ids {
+            let holdings = self
+                .holdings_service
+                .get_holdings(account_id, base_currency)
+                .await?;
+            all_holdings.extend(holdings);
+        }
+        Ok(all_holdings)
+    }
+
     async fn get_holdings_for_allocation(
         &self,
         account_ids: &[String],
@@ -124,15 +224,8 @@ impl AllocationService {
                 .get_holdings_for_accounts(account_ids, base_currency, aggregated_account_id)
                 .await;
         }
-        let mut all_holdings: Vec<Holding> = Vec::new();
-        for account_id in account_ids {
-            let holdings = self
-                .holdings_service
-                .get_holdings(account_id, base_currency)
-                .await?;
-            all_holdings.extend(holdings);
-        }
-        Ok(all_holdings)
+        self.get_unmerged_holdings_for_accounts(account_ids, base_currency)
+            .await
     }
 
     fn rollup_to_top_level(taxonomy_id: &str) -> bool {
@@ -897,6 +990,7 @@ impl AllocationService {
                 .collect()
         };
         let assignments_by_asset = self.collect_assignments_by_asset(holdings)?;
+        let account_names = self.load_account_names(&Self::account_ids_for_holdings(holdings));
 
         let mut matched_values: Vec<(HoldingSummary, Decimal)> = Vec::new();
         for holding in holdings {
@@ -928,6 +1022,7 @@ impl AllocationService {
                     id: asset_id,
                     symbol,
                     name: Some(name),
+                    account_name: Self::cash_account_name(holding, &account_names),
                     holding_type: holding.holding_type.clone(),
                     quantity: holding.quantity,
                     market_value: matched_value,
@@ -939,6 +1034,7 @@ impl AllocationService {
             ));
         }
 
+        let matched_values = Self::merge_non_cash_detail_rows(matched_values);
         let total_matched_value: Decimal = matched_values.iter().map(|(_, value)| *value).sum();
 
         let mut summaries: Vec<HoldingSummary> = matched_values
@@ -1038,14 +1134,18 @@ impl AllocationServiceTrait for AllocationService {
         aggregated_account_id: &str,
     ) -> Result<AllocationHoldings> {
         let overrides = self.load_cash_overrides(account_ids);
-        let holdings = self
-            .get_holdings_for_allocation(
+        let holdings = if Self::should_load_cash_detail_by_account(taxonomy_id, category_id) {
+            self.get_unmerged_holdings_for_accounts(account_ids, base_currency)
+                .await?
+        } else {
+            self.get_holdings_for_allocation(
                 account_ids,
                 base_currency,
                 aggregated_account_id,
                 &overrides,
             )
-            .await?;
+            .await?
+        };
         self.compute_holdings_by_allocation_from_holdings(
             &holdings,
             base_currency,
@@ -1085,6 +1185,7 @@ impl AllocationServiceTrait for AllocationService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::accounts::{Account, AccountUpdate, NewAccount};
     use crate::portfolio::holdings::holdings_model::{Instrument, MonetaryValue};
     use crate::taxonomies::{
         AssetTaxonomyAssignment, Category, NewAssetTaxonomyAssignment, NewCategory, NewTaxonomy,
@@ -1100,6 +1201,20 @@ mod tests {
     struct StaticTaxonomies {
         taxonomies: Vec<TaxonomyWithCategories>,
         assignments_by_asset: HashMap<String, Vec<AssetTaxonomyAssignment>>,
+    }
+    struct StaticAccountService {
+        accounts: HashMap<String, Account>,
+    }
+
+    impl StaticAccountService {
+        fn new(accounts: Vec<Account>) -> Self {
+            Self {
+                accounts: accounts
+                    .into_iter()
+                    .map(|account| (account.id.clone(), account))
+                    .collect(),
+            }
+        }
     }
 
     #[async_trait]
@@ -1124,6 +1239,66 @@ mod tests {
             _: &str,
         ) -> Result<Vec<Holding>> {
             unimplemented!()
+        }
+    }
+
+    #[async_trait]
+    impl AccountServiceTrait for StaticAccountService {
+        async fn create_account(&self, _: NewAccount) -> Result<Account> {
+            unimplemented!()
+        }
+
+        async fn update_account(&self, _: AccountUpdate) -> Result<Account> {
+            unimplemented!()
+        }
+
+        async fn delete_account(&self, _: &str) -> Result<()> {
+            unimplemented!()
+        }
+
+        fn get_account(&self, account_id: &str) -> Result<Account> {
+            self.accounts.get(account_id).cloned().ok_or_else(|| {
+                crate::Error::Database(crate::errors::DatabaseError::NotFound(format!(
+                    "Account {} not found",
+                    account_id
+                )))
+            })
+        }
+
+        fn list_accounts(
+            &self,
+            _: Option<bool>,
+            _: Option<bool>,
+            _: Option<&[String]>,
+        ) -> Result<Vec<Account>> {
+            unimplemented!()
+        }
+
+        fn get_all_accounts(&self) -> Result<Vec<Account>> {
+            unimplemented!()
+        }
+
+        fn get_active_accounts(&self) -> Result<Vec<Account>> {
+            unimplemented!()
+        }
+
+        fn get_accounts_by_ids(&self, account_ids: &[String]) -> Result<Vec<Account>> {
+            Ok(account_ids
+                .iter()
+                .filter_map(|id| self.accounts.get(id).cloned())
+                .collect())
+        }
+
+        fn get_non_archived_accounts(&self) -> Result<Vec<Account>> {
+            unimplemented!()
+        }
+
+        fn get_active_non_archived_accounts(&self) -> Result<Vec<Account>> {
+            unimplemented!()
+        }
+
+        fn get_base_currency(&self) -> Option<String> {
+            None
         }
     }
 
@@ -1765,6 +1940,109 @@ mod tests {
         assert_eq!(child.holdings[0].holding_type, HoldingType::Cash);
         assert_eq!(parent.total_value, dec!(2000));
         assert_eq!(parent.holdings[0].holding_type, HoldingType::Cash);
+    }
+
+    #[tokio::test]
+    async fn holdings_by_allocation_names_cash_rows_by_account() {
+        let account_id = "cash-account";
+        let account_name = "Emergency Fund";
+        let holdings = vec![make_cash_holding_for_account("USD", dec!(2000), account_id)];
+        let taxonomies = StaticTaxonomies {
+            taxonomies: vec![TaxonomyWithCategories {
+                taxonomy: make_taxonomy("asset_classes", "Asset Classes", true),
+                categories: vec![
+                    make_category_for_taxonomy("asset_classes", "CASH", None),
+                    make_category_for_taxonomy("asset_classes", "CASH_BANK_DEPOSITS", Some("CASH")),
+                    make_category_for_taxonomy("asset_classes", "FIXED_INCOME", None),
+                ],
+            }],
+            assignments_by_asset: HashMap::new(),
+        };
+        let account_service = StaticAccountService::new(vec![Account {
+            id: account_id.to_string(),
+            name: account_name.to_string(),
+            ..Account::default()
+        }]);
+        let svc = AllocationService::new(Arc::new(NoopHoldings), Arc::new(taxonomies))
+            .with_account_service(Arc::new(account_service));
+
+        let cash = svc
+            .compute_holdings_by_allocation_from_holdings(
+                &holdings,
+                "USD",
+                "asset_classes",
+                "CASH",
+                &HashMap::new(),
+            )
+            .await
+            .unwrap();
+        let fixed_income = svc
+            .compute_holdings_by_allocation_from_holdings(
+                &holdings,
+                "USD",
+                "asset_classes",
+                "FIXED_INCOME",
+                &HashMap::from([(account_id.to_string(), "FIXED_INCOME".to_string())]),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(cash.holdings[0].account_name.as_deref(), Some(account_name));
+        assert_eq!(
+            fixed_income.holdings[0].account_name.as_deref(),
+            Some(account_name)
+        );
+    }
+
+    #[tokio::test]
+    async fn holdings_by_allocation_merges_duplicate_non_cash_rows() {
+        let holdings = vec![
+            Holding {
+                account_id: "account-a".to_string(),
+                ..make_holding("ZGRO", dec!(1185.01))
+            },
+            Holding {
+                account_id: "account-b".to_string(),
+                ..make_holding("ZGRO", dec!(610.83))
+            },
+        ];
+        let taxonomies = StaticTaxonomies {
+            taxonomies: vec![TaxonomyWithCategories {
+                taxonomy: make_taxonomy("asset_classes", "Asset Classes", true),
+                categories: vec![make_category_for_taxonomy(
+                    "asset_classes",
+                    "FIXED_INCOME",
+                    None,
+                )],
+            }],
+            assignments_by_asset: HashMap::from([(
+                "ZGRO".to_string(),
+                vec![make_assignment(
+                    "ZGRO",
+                    "asset_classes",
+                    "FIXED_INCOME",
+                    10000,
+                )],
+            )]),
+        };
+        let svc = AllocationService::new(Arc::new(NoopHoldings), Arc::new(taxonomies));
+
+        let fixed_income = svc
+            .compute_holdings_by_allocation_from_holdings(
+                &holdings,
+                "USD",
+                "asset_classes",
+                "FIXED_INCOME",
+                &HashMap::new(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(fixed_income.holdings.len(), 1);
+        assert_eq!(fixed_income.holdings[0].symbol, "ZGRO");
+        assert_eq!(fixed_income.holdings[0].quantity, dec!(2));
+        assert_eq!(fixed_income.holdings[0].market_value, dec!(1795.84));
+        assert_eq!(fixed_income.holdings[0].weight_in_category, dec!(100));
     }
 
     #[tokio::test]

--- a/crates/core/src/portfolio/holdings/holdings_model.rs
+++ b/crates/core/src/portfolio/holdings/holdings_model.rs
@@ -142,3 +142,133 @@ pub struct Holding {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub source_account_ids: Vec<String>,
 }
+
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct HoldingListInstrument {
+    pub id: String,
+    pub symbol: String,
+    pub name: Option<String>,
+    pub currency: String,
+    #[serde(rename = "quoteMode")]
+    pub quote_mode: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub isin: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exchange_mic: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub classifications: Option<AssetClassifications>,
+}
+
+/// List-oriented holding payload for app tables and dashboards.
+/// Omits full asset profile fields such as notes, provider config, lots, and metadata.
+#[derive(Serialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct HoldingListItem {
+    pub id: String,
+    pub account_id: String,
+    pub holding_type: HoldingType,
+    pub instrument: Option<HoldingListInstrument>,
+    pub asset_kind: Option<AssetKind>,
+    pub quantity: Decimal,
+    pub open_date: Option<DateTime<Utc>>,
+    pub contract_multiplier: Decimal,
+    pub local_currency: String,
+    pub base_currency: String,
+    pub fx_rate: Option<Decimal>,
+    pub market_value: MonetaryValue,
+    pub cost_basis: Option<MonetaryValue>,
+    pub price: Option<Decimal>,
+    pub unrealized_gain: Option<MonetaryValue>,
+    pub unrealized_gain_pct: Option<Decimal>,
+    pub realized_gain: Option<MonetaryValue>,
+    pub realized_gain_pct: Option<Decimal>,
+    pub total_gain: Option<MonetaryValue>,
+    pub total_gain_pct: Option<Decimal>,
+    pub income: Option<MonetaryValue>,
+    pub total_return: Option<MonetaryValue>,
+    pub total_return_pct: Option<Decimal>,
+    pub return_basis: Option<MonetaryValue>,
+    pub day_change: Option<MonetaryValue>,
+    pub day_change_pct: Option<Decimal>,
+    pub prev_close_value: Option<MonetaryValue>,
+    pub weight: Decimal,
+    pub as_of_date: NaiveDate,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub source_account_ids: Vec<String>,
+}
+
+impl From<Holding> for HoldingListItem {
+    fn from(holding: Holding) -> Self {
+        let isin = holding_metadata_isin(holding.metadata.as_ref());
+        let instrument = holding.instrument.map(|instrument| {
+            let classifications = instrument
+                .classifications
+                .as_ref()
+                .and_then(|classifications| {
+                    classifications.asset_type.as_ref()?;
+                    Some(AssetClassifications {
+                        asset_type: classifications.asset_type.clone(),
+                        ..AssetClassifications::default()
+                    })
+                });
+
+            HoldingListInstrument {
+                id: instrument.id,
+                symbol: instrument.symbol,
+                name: instrument.name,
+                currency: instrument.currency,
+                quote_mode: instrument.pricing_mode,
+                isin,
+                exchange_mic: instrument.exchange_mic,
+                classifications,
+            }
+        });
+
+        Self {
+            id: holding.id,
+            account_id: holding.account_id,
+            holding_type: holding.holding_type,
+            instrument,
+            asset_kind: holding.asset_kind,
+            quantity: holding.quantity,
+            open_date: holding.open_date,
+            contract_multiplier: holding.contract_multiplier,
+            local_currency: holding.local_currency,
+            base_currency: holding.base_currency,
+            fx_rate: holding.fx_rate,
+            market_value: holding.market_value,
+            cost_basis: holding.cost_basis,
+            price: holding.price,
+            unrealized_gain: holding.unrealized_gain,
+            unrealized_gain_pct: holding.unrealized_gain_pct,
+            realized_gain: holding.realized_gain,
+            realized_gain_pct: holding.realized_gain_pct,
+            total_gain: holding.total_gain,
+            total_gain_pct: holding.total_gain_pct,
+            income: holding.income,
+            total_return: holding.total_return,
+            total_return_pct: holding.total_return_pct,
+            return_basis: holding.return_basis,
+            day_change: holding.day_change,
+            day_change_pct: holding.day_change_pct,
+            prev_close_value: holding.prev_close_value,
+            weight: holding.weight,
+            as_of_date: holding.as_of_date,
+            source_account_ids: holding.source_account_ids,
+        }
+    }
+}
+
+fn holding_metadata_isin(metadata: Option<&Value>) -> Option<String> {
+    metadata
+        .and_then(|metadata| {
+            metadata
+                .pointer("/identifiers/isin")
+                .or_else(|| metadata.pointer("/bond/isin"))
+        })
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|isin| !isin.is_empty())
+        .map(ToOwned::to_owned)
+}

--- a/crates/core/src/portfolio/holdings/holdings_model.rs
+++ b/crates/core/src/portfolio/holdings/holdings_model.rs
@@ -59,6 +59,8 @@ pub struct HoldingSummary {
     pub id: String,
     pub symbol: String,
     pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub account_name: Option<String>,
     pub holding_type: HoldingType,
     pub quantity: Decimal,
     pub market_value: Decimal,

--- a/packages/ui/src/components/ui/data-table/index.tsx
+++ b/packages/ui/src/components/ui/data-table/index.tsx
@@ -54,9 +54,13 @@ export function DataTable<TData, TValue>({
   toolbarActions,
 }: DataTableProps<TData, TValue>) {
   const [rowSelection, setRowSelection] = React.useState({});
-  const [columnVisibility, setColumnVisibility] = storageKey
+  const [storedColumnVisibility, setColumnVisibility] = storageKey
     ? usePersistentState<VisibilityState>(`${storageKey}:column-visibility`, defaultColumnVisibility || {})
     : React.useState<VisibilityState>(defaultColumnVisibility || {});
+  const columnVisibility = {
+    ...(defaultColumnVisibility || {}),
+    ...storedColumnVisibility,
+  };
   const [columnFilters, setColumnFilters] = storageKey
     ? usePersistentState<ColumnFiltersState>(`${storageKey}:column-filters`, defaultColumnFilters || [])
     : React.useState<ColumnFiltersState>(defaultColumnFilters || []);


### PR DESCRIPTION
## Summary

This PR prepares the 5.5.3 branch with holdings, allocation, export, account form, and iOS viewport fixes.

- Adds a lean holdings list path across frontend adapters, Tauri commands, web/server APIs, and core holdings models so pages can fetch lighter holdings data where full portfolio detail is not needed.
- Adds holdings export support through the exports UI, shared export constants, Tauri utilities, server data export handling, and core export generation.
- Fixes allocation target/rebalance display issues, including drift tolerance rendering, cash allocation detail rows, and allocation detail category switching.
- Updates the account edit form layout while preserving the existing account modal flow.
- Fixes the iOS fullscreen regression reported in #1170 by removing the problematic dynamic viewport shell sizing and capping the mobile bottom safe-area offset.
- Includes the generated iOS `CFBundleVersion` update for 3.5.3 and a formatting-only follow-up commit.

Fixes #1170.

## Root Cause

For #1170, the iOS app shell was using dynamic viewport height (`100dvh`) together with a raw `env(safe-area-inset-bottom)` value for the mobile bottom navigation offset. On iOS WKWebView, especially after relaunch on iPhone 16 Pro simulators/devices, those viewport/safe-area values can be reported in a way that leaves the bottom navigation floating too high and exposes unused black space below the app content.

The fix keeps the shell on the stable full-height layout and caps the mobile bottom safe-area contribution so abnormal WKWebView inset values cannot push the navigation bar far above the home indicator.

## Commits Included

- `098ea7a81` Fix allocation drift tolerance display
- `5fdcd4c71` Fix cash allocation detail rows
- `9df81c4c1` Update account edit form layout
- `2c9a8d232` Add lean holdings list endpoint
- `b0dd1e5ad` Fix allocation detail category switching
- `85a93dc64` Add holdings data export
- `04d4cb5af` Fix iOS mobile viewport gap (#1170)
- `b956e4e8f` Format frontend files (#1170)

## Impacted Areas

- Frontend holdings/account/asset pages, allocation target rebalance UI, allocation detail sheet, export settings UI, account settings form, and mobile app shell layout.
- Frontend adapter parity coverage for portfolio commands.
- Tauri portfolio and utility command surfaces.
- Web/server holdings and data export endpoints.
- Core export, allocation, and holdings models/services.
- iOS generated `Info.plist` bundle version metadata.

## Validation

- `pnpm run build:types`
- `pnpm format:check`
- `pnpm lint` (warnings only, no errors)
- `pnpm type-check`
- `pnpm test` (`106` files, `933` tests passed)
- `pnpm build`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `CONNECT_API_URL=http://test.local cargo test --workspace`

## Notes

- `pnpm format:check` initially found three pre-existing formatting differences; they were fixed in the final formatting commit and the check now passes.
- The branch was compared against `origin/main` and contains eight commits total.