### PR TITLE
fix(connect): aggregate duplicate broker position lots into one holding

### DIFF
--- a/crates/connect/src/broker/service.rs
+++ b/crates/connect/src/broker/service.rs
@@ -19,7 +19,7 @@ use crate::platform::Platform;
 use chrono::{DateTime, NaiveDate, Utc};
 use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::Decimal;
-use std::collections::{HashMap, HashSet};
+use std::collections::{hash_map::Entry, HashMap, HashSet};
 use wealthfolio_core::accounts::{
     account_types, Account, AccountServiceTrait, NewAccount, TrackingMode,
 };
@@ -1013,7 +1013,7 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 (position.quantity * avg_cost).round_dp(HOLDINGS_DECIMAL_PRECISION);
             total_cost_basis += position_cost_basis;
 
-            let position = Position {
+            let new_position = Position {
                 id: format!("{}_{}", account_id, asset_id),
                 account_id: account_id.clone(),
                 asset_id: asset_id.clone(),
@@ -1028,7 +1028,21 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 is_alternative: false,
                 contract_multiplier,
             };
-            positions_map.insert(asset_id, position);
+
+            // Brokers (e.g. Fidelity via SnapTrade) can report multiple position rows for the
+            // same instrument — one per lot type (margin vs. cash sub-account) or per tax lot.
+            // They all resolve to the same asset_id, so merge them into a single holding by
+            // summing quantities and cost basis and recomputing the weighted-average cost.
+            // Without this, each later row would overwrite the previous one, undercounting the
+            // position (e.g. a margin + non-margin VTI lot would show only half the shares).
+            match positions_map.entry(asset_id) {
+                Entry::Occupied(mut existing) => {
+                    Self::merge_broker_position(existing.get_mut(), new_position);
+                }
+                Entry::Vacant(slot) => {
+                    slot.insert(new_position);
+                }
+            }
         }
 
         // Calculate cash totals
@@ -1144,6 +1158,28 @@ impl BrokerSyncService {
         }
 
         Decimal::ZERO
