### PR TITLE
Fix CSV import currency resolution

### DIFF
--- a/apps/frontend/src/pages/activity/import/components/import-review-grid.tsx
+++ b/apps/frontend/src/pages/activity/import/components/import-review-grid.tsx
@@ -628,6 +628,7 @@ export function ImportReviewGrid({
       onDraftUpdate(rowIndex, {
         symbol: canonicalSymbol,
         currency,
+        currencySource: result.currency ? "resolved" : draft.currencySource,
         exchangeMic: canonicalExchangeMic,
         quoteCcy: result.currency ?? draft.quoteCcy,
         instrumentType: result.quoteType,
@@ -664,6 +665,7 @@ export function ImportReviewGrid({
       onDraftUpdate(rowIndex, {
         symbol: canonicalSymbol,
         currency,
+        currencySource: result.currency ? "resolved" : draft.currencySource,
         exchangeMic: canonicalExchangeMic,
         quoteCcy: result.currency ?? draft.quoteCcy,
         instrumentType: result.quoteType,

--- a/apps/frontend/src/pages/activity/import/context/import-context.tsx
+++ b/apps/frontend/src/pages/activity/import/context/import-context.tsx
@@ -40,6 +40,7 @@ export interface ParseConfig {
 }
 
 export type DraftActivityStatus = "valid" | "warning" | "error" | "skipped" | "duplicate";
+export type DraftCurrencySource = "csv" | "default" | "manual" | "resolved";
 
 export interface DraftActivity {
   rowIndex: number;
@@ -54,6 +55,7 @@ export interface DraftActivity {
   unitPrice?: string | null;
   amount?: string | null;
   currency: string;
+  currencySource?: DraftCurrencySource;
   fee?: string | null;
   tax?: string | null;
   accountId: string;
@@ -262,6 +264,17 @@ function coerceStepForOrder(current: ImportStep, nextOrder: ImportStep[]): Impor
 // ─────────────────────────────────────────────────────────────────────────────
 
 function importReducer(state: ImportState, action: ImportAction): ImportState {
+  const applyUserDraftUpdates = (
+    draft: DraftActivity,
+    updates: Partial<DraftActivity>,
+  ): DraftActivity => {
+    const normalizedUpdates =
+      "currency" in updates && !("currencySource" in updates)
+        ? { ...updates, currencySource: "manual" as const }
+        : updates;
+    return { ...draft, ...normalizedUpdates, isEdited: true };
+  };
+
   const updatesAffectAssetPreview = (updates: Partial<DraftActivity>) =>
     [
       "activityType",
@@ -320,7 +333,7 @@ function importReducer(state: ImportState, action: ImportAction): ImportState {
       return {
         ...state,
         draftActivities: state.draftActivities.map((draft) =>
-          draft.rowIndex === rowIndex ? { ...draft, ...updates, isEdited: true } : draft,
+          draft.rowIndex === rowIndex ? applyUserDraftUpdates(draft, updates) : draft,
         ),
         ...(shouldClearAssetPreview
           ? {
@@ -341,7 +354,7 @@ function importReducer(state: ImportState, action: ImportAction): ImportState {
       return {
         ...state,
         draftActivities: state.draftActivities.map((draft) =>
-          indexSet.has(draft.rowIndex) ? { ...draft, ...updates, isEdited: true } : draft,
+          indexSet.has(draft.rowIndex) ? applyUserDraftUpdates(draft, updates) : draft,
         ),
         ...(shouldClearAssetPreview
           ? {
@@ -537,8 +550,6 @@ export function ImportProvider({ children, initialAccountId }: ImportProviderPro
   // "Latest ref" pattern — keeps validateDrafts stable while reading current values
   const accountIdRef = useRef(state.accountId);
   accountIdRef.current = state.accountId;
-  const defaultCurrencyRef = useRef(state.parseConfig.defaultCurrency);
-  defaultCurrencyRef.current = state.parseConfig.defaultCurrency;
   const draftRevisionRef = useRef(state.draftRevision);
   draftRevisionRef.current = state.draftRevision;
 
@@ -569,7 +580,7 @@ export function ImportProvider({ children, initialAccountId }: ImportProviderPro
                 quantity: draft.quantity,
                 unitPrice: draft.unitPrice,
                 amount: draft.amount,
-                currency: draft.currency || defaultCurrencyRef.current || "",
+                currency: draft.currencySource === "default" ? "" : draft.currency || "",
                 fee: draft.fee,
                 tax: draft.tax,
                 isDraft: true,
@@ -644,6 +655,12 @@ export function ImportProvider({ children, initialAccountId }: ImportProviderPro
               symbolName: backendResult.symbolName,
               exchangeMic: backendResult.exchangeMic,
               quoteCcy: backendResult.quoteCcy,
+              currency: backendResult.currency || draft.currency,
+              currencySource: backendResult.currency
+                ? draft.currencySource === "csv" || draft.currencySource === "manual"
+                  ? draft.currencySource
+                  : "resolved"
+                : draft.currencySource,
               instrumentType: backendResult.instrumentType,
               providerId: backendResult.providerId,
               providerSymbol: backendResult.providerSymbol,

--- a/apps/frontend/src/pages/activity/import/utils/asset-review-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/asset-review-utils.ts
@@ -21,12 +21,17 @@ export function applyAssetResolution(
     if (row.assetCandidateKey !== key && buildImportAssetCandidateKeyFromDraft(row) !== key) {
       return row;
     }
+    const resolvedCurrency =
+      row.currencySource === "default" && draft.quoteCcy ? draft.quoteCcy : row.currency;
     return {
       ...row,
       symbol: draft.instrumentSymbol || draft.displayCode || row.symbol,
       symbolName: draft.name || row.symbolName,
       exchangeMic: draft.instrumentExchangeMic || undefined,
       quoteCcy: draft.quoteCcy || row.quoteCcy,
+      currency: resolvedCurrency,
+      currencySource:
+        row.currencySource === "default" && draft.quoteCcy ? "resolved" : row.currencySource,
       instrumentType: draft.instrumentType || row.instrumentType,
       quoteMode: draft.quoteMode || row.quoteMode,
       providerId: draft.providerId,

--- a/apps/frontend/src/pages/activity/import/utils/draft-utils.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/draft-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import { ACTIVITY_SUBTYPES, AccountType, ActivityType, ImportFormat } from "@/lib/constants";
 import { createDraftActivities, draftToActivityImport } from "./draft-utils";
 import { getActivityImportProfileForAccountType } from "./activity-import-profile";
+import { applyAssetResolution } from "./asset-review-utils";
 
 const headers = [
   ImportFormat.DATE,
@@ -48,6 +49,121 @@ function createSingleDraftWithMapping(row: string[], activityMappings: Record<st
 }
 
 describe("createDraftActivities explicit activity mapping", () => {
+  it("uses the resolved asset currency for security rows when the CSV has no currency column", () => {
+    const [draft] = createDraftActivities(
+      [["2026-06-30", "BUY", "KWEB", "10", "28.50", "285.00", "0"]],
+      [
+        ImportFormat.DATE,
+        ImportFormat.ACTIVITY_TYPE,
+        ImportFormat.SYMBOL,
+        ImportFormat.QUANTITY,
+        ImportFormat.UNIT_PRICE,
+        ImportFormat.AMOUNT,
+        ImportFormat.FEE,
+      ],
+      {
+        ...baseMapping,
+        fieldMappings: {
+          [ImportFormat.DATE]: ImportFormat.DATE,
+          [ImportFormat.ACTIVITY_TYPE]: ImportFormat.ACTIVITY_TYPE,
+          [ImportFormat.SYMBOL]: ImportFormat.SYMBOL,
+          [ImportFormat.QUANTITY]: ImportFormat.QUANTITY,
+          [ImportFormat.UNIT_PRICE]: ImportFormat.UNIT_PRICE,
+          [ImportFormat.AMOUNT]: ImportFormat.AMOUNT,
+          [ImportFormat.FEE]: ImportFormat.FEE,
+        },
+        activityMappings: {
+          [ActivityType.BUY]: ["BUY"],
+        },
+      },
+      { ...parseConfig, defaultCurrency: "CAD" },
+      "account-1",
+    );
+
+    expect(draft.currency).toBe("CAD");
+    expect(draft.currencySource).toBe("default");
+
+    const [resolved] = applyAssetResolution(
+      [draft],
+      draft.assetCandidateKey ?? "",
+      {
+        kind: "INVESTMENT",
+        name: "KraneShares CSI China Internet ETF",
+        displayCode: "KWEB",
+        isActive: true,
+        quoteMode: "MARKET",
+        quoteCcy: "USD",
+        instrumentType: "EQUITY",
+        instrumentSymbol: "KWEB",
+        instrumentExchangeMic: "ARCX",
+      },
+      { importAssetKey: draft.assetCandidateKey },
+    );
+
+    expect(resolved.currency).toBe("USD");
+    expect(resolved.currencySource).toBe("resolved");
+    expect(draftToActivityImport(resolved).currency).toBe("USD");
+  });
+
+  it("preserves an explicit CSV currency even when the resolved asset quote currency differs", () => {
+    const [draft] = createDraftActivities(
+      [["2026-06-30", "BUY", "KWEB", "10", "28.50", "285.00", "0", "CAD"]],
+      [
+        ImportFormat.DATE,
+        ImportFormat.ACTIVITY_TYPE,
+        ImportFormat.SYMBOL,
+        ImportFormat.QUANTITY,
+        ImportFormat.UNIT_PRICE,
+        ImportFormat.AMOUNT,
+        ImportFormat.FEE,
+        ImportFormat.CURRENCY,
+      ],
+      {
+        ...baseMapping,
+        fieldMappings: {
+          [ImportFormat.DATE]: ImportFormat.DATE,
+          [ImportFormat.ACTIVITY_TYPE]: ImportFormat.ACTIVITY_TYPE,
+          [ImportFormat.SYMBOL]: ImportFormat.SYMBOL,
+          [ImportFormat.QUANTITY]: ImportFormat.QUANTITY,
+          [ImportFormat.UNIT_PRICE]: ImportFormat.UNIT_PRICE,
+          [ImportFormat.AMOUNT]: ImportFormat.AMOUNT,
+          [ImportFormat.FEE]: ImportFormat.FEE,
+          [ImportFormat.CURRENCY]: ImportFormat.CURRENCY,
+        },
+        activityMappings: {
+          [ActivityType.BUY]: ["BUY"],
+        },
+      },
+      { ...parseConfig, defaultCurrency: "CAD" },
+      "account-1",
+    );
+
+    expect(draft.currency).toBe("CAD");
+    expect(draft.currencySource).toBe("csv");
+
+    const [resolved] = applyAssetResolution(
+      [draft],
+      draft.assetCandidateKey ?? "",
+      {
+        kind: "INVESTMENT",
+        name: "KraneShares CSI China Internet ETF",
+        displayCode: "KWEB",
+        isActive: true,
+        quoteMode: "MARKET",
+        quoteCcy: "USD",
+        instrumentType: "EQUITY",
+        instrumentSymbol: "KWEB",
+        instrumentExchangeMic: "ARCX",
+      },
+      { importAssetKey: draft.assetCandidateKey },
+    );
+
+    expect(resolved.currency).toBe("CAD");
+    expect(resolved.currencySource).toBe("csv");
+    expect(resolved.quoteCcy).toBe("USD");
+    expect(draftToActivityImport(resolved).currency).toBe("CAD");
+  });
+
   it("carries provider config from symbol mapping into the final import payload", () => {
     const [draft] = createDraftActivities(
       [["2024-03-15", "BUY", "SHOP.TO", "1", "100", "CAD"]],

--- a/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
@@ -635,7 +635,9 @@ export function createDraftActivities(
     const quantity = parseNumericValue(rawQuantity, decimalSeparator, thousandsSeparator);
     const unitPrice = parseNumericValue(rawUnitPrice, decimalSeparator, thousandsSeparator);
     let amount = parseNumericValue(rawAmount, decimalSeparator, thousandsSeparator);
-    const currency = rawCurrency?.trim() || defaultCurrency;
+    const rawCurrencyValue = rawCurrency?.trim();
+    const currency = rawCurrencyValue || defaultCurrency;
+    const currencySource = rawCurrencyValue ? "csv" : "default";
     const fee = parseNumericValue(rawFee, decimalSeparator, thousandsSeparator);
     let tax = parseNumericValue(rawTax, decimalSeparator, thousandsSeparator);
     const comment = rawComment?.trim();
@@ -724,6 +726,7 @@ export function createDraftActivities(
       unitPrice,
       amount: resolved.amount,
       currency,
+      currencySource,
       fee,
       tax,
       fxRate,

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -5282,6 +5282,156 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_check_import_uses_existing_asset_currency_when_import_currency_is_missing() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let account = create_test_account("acc-1", "CAD");
+        account_service.add_account(account);
+
+        let asset = create_test_asset_with_instrument(
+            "kweb-uuid",
+            "KWEB",
+            Some("ARCX"),
+            Some(InstrumentType::Equity),
+            "USD",
+        );
+        asset_service.add_asset(asset);
+
+        let quote_service = Arc::new(MockQuoteService);
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            quote_service,
+        );
+
+        let import = ActivityImport {
+            id: None,
+            date: "2026-06-30".to_string(),
+            symbol: "KWEB".to_string(),
+            activity_type: "BUY".to_string(),
+            quantity: Some(dec!(10)),
+            unit_price: Some(dec!(28.50)),
+            currency: String::new(),
+            fee: Some(dec!(0)),
+            tax: None,
+            amount: Some(dec!(285)),
+            comment: None,
+            account_id: Some("acc-1".to_string()),
+            account_name: None,
+            symbol_name: None,
+            exchange_mic: Some("ARCX".to_string()),
+            quote_ccy: None,
+            instrument_type: None,
+            quote_mode: None,
+            provider_id: None,
+            provider_symbol: None,
+            errors: None,
+            warnings: None,
+            duplicate_of_id: None,
+            duplicate_of_line_number: None,
+            is_draft: false,
+            is_valid: true,
+            line_number: Some(1),
+            fx_rate: None,
+            subtype: None,
+            asset_id: None,
+            isin: None,
+            force_import: false,
+            is_external: None,
+        };
+
+        let result = activity_service
+            .check_activities_import(vec![import])
+            .await
+            .expect("import check should succeed");
+
+        let checked = &result[0];
+        assert_eq!(checked.asset_id.as_deref(), Some("kweb-uuid"));
+        assert_eq!(checked.currency, "USD");
+        assert_eq!(checked.quote_ccy.as_deref(), Some("USD"));
+    }
+
+    #[tokio::test]
+    async fn test_check_import_preserves_explicit_import_currency_for_existing_asset() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let account = create_test_account("acc-1", "CAD");
+        account_service.add_account(account);
+
+        let asset = create_test_asset_with_instrument(
+            "kweb-uuid",
+            "KWEB",
+            Some("ARCX"),
+            Some(InstrumentType::Equity),
+            "USD",
+        );
+        asset_service.add_asset(asset);
+
+        let quote_service = Arc::new(MockQuoteService);
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            quote_service,
+        );
+
+        let import = ActivityImport {
+            id: None,
+            date: "2026-06-30".to_string(),
+            symbol: "KWEB".to_string(),
+            activity_type: "BUY".to_string(),
+            quantity: Some(dec!(10)),
+            unit_price: Some(dec!(28.50)),
+            currency: "CAD".to_string(),
+            fee: Some(dec!(0)),
+            tax: None,
+            amount: Some(dec!(285)),
+            comment: None,
+            account_id: Some("acc-1".to_string()),
+            account_name: None,
+            symbol_name: None,
+            exchange_mic: Some("ARCX".to_string()),
+            quote_ccy: None,
+            instrument_type: None,
+            quote_mode: None,
+            provider_id: None,
+            provider_symbol: None,
+            errors: None,
+            warnings: None,
+            duplicate_of_id: None,
+            duplicate_of_line_number: None,
+            is_draft: false,
+            is_valid: true,
+            line_number: Some(1),
+            fx_rate: None,
+            subtype: None,
+            asset_id: None,
+            isin: None,
+            force_import: false,
+            is_external: None,
+        };
+
+        let result = activity_service
+            .check_activities_import(vec![import])
+            .await
+            .expect("import check should succeed");
+
+        let checked = &result[0];
+        assert_eq!(checked.asset_id.as_deref(), Some("kweb-uuid"));
+        assert_eq!(checked.currency, "CAD");
+        assert_eq!(checked.quote_ccy.as_deref(), Some("USD"));
+    }
+
+    #[tokio::test]
     async fn test_check_import_does_not_resolve_reviewed_assets_again() {
         let account_service = Arc::new(MockAccountService::new());
         let asset_service = Arc::new(MockAssetService::new());

--- a/e2e/15-csv-import-currency-resolution.spec.ts
+++ b/e2e/15-csv-import-currency-resolution.spec.ts
@@ -1,0 +1,144 @@
+import { expect, Page, test } from "@playwright/test";
+import path from "path";
+import { fileURLToPath } from "url";
+import { BASE_URL, createAccount, loginIfNeeded } from "./helpers";
+
+test.describe.configure({ mode: "serial" });
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURES = path.join(__dirname, "fixtures");
+const KWEB_NO_CURRENCY_CSV = path.join(FIXTURES, "cad-account-usd-symbol-import.csv");
+
+const IMPORT_ACCOUNT = "Currency Resolution Import Account";
+
+async function selectImportAccount(page: Page, accountName: string) {
+  const selectorTrigger = page.getByRole("combobox", { name: /Select an account/i });
+  await expect(selectorTrigger).toBeVisible({ timeout: 5000 });
+  await selectorTrigger.click();
+  await page.waitForTimeout(300);
+
+  const searchInput = page.getByPlaceholder("Search accounts...");
+  await searchInput.fill(accountName);
+  await page.waitForTimeout(300);
+
+  const accountOption = page.getByRole("option", { name: new RegExp(accountName, "i") }).first();
+  await expect(accountOption).toBeVisible({ timeout: 5000 });
+  await accountOption.click();
+  await page.waitForTimeout(300);
+}
+
+async function searchImportedKwebActivity(page: Page) {
+  return page.evaluate(async () => {
+    const response = await fetch("/api/v1/activities/search", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "same-origin",
+      body: JSON.stringify({
+        page: 0,
+        pageSize: 10,
+        assetIdKeyword: "KWEB",
+        sort: { id: "date", desc: true },
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Activity search failed: ${response.status} ${response.statusText}`);
+    }
+
+    const payload = (await response.json()) as {
+      data: Array<{
+        accountName: string;
+        accountCurrency: string;
+        assetSymbol: string;
+        currency: string;
+        unitPrice: string | null;
+        amount: string | null;
+      }>;
+    };
+
+    return payload.data.find(
+      (activity) =>
+        activity.accountName === "Currency Resolution Import Account" &&
+        activity.assetSymbol === "KWEB",
+    );
+  });
+}
+
+test.describe("CSV import currency resolution", () => {
+  let page: Page;
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage();
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test("imports USD-quoted KWEB into a CAD account without mixing activity currency", async () => {
+    test.setTimeout(180000);
+
+    await loginIfNeeded(page);
+    await createAccount(page, IMPORT_ACCOUNT, "CAD", "Transactions");
+
+    await page.goto(`${BASE_URL}/import`, { waitUntil: "domcontentloaded" });
+    await expect(page.getByRole("heading", { name: /Import Activities/i })).toBeVisible({
+      timeout: 10000,
+    });
+
+    await selectImportAccount(page, IMPORT_ACCOUNT);
+
+    const fileInput = page.locator('input[type="file"]');
+    await fileInput.setInputFiles(KWEB_NO_CURRENCY_CSV);
+
+    await expect(page.getByText("CSV Preview")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/1 row/i)).toBeVisible({ timeout: 5000 });
+
+    await page.getByRole("button", { name: /Configure Mapping/i }).click();
+    await page.waitForTimeout(1000);
+
+    await page.getByRole("button", { name: /Review Assets/i }).click();
+
+    const assetRow = page.getByTestId("asset-review-row").filter({ hasText: "KWEB" }).first();
+    await expect(assetRow).toContainText("KraneShares CSI China Internet ETF", {
+      timeout: 60000,
+    });
+    await expect(assetRow).toContainText("USD");
+
+    const reviewActivitiesBtn = page.getByRole("button", { name: /Review Activities/i });
+    await expect(reviewActivitiesBtn).toBeEnabled({ timeout: 60000 });
+    await reviewActivitiesBtn.click();
+
+    const reviewGrid = page.getByRole("grid", { name: "Data grid" });
+    await expect(
+      reviewGrid.locator('[data-slot="grid-cell"][data-column-id="symbol"]'),
+    ).toContainText("KWEB", { timeout: 30000 });
+    await expect(
+      reviewGrid.locator('[data-slot="grid-cell"][data-column-id="currency"]'),
+    ).toContainText("USD", { timeout: 30000 });
+
+    const continueToImportBtn = page.getByRole("button", { name: /Continue to Import/i });
+    await expect(continueToImportBtn).toBeEnabled({ timeout: 30000 });
+    await continueToImportBtn.click();
+
+    await expect(page.getByText("To Import", { exact: true }).first()).toBeVisible({
+      timeout: 10000,
+    });
+
+    const importBtn = page.getByRole("button", { name: /Import \d+ Activit/i });
+    await expect(importBtn).toBeEnabled({ timeout: 10000 });
+    await importBtn.click();
+
+    await expect(page.getByText("Import Complete")).toBeVisible({ timeout: 60000 });
+
+    const imported = await searchImportedKwebActivity(page);
+    expect(imported).toMatchObject({
+      accountName: IMPORT_ACCOUNT,
+      accountCurrency: "CAD",
+      assetSymbol: "KWEB",
+      currency: "USD",
+      unitPrice: "28.50",
+      amount: "285.00",
+    });
+  });
+});

--- a/e2e/fixtures/cad-account-usd-symbol-import.csv
+++ b/e2e/fixtures/cad-account-usd-symbol-import.csv
@@ -1,0 +1,2 @@
+date,type,symbol,quantity,unit_price,amount,fee
+2026-06-30,BUY,KWEB,10,28.50,285.00,0

--- a/e2e/fixtures/quotes/instruments.json
+++ b/e2e/fixtures/quotes/instruments.json
@@ -436,6 +436,22 @@
       "country": "United States"
     },
     {
+      "symbol": "KWEB",
+      "name": "KraneShares CSI China Internet ETF",
+      "provider": "YAHOO",
+      "assetType": "ETF",
+      "currency": "USD",
+      "exchange": "PCX",
+      "exchangeMic": "ARCX",
+      "exchangeName": "NYSE Arca",
+      "basePrice": 28.5,
+      "baseVolume": 3500000,
+      "seed": 133,
+      "sector": "Global",
+      "industry": "Exchange Traded Fund",
+      "country": "United States"
+    },
+    {
       "symbol": "4GLD.DE",
       "aliases": ["4GLD"],
       "name": "Xetra-Gold",


### PR DESCRIPTION
## Summary
- Track whether an imported activity currency came from CSV input, account defaults, manual edits, or asset resolution.
- Resolve defaulted security-row currencies from the matched asset quote currency instead of persisting the account currency.
- Add frontend, core, and e2e coverage for importing USD-quoted KWEB into a CAD account from a CSV with no currency column.

## Root Cause
CSV rows without a currency column were initialized with the selected account currency, so backend validation treated that value as explicit user input. For a CAD account importing a USD-quoted security such as KWEB, the activity stayed CAD even though the resolved asset quote currency was USD.

## Validation
- `pnpm format:check`
- `cargo fmt --all -- --check`
- `pnpm lint`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `pnpm test:e2e -- e2e/15-csv-import-currency-resolution.spec.ts`
- Targeted frontend/Rust import currency tests from the implementation pass


## Related
- Refs discussion #1199: https://github.com/wealthfolio/wealthfolio/discussions/1199
