### PR TITLE
test(storage): cover account activity cascade on delete

### DIFF
--- a/crates/storage-sqlite/src/db/mod.rs
+++ b/crates/storage-sqlite/src/db/mod.rs
@@ -176,6 +176,59 @@ mod migration_tests {
     }
 
     #[test]
+    fn migrated_activities_cascade_when_account_is_deleted() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("cascade.db").to_string_lossy().to_string();
+        run_migrations(&db_path).unwrap();
+
+        let mut conn = SqliteConnection::establish(&db_path).unwrap();
+        conn.batch_execute(
+            "
+            PRAGMA foreign_keys = ON;
+
+            INSERT INTO accounts (
+                id, name, account_type, `group`, currency, is_default, is_active,
+                created_at, updated_at, platform_id, account_number, meta, provider,
+                provider_account_id, is_archived, tracking_mode
+            ) VALUES (
+                'account-to-delete', 'Test', 'REGULAR', NULL, 'USD', 0, 1,
+                '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z', NULL, NULL, NULL,
+                NULL, NULL, 0, 'TRANSACTIONS'
+            );
+
+            INSERT INTO assets (
+                id, kind, name, display_code, is_active, quote_mode, quote_ccy,
+                created_at, updated_at
+            ) VALUES (
+                'asset-with-activity', 'INVESTMENT', 'Asset', 'ASSET', 1, 'MANUAL', 'USD',
+                '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'
+            );
+
+            INSERT INTO activities (
+                id, account_id, asset_id, activity_type, status, activity_date,
+                quantity, unit_price, amount, fee, currency, is_user_modified,
+                needs_review, created_at, updated_at
+            ) VALUES (
+                'activity-to-cascade', 'account-to-delete', 'asset-with-activity', 'BUY',
+                'POSTED', '2026-01-01T00:00:00Z', '1', '10', '10', '0', 'USD',
+                0, 0, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z'
+            );
+
+            DELETE FROM accounts WHERE id = 'account-to-delete';
+            ",
+        )
+        .unwrap();
+
+        assert_eq!(
+            count(
+                &mut conn,
+                "SELECT COUNT(*) AS count FROM activities WHERE id = 'activity-to-cascade'"
+            ),
+            0
+        );
+    }
+
+    #[test]
     fn lot_disposals_migration_clears_generated_data() {
         let mut conn = SqliteConnection::establish(":memory:").unwrap();
         conn.batch_execute(


### PR DESCRIPTION
## Description

Adds focused regression coverage for the account-deletion cascade behind #515.

The test migrates a fresh SQLite database, inserts an account, security, and activity, deletes the account with foreign keys enabled, and asserts the activity row is removed. This locks in the current migrated schema behavior so activities cannot linger and later block security deletion.

Notes:
- Current `main` already restores the `activities.account_id -> accounts.id ON DELETE CASCADE` relationship in the v2 asset-model migration.
- This PR is intentionally test-only: no production behavior changes, just regression coverage for the reported failure mode.

Refs #515

## Validation

- `cargo fmt --check`
- `cargo test -p wealthfolio-storage-sqlite migrated_activities_cascade_when_account_is_deleted -- --nocapture`
- `cargo check -p wealthfolio-storage-sqlite`
- `git diff --check`

## Second-agent review

- Preferred reviewer: `claude -p` attempted, but local Claude CLI returned 401 authentication failure.
- Fallback reviewer: `hermes chat -Q`
- Result: CLEAN. No blocking correctness, regression, security, duplicate/superseded-work, or maintainer-fit issues found.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
