### PR TITLE
Fix signed short lot review findings

### DIFF
--- a/apps/frontend/src/pages/activity/components/forms/buy-form.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/buy-form.tsx
@@ -546,6 +546,7 @@ export function BuyForm({
               assetCurrency={assetCurrencyFromSymbol ?? normalizeCurrency(assetCurrency)}
               accountCurrency={accountCurrency}
               baseCurrency={baseCurrency}
+              showSubtype={false}
             />
 
             {/* Notes */}

--- a/apps/frontend/src/pages/activity/components/forms/fields/stock-trade-intent-selector.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/fields/stock-trade-intent-selector.tsx
@@ -44,7 +44,7 @@ export function StockTradeIntentSelector<TFieldValues extends FieldValues = Fiel
   const selectedValue = field.value === shortValue ? shortValue : NORMAL;
 
   return (
-    <div className={cn("space-y-2", className)}>
+    <div role="group" aria-label="Trade Type" className={cn("space-y-2", className)}>
       <span className="text-sm font-medium">Trade Type</span>
       <AnimatedToggleGroup
         value={selectedValue}

--- a/apps/frontend/src/pages/activity/components/forms/sell-form.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/sell-form.tsx
@@ -621,6 +621,7 @@ export function SellForm({
               assetCurrency={assetCurrencyFromSymbol ?? normalizeCurrency(assetCurrency)}
               accountCurrency={accountCurrency}
               baseCurrency={baseCurrency}
+              showSubtype={false}
             />
 
             {/* Notes */}

--- a/apps/frontend/src/pages/activity/import/utils/draft-utils.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/draft-utils.test.ts
@@ -278,6 +278,44 @@ describe("createDraftActivities explicit activity mapping", () => {
     expect(drafts[1].subtype).toBe(ACTIVITY_SUBTYPES.POSITION_CLOSE);
   });
 
+  it("preserves raw stock short intent when mapped subtype column is blank", () => {
+    const drafts = createDraftActivities(
+      [
+        ["2024-03-15", "SELL_SHORT", "AAPL", "1", "200", "USD", ""],
+        ["2024-03-16", "BUY_TO_COVER", "AAPL", "1", "180", "USD", "   "],
+      ],
+      [
+        ImportFormat.DATE,
+        ImportFormat.ACTIVITY_TYPE,
+        ImportFormat.SYMBOL,
+        ImportFormat.QUANTITY,
+        ImportFormat.UNIT_PRICE,
+        ImportFormat.CURRENCY,
+        ImportFormat.SUBTYPE,
+      ],
+      {
+        ...baseMapping,
+        fieldMappings: {
+          [ImportFormat.DATE]: ImportFormat.DATE,
+          [ImportFormat.ACTIVITY_TYPE]: ImportFormat.ACTIVITY_TYPE,
+          [ImportFormat.SYMBOL]: ImportFormat.SYMBOL,
+          [ImportFormat.QUANTITY]: ImportFormat.QUANTITY,
+          [ImportFormat.UNIT_PRICE]: ImportFormat.UNIT_PRICE,
+          [ImportFormat.CURRENCY]: ImportFormat.CURRENCY,
+          [ImportFormat.SUBTYPE]: ImportFormat.SUBTYPE,
+        },
+      },
+      parseConfig,
+      "account-1",
+    );
+
+    expect(drafts).toHaveLength(2);
+    expect(drafts[0].activityType).toBe(ActivityType.SELL);
+    expect(drafts[0].subtype).toBe(ACTIVITY_SUBTYPES.POSITION_OPEN);
+    expect(drafts[1].activityType).toBe(ActivityType.BUY);
+    expect(drafts[1].subtype).toBe(ACTIVITY_SUBTYPES.POSITION_CLOSE);
+  });
+
   it("infers Wealthsimple FxExchange transfer direction from signed amount", () => {
     const drafts = createDraftActivities(
       [

--- a/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
@@ -642,7 +642,8 @@ export function createDraftActivities(
       ? normalizeSignAwareActivityLabel(rawType)
       : undefined;
     const rawTypePositionIntentSubtype = rawTypePositionIntentType ? rawType : undefined;
-    const normalizedSubtype = rawSubtype?.trim() ?? rawTypePositionIntentSubtype ?? signedFxSubtype;
+    const trimmedRawSubtype = rawSubtype?.trim();
+    const normalizedSubtype = trimmedRawSubtype || rawTypePositionIntentSubtype || signedFxSubtype;
     const inferredCreditSubtype =
       activityType === ActivityType.CREDIT &&
       (REIMBURSEMENT_LABELS.has(normalizeSignAwareActivityLabel(rawType)) ||

--- a/crates/core/src/portfolio/snapshot/holdings_calculator/handlers/transfers.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator/handlers/transfers.rs
@@ -455,18 +455,24 @@ impl HoldingsCalculator {
                 // Positions are single-signed (transfer-in nets opposite-sign
                 // lots), so dispatching on the net position sign relieves the
                 // correct leg.
-                let reduction = if position.quantity.is_sign_negative() {
+                let transferred_short_position = position.quantity.is_sign_negative();
+                let reduction = if transferred_short_position {
                     position.reduce_negative_lots_fifo(activity.qty())?
                 } else {
                     position.reduce_lots_fifo(activity.qty())?
                 };
                 let cost_basis_removed = reduction.cost_basis_removed;
+                let disposal_proceeds = if transferred_short_position {
+                    cost_basis_removed.abs()
+                } else {
+                    cost_basis_removed
+                };
                 self.record_reduction(
                     &state.account_id,
                     asset_id,
                     activity,
                     &reduction,
-                    cost_basis_removed,
+                    disposal_proceeds,
                     &position_currency,
                     run,
                     buffer,

--- a/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
@@ -7305,6 +7305,27 @@ mod tests {
         let pos_a_after = result_a_xfer.snapshot.positions.get(option_symbol);
         assert!(pos_a_after.is_none_or(|position| position.quantity == Decimal::ZERO));
 
+        let transfer_disposals = calculator.take_lot_disposals("acc_a", "FIFO");
+        assert_eq!(transfer_disposals.len(), 1);
+        let transfer_disposal = &transfer_disposals[0];
+        assert_eq!(transfer_disposal.disposal_activity_id, "xfer_out_short_opt");
+        assert_eq!(
+            Decimal::from_str(&transfer_disposal.quantity).unwrap(),
+            dec!(-2)
+        );
+        assert_eq!(
+            Decimal::from_str(&transfer_disposal.proceeds).unwrap(),
+            dec!(-400)
+        );
+        assert_eq!(
+            Decimal::from_str(&transfer_disposal.cost_basis).unwrap(),
+            dec!(-400)
+        );
+        assert_eq!(
+            Decimal::from_str(&transfer_disposal.realized_pnl).unwrap(),
+            Decimal::ZERO
+        );
+
         let prev_b = create_initial_snapshot("acc_b", "USD", "2025-05-31");
         let transfer_in = create_transfer_activity(
             "xfer_in_short_opt",
@@ -7759,6 +7780,30 @@ mod tests {
             .unwrap();
         let pos_a_after = result_a_xfer.snapshot.positions.get("AAPL");
         assert!(pos_a_after.is_none_or(|position| position.quantity == Decimal::ZERO));
+
+        let transfer_disposals = calculator.take_lot_disposals("acc_a", "FIFO");
+        assert_eq!(transfer_disposals.len(), 1);
+        let transfer_disposal = &transfer_disposals[0];
+        assert_eq!(
+            transfer_disposal.disposal_activity_id,
+            "xfer_out_short_stock"
+        );
+        assert_eq!(
+            Decimal::from_str(&transfer_disposal.quantity).unwrap(),
+            dec!(-4)
+        );
+        assert_eq!(
+            Decimal::from_str(&transfer_disposal.proceeds).unwrap(),
+            dec!(-400)
+        );
+        assert_eq!(
+            Decimal::from_str(&transfer_disposal.cost_basis).unwrap(),
+            dec!(-400)
+        );
+        assert_eq!(
+            Decimal::from_str(&transfer_disposal.realized_pnl).unwrap(),
+            Decimal::ZERO
+        );
 
         let prev_b = create_initial_snapshot("acc_b", "USD", "2026-06-26");
         let transfer_in = create_transfer_activity(

--- a/e2e/02-activities.spec.ts
+++ b/e2e/02-activities.spec.ts
@@ -1,11 +1,10 @@
 import { expect, Page, test } from "@playwright/test";
-import { gotoActivities } from "./helpers";
+import { completeOnboardingIfNeeded, gotoActivities } from "./helpers";
 
 test.describe.configure({ mode: "serial" });
 
 test.describe("Activity Creation Tests", () => {
   const BASE_URL = process.env.WF_E2E_BASE_URL || "http://localhost:1420";
-  const TEST_PASSWORD = "password001";
   let page: Page;
 
   // Test data for activities
@@ -430,24 +429,7 @@ test.describe("Activity Creation Tests", () => {
   test("1. Setup: Login and navigate to app", async () => {
     test.setTimeout(180000);
 
-    await page.goto(BASE_URL, { waitUntil: "domcontentloaded" });
-
-    // Handle login if needed - check for login page or any authenticated page
-    const loginInput = page.getByPlaceholder("Enter your password");
-    const accountsHeading = page.getByRole("heading", { name: "Accounts" });
-    const dashboardHeading = page.getByRole("heading", { name: "Dashboard" });
-
-    // Wait for any of: login page, dashboard, or accounts page (where 01-happy-path ends)
-    await expect(loginInput.or(dashboardHeading).or(accountsHeading)).toBeVisible({
-      timeout: 120000,
-    });
-
-    if (await loginInput.isVisible()) {
-      await loginInput.fill(TEST_PASSWORD);
-      await page.getByRole("button", { name: "Sign In", exact: true }).click();
-      // After login, wait for either dashboard or accounts page
-      await expect(dashboardHeading.or(accountsHeading)).toBeVisible({ timeout: 15000 });
-    }
+    await completeOnboardingIfNeeded(page);
 
     // Navigate to dashboard to confirm app is ready
     await page.goto(`${BASE_URL}/dashboard`, { waitUntil: "domcontentloaded" });


### PR DESCRIPTION
## Summary

Fixes the review findings around signed short lot behavior and affected activity import/form flows.

## Changes

- Preserve raw `SELL_SHORT` / `BUY_TO_COVER` intent during CSV import when the mapped subtype column is blank.
- Keep buy/sell advanced subtype selects hidden so stock trade intent controls remain the source of truth.
- Record short transfer-out lot disposals with matching signed proceeds and cost basis, avoiding fake realized P/L.
- Add the accessible `Trade Type` group expected by the stock-short E2E workflow.
- Reuse the shared onboarding helper in the activity E2E setup so the spec reaches the activity workflows reliably.

## Validation

- `pnpm format:check`
- `cargo fmt --check`
- `pnpm lint` (passes with existing warnings)
- `pnpm --filter frontend type-check`
- `cargo test -p wealthfolio-core holdings_calculator_tests --lib`
- `cargo check -p wealthfolio-core`
- `pnpm --filter frontend exec vitest run --environment node src/lib/activity-utils.test.ts src/pages/activity/import/utils/draft-utils.test.ts`
- `node scripts/run-e2e.mjs e2e/14-stock-short-workflow.spec.ts` using bundled Node 24
- `node scripts/run-e2e.mjs e2e/02-activities.spec.ts e2e/04-csv-import.spec.ts` using bundled Node 24