### PR TITLE
Fix mobile account tabs and net worth breakdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8139,7 +8139,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-ai"
-version = "3.5.3"
+version = "3.5.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8169,7 +8169,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-app"
-version = "3.5.3"
+version = "3.5.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8219,7 +8219,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-connect"
-version = "3.5.3"
+version = "3.5.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8237,7 +8237,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-core"
-version = "3.5.3"
+version = "3.5.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8282,7 +8282,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-device-sync"
-version = "3.5.3"
+version = "3.5.4"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8306,7 +8306,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-market-data"
-version = "3.5.3"
+version = "3.5.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8328,7 +8328,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-server"
-version = "3.5.3"
+version = "3.5.4"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8376,7 +8376,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-spending"
-version = "3.5.3"
+version = "3.5.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8394,7 +8394,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-storage-sqlite"
-version = "3.5.3"
+version = "3.5.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.5.3"
+version = "3.5.4"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "3.5.3",
+  "version": "3.5.4",
   "type": "module",
   "homepage": "https://wealthfolio.app",
   "repository": {

--- a/apps/frontend/src/pages/account/account-page.test.tsx
+++ b/apps/frontend/src/pages/account/account-page.test.tsx
@@ -455,7 +455,7 @@ describe("AccountPage", () => {
       mode: "infinite",
       filters: { accountIds: ["account-1"] },
     });
-    expect(screen.getByRole("link", { name: /Explore activities/i })).toHaveAttribute(
+    expect(screen.getByRole("link", { name: /Explore/i })).toHaveAttribute(
       "href",
       "/activities?account=account-1",
     );

--- a/apps/frontend/src/pages/account/account-page.tsx
+++ b/apps/frontend/src/pages/account/account-page.tsx
@@ -645,13 +645,14 @@ const AccountPage = () => {
   const accountDetailsContent = (
     <div className="space-y-4">
       {(accountDetailTabs.length > 1 || activeAccountDetailTab === "activities") && (
-        <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center justify-between gap-2 sm:gap-3">
           {accountDetailTabs.length > 1 ? (
             <AnimatedToggleGroup<AccountDetailTab>
               items={accountDetailTabs}
               value={activeAccountDetailTab}
               onValueChange={setAccountDetailTab}
-              className="text-sm"
+              size={isMobile ? "compact" : "default"}
+              className="min-w-0"
             />
           ) : (
             <div />
@@ -660,7 +661,7 @@ const AccountPage = () => {
           {activeAccountDetailTab === "activities" && (
             <Button variant="ghost" size="sm" className="shrink-0" asChild>
               <Link to={`/activities?account=${id}`} className="inline-flex items-center gap-1.5">
-                Explore activities
+                Explore
                 <Icons.ArrowRight className="h-3.5 w-3.5" />
               </Link>
             </Button>

--- a/apps/frontend/src/pages/net-worth/components/breakdown-table.tsx
+++ b/apps/frontend/src/pages/net-worth/components/breakdown-table.tsx
@@ -23,7 +23,7 @@ import {
 // name | % | value | Δ. Fixed widths so columns line up across rows (each row is
 // its own grid). On mobile the % column and the Δ-percent collapse.
 const ROW_GRID =
-  "grid grid-cols-[minmax(0,1fr)_4.5rem_5rem] md:grid-cols-[minmax(0,1fr)_3rem_7rem_8rem] items-center gap-x-3 md:gap-x-4";
+  "grid grid-cols-[minmax(0,1fr)_4.5rem_5.75rem] md:grid-cols-[minmax(0,1fr)_3rem_7rem_9.5rem] items-center gap-x-3 md:gap-x-4";
 
 function ChangeCell({ change, currency }: { change: Change; currency: string }) {
   const isZero = Math.abs(change.amount) < 0.005;
@@ -34,12 +34,14 @@ function ChangeCell({ change, currency }: { change: Change; currency: string }) 
       : "text-destructive";
   const sign = isZero ? "" : change.amount > 0 ? "+" : "-";
   return (
-    <div className="flex items-baseline justify-end gap-2.5">
-      <span className={`text-xs tabular-nums md:text-sm ${color}`}>
+    <div className="flex items-baseline justify-end gap-1.5 md:gap-2">
+      <span
+        className={`inline-flex shrink-0 items-baseline whitespace-nowrap text-xs tabular-nums md:text-sm ${color}`}
+      >
         {sign}
         <CompactAmount value={Math.abs(change.amount)} currency={currency} />
       </span>
-      <span className="text-muted-foreground/60 hidden w-12 text-right text-sm tabular-nums md:block">
+      <span className="text-muted-foreground/60 hidden w-12 shrink-0 text-right text-sm tabular-nums md:block">
         {formatChangePercent(change.percent)}
       </span>
     </div>

--- a/apps/tauri/gen/apple/wealthfolio-app_iOS/Info.plist
+++ b/apps/tauri/gen/apple/wealthfolio-app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.5.3</string>
+	<string>3.5.4</string>
 	<key>CFBundleVersion</key>
-	<string>3.5.3</string>
+	<string>3.5.4</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/apps/tauri/tauri.conf.json
+++ b/apps/tauri/tauri.conf.json
@@ -40,7 +40,7 @@
   },
   "productName": "Wealthfolio",
   "mainBinaryName": "Wealthfolio",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "identifier": "com.teymz.wealthfolio",
   "plugins": {
     "updater": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wealthfolio-app",
   "private": true,
-  "version": "3.5.3",
+  "version": "3.5.4",
   "packageManager": "pnpm@10.33.4",
   "type": "module",
   "workspaces": [

--- a/packages/addon-dev-tools/package.json
+++ b/packages/addon-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/addon-dev-tools",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "description": "Development tools for Wealthfolio addons - hot reload server and CLI",
   "main": "index.js",
   "bin": {

--- a/packages/addon-sdk/package.json
+++ b/packages/addon-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/addon-sdk",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "type": "module",
   "description": "TypeScript SDK for building Wealthfolio addons with enhanced functionality and type safety",
   "main": "dist/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/ui",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "type": "module",
   "description": "Wealthfolio UI components based on shadcn/ui and Tailwind CSS",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Compact the account detail tabs on mobile and shorten the activity exploration action to `Explore`.
- Keep Net Worth Breakdown change amounts on one line by widening the delta column and preventing signed compact amounts from wrapping.
- Bump app/package/workspace version metadata to `3.5.4`.

## Validation
- `bash scripts/ci-check.sh` reached and passed `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --all-features -- -D warnings`.
- The script's frontend phase was blocked locally by the Codex PATH selecting pnpm 11, which conflicts with this repo's pnpm 10 lockfile/override layout.
- Restored dependencies with `CI=true corepack pnpm install --frozen-lockfile` using `pnpm@10.33.4`.
- Ran frontend-equivalent checks with pnpm 10.x: `pnpm run build:types`, `pnpm format:check`, `pnpm lint`, and `pnpm type-check`.
- `git diff --check --cached`.