### PR TITLE
Fix activity import date validation

### DIFF
--- a/apps/frontend/src/lib/utils.ts
+++ b/apps/frontend/src/lib/utils.ts
@@ -50,6 +50,8 @@ export function tryParseDate(dateStr: string): Date | null {
     // North American Banking Formats
     "MMM dd yyyy", // "MAY 01 2024" - Common in North American banks
     "MMMM dd yyyy", // "MAY 01 2024" (full month)
+    "MMM-dd-yyyy", // "MAY-01-2024" - Month name with separators
+    "MMMM-dd-yyyy", // "MAY-01-2024" (full month)
     "MM/dd/yyyy", // "05/01/2024" - US Standard
     "M/d/yyyy", // "5/1/2024" - US Relaxed
 

--- a/apps/frontend/src/pages/activity/import/utils/parse-date-value.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/parse-date-value.test.ts
@@ -65,3 +65,10 @@ describe("parseDateValue — 12-hour AM/PM (issue #984)", () => {
     expect({ y: r.y, mo: r.mo, day: r.day }).toEqual({ y: 2026, mo: 5, day: 4 });
   });
 });
+
+describe("parseDateValue — month-name dates", () => {
+  it("auto-detects month-name dates with hyphens", () => {
+    const r = local(parseDateValue("May-19-2023", "auto"));
+    expect({ y: r.y, mo: r.mo, day: r.day }).toEqual({ y: 2023, mo: 5, day: 19 });
+  });
+});

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -4679,7 +4679,7 @@ impl ActivityServiceTrait for ActivityService {
 
         // ── 3.5: Lightweight pre-insert validation (no asset/FX resolution) ───
         // Catches rows that slipped through the review step without proper resolution.
-        // date errors → "symbol" to match frontend field-keying convention.
+        // Use the review-grid field key so invalid dates highlight the date cell.
         let mut has_validation_errors = false;
         for (_, activity) in import_activities_indexed.iter_mut() {
             let has_symbol = !activity.symbol.trim().is_empty();
@@ -4701,7 +4701,7 @@ impl ActivityServiceTrait for ActivityService {
                 activity.is_valid = false;
                 Self::add_activity_error(
                     activity,
-                    "symbol",
+                    "activityDate",
                     &format!("Invalid date '{}'.", activity.date),
                 );
                 has_validation_errors = true;

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -7297,7 +7297,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_import_prepare_errors_are_keyed_under_symbol_field() {
+    async fn test_import_prepare_date_errors_are_keyed_under_activity_date_field() {
         let account_service = Arc::new(MockAccountService::new());
         let asset_service = Arc::new(MockAssetService::new());
         let fx_service = Arc::new(MockFxService::new());
@@ -7363,8 +7363,8 @@ mod tests {
             .errors
             .as_ref()
             .expect("expected prepare errors");
-        assert!(errors.contains_key("symbol"));
-        assert!(!errors.contains_key("VWRPL"));
+        assert!(errors.contains_key("activityDate"));
+        assert!(!errors.contains_key("symbol"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes activity CSV imports where month-name dates such as `Nov-02-2023` could appear valid in review but fail at the final import step.

Closes #1193

## Root Cause

The frontend review grid could display these date strings because browser date parsing accepted them, but the import draft parser did not normalize `MMM-dd-yyyy` values before sending them to the backend. The backend final import validation only accepts RFC3339 or `YYYY-MM-DD`, so those rows failed late. The backend also attached final invalid-date errors to the `symbol` field key, which highlighted the Symbol cell instead of the Date cell.

## Changes

- Add auto-detection for `MMM-dd-yyyy` and `MMMM-dd-yyyy` date formats.
- Add parser regression coverage for `May-19-2023`.
- Key final import invalid-date errors as `activityDate` so the review grid highlights the Date cell.
- Update the Rust regression test for the corrected field key.

## Validation

- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test test_import_prepare_date_errors_are_keyed_under_activity_date_field`
- `pnpm --filter frontend exec vitest run src/pages/activity/import/utils/parse-date-value.test.ts --environment node --pool threads`
- `pnpm --filter frontend type-check`