+    }
+
+    /// Merge an additional broker-reported lot into an existing position for the same asset.
+    ///
+    /// Some brokers (notably Fidelity via SnapTrade) return one position row per lot type
+    /// (margin vs. cash sub-account) or per tax lot, all for the same instrument. Quantities and
+    /// cost basis are summed and the average cost is recomputed as a quantity-weighted average so
+    /// the merged holding reflects the full position rather than a single lot.
+    fn merge_broker_position(existing: &mut Position, incoming: Position) {
+        let combined_quantity =
+            (existing.quantity + incoming.quantity).round_dp(HOLDINGS_DECIMAL_PRECISION);
+        let combined_cost_basis = (existing.total_cost_basis + incoming.total_cost_basis)
+            .round_dp(HOLDINGS_DECIMAL_PRECISION);
+
+        existing.average_cost = if combined_quantity == Decimal::ZERO {
+            Decimal::ZERO
+        } else {
+            (combined_cost_basis / combined_quantity).round_dp(HOLDINGS_DECIMAL_PRECISION)
+        };
+        existing.quantity = combined_quantity;
+        existing.total_cost_basis = combined_cost_basis;
+        existing.last_updated = incoming.last_updated;
     }
 
     fn compute_holdings_diff(
@@ -1722,5 +1758,89 @@ mod tests {
         assert_eq!(quantity_changed, Decimal::ZERO);
         assert_eq!(currency_changed, Decimal::ZERO);
         assert_eq!(missing, Decimal::ZERO);
+    }
+
+    #[test]
+    fn merge_broker_position_sums_quantities_and_weights_average_cost() {
+        // Two lots of the same instrument: 30 @ 100 and 10 @ 200.
+        let mut existing = position("acc-1", "vti", "30", "100", "3000", "USD");
+        let incoming = position("acc-1", "vti", "10", "200", "2000", "USD");
+
+        BrokerSyncService::merge_broker_position(&mut existing, incoming);
+
+        assert_eq!(existing.quantity, decimal("40"));
+        assert_eq!(existing.total_cost_basis, decimal("5000"));
+        // Quantity-weighted average: 5000 / 40 = 125.
+        assert_eq!(existing.average_cost, decimal("125"));
+    }
+
+    #[test]
+    fn merge_broker_position_matches_fidelity_combined_share_count() {
+        // Reproduces the reported Fidelity-via-SnapTrade bug: VTI is returned as two lots
+        // (a margin lot and a non-margin lot) that both resolve to the same asset_id.
+        // Before the fix the second lot overwrote the first, halving the share count.
+        let margin_basis = (decimal("32.005") * decimal("324.2431")).round_dp(12);
+        let non_margin_basis = (decimal("18.423") * decimal("362.4893")).round_dp(12);
+
+        let mut margin_lot = position(
+            "acc-1",
+            "vti",
+            "32.005",
+            "324.2431",
+            &margin_basis.to_string(),
+            "USD",
+        );
+        let non_margin_lot = position(
+            "acc-1",
+            "vti",
+            "18.423",
+            "362.4893",
+            &non_margin_basis.to_string(),
+            "USD",
+        );
+
+        BrokerSyncService::merge_broker_position(&mut margin_lot, non_margin_lot);
+
+        // Fidelity's combined total for VTI is 50.428 shares.
+        assert_eq!(margin_lot.quantity, decimal("50.428"));
+
+        let combined_basis = (margin_basis + non_margin_basis).round_dp(12);
+        assert_eq!(margin_lot.total_cost_basis, combined_basis);
+        assert_eq!(
+            margin_lot.average_cost,
+            (combined_basis / decimal("50.428")).round_dp(12)
+        );
+    }
+
+    #[test]
+    fn merge_broker_position_handles_offsetting_quantities_without_dividing_by_zero() {
+        // A net-flat instrument (e.g. a long lot fully offset by a short lot) must not panic.
+        let mut existing = position("acc-1", "vti", "10", "100", "1000", "USD");
+        let incoming = position("acc-1", "vti", "-10", "100", "-1000", "USD");
+
+        BrokerSyncService::merge_broker_position(&mut existing, incoming);
+
+        assert_eq!(existing.quantity, Decimal::ZERO);
+        assert_eq!(existing.total_cost_basis, Decimal::ZERO);
+        assert_eq!(existing.average_cost, Decimal::ZERO);
+    }
+
+    #[test]
+    fn merge_broker_position_is_order_independent() {
+        let mut a_then_b = position("acc-1", "vti", "30", "100", "3000", "USD");
+        BrokerSyncService::merge_broker_position(
+            &mut a_then_b,
+            position("acc-1", "vti", "10", "200", "2000", "USD"),
+        );
+
+        let mut b_then_a = position("acc-1", "vti", "10", "200", "2000", "USD");
+        BrokerSyncService::merge_broker_position(
+            &mut b_then_a,
+            position("acc-1", "vti", "30", "100", "3000", "USD"),
+        );
+
+        assert_eq!(a_then_b.quantity, b_then_a.quantity);
+        assert_eq!(a_then_b.total_cost_basis, b_then_a.total_cost_basis);
+        assert_eq!(a_then_b.average_cost, b_then_a.average_cost);
     }
 }

--- a/crates/connect/src/broker/service.rs
+++ b/crates/connect/src/broker/service.rs
@@ -978,7 +978,14 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
             .snapshot_repository
             .get_latest_snapshot_before_date(&account_id, tomorrow)?;
 
-        // 4. Build positions_map using resolved asset IDs
+        // 4. Build positions_map using resolved asset IDs.
+        // Pre-sum quantities per asset so the cost-basis fallback below compares the latest
+        // snapshot against the COMBINED position rather than an individual split row. A broker
+        // that splits one holding across rows (margin/cash) and omits average_purchase_price
+        // would otherwise never match the prior quantity, skip the "quantity unchanged -> reuse
+        // prior cost" fallback, and overwrite a previously known basis with zero.
+        let combined_quantities =
+            Self::combined_quantities_by_asset(&position_data, &spec_key_to_asset_id);
         let mut positions_map: HashMap<String, Position> = HashMap::new();
         let mut total_cost_basis = Decimal::ZERO;
 
@@ -1001,12 +1008,18 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 .and_then(|spec| spec.option_multiplier())
                 .unwrap_or(Decimal::ONE);
 
+            // Resolve cost against the combined quantity (all split rows for this asset) so the
+            // prior-cost fallback works even when the broker splits the holding into rows.
+            let combined_quantity = combined_quantities
+                .get(&asset_id)
+                .copied()
+                .unwrap_or(position.quantity);
             let avg_cost = Self::resolve_position_average_cost(
                 position.average_cost,
                 latest
                     .as_ref()
                     .and_then(|snapshot| snapshot.positions.get(&asset_id)),
-                position.quantity,
+                combined_quantity,
                 &position.position_currency,
             );
             let position_cost_basis =
