### PR TITLE
fix(rebalance): exclude tagged cash from deployable cash

### DIFF
--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -2555,6 +2555,7 @@ export interface DriftHoldingsReport {
 export type RebalanceWarningKind =
   | "missing_quote"
   | "no_buy_candidate"
+  | "tagged_cash"
   | "unclassified_asset"
   | "partial_classification";
 

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -2520,6 +2520,7 @@ export interface DriftReport {
   outOfBandCount: number;
   rows: DriftRow[];
   holdings?: DriftHoldingsReport | null;
+  deployableCash: number;
 }
 
 export interface DriftHoldingRow {

--- a/apps/frontend/src/pages/allocation-targets/components/drift-report-resolver.test.ts
+++ b/apps/frontend/src/pages/allocation-targets/components/drift-report-resolver.test.ts
@@ -65,6 +65,7 @@ describe("resolveDriftReportCategories", () => {
         baseCurrency: "USD",
         rows: [holdingRow({ categoryId: "region-a" })],
       },
+      deployableCash: 5000,
     };
     const categories: TaxonomyCategory[] = [
       {

--- a/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
@@ -987,6 +987,7 @@ function SleeveReshapeCard({ sleeves, mode }: { sleeves: SleeveSummaryRow[]; mod
 const WARN_LABEL: Record<string, string> = {
   missing_quote: "Missing quote",
   no_buy_candidate: "No buy candidate",
+  tagged_cash: "Tagged cash",
   unclassified_asset: "Unclassified",
   partial_classification: "Partial classification",
 };

--- a/apps/frontend/src/pages/insights/overview/overview-page.tsx
+++ b/apps/frontend/src/pages/insights/overview/overview-page.tsx
@@ -132,13 +132,14 @@ export function OverviewPage({
     () => portfolioHoldings.filter((h) => h.holdingType?.toLowerCase() !== "cash"),
     [portfolioHoldings],
   );
-  const availableCash = useMemo(
+  const totalCash = useMemo(
     () =>
       holdings
         .filter((h) => h.holdingType === HoldingType.CASH)
         .reduce((sum, h) => sum + (h.marketValue.base ?? 0), 0),
     [holdings],
   );
+  const availableCash = driftReport?.deployableCash ?? totalCash;
   const rebalanceSourceVersion = `${holdingsUpdatedAt}:${driftUpdatedAt}:${effectiveTarget?.updatedAt ?? ""}`;
 
   const valueStrip = useMemo(

--- a/apps/server/src/main_lib.rs
+++ b/apps/server/src/main_lib.rs
@@ -468,6 +468,7 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
             allocation_target_service.clone(),
             allocation_service.clone(),
         )
+        .with_holdings_service(holdings_service.clone())
         .with_taxonomy_service(taxonomy_service.clone()),
     );
     let rebalance_service: Arc<

--- a/apps/tauri/src/context/providers.rs
+++ b/apps/tauri/src/context/providers.rs
@@ -446,6 +446,7 @@ pub async fn initialize_context(
             allocation_target_service.clone(),
             allocation_service.clone(),
         )
+        .with_holdings_service(holdings_service.clone())
         .with_taxonomy_service(taxonomy_service.clone()),
     );
     let rebalance_service = Arc::new(RebalanceService::new(

--- a/crates/core/src/portfolio/allocation_targets/cash.rs
+++ b/crates/core/src/portfolio/allocation_targets/cash.rs
@@ -1,0 +1,136 @@
+use rust_decimal::Decimal;
+
+use crate::portfolio::{
+    allocation::TaxonomyHoldingContributions,
+    holdings::{Holding, HoldingType},
+};
+
+fn deployable_cash_category_ids(taxonomy_id: &str) -> &'static [&'static str] {
+    match taxonomy_id {
+        "asset_classes" => &["CASH"],
+        // Cash rolls up to CASH_FX in the system taxonomy. Keep CASH as a
+        // fallback for tests or missing hierarchy metadata.
+        "instrument_type" => &["CASH_FX", "CASH"],
+        _ => &[],
+    }
+}
+
+pub(super) fn deployable_cash_from_contributions(
+    taxonomy_id: &str,
+    contributions: &TaxonomyHoldingContributions,
+) -> Option<Decimal> {
+    let category_ids = deployable_cash_category_ids(taxonomy_id);
+    if category_ids.is_empty() {
+        return None;
+    }
+
+    Some(
+        contributions
+            .contributions
+            .iter()
+            .filter(|c| {
+                c.holding_type == HoldingType::Cash
+                    && category_ids.contains(&c.category_id.as_str())
+            })
+            .map(|c| c.value)
+            .sum(),
+    )
+}
+
+pub(super) fn tracked_cash(holdings: &[Holding]) -> Decimal {
+    holdings
+        .iter()
+        .filter(|h| h.holding_type == HoldingType::Cash)
+        .map(|h| h.market_value.base)
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::portfolio::allocation::HoldingAllocationContribution;
+    use rust_decimal_macros::dec;
+
+    fn contributions(
+        taxonomy_id: &str,
+        rows: Vec<HoldingAllocationContribution>,
+    ) -> TaxonomyHoldingContributions {
+        let total_value = rows.iter().map(|row| row.value).sum();
+        TaxonomyHoldingContributions {
+            taxonomy_id: taxonomy_id.to_string(),
+            taxonomy_name: taxonomy_id.to_string(),
+            total_value,
+            currency: "USD".to_string(),
+            contributions: rows,
+        }
+    }
+
+    fn contribution(
+        category_id: &str,
+        holding_type: HoldingType,
+        value: Decimal,
+    ) -> HoldingAllocationContribution {
+        HoldingAllocationContribution {
+            id: format!("holding:{category_id}"),
+            holding_id: format!("holding-{category_id}"),
+            asset_id: format!("asset-{category_id}"),
+            account_id: "acc".to_string(),
+            source_account_ids: vec![],
+            symbol: category_id.to_string(),
+            name: category_id.to_string(),
+            holding_type,
+            quantity: Decimal::ONE,
+            category_id: category_id.to_string(),
+            category_name: category_id.to_string(),
+            category_color: "#000000".to_string(),
+            value,
+        }
+    }
+
+    #[test]
+    fn asset_class_cash_must_be_in_cash_sleeve() {
+        let tagged_cash = contributions(
+            "asset_classes",
+            vec![contribution("FIXED_INCOME", HoldingType::Cash, dec!(1000))],
+        );
+        let default_cash = contributions(
+            "asset_classes",
+            vec![contribution("CASH", HoldingType::Cash, dec!(500))],
+        );
+
+        assert_eq!(
+            deployable_cash_from_contributions("asset_classes", &tagged_cash),
+            Some(Decimal::ZERO)
+        );
+        assert_eq!(
+            deployable_cash_from_contributions("asset_classes", &default_cash),
+            Some(dec!(500))
+        );
+    }
+
+    #[test]
+    fn instrument_type_uses_cash_fx_rollup() {
+        let contributions = contributions(
+            "instrument_type",
+            vec![contribution("CASH_FX", HoldingType::Cash, dec!(250))],
+        );
+
+        assert_eq!(
+            deployable_cash_from_contributions("instrument_type", &contributions),
+            Some(dec!(250))
+        );
+    }
+
+    #[test]
+    fn non_cash_taxonomy_falls_back_to_tracked_cash() {
+        let contributions = contributions(
+            "industries_gics",
+            vec![contribution("45", HoldingType::Security, dec!(1000))],
+        );
+
+        assert_eq!(
+            deployable_cash_from_contributions("industries_gics", &contributions),
+            None
+        );
+    }
+}

--- a/crates/core/src/portfolio/allocation_targets/cash.rs
+++ b/crates/core/src/portfolio/allocation_targets/cash.rs
@@ -15,6 +15,14 @@ fn deployable_cash_category_ids(taxonomy_id: &str) -> &'static [&'static str] {
     }
 }
 
+pub(super) fn has_deployable_cash_categories(taxonomy_id: &str) -> bool {
+    !deployable_cash_category_ids(taxonomy_id).is_empty()
+}
+
+pub(super) fn is_deployable_cash_category(taxonomy_id: &str, category_id: &str) -> bool {
+    deployable_cash_category_ids(taxonomy_id).contains(&category_id)
+}
+
 pub(super) fn deployable_cash_from_contributions(
     taxonomy_id: &str,
     contributions: &TaxonomyHoldingContributions,
@@ -30,7 +38,7 @@ pub(super) fn deployable_cash_from_contributions(
             .iter()
             .filter(|c| {
                 c.holding_type == HoldingType::Cash
-                    && category_ids.contains(&c.category_id.as_str())
+                    && is_deployable_cash_category(taxonomy_id, &c.category_id)
             })
             .map(|c| c.value)
             .sum(),
@@ -106,6 +114,11 @@ mod tests {
             deployable_cash_from_contributions("asset_classes", &default_cash),
             Some(dec!(500))
         );
+        assert!(is_deployable_cash_category("asset_classes", "CASH"));
+        assert!(!is_deployable_cash_category(
+            "asset_classes",
+            "FIXED_INCOME"
+        ));
     }
 
     #[test]

--- a/crates/core/src/portfolio/allocation_targets/drift_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/drift_service.rs
@@ -7,9 +7,10 @@ use std::sync::Arc;
 
 use crate::errors::Result as CoreResult;
 use crate::portfolio::allocation::{AllocationServiceTrait, TaxonomyHoldingContributions};
-use crate::portfolio::holdings::HoldingType;
+use crate::portfolio::holdings::{HoldingType, HoldingsServiceTrait};
 use crate::taxonomies::TaxonomyServiceTrait;
 
+use super::cash::{deployable_cash_from_contributions, tracked_cash};
 use super::model::{
     AllocationTarget, AllocationTargetWeight, DriftHoldingRow, DriftHoldingsReport, DriftReport,
     DriftRow, DriftStatus, ScopeType,
@@ -56,6 +57,7 @@ pub trait DriftServiceTrait: Send + Sync {
 pub struct DriftService {
     target_service: Arc<dyn AllocationTargetServiceTrait>,
     allocation_service: Arc<dyn AllocationServiceTrait>,
+    holdings_service: Option<Arc<dyn HoldingsServiceTrait>>,
     taxonomy_service: Option<Arc<dyn TaxonomyServiceTrait>>,
 }
 
@@ -67,8 +69,17 @@ impl DriftService {
         Self {
             target_service,
             allocation_service,
+            holdings_service: None,
             taxonomy_service: None,
         }
+    }
+
+    pub fn with_holdings_service(
+        mut self,
+        holdings_service: Arc<dyn HoldingsServiceTrait>,
+    ) -> Self {
+        self.holdings_service = Some(holdings_service);
+        self
     }
 
     /// Provide the taxonomy service so category display names/colors can be
@@ -392,20 +403,18 @@ impl DriftService {
             Self::build_drift_holdings_report(target_id, base_currency, &weights, &contributions)
         });
 
-        let default_cash_cat = match target.taxonomy_id.as_str() {
-            "asset_classes" => Some("CASH"),
-            "instrument_type" => Some("CASH"),
-            _ => None,
+        let deployable_cash = if let Some(cash) =
+            deployable_cash_from_contributions(&target.taxonomy_id, &contributions)
+        {
+            cash
+        } else if let Some(holdings_service) = self.holdings_service.as_ref() {
+            let holdings = holdings_service
+                .get_holdings_for_accounts(account_ids, base_currency, aggregated_account_id)
+                .await?;
+            tracked_cash(&holdings)
+        } else {
+            Decimal::ZERO
         };
-        let deployable_cash: Decimal = contributions
-            .contributions
-            .iter()
-            .filter(|c| {
-                c.holding_type == HoldingType::Cash
-                    && default_cash_cat.is_none_or(|cat| c.category_id == cat)
-            })
-            .map(|c| c.value)
-            .sum();
 
         Ok(DriftReport {
             target_id: target_id.to_string(),
@@ -472,7 +481,7 @@ mod tests {
         NewAllocationTargetWeight, RebalanceGoal, SaveAllocationTargetResult, ScopeType,
         TriggerType,
     };
-    use crate::portfolio::holdings::HoldingType;
+    use crate::portfolio::holdings::{Holding, HoldingType, MonetaryValue};
     use async_trait::async_trait;
     use rust_decimal_macros::dec;
 
@@ -535,6 +544,47 @@ mod tests {
             value,
             percentage: rust_decimal::Decimal::ZERO,
             children: vec![],
+        }
+    }
+
+    fn make_cash_holding(amount: Decimal, currency: &str) -> Holding {
+        Holding {
+            id: "cash".to_string(),
+            account_id: "acc".to_string(),
+            holding_type: HoldingType::Cash,
+            instrument: None,
+            asset_kind: None,
+            quantity: amount,
+            open_date: None,
+            lots: None,
+            contract_multiplier: Decimal::ONE,
+            local_currency: currency.to_string(),
+            base_currency: currency.to_string(),
+            fx_rate: None,
+            market_value: MonetaryValue {
+                local: amount,
+                base: amount,
+            },
+            cost_basis: None,
+            price: None,
+            purchase_price: None,
+            unrealized_gain: None,
+            unrealized_gain_pct: None,
+            realized_gain: None,
+            realized_gain_pct: None,
+            total_gain: None,
+            total_gain_pct: None,
+            income: None,
+            total_return: None,
+            total_return_pct: None,
+            return_basis: None,
+            day_change: None,
+            day_change_pct: None,
+            prev_close_value: None,
+            weight: Decimal::ZERO,
+            as_of_date: chrono::NaiveDate::from_ymd_opt(2026, 1, 1).unwrap(),
+            metadata: None,
+            source_account_ids: vec![],
         }
     }
 
@@ -757,6 +807,44 @@ mod tests {
         }
     }
 
+    struct MockHoldingsService {
+        holdings: Vec<Holding>,
+    }
+
+    #[async_trait]
+    impl crate::portfolio::holdings::HoldingsServiceTrait for MockHoldingsService {
+        async fn get_holdings(
+            &self,
+            _account_id: &str,
+            _base_currency: &str,
+        ) -> CoreResult<Vec<Holding>> {
+            Ok(self.holdings.clone())
+        }
+        async fn get_holdings_for_accounts(
+            &self,
+            _account_ids: &[String],
+            _base_currency: &str,
+            _aggregated_account_id: &str,
+        ) -> CoreResult<Vec<Holding>> {
+            Ok(self.holdings.clone())
+        }
+        async fn get_holding(
+            &self,
+            _holding_id: &str,
+            _account_id: &str,
+            _base_currency: &str,
+        ) -> CoreResult<Option<Holding>> {
+            Ok(self.holdings.first().cloned())
+        }
+        async fn holdings_from_snapshot(
+            &self,
+            _snapshot: &crate::portfolio::snapshot::AccountStateSnapshot,
+            _base_currency: &str,
+        ) -> CoreResult<Vec<Holding>> {
+            Ok(self.holdings.clone())
+        }
+    }
+
     fn make_service(
         target: AllocationTarget,
         weights: Vec<AllocationTargetWeight>,
@@ -785,6 +873,23 @@ mod tests {
                 contributions,
             }),
         )
+    }
+
+    fn make_service_with_holdings(
+        target: AllocationTarget,
+        weights: Vec<AllocationTargetWeight>,
+        allocations: PortfolioAllocations,
+        holdings: Vec<Holding>,
+    ) -> DriftService {
+        let contributions = contributions_from_allocations(&target.taxonomy_id, &allocations);
+        DriftService::new(
+            Arc::new(MockTargetService { target, weights }),
+            Arc::new(MockAllocationService {
+                allocations,
+                contributions,
+            }),
+        )
+        .with_holdings_service(Arc::new(MockHoldingsService { holdings }))
     }
 
     // ── Tests ────────────────────────────────────────────────────────────────
@@ -1215,6 +1320,30 @@ mod tests {
         assert_eq!(technology.current_bps, 7000);
         assert_eq!(technology.target_bps, 7000);
         assert_eq!(technology.status, DriftStatus::InBand);
+    }
+
+    #[tokio::test]
+    async fn non_asset_taxonomy_deployable_cash_uses_tracked_cash() {
+        let svc = make_service_with_holdings(
+            target_with_taxonomy("industries_gics", 500),
+            vec![weight("45", 7000), weight("40", 3000)],
+            PortfolioAllocations {
+                sectors: taxonomy_alloc(
+                    "industries_gics",
+                    vec![cat("45", dec!(7000)), cat("40", dec!(3000))],
+                ),
+                total_value: dec!(12000),
+                ..Default::default()
+            },
+            vec![make_cash_holding(dec!(2000), "USD")],
+        );
+
+        let report = svc
+            .get_drift_report_for_target("p1", &[], "USD", "agg")
+            .await
+            .unwrap();
+
+        assert_eq!(report.deployable_cash, dec!(2000));
     }
 
     #[tokio::test]

--- a/crates/core/src/portfolio/allocation_targets/drift_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/drift_service.rs
@@ -10,7 +10,7 @@ use crate::portfolio::allocation::{AllocationServiceTrait, TaxonomyHoldingContri
 use crate::portfolio::holdings::{HoldingType, HoldingsServiceTrait};
 use crate::taxonomies::TaxonomyServiceTrait;
 
-use super::cash::{deployable_cash_from_contributions, tracked_cash};
+use super::cash::{deployable_cash_from_contributions, is_deployable_cash_category, tracked_cash};
 use super::model::{
     AllocationTarget, AllocationTargetWeight, DriftHoldingRow, DriftHoldingsReport, DriftReport,
     DriftRow, DriftStatus, ScopeType,
@@ -22,15 +22,6 @@ struct CategoryCurrent {
     value: Decimal,
     name: String,
     color: String,
-    has_cash: bool,
-    has_non_cash: bool,
-}
-
-impl CategoryCurrent {
-    /// A category that holds cash and nothing else is the cash sleeve.
-    fn is_cash(&self) -> bool {
-        self.has_cash && !self.has_non_cash
-    }
 }
 
 #[async_trait]
@@ -154,15 +145,8 @@ impl DriftService {
                     value: Decimal::ZERO,
                     name: contribution.category_name.clone(),
                     color: contribution.category_color.clone(),
-                    has_cash: false,
-                    has_non_cash: false,
                 });
             entry.value += contribution.value;
-            if contribution.holding_type == HoldingType::Cash {
-                entry.has_cash = true;
-            } else {
-                entry.has_non_cash = true;
-            }
         }
 
         current_by_category
@@ -235,7 +219,7 @@ impl DriftService {
                     status,
                     is_required: weight.is_required,
                     is_zero_current: current_value == Decimal::ZERO,
-                    is_cash: current.map(|current| current.is_cash()).unwrap_or(false),
+                    is_cash: is_deployable_cash_category(&target.taxonomy_id, &weight.category_id),
                 }
             })
             .filter(|row| row.is_required || row.current_value > Decimal::ZERO)
@@ -252,7 +236,7 @@ impl DriftService {
             }
 
             let current_bps = Self::current_bps(current.value, total_value);
-            let is_cash = current.is_cash();
+            let is_cash = is_deployable_cash_category(&target.taxonomy_id, &category_id);
             rows.push(DriftRow {
                 category_id,
                 category_name: current.name,
@@ -603,6 +587,19 @@ mod tests {
             category_name: category_id.to_string(),
             category_color: "#111111".to_string(),
             value,
+        }
+    }
+
+    fn cash_contribution(category_id: &str, value: Decimal) -> HoldingAllocationContribution {
+        HoldingAllocationContribution {
+            id: format!("cash:{category_id}:0"),
+            holding_id: "cash".to_string(),
+            asset_id: "cash".to_string(),
+            symbol: "USD".to_string(),
+            name: "Cash (USD)".to_string(),
+            holding_type: HoldingType::Cash,
+            quantity: value,
+            ..holding_contribution(category_id, value)
         }
     }
 
@@ -1344,6 +1341,42 @@ mod tests {
             .unwrap();
 
         assert_eq!(report.deployable_cash, dec!(2000));
+    }
+
+    #[tokio::test]
+    async fn tagged_cash_in_non_cash_category_is_not_cash_sleeve() {
+        let svc = make_service_with_contributions(
+            base_target(500),
+            vec![weight("FIXED_INCOME", 10000), weight("CASH", 0)],
+            alloc_with(vec![], dec!(1000)),
+            TaxonomyHoldingContributions {
+                taxonomy_id: "asset_classes".to_string(),
+                taxonomy_name: "Asset Classes".to_string(),
+                total_value: dec!(1000),
+                currency: "USD".to_string(),
+                contributions: vec![cash_contribution("FIXED_INCOME", dec!(1000))],
+            },
+        );
+
+        let report = svc
+            .get_drift_report_for_target("p1", &[], "USD", "agg")
+            .await
+            .unwrap();
+
+        let fixed_income = report
+            .rows
+            .iter()
+            .find(|row| row.category_id == "FIXED_INCOME")
+            .unwrap();
+        assert!(!fixed_income.is_cash);
+
+        let cash = report
+            .rows
+            .iter()
+            .find(|row| row.category_id == "CASH")
+            .unwrap();
+        assert!(cash.is_cash);
+        assert_eq!(cash.current_value, Decimal::ZERO);
     }
 
     #[tokio::test]

--- a/crates/core/src/portfolio/allocation_targets/drift_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/drift_service.rs
@@ -402,7 +402,7 @@ impl DriftService {
             .iter()
             .filter(|c| {
                 c.holding_type == HoldingType::Cash
-                    && default_cash_cat.map_or(true, |cat| c.category_id == cat)
+                    && default_cash_cat.is_none_or(|cat| c.category_id == cat)
             })
             .map(|c| c.value)
             .sum();

--- a/crates/core/src/portfolio/allocation_targets/drift_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/drift_service.rs
@@ -392,6 +392,21 @@ impl DriftService {
             Self::build_drift_holdings_report(target_id, base_currency, &weights, &contributions)
         });
 
+        let default_cash_cat = match target.taxonomy_id.as_str() {
+            "asset_classes" => Some("CASH"),
+            "instrument_type" => Some("CASH"),
+            _ => None,
+        };
+        let deployable_cash: Decimal = contributions
+            .contributions
+            .iter()
+            .filter(|c| {
+                c.holding_type == HoldingType::Cash
+                    && default_cash_cat.map_or(true, |cat| c.category_id == cat)
+            })
+            .map(|c| c.value)
+            .sum();
+
         Ok(DriftReport {
             target_id: target_id.to_string(),
             scope_type,
@@ -402,6 +417,7 @@ impl DriftService {
             out_of_band_count,
             rows,
             holdings,
+            deployable_cash,
         })
     }
 }

--- a/crates/core/src/portfolio/allocation_targets/mod.rs
+++ b/crates/core/src/portfolio/allocation_targets/mod.rs
@@ -1,3 +1,4 @@
+mod cash;
 mod drift_service;
 mod model;
 mod optimizer;

--- a/crates/core/src/portfolio/allocation_targets/model.rs
+++ b/crates/core/src/portfolio/allocation_targets/model.rs
@@ -309,6 +309,7 @@ pub struct CalculateRebalancePlanInput {
 pub enum RebalanceWarningKind {
     MissingQuote,
     NoBuyCandidate,
+    TaggedCash,
     /// Asset has no taxonomy assignments for the active taxonomy — skipped as buy candidate.
     UnclassifiedAsset,
     /// Asset has partial taxonomy weights (<100%) — known exposure used, remainder ignored.

--- a/crates/core/src/portfolio/allocation_targets/model.rs
+++ b/crates/core/src/portfolio/allocation_targets/model.rs
@@ -253,6 +253,10 @@ pub struct DriftReport {
     pub rows: Vec<DriftRow>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub holdings: Option<DriftHoldingsReport>,
+    /// Cash that is available for deployment — excludes cash tagged into
+    /// a non-cash sleeve (e.g. a cash account classified as Fixed Income).
+    #[serde(default)]
+    pub deployable_cash: Decimal,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -9,6 +9,7 @@ use crate::errors::{Error as CoreError, Result as CoreResult};
 use crate::portfolio::allocation::{AllocationServiceTrait, HoldingAllocationContribution};
 use crate::portfolio::holdings::{HoldingType, HoldingsServiceTrait};
 
+use super::cash::{deployable_cash_from_contributions, tracked_cash};
 use super::drift_service::DriftServiceTrait;
 use super::model::{
     CalculateRebalancePlanInput, RebalancePlan, RebalanceWarning, RebalanceWarningKind,
@@ -63,13 +64,6 @@ impl RebalanceService {
 
     fn currency_rounding_tolerance(currency: &str) -> Decimal {
         Decimal::ONE / Decimal::from(10_i64.pow(Self::currency_fraction_digits(currency)))
-    }
-
-    fn default_cash_category_id(taxonomy_id: &str) -> Option<&'static str> {
-        match taxonomy_id {
-            "asset_classes" | "instrument_type" => Some("CASH"),
-            _ => None,
-        }
     }
 
     fn base_price_per_unit(holding: &crate::portfolio::holdings::Holding) -> Option<Decimal> {
@@ -318,19 +312,9 @@ impl RebalanceServiceTrait for RebalanceService {
             )
             .await?;
 
-        // Deployable cash = cash holdings that are classified in the default
-        // cash category.  Cash tagged into another sleeve (e.g. Fixed Income)
-        // is excluded — it belongs to that sleeve and must not be double-counted.
-        let default_cash_cat = Self::default_cash_category_id(&profile.taxonomy_id);
-        let cash_in_scope: Decimal = taxonomy_contributions
-            .contributions
-            .iter()
-            .filter(|c| {
-                c.holding_type == HoldingType::Cash
-                    && default_cash_cat.is_none_or(|cat| c.category_id == cat)
-            })
-            .map(|c| c.value)
-            .sum();
+        let cash_in_scope =
+            deployable_cash_from_contributions(&profile.taxonomy_id, &taxonomy_contributions)
+                .unwrap_or_else(|| tracked_cash(&all_holdings));
 
         let available_cash = if input.available_cash > cash_in_scope {
             let overage = input.available_cash - cash_in_scope;
@@ -920,6 +904,64 @@ mod tests {
             err.to_string().contains("exceeds tracked cash in scope"),
             "{err}"
         );
+    }
+
+    #[tokio::test]
+    async fn asset_class_tagged_cash_is_not_deployable() {
+        let cash = make_cash_holding(dec!(1000), "USD");
+        let tagged_cash = make_contribution(&cash, "FIXED_INCOME", dec!(1000));
+        let svc = RebalanceService::new(
+            Arc::new(MockTargetService {
+                profile: make_profile(RebalanceGoal::ExactTarget, false),
+            }),
+            Arc::new(MockDriftService {
+                report: make_report(
+                    vec![make_drift_row("FIXED_INCOME", 10000, 0, dec!(1000))],
+                    dec!(1000),
+                ),
+            }),
+            Arc::new(MockAllocationService {
+                contributions: make_contributions(vec![tagged_cash]),
+            }),
+            Arc::new(MockHoldingsService {
+                holdings: vec![cash],
+            }),
+        );
+
+        let err = svc
+            .calculate_plan(make_input(dec!(1000)))
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("exceeds tracked cash in scope"),
+            "{err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn non_cash_taxonomy_uses_tracked_cash_for_deployment() {
+        let total = dec!(10000);
+        let h = make_holding("h1", "XLK", dec!(10), dec!(6000));
+        let c = make_contribution(&h, "45", dec!(6000));
+        let mut profile = make_profile(RebalanceGoal::ExactTarget, false);
+        profile.taxonomy_id = "industries_gics".to_string();
+        let mut contributions = make_contributions(vec![c]);
+        contributions.taxonomy_id = "industries_gics".to_string();
+        let svc = RebalanceService::new(
+            Arc::new(MockTargetService { profile }),
+            Arc::new(MockDriftService {
+                report: make_report(vec![make_drift_row("45", 6000, 7000, total)], total),
+            }),
+            Arc::new(MockAllocationService { contributions }),
+            Arc::new(MockHoldingsService {
+                holdings: vec![make_cash_holding(dec!(1000), "USD"), h],
+            }),
+        );
+
+        let plan = svc.calculate_plan(make_input(dec!(1000))).await.unwrap();
+
+        assert_eq!(plan.available_cash, dec!(1000));
     }
 
     #[tokio::test]

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -9,7 +9,10 @@ use crate::errors::{Error as CoreError, Result as CoreResult};
 use crate::portfolio::allocation::{AllocationServiceTrait, HoldingAllocationContribution};
 use crate::portfolio::holdings::{HoldingType, HoldingsServiceTrait};
 
-use super::cash::{deployable_cash_from_contributions, tracked_cash};
+use super::cash::{
+    deployable_cash_from_contributions, has_deployable_cash_categories,
+    is_deployable_cash_category, tracked_cash,
+};
 use super::drift_service::DriftServiceTrait;
 use super::model::{
     CalculateRebalancePlanInput, RebalancePlan, RebalanceWarning, RebalanceWarningKind,
@@ -87,6 +90,44 @@ impl RebalanceService {
             };
             price * fx_rate
         })
+    }
+
+    fn tagged_cash_warnings(
+        taxonomy_id: &str,
+        contributions: &[HoldingAllocationContribution],
+    ) -> Vec<RebalanceWarning> {
+        if !has_deployable_cash_categories(taxonomy_id) {
+            return vec![];
+        }
+
+        let mut value_by_category: HashMap<String, (String, Decimal)> = HashMap::new();
+        for contribution in contributions {
+            if contribution.holding_type != HoldingType::Cash
+                || is_deployable_cash_category(taxonomy_id, &contribution.category_id)
+            {
+                continue;
+            }
+
+            let entry = value_by_category
+                .entry(contribution.category_id.clone())
+                .or_insert_with(|| (contribution.category_name.clone(), Decimal::ZERO));
+            entry.1 += contribution.value;
+        }
+
+        let mut categories: Vec<_> = value_by_category.into_iter().collect();
+        categories.sort_by(|a, b| a.0.cmp(&b.0));
+
+        categories
+            .into_iter()
+            .map(|(category_id, (category_name, value))| RebalanceWarning {
+                kind: RebalanceWarningKind::TaggedCash,
+                category_id,
+                message: format!(
+                    "{} contains {:.2} of tagged cash. It is excluded from cash to deploy; move or reclassify that cash before the plan can rebalance this sleeve.",
+                    category_name, value
+                ),
+            })
+            .collect()
     }
 
     /// Build `AssetCandidate` list from holdings + contributions.
@@ -327,7 +368,7 @@ impl RebalanceServiceTrait for RebalanceService {
             } else {
                 return Err(CoreError::Validation(
                     crate::errors::ValidationError::InvalidInput(
-                        "cash to deploy exceeds tracked cash in scope".to_string(),
+                        "cash to deploy exceeds deployable cash in scope".to_string(),
                     ),
                 ));
             }
@@ -375,12 +416,16 @@ impl RebalanceServiceTrait for RebalanceService {
             .map(|h| (Self::asset_key(h), h.quantity))
             .collect();
 
-        let (candidates, classification_warnings) = Self::build_candidates(
+        let (candidates, mut classification_warnings) = Self::build_candidates(
             &taxonomy_contributions.contributions,
             &price_by_asset,
             &quantity_by_asset,
             profile.whole_shares_only,
         );
+        classification_warnings.extend(Self::tagged_cash_warnings(
+            &profile.taxonomy_id,
+            &taxonomy_contributions.contributions,
+        ));
 
         let sell_candidates = if profile.allow_sells
             && !matches!(
@@ -986,7 +1031,7 @@ mod tests {
             .await
             .unwrap_err();
         assert!(
-            err.to_string().contains("exceeds tracked cash in scope"),
+            err.to_string().contains("exceeds deployable cash in scope"),
             "{err}"
         );
     }
@@ -1019,9 +1064,48 @@ mod tests {
             .unwrap_err();
 
         assert!(
-            err.to_string().contains("exceeds tracked cash in scope"),
+            err.to_string().contains("exceeds deployable cash in scope"),
             "{err}"
         );
+    }
+
+    #[tokio::test]
+    async fn tagged_cash_in_non_cash_sleeve_emits_warning() {
+        let cash = make_cash_holding(dec!(1000), "USD");
+        let tagged_cash = make_contribution(&cash, "FIXED_INCOME", dec!(1000));
+        let svc = RebalanceService::new(
+            Arc::new(MockTargetService {
+                profile: make_sell_profile(RebalanceGoal::ExactTarget),
+            }),
+            Arc::new(MockDriftService {
+                report: make_report(
+                    vec![make_drift_row("FIXED_INCOME", 10000, 0, dec!(1000))],
+                    dec!(1000),
+                ),
+            }),
+            Arc::new(MockAllocationService {
+                contributions: make_contributions(vec![tagged_cash]),
+            }),
+            Arc::new(MockHoldingsService {
+                holdings: vec![cash],
+            }),
+        );
+
+        let plan = svc
+            .calculate_plan(make_input_with_mode(
+                Decimal::ZERO,
+                ScenarioMode::SellToRebalance,
+            ))
+            .await
+            .unwrap();
+
+        let warning = plan
+            .warnings
+            .iter()
+            .find(|warning| warning.kind == RebalanceWarningKind::TaggedCash)
+            .expect("tagged cash warning expected");
+        assert_eq!(warning.category_id, "FIXED_INCOME");
+        assert!(warning.message.contains("move or reclassify"));
     }
 
     #[tokio::test]

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -327,7 +327,7 @@ impl RebalanceServiceTrait for RebalanceService {
             .iter()
             .filter(|c| {
                 c.holding_type == HoldingType::Cash
-                    && default_cash_cat.map_or(true, |cat| c.category_id == cat)
+                    && default_cash_cat.is_none_or(|cat| c.category_id == cat)
             })
             .map(|c| c.value)
             .sum();

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -65,6 +65,13 @@ impl RebalanceService {
         Decimal::ONE / Decimal::from(10_i64.pow(Self::currency_fraction_digits(currency)))
     }
 
+    fn default_cash_category_id(taxonomy_id: &str) -> Option<&'static str> {
+        match taxonomy_id {
+            "asset_classes" | "instrument_type" => Some("CASH"),
+            _ => None,
+        }
+    }
+
     fn base_price_per_unit(holding: &crate::portfolio::holdings::Holding) -> Option<Decimal> {
         if holding.quantity > Decimal::ZERO && holding.market_value.base > Decimal::ZERO {
             return Some(holding.market_value.base / holding.quantity);
@@ -279,6 +286,17 @@ impl RebalanceServiceTrait for RebalanceService {
             ));
         }
 
+        // Load profile early — needed for taxonomy_id before cash calculation.
+        let profile = self
+            .allocation_target_service
+            .get_target(&input.target_id)?
+            .ok_or_else(|| {
+                CoreError::Database(crate::errors::DatabaseError::NotFound(format!(
+                    "AllocationTarget {} not found",
+                    input.target_id
+                )))
+            })?;
+
         // Fetch holdings once — used for both cash check and price extraction.
         let all_holdings = self
             .holdings_service
@@ -289,11 +307,29 @@ impl RebalanceServiceTrait for RebalanceService {
             )
             .await?;
 
-        // Authoritative tracked cash in scope.
-        let cash_in_scope: Decimal = all_holdings
+        // Holding contributions for exposure vectors.
+        let taxonomy_contributions = self
+            .allocation_service
+            .get_holding_contributions_for_taxonomy_for_accounts(
+                &input.account_ids,
+                &input.base_currency,
+                &profile.taxonomy_id,
+                &input.aggregated_account_id,
+            )
+            .await?;
+
+        // Deployable cash = cash holdings that are classified in the default
+        // cash category.  Cash tagged into another sleeve (e.g. Fixed Income)
+        // is excluded — it belongs to that sleeve and must not be double-counted.
+        let default_cash_cat = Self::default_cash_category_id(&profile.taxonomy_id);
+        let cash_in_scope: Decimal = taxonomy_contributions
+            .contributions
             .iter()
-            .filter(|h| h.holding_type == HoldingType::Cash)
-            .map(|h| h.market_value.base)
+            .filter(|c| {
+                c.holding_type == HoldingType::Cash
+                    && default_cash_cat.map_or(true, |cat| c.category_id == cat)
+            })
+            .map(|c| c.value)
             .sum();
 
         let available_cash = if input.available_cash > cash_in_scope {
@@ -310,17 +346,6 @@ impl RebalanceServiceTrait for RebalanceService {
         } else {
             input.available_cash
         };
-
-        // Load profile.
-        let profile = self
-            .allocation_target_service
-            .get_target(&input.target_id)?
-            .ok_or_else(|| {
-                CoreError::Database(crate::errors::DatabaseError::NotFound(format!(
-                    "AllocationTarget {} not found",
-                    input.target_id
-                )))
-            })?;
 
         // Drift report — provides total_value and per-category target/current data.
         let drift = self
@@ -348,17 +373,6 @@ impl RebalanceServiceTrait for RebalanceService {
                 after_bps_by_category: std::collections::HashMap::new(),
             });
         }
-
-        // Holding contributions for exposure vectors.
-        let taxonomy_contributions = self
-            .allocation_service
-            .get_holding_contributions_for_taxonomy_for_accounts(
-                &input.account_ids,
-                &input.base_currency,
-                &profile.taxonomy_id,
-                &input.aggregated_account_id,
-            )
-            .await?;
 
         // Price map and quantity map: holding_id → value in base currency.
         let price_by_holding: HashMap<String, Decimal> = all_holdings
@@ -670,6 +684,7 @@ mod tests {
             out_of_band_count: out,
             rows,
             holdings: None,
+            deployable_cash: Decimal::ZERO,
         }
     }
 
@@ -834,9 +849,19 @@ mod tests {
     fn make_service(
         profile: AllocationTarget,
         report: DriftReport,
-        contributions: TaxonomyHoldingContributions,
+        mut contributions: TaxonomyHoldingContributions,
         holdings: Vec<Holding>,
     ) -> RebalanceService {
+        // Auto-inject cash contributions so cash_in_scope (now derived from
+        // contributions) matches the cash holdings the test provides.
+        for h in &holdings {
+            if h.holding_type == HoldingType::Cash {
+                contributions
+                    .contributions
+                    .push(make_contribution(h, "CASH", h.market_value.base));
+                contributions.total_value += h.market_value.base;
+            }
+        }
         RebalanceService::new(
             Arc::new(MockTargetService { profile }),
             Arc::new(MockDriftService { report }),


### PR DESCRIPTION
Hey Afadil! 👋

This PR addresses the double-counting issue described in #1173. 
It depends on #1172 being merged first (the scope-All missing quote fix), since both touch `rebalance_service.rs`.

## Context

When a user tags a cash account into a non-cash sleeve (e.g. classifying a cash account as "Fixed Income" via the account cash override), that cash gets counted **twice** in the rebalance planner:

1. In the drift report as part of Fixed Income (correct — that's what the user wanted)
2. In the "Cash to deploy" slider as money available to invest (incorrect — it's already allocated)

This means the planner shows more investable cash than actually exists, and the optimizer can only sell bond holdings to reduce the overweight sleeve.
Iit can't act on the tagged cash at all.

## What this PR does (step 1 — excludes tagged cash from deployable cash)

**Backend:**
- Adds a `deployableCash` field to `DriftReport`, computed from taxonomy contributions by summing only cash holdings whose category matches the default cash category (top-level `"CASH"` after rollup)
- Reorders `rebalance_service::calculate_plan` to load the profile and contributions before computing `cash_in_scope`, using the same contribution-based filter so the validation cap is consistent

**Frontend:**
- Adds `deployableCash` to the `DriftReport` TypeScript interface
- Uses `driftReport.deployableCash` for the rebalance slider, with fallback to total cash from holdings when the drift report is not yet loaded

## Step 2 — treat tagged cash as a sell candidate (pending your input)

Once step 1 is in, I think the natural next move is to make tagged cash **actionable** in Sell-to-rebalance and Hybrid modes. The idea:

- If the user explicitly said "this cash belongs to Fixed Income", it should follow the same rules as any other holding in that sleeve. If Fixed Income is overweight, the optimizer should be able to suggest reducing the tagged cash — just like it suggests selling bond ETFs.
- This keeps tagged cash fully under the user's control through their allocation targets: it's not free cash anymore, but it's not frozen either. The planner can work with it when the sleeve is overweight.
- Without this, tagged cash that makes a sleeve overweight can only be reduced by selling the *other* holdings in that sleeve (the bonds), which isn't always what the user wants.

I'd love your take on this before implementing it. See #1173 for the full discussion.

## Testing

- `cargo check --workspace` ✅
- `cargo clippy -p wealthfolio-core -- -D warnings` ✅
- `cargo test -p wealthfolio-core` — all tests pass ✅
- `npx tsc --noEmit` — no new errors (pre-existing ones in other modules) ✅
- Manual: tagged cash no longer inflates the "cash to deploy" slider

---

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).