### PR TITLE
fix(rebalance): reorder stacked bars to Now → After → Target

### DIFF
--- a/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
@@ -181,7 +181,7 @@ function modeVerb(mode: ScenarioMode): string {
   return "Cash-flow buys";
 }
 
-/** Narrative for the Before · Target · After card. */
+/** Narrative for the Now · After · Target card. */
 function reshapeNarrative(sleeves: SleeveSummaryRow[], mode: ScenarioMode): string {
   const movers = sleeves.map((s) => ({
     name: s.categoryName,
@@ -825,7 +825,7 @@ function PlannerResult({
   );
 }
 
-// ── Before · Target · After ───────────────────────────────────────────────────
+// ── Now · After · Target ─────────────────────────────────────────────────────
 
 function StackedBar({
   label,
@@ -935,9 +935,7 @@ function SleeveReshapeCard({ sleeves, mode }: { sleeves: SleeveSummaryRow[]; mod
     <Card>
       <CardContent className="p-0">
         <div className="px-5 pt-4">
-          <h3 className="text-foreground font-mono text-sm font-semibold">
-            Before · Target · After
-          </h3>
+          <h3 className="text-foreground font-mono text-sm font-semibold">Now · After · Target</h3>
           <p className="text-muted-foreground mt-1 font-mono text-xs leading-relaxed">
             How deploying this cash reshapes the portfolio by sleeve. Sleeves are stacked in the
             same order across all three bars.
@@ -949,8 +947,8 @@ function SleeveReshapeCard({ sleeves, mode }: { sleeves: SleeveSummaryRow[]; mod
           <div className="border-border/60 px-5 py-5 lg:border-r">
             <div className="space-y-3">
               <StackedBar label="Now" field="currentBps" sleeves={sleeves} />
-              <StackedBar label="Target" field="targetBps" sleeves={sleeves} />
               <StackedBar label="After" field="afterBps" sleeves={sleeves} bold />
+              <StackedBar label="Target" field="targetBps" sleeves={sleeves} />
             </div>
             <div className="border-border/60 mt-5 flex flex-wrap gap-x-5 gap-y-2 border-t pt-4">
               {sleeves


### PR DESCRIPTION
Hey Afadil! 👋

Small UX improvement for the rebalance planner's stacked bar chart, based on user feedback in #1135.

## What changed

Reordered the stacked bars from **Now → Target → After** to **Now → After → Target**.

The previous order forced the user to compare the first and third bars (skipping the middle one) to see the plan's impact. The new order places Now and After side by side, making the before/after comparison immediate. Target stays as a reference below.

The sleeve table already had this order (Now, After, Tgt) — this aligns the bars with it.

## Files changed

- `rebalance-tab.tsx` — swapped the `StackedBar` render order and updated the section title/comments

---

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/afadil/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/afadil/wealthfolio/blob/main/CLA.md).