@@ -1137,6 +1150,22 @@ impl BrokerSyncService {
                 if snapshot.snapshot_date == snapshot_date
                     && snapshot.source == SnapshotSource::ManualEntry
         )
+    }
+
+    /// Sum position quantities per resolved asset. Used so the cost-basis fallback can compare
+    /// the latest snapshot against the combined position rather than an individual split row
+    /// (brokers may report one holding as several rows — e.g. margin vs. cash sub-account).
+    fn combined_quantities_by_asset(
+        position_data: &[HoldingsPositionData],
+        spec_key_to_asset_id: &HashMap<String, String>,
+    ) -> HashMap<String, Decimal> {
+        let mut totals: HashMap<String, Decimal> = HashMap::new();
+        for position in position_data {
+            if let Some(asset_id) = spec_key_to_asset_id.get(&position.spec_key) {
+                *totals.entry(asset_id.clone()).or_insert(Decimal::ZERO) += position.quantity;
+            }
+        }
+        totals
     }
 
     fn resolve_position_average_cost(
@@ -1842,5 +1871,56 @@ mod tests {
         assert_eq!(a_then_b.quantity, b_then_a.quantity);
         assert_eq!(a_then_b.total_cost_basis, b_then_a.total_cost_basis);
         assert_eq!(a_then_b.average_cost, b_then_a.average_cost);
+    }
+
+    #[test]
+    fn combined_quantities_by_asset_sums_split_rows() {
+        let row = |spec_key: &str, quantity: &str| super::HoldingsPositionData {
+            spec_key: spec_key.to_string(),
+            quantity: decimal(quantity),
+            quote_price: decimal("100"),
+            quote_currency: "USD".to_string(),
+            average_cost: None,
+            position_currency: "USD".to_string(),
+        };
+        let position_data = vec![
+            row("EQUITY:VTI", "32.005"),
+            row("EQUITY:VTI", "18.423"),
+            row("EQUITY:VXUS", "10"),
+        ];
+        let mut spec_key_to_asset_id = HashMap::new();
+        spec_key_to_asset_id.insert("EQUITY:VTI".to_string(), "asset-vti".to_string());
+        spec_key_to_asset_id.insert("EQUITY:VXUS".to_string(), "asset-vxus".to_string());
+
+        let totals =
+            BrokerSyncService::combined_quantities_by_asset(&position_data, &spec_key_to_asset_id);
+
+        assert_eq!(totals.get("asset-vti").copied(), Some(decimal("50.428")));
+        assert_eq!(totals.get("asset-vxus").copied(), Some(decimal("10")));
+    }
+
+    #[test]
+    fn resolve_position_average_cost_reuses_prior_cost_for_combined_split_quantity() {
+        // Broker omits cost and splits the holding into two rows. Resolving against the COMBINED
+        // quantity (50.428) — not a single 32.005 row — matches the prior snapshot and preserves
+        // its average cost instead of zeroing it (the regression Codex flagged).
+        let latest = position("acc-1", "vti", "50.428", "300", "15128.4", "USD");
+
+        let combined = BrokerSyncService::resolve_position_average_cost(
+            None,
+            Some(&latest),
+            decimal("50.428"),
+            "USD",
+        );
+        let single_row = BrokerSyncService::resolve_position_average_cost(
+            None,
+            Some(&latest),
+            decimal("32.005"),
+            "USD",
+        );
+
+        assert_eq!(combined, decimal("300"));
+        // The pre-fix per-row path compared 32.005 against 50.428 and lost the known basis.
+        assert_eq!(single_row, Decimal::ZERO);
     }
 }


### PR DESCRIPTION
## Problem

Some brokerages — notably **Fidelity via SnapTrade** — report a separate position row **per lot type** (a margin lot and a cash/non-margin lot) for the *same* instrument. Every row resolves to the same `asset_id`, but `build_holdings_snapshot` stored positions with:

```rust
positions_map.insert(asset_id, position); // overwrites earlier lots
```

So each later lot **overwrote** the previous one, keeping only the last. The account total then showed **roughly half** the real value.

## Fix

Merge same-asset lots instead of overwriting — sum quantities and cost basis, and recompute a **quantity-weighted average cost**. The merge is idempotent, so already-deduplicated input is unchanged. This makes the snapshot builder robust to any broker that reports multiple lots per instrument (margin/cash sub-accounts, separate tax lots, etc.).

## Tests

Adds unit tests covering:
- weighted-average cost across two lots,
- the real Fidelity VTI case,
- order independence,
- a net-flat (long fully offset by short) **divide-by-zero guard**.