### PR TITLE
Holdings & performance UI: Realized P&L, Book cost, metric tooltip fixes

### DIFF
--- a/apps/frontend/src/components/metric-display.tsx
+++ b/apps/frontend/src/components/metric-display.tsx
@@ -198,18 +198,42 @@ export interface MetricLabelWithInfoProps {
   label: string;
   infoText: string;
   warningText?: string | string[];
+  /** Substrings (e.g. account names) to render in bold within each warning. */
+  boldTerms?: string[];
   className?: string;
+}
+
+/** Render a warning string, bolding any occurrences of the provided terms. */
+function renderWarningText(text: string, boldTerms: string[]): React.ReactNode {
+  const terms = boldTerms.filter(Boolean).sort((a, b) => b.length - a.length);
+  if (terms.length === 0) return text;
+  const escaped = terms.map((term) => term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+  const parts = text.split(new RegExp(`(${escaped.join("|")})`, "g"));
+  return parts.map((part, index) =>
+    terms.includes(part) ? (
+      <strong key={index} className="text-foreground font-semibold">
+        {part}
+      </strong>
+    ) : (
+      part
+    ),
+  );
 }
 
 export const MetricLabelWithInfo: React.FC<MetricLabelWithInfoProps> = ({
   label,
   infoText,
   warningText,
+  boldTerms = [],
   className,
 }) => {
-  const warningItems = (Array.isArray(warningText) ? warningText : warningText ? [warningText] : [])
-    .map((warning) => warning.trim())
-    .filter(Boolean);
+  const warningItems = Array.from(
+    new Set(
+      (Array.isArray(warningText) ? warningText : warningText ? [warningText] : [])
+        .map((warning) => warning.trim())
+        .filter(Boolean),
+    ),
+  );
   const hasWarnings = warningItems.length > 0;
 
   return (
@@ -235,14 +259,33 @@ export const MetricLabelWithInfo: React.FC<MetricLabelWithInfoProps> = ({
             </span>
           </Button>
         </PopoverTrigger>
-        <PopoverContent className="w-72 text-xs" side="top" align="center">
-          <div className="space-y-2">
-            <p>{infoText}</p>
+        <PopoverContent
+          className="w-[40rem] max-w-[calc(100vw-2rem)] p-0 text-sm"
+          side="top"
+          align="center"
+        >
+          <div className="space-y-3 p-5">
+            <p className="text-muted-foreground leading-relaxed">{infoText}</p>
             {hasWarnings && (
-              <div className="border-warning/30 text-warning space-y-1 border-t pt-2">
-                {warningItems.map((warning, index) => (
-                  <p key={`${warning}-${index}`}>{warning}</p>
-                ))}
+              <div className="space-y-2 border-t pt-3">
+                <div className="text-warning flex items-center gap-1.5 font-medium">
+                  <Icons.AlertTriangle className="h-4 w-4 shrink-0" />
+                  <span>
+                    {warningItems.length === 1
+                      ? "Calculation note"
+                      : `Calculation notes (${warningItems.length})`}
+                  </span>
+                </div>
+                <ul className="text-muted-foreground max-h-[60vh] space-y-2 overflow-y-auto pr-1 leading-relaxed">
+                  {warningItems.map((warning, index) => (
+                    <li key={`${warning}-${index}`} className="flex gap-1.5">
+                      <span className="bg-warning/70 mt-1.5 h-1 w-1 shrink-0 rounded-full" />
+                      <span className="min-w-0 break-words">
+                        {renderWarningText(warning, boldTerms)}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
               </div>
             )}
           </div>

--- a/apps/frontend/src/pages/holdings/components/holdings-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table.tsx
@@ -584,7 +584,11 @@ const getColumns = (
       return (
         <div className="flex min-h-[40px] flex-col items-end justify-center px-4">
           <AmountDisplay value={value} currency={currency} colorFormat={true} isHidden={isHidden} />
-          <GainPercent className="text-xs" value={holding.realizedGainPct || 0} />
+          {holding.realizedGainPct == null ? (
+            <span className="text-muted-foreground text-xs">-</span>
+          ) : (
+            <GainPercent className="text-xs" value={holding.realizedGainPct} />
+          )}
         </div>
       );
     },

--- a/apps/frontend/src/pages/holdings/components/holdings-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table.tsx
@@ -1,3 +1,7 @@
+import { parseOccSymbol } from "@/lib/occ-symbol";
+import { safeDivide } from "@/lib/utils";
+import type { ColumnDef } from "@tanstack/react-table";
+import { Badge, GainPercent } from "@wealthfolio/ui";
 import { Button } from "@wealthfolio/ui/components/ui/button";
 import { DataTable } from "@wealthfolio/ui/components/ui/data-table";
 import { DataTableColumnHeader } from "@wealthfolio/ui/components/ui/data-table/data-table-column-header";
@@ -8,19 +12,15 @@ import {
   DropdownMenuTrigger,
 } from "@wealthfolio/ui/components/ui/dropdown-menu";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
-import { parseOccSymbol } from "@/lib/occ-symbol";
-import { safeDivide } from "@/lib/utils";
-import type { ColumnDef } from "@tanstack/react-table";
-import { GainPercent, Badge } from "@wealthfolio/ui";
 
 import { TickerAvatar } from "@/components/ticker-avatar";
-import { Skeleton } from "@wealthfolio/ui/components/ui/skeleton";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@wealthfolio/ui/components/ui/tooltip";
 import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
 import { HoldingType } from "@/lib/constants";
 import { useSettingsContext } from "@/lib/settings-provider";
 import { Holding } from "@/lib/types";
 import { AmountDisplay, QuantityDisplay, formatPercent } from "@wealthfolio/ui";
+import { Skeleton } from "@wealthfolio/ui/components/ui/skeleton";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@wealthfolio/ui/components/ui/tooltip";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
@@ -136,6 +136,7 @@ export const HoldingsTable = ({
           bookValue: false,
           totalPnl: false,
           unrealizedPnl: false,
+          realizedPnl: false,
           income: false,
           dayPnl: false,
         }}
@@ -560,6 +561,36 @@ const getColumns = (
     sortingFn: (rowA, rowB) => {
       const valueA = rowA.original.unrealizedGain?.base ?? 0;
       const valueB = rowB.original.unrealizedGain?.base ?? 0;
+      return valueA - valueB;
+    },
+  },
+  {
+    id: "realizedPnl",
+    accessorFn: (row) => row.realizedGain?.base ?? 0,
+    enableHiding: true,
+    header: ({ column }) => (
+      <DataTableColumnHeader className="justify-end" column={column} title="Realized P&L" />
+    ),
+    meta: {
+      label: "Realized P&L",
+    },
+    cell: ({ row }) => {
+      const holding = row.original;
+      const value = showConvertedValues
+        ? (holding.realizedGain?.base ?? 0)
+        : (holding.realizedGain?.local ?? 0);
+      const currency = showConvertedValues ? holding.baseCurrency : holding.localCurrency;
+
+      return (
+        <div className="flex min-h-[40px] flex-col items-end justify-center px-4">
+          <AmountDisplay value={value} currency={currency} colorFormat={true} isHidden={isHidden} />
+          <GainPercent className="text-xs" value={holding.realizedGainPct || 0} />
+        </div>
+      );
+    },
+    sortingFn: (rowA, rowB) => {
+      const valueA = rowA.original.realizedGain?.base ?? 0;
+      const valueB = rowB.original.realizedGain?.base ?? 0;
       return valueA - valueB;
     },
   },

--- a/apps/frontend/src/pages/insights/overview/allocation-derivations.ts
+++ b/apps/frontend/src/pages/insights/overview/allocation-derivations.ts
@@ -39,13 +39,50 @@ export interface ValueStripData {
   cash: number;
   invested: number;
   investedPercent: number;
+  bookCost: number;
   holdingsCount: number;
   accountsCount: number;
   currencySplit: { currency: string; value: number; percentage: number }[];
   cashCurrencySplit: { currency: string; value: number; percentage: number }[];
+  bookCostCurrencySplit: { currency: string; value: number; percentage: number }[];
 }
 
 const num = (v: number | null | undefined): number => Number(v) || 0;
+
+/**
+ * Total cost basis of invested (non-cash) holdings, plus a per-currency breakdown
+ * (local value + base-weighted percentage) — mirrors the cash-by-currency split.
+ */
+export function computeBookCost(holdings: Holding[]): {
+  total: number;
+  currencySplit: { currency: string; value: number; percentage: number }[];
+} {
+  let total = 0;
+  const byCurrency = new Map<string, { localValue: number; baseValue: number }>();
+
+  for (const holding of holdings) {
+    if (isCash(holding)) continue;
+    const base = num(holding.costBasis?.base);
+    const local = holding.costBasis?.local != null ? num(holding.costBasis.local) : base;
+    const currency = holding.localCurrency || holding.baseCurrency;
+    total += base;
+    const existing = byCurrency.get(currency) ?? { localValue: 0, baseValue: 0 };
+    byCurrency.set(currency, {
+      localValue: existing.localValue + local,
+      baseValue: existing.baseValue + base,
+    });
+  }
+
+  const currencySplit = [...byCurrency.entries()]
+    .map(([currency, value]) => ({
+      currency,
+      value: value.localValue,
+      percentage: total > 0 ? (value.baseValue / total) * 100 : 0,
+    }))
+    .sort((a, b) => b.percentage - a.percentage);
+
+  return { total, currencySplit };
+}
 
 function currencySymbol(currency: string): string {
   try {
@@ -129,28 +166,41 @@ export function computeValueStrip(holdings: Holding[], accounts: Account[]): Val
   // Prefer in-scope accounts derived from holdings; fall back to the account list.
   const accountsCount = accountIds.size || accounts.length;
 
+  const bookCost = computeBookCost(holdings);
+
   return {
     total,
     cash,
     invested,
     investedPercent: total > 0 ? (invested / total) * 100 : 0,
+    bookCost: bookCost.total,
     holdingsCount: holdings.length,
     accountsCount,
     currencySplit,
     cashCurrencySplit,
+    bookCostCurrencySplit: bookCost.currencySplit,
   };
 }
 
-export function valueStripFromCurrentSummary(summary: CurrentValuationSummary): ValueStripData {
+/**
+ * Map a scoped current-valuation summary into value-strip data. The summary has no cost basis,
+ * so pass `holdings` to populate book cost; otherwise it falls back to 0.
+ */
+export function valueStripFromCurrentSummary(
+  summary: CurrentValuationSummary,
+  holdings: Holding[] = [],
+): ValueStripData {
   const total = num(summary.totalValueBase);
   const cash = num(summary.cashBalanceBase);
   const invested = num(summary.investmentMarketValueBase);
+  const bookCost = computeBookCost(holdings);
 
   return {
     total,
     cash,
     invested,
     investedPercent: total > 0 ? (invested / total) * 100 : 0,
+    bookCost: bookCost.total,
     holdingsCount: summary.holdingsCount,
     accountsCount: summary.accountCount,
     currencySplit: summary.currencySplit.map((split) => ({
@@ -163,6 +213,7 @@ export function valueStripFromCurrentSummary(summary: CurrentValuationSummary): 
       value: num(split.valueLocal ?? split.valueBase),
       percentage: split.percentage,
     })),
+    bookCostCurrencySplit: bookCost.currencySplit,
   };
 }
 

--- a/apps/frontend/src/pages/insights/overview/overview-page.tsx
+++ b/apps/frontend/src/pages/insights/overview/overview-page.tsx
@@ -145,7 +145,7 @@ export function OverviewPage({
   const valueStrip = useMemo(
     () =>
       currentValuation?.summary
-        ? valueStripFromCurrentSummary(currentValuation.summary)
+        ? valueStripFromCurrentSummary(currentValuation.summary, portfolioHoldings)
         : computeValueStrip(portfolioHoldings, accounts),
     [currentValuation?.summary, portfolioHoldings, accounts],
   );

--- a/apps/frontend/src/pages/insights/overview/value-strip.tsx
+++ b/apps/frontend/src/pages/insights/overview/value-strip.tsx
@@ -51,7 +51,7 @@ function CurrencyExposurePill({
   );
 }
 
-function CashCurrencyPill({
+function CurrencyValuePill({
   currency,
   value,
   color,
@@ -81,6 +81,7 @@ export function ValueStrip({ data, currency, isLoading, compact }: ValueStripPro
   const { isBalanceHidden } = useBalancePrivacy();
 
   const cashRatio = data.total > 0 ? data.cash / data.total : 0;
+  const bookCostRatio = data.total > 0 ? data.bookCost / data.total : 0;
   const pad = compact ? "px-3.5 py-2.5" : "p-5";
   const gap = compact ? "space-y-0.5" : "space-y-2";
   const totalSize = compact ? "text-[22px] leading-7" : "text-3xl";
@@ -96,8 +97,8 @@ export function ValueStrip({ data, currency, isLoading, compact }: ValueStripPro
             <Skeleton className="h-7 w-40" />
             <Skeleton className="h-3 w-36" />
           </div>
-          <div className="grid grid-cols-2 divide-x border-t">
-            {[0, 1].map((i) => (
+          <div className="grid grid-cols-3 divide-x border-t">
+            {[0, 1, 2].map((i) => (
               <div key={i} className="space-y-1.5 px-4 py-3.5">
                 <Skeleton className="h-2.5 w-20" />
                 <Skeleton className="h-4 w-24" />
@@ -106,8 +107,8 @@ export function ValueStrip({ data, currency, isLoading, compact }: ValueStripPro
             ))}
           </div>
         </Card>
-        <Card className="hidden grid-cols-1 divide-y overflow-hidden sm:grid sm:grid-cols-[2.25fr_1.35fr_1fr] sm:divide-x sm:divide-y-0">
-          {[0, 1, 2].map((i) => (
+        <Card className="hidden grid-cols-1 divide-y overflow-hidden sm:grid sm:grid-cols-[2.25fr_1.35fr_1fr_1fr] sm:divide-x sm:divide-y-0">
+          {[0, 1, 2, 3].map((i) => (
             <div key={i} className={cn(gap, pad)}>
               <Skeleton className="h-3 w-24" />
               <Skeleton className={compact ? "h-6 w-32" : "h-7 w-32"} />
@@ -132,7 +133,7 @@ export function ValueStrip({ data, currency, isLoading, compact }: ValueStripPro
           </div>
         </div>
 
-        <div className="grid grid-cols-2 divide-x border-t">
+        <div className="grid grid-cols-3 divide-x border-t">
           <div className="space-y-1.5 px-4 py-3.5">
             <MobileEyebrow>Cash balance</MobileEyebrow>
             <div className="text-foreground text-[15px] font-bold leading-5 tracking-tight">
@@ -156,10 +157,20 @@ export function ValueStrip({ data, currency, isLoading, compact }: ValueStripPro
               {formatPercent(data.investedPercent / 100)} of portfolio
             </div>
           </div>
+
+          <div className="space-y-1.5 px-4 py-3.5">
+            <MobileEyebrow>Book cost</MobileEyebrow>
+            <div className="text-foreground text-[15px] font-bold leading-5 tracking-tight">
+              <AmountDisplay value={data.bookCost} currency={currency} isHidden={isBalanceHidden} />
+            </div>
+            <div className="text-muted-foreground leading-3.5 text-[10px] tabular-nums">
+              {formatPercent(bookCostRatio)} of portfolio
+            </div>
+          </div>
         </div>
       </Card>
 
-      <Card className="hidden grid-cols-1 divide-y overflow-hidden sm:grid sm:grid-cols-[2.25fr_1.35fr_1fr] sm:divide-x sm:divide-y-0">
+      <Card className="hidden grid-cols-1 divide-y overflow-hidden sm:grid sm:grid-cols-[2.25fr_1.35fr_1fr_1fr] sm:divide-x sm:divide-y-0">
         {/* Portfolio value — hero cell with a slight top-to-center gradient wash */}
         <div className={cn(gap, pad, "from-muted/60 bg-gradient-to-b to-transparent to-[60%]")}>
           <Eyebrow>Portfolio value</Eyebrow>
@@ -193,7 +204,7 @@ export function ValueStrip({ data, currency, isLoading, compact }: ValueStripPro
           {data.cashCurrencySplit.length > 1 ? (
             <div className={cn("flex flex-wrap items-center gap-1.5", subSize)}>
               {data.cashCurrencySplit.slice(0, 4).map((c, index) => (
-                <CashCurrencyPill
+                <CurrencyValuePill
                   key={c.currency}
                   currency={c.currency}
                   value={c.value}
@@ -218,6 +229,31 @@ export function ValueStrip({ data, currency, isLoading, compact }: ValueStripPro
           <div className={cn("text-muted-foreground tabular-nums", subSize)}>
             {formatPercent(data.investedPercent / 100)} of portfolio
           </div>
+        </div>
+
+        {/* Book cost — total cost basis of invested (non-cash) holdings */}
+        <div className={cn(gap, pad)}>
+          <Eyebrow>Book cost</Eyebrow>
+          <div className={cn("text-foreground font-bold tabular-nums tracking-tight", secSize)}>
+            <AmountDisplay value={data.bookCost} currency={currency} isHidden={isBalanceHidden} />
+          </div>
+          {data.bookCostCurrencySplit.length > 1 ? (
+            <div className={cn("flex flex-wrap items-center gap-1.5", subSize)}>
+              {data.bookCostCurrencySplit.slice(0, 4).map((c, index) => (
+                <CurrencyValuePill
+                  key={c.currency}
+                  currency={c.currency}
+                  value={c.value}
+                  color={paletteColor(index)}
+                  isHidden={isBalanceHidden}
+                />
+              ))}
+            </div>
+          ) : (
+            <div className={cn("text-muted-foreground tabular-nums", subSize)}>
+              {formatPercent(bookCostRatio)} of portfolio
+            </div>
+          )}
         </div>
       </Card>
     </>

--- a/apps/frontend/src/pages/performance/performance-page.tsx
+++ b/apps/frontend/src/pages/performance/performance-page.tsx
@@ -22,7 +22,7 @@ import { AccountPurpose, PORTFOLIO_SCOPE_ID } from "@/lib/constants";
 import { performancePeriodPnl, performanceSummaryReturn } from "@/lib/performance";
 import { getPerformanceDateRangeForRequest } from "@/lib/performance-date-range";
 import { DateRange, PerformanceResult, TrackedItem } from "@/lib/types";
-import { cn } from "@/lib/utils";
+import { cn, formatAmount } from "@/lib/utils";
 import {
   AlertFeedback,
   Badge,
@@ -236,6 +236,24 @@ function firstNotApplicableReason(result: PerformanceResult): string | undefined
   return result.dataQuality.notApplicableReasons?.[0];
 }
 
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
+const DECIMAL_RE = /\d+\.\d+/g;
+
+/** Replace raw account UUIDs embedded in data-quality warnings with human-readable account names. */
+function humanizeAccountIds(text: string, namesById: Map<string, string>): string {
+  return text.replace(UUID_RE, (id) => namesById.get(id.toLowerCase()) ?? id);
+}
+
+/** Trim long raw decimals (e.g. "95.50000000") in warnings to readable amounts. */
+function formatWarningNumbers(text: string): string {
+  return text.replace(DECIMAL_RE, (value) => formatAmount(Number(value), "USD", false));
+}
+
+/** Make a data-quality warning user-facing: real account names + tidy numbers. */
+function presentWarning(text: string, namesById: Map<string, string>): string {
+  return formatWarningNumbers(humanizeAccountIds(text, namesById));
+}
+
 function MetricValue({
   value,
   className,
@@ -246,7 +264,7 @@ function MetricValue({
   tone?: "gain" | "neutral";
 }) {
   if (value == null) {
-    return <span className={cn("text-muted-foreground font-medium", className)}>N/A</span>;
+    return <span className={cn(className, "text-muted-foreground/50 font-normal")}>N/A</span>;
   }
 
   if (tone === "neutral") {
@@ -262,6 +280,7 @@ function HeaderMetric({
   label,
   infoText,
   warningText,
+  boldTerms,
   value,
   tone = "gain",
   align = "center",
@@ -271,6 +290,7 @@ function HeaderMetric({
   label: string;
   infoText: string;
   warningText?: string | string[];
+  boldTerms?: string[];
   value: number | null;
   tone?: "gain" | "neutral";
   align?: "left" | "center" | "right";
@@ -290,21 +310,23 @@ function HeaderMetric({
         label={label}
         infoText={infoText}
         warningText={warningText}
+        boldTerms={boldTerms}
         className={cn(
           align === "left" && "justify-start",
           align === "center" && "justify-center",
           align === "right" && "justify-end",
         )}
       />
-      <MetricValue
-        value={value}
-        tone={tone}
-        className={cn("text-base font-semibold", valueClassName)}
-      />
-      {reason && (
-        <span className="text-muted-foreground line-clamp-1 max-w-[12rem] text-[10px]">
+      {value == null && reason ? (
+        <span className="text-muted-foreground line-clamp-2 max-w-[12rem] text-xs leading-snug">
           {reason}
         </span>
+      ) : (
+        <MetricValue
+          value={value}
+          tone={tone}
+          className={cn("text-base font-semibold", valueClassName)}
+        />
       )}
     </div>
   );
@@ -820,6 +842,12 @@ export default function PerformancePage() {
     setSelectedItems,
   ]);
 
+  const accountNamesById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const account of accounts) map.set(account.id.toLowerCase(), account.name);
+    return map;
+  }, [accounts]);
+
   // Helper function to sort comparison items (accounts first, then symbols)
   const sortComparisonItems = (items: TrackedItem[]): TrackedItem[] => {
     return [...items].sort((a, b) => {
@@ -942,15 +970,18 @@ export default function PerformancePage() {
           }
         : metricPresentation(selectedMetric);
     const selectedMetricValue = displayMetricValue(found, selectedMetric);
-    const visibleWarnings = found.dataQuality.warnings ?? [];
+    const visibleWarnings = (found.dataQuality.warnings ?? []).map((warning) =>
+      presentWarning(warning, accountNamesById),
+    );
+    const rawReason = selectedMetricValue == null ? firstNotApplicableReason(found) : undefined;
     return {
       id: found.id,
       name: selectedPerformanceData.name,
       result: found,
       chartMetric: selectedMetric,
       selectedMetricValue,
-      selectedMetricReason:
-        selectedMetricValue == null ? firstNotApplicableReason(found) : undefined,
+      selectedMetricReason: rawReason ? presentWarning(rawReason, accountNamesById) : undefined,
+      warningTerms: Array.from(accountNamesById.values()),
       annualizedReturn: annualizedDisplayMetricValue(found, selectedMetric),
       volatility: metricValue(found, "volatility"),
       maxDrawdown: metricValue(found, "drawdown"),
@@ -962,7 +993,7 @@ export default function PerformancePage() {
       warnings: visibleWarnings,
       notApplicableReasons: found.dataQuality.notApplicableReasons ?? [],
     };
-  }, [selectedPerformanceData]);
+  }, [selectedPerformanceData, accountNamesById]);
 
   const preserveCurrentChartAnchor = (fallbackId: string) => {
     setSelectedItemId(
@@ -1260,6 +1291,7 @@ export default function PerformancePage() {
                                 label={selectedItemData?.mobileLabel ?? "Return"}
                                 infoText={selectedItemData?.infoText ?? SIMPLE_RETURN_INFO}
                                 warningText={selectedItemData?.returnWarnings}
+                                boldTerms={selectedItemData?.warningTerms}
                                 value={selectedItemData?.selectedMetricValue ?? null}
                                 reason={selectedItemData?.selectedMetricReason}
                                 align="left"
@@ -1320,7 +1352,7 @@ export default function PerformancePage() {
                     ) : (
                       <div
                         className={cn(
-                          "grid min-w-0 gap-4 rounded-lg p-2 backdrop-blur-sm sm:gap-5",
+                          "grid min-w-0 items-start gap-4 rounded-lg p-2 backdrop-blur-sm sm:gap-5",
                           selectedItemData?.periodPnl != null
                             ? "grid-cols-5 xl:min-w-[58rem]"
                             : "grid-cols-4 xl:min-w-[46rem]",
@@ -1330,6 +1362,7 @@ export default function PerformancePage() {
                           label={selectedItemData?.label ?? "Return"}
                           infoText={selectedItemData?.infoText ?? SIMPLE_RETURN_INFO}
                           warningText={selectedItemData?.returnWarnings}
+                          boldTerms={selectedItemData?.warningTerms}
                           value={selectedItemData?.selectedMetricValue ?? null}
                           reason={selectedItemData?.selectedMetricReason}
                           valueClassName="text-base"
@@ -1361,6 +1394,9 @@ export default function PerformancePage() {
                             dateRangeLabel={displayDateRange}
                             isMobile={isMobile}
                             valueClassName="text-base"
+                            // Offset the button's own py-1 so its label/value top-align with the
+                            // no-padding HeaderMetric siblings in this top-aligned grid row.
+                            className="-my-1"
                           />
                         )}
                       </div>


### PR DESCRIPTION
## Summary

Three independent UI improvements across the holdings, overview, and performance pages. Each is a separate commit.

### 1. Realized P&L column (holdings table)
Adds a **Realized P&L** column sourced from `holding.realizedGain`, hidden by default and toggleable like the other P&L columns — mirroring the existing Unrealized P&L column.

### 2. Book cost (overview value strip)
Adds a **Book cost** cell after Invested showing total cost basis of non-cash holdings, with a per-currency pill breakdown that mirrors the Cash balance cell. Computed via a new `computeBookCost()`; the scoped-summary path receives holdings to populate it since the summary carries no cost basis.

### 3. Performance header metric & warning tooltip
- **Warning popover redesign**: de-duplicates repeated notes, structured layout with a labeled "Calculation notes" section, scrollable (`max-h-[60vh]`), wider, with word-breaking for long values.
- **Readable warnings**: raw account UUIDs replaced with account names (bolded); embedded decimals tidied via `formatAmount`.
- **N/A state**: when a metric is unavailable but has a reason, the reason message shows in place of "N/A"; the plain N/A state is de-emphasized.
- **Alignment fix**: Period Gain/Loss now top-aligns with the other header metrics (was vertically centered when the row grew taller).

## Verification
- `prettier --check` clean on all changed files
- `eslint` — 0 errors (pre-existing warnings in holdings-table.tsx only)
- `tsc --noEmit` passes
- `allocation-derivations` unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)