### PR TITLE
Fix import currency precedence

### DIFF
--- a/apps/frontend/src/pages/activity/import/context/import-context.tsx
+++ b/apps/frontend/src/pages/activity/import/context/import-context.tsx
@@ -645,6 +645,11 @@ export function ImportProvider({ children, initialAccountId }: ImportProviderPro
                       ? "warning"
                       : "valid";
 
+            const backendCurrency = backendResult.currency || undefined;
+            const shouldMarkCurrencyResolved =
+              Boolean(backendCurrency) &&
+              (draft.currencySource !== "default" || backendCurrency !== draft.currency);
+
             return {
               ...draft,
               assetId: backendResult.assetId,
@@ -655,11 +660,13 @@ export function ImportProvider({ children, initialAccountId }: ImportProviderPro
               symbolName: backendResult.symbolName,
               exchangeMic: backendResult.exchangeMic,
               quoteCcy: backendResult.quoteCcy,
-              currency: backendResult.currency || draft.currency,
-              currencySource: backendResult.currency
+              currency: backendCurrency || draft.currency,
+              currencySource: backendCurrency
                 ? draft.currencySource === "csv" || draft.currencySource === "manual"
                   ? draft.currencySource
-                  : "resolved"
+                  : shouldMarkCurrencyResolved
+                    ? "resolved"
+                    : draft.currencySource
                 : draft.currencySource,
               instrumentType: backendResult.instrumentType,
               providerId: backendResult.providerId,

--- a/apps/frontend/src/pages/activity/import/utils/asset-review-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/asset-review-utils.ts
@@ -1,6 +1,7 @@
 import { isCashSymbol, needsImportAssetResolution } from "@/lib/activity-utils";
 import { quoteModeFromSearchResult } from "@/lib/asset-utils";
 import { ActivityType } from "@/lib/constants";
+import { getQuoteUnitCurrency } from "@wealthfolio/ui/lib/currencies";
 import type {
   ImportAssetCandidate,
   ImportAssetPreviewItem,
@@ -21,8 +22,8 @@ export function applyAssetResolution(
     if (row.assetCandidateKey !== key && buildImportAssetCandidateKeyFromDraft(row) !== key) {
       return row;
     }
-    const resolvedCurrency =
-      row.currencySource === "default" && draft.quoteCcy ? draft.quoteCcy : row.currency;
+    const resolvedDefaultCurrency = resolvedActivityCurrencyFromAssetQuote(row, draft.quoteCcy);
+    const resolvedCurrency = resolvedDefaultCurrency ?? row.currency;
     return {
       ...row,
       symbol: draft.instrumentSymbol || draft.displayCode || row.symbol,
@@ -30,8 +31,7 @@ export function applyAssetResolution(
       exchangeMic: draft.instrumentExchangeMic || undefined,
       quoteCcy: draft.quoteCcy || row.quoteCcy,
       currency: resolvedCurrency,
-      currencySource:
-        row.currencySource === "default" && draft.quoteCcy ? "resolved" : row.currencySource,
+      currencySource: resolvedDefaultCurrency ? "resolved" : row.currencySource,
       instrumentType: draft.instrumentType || row.instrumentType,
       quoteMode: draft.quoteMode || row.quoteMode,
       providerId: draft.providerId,
@@ -41,6 +41,23 @@ export function applyAssetResolution(
       importAssetKey: options.importAssetKey,
     };
   });
+}
+
+function resolvedActivityCurrencyFromAssetQuote(
+  row: DraftActivity,
+  quoteCcy: string | undefined,
+): string | undefined {
+  if (row.currencySource !== "default") {
+    return undefined;
+  }
+  const currency = quoteCcy?.trim();
+  if (!currency || getQuoteUnitCurrency(currency)) {
+    return undefined;
+  }
+  if (currency.toUpperCase() === row.currency?.trim().toUpperCase()) {
+    return undefined;
+  }
+  return currency.toUpperCase();
 }
 
 export function mapQuoteTypeToInstrumentType(quoteType?: string): string | undefined {

--- a/apps/frontend/src/pages/activity/import/utils/asset-review-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/asset-review-utils.ts
@@ -108,17 +108,26 @@ function hasProviderIdentity(input: { providerId?: string; providerSymbol?: stri
   return Boolean(input.providerId?.trim() || input.providerSymbol?.trim());
 }
 
+function draftAssetResolutionCurrency(draft: DraftActivity): string | undefined {
+  const currency = draft.currency?.trim();
+  if (!currency || draft.currencySource === "default") {
+    return undefined;
+  }
+  return currency;
+}
+
 function buildImportAssetCandidateKeyFromDraft(draft: DraftActivity): string | undefined {
   if (!draft.symbol || !draft.accountId) {
     return undefined;
   }
 
+  const currency = draftAssetResolutionCurrency(draft);
   return buildImportAssetCandidateKey({
     accountId: draft.accountId,
     symbol: draft.symbol,
     instrumentType: draft.instrumentType,
     quoteMode: draft.quoteMode,
-    quoteCcy: draft.quoteCcy || draft.currency,
+    quoteCcy: draft.quoteCcy || currency,
     exchangeMic: draft.exchangeMic,
     isin: draft.isin,
     providerId: draft.providerId,
@@ -155,7 +164,7 @@ export function buildImportAssetCandidateFromDraft(
     key: shouldUseStoredKey && storedKey ? storedKey : computedKey,
     accountId: draft.accountId,
     symbol: draft.symbol,
-    currency: draft.currency,
+    currency: draftAssetResolutionCurrency(draft),
     instrumentType: draft.instrumentType,
     quoteCcy: draft.quoteCcy,
     quoteMode: draft.quoteMode,

--- a/apps/frontend/src/pages/activity/import/utils/draft-utils.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/draft-utils.test.ts
@@ -105,6 +105,60 @@ describe("createDraftActivities explicit activity mapping", () => {
     expect(draftToActivityImport(resolved).currency).toBe("USD");
   });
 
+  it("does not serialize quote-unit asset currency when the CSV has no currency column", () => {
+    const [draft] = createDraftActivities(
+      [["2026-06-30", "BUY", "VOD.L", "10", "75.00", "750.00", "0"]],
+      [
+        ImportFormat.DATE,
+        ImportFormat.ACTIVITY_TYPE,
+        ImportFormat.SYMBOL,
+        ImportFormat.QUANTITY,
+        ImportFormat.UNIT_PRICE,
+        ImportFormat.AMOUNT,
+        ImportFormat.FEE,
+      ],
+      {
+        ...baseMapping,
+        fieldMappings: {
+          [ImportFormat.DATE]: ImportFormat.DATE,
+          [ImportFormat.ACTIVITY_TYPE]: ImportFormat.ACTIVITY_TYPE,
+          [ImportFormat.SYMBOL]: ImportFormat.SYMBOL,
+          [ImportFormat.QUANTITY]: ImportFormat.QUANTITY,
+          [ImportFormat.UNIT_PRICE]: ImportFormat.UNIT_PRICE,
+          [ImportFormat.AMOUNT]: ImportFormat.AMOUNT,
+          [ImportFormat.FEE]: ImportFormat.FEE,
+        },
+        activityMappings: {
+          [ActivityType.BUY]: ["BUY"],
+        },
+      },
+      { ...parseConfig, defaultCurrency: "USD" },
+      "account-1",
+    );
+
+    const [resolved] = applyAssetResolution(
+      [draft],
+      draft.assetCandidateKey ?? "",
+      {
+        kind: "INVESTMENT",
+        name: "Vodafone Group Public Limited Company",
+        displayCode: "VOD.L",
+        isActive: true,
+        quoteMode: "MARKET",
+        quoteCcy: "GBp",
+        instrumentType: "EQUITY",
+        instrumentSymbol: "VOD",
+        instrumentExchangeMic: "XLON",
+      },
+      { importAssetKey: draft.assetCandidateKey },
+    );
+
+    expect(resolved.currency).toBe("USD");
+    expect(resolved.currencySource).toBe("default");
+    expect(resolved.quoteCcy).toBe("GBp");
+    expect(draftToActivityImport(resolved).currency).toBe("");
+  });
+
   it("preserves an explicit CSV currency even when the resolved asset quote currency differs", () => {
     const [draft] = createDraftActivities(
       [["2026-06-30", "BUY", "KWEB", "10", "28.50", "285.00", "0", "CAD"]],

--- a/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
@@ -762,7 +762,7 @@ export function draftToActivityImport(draft: DraftActivity): ActivityImport {
     id: undefined,
     accountId: draft.accountId,
     assetId: draft.assetId,
-    currency: draft.currency ?? "",
+    currency: draft.currencySource === "default" ? "" : (draft.currency ?? ""),
     activityType: draft.activityType as ActivityImport["activityType"],
     date: draft.activityDate,
     symbol: draft.symbol ?? "",

--- a/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
@@ -638,6 +638,7 @@ export function createDraftActivities(
     const rawCurrencyValue = rawCurrency?.trim();
     const currency = rawCurrencyValue || defaultCurrency;
     const currencySource = rawCurrencyValue ? "csv" : "default";
+    const assetResolutionCurrency = rawCurrencyValue || undefined;
     const fee = parseNumericValue(rawFee, decimalSeparator, thousandsSeparator);
     let tax = parseNumericValue(rawTax, decimalSeparator, thousandsSeparator);
     const comment = rawComment?.trim();
@@ -717,7 +718,7 @@ export function createDraftActivities(
               symbol,
               instrumentType: resolvedInstrumentType,
               quoteMode: mappedQuoteMode,
-              quoteCcy: mappedQuoteCcy || currency,
+              quoteCcy: mappedQuoteCcy || assetResolutionCurrency,
               exchangeMic: mappedExchangeMic,
               isin: rawIsin?.trim() || undefined,
             })

--- a/apps/frontend/src/pages/activity/import/utils/import-asset-rules.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/import-asset-rules.test.ts
@@ -80,6 +80,47 @@ describe("import asset rules", () => {
     expect(key).toBe("SHOP::EQUITY::::XTSE::CAD::");
   });
 
+  it("omits default-sourced currency from asset preview candidates", () => {
+    const candidate = buildImportAssetCandidateFromDraft(
+      createDraft({
+        symbol: "VOD.L",
+        instrumentType: "EQUITY",
+        currency: "CAD",
+        currencySource: "default",
+      }),
+    );
+
+    expect(candidate?.currency).toBeUndefined();
+    expect(candidate?.key).toBe(
+      buildImportAssetCandidateKey({
+        accountId: "acc-1",
+        symbol: "VOD.L",
+        instrumentType: "EQUITY",
+      }),
+    );
+  });
+
+  it("keeps explicit CSV currency in asset preview candidates", () => {
+    const candidate = buildImportAssetCandidateFromDraft(
+      createDraft({
+        symbol: "VOD.L",
+        instrumentType: "EQUITY",
+        currency: "USD",
+        currencySource: "csv",
+      }),
+    );
+
+    expect(candidate?.currency).toBe("USD");
+    expect(candidate?.key).toBe(
+      buildImportAssetCandidateKey({
+        accountId: "acc-1",
+        symbol: "VOD.L",
+        instrumentType: "EQUITY",
+        quoteCcy: "USD",
+      }),
+    );
+  });
+
   it("keeps same-symbol provider variants distinct for asset preview", () => {
     const staleKey = buildImportAssetCandidateKey({
       accountId: "acc-1",

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -23,9 +23,9 @@ use crate::activities::{
 };
 use crate::assets::{
     canonicalize_market_identity, normalize_quote_ccy_code, parse_crypto_pair_symbol,
-    parse_symbol_with_exchange_suffix, resolve_quote_ccy_precedence, AssetKind,
-    AssetResolutionInput as ImportAssetResolutionInput, AssetServiceTrait, InstrumentType,
-    QuoteCcyResolutionSource, QuoteMode,
+    parse_symbol_with_exchange_suffix, resolve_import_quote_ccy_precedence,
+    resolve_quote_ccy_precedence, AssetKind, AssetResolutionInput as ImportAssetResolutionInput,
+    AssetServiceTrait, InstrumentType, QuoteCcyResolutionSource, QuoteMode,
 };
 use crate::errors::{DatabaseError, Error};
 use crate::events::{DomainEvent, DomainEventSink, NoOpDomainEventSink};
@@ -3133,17 +3133,14 @@ impl ActivityService {
                     return None;
                 }
 
-                let ccy = if a.currency.is_empty() {
-                    account_currency.clone()
-                } else {
-                    a.currency.clone()
-                };
-                let input_key = import_asset_resolution_key(a, &ccy);
+                let activity_currency = a.currency.trim();
+                let input_key = import_asset_resolution_key(a, activity_currency);
                 Some(ImportAssetResolutionInput {
                     key: input_key,
                     source_symbol: a.symbol.clone(),
                     account_currency: account_currency.clone(),
-                    activity_currency: Some(ccy),
+                    activity_currency: (!activity_currency.is_empty())
+                        .then(|| activity_currency.to_string()),
                     exchange_mic: a.exchange_mic.clone(),
                     quote_ccy: a.quote_ccy.clone(),
                     instrument_type: Self::parse_instrument_type(a.instrument_type.as_deref()),
@@ -3261,12 +3258,7 @@ impl ActivityService {
                 }
             }
 
-            let resolve_ccy = if activity.currency.is_empty() {
-                account_currency.clone()
-            } else {
-                activity.currency.clone()
-            };
-            let resolution_key = import_asset_resolution_key(&activity, &resolve_ccy);
+            let resolution_key = import_asset_resolution_key(&activity, activity.currency.trim());
             let asset_resolution = asset_resolution_cache.get(&resolution_key);
             let resolution_quote_ccy = asset_resolution
                 .and_then(|output| output.quote_ccy.clone())
@@ -3279,6 +3271,12 @@ impl ActivityService {
                 .or_else(|| asset_resolution.and_then(|output| output.exchange_mic.clone()));
 
             let (base_symbol, suffix_mic) = parse_symbol_with_exchange_suffix(&symbol);
+            let has_import_market_hint = activity
+                .exchange_mic
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|mic| !mic.is_empty())
+                || suffix_mic.is_some();
             let resolved_mic = activity
                 .exchange_mic
                 .clone()
@@ -3429,7 +3427,15 @@ impl ActivityService {
                 } else {
                     activity.currency.as_str()
                 };
-                let explicit_quote_ccy = Self::normalize_quote_ccy(activity.quote_ccy.as_deref());
+                let resolution_explicit_quote_ccy = if resolution_quote_ccy_source
+                    == Some(QuoteCcyResolutionSource::ExplicitInput)
+                {
+                    resolution_quote_ccy.as_deref()
+                } else {
+                    None
+                };
+                let explicit_quote_ccy = Self::normalize_quote_ccy(activity.quote_ccy.as_deref())
+                    .or_else(|| Self::normalize_quote_ccy(resolution_explicit_quote_ccy));
 
                 let (resolved_quote_ccy, resolution_source) = if matches!(
                     effective_instrument_type,
@@ -3450,6 +3456,9 @@ impl ActivityService {
                     )
                     .await
                 } else {
+                    let activity_quote_ccy = (has_import_market_hint
+                        && !activity.currency.trim().is_empty())
+                    .then_some(activity.currency.as_str());
                     let has_deterministic = normalize_quote_ccy_code(explicit_quote_ccy.as_deref())
                         .is_some()
                         || normalize_quote_ccy_code(asset_currency.as_deref()).is_some();
@@ -3475,9 +3484,10 @@ impl ActivityService {
                     } else {
                         resolved_mic.as_deref().and_then(mic_to_currency)
                     };
-                    resolve_quote_ccy_precedence(
+                    resolve_import_quote_ccy_precedence(
                         explicit_quote_ccy.as_deref(),
                         asset_currency.as_deref(),
+                        activity_quote_ccy,
                         provider_ccy.as_deref(),
                         mic_fallback_ccy,
                         Some(terminal_fallback),

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -6203,7 +6203,7 @@ mod tests {
             activity_type: "BUY".to_string(),
             quantity: Some(dec!(10)),
             unit_price: Some(dec!(120)),
-            currency: "CAD".to_string(),
+            currency: String::new(),
             fee: Some(dec!(0)),
             tax: None,
             amount: Some(dec!(1200)),

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -8,9 +8,10 @@ mod tests {
     };
     use crate::assets::{
         normalize_quote_ccy_code, parse_crypto_pair_symbol, parse_symbol_with_exchange_suffix,
-        Asset, AssetKind, AssetResolutionInput as ImportAssetResolutionInput,
-        AssetResolutionOutput, AssetServiceTrait, InstrumentType, NewAsset, ProviderProfile,
-        QuoteCcyResolutionSource, QuoteMode, UpdateAssetProfile,
+        resolve_import_quote_ccy_precedence, Asset, AssetKind,
+        AssetResolutionInput as ImportAssetResolutionInput, AssetResolutionOutput,
+        AssetServiceTrait, InstrumentType, NewAsset, ProviderProfile, QuoteCcyResolutionSource,
+        QuoteMode, UpdateAssetProfile,
     };
     use crate::errors::{DatabaseError, Error, Result};
     use crate::events::{DomainEvent, MockDomainEventSink};
@@ -404,24 +405,20 @@ mod tests {
                         .activity_currency
                         .clone()
                         .filter(|currency| !currency.trim().is_empty());
-                    let (quote_ccy, quote_ccy_source) = if let Some(quote) = explicit_quote_ccy {
-                        (quote, QuoteCcyResolutionSource::ExplicitInput)
-                    } else if let Some(quote) = existing_quote_ccy {
-                        (quote, QuoteCcyResolutionSource::ExistingAsset)
-                    } else if let Some(quote) = provider_quote_ccy {
-                        (quote, QuoteCcyResolutionSource::ProviderQuote)
-                    } else if let Some(quote) = pair_quote {
-                        (quote, QuoteCcyResolutionSource::ExplicitInput)
-                    } else if let Some(quote) = mic_quote_ccy {
-                        (quote, QuoteCcyResolutionSource::MicFallback)
-                    } else if let Some(quote) = activity_quote_ccy {
-                        (quote, QuoteCcyResolutionSource::TerminalFallback)
-                    } else {
+                    let (quote_ccy, quote_ccy_source) = resolve_import_quote_ccy_precedence(
+                        explicit_quote_ccy.as_deref().or(pair_quote.as_deref()),
+                        existing_quote_ccy.as_deref(),
+                        activity_quote_ccy.as_deref(),
+                        provider_quote_ccy.as_deref(),
+                        mic_quote_ccy.as_deref(),
+                        Some(input.account_currency.as_str()),
+                    )
+                    .unwrap_or_else(|| {
                         (
                             input.account_currency.clone(),
                             QuoteCcyResolutionSource::TerminalFallback,
                         )
-                    };
+                    });
                     let kind = match instrument_type.as_ref() {
                         Some(InstrumentType::Fx) => AssetKind::Fx,
                         _ => AssetKind::Investment,
@@ -5429,6 +5426,223 @@ mod tests {
         assert_eq!(checked.asset_id.as_deref(), Some("kweb-uuid"));
         assert_eq!(checked.currency, "CAD");
         assert_eq!(checked.quote_ccy.as_deref(), Some("USD"));
+    }
+
+    #[tokio::test]
+    async fn test_check_import_uses_activity_currency_before_provider_quote_for_new_asset() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let account = create_test_account("acc-1", "USD");
+        account_service.add_account(account);
+
+        let quote_service = Arc::new(MockQuoteService);
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            quote_service,
+        );
+
+        let import = ActivityImport {
+            id: None,
+            date: "2026-06-30".to_string(),
+            symbol: "VOD.L".to_string(),
+            activity_type: "BUY".to_string(),
+            quantity: Some(dec!(10)),
+            unit_price: Some(dec!(28.50)),
+            currency: "USD".to_string(),
+            fee: Some(dec!(0)),
+            tax: None,
+            amount: Some(dec!(285)),
+            comment: None,
+            account_id: Some("acc-1".to_string()),
+            account_name: None,
+            symbol_name: None,
+            exchange_mic: None,
+            quote_ccy: None,
+            instrument_type: None,
+            quote_mode: None,
+            provider_id: None,
+            provider_symbol: None,
+            errors: None,
+            warnings: None,
+            duplicate_of_id: None,
+            duplicate_of_line_number: None,
+            is_draft: false,
+            is_valid: true,
+            line_number: Some(1),
+            fx_rate: None,
+            subtype: None,
+            asset_id: None,
+            isin: None,
+            force_import: false,
+            is_external: None,
+        };
+
+        let result = activity_service
+            .check_activities_import(vec![import])
+            .await
+            .expect("import check should succeed");
+
+        let checked = &result[0];
+        assert_eq!(checked.exchange_mic.as_deref(), Some("XLON"));
+        assert_eq!(checked.currency, "USD");
+        assert_eq!(checked.quote_ccy.as_deref(), Some("USD"));
+        assert_eq!(
+            checked
+                .warnings
+                .as_ref()
+                .and_then(|warnings| warnings.get("_quote_ccy_fallback")),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_import_keeps_provider_quote_unit_when_activity_currency_is_major() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let account = create_test_account("acc-1", "GBP");
+        account_service.add_account(account);
+
+        let quote_service = Arc::new(MockQuoteService);
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service,
+            fx_service,
+            quote_service,
+        );
+
+        let import = ActivityImport {
+            id: None,
+            date: "2026-06-30".to_string(),
+            symbol: "VOD.L".to_string(),
+            activity_type: "BUY".to_string(),
+            quantity: Some(dec!(10)),
+            unit_price: Some(dec!(28.50)),
+            currency: "GBP".to_string(),
+            fee: Some(dec!(0)),
+            tax: None,
+            amount: Some(dec!(285)),
+            comment: None,
+            account_id: Some("acc-1".to_string()),
+            account_name: None,
+            symbol_name: None,
+            exchange_mic: None,
+            quote_ccy: None,
+            instrument_type: None,
+            quote_mode: None,
+            provider_id: None,
+            provider_symbol: None,
+            errors: None,
+            warnings: None,
+            duplicate_of_id: None,
+            duplicate_of_line_number: None,
+            is_draft: false,
+            is_valid: true,
+            line_number: Some(1),
+            fx_rate: None,
+            subtype: None,
+            asset_id: None,
+            isin: None,
+            force_import: false,
+            is_external: None,
+        };
+
+        let result = activity_service
+            .check_activities_import(vec![import])
+            .await
+            .expect("import check should succeed");
+
+        let checked = &result[0];
+        assert_eq!(checked.exchange_mic.as_deref(), Some("XLON"));
+        assert_eq!(checked.currency, "GBP");
+        assert_eq!(checked.quote_ccy.as_deref(), Some("GBp"));
+        assert_eq!(
+            checked
+                .warnings
+                .as_ref()
+                .and_then(|warnings| warnings.get("_quote_ccy_fallback")),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn test_check_import_does_not_default_missing_currency_before_asset_resolution() {
+        let account_service = Arc::new(MockAccountService::new());
+        let asset_service = Arc::new(MockAssetService::new());
+        let fx_service = Arc::new(MockFxService::new());
+        let activity_repository = Arc::new(MockActivityRepository::new());
+
+        let account = create_test_account("acc-1", "USD");
+        account_service.add_account(account);
+
+        let quote_service = Arc::new(MockQuoteService);
+        let activity_service = ActivityService::new(
+            activity_repository,
+            account_service,
+            asset_service.clone(),
+            fx_service,
+            quote_service,
+        );
+
+        let import = ActivityImport {
+            id: None,
+            date: "2026-06-30".to_string(),
+            symbol: "VOD.L".to_string(),
+            activity_type: "BUY".to_string(),
+            quantity: Some(dec!(10)),
+            unit_price: Some(dec!(28.50)),
+            currency: String::new(),
+            fee: Some(dec!(0)),
+            tax: None,
+            amount: Some(dec!(285)),
+            comment: None,
+            account_id: Some("acc-1".to_string()),
+            account_name: None,
+            symbol_name: None,
+            exchange_mic: None,
+            quote_ccy: None,
+            instrument_type: None,
+            quote_mode: None,
+            provider_id: None,
+            provider_symbol: None,
+            errors: None,
+            warnings: None,
+            duplicate_of_id: None,
+            duplicate_of_line_number: None,
+            is_draft: false,
+            is_valid: true,
+            line_number: Some(1),
+            fx_rate: None,
+            subtype: None,
+            asset_id: None,
+            isin: None,
+            force_import: false,
+            is_external: None,
+        };
+
+        let result = activity_service
+            .check_activities_import(vec![import])
+            .await
+            .expect("import check should succeed");
+
+        let batches = asset_service
+            .resolve_import_asset_input_batches
+            .lock()
+            .unwrap();
+        assert_eq!(batches[0][0].activity_currency, None);
+
+        let checked = &result[0];
+        assert_eq!(checked.quote_ccy.as_deref(), Some("GBp"));
+        assert_eq!(checked.currency, "USD");
     }
 
     #[tokio::test]

--- a/crates/core/src/assets/assets_model.rs
+++ b/crates/core/src/assets/assets_model.rs
@@ -947,11 +947,11 @@ pub fn resolve_import_quote_ccy_precedence(
             QuoteCcyResolutionSource::ProviderQuote,
         ));
     }
-    if let Some(ccy) = normalize_quote_ccy(mic_fallback_quote_ccy) {
-        return Some((ccy, QuoteCcyResolutionSource::MicFallback));
-    }
     if let Some(ccy) = activity_ccy {
         return Some((ccy, QuoteCcyResolutionSource::ExplicitInput));
+    }
+    if let Some(ccy) = normalize_quote_ccy(mic_fallback_quote_ccy) {
+        return Some((ccy, QuoteCcyResolutionSource::MicFallback));
     }
     normalize_quote_ccy(terminal_fallback_quote_ccy)
         .map(|ccy| (ccy, QuoteCcyResolutionSource::TerminalFallback))

--- a/crates/core/src/assets/assets_model.rs
+++ b/crates/core/src/assets/assets_model.rs
@@ -12,6 +12,7 @@ use serde_json::Value;
 use super::asset_id::{parse_crypto_pair_symbol, parse_symbol_with_exchange_suffix};
 use crate::errors::Result;
 use crate::errors::ValidationError;
+use crate::fx::currency::normalize_currency_code;
 use crate::Error;
 use wealthfolio_market_data::mic_to_currency;
 
@@ -910,6 +911,55 @@ pub fn resolve_quote_ccy_precedence(
     }
     normalize_quote_ccy(terminal_fallback_quote_ccy)
         .map(|ccy| (ccy, QuoteCcyResolutionSource::TerminalFallback))
+}
+
+pub fn resolve_import_quote_ccy_precedence(
+    explicit_quote_ccy: Option<&str>,
+    existing_asset_quote_ccy: Option<&str>,
+    activity_quote_ccy: Option<&str>,
+    provider_quote_ccy: Option<&str>,
+    mic_fallback_quote_ccy: Option<&str>,
+    terminal_fallback_quote_ccy: Option<&str>,
+) -> Option<(String, QuoteCcyResolutionSource)> {
+    if let Some(ccy) = normalize_quote_ccy(explicit_quote_ccy) {
+        return Some((ccy, QuoteCcyResolutionSource::ExplicitInput));
+    }
+    if let Some(ccy) = normalize_quote_ccy(existing_asset_quote_ccy) {
+        return Some((ccy, QuoteCcyResolutionSource::ExistingAsset));
+    }
+    let activity_ccy = normalize_quote_ccy(activity_quote_ccy);
+    let provider_ccy = normalize_quote_ccy(provider_quote_ccy);
+    if let Some(provider) = provider_ccy.as_deref() {
+        if activity_ccy
+            .as_deref()
+            .is_some_and(|activity| provider_quote_unit_matches_activity_major(provider, activity))
+        {
+            return Some((
+                provider.to_string(),
+                QuoteCcyResolutionSource::ProviderQuote,
+            ));
+        }
+        if let Some(activity) = activity_ccy {
+            return Some((activity, QuoteCcyResolutionSource::ExplicitInput));
+        }
+        return Some((
+            provider.to_string(),
+            QuoteCcyResolutionSource::ProviderQuote,
+        ));
+    }
+    if let Some(ccy) = normalize_quote_ccy(mic_fallback_quote_ccy) {
+        return Some((ccy, QuoteCcyResolutionSource::MicFallback));
+    }
+    if let Some(ccy) = activity_ccy {
+        return Some((ccy, QuoteCcyResolutionSource::ExplicitInput));
+    }
+    normalize_quote_ccy(terminal_fallback_quote_ccy)
+        .map(|ccy| (ccy, QuoteCcyResolutionSource::TerminalFallback))
+}
+
+fn provider_quote_unit_matches_activity_major(provider_quote: &str, activity_quote: &str) -> bool {
+    let provider_major = normalize_currency_code(provider_quote);
+    provider_major != provider_quote && provider_major.eq_ignore_ascii_case(activity_quote)
 }
 
 fn parse_fx_symbol_parts(symbol: &str) -> Option<(String, String)> {

--- a/crates/core/src/assets/assets_model_tests.rs
+++ b/crates/core/src/assets/assets_model_tests.rs
@@ -3,8 +3,9 @@
 #[cfg(test)]
 mod tests {
     use crate::assets::{
-        canonicalize_market_identity, resolve_quote_ccy_precedence, Asset, AssetKind,
-        InstrumentType, OptionSpec, QuoteCcyResolutionSource, QuoteMode,
+        canonicalize_market_identity, resolve_import_quote_ccy_precedence,
+        resolve_quote_ccy_precedence, Asset, AssetKind, InstrumentType, OptionSpec,
+        QuoteCcyResolutionSource, QuoteMode,
     };
     use chrono::NaiveDateTime;
     use rust_decimal_macros::dec;
@@ -394,6 +395,74 @@ mod tests {
         assert_eq!(
             resolved,
             Some(("GBP".to_string(), QuoteCcyResolutionSource::ProviderQuote))
+        );
+    }
+
+    #[test]
+    fn test_resolve_import_quote_ccy_precedence_uses_activity_before_provider() {
+        let resolved = resolve_import_quote_ccy_precedence(
+            None,
+            None,
+            Some("USD"),
+            Some("GBp"),
+            Some("GBP"),
+            Some("CAD"),
+        );
+
+        assert_eq!(
+            resolved,
+            Some(("USD".to_string(), QuoteCcyResolutionSource::ExplicitInput))
+        );
+    }
+
+    #[test]
+    fn test_resolve_import_quote_ccy_precedence_keeps_provider_quote_unit_for_activity_major() {
+        let resolved = resolve_import_quote_ccy_precedence(
+            None,
+            None,
+            Some("GBP"),
+            Some("GBp"),
+            Some("GBP"),
+            Some("CAD"),
+        );
+
+        assert_eq!(
+            resolved,
+            Some(("GBp".to_string(), QuoteCcyResolutionSource::ProviderQuote))
+        );
+    }
+
+    #[test]
+    fn test_resolve_import_quote_ccy_precedence_uses_existing_before_activity() {
+        let resolved = resolve_import_quote_ccy_precedence(
+            None,
+            Some("EUR"),
+            Some("USD"),
+            Some("GBp"),
+            Some("GBP"),
+            Some("CAD"),
+        );
+
+        assert_eq!(
+            resolved,
+            Some(("EUR".to_string(), QuoteCcyResolutionSource::ExistingAsset))
+        );
+    }
+
+    #[test]
+    fn test_resolve_import_quote_ccy_precedence_uses_mic_before_activity_without_provider() {
+        let resolved = resolve_import_quote_ccy_precedence(
+            None,
+            None,
+            Some("CAD"),
+            None,
+            Some("GBp"),
+            Some("USD"),
+        );
+
+        assert_eq!(
+            resolved,
+            Some(("GBp".to_string(), QuoteCcyResolutionSource::MicFallback))
         );
     }
 

--- a/crates/core/src/assets/assets_model_tests.rs
+++ b/crates/core/src/assets/assets_model_tests.rs
@@ -450,7 +450,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_import_quote_ccy_precedence_uses_mic_before_activity_without_provider() {
+    fn test_resolve_import_quote_ccy_precedence_uses_activity_before_mic_without_provider() {
         let resolved = resolve_import_quote_ccy_precedence(
             None,
             None,
@@ -462,7 +462,7 @@ mod tests {
 
         assert_eq!(
             resolved,
-            Some(("GBp".to_string(), QuoteCcyResolutionSource::MicFallback))
+            Some(("CAD".to_string(), QuoteCcyResolutionSource::ExplicitInput))
         );
     }
 

--- a/crates/core/src/assets/assets_service.rs
+++ b/crates/core/src/assets/assets_service.rs
@@ -1234,7 +1234,11 @@ impl AssetServiceTrait for AssetService {
                     .activity_currency
                     .as_deref()
                     .map(str::trim)
-                    .filter(|ccy| !ccy.is_empty()));
+                    .filter(|ccy| !ccy.is_empty()))
+                .or_else(|| {
+                    let account_currency = input.account_currency.trim();
+                    (!account_currency.is_empty()).then_some(account_currency)
+                });
 
             let local_existing_asset = local_index.find_for_import_input(
                 input.asset_id.as_deref(),
@@ -3199,6 +3203,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_resolve_import_asset_inputs_uses_activity_currency_before_mic_without_provider_quote(
+    ) {
+        let mut vod = yahoo_search_result(
+            "VOD.L",
+            "VOD",
+            "XLON",
+            "Vodafone Group Public Limited Company",
+            "GBp",
+            "VOD.L",
+        );
+        vod.currency = None;
+        let service = test_asset_service(
+            Vec::new(),
+            TestQuoteService::default().with_result("VOD.L", vec![vod]),
+        );
+
+        let output = service
+            .resolve_import_asset_inputs(vec![import_input("VOD.L", "USD")])
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
+
+        assert_eq!(output.canonical_symbol.as_deref(), Some("VOD"));
+        assert_eq!(output.exchange_mic.as_deref(), Some("XLON"));
+        assert_eq!(output.quote_ccy.as_deref(), Some("USD"));
+        assert_eq!(
+            output.quote_ccy_source,
+            Some(QuoteCcyResolutionSource::ExplicitInput)
+        );
+
+        let draft = output.draft.expect("new LSE asset draft");
+        assert_eq!(draft.quote_ccy, "USD");
+        assert_eq!(draft.provider_symbol.as_deref(), Some("VOD.L"));
+    }
+
+    #[tokio::test]
     async fn test_resolve_import_asset_inputs_keeps_provider_quote_unit_for_activity_major() {
         let service = test_asset_service(
             Vec::new(),
@@ -3857,6 +3898,52 @@ mod tests {
         assert_eq!(output.exchange_mic.as_deref(), Some("XNYS"));
         assert_eq!(output.quote_ccy.as_deref(), Some("USD"));
         assert_eq!(output.review_symbol.as_deref(), Some("SHOP"));
+        assert!(output.draft.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_resolve_import_asset_inputs_missing_activity_currency_uses_account_currency_to_avoid_cross_listing_match(
+    ) {
+        let shop_tsx = Asset {
+            id: "shop-tsx".to_string(),
+            name: Some("Shopify Inc.".to_string()),
+            display_code: Some("SHOP".to_string()),
+            instrument_symbol: Some("SHOP".to_string()),
+            instrument_exchange_mic: Some("XTSE".to_string()),
+            instrument_type: Some(InstrumentType::Equity),
+            quote_ccy: "CAD".to_string(),
+            kind: AssetKind::Investment,
+            ..Default::default()
+        };
+        let quote_service = TestQuoteService::default().with_result(
+            "SHOP",
+            vec![yahoo_search_result(
+                "SHOP",
+                "SHOP",
+                "XNYS",
+                "Shopify Inc.",
+                "USD",
+                "SHOP",
+            )],
+        );
+        let search_calls = Arc::clone(&quote_service.search_calls);
+        let service = test_asset_service(vec![shop_tsx], quote_service);
+        let mut input = import_input("SHOP", "USD");
+        input.activity_currency = None;
+
+        let output = service
+            .resolve_import_asset_inputs(vec![input])
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
+
+        assert_eq!(search_calls.lock().unwrap().as_slice(), ["SHOP"]);
+        assert_eq!(output.existing_asset_id, None);
+        assert_eq!(output.canonical_symbol.as_deref(), Some("SHOP"));
+        assert_eq!(output.exchange_mic.as_deref(), Some("XNYS"));
+        assert_eq!(output.quote_ccy.as_deref(), Some("USD"));
+        assert_eq!(output.provider_symbol.as_deref(), Some("SHOP"));
         assert!(output.draft.is_some());
     }
 

--- a/crates/core/src/assets/assets_service.rs
+++ b/crates/core/src/assets/assets_service.rs
@@ -10,9 +10,9 @@ use crate::utils::isin::looks_like_isin;
 use futures::stream::{self, StreamExt};
 
 use super::assets_model::{
-    canonicalize_market_identity, normalize_quote_ccy_code, resolve_quote_ccy_precedence, Asset,
-    AssetKind, AssetSpec, EnsureAssetsResult, InstrumentType, NewAsset, QuoteCcyResolutionSource,
-    QuoteMode, UpdateAssetProfile,
+    canonicalize_market_identity, normalize_quote_ccy_code, resolve_import_quote_ccy_precedence,
+    resolve_quote_ccy_precedence, Asset, AssetKind, AssetSpec, EnsureAssetsResult, InstrumentType,
+    NewAsset, QuoteCcyResolutionSource, QuoteMode, UpdateAssetProfile,
 };
 use super::assets_traits::{AssetRepositoryTrait, AssetServiceTrait};
 use super::auto_classification::{AutoClassificationService, ClassificationInput};
@@ -1187,6 +1187,12 @@ impl AssetServiceTrait for AssetService {
             }
 
             let (base_symbol, suffix_mic) = parse_symbol_with_exchange_suffix(&resolution_symbol);
+            let has_import_market_hint = input
+                .exchange_mic
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|mic| !mic.is_empty())
+                || suffix_mic.is_some();
             let mut exchange_mic = input
                 .exchange_mic
                 .clone()
@@ -1394,12 +1400,22 @@ impl AssetServiceTrait for AssetService {
                 .map(|asset| asset.quote_ccy.as_str());
 
             let explicit_quote_ccy = input.quote_ccy.as_deref().or(pair_quote_ccy.as_deref());
+            let activity_quote_ccy = if has_import_market_hint {
+                input
+                    .activity_currency
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|currency| !currency.is_empty())
+            } else {
+                None
+            };
             let provider_quote_ccy = provider_result
                 .as_ref()
                 .and_then(|result| result.currency.as_deref());
-            let (quote_ccy, quote_ccy_source) = resolve_quote_ccy_precedence(
+            let (quote_ccy, quote_ccy_source) = resolve_import_quote_ccy_precedence(
                 explicit_quote_ccy,
                 existing_quote_ccy,
+                activity_quote_ccy,
                 provider_quote_ccy,
                 exchange_mic.as_deref().and_then(mic_to_currency),
                 Some(&terminal_currency),
@@ -2612,7 +2628,8 @@ impl AssetServiceTrait for AssetService {
 #[cfg(test)]
 mod tests {
     use super::super::assets_model::{
-        Asset, AssetKind, InstrumentType, NewAsset, ProviderProfile, UpdateAssetProfile,
+        Asset, AssetKind, InstrumentType, NewAsset, ProviderProfile, QuoteCcyResolutionSource,
+        UpdateAssetProfile,
     };
     use super::{AssetRepositoryTrait, AssetService, AssetServiceTrait, QuoteMode};
     use crate::assets::AssetResolutionInput;
@@ -3142,6 +3159,113 @@ mod tests {
         assert_eq!(draft.provider_config, None);
         assert_eq!(draft.provider_id.as_deref(), Some("YAHOO"));
         assert_eq!(draft.provider_symbol.as_deref(), Some("VOD.L"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_import_asset_inputs_uses_activity_currency_before_provider_quote() {
+        let service = test_asset_service(
+            Vec::new(),
+            TestQuoteService::default().with_result(
+                "VOD.L",
+                vec![yahoo_search_result(
+                    "VOD.L",
+                    "VOD",
+                    "XLON",
+                    "Vodafone Group Public Limited Company",
+                    "GBp",
+                    "VOD.L",
+                )],
+            ),
+        );
+
+        let output = service
+            .resolve_import_asset_inputs(vec![import_input("VOD.L", "USD")])
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
+
+        assert_eq!(output.canonical_symbol.as_deref(), Some("VOD"));
+        assert_eq!(output.exchange_mic.as_deref(), Some("XLON"));
+        assert_eq!(output.quote_ccy.as_deref(), Some("USD"));
+        assert_eq!(
+            output.quote_ccy_source,
+            Some(QuoteCcyResolutionSource::ExplicitInput)
+        );
+
+        let draft = output.draft.expect("new LSE asset draft");
+        assert_eq!(draft.quote_ccy, "USD");
+        assert_eq!(draft.provider_symbol.as_deref(), Some("VOD.L"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_import_asset_inputs_keeps_provider_quote_unit_for_activity_major() {
+        let service = test_asset_service(
+            Vec::new(),
+            TestQuoteService::default().with_result(
+                "VOD.L",
+                vec![yahoo_search_result(
+                    "VOD.L",
+                    "VOD",
+                    "XLON",
+                    "Vodafone Group Public Limited Company",
+                    "GBp",
+                    "VOD.L",
+                )],
+            ),
+        );
+
+        let output = service
+            .resolve_import_asset_inputs(vec![import_input("VOD.L", "GBP")])
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
+
+        assert_eq!(output.canonical_symbol.as_deref(), Some("VOD"));
+        assert_eq!(output.exchange_mic.as_deref(), Some("XLON"));
+        assert_eq!(output.quote_ccy.as_deref(), Some("GBp"));
+        assert_eq!(
+            output.quote_ccy_source,
+            Some(QuoteCcyResolutionSource::ProviderQuote)
+        );
+
+        let draft = output.draft.expect("new LSE asset draft");
+        assert_eq!(draft.quote_ccy, "GBp");
+        assert_eq!(draft.provider_symbol.as_deref(), Some("VOD.L"));
+    }
+
+    #[tokio::test]
+    async fn test_resolve_import_asset_inputs_uses_provider_when_activity_currency_is_missing() {
+        let service = test_asset_service(
+            Vec::new(),
+            TestQuoteService::default().with_result(
+                "VOD.L",
+                vec![yahoo_search_result(
+                    "VOD.L",
+                    "VOD",
+                    "XLON",
+                    "Vodafone Group Public Limited Company",
+                    "GBp",
+                    "VOD.L",
+                )],
+            ),
+        );
+        let mut input = import_input("VOD.L", "USD");
+        input.activity_currency = None;
+
+        let output = service
+            .resolve_import_asset_inputs(vec![input])
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
+
+        assert_eq!(output.quote_ccy.as_deref(), Some("GBp"));
+        assert_eq!(
+            output.quote_ccy_source,
+            Some(QuoteCcyResolutionSource::ProviderQuote)
+        );
     }
 
     #[tokio::test]

--- a/crates/core/src/assets/mod.rs
+++ b/crates/core/src/assets/mod.rs
@@ -33,9 +33,10 @@ pub(crate) use asset_resolution::asset_provider_alias_symbols;
 pub use asset_resolution::{AssetResolutionInput, AssetResolutionOutput};
 pub use assets_model::{
     build_asset_metadata, build_option_metadata, canonicalize_market_identity,
-    normalize_quote_ccy_code, resolve_quote_ccy_precedence, Asset, AssetKind, AssetMetadata,
-    AssetSpec, BondSpec, Country, EnsureAssetsResult, InstrumentId, InstrumentType, NewAsset,
-    OptionSpec, ProviderProfile, QuoteCcyResolutionSource, QuoteMode, Sector, UpdateAssetProfile,
+    normalize_quote_ccy_code, resolve_import_quote_ccy_precedence, resolve_quote_ccy_precedence,
+    Asset, AssetKind, AssetMetadata, AssetSpec, BondSpec, Country, EnsureAssetsResult,
+    InstrumentId, InstrumentType, NewAsset, OptionSpec, ProviderProfile, QuoteCcyResolutionSource,
+    QuoteMode, Sector, UpdateAssetProfile,
 };
 pub use assets_service::AssetService;
 pub use assets_traits::{AssetRepositoryTrait, AssetServiceTrait};


### PR DESCRIPTION
Refs discussion #1199: https://github.com/wealthfolio/wealthfolio/discussions/1199

## Summary
- Keep account-default currencies out of asset preview candidates when the CSV row did not provide a currency.
- Centralize import quote currency precedence across asset resolution and activity import checks.
- Preserve provider quote-unit currencies such as `GBp` when the activity currency is the matching major currency, while still allowing explicit import currency to win for market-hinted rows.
- Add frontend, core resolver, activity import, and e2e coverage for the CAD account / USD-quoted KWEB import path and related quote-unit cases.

## Root Cause
Rows without a CSV currency were being defaulted to the account currency early enough that the default looked like an explicit import currency during asset review and validation. That allowed CAD account currency to mix into a USD-quoted KWEB import.

## Validation
- `pnpm test:e2e -- e2e/15-csv-import-currency-resolution.spec.ts` on isolated frontend/backend ports
- `cargo fmt --all -- --check`
- `pnpm format:check`
- `pnpm --filter frontend type-check`
- `pnpm --filter frontend test -- src/pages/activity/import/utils/import-asset-rules.test.ts src/pages/activity/import/utils/draft-utils.test.ts --runInBand`
- `cargo test -p wealthfolio-core test_resolve_import_quote_ccy_precedence -- --nocapture`
- `cargo test -p wealthfolio-core test_resolve_import_asset_inputs_ -- --nocapture`
- `cargo test -p wealthfolio-core test_check_import_ -- --nocapture`
- `pnpm lint`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `git diff --check`