### PR TITLE
Fix standalone tax charge handling

### DIFF
--- a/crates/core/src/activities/activities_model.rs
+++ b/crates/core/src/activities/activities_model.rs
@@ -222,6 +222,19 @@ impl Activity {
         self.tax.unwrap_or(Decimal::ZERO).abs()
     }
 
+    /// Get the charge amount for standalone charge handling.
+    pub(crate) fn charge_amt_for(&self, activity_type: &ActivityType) -> Decimal {
+        if matches!(activity_type, ActivityType::Tax) && !self.tax_amt().is_zero() {
+            return self.tax_amt();
+        }
+
+        if !self.fee_amt().is_zero() {
+            return self.fee_amt();
+        }
+
+        self.amt()
+    }
+
     /// Get typed metadata value
     pub fn get_meta<T: serde::de::DeserializeOwned>(&self, key: &str) -> Option<T> {
         self.metadata

--- a/crates/core/src/portfolio/performance/performance_service.rs
+++ b/crates/core/src/portfolio/performance/performance_service.rs
@@ -2166,7 +2166,7 @@ impl PerformanceService {
             }
             ActivityType::Fee => (
                 Decimal::ZERO,
-                Self::activity_charge_amount(activity),
+                Self::activity_charge_amount(activity, activity_type),
                 Decimal::ZERO,
             ),
             ActivityType::Buy | ActivityType::Sell => {
@@ -2175,18 +2175,22 @@ impl PerformanceService {
             ActivityType::Tax => (
                 Decimal::ZERO,
                 Decimal::ZERO,
-                Self::activity_charge_amount(activity),
+                Self::activity_charge_amount(activity, activity_type),
             ),
             _ => (Decimal::ZERO, Decimal::ZERO, Decimal::ZERO),
         }
     }
 
-    fn activity_charge_amount(activity: &Activity) -> Decimal {
-        if activity.fee_amt().is_zero() {
-            activity.amt()
-        } else {
-            activity.fee_amt()
+    fn activity_charge_amount(activity: &Activity, activity_type: &ActivityType) -> Decimal {
+        if matches!(activity_type, ActivityType::Tax) && !activity.tax_amt().is_zero() {
+            return activity.tax_amt();
         }
+
+        if !activity.fee_amt().is_zero() {
+            return activity.fee_amt();
+        }
+
+        activity.amt()
     }
 
     fn attribution_unit_multiplier(activity: &Activity) -> Decimal {
@@ -7835,6 +7839,13 @@ mod tests {
         assert_eq!(
             PerformanceService::activity_attribution_components(&tax, &ActivityType::Tax),
             (Decimal::ZERO, Decimal::ZERO, dec!(7))
+        );
+
+        let mut explicit_tax = activity_fixture(ActivityType::Tax, Decimal::ZERO, Decimal::ZERO);
+        explicit_tax.tax = Some(dec!(9));
+        assert_eq!(
+            PerformanceService::activity_attribution_components(&explicit_tax, &ActivityType::Tax),
+            (Decimal::ZERO, Decimal::ZERO, dec!(9))
         );
 
         let buy = activity_fixture(ActivityType::Buy, dec!(100), dec!(1));

--- a/crates/core/src/portfolio/performance/performance_service.rs
+++ b/crates/core/src/portfolio/performance/performance_service.rs
@@ -2166,7 +2166,7 @@ impl PerformanceService {
             }
             ActivityType::Fee => (
                 Decimal::ZERO,
-                Self::activity_charge_amount(activity, activity_type),
+                activity.charge_amt_for(activity_type),
                 Decimal::ZERO,
             ),
             ActivityType::Buy | ActivityType::Sell => {
@@ -2175,22 +2175,10 @@ impl PerformanceService {
             ActivityType::Tax => (
                 Decimal::ZERO,
                 Decimal::ZERO,
-                Self::activity_charge_amount(activity, activity_type),
+                activity.charge_amt_for(activity_type),
             ),
             _ => (Decimal::ZERO, Decimal::ZERO, Decimal::ZERO),
         }
-    }
-
-    fn activity_charge_amount(activity: &Activity, activity_type: &ActivityType) -> Decimal {
-        if matches!(activity_type, ActivityType::Tax) && !activity.tax_amt().is_zero() {
-            return activity.tax_amt();
-        }
-
-        if !activity.fee_amt().is_zero() {
-            return activity.fee_amt();
-        }
-
-        activity.amt()
     }
 
     fn attribution_unit_multiplier(activity: &Activity) -> Decimal {

--- a/crates/core/src/portfolio/snapshot/holdings_calculator/economics.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator/economics.rs
@@ -56,7 +56,7 @@ fn should_use_activity_amount(activity: &Activity, asset_info: &AssetPositionInf
         return false;
     }
 
-    let activity_type = ActivityType::from_str(&activity.activity_type);
+    let activity_type = ActivityType::from_str(activity.effective_type());
     let has_qty = activity.quantity.is_some_and(|qty| !qty.is_zero());
     let has_unit_price = activity.unit_price.is_some_and(|price| !price.is_zero());
     let is_buy_or_sell = matches!(activity_type, Ok(ActivityType::Buy | ActivityType::Sell));

--- a/crates/core/src/portfolio/snapshot/holdings_calculator/handlers/cash_flows.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator/handlers/cash_flows.rs
@@ -188,18 +188,18 @@ impl HoldingsCalculator {
     ) -> Result<()> {
         let activity_currency = &activity.currency;
 
-        // Determine charge amount: prefer fee field, fall back to amount
-        let charge = if activity.fee_amt() != Decimal::ZERO {
-            activity.fee_amt()
-        } else {
-            activity.amt()
-        };
+        let charge = Self::activity_charge_amount(activity, activity_type);
 
         if charge == Decimal::ZERO {
+            let expected_fields = match activity_type {
+                ActivityType::Tax => "'tax', 'fee', and 'amount'",
+                _ => "'fee' and 'amount'",
+            };
             warn!(
-                "Activity {} ({}): 'fee' and 'amount' are both zero. No cash change.",
+                "Activity {} ({}): {} are zero. No cash change.",
                 activity.id,
-                activity_type.as_str()
+                activity_type.as_str(),
+                expected_fields
             );
             return Ok(());
         }
@@ -209,5 +209,17 @@ impl HoldingsCalculator {
 
         // Charges do not affect net_contribution
         Ok(())
+    }
+
+    fn activity_charge_amount(activity: &Activity, activity_type: &ActivityType) -> Decimal {
+        if matches!(activity_type, ActivityType::Tax) && !activity.tax_amt().is_zero() {
+            return activity.tax_amt();
+        }
+
+        if !activity.fee_amt().is_zero() {
+            return activity.fee_amt();
+        }
+
+        activity.amt()
     }
 }

--- a/crates/core/src/portfolio/snapshot/holdings_calculator/handlers/cash_flows.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator/handlers/cash_flows.rs
@@ -188,7 +188,7 @@ impl HoldingsCalculator {
     ) -> Result<()> {
         let activity_currency = &activity.currency;
 
-        let charge = Self::activity_charge_amount(activity, activity_type);
+        let charge = activity.charge_amt_for(activity_type);
 
         if charge == Decimal::ZERO {
             let expected_fields = match activity_type {
@@ -209,17 +209,5 @@ impl HoldingsCalculator {
 
         // Charges do not affect net_contribution
         Ok(())
-    }
-
-    fn activity_charge_amount(activity: &Activity, activity_type: &ActivityType) -> Decimal {
-        if matches!(activity_type, ActivityType::Tax) && !activity.tax_amt().is_zero() {
-            return activity.tax_amt();
-        }
-
-        if !activity.fee_amt().is_zero() {
-            return activity.fee_amt();
-        }
-
-        activity.amt()
     }
 }

--- a/crates/core/src/portfolio/snapshot/holdings_calculator/mod.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator/mod.rs
@@ -351,7 +351,7 @@ impl HoldingsCalculator {
                 warnings.push(warning);
                 continue;
             }
-            let activity_type = ActivityType::from_str(&activity.activity_type).ok();
+            let activity_type = ActivityType::from_str(activity.effective_type()).ok();
             let requires_atomic_scratch = activity_type
                 .as_ref()
                 .is_some_and(Self::activity_requires_atomic_scratch);
@@ -456,8 +456,8 @@ impl HoldingsCalculator {
         run: &ProjectionRun,
         buffer: &mut SideEffectBuffer,
     ) -> Result<()> {
-        let activity_type = ActivityType::from_str(&activity.activity_type).map_err(|_| {
-            CalculatorError::UnsupportedActivityType(activity.activity_type.clone())
+        let activity_type = ActivityType::from_str(activity.effective_type()).map_err(|_| {
+            CalculatorError::UnsupportedActivityType(activity.effective_type().to_string())
         })?;
 
         // Dispatch to Specific Handlers

--- a/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
@@ -2146,6 +2146,55 @@ mod tests {
     }
 
     #[test]
+    fn test_tax_activity_uses_tax_field_for_charge() {
+        let mock_fx_service = MockFxService::new();
+        let target_date_str = "2023-01-07";
+        let target_date = NaiveDate::from_str(target_date_str).unwrap();
+        let account_currency = "CAD";
+
+        let base_currency = Arc::new(RwLock::new(account_currency.to_string()));
+        let mut calculator = create_calculator(Arc::new(mock_fx_service), base_currency);
+
+        let mut previous_snapshot =
+            create_initial_snapshot("acc_tax_field", account_currency, "2023-01-06");
+        previous_snapshot
+            .cash_balances
+            .insert(account_currency.to_string(), dec!(1000));
+        previous_snapshot.net_contribution = dec!(500);
+        previous_snapshot.net_contribution_base = dec!(500);
+
+        let mut tax_activity = create_cash_activity(
+            "act_tax_field_1",
+            ActivityType::Tax,
+            Decimal::ZERO,
+            Decimal::ZERO,
+            account_currency,
+            target_date_str,
+        );
+        tax_activity.amount = None;
+        tax_activity.tax = Some(dec!(42));
+
+        let result = calculator.calculate_next_holdings(
+            &previous_snapshot,
+            std::slice::from_ref(&tax_activity),
+            target_date,
+        );
+        assert!(result.is_ok(), "Calculation failed: {:?}", result.err());
+        let next_state = result.unwrap().snapshot;
+
+        assert_eq!(
+            next_state.cash_balances.get(account_currency),
+            Some(&dec!(958))
+        );
+        assert_eq!(next_state.cash_total_account_currency, dec!(958));
+        assert_eq!(
+            next_state.net_contribution,
+            previous_snapshot.net_contribution
+        );
+        assert!(next_state.positions.is_empty());
+    }
+
+    #[test]
     fn test_add_and_remove_holding_activities() {
         let mut mock_fx_service = MockFxService::new();
         let target_date_add_str = "2023-01-08";

--- a/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
@@ -2195,6 +2195,56 @@ mod tests {
     }
 
     #[test]
+    fn test_tax_activity_override_uses_effective_type_for_charge() {
+        let mock_fx_service = MockFxService::new();
+        let target_date_str = "2023-01-07";
+        let target_date = NaiveDate::from_str(target_date_str).unwrap();
+        let account_currency = "CAD";
+
+        let base_currency = Arc::new(RwLock::new(account_currency.to_string()));
+        let mut calculator = create_calculator(Arc::new(mock_fx_service), base_currency);
+
+        let mut previous_snapshot =
+            create_initial_snapshot("acc_tax_override", account_currency, "2023-01-06");
+        previous_snapshot
+            .cash_balances
+            .insert(account_currency.to_string(), dec!(1000));
+        previous_snapshot.net_contribution = dec!(500);
+        previous_snapshot.net_contribution_base = dec!(500);
+
+        let mut tax_activity = create_cash_activity(
+            "act_tax_override_1",
+            ActivityType::Fee,
+            Decimal::ZERO,
+            Decimal::ZERO,
+            account_currency,
+            target_date_str,
+        );
+        tax_activity.amount = None;
+        tax_activity.tax = Some(dec!(42));
+        tax_activity.activity_type_override = Some(ActivityType::Tax.as_str().to_string());
+
+        let result = calculator.calculate_next_holdings(
+            &previous_snapshot,
+            std::slice::from_ref(&tax_activity),
+            target_date,
+        );
+        assert!(result.is_ok(), "Calculation failed: {:?}", result.err());
+        let next_state = result.unwrap().snapshot;
+
+        assert_eq!(
+            next_state.cash_balances.get(account_currency),
+            Some(&dec!(958))
+        );
+        assert_eq!(next_state.cash_total_account_currency, dec!(958));
+        assert_eq!(
+            next_state.net_contribution,
+            previous_snapshot.net_contribution
+        );
+        assert!(next_state.positions.is_empty());
+    }
+
+    #[test]
     fn test_add_and_remove_holding_activities() {
         let mut mock_fx_service = MockFxService::new();
         let target_date_add_str = "2023-01-08";


### PR DESCRIPTION
## Summary

- Make standalone `TAX` activities read `tax` as the primary charge amount, with existing fallbacks to `fee` and `amount` preserved.
- Apply the same type-aware charge resolution to performance attribution so tax-only activities no longer persist without attribution impact.
- Add regression coverage for cash balance impact and attribution components.

## Root Cause

PR #1198 added a `tax` field to create/API surfaces, but standalone `TAX` charge handling still resolved charges from `fee` or `amount` only. A tax-only activity could therefore persist `tax` while producing no cash or performance tax effect.

## Validation

- `cargo fmt`
- `cargo check -p wealthfolio-core`
- `cargo clippy -p wealthfolio-core --all-targets -- -D warnings`
- `cargo test -p wealthfolio-core test_tax_activity_uses_tax_field_for_charge -- --nocapture`
- `cargo test -p wealthfolio-core activity_attribution_components_separate_income_fees_and_taxes -- --nocapture`
- `cargo test -p wealthfolio-core test_charge_activities_fee_and_tax -- --nocapture`
- `git diff --check`