### PR TITLE
Refactor Health Center diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3092,7 +3092,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.4.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -6731,16 +6731,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
@@ -7089,9 +7079,9 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tauri"
-version = "2.11.2"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437404997acf375d85f1177afa7e11bb971f274ed6a7b83a2a3e339015f4cc28"
+checksum = "766b7bd007abce1210b89d3b9cb36c09d0e4b258f52a77e1ca0874e86efae338"
 dependencies = [
  "anyhow",
  "bytes",
@@ -7129,6 +7119,7 @@ dependencies = [
  "tauri-runtime-wry",
  "tauri-utils",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tray-icon",
  "url",
@@ -7140,9 +7131,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-build"
-version = "2.6.2"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa1f9055fc23919a54e4e125052bed16ed04aef0487086e758fe01a67b451c7"
+checksum = "bc9ce40b16101cb6ea63d3e221567affd1c3a9205f95d7bc574941a10636b632"
 dependencies = [
  "anyhow",
  "cargo_toml",
@@ -7161,9 +7152,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.6.2"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a0319528a025a38c4078e7dae2c446f4e63620ddb0659a643ede1cb38f90e9"
+checksum = "08279169ff42f8fc45a1dbc9dcae888893ba95288142e5880c59b93a26d2cfc5"
 dependencies = [
  "base64 0.22.1",
  "brotli",
@@ -7188,9 +7179,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.6.2"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6cb4e3896c21d2f6da5b31251d2faea0153bba56ed0e970f918115dbee4924"
+checksum = "e8b394794f399a421811d06966343e7933fcae92d59f5180b9388d1174497a45"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -7437,9 +7428,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.11.2"
+version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48222d7116c8807eaa6fe2f372e023fae125084e61e6eca6d70b7961cdf129ef"
+checksum = "b0b4bc95aed361b0019067d189a1174a603d460d0f6c72606512d59fc9c12ec8"
 dependencies = [
  "cookie",
  "dpi",
@@ -7462,9 +7453,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.11.2"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
+checksum = "4e6fac707727b7a2f48e4ded90976324267371073edbb415ffb73bb0458d203f"
 dependencies = [
  "gtk",
  "http 1.4.1",
@@ -7488,9 +7479,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.9.2"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092379df9a707631978e6c56b1bc2401d387f01e2d4a3c123360d167bbb9aa95"
+checksum = "3e176a18e67764923c4f1ce66f25ae4abe5f688384d5eb1a0fa6c77f3d90f887"
 dependencies = [
  "anyhow",
  "brotli",
@@ -8080,9 +8071,9 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.23.1"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15edbb0d80583e85ee8df283410038e17314df5cba30da2087a54a85216c0773"
+checksum = "65ba1e5f6b9ef9fd87e21b9c6f351554dbd717960089168fcfdef854686961dc"
 dependencies = [
  "crossbeam-channel",
  "dirs",
@@ -8569,7 +8560,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-agent-tools"
-version = "3.5.4"
+version = "3.6.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8586,7 +8577,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-ai"
-version = "3.5.4"
+version = "3.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8617,7 +8608,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-app"
-version = "3.5.4"
+version = "3.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8674,7 +8665,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-connect"
-version = "3.5.4"
+version = "3.6.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8692,7 +8683,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-core"
-version = "3.5.4"
+version = "3.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8737,7 +8728,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-device-sync"
-version = "3.5.4"
+version = "3.6.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8761,7 +8752,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-market-data"
-version = "3.5.4"
+version = "3.6.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8783,7 +8774,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-mcp"
-version = "3.5.4"
+version = "3.6.0"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8808,7 +8799,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-server"
-version = "3.5.4"
+version = "3.6.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8861,7 +8852,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-spending"
-version = "3.5.4"
+version = "3.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8879,7 +8870,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-storage-sqlite"
-version = "3.5.4"
+version = "3.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.5.4"
+version = "3.6.0"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "3.5.4",
+  "version": "3.6.0",
   "type": "module",
   "homepage": "https://wealthfolio.app",
   "repository": {
@@ -97,7 +97,7 @@
     "jsdom": "^28.0.0",
     "tailwindcss": "^4.1.18",
     "tw-animate-css": "^1.4.0",
-    "vite": "^7.3.2",
+    "vite": "^7.3.6",
     "vitest": "^4.1.0"
   }
 }

--- a/apps/frontend/src/adapters/shared/activities.ts
+++ b/apps/frontend/src/adapters/shared/activities.ts
@@ -32,6 +32,7 @@ interface ActivityFilters {
   dateFrom?: string; // YYYY-MM-DD format
   dateTo?: string; // YYYY-MM-DD format
   instrumentTypes?: string | string[];
+  activityIds?: string | string[];
 }
 
 interface ActivitySort {
@@ -73,6 +74,7 @@ export const searchActivities = async (
   const accountIdFilter = normalizeStringArray(filters?.accountIds);
   const activityTypeFilter = normalizeStringArray(filters?.activityTypes);
   const instrumentTypeFilter = normalizeStringArray(filters?.instrumentTypes);
+  const activityIdFilter = normalizeStringArray(filters?.activityIds);
   const assetIdKeywordRaw = filters?.symbol ?? searchKeyword;
   const assetIdKeyword = assetIdKeywordRaw?.trim() ? assetIdKeywordRaw.trim() : undefined;
   const sortOption = sort?.id
@@ -94,6 +96,7 @@ export const searchActivities = async (
       dateFrom,
       dateTo,
       instrumentTypeFilter,
+      activityIdFilter,
     });
   } catch (err) {
     logger.error("Error fetching activities.");

--- a/apps/frontend/src/hooks/use-health.ts
+++ b/apps/frontend/src/hooks/use-health.ts
@@ -102,18 +102,27 @@ export function useExecuteHealthFix() {
     mutationFn: async (action: FixAction) => {
       // Execute the fix
       await executeHealthFix(action);
+      if (action.id === "rebuild_account_history") {
+        return { status: undefined, actionId: action.id };
+      }
       // Run health checks to get fresh status
       const status = await runHealthChecks();
       return { status, actionId: action.id };
     },
     onSuccess: ({ status, actionId }) => {
       // Update health status with fresh data from health checks
-      queryClient.setQueryData([QueryKeys.HEALTH_STATUS], status);
+      if (status) {
+        queryClient.setQueryData([QueryKeys.HEALTH_STATUS], status);
+      }
       // Invalidate holdings so related pages refresh
       queryClient.invalidateQueries({ queryKey: [QueryKeys.HOLDINGS] });
       queryClient.invalidateQueries({ queryKey: [QueryKeys.PORTFOLIO_ALLOCATIONS] });
       // Skip toast for sync actions — global event listeners handle feedback
-      if (actionId !== "sync_prices" && actionId !== "retry_sync") {
+      if (actionId === "rebuild_account_history") {
+        toast.success("History rebuild started", {
+          description: "Health will refresh after recalculation finishes.",
+        });
+      } else if (actionId !== "sync_prices" && actionId !== "retry_sync") {
         toast.success("Fix applied successfully");
       }
     },

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -2157,7 +2157,8 @@ export interface NavigateAction {
 export interface FixAction {
   id: string;
   label: string;
-  payload: Record<string, unknown>;
+  /** Arbitrary JSON payload (e.g. an array of asset IDs); shape varies by action id. */
+  payload: unknown;
 }
 
 /**
@@ -2168,6 +2169,78 @@ export interface AffectedItem {
   name: string;
   symbol?: string;
   route?: string;
+}
+
+/**
+ * A single supporting-evidence row for a diagnostic.
+ */
+export interface Evidence {
+  label: string;
+  value: string;
+  route?: string;
+}
+
+/**
+ * An ordered remediation action attached to a diagnostic.
+ *
+ * Serialized flat with a `kind` discriminator: `fix` carries the {@link FixAction}
+ * fields (id/label/payload); `navigate` carries the {@link NavigateAction} fields
+ * (route/query/label).
+ */
+export type DiagnosticAction = { primary: boolean } & (
+  | ({ kind: "fix" } & FixAction)
+  | ({ kind: "navigate" } & NavigateAction)
+);
+
+export type DiagnosticDomain =
+  | "unknown"
+  | "accountSetup"
+  | "ledger"
+  | "marketData"
+  | "fx"
+  | "classification"
+  | "generatedData"
+  | "performanceInputs";
+
+export type DiagnosticLevel = "source" | "generated" | "workflow";
+
+export interface HealthImpact {
+  affectedCount?: number;
+  affectedMvPct?: number;
+  amount?: number;
+  currency?: string;
+  description?: string;
+}
+
+export interface HealthEntityRef {
+  kind: string;
+  id: string;
+  label?: string;
+  route?: string;
+}
+
+export interface HealthDateRange {
+  start: string;
+  end: string;
+}
+
+/**
+ * A structured diagnostic: root cause, supporting evidence, and ordered actions.
+ */
+export interface HealthDiagnostic {
+  fingerprint: string;
+  domain: DiagnosticDomain;
+  level: DiagnosticLevel;
+  severity: HealthSeverity;
+  code: string;
+  title: string;
+  explanation: string;
+  impact?: HealthImpact;
+  entities: HealthEntityRef[];
+  date?: string;
+  dateRange?: HealthDateRange;
+  evidence: Evidence[];
+  actions: DiagnosticAction[];
 }
 
 /**
@@ -2185,6 +2258,7 @@ export interface HealthIssue {
   navigateAction?: NavigateAction;
   details?: string;
   affectedItems?: AffectedItem[];
+  diagnostics?: HealthDiagnostic[];
   dataHash: string;
   timestamp: string;
 }

--- a/apps/frontend/src/pages/activity/activity-page.tsx
+++ b/apps/frontend/src/pages/activity/activity-page.tsx
@@ -162,7 +162,10 @@ const ActivityPage = () => {
     searchParams.has("types") ||
     searchParams.has("from") ||
     searchParams.has("to") ||
-    searchParams.has("q");
+    searchParams.has("q") ||
+    searchParams.has("activity") ||
+    searchParams.has("healthContext");
+  const isHealthActivityDeepLink = activityUrlFilters.healthContext === "activity";
   const accountScope =
     activityUrlFilters.accountScope ??
     (hasActivityUrlFilters ? ALL_ACCOUNT_SCOPE : persistedAccountScope);
@@ -427,6 +430,12 @@ const ActivityPage = () => {
     return effectiveAccountIds.filter((id) => allowed.has(id));
   }, [effectiveAccountIds, investmentAccountIds, isSpendingEnabled, spendingAccountIds]);
 
+  // A health-check deep-link (?activity=<id>) pins the list to one transaction,
+  // filtered server-side so it's found regardless of paging.
+  const activityIdFilter = activityUrlFilters.activityId
+    ? [activityUrlFilters.activityId]
+    : undefined;
+
   // Infinite scroll search for table view
   const infiniteSearch = useActivitySearch({
     mode: "infinite",
@@ -437,6 +446,7 @@ const ActivityPage = () => {
       status: statusFilter,
       dateFrom: effectiveDateFrom,
       dateTo: effectiveDateTo,
+      activityIds: activityIdFilter,
     },
     searchQuery: effectiveSearchQuery,
     sorting,
@@ -452,6 +462,7 @@ const ActivityPage = () => {
       status: statusFilter,
       dateFrom: effectiveDateFrom,
       dateTo: effectiveDateTo,
+      activityIds: activityIdFilter,
     },
     searchQuery: effectiveSearchQuery,
     sorting,
@@ -477,7 +488,8 @@ const ActivityPage = () => {
     sorting,
   ]);
 
-  // Use appropriate data based on view mode
+  // Use appropriate data based on view mode. The ?activity=<id> deep-link is
+  // applied server-side via the activityIds filter, so no client-side narrowing.
   const tableActivities = infiniteSearch.data;
   const datagridActivities = paginatedSearch.data;
   const totalFetched = tableActivities.length;
@@ -654,6 +666,22 @@ const ActivityPage = () => {
 
   const investmentContent = (
     <div className="flex min-h-0 flex-1 flex-col space-y-4 overflow-hidden">
+      {isHealthActivityDeepLink && (
+        <div className="border-border bg-muted/30 flex items-center justify-between gap-3 rounded-md border px-3 py-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <Icons.Info className="text-muted-foreground h-4 w-4 shrink-0" />
+            <p className="text-sm">
+              {activityUrlFilters.activityId
+                ? "Showing the transaction flagged by Health Center"
+                : "Showing transactions flagged by Health Center"}
+            </p>
+          </div>
+          <Button variant="ghost" size="sm" onClick={clearActivityUrlFilterParams}>
+            Clear
+          </Button>
+        </div>
+      )}
+
       {isMobileViewport ? (
         <ActivityMobileControls
           accounts={investmentAccounts}

--- a/apps/frontend/src/pages/activity/hooks/use-activity-search.ts
+++ b/apps/frontend/src/pages/activity/hooks/use-activity-search.ts
@@ -16,6 +16,8 @@ export interface ActivitySearchFilters {
   /** Inclusive date bounds (YYYY-MM-DD) — used by Health Center deeplinks. */
   dateFrom?: string;
   dateTo?: string;
+  /** Exact activity ids — used by Health Center deep-links to one transaction. */
+  activityIds?: string[];
 }
 
 interface BaseOptions {
@@ -99,6 +101,7 @@ export function useActivitySearch(options: UseActivitySearchOptions): UseActivit
       needsReview,
       dateFrom: filters.dateFrom,
       dateTo: filters.dateTo,
+      activityIds: filters.activityIds?.length ? filters.activityIds : undefined,
     } as Record<string, unknown>;
   }, [
     filters.accountIds,
@@ -107,6 +110,7 @@ export function useActivitySearch(options: UseActivitySearchOptions): UseActivit
     filters.status,
     filters.dateFrom,
     filters.dateTo,
+    filters.activityIds,
   ]);
 
   const primarySort = useMemo(

--- a/apps/frontend/src/pages/activity/utils/url-filters.test.ts
+++ b/apps/frontend/src/pages/activity/utils/url-filters.test.ts
@@ -41,6 +41,15 @@ describe("resolveActivityUrlFilters", () => {
     });
   });
 
+  it("maps health activity deep links to exact activity and context filters", () => {
+    expect(
+      resolveActivityUrlFilters(new URLSearchParams("activity=act-1&healthContext=activity")),
+    ).toEqual({
+      activityId: "act-1",
+      healthContext: "activity",
+    });
+  });
+
   it("ignores an empty types param", () => {
     expect(resolveActivityUrlFilters(new URLSearchParams("types="))).toEqual({});
   });
@@ -73,7 +82,9 @@ describe("resolveActivityUrlFilters", () => {
 
   it("clears transfer-integrity deeplink params", () => {
     const cleared = clearActivityUrlFilters(
-      new URLSearchParams("tab=investments&types=TRANSFER_IN&from=2026-06-01&to=2026-06-04&q=AAPL"),
+      new URLSearchParams(
+        "tab=investments&types=TRANSFER_IN&from=2026-06-01&to=2026-06-04&q=AAPL&healthContext=activity",
+      ),
     );
 
     expect(cleared.toString()).toBe("tab=investments");

--- a/apps/frontend/src/pages/activity/utils/url-filters.ts
+++ b/apps/frontend/src/pages/activity/utils/url-filters.ts
@@ -9,6 +9,10 @@ interface ActivityUrlFilters {
   dateFrom?: string;
   dateTo?: string;
   searchQuery?: string;
+  /** A single activity id to focus on (e.g. from a health-check deep-link). */
+  activityId?: string;
+  /** Identifies Health Center deep-links so the destination can show context copy. */
+  healthContext?: string;
 }
 
 export type ActivityTab = "investments" | "spending";
@@ -20,6 +24,8 @@ export function resolveActivityUrlFilters(searchParams: URLSearchParams): Activi
   const dateFrom = searchParams.get("from")?.trim();
   const dateTo = searchParams.get("to")?.trim();
   const searchQuery = searchParams.get("q")?.trim();
+  const activityId = searchParams.get("activity")?.trim();
+  const healthContext = searchParams.get("healthContext")?.trim();
 
   const activityTypes = typesRaw
     ? (typesRaw
@@ -35,6 +41,8 @@ export function resolveActivityUrlFilters(searchParams: URLSearchParams): Activi
     ...(dateFrom ? { dateFrom } : {}),
     ...(dateTo ? { dateTo } : {}),
     ...(searchQuery ? { searchQuery } : {}),
+    ...(activityId ? { activityId } : {}),
+    ...(healthContext ? { healthContext } : {}),
   };
 }
 
@@ -55,6 +63,8 @@ export function clearActivityUrlFilters(searchParams: URLSearchParams): URLSearc
   next.delete("from");
   next.delete("to");
   next.delete("q");
+  next.delete("activity");
+  next.delete("healthContext");
   return next;
 }
 

--- a/apps/frontend/src/pages/asset/asset-profile-page.tsx
+++ b/apps/frontend/src/pages/asset/asset-profile-page.tsx
@@ -126,6 +126,7 @@ interface AssetDetailData {
 
 type AssetTab = "overview" | "history";
 type OverviewSubTab = "about" | "holdings" | "activities" | "snapshots" | "quotes";
+type AssetHealthContext = "price" | "basis" | "activity";
 
 const REGULAR_SUB_TAB_VALUES: OverviewSubTab[] = [
   "about",
@@ -145,6 +146,108 @@ const parseSubTabParam = (param: string | null): OverviewSubTab => {
   return "about";
 };
 
+const parseHealthContext = (value: string | null): AssetHealthContext | null => {
+  if (value === "price" || value === "basis" || value === "activity") {
+    return value;
+  }
+  return null;
+};
+
+const formatHealthDate = (value: string | null): string | null => {
+  if (!value) return null;
+  const date = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(date);
+};
+
+function AssetHealthBanner({
+  context,
+  isManualPricingMode,
+  date,
+  canRefreshPrices,
+  isRefreshingPrices,
+  onRefreshPrices,
+  onClear,
+}: {
+  context: AssetHealthContext | null;
+  isManualPricingMode: boolean;
+  date: string | null;
+  canRefreshPrices: boolean;
+  isRefreshingPrices: boolean;
+  onRefreshPrices: () => void;
+  onClear: () => void;
+}) {
+  if (!context) return null;
+
+  const dateLabel = formatHealthDate(date);
+  const copy =
+    context === "price"
+      ? isManualPricingMode
+        ? {
+            title: dateLabel ? `Add a price for ${dateLabel}` : "Manual prices need review",
+            description: dateLabel
+              ? "Wealthfolio is carrying forward the last price. Add this date only if it needs its own value."
+              : "Review the missing dates. Add prices that need their own value; carried-forward prices are still used between entries.",
+          }
+        : {
+            title: dateLabel ? `Price missing for ${dateLabel}` : "Price history needs review",
+            description: dateLabel
+              ? "Wealthfolio is carrying forward the last available price. Refetch prices if this was a trading day."
+              : "Refetch provider history to restore missing or stale prices. Carried-forward prices are used until exact prices are available.",
+          }
+      : context === "basis"
+        ? {
+            title: "Cost basis needs review",
+            description:
+              "Update what you paid for this holding so Wealthfolio can calculate gain/loss.",
+          }
+        : {
+            title: "Transactions need review",
+            description:
+              "Review the transactions Health Center flagged for this investment.",
+          };
+
+  return (
+    <div className="border-warning/30 bg-warning/10 mb-4 rounded-md border px-3 py-3">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div className="flex min-w-0 items-start gap-2">
+          <Icons.AlertTriangle className="text-warning mt-0.5 h-4 w-4 shrink-0" />
+          <div className="min-w-0 space-y-1">
+            <p className="text-sm font-medium">{copy.title}</p>
+            <p className="text-muted-foreground text-sm leading-relaxed">{copy.description}</p>
+          </div>
+        </div>
+        <div className="flex shrink-0 flex-wrap items-center gap-2 md:justify-end">
+          {context === "price" && !isManualPricingMode && (
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={!canRefreshPrices || isRefreshingPrices}
+              onClick={onRefreshPrices}
+            >
+              {isRefreshingPrices ? (
+                <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Icons.Refresh className="mr-2 h-4 w-4" />
+              )}
+              Refetch Prices
+            </Button>
+          )}
+          <Button type="button" variant="ghost" size="sm" onClick={onClear}>
+            Clear
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export const AssetProfilePage = () => {
   const { settings } = useSettingsContext();
   const baseCurrency = settings?.baseCurrency ?? "USD";
@@ -154,6 +257,8 @@ export const AssetProfilePage = () => {
   const navigate = useNavigate();
   const queryParams = new URLSearchParams(location.search);
   const tabParam = queryParams.get("tab");
+  const healthContext = parseHealthContext(queryParams.get("healthContext"));
+  const healthDate = queryParams.get("date");
   // activeTab is only used by alternative assets (Overview | Values).
   const defaultTab: AssetTab = tabParam === "history" ? "history" : "overview";
   const [activeTab, setActiveTab] = useState<AssetTab>(defaultTab);
@@ -936,6 +1041,14 @@ export const AssetProfilePage = () => {
     navigate(-1);
   }, [navigate]);
 
+  const clearHealthContext = useCallback(() => {
+    const next = new URLSearchParams(location.search);
+    next.delete("healthContext");
+    next.delete("date");
+    const query = next.toString();
+    navigate(`${location.pathname}${query ? `?${query}` : ""}`, { replace: true });
+  }, [location.pathname, location.search, navigate]);
+
   // Alternative asset actions hook (only used when isAltAsset && altHolding)
   const altAssetActions = useAlternativeAssetActions({
     holding: altHolding,
@@ -1015,6 +1128,16 @@ export const AssetProfilePage = () => {
           }
         />
         <PageContent>
+          <AssetHealthBanner
+            context={healthContext}
+            isManualPricingMode={isManualPricingMode}
+            date={healthDate}
+            canRefreshPrices={Boolean(profile?.id)}
+            isRefreshingPrices={syncMarketDataMutation.isPending}
+            onRefreshPrices={handleRefreshQuotesWithConfirm}
+            onClear={clearHealthContext}
+          />
+
           {fxActiveTab === "overview" && (
             <div className="space-y-4">
               <AssetHistoryCard
@@ -1281,6 +1404,16 @@ export const AssetProfilePage = () => {
         </div>
       </PageHeader>
       <PageContent>
+        <AssetHealthBanner
+          context={healthContext}
+          isManualPricingMode={isManualPricingMode}
+          date={healthDate}
+          canRefreshPrices={Boolean(profile?.id)}
+          isRefreshingPrices={syncMarketDataMutation.isPending}
+          onRefreshPrices={handleRefreshQuotesWithConfirm}
+          onClear={clearHealthContext}
+        />
+
         {/* Alternative Asset Content */}
         {isAltAsset && altHolding && assetProfile ? (
           isMobile ? (

--- a/apps/frontend/src/pages/asset/asset-profile-page.tsx
+++ b/apps/frontend/src/pages/asset/asset-profile-page.tsx
@@ -208,8 +208,7 @@ function AssetHealthBanner({
           }
         : {
             title: "Transactions need review",
-            description:
-              "Review the transactions Health Center flagged for this investment.",
+            description: "Review the transactions Health Center flagged for this investment.",
           };
 
   return (

--- a/apps/frontend/src/pages/health/components/issue-detail-sheet.test.tsx
+++ b/apps/frontend/src/pages/health/components/issue-detail-sheet.test.tsx
@@ -6,6 +6,14 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi } from "vitest";
 import { IssueDetailSheet } from "./issue-detail-sheet";
 
+const diagnosticMeta = {
+  fingerprint: "diagnostic-fingerprint",
+  domain: "performanceInputs" as const,
+  level: "source" as const,
+  severity: "WARNING" as const,
+  entities: [],
+};
+
 vi.mock("@wealthfolio/ui", () => ({
   ActionConfirm: ({ button }: { button: React.ReactNode }) => <>{button}</>,
   Badge: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
@@ -79,6 +87,7 @@ function renderIssueSheet(issue: HealthIssue) {
               onOpenChange={noop}
               onDismiss={noop}
               onFix={noop}
+              onRunFixAction={noop}
               isDismissing={false}
               isFixing={false}
             />
@@ -111,17 +120,17 @@ describe("IssueDetailSheet", () => {
     renderIssueSheet({
       ...baseIssue,
       category: "DATA_CONSISTENCY",
-      title: "9 incomplete transfers detected",
-      message: "A transfer is unpaired or missing its matching leg.",
+      title: "9 transfers need matching or confirmation",
+      message: "Some transfers are missing the other side of the move.",
       affectedCount: 9,
       affectedItems: Array.from({ length: 9 }, (_, index) => ({
         id: `transfer-${index}`,
-        name: `Incomplete transfer ${index + 1}`,
+        name: `Transfer ${index + 1} needs review`,
       })),
       details: Array.from(
         { length: 9 },
         (_, index) =>
-          `Incomplete transfer ${index + 1}\nThis transfer was treated as external; pair it or mark it external if intended.`,
+          `Transfer ${index + 1} needs review\nMatch this with the other side of the transfer, or mark it external if money entered or left your portfolio.`,
       ).join("\n\n"),
     });
 
@@ -139,7 +148,7 @@ describe("IssueDetailSheet", () => {
     renderIssueSheet({
       ...baseIssue,
       category: "DATA_CONSISTENCY",
-      title: "7 incomplete transfers detected",
+      title: "7 transfers need matching or confirmation",
       affectedCount: 7,
     });
 
@@ -150,7 +159,7 @@ describe("IssueDetailSheet", () => {
     renderIssueSheet({
       ...baseIssue,
       category: "DATA_CONSISTENCY",
-      title: "2 valuation rows have unknown transfer classification",
+      title: "2 transfer dates need review",
       details: "Personal\nDate: 2023-02-20\n\nPersonal\nDate: 2025-03-02",
     });
 
@@ -162,10 +171,10 @@ describe("IssueDetailSheet", () => {
     renderIssueSheet({
       ...baseIssue,
       category: "DATA_CONSISTENCY",
-      title: "2 valuation rows have unknown transfer classification",
+      title: "2 transfer dates need review",
       navigateAction: {
         route: "/activities",
-        label: "View Activities",
+        label: "Review Transactions",
         query: {
           account: "acc-personal",
           types: "TRANSFER_IN,TRANSFER_OUT",
@@ -176,7 +185,7 @@ describe("IssueDetailSheet", () => {
       },
     });
 
-    const href = screen.getByRole("link", { name: /View Activities/i }).getAttribute("href");
+    const href = screen.getByRole("link", { name: /Review Transactions/i }).getAttribute("href");
     const url = new URL(href ?? "", "http://localhost");
 
     expect(url.pathname).toBe("/activities");
@@ -191,11 +200,11 @@ describe("IssueDetailSheet", () => {
     renderIssueSheet({
       ...baseIssue,
       category: "DATA_CONSISTENCY",
-      title: "2 valuation rows have unknown transfer classification",
+      title: "2 transfer dates need review",
       details: "Personal\nDate: 2023-02-20\n\nPersonal\nDate: 2025-03-02",
       navigateAction: {
         route: "/activities",
-        label: "View Activities",
+        label: "Review Transactions",
         query: {
           account: "acc-personal",
           types: "TRANSFER_IN,TRANSFER_OUT",
@@ -219,5 +228,407 @@ describe("IssueDetailSheet", () => {
     expect(secondUrl.searchParams.get("from")).toBe("2025-03-02");
     expect(secondUrl.searchParams.get("to")).toBe("2025-03-02");
     expect(secondUrl.searchParams.get("account")).toBe("acc-personal");
+  });
+
+  const diagnosticIssue: HealthIssue = {
+    ...baseIssue,
+    id: "incomplete_valuation_value:xyz",
+    category: "DATA_CONSISTENCY",
+    title: "55 prices or values are missing",
+    message: "Some holdings are missing a market price, manual value, or exchange rate.",
+    navigateAction: { route: "/activities", label: "Review Transactions" },
+    details: "Trade Republic\nDate: 2025-11-05",
+    diagnostics: [
+      {
+        ...diagnosticMeta,
+        code: "INCOMPLETE_BASIS_ACTIVITY",
+        title: "Missing purchase price",
+        explanation: "This buy has no price, so its cost can't be calculated.",
+        evidence: [
+          { label: "Asset", value: "CGX — Cineplex Inc.", route: "/holdings/asset_cgx" },
+          { label: "Trade date", value: "2020-06-22" },
+        ],
+        actions: [
+          {
+            primary: true,
+            kind: "navigate",
+            route: "/activities",
+            query: { activity: "buy-1", healthContext: "activity" },
+            label: "Review Transaction",
+          },
+          {
+            primary: false,
+            kind: "fix",
+            id: "rebuild_account_history",
+            label: "Rebuild History",
+            payload: ["acc-1"],
+          },
+        ],
+      },
+    ],
+  };
+
+  it("renders a compact root cause with one deep-linked row per item, no technical labels", () => {
+    render(
+      <MemoryRouter>
+        <IssueDetailSheet
+          issue={diagnosticIssue}
+          open={true}
+          onOpenChange={noop}
+          onDismiss={noop}
+          onFix={noop}
+          onRunFixAction={noop}
+          isDismissing={false}
+          isFixing={false}
+        />
+      </MemoryRouter>,
+    );
+
+    // Root cause is shown once; the item row shows the asset + trade date.
+    expect(screen.getByText("Missing purchase price")).toBeInTheDocument();
+    expect(screen.getByText(/no price/i)).toBeInTheDocument();
+    expect(screen.getByText("CGX — Cineplex Inc.")).toBeInTheDocument();
+    expect(screen.getByText("2020-06-22")).toBeInTheDocument();
+    // No technical code, no section headers, no legacy details.
+    expect(screen.queryByText("INCOMPLETE_BASIS_ACTIVITY")).not.toBeInTheDocument();
+    expect(screen.queryByText("Root cause")).not.toBeInTheDocument();
+    expect(screen.queryByText("Details")).not.toBeInTheDocument();
+    // Only the primary "go to the activity" affordance; the secondary rebuild is dropped.
+    expect(screen.queryByText("Rebuild History")).not.toBeInTheDocument();
+    // The whole row links to the exact activity.
+    const row = screen.getByText("CGX — Cineplex Inc.").closest("a");
+    const url = new URL(row?.getAttribute("href") ?? "", "http://localhost");
+    expect(url.pathname).toBe("/activities");
+    expect(url.searchParams.get("activity")).toBe("buy-1");
+    expect(url.searchParams.get("healthContext")).toBe("activity");
+  });
+
+  it("renders transfer date diagnostics as date-filtered transfer rows", () => {
+    renderIssueSheet({
+      ...baseIssue,
+      severity: "ERROR",
+      category: "DATA_CONSISTENCY",
+      title: "2 transfer dates need review",
+      message:
+        "Some transfers are unclear: Wealthfolio cannot tell if money moved between your own accounts or entered/left your portfolio.",
+      navigateAction: {
+        route: "/activities",
+        label: "Review Transactions",
+        query: { types: "TRANSFER_IN,TRANSFER_OUT", healthContext: "activity" },
+      },
+      diagnostics: [
+        {
+          ...diagnosticMeta,
+          fingerprint: "transfer-rrsp-2026-06-01",
+          domain: "ledger",
+          code: "TRANSFER_DATE_NEEDS_REVIEW",
+          title: "Transfer needs review",
+          explanation:
+            "Review the transfers on this date. Match the two transactions if money moved between your accounts, or mark it external if money entered or left your portfolio.",
+          evidence: [
+            {
+              label: "Transfer",
+              value: "RRSP",
+              route:
+                "/activities?account=acc-rrsp&from=2026-06-01&to=2026-06-01&types=TRANSFER_IN%2CTRANSFER_OUT&healthContext=activity",
+            },
+            { label: "Date", value: "2026-06-01" },
+          ],
+          actions: [
+            {
+              primary: true,
+              kind: "navigate",
+              route: "/activities",
+              query: {
+                account: "acc-rrsp",
+                from: "2026-06-01",
+                to: "2026-06-01",
+                types: "TRANSFER_IN,TRANSFER_OUT",
+                healthContext: "activity",
+              },
+              label: "Review Transactions",
+            },
+          ],
+        },
+        {
+          ...diagnosticMeta,
+          fingerprint: "transfer-tfsa-2026-06-02",
+          domain: "ledger",
+          code: "TRANSFER_DATE_NEEDS_REVIEW",
+          title: "Transfer needs review",
+          explanation:
+            "Review the transfers on this date. Match the two transactions if money moved between your accounts, or mark it external if money entered or left your portfolio.",
+          evidence: [
+            {
+              label: "Transfer",
+              value: "TFSA",
+              route:
+                "/activities?account=acc-tfsa&from=2026-06-02&to=2026-06-02&types=TRANSFER_IN%2CTRANSFER_OUT&healthContext=activity",
+            },
+            { label: "Date", value: "2026-06-02" },
+          ],
+          actions: [
+            {
+              primary: true,
+              kind: "navigate",
+              route: "/activities",
+              query: {
+                account: "acc-tfsa",
+                from: "2026-06-02",
+                to: "2026-06-02",
+                types: "TRANSFER_IN,TRANSFER_OUT",
+                healthContext: "activity",
+              },
+              label: "Review Transactions",
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(screen.getByText("Transfer needs review")).toBeInTheDocument();
+    expect(screen.queryByText("Item")).not.toBeInTheDocument();
+    expect(screen.getAllByText("Transfer")).toHaveLength(2);
+    expect(screen.getByText("2026-06-01")).toBeInTheDocument();
+    expect(screen.getByText("2026-06-02")).toBeInTheDocument();
+
+    const rrspUrl = new URL(
+      screen.getByText("RRSP").closest("a")?.getAttribute("href") ?? "",
+      "http://localhost",
+    );
+    expect(rrspUrl.pathname).toBe("/activities");
+    expect(rrspUrl.searchParams.get("account")).toBe("acc-rrsp");
+    expect(rrspUrl.searchParams.get("from")).toBe("2026-06-01");
+    expect(rrspUrl.searchParams.get("to")).toBe("2026-06-01");
+    expect(rrspUrl.searchParams.get("types")).toBe("TRANSFER_IN,TRANSFER_OUT");
+    expect(rrspUrl.searchParams.get("healthContext")).toBe("activity");
+  });
+
+  it("runs the primary fix action from the diagnostic action button", async () => {
+    const user = userEvent.setup();
+    const onRunFixAction = vi.fn();
+    const fixIssue: HealthIssue = {
+      ...diagnosticIssue,
+      diagnostics: [
+        {
+          ...diagnosticMeta,
+          fingerprint: "market-quote",
+          domain: "marketData",
+          code: "MISSING_MARKET_QUOTE",
+          title: "No price found",
+          explanation: "We couldn't find a price for this holding.",
+          evidence: [{ label: "Asset", value: "XYZ — Example Corp" }],
+          actions: [
+            {
+              primary: true,
+              kind: "fix",
+              id: "sync_prices",
+              label: "Sync Prices",
+              payload: ["asset_xyz"],
+            },
+          ],
+        },
+      ],
+    };
+    render(
+      <MemoryRouter>
+        <IssueDetailSheet
+          issue={fixIssue}
+          open={true}
+          onOpenChange={noop}
+          onDismiss={noop}
+          onFix={noop}
+          onRunFixAction={onRunFixAction}
+          isDismissing={false}
+          isFixing={false}
+        />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Sync Prices/i }));
+
+    expect(onRunFixAction).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "sync_prices", payload: ["asset_xyz"] }),
+    );
+  });
+
+  it("groups missing price diagnostics by asset with missing-date summary", () => {
+    renderIssueSheet({
+      ...diagnosticIssue,
+      title: "3 price dates need review",
+      message:
+        "Some trading days are missing exact market prices. If a date was a market holiday, dismiss this issue.",
+      diagnostics: [
+        {
+          ...diagnosticMeta,
+          fingerprint: "aapl-2026-06-01",
+          domain: "marketData",
+          code: "MISSING_MARKET_QUOTE",
+          title: "No price found",
+          explanation:
+            "Wealthfolio is missing the exact market price for this holding on the affected date.",
+          date: "2026-06-01",
+          evidence: [
+            {
+              label: "Asset",
+              value: "AAPL — Apple Inc.",
+              route: "/holdings/asset_aapl?tab=quotes&healthContext=price&date=2026-06-01",
+            },
+            { label: "Date", value: "2026-06-01" },
+          ],
+          entities: [{ kind: "asset", id: "asset_aapl", label: "AAPL — Apple Inc." }],
+          actions: [
+            {
+              primary: true,
+              kind: "fix",
+              id: "sync_prices",
+              label: "Sync Prices",
+              payload: ["asset_aapl"],
+            },
+          ],
+        },
+        {
+          ...diagnosticMeta,
+          fingerprint: "aapl-2026-06-02",
+          domain: "marketData",
+          code: "MISSING_MARKET_QUOTE",
+          title: "No price found",
+          explanation:
+            "Wealthfolio is missing the exact market price for this holding on the affected date.",
+          date: "2026-06-02",
+          evidence: [
+            {
+              label: "Asset",
+              value: "AAPL — Apple Inc.",
+              route: "/holdings/asset_aapl?tab=quotes&healthContext=price&date=2026-06-02",
+            },
+            { label: "Date", value: "2026-06-02" },
+          ],
+          entities: [{ kind: "asset", id: "asset_aapl", label: "AAPL — Apple Inc." }],
+          actions: [
+            {
+              primary: true,
+              kind: "fix",
+              id: "sync_prices",
+              label: "Sync Prices",
+              payload: ["asset_aapl"],
+            },
+          ],
+        },
+        {
+          ...diagnosticMeta,
+          fingerprint: "msft-2026-06-02",
+          domain: "marketData",
+          code: "MISSING_MARKET_QUOTE",
+          title: "No price found",
+          explanation:
+            "Wealthfolio is missing the exact market price for this holding on the affected date.",
+          date: "2026-06-02",
+          evidence: [
+            {
+              label: "Asset",
+              value: "MSFT — Microsoft Corporation",
+              route: "/holdings/asset_msft?tab=quotes&healthContext=price&date=2026-06-02",
+            },
+            { label: "Date", value: "2026-06-02" },
+          ],
+          entities: [{ kind: "asset", id: "asset_msft", label: "MSFT — Microsoft Corporation" }],
+          actions: [
+            {
+              primary: true,
+              kind: "fix",
+              id: "sync_prices",
+              label: "Sync Prices",
+              payload: ["asset_msft"],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(screen.getAllByText("AAPL — Apple Inc.")).toHaveLength(1);
+    expect(screen.getByText("MSFT — Microsoft Corporation")).toBeInTheDocument();
+    expect(screen.getByText(/2 missing trading days/i)).toBeInTheDocument();
+    expect(screen.getByText(/1 missing trading day/i)).toBeInTheDocument();
+    expect(screen.getByText("Prices by investment")).toBeInTheDocument();
+    expect(screen.getByText(/2 investments/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/holidays or non-trading days/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText("About this issue")).not.toBeInTheDocument();
+    expect(screen.queryByText("No price found")).not.toBeInTheDocument();
+
+    const aaplUrl = new URL(
+      screen.getByText("AAPL — Apple Inc.").closest("a")?.getAttribute("href") ?? "",
+      "http://localhost",
+    );
+    expect(aaplUrl.pathname).toBe("/holdings/asset_aapl");
+    expect(aaplUrl.searchParams.get("tab")).toBe("quotes");
+    expect(aaplUrl.searchParams.get("healthContext")).toBe("price");
+    expect(aaplUrl.searchParams.has("date")).toBe(false);
+  });
+
+  it("renders mixed diagnostic causes with their own copy", () => {
+    render(
+      <MemoryRouter>
+        <IssueDetailSheet
+          issue={{
+            ...diagnosticIssue,
+            diagnostics: [
+              {
+                ...diagnosticMeta,
+                fingerprint: "basis",
+                code: "INCOMPLETE_BASIS_ACTIVITY",
+                title: "Missing purchase price",
+                explanation: "This buy has no price, so cost cannot be calculated.",
+                evidence: [{ label: "Asset", value: "CGX — Cineplex Inc." }],
+                actions: [
+                  {
+                    primary: true,
+                    kind: "navigate",
+                    route: "/activities",
+                    query: { activity: "buy-1", healthContext: "activity" },
+                    label: "Review Transaction",
+                  },
+                ],
+              },
+              {
+                ...diagnosticMeta,
+                fingerprint: "manual-value",
+                domain: "marketData",
+                code: "MISSING_MANUAL_VALUATION",
+                title: "Missing manual valuation",
+                explanation: "This manual holding needs a price before it can be valued.",
+                evidence: [{ label: "Holding", value: "ALT — Private Fund" }],
+                actions: [
+                  {
+                    primary: true,
+                    kind: "navigate",
+                    route: "/holdings/asset_alt",
+                    query: { tab: "quotes" },
+                    label: "Add Price",
+                  },
+                ],
+              },
+            ],
+          }}
+          open={true}
+          onOpenChange={noop}
+          onDismiss={noop}
+          onFix={noop}
+          onRunFixAction={noop}
+          isDismissing={false}
+          isFixing={false}
+        />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("Missing purchase price")).toBeInTheDocument();
+    expect(
+      screen.getByText("This buy has no price, so cost cannot be calculated."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Missing manual valuation")).toBeInTheDocument();
+    expect(
+      screen.getByText("This manual holding needs a price before it can be valued."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("ALT — Private Fund")).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/pages/health/components/issue-detail-sheet.test.tsx
+++ b/apps/frontend/src/pages/health/components/issue-detail-sheet.test.tsx
@@ -167,6 +167,36 @@ describe("IssueDetailSheet", () => {
     expect(screen.getByText("Date: 2025-03-02")).toHaveClass("font-mono", "tabular-nums");
   });
 
+  it("keeps legacy details visible for fallback diagnostics", () => {
+    const message =
+      "One or more accounts show a negative total value in their history. This is usually caused by missing buy transactions. Review your activities to fix this.";
+    renderIssueSheet({
+      ...baseIssue,
+      id: "negative_account_balance:abc123",
+      category: "DATA_CONSISTENCY",
+      title: "Account has negative portfolio balance",
+      message,
+      details:
+        "TFSA\nFirst went negative on 2026-06-01.\nCash: -100.00 CAD | Investments: 50.00 CAD\nLikely missing Transfer In or deposit before a buy transaction.",
+      diagnostics: [
+        {
+          ...diagnosticMeta,
+          fingerprint: "fallback",
+          domain: "ledger",
+          code: "NEGATIVE_ACCOUNT_BALANCE",
+          title: "Account has negative portfolio balance",
+          explanation: message,
+          evidence: [{ label: "Item", value: "TFSA" }],
+          actions: [],
+        },
+      ],
+    });
+
+    expect(screen.getByText("Details")).toBeInTheDocument();
+    expect(screen.getByText("First went negative on 2026-06-01.")).toBeInTheDocument();
+    expect(screen.getByText(/Likely missing Transfer In/i)).toBeInTheDocument();
+  });
+
   it("serializes filtered activity navigation query params", () => {
     renderIssueSheet({
       ...baseIssue,
@@ -293,8 +323,8 @@ describe("IssueDetailSheet", () => {
     expect(screen.queryByText("INCOMPLETE_BASIS_ACTIVITY")).not.toBeInTheDocument();
     expect(screen.queryByText("Root cause")).not.toBeInTheDocument();
     expect(screen.queryByText("Details")).not.toBeInTheDocument();
-    // Only the primary "go to the activity" affordance; the secondary rebuild is dropped.
-    expect(screen.queryByText("Rebuild History")).not.toBeInTheDocument();
+    // Secondary actions remain available.
+    expect(screen.getByRole("button", { name: /Rebuild History/i })).toBeInTheDocument();
     // The whole row links to the exact activity.
     const row = screen.getByText("CGX — Cineplex Inc.").closest("a");
     const url = new URL(row?.getAttribute("href") ?? "", "http://localhost");
@@ -452,6 +482,31 @@ describe("IssueDetailSheet", () => {
     );
   });
 
+  it("runs a secondary fix action from the diagnostic action list", async () => {
+    const user = userEvent.setup();
+    const onRunFixAction = vi.fn();
+    render(
+      <MemoryRouter>
+        <IssueDetailSheet
+          issue={diagnosticIssue}
+          open={true}
+          onOpenChange={noop}
+          onDismiss={noop}
+          onFix={noop}
+          onRunFixAction={onRunFixAction}
+          isDismissing={false}
+          isFixing={false}
+        />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole("button", { name: /Rebuild History/i }));
+
+    expect(onRunFixAction).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "rebuild_account_history", payload: ["acc-1"] }),
+    );
+  });
+
   it("groups missing price diagnostics by asset with missing-date summary", () => {
     renderIssueSheet({
       ...diagnosticIssue,
@@ -588,6 +643,13 @@ describe("IssueDetailSheet", () => {
                     query: { activity: "buy-1", healthContext: "activity" },
                     label: "Review Transaction",
                   },
+                  {
+                    primary: false,
+                    kind: "fix",
+                    id: "rebuild_account_history",
+                    label: "Rebuild History",
+                    payload: ["acc-1"],
+                  },
                 ],
               },
               {
@@ -630,5 +692,6 @@ describe("IssueDetailSheet", () => {
       screen.getByText("This manual holding needs a price before it can be valued."),
     ).toBeInTheDocument();
     expect(screen.getByText("ALT — Private Fund")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Rebuild History/i })).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/pages/health/components/issue-detail-sheet.tsx
+++ b/apps/frontend/src/pages/health/components/issue-detail-sheet.tsx
@@ -134,6 +134,25 @@ function getDetailDate(lines: string[]): string | null {
   return match?.[1] ?? null;
 }
 
+function diagnosticCodeFromIssueId(id: string): string {
+  const groupingKey = id.includes(":") ? id.slice(0, id.lastIndexOf(":")) : id;
+  return groupingKey
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((part) => part.toUpperCase())
+    .join("_");
+}
+
+function isFallbackDiagnosticIssue(issue: HealthIssue, diagnostics: HealthDiagnostic[]): boolean {
+  if (diagnostics.length !== 1) return false;
+  const [diagnostic] = diagnostics;
+  return (
+    diagnostic.code === diagnosticCodeFromIssueId(issue.id) &&
+    diagnostic.title === issue.title &&
+    diagnostic.explanation === issue.message
+  );
+}
+
 interface DiagnosticGroup {
   key: string;
   title: string;
@@ -154,6 +173,11 @@ interface PriceDiagnosticAssetGroup {
   label: string;
   dates: string[];
   route?: string;
+}
+
+interface DiagnosticActionEntry {
+  key: string;
+  action: DiagnosticAction;
 }
 
 const GENERIC_EVIDENCE_LABELS = new Set([
@@ -186,6 +210,43 @@ function groupDiagnostics(diagnostics: HealthDiagnostic[]): DiagnosticGroup[] {
 
 function getPrimaryDiagnosticAction(diagnostic: HealthDiagnostic): DiagnosticAction | undefined {
   return diagnostic.actions.find((action) => action.primary) ?? diagnostic.actions[0];
+}
+
+function getOrderedDiagnosticActions(diagnostic: HealthDiagnostic): DiagnosticAction[] {
+  const primary = diagnostic.actions.filter((action) => action.primary);
+  const secondary = diagnostic.actions.filter((action) => !action.primary);
+  return [...primary, ...secondary];
+}
+
+function stringifyActionPart(value: unknown): string {
+  try {
+    return JSON.stringify(value ?? null);
+  } catch {
+    return String(value);
+  }
+}
+
+function getDiagnosticActionSignature(action: DiagnosticAction): string {
+  if (action.kind === "navigate") {
+    return `navigate:${action.route}:${action.label}:${stringifyActionPart(action.query)}`;
+  }
+  return `fix:${action.id}:${action.label}:${stringifyActionPart(action.payload)}`;
+}
+
+function getDiagnosticActionEntries(
+  diagnostics: HealthDiagnostic[],
+  includePrimary: boolean,
+): DiagnosticActionEntry[] {
+  const seen = new Set<string>();
+  return diagnostics.flatMap((diagnostic) =>
+    getOrderedDiagnosticActions(diagnostic).flatMap((action) => {
+      if (!includePrimary && action.primary) return [];
+      const signature = getDiagnosticActionSignature(action);
+      if (seen.has(signature)) return [];
+      seen.add(signature);
+      return [{ key: `${diagnostic.fingerprint}:${signature}`, action }];
+    }),
+  );
 }
 
 function isPriceDateDiagnostic(diagnostic: HealthDiagnostic): boolean {
@@ -345,6 +406,8 @@ export function IssueDetailSheet({
   const diagnosticGroups = groupDiagnostics(diagnostics);
   const isGroupedPrice = isGroupedPriceIssue(diagnosticGroups);
   const hasDiagnosticActions = diagnostics.some((diagnostic) => diagnostic.actions.length > 0);
+  const shouldRenderDetails =
+    !hasDiagnostics || isFallbackDiagnosticIssue(issue, diagnostics);
   const detailItems =
     issue.details
       ?.split(/\n\s*\n/)
@@ -444,6 +507,12 @@ export function IssueDetailSheet({
                   const priceAssetGroups = shouldGroupByAsset
                     ? buildPriceAssetGroups(group.diagnostics)
                     : [];
+                  const actionEntries = shouldGroupByAsset
+                    ? []
+                    : getDiagnosticActionEntries(
+                        group.diagnostics,
+                        group.diagnostics.length === 1,
+                      );
 
                   return (
                     <div key={group.key} className="space-y-3">
@@ -542,51 +611,49 @@ export function IssueDetailSheet({
                             })}
                       </div>
 
-                      {group.diagnostics.length === 1 &&
-                        (() => {
-                          const action = getPrimaryDiagnosticAction(group.diagnostics[0]);
-                          if (!action) return null;
-
-                          if (action.kind === "navigate") {
-                            return (
-                              <Button variant="outline" size="sm" asChild>
+                      {actionEntries.length > 0 && (
+                        <div className="flex flex-wrap gap-2">
+                          {actionEntries.map(({ key, action }) =>
+                            action.kind === "navigate" ? (
+                              <Button key={key} variant="outline" size="sm" asChild>
                                 <Link to={buildDiagnosticRoute(action)}>
                                   <Icons.ArrowRight className="mr-2 h-4 w-4" />
                                   {action.label}
                                 </Link>
                               </Button>
-                            );
-                          }
-
-                          return (
-                            <Button
-                              type="button"
-                              size="sm"
-                              disabled={isFixing}
-                              onClick={() =>
-                                onRunFixAction({
-                                  id: action.id,
-                                  label: action.label,
-                                  payload: action.payload,
-                                })
-                              }
-                            >
-                              {isFixing ? (
-                                <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />
-                              ) : (
-                                <Icons.Wand2 className="mr-2 h-4 w-4" />
-                              )}
-                              {action.label}
-                            </Button>
-                          );
-                        })()}
+                            ) : (
+                              <Button
+                                key={key}
+                                type="button"
+                                variant={action.primary ? "default" : "outline"}
+                                size="sm"
+                                disabled={isFixing}
+                                onClick={() =>
+                                  onRunFixAction({
+                                    id: action.id,
+                                    label: action.label,
+                                    payload: action.payload,
+                                  })
+                                }
+                              >
+                                {isFixing ? (
+                                  <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />
+                                ) : (
+                                  <Icons.Wand2 className="mr-2 h-4 w-4" />
+                                )}
+                                {action.label}
+                              </Button>
+                            ),
+                          )}
+                        </div>
+                      )}
                     </div>
                   );
                 })}
               </div>
             )}
 
-            {!hasDiagnostics && detailItems.length > 0 && (
+            {shouldRenderDetails && detailItems.length > 0 && (
               <div className="space-y-2">
                 <h4 className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
                   Details

--- a/apps/frontend/src/pages/health/components/issue-detail-sheet.tsx
+++ b/apps/frontend/src/pages/health/components/issue-detail-sheet.tsx
@@ -1,4 +1,11 @@
-import type { HealthCategory, HealthIssue, HealthSeverity } from "@/lib/types";
+import type {
+  DiagnosticAction,
+  FixAction,
+  HealthCategory,
+  HealthDiagnostic,
+  HealthIssue,
+  HealthSeverity,
+} from "@/lib/types";
 import {
   ActionConfirm,
   Badge,
@@ -19,8 +26,18 @@ interface IssueDetailSheetProps {
   onOpenChange: (open: boolean) => void;
   onDismiss: () => void;
   onFix: () => void;
+  /** Runs a specific fix action from a diagnostic's "How to fix" list. */
+  onRunFixAction: (action: FixAction) => void;
   isDismissing: boolean;
   isFixing: boolean;
+}
+
+/** Builds a route string from a diagnostic navigate action ({ route, query }). */
+function buildDiagnosticRoute(action: Extract<DiagnosticAction, { kind: "navigate" }>): string {
+  const query = new URLSearchParams(
+    Object.entries(action.query ?? {}).map(([key, value]) => [key, String(value)]),
+  ).toString();
+  return `${action.route}${query ? `?${query}` : ""}`;
 }
 
 const SEVERITY_CONFIG: Record<HealthSeverity, { label: string; color: string }> = {
@@ -117,12 +134,205 @@ function getDetailDate(lines: string[]): string | null {
   return match?.[1] ?? null;
 }
 
+interface DiagnosticGroup {
+  key: string;
+  title: string;
+  explanation: string;
+  diagnostics: HealthDiagnostic[];
+}
+
+interface DiagnosticEvidenceRow {
+  key: string;
+  label: string;
+  value: string;
+  detail?: string;
+  route?: string;
+}
+
+interface PriceDiagnosticAssetGroup {
+  key: string;
+  label: string;
+  dates: string[];
+  route?: string;
+}
+
+const GENERIC_EVIDENCE_LABELS = new Set([
+  "asset",
+  "holding",
+  "transaction",
+  "transfer",
+  "account",
+  "item",
+]);
+
+function groupDiagnostics(diagnostics: HealthDiagnostic[]): DiagnosticGroup[] {
+  const groups = new Map<string, DiagnosticGroup>();
+  diagnostics.forEach((diagnostic) => {
+    const key = `${diagnostic.code}:${diagnostic.title}:${diagnostic.explanation}`;
+    const existing = groups.get(key);
+    if (existing) {
+      existing.diagnostics.push(diagnostic);
+      return;
+    }
+    groups.set(key, {
+      key,
+      title: diagnostic.title,
+      explanation: diagnostic.explanation,
+      diagnostics: [diagnostic],
+    });
+  });
+  return Array.from(groups.values());
+}
+
+function getPrimaryDiagnosticAction(diagnostic: HealthDiagnostic): DiagnosticAction | undefined {
+  return diagnostic.actions.find((action) => action.primary) ?? diagnostic.actions[0];
+}
+
+function isPriceDateDiagnostic(diagnostic: HealthDiagnostic): boolean {
+  return diagnostic.code === "MISSING_MARKET_QUOTE" || diagnostic.code === "MISSING_MANUAL_VALUATION";
+}
+
+function isDateEvidence(label: string): boolean {
+  return /date/i.test(label);
+}
+
+function getEvidenceDisplay(row: HealthDiagnostic["evidence"][number]): {
+  label: string;
+  value: string;
+} {
+  if (GENERIC_EVIDENCE_LABELS.has(row.label.toLowerCase())) {
+    return { label: row.value, value: row.label };
+  }
+  return { label: row.label, value: row.value };
+}
+
+function buildDiagnosticRows(diagnostic: HealthDiagnostic): DiagnosticEvidenceRow[] {
+  const dateRow = diagnostic.evidence.find((row) => isDateEvidence(row.label));
+  const objectRows = diagnostic.evidence.filter((row) => !isDateEvidence(row.label));
+  const sourceRows = objectRows.length > 0 ? objectRows : diagnostic.evidence;
+
+  if (sourceRows.length === 0) {
+    const entity = diagnostic.entities[0];
+    return [
+      {
+        key: `${diagnostic.fingerprint}:diagnostic`,
+        label: entity?.label ?? diagnostic.title,
+        value: entity?.kind ?? "",
+        detail: diagnostic.date,
+        route: entity?.route,
+      },
+    ];
+  }
+
+  return sourceRows.map((row, index) => {
+    const display = getEvidenceDisplay(row);
+    return {
+      key: `${diagnostic.fingerprint}:${index}:${row.label}:${row.value}`,
+      label: display.label,
+      value: display.value,
+      detail: dateRow && dateRow !== row ? dateRow.value : undefined,
+      route: row.route,
+    };
+  });
+}
+
+function compactHealthDate(value: string): string {
+  const date = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  }).format(date);
+}
+
+function stripGroupedDateParam(route: string, dates: string[]): string {
+  if (dates.length <= 1) return route;
+  try {
+    const url = new URL(route, "http://localhost");
+    url.searchParams.delete("date");
+    return `${url.pathname}${url.search}`;
+  } catch {
+    return route;
+  }
+}
+
+function summarizePriceDates(dates: string[]): string {
+  const uniqueDates = Array.from(new Set(dates)).sort();
+  if (uniqueDates.length === 0) return "Price history needs review";
+
+  if (uniqueDates.length === 1) {
+    return `1 missing trading day: ${compactHealthDate(uniqueDates[0])}`;
+  }
+
+  if (uniqueDates.length <= 3) {
+    return `${uniqueDates.length} missing trading days: ${uniqueDates
+      .map(compactHealthDate)
+      .join(", ")}`;
+  }
+
+  return `${uniqueDates.length} missing trading days: ${compactHealthDate(
+    uniqueDates[0],
+  )} to ${compactHealthDate(uniqueDates[uniqueDates.length - 1])}`;
+}
+
+function buildPriceAssetGroups(diagnostics: HealthDiagnostic[]): PriceDiagnosticAssetGroup[] {
+  const groups = new Map<string, PriceDiagnosticAssetGroup>();
+
+  diagnostics.forEach((diagnostic) => {
+    const assetEvidence = diagnostic.evidence.find((row) => !isDateEvidence(row.label));
+    const dateEvidence = diagnostic.evidence.find((row) => isDateEvidence(row.label));
+    const label = assetEvidence?.value ?? diagnostic.entities[0]?.label ?? diagnostic.title;
+    const route = assetEvidence?.route ?? diagnostic.entities[0]?.route;
+    const key =
+      diagnostic.entities.find((entity) => entity.kind === "asset")?.id ??
+      route ??
+      label;
+    const date = diagnostic.date ?? dateEvidence?.value;
+    const existing = groups.get(key);
+
+    if (existing) {
+      if (date) existing.dates.push(date);
+      if (!existing.route && route) existing.route = route;
+      return;
+    }
+
+    groups.set(key, {
+      key,
+      label,
+      dates: date ? [date] : [],
+      route,
+    });
+  });
+
+  return Array.from(groups.values()).map((group) => ({
+    ...group,
+    dates: Array.from(new Set(group.dates)).sort(),
+    route: group.route ? stripGroupedDateParam(group.route, group.dates) : undefined,
+  }));
+}
+
+function isGroupedPriceIssue(diagnosticGroups: DiagnosticGroup[]): boolean {
+  return (
+    diagnosticGroups.length === 1 &&
+    diagnosticGroups[0].diagnostics.length > 1 &&
+    diagnosticGroups[0].diagnostics.every(isPriceDateDiagnostic)
+  );
+}
+
+function priceIssueSummary(diagnosticCount: number, assetCount: number): string {
+  const assetLabel = assetCount === 1 ? "investment" : "investments";
+  return `${diagnosticCount} price ${diagnosticCount === 1 ? "date" : "dates"} across ${assetCount} ${assetLabel}`;
+}
+
 export function IssueDetailSheet({
   issue,
   open,
   onOpenChange,
   onDismiss,
   onFix,
+  onRunFixAction,
   isDismissing,
   isFixing,
 }: IssueDetailSheetProps) {
@@ -131,6 +341,11 @@ export function IssueDetailSheet({
   const severityConfig = SEVERITY_CONFIG[issue.severity];
   const categoryConfig = getCategoryConfigForIssue(issue);
   const navigateActionRoute = buildNavigateActionRoute(issue.navigateAction);
+  const diagnostics = issue.diagnostics ?? [];
+  const hasDiagnostics = diagnostics.length > 0;
+  const diagnosticGroups = groupDiagnostics(diagnostics);
+  const isGroupedPrice = isGroupedPriceIssue(diagnosticGroups);
+  const hasDiagnosticActions = diagnostics.some((diagnostic) => diagnostic.actions.length > 0);
   const detailItems =
     issue.details
       ?.split(/\n\s*\n/)
@@ -147,12 +362,16 @@ export function IssueDetailSheet({
             <span className="text-muted-foreground">{categoryConfig.label}</span>
           </div>
           <SheetTitle className="text-xl leading-tight">{issue.title}</SheetTitle>
-          <p className="text-muted-foreground text-sm leading-relaxed">{issue.message}</p>
+          <p className="text-muted-foreground text-sm leading-relaxed">
+            {isGroupedPrice
+              ? "Wealthfolio is using carried-forward prices for these dates. Refetch or add prices for real trading days; dismiss the issue if the dates were holidays or non-trading days."
+              : issue.message}
+          </p>
         </SheetHeader>
 
         <ScrollArea className="min-h-0 flex-1">
           <div className="space-y-6 pr-4">
-            {issue.affectedItems && issue.affectedItems.length > 0 && (
+            {!hasDiagnostics && issue.affectedItems && issue.affectedItems.length > 0 && (
               <div className="space-y-3">
                 <h4 className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
                   Affected Items ({issue.affectedItems.length})
@@ -193,7 +412,8 @@ export function IssueDetailSheet({
 
             {(issue.affectedCount > 0 ||
               (issue.affectedMvPct != null && issue.affectedMvPct > 0)) &&
-              !issue.affectedItems && (
+              !issue.affectedItems &&
+              !isGroupedPrice && (
                 <div className="space-y-3">
                   <h4 className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
                     Impact
@@ -217,7 +437,157 @@ export function IssueDetailSheet({
                 </div>
               )}
 
-            {detailItems.length > 0 && (
+            {hasDiagnostics && (
+              <div className="space-y-4">
+                {diagnosticGroups.map((group) => {
+                  const shouldGroupByAsset =
+                    group.diagnostics.length > 1 && group.diagnostics.every(isPriceDateDiagnostic);
+                  const priceAssetGroups = shouldGroupByAsset
+                    ? buildPriceAssetGroups(group.diagnostics)
+                    : [];
+
+                  return (
+                    <div key={group.key} className="space-y-3">
+                      <div className="space-y-1">
+                        <div className="flex flex-wrap items-baseline justify-between gap-2">
+                          <p className="text-sm font-medium">
+                            {shouldGroupByAsset ? "Prices by investment" : group.title}
+                          </p>
+                          {shouldGroupByAsset && (
+                            <p className="text-muted-foreground text-xs">
+                              {priceIssueSummary(group.diagnostics.length, priceAssetGroups.length)}
+                            </p>
+                          )}
+                        </div>
+                        {!shouldGroupByAsset && (
+                          <p className="text-muted-foreground text-xs leading-relaxed">
+                            {group.explanation}
+                          </p>
+                        )}
+                        {shouldGroupByAsset && (
+                          <p className="text-muted-foreground text-xs leading-relaxed">
+                            Open an investment to refetch or add prices. If the dates were holidays
+                            or non-trading days, dismiss the issue.
+                          </p>
+                        )}
+                      </div>
+
+                      <div className="divide-y overflow-hidden rounded-md border">
+                        {shouldGroupByAsset
+                          ? priceAssetGroups.map((assetGroup) => {
+                              const row = (
+                                <div className="flex items-center justify-between gap-3 px-3 py-2">
+                                  <div className="min-w-0">
+                                    <p className="truncate text-sm">{assetGroup.label}</p>
+                                    <p className="text-muted-foreground mt-0.5 truncate text-xs">
+                                      {summarizePriceDates(assetGroup.dates)}
+                                    </p>
+                                  </div>
+                                  {assetGroup.route && (
+                                    <Icons.ChevronRight className="text-muted-foreground h-4 w-4 shrink-0" />
+                                  )}
+                                </div>
+                              );
+
+                              return assetGroup.route ? (
+                                <Link
+                                  key={assetGroup.key}
+                                  to={assetGroup.route}
+                                  className="hover:bg-muted/40 block transition-colors"
+                                >
+                                  {row}
+                                </Link>
+                              ) : (
+                                <div key={assetGroup.key}>{row}</div>
+                              );
+                            })
+                          : group.diagnostics.flatMap((diagnostic) => {
+                              const action = getPrimaryDiagnosticAction(diagnostic);
+                              const rows = buildDiagnosticRows(diagnostic);
+                              return rows.map((evidenceRow) => {
+                                const rowRoute =
+                                  action?.kind === "navigate" && rows.length === 1
+                                    ? buildDiagnosticRoute(action)
+                                    : evidenceRow.route;
+                                const row = (
+                                  <div className="flex items-center justify-between gap-3 px-3 py-2">
+                                    <div className="min-w-0">
+                                      <p className="truncate text-sm">{evidenceRow.label}</p>
+                                      <div className="text-muted-foreground mt-0.5 flex min-w-0 flex-wrap items-center gap-x-2 gap-y-0.5 text-xs">
+                                        {evidenceRow.value && <span>{evidenceRow.value}</span>}
+                                        {evidenceRow.detail && (
+                                          <span className="font-mono tabular-nums">
+                                            {evidenceRow.detail}
+                                          </span>
+                                        )}
+                                      </div>
+                                    </div>
+                                    {rowRoute && (
+                                      <Icons.ChevronRight className="text-muted-foreground h-4 w-4 shrink-0" />
+                                    )}
+                                  </div>
+                                );
+
+                                return rowRoute ? (
+                                  <Link
+                                    key={evidenceRow.key}
+                                    to={rowRoute}
+                                    className="hover:bg-muted/40 block transition-colors"
+                                  >
+                                    {row}
+                                  </Link>
+                                ) : (
+                                  <div key={evidenceRow.key}>{row}</div>
+                                );
+                              });
+                            })}
+                      </div>
+
+                      {group.diagnostics.length === 1 &&
+                        (() => {
+                          const action = getPrimaryDiagnosticAction(group.diagnostics[0]);
+                          if (!action) return null;
+
+                          if (action.kind === "navigate") {
+                            return (
+                              <Button variant="outline" size="sm" asChild>
+                                <Link to={buildDiagnosticRoute(action)}>
+                                  <Icons.ArrowRight className="mr-2 h-4 w-4" />
+                                  {action.label}
+                                </Link>
+                              </Button>
+                            );
+                          }
+
+                          return (
+                            <Button
+                              type="button"
+                              size="sm"
+                              disabled={isFixing}
+                              onClick={() =>
+                                onRunFixAction({
+                                  id: action.id,
+                                  label: action.label,
+                                  payload: action.payload,
+                                })
+                              }
+                            >
+                              {isFixing ? (
+                                <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />
+                              ) : (
+                                <Icons.Wand2 className="mr-2 h-4 w-4" />
+                              )}
+                              {action.label}
+                            </Button>
+                          );
+                        })()}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+
+            {!hasDiagnostics && detailItems.length > 0 && (
               <div className="space-y-2">
                 <h4 className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
                   Details
@@ -279,17 +649,19 @@ export function IssueDetailSheet({
               </div>
             )}
 
-            <div className="space-y-2 border-t pt-6">
-              <h4 className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
-                About this issue
-              </h4>
-              <p className="text-muted-foreground text-sm">{categoryConfig.description}</p>
-            </div>
+            {!isGroupedPrice && (
+              <div className="space-y-2 border-t pt-6">
+                <h4 className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+                  About this issue
+                </h4>
+                <p className="text-muted-foreground text-sm">{categoryConfig.description}</p>
+              </div>
+            )}
           </div>
         </ScrollArea>
 
         <div className="shrink-0 space-y-2 border-t pt-4">
-          {issue.fixAction && (
+          {issue.fixAction && !hasDiagnosticActions && (
             <Button onClick={onFix} disabled={isFixing} className="w-full">
               {isFixing ? (
                 <Icons.Spinner className="mr-2 h-4 w-4 animate-spin" />
@@ -300,7 +672,7 @@ export function IssueDetailSheet({
             </Button>
           )}
 
-          {issue.navigateAction && (
+          {issue.navigateAction && !hasDiagnosticActions && (
             <Button variant="outline" className="w-full" asChild>
               <Link to={navigateActionRoute ?? issue.navigateAction.route}>
                 <Icons.ArrowRight className="mr-2 h-4 w-4" />

--- a/apps/frontend/src/pages/health/components/issue-detail-sheet.tsx
+++ b/apps/frontend/src/pages/health/components/issue-detail-sheet.tsx
@@ -406,8 +406,7 @@ export function IssueDetailSheet({
   const diagnosticGroups = groupDiagnostics(diagnostics);
   const isGroupedPrice = isGroupedPriceIssue(diagnosticGroups);
   const hasDiagnosticActions = diagnostics.some((diagnostic) => diagnostic.actions.length > 0);
-  const shouldRenderDetails =
-    !hasDiagnostics || isFallbackDiagnosticIssue(issue, diagnostics);
+  const shouldRenderDetails = !hasDiagnostics || isFallbackDiagnosticIssue(issue, diagnostics);
   const detailItems =
     issue.details
       ?.split(/\n\s*\n/)
@@ -509,10 +508,7 @@ export function IssueDetailSheet({
                     : [];
                   const actionEntries = shouldGroupByAsset
                     ? []
-                    : getDiagnosticActionEntries(
-                        group.diagnostics,
-                        group.diagnostics.length === 1,
-                      );
+                    : getDiagnosticActionEntries(group.diagnostics, group.diagnostics.length === 1);
 
                   return (
                     <div key={group.key} className="space-y-3">

--- a/apps/frontend/src/pages/health/components/issue-detail-sheet.tsx
+++ b/apps/frontend/src/pages/health/components/issue-detail-sheet.tsx
@@ -189,7 +189,9 @@ function getPrimaryDiagnosticAction(diagnostic: HealthDiagnostic): DiagnosticAct
 }
 
 function isPriceDateDiagnostic(diagnostic: HealthDiagnostic): boolean {
-  return diagnostic.code === "MISSING_MARKET_QUOTE" || diagnostic.code === "MISSING_MANUAL_VALUATION";
+  return (
+    diagnostic.code === "MISSING_MARKET_QUOTE" || diagnostic.code === "MISSING_MANUAL_VALUATION"
+  );
 }
 
 function isDateEvidence(label: string): boolean {
@@ -285,10 +287,7 @@ function buildPriceAssetGroups(diagnostics: HealthDiagnostic[]): PriceDiagnostic
     const dateEvidence = diagnostic.evidence.find((row) => isDateEvidence(row.label));
     const label = assetEvidence?.value ?? diagnostic.entities[0]?.label ?? diagnostic.title;
     const route = assetEvidence?.route ?? diagnostic.entities[0]?.route;
-    const key =
-      diagnostic.entities.find((entity) => entity.kind === "asset")?.id ??
-      route ??
-      label;
+    const key = diagnostic.entities.find((entity) => entity.kind === "asset")?.id ?? route ?? label;
     const date = diagnostic.date ?? dateEvidence?.value;
     const existing = groups.get(key);
 

--- a/apps/frontend/src/pages/health/health-page.tsx
+++ b/apps/frontend/src/pages/health/health-page.tsx
@@ -86,6 +86,9 @@ function HealthIssueRow({
 }) {
   const categoryConfig = getCategoryConfig(issue);
   const CategoryIcon = Icons[categoryConfig.icon];
+  const hasDiagnosticActions =
+    issue.diagnostics?.some((diagnostic) => diagnostic.actions.length > 0) ?? false;
+  const showQuickFix = Boolean(issue.fixAction && !hasDiagnosticActions);
 
   return (
     <div
@@ -120,7 +123,7 @@ function HealthIssueRow({
           <TooltipContent side="top">{categoryConfig.label}</TooltipContent>
         </Tooltip>
 
-        {issue.fixAction && (
+        {showQuickFix && (
           <Button
             size="sm"
             variant="secondary"
@@ -382,6 +385,7 @@ export default function HealthPage() {
             fixMutation.mutate(selectedIssue.fixAction);
           }
         }}
+        onRunFixAction={(action) => fixMutation.mutate(action)}
         isDismissing={dismissMutation.isPending}
         isFixing={fixMutation.isPending}
       />

--- a/apps/frontend/src/pages/holdings/holdings-page.tsx
+++ b/apps/frontend/src/pages/holdings/holdings-page.tsx
@@ -55,8 +55,11 @@ import { useSettingsContext } from "@/lib/settings-provider";
 export const HoldingsPage = () => {
   const isMobileViewport = useIsMobileViewport();
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const currentTab = searchParams.get("tab") ?? "investments";
+  // Health-center deep-links (e.g. /holdings?filter=negative|unclassified).
+  const healthFilter = searchParams.get("filter");
+  const healthContext = searchParams.get("healthContext");
   const queryClient = useQueryClient();
   const { settings } = useSettingsContext();
   const baseCurrency = settings?.baseCurrency ?? "USD";
@@ -134,6 +137,18 @@ export const HoldingsPage = () => {
     },
     [accounts],
   );
+
+  const clearHealthContext = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete("filter");
+        next.delete("healthContext");
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
 
   // Check if the selected account supports manual holdings editing
   const canEditHoldings = useMemo(() => {
@@ -334,12 +349,19 @@ export const HoldingsPage = () => {
       });
     }
 
+    // Health-center deep-link filters.
+    if (healthFilter === "negative") {
+      filtered = filtered.filter((holding) => holding.quantity < 0);
+    } else if (healthFilter === "unclassified") {
+      filtered = filtered.filter((holding) => !holding.instrument?.classifications?.assetType);
+    }
+
     return {
       nonCashHoldings: nonCash,
       filteredHoldings: filtered,
       availableTypeOptions: typeOptions,
     };
-  }, [holdings, selectedTypes, investmentsFilter]);
+  }, [holdings, selectedTypes, investmentsFilter, healthFilter]);
 
   // Combined loading state
   const isDataLoading = isLoading || isAccountsLoading || isAlternativeHoldingsLoading;
@@ -352,6 +374,18 @@ export const HoldingsPage = () => {
   // Investments content
   const investmentsContent = (
     <>
+      {(healthFilter || healthContext === "holding") && (
+        <div className="border-border bg-muted/30 mb-4 flex items-center justify-between gap-3 rounded-md border px-3 py-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <Icons.Info className="text-muted-foreground h-4 w-4 shrink-0" />
+            <p className="text-sm">Showing holdings flagged by Health Center</p>
+          </div>
+          <Button variant="ghost" size="sm" onClick={clearHealthContext}>
+            Clear
+          </Button>
+        </div>
+      )}
+
       {/* Edit Mode for HOLDINGS-mode accounts */}
       {isEditMode && selectedAccount && canEditHoldings ? (
         <HoldingsEditMode

--- a/apps/frontend/src/pages/settings/market-data/market-data-settings.tsx
+++ b/apps/frontend/src/pages/settings/market-data/market-data-settings.tsx
@@ -7,7 +7,7 @@ import { Separator } from "@wealthfolio/ui/components/ui/separator";
 import { Skeleton } from "@wealthfolio/ui/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@wealthfolio/ui/components/ui/tabs";
 import { useMemo, useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 
 import { SettingsHeader } from "../settings-header";
 
@@ -563,6 +563,7 @@ function CustomProviderCard({
 }
 
 export default function MarketDataSettingsPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
   const { data: providers, isLoading, error } = useMarketDataProviderSettings();
   const { mutate: updateSettings } = useUpdateMarketDataProviderSettings();
   const { mutate: updatePortfolio, isPending: isUpdating } = useUpdatePortfolioMutation();
@@ -577,6 +578,7 @@ export default function MarketDataSettingsPage() {
   const [editingProvider, setEditingProvider] = useState<CustomProviderWithSources | undefined>();
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [togglingId, setTogglingId] = useState<string | null>(null);
+  const showHealthBanner = searchParams.get("healthContext") === "marketData";
 
   // Split providers into built-in providers and the CUSTOM_SCRAPER aggregate
   const { builtinProviders, customScraperErrors } = useMemo(() => {
@@ -806,6 +808,30 @@ export default function MarketDataSettingsPage() {
         </div>
       </SettingsHeader>
       <Separator />
+      {showHealthBanner && (
+        <div className="border-border bg-muted/30 flex items-center justify-between gap-3 rounded-md border px-3 py-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <Icons.Info className="text-muted-foreground h-4 w-4 shrink-0" />
+            <p className="text-sm">Showing market data settings flagged by Health Center</p>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() =>
+              setSearchParams(
+                (prev) => {
+                  const next = new URLSearchParams(prev);
+                  next.delete("healthContext");
+                  return next;
+                },
+                { replace: true },
+              )
+            }
+          >
+            Clear
+          </Button>
+        </div>
+      )}
 
       <Tabs defaultValue="builtin" className="w-full">
         <TabsList className="grid w-full grid-cols-2">

--- a/apps/frontend/src/pages/settings/taxonomies/taxonomies-page.tsx
+++ b/apps/frontend/src/pages/settings/taxonomies/taxonomies-page.tsx
@@ -10,8 +10,10 @@ import { SettingsHeader } from "../settings-header";
 import { CategoryForm } from "./components/category-form";
 import { MigrationBanner } from "./migration-banner";
 import { toast } from "sonner";
+import { useSearchParams } from "react-router-dom";
 
 export default function TaxonomiesPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
   // Settings → Classifications is asset-only. Spending categories live at /settings/spending/categories.
   const { data: taxonomies = [], isLoading: isLoadingTaxonomies } = useTaxonomies({
     scope: "asset",
@@ -75,6 +77,7 @@ export default function TaxonomiesPage() {
   };
 
   const isLoading = isLoadingTaxonomies || isLoadingCategories;
+  const showHealthBanner = searchParams.get("healthContext") === "classification";
 
   return (
     <div className="space-y-6">
@@ -82,6 +85,31 @@ export default function TaxonomiesPage() {
         heading="Classifications"
         text="Manage asset classification hierarchies like sectors, regions, and asset classes."
       />
+
+      {showHealthBanner && (
+        <div className="border-border bg-muted/30 flex items-center justify-between gap-3 rounded-md border px-3 py-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <Icons.Info className="text-muted-foreground h-4 w-4 shrink-0" />
+            <p className="text-sm">Showing classifications flagged by Health Center</p>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() =>
+              setSearchParams(
+                (prev) => {
+                  const next = new URLSearchParams(prev);
+                  next.delete("healthContext");
+                  return next;
+                },
+                { replace: true },
+              )
+            }
+          >
+            Clear
+          </Button>
+        </div>
+      )}
 
       <MigrationBanner />
 

--- a/apps/server/src/api/activities.rs
+++ b/apps/server/src/api/activities.rs
@@ -55,6 +55,8 @@ struct ActivitySearchBody {
     date_to: Option<String>, // YYYY-MM-DD format
     #[serde(rename = "instrumentTypeFilter")]
     instrument_type_filter: Option<StringOrVec>,
+    #[serde(rename = "activityIdFilter")]
+    activity_id_filter: Option<StringOrVec>,
 }
 
 async fn search_activities(
@@ -82,6 +84,11 @@ async fn search_activities(
         Some(StringOrVec::Many(v)) => Some(v),
         None => None,
     };
+    let activity_ids: Option<Vec<String>> = match body.activity_id_filter {
+        Some(StringOrVec::One(s)) => Some(vec![s]),
+        Some(StringOrVec::Many(v)) => Some(v),
+        None => None,
+    };
     // Parse date filters
     let date_from_parsed = parse_date_optional(body.date_from, "dateFrom")?;
     let date_to_parsed = parse_date_optional(body.date_to, "dateTo")?;
@@ -101,6 +108,7 @@ async fn search_activities(
         date_from_utc,
         date_to_utc_exclusive,
         instrument_types,
+        activity_ids,
     )?;
     Ok(Json(resp))
 }

--- a/apps/server/src/api/data_exports.rs
+++ b/apps/server/src/api/data_exports.rs
@@ -54,6 +54,7 @@ async fn build_data_export_content(
                     None,
                     None,
                     None,
+                    None,
                 )?
                 .data;
             Ok(format_records(&records, format)?)

--- a/apps/server/src/api/health.rs
+++ b/apps/server/src/api/health.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use crate::{
+    api::shared::{process_portfolio_job, PortfolioJobConfig},
     error::{ApiError, ApiResult},
     main_lib::AppState,
 };
@@ -10,7 +11,11 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use wealthfolio_core::health::{FixAction, HealthConfig, HealthStatus};
+use wealthfolio_core::{
+    health::{FixAction, HealthConfig, HealthStatus},
+    portfolio::{snapshot::SnapshotRecalcMode, valuation::ValuationRecalcMode},
+    quotes::MarketSyncMode,
+};
 
 /// Get current health status (cached or fresh check).
 async fn get_health_status(
@@ -155,6 +160,34 @@ async fn execute_health_fix(
             )
             .await
             .map_err(|e| anyhow::anyhow!("Market data sync failed: {}", e))?;
+
+        state.health_service.clear_cache().await;
+        return Ok(());
+    }
+
+    // Handle rebuild_account_history by running an account-scoped full snapshot
+    // + valuation recalculation via the shared portfolio job pipeline.
+    if action.id == "rebuild_account_history" {
+        let account_ids: Vec<String> = serde_json::from_value(action.payload.clone())
+            .map_err(|e| anyhow::anyhow!("Invalid payload for {}: {}", action.id, e))?;
+        if account_ids.is_empty() {
+            return Err(ApiError::BadRequest(
+                "No accounts selected for history rebuild".to_string(),
+            ));
+        }
+
+        let job_config = PortfolioJobConfig {
+            account_ids: Some(account_ids),
+            // Prices/valuations were already fixed by the user; just rebuild.
+            market_sync_mode: MarketSyncMode::Incremental { asset_ids: None },
+            snapshot_mode: SnapshotRecalcMode::Full,
+            valuation_mode: ValuationRecalcMode::Full,
+            since_date: None,
+        };
+
+        process_portfolio_job(state.clone(), job_config)
+            .await
+            .map_err(|e| anyhow::anyhow!("Account history rebuild failed: {}", e))?;
 
         state.health_service.clear_cache().await;
         return Ok(());

--- a/apps/tauri/src/commands/activity.rs
+++ b/apps/tauri/src/commands/activity.rs
@@ -29,6 +29,7 @@ pub async fn search_activities(
     date_from: Option<String>,         // Optional start date filter (YYYY-MM-DD, inclusive)
     date_to: Option<String>,           // Optional end date filter (YYYY-MM-DD, inclusive)
     instrument_type_filter: Option<Vec<String>>, // Optional instrument_type filter
+    activity_id_filter: Option<Vec<String>>, // Optional exact activity-id filter
     state: State<'_, Arc<ServiceContext>>,
 ) -> Result<ActivitySearchResponse, String> {
     debug!("Search activities... {}, {}", page, page_size);
@@ -59,6 +60,7 @@ pub async fn search_activities(
         date_from_utc,
         date_to_utc_exclusive,
         instrument_type_filter,
+        activity_id_filter,
     )?)
 }
 

--- a/apps/tauri/src/commands/health.rs
+++ b/apps/tauri/src/commands/health.rs
@@ -1,11 +1,14 @@
 use std::sync::Arc;
 
 use crate::context::ServiceContext;
-use crate::events::{MarketSyncResult, MARKET_SYNC_COMPLETE, MARKET_SYNC_ERROR, MARKET_SYNC_START};
+use crate::events::{
+    emit_portfolio_trigger_recalculate, MarketSyncResult, PortfolioRequestPayload,
+    MARKET_SYNC_COMPLETE, MARKET_SYNC_ERROR, MARKET_SYNC_START,
+};
 use log::{debug, error, info, warn};
 use tauri::{AppHandle, Emitter, State};
 use wealthfolio_core::health::{FixAction, HealthConfig, HealthServiceTrait, HealthStatus};
-use wealthfolio_core::quotes::SyncMode;
+use wealthfolio_core::quotes::{MarketSyncMode, SyncMode};
 
 /// Get current health status (cached or fresh check).
 #[tauri::command]
@@ -184,6 +187,33 @@ pub async fn execute_health_fix(
 
         // Clear health cache so next check reflects the sync results
         state.health_service().clear_cache().await;
+
+        return Ok(());
+    }
+
+    // Handle rebuild_account_history - trigger an account-scoped full recalculation
+    // by reusing the existing portfolio recalculation pipeline (which maps the
+    // recalculate trigger to SnapshotRecalcMode::Full for the given accounts).
+    if action.id == "rebuild_account_history" {
+        let account_ids: Vec<String> = serde_json::from_value(action.payload.clone())
+            .map_err(|e| format!("Failed to parse account IDs: {}", e))?;
+        if account_ids.is_empty() {
+            return Err("No accounts selected for history rebuild".to_string());
+        }
+
+        info!(
+            "Rebuilding account history for {} account(s): {:?}",
+            account_ids.len(),
+            account_ids
+        );
+
+        // Incremental market sync (prices/valuations were already fixed by the
+        // user); the recalculate trigger performs the full snapshot rebuild.
+        let payload = PortfolioRequestPayload::builder()
+            .account_ids(Some(account_ids))
+            .market_sync_mode(MarketSyncMode::Incremental { asset_ids: None })
+            .build();
+        emit_portfolio_trigger_recalculate(&app_handle, payload);
 
         return Ok(());
     }

--- a/apps/tauri/src/commands/utilities.rs
+++ b/apps/tauri/src/commands/utilities.rs
@@ -283,6 +283,7 @@ async fn build_data_export_content(
                     None,
                     None,
                     None,
+                    None,
                 )
                 .map_err(|e| format!("Failed to load activities for export: {}", e))?
                 .data;

--- a/apps/tauri/src/listeners.rs
+++ b/apps/tauri/src/listeners.rs
@@ -357,6 +357,8 @@ fn handle_portfolio_calculation(
             }
         }
 
+        context.health_service().clear_cache().await;
+
         if let Err(e) = app_handle.emit(PORTFOLIO_UPDATE_COMPLETE, ()) {
             error!("Failed to emit {} event: {}", PORTFOLIO_UPDATE_COMPLETE, e);
         }

--- a/apps/tauri/tauri.conf.json
+++ b/apps/tauri/tauri.conf.json
@@ -40,7 +40,7 @@
   },
   "productName": "Wealthfolio",
   "mainBinaryName": "Wealthfolio",
-  "version": "3.5.4",
+  "version": "3.6.0",
   "identifier": "com.teymz.wealthfolio",
   "plugins": {
     "updater": {

--- a/crates/agent-tools/src/tools/activities.rs
+++ b/crates/agent-tools/src/tools/activities.rs
@@ -215,6 +215,7 @@ impl AgentTool for SearchActivities {
                 date_from,
                 date_to,
                 None, // instrument_type_filter
+                None, // activity_id_filter
             )
             .map_err(|e| AgentToolError::ExecutionFailed(e.to_string()))?;
 

--- a/crates/ai/src/env/test_env.rs
+++ b/crates/ai/src/env/test_env.rs
@@ -431,6 +431,7 @@ impl ActivityServiceTrait for MockActivityService {
         _date_from: Option<chrono::NaiveDate>,
         _date_to: Option<chrono::NaiveDate>,
         _instrument_type_filter: Option<Vec<String>>,
+        _activity_id_filter: Option<Vec<String>>,
     ) -> CoreResult<ActivitySearchResponse> {
         Ok(ActivitySearchResponse {
             data: self.activities.clone(),

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -3678,6 +3678,7 @@ impl ActivityServiceTrait for ActivityService {
         date_from: Option<NaiveDate>,
         date_to: Option<NaiveDate>,
         instrument_type_filter: Option<Vec<String>>,
+        activity_id_filter: Option<Vec<String>>,
     ) -> Result<ActivitySearchResponse> {
         self.activity_repository.search_activities(
             page,
@@ -3690,6 +3691,7 @@ impl ActivityServiceTrait for ActivityService {
             date_from,
             date_to,
             instrument_type_filter,
+            activity_id_filter,
         )
     }
 
@@ -3707,6 +3709,7 @@ impl ActivityServiceTrait for ActivityService {
         date_from_utc: Option<DateTime<Utc>>,
         date_to_utc_exclusive: Option<DateTime<Utc>>,
         instrument_type_filter: Option<Vec<String>>,
+        activity_id_filter: Option<Vec<String>>,
     ) -> Result<ActivitySearchResponse> {
         self.activity_repository.search_activities_in_utc_range(
             page,
@@ -3719,6 +3722,7 @@ impl ActivityServiceTrait for ActivityService {
             date_from_utc,
             date_to_utc_exclusive,
             instrument_type_filter,
+            activity_id_filter,
         )
     }
 

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -1315,6 +1315,7 @@ mod tests {
             _date_from: Option<chrono::NaiveDate>,
             _date_to: Option<chrono::NaiveDate>,
             _instrument_type_filter: Option<Vec<String>>,
+            _activity_id_filter: Option<Vec<String>>,
         ) -> Result<ActivitySearchResponse> {
             unimplemented!()
         }

--- a/crates/core/src/activities/activities_traits.rs
+++ b/crates/core/src/activities/activities_traits.rs
@@ -138,6 +138,7 @@ pub trait ActivityRepositoryTrait: Send + Sync {
         date_from: Option<NaiveDate>,
         date_to: Option<NaiveDate>,
         instrument_type_filter: Option<Vec<String>>,
+        activity_id_filter: Option<Vec<String>>,
     ) -> Result<ActivitySearchResponse>;
     #[allow(clippy::too_many_arguments)]
     fn search_activities_in_utc_range(
@@ -152,6 +153,7 @@ pub trait ActivityRepositoryTrait: Send + Sync {
         date_from_utc: Option<DateTime<Utc>>,
         date_to_utc_exclusive: Option<DateTime<Utc>>,
         instrument_type_filter: Option<Vec<String>>,
+        activity_id_filter: Option<Vec<String>>,
     ) -> Result<ActivitySearchResponse> {
         let date_from = date_from_utc.map(|dt| dt.date_naive());
         let date_to =
@@ -168,6 +170,7 @@ pub trait ActivityRepositoryTrait: Send + Sync {
             date_from,
             date_to,
             instrument_type_filter,
+            activity_id_filter,
         )
     }
     async fn create_activity(&self, new_activity: NewActivity) -> Result<Activity>;
@@ -311,6 +314,7 @@ pub trait ActivityServiceTrait: Send + Sync {
         date_from: Option<NaiveDate>,
         date_to: Option<NaiveDate>,
         instrument_type_filter: Option<Vec<String>>,
+        activity_id_filter: Option<Vec<String>>,
     ) -> Result<ActivitySearchResponse>;
     #[allow(clippy::too_many_arguments)]
     fn search_activities_in_utc_range(
@@ -325,6 +329,7 @@ pub trait ActivityServiceTrait: Send + Sync {
         date_from_utc: Option<DateTime<Utc>>,
         date_to_utc_exclusive: Option<DateTime<Utc>>,
         instrument_type_filter: Option<Vec<String>>,
+        activity_id_filter: Option<Vec<String>>,
     ) -> Result<ActivitySearchResponse> {
         let date_from = date_from_utc.map(|dt| dt.date_naive());
         let date_to =
@@ -341,6 +346,7 @@ pub trait ActivityServiceTrait: Send + Sync {
             date_from,
             date_to,
             instrument_type_filter,
+            activity_id_filter,
         )
     }
     fn get_first_activity_date(

--- a/crates/core/src/health/checks/classification.rs
+++ b/crates/core/src/health/checks/classification.rs
@@ -8,7 +8,8 @@ use async_trait::async_trait;
 use crate::assets::AssetServiceTrait;
 use crate::errors::Result;
 use crate::health::model::{
-    AffectedItem, FixAction, HealthCategory, HealthIssue, NavigateAction, Severity,
+    AffectedItem, DiagnosticDomain, Evidence, FixAction, HealthCategory, HealthDiagnostic,
+    HealthEntityRef, HealthIssue, NavigateAction, Severity,
 };
 use crate::health::traits::{HealthCheck, HealthContext};
 use crate::taxonomies::TaxonomyServiceTrait;
@@ -153,6 +154,74 @@ pub fn gather_legacy_migration_status(
     })
 }
 
+/// Gathers held assets that are missing an **asset class** taxonomy assignment.
+///
+/// Asset class is the core "category" surfaced by the Classification check and is
+/// normally auto-assigned from an instrument's type, so a missing assignment is a
+/// genuine gap rather than routine noise. Only currently-held assets (present in
+/// `holding_mv_map`) are considered, and market value drives the finding severity.
+///
+/// GICS sector / region are intentionally not flagged here to avoid overwhelming
+/// users who have not opted into those taxonomies.
+pub fn gather_unclassified_assets(
+    asset_service: &dyn AssetServiceTrait,
+    taxonomy_service: &dyn TaxonomyServiceTrait,
+    holding_mv_map: &std::collections::HashMap<String, f64>,
+) -> Vec<UnclassifiedAssetInfo> {
+    use log::warn;
+
+    if holding_mv_map.is_empty() {
+        return Vec::new();
+    }
+
+    let asset_classes = match taxonomy_service.get_taxonomy("asset_classes") {
+        Ok(Some(taxonomy)) => taxonomy,
+        Ok(None) => return Vec::new(),
+        Err(error) => {
+            warn!("gather_unclassified_assets: failed to load asset_classes taxonomy: {error}");
+            return Vec::new();
+        }
+    };
+
+    let assets = match asset_service.get_assets() {
+        Ok(assets) => assets,
+        Err(error) => {
+            warn!("gather_unclassified_assets: failed to load assets: {error}");
+            return Vec::new();
+        }
+    };
+
+    let mut unclassified = Vec::new();
+    for asset in &assets {
+        let Some(&market_value) = holding_mv_map.get(&asset.id) else {
+            continue;
+        };
+
+        let assignments = taxonomy_service
+            .get_asset_assignments(&asset.id)
+            .unwrap_or_default();
+        let has_asset_class = assignments
+            .iter()
+            .any(|assignment| assignment.taxonomy_id == asset_classes.taxonomy.id);
+
+        if !has_asset_class {
+            unclassified.push(UnclassifiedAssetInfo {
+                asset_id: asset.id.clone(),
+                symbol: asset.display_code.clone().unwrap_or_default(),
+                name: asset.name.clone(),
+                market_value,
+                missing_taxonomy: "asset_class".to_string(),
+            });
+        }
+    }
+
+    debug!(
+        "gather_unclassified_assets: {} held assets missing an asset class",
+        unclassified.len()
+    );
+    unclassified
+}
+
 /// Health check that detects missing asset classifications.
 pub struct ClassificationCheck;
 
@@ -243,6 +312,11 @@ impl ClassificationCheck {
                     .affected_mv_pct(mv_pct)
                     .affected_items(affected_items)
                     .navigate_action(NavigateAction::to_holdings(Some("unclassified")))
+                    .diagnostics(vec![classification_diagnostic(
+                        &taxonomy,
+                        taxonomy_label,
+                        &assets,
+                    )])
                     .data_hash(data_hash)
                     .build(),
             );
@@ -295,12 +369,76 @@ impl ClassificationCheck {
                 .affected_items(affected_items)
                 .fix_action(FixAction::migrate_legacy_classifications())
                 .navigate_action(NavigateAction::to_taxonomies())
+                .diagnostics(vec![legacy_classification_diagnostic(info)])
                 .data_hash(data_hash)
                 .build(),
         );
 
         issues
     }
+}
+
+fn classification_diagnostic(
+    taxonomy: &str,
+    taxonomy_label: &str,
+    assets: &[&UnclassifiedAssetInfo],
+) -> HealthDiagnostic {
+    let mut diagnostic = HealthDiagnostic::new(
+        format!("MISSING_{}", taxonomy.to_ascii_uppercase()),
+        format!("Missing {taxonomy_label}"),
+        format!(
+            "These holdings do not have an {taxonomy_label} assigned, so allocation charts and analytics are incomplete."
+        ),
+    )
+    .domain(DiagnosticDomain::Classification)
+    .navigate(true, NavigateAction::to_holdings(Some("unclassified")));
+
+    for asset in assets {
+        let route = format!("/holdings/{}", urlencoding::encode(&asset.asset_id));
+        let label = asset
+            .name
+            .as_ref()
+            .map(|name| format!("{} — {name}", asset.symbol))
+            .unwrap_or_else(|| asset.symbol.clone());
+        diagnostic = diagnostic
+            .entity(
+                HealthEntityRef::new("asset", asset.asset_id.clone())
+                    .label(label.clone())
+                    .route(route.clone()),
+            )
+            .evidence(Evidence::new("Holding", label).with_route(route));
+    }
+
+    diagnostic
+}
+
+fn legacy_classification_diagnostic(info: &LegacyMigrationInfo) -> HealthDiagnostic {
+    let mut diagnostic = HealthDiagnostic::new(
+        "LEGACY_CLASSIFICATION_MIGRATION",
+        "Legacy classification data",
+        "These assets still use the previous sector/country fields. Migrate them to the taxonomy system to keep allocation reporting consistent.",
+    )
+    .domain(DiagnosticDomain::Classification)
+    .fix(true, FixAction::migrate_legacy_classifications())
+    .navigate(false, NavigateAction::to_taxonomies());
+
+    for asset in &info.assets_needing_migration {
+        let route = format!("/holdings/{}", urlencoding::encode(&asset.asset_id));
+        let label = asset
+            .name
+            .as_ref()
+            .map(|name| format!("{} — {name}", asset.symbol))
+            .unwrap_or_else(|| asset.symbol.clone());
+        diagnostic = diagnostic
+            .entity(
+                HealthEntityRef::new("asset", asset.asset_id.clone())
+                    .label(label.clone())
+                    .route(route.clone()),
+            )
+            .evidence(Evidence::new("Asset", label).with_route(route));
+    }
+
+    diagnostic
 }
 
 impl Default for ClassificationCheck {

--- a/crates/core/src/health/checks/data_consistency.rs
+++ b/crates/core/src/health/checks/data_consistency.rs
@@ -8,7 +8,8 @@ use rust_decimal::Decimal;
 
 use crate::errors::Result;
 use crate::health::model::{
-    AffectedItem, FixAction, HealthCategory, HealthIssue, NavigateAction, Severity,
+    AffectedItem, DiagnosticDomain, DiagnosticLevel, Evidence, FixAction, HealthCategory,
+    HealthDiagnostic, HealthEntityRef, HealthIssue, NavigateAction, Severity,
 };
 use crate::health::traits::{HealthCheck, HealthContext};
 
@@ -37,6 +38,44 @@ pub enum ConsistencyIssueType {
     IncompleteValuationBasis,
     /// A generated valuation row has an unknown performance flow boundary
     UnknownPerformanceFlowSource,
+}
+
+/// Root cause classification for valuation-quality issues (incomplete value /
+/// missing generated row). Drives the structured diagnostic `code`, wording and
+/// remediation action shown to the user.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ValuationIssueReason {
+    /// A held asset has no market quotes at all (unresolved symbol / provider gap).
+    MissingMarketQuote,
+    /// A manual/custom asset has no manual valuation entered.
+    MissingManualValuation,
+    /// A required FX rate is missing for the account/base currency conversion.
+    MissingFxRate,
+    /// The row is fully unavailable for returns (nothing priced, no cash).
+    Unavailable,
+    /// Cause could not be pinned to a specific asset (generic fallback).
+    Unknown,
+    /// Incomplete cost basis on a TRANSACTIONS-tracked account (an acquiring
+    /// activity has no cost basis).
+    IncompleteBasisActivity,
+    /// Incomplete cost basis on a HOLDINGS-tracked account (the holdings
+    /// snapshot has no cost basis; there are no transactions to fix).
+    IncompleteBasisSnapshot,
+}
+
+impl ValuationIssueReason {
+    /// Stable machine code used as the diagnostic `code`.
+    pub fn code(self) -> &'static str {
+        match self {
+            ValuationIssueReason::MissingMarketQuote => "MISSING_MARKET_QUOTE",
+            ValuationIssueReason::MissingManualValuation => "MISSING_MANUAL_VALUATION",
+            ValuationIssueReason::MissingFxRate => "MISSING_FX_RATE",
+            ValuationIssueReason::Unavailable => "UNAVAILABLE_VALUATION",
+            ValuationIssueReason::Unknown => "INCOMPLETE_VALUATION",
+            ValuationIssueReason::IncompleteBasisActivity => "INCOMPLETE_BASIS_ACTIVITY",
+            ValuationIssueReason::IncompleteBasisSnapshot => "INCOMPLETE_BASIS_SNAPSHOT",
+        }
+    }
 }
 
 /// Data about a consistency issue.
@@ -70,6 +109,11 @@ pub struct ConsistencyIssueInfo {
     pub quantity: Option<Decimal>,
     /// Activity proceeds for activity-specific issues
     pub proceeds: Option<Decimal>,
+    /// Root cause classification for valuation-quality issues (drives diagnostics).
+    pub reason: Option<ValuationIssueReason>,
+    /// The specific activity to deep-link to (e.g. the acquiring transaction that
+    /// lacks a cost basis), when the issue traces to one activity row.
+    pub activity_id: Option<String>,
 }
 
 /// Health check that detects data consistency problems.
@@ -131,7 +175,10 @@ impl DataConsistencyCheck {
                         "Some transactions point to accounts that no longer exist. This may cause calculation errors.",
                     )
                     .affected_count(count as u32)
-                    .navigate_action(NavigateAction::to_activities(Some("orphan")))
+                    // Orphan activities reference a missing account, so they cannot
+                    // be surfaced by the account-scoped activity search; link to the
+                    // full activities view rather than an unsupported filter.
+                    .navigate_action(NavigateAction::to_activities(None))
                     .data_hash(data_hash)
                     .build(),
             );
@@ -160,7 +207,8 @@ impl DataConsistencyCheck {
                         "Some transactions point to assets that no longer exist. This may cause calculation errors.",
                     )
                     .affected_count(count as u32)
-                    .navigate_action(NavigateAction::to_activities(Some("orphan")))
+                    // No orphan filter on the activity search; link to the full view.
+                    .navigate_action(NavigateAction::to_activities(None))
                     .data_hash(data_hash)
                     .build(),
             );
@@ -218,7 +266,7 @@ impl DataConsistencyCheck {
                         "Some assets have legacy sector/country data that can be migrated to the new classification system.",
                     )
                     .affected_count(count as u32)
-                    .fix_action(FixAction::migrate_classifications(asset_ids))
+                    .navigate_action(NavigateAction::to_taxonomies())
                     .data_hash(data_hash)
                     .build(),
             );
@@ -428,7 +476,7 @@ impl DataConsistencyCheck {
                 .navigate_action(NavigateAction {
                     route: "/activities".to_string(),
                     query: Some(serde_json::json!({ "types": "SELL" })),
-                    label: "View Activities".to_string(),
+                    label: "Review Transactions".to_string(),
                 })
                 .data_hash(data_hash);
             if !affected_items.is_empty() {
@@ -446,31 +494,33 @@ impl DataConsistencyCheck {
                 "missing_generated_valuation",
                 missing_issues,
                 Severity::Warning,
-                "Generated valuation history is incomplete",
-                "generated valuation rows are missing",
-                "Some holdings snapshot dates do not have generated valuation rows. Rebuild account history after fixing missing prices, manual valuations, or FX rates.",
+                "Account history needs rebuilding",
+                "daily account values are missing",
+                "Some daily account values are missing. Fix any missing prices, manual values, or exchange rates, then rebuild account history.",
             ));
         }
 
         if let Some(value_issues) = by_type.get(&ConsistencyIssueType::IncompleteValuationValue) {
+            let copy = value_issue_copy(value_issues);
             health_issues.push(build_valuation_quality_issue(
                 "incomplete_valuation_value",
                 value_issues,
                 Severity::Warning,
-                "Valuation coverage is incomplete",
-                "valuation rows have incomplete market value",
-                "Some generated valuation rows have incomplete market value coverage. Performance protects correctness by marking affected returns unavailable or degraded; review missing prices or manual valuations.",
+                copy.title,
+                copy.plural_title,
+                copy.message,
             ));
         }
 
         if let Some(basis_issues) = by_type.get(&ConsistencyIssueType::IncompleteValuationBasis) {
+            let copy = basis_issue_copy(basis_issues);
             health_issues.push(build_valuation_quality_issue(
                 "incomplete_valuation_basis",
                 basis_issues,
                 Severity::Warning,
-                "Cost basis coverage is incomplete",
-                "positions have incomplete cost basis",
-                "Some positions have missing or partial acquisition cost basis. Market value can still be shown, but gain/loss and cost-basis returns may be unavailable until the related activities are fixed.",
+                copy.title,
+                copy.plural_title,
+                copy.message,
             ));
         }
 
@@ -480,13 +530,99 @@ impl DataConsistencyCheck {
                 "unknown_performance_flow_source",
                 flow_issues,
                 Severity::Error,
-                "Performance flow boundary is unknown",
-                "valuation rows have unknown transfer classification",
-                "Some generated valuation rows include a transfer or flow whose portfolio boundary is unknown. Review transfer activities on the affected dates and mark each transfer external or link it to its matching account.",
+                "Transfer date needs review",
+                "transfer dates need review",
+                "Some transfers are unclear: Wealthfolio cannot tell if money moved between your own accounts or entered/left your portfolio. Review those transfers so returns are not overstated or understated.",
             ));
         }
 
         health_issues
+    }
+}
+
+struct IssueCopy {
+    title: &'static str,
+    plural_title: &'static str,
+    message: &'static str,
+}
+
+fn value_issue_copy(issues: &[&ConsistencyIssueInfo]) -> IssueCopy {
+    let has_market_quote = issues
+        .iter()
+        .any(|issue| issue.reason == Some(ValuationIssueReason::MissingMarketQuote));
+    let has_manual_value = issues
+        .iter()
+        .any(|issue| issue.reason == Some(ValuationIssueReason::MissingManualValuation));
+    let has_fx = issues
+        .iter()
+        .any(|issue| issue.reason == Some(ValuationIssueReason::MissingFxRate));
+    let has_generic = issues.iter().any(|issue| {
+        matches!(
+            issue.reason,
+            None | Some(ValuationIssueReason::Unavailable) | Some(ValuationIssueReason::Unknown)
+        )
+    });
+
+    if has_market_quote && !has_manual_value && !has_fx && !has_generic {
+        return IssueCopy {
+            title: "Price date needs review",
+            plural_title: "price dates need review",
+            message: "Some trading days are missing exact market prices. Wealthfolio can carry forward the last available price, but syncing or adding the missing prices keeps daily values and returns accurate. If a date was a market holiday or the investment did not trade, dismiss this issue.",
+        };
+    }
+
+    if has_manual_value && !has_market_quote && !has_fx && !has_generic {
+        return IssueCopy {
+            title: "Manual price date needs review",
+            plural_title: "manual price dates need review",
+            message: "Some manual holdings are missing values on days they were held. Wealthfolio can carry forward the last value, but adding the missing dates keeps daily values and returns accurate. If a separate value is not needed for the date, dismiss this issue.",
+        };
+    }
+
+    if has_fx && !has_market_quote && !has_manual_value && !has_generic {
+        return IssueCopy {
+            title: "Exchange rate is missing",
+            plural_title: "exchange rates are missing",
+            message: "Some holdings need exchange rates before Wealthfolio can convert them to your base currency.",
+        };
+    }
+
+    IssueCopy {
+        title: "Holding value is missing",
+        plural_title: "prices or values are missing",
+        message: "Some holdings are missing a market price, manual value, or exchange rate. Add the missing data so Wealthfolio can calculate their value and returns.",
+    }
+}
+
+fn basis_issue_copy(issues: &[&ConsistencyIssueInfo]) -> IssueCopy {
+    let has_activity = issues
+        .iter()
+        .any(|issue| issue.reason == Some(ValuationIssueReason::IncompleteBasisActivity));
+    let has_snapshot = issues
+        .iter()
+        .any(|issue| issue.reason == Some(ValuationIssueReason::IncompleteBasisSnapshot));
+    let has_unclassified = issues.iter().any(|issue| issue.reason.is_none());
+
+    if has_activity && !has_snapshot && !has_unclassified {
+        return IssueCopy {
+            title: "Transaction is missing a purchase price",
+            plural_title: "transactions are missing purchase prices",
+            message: "Some buys or transfer-ins are missing the price paid. Add the price to each transaction so Wealthfolio can calculate cost basis, gains/losses, and returns.",
+        };
+    }
+
+    if has_snapshot && !has_activity && !has_unclassified {
+        return IssueCopy {
+            title: "Holding is missing cost basis",
+            plural_title: "holdings are missing cost basis",
+            message: "Some holdings are missing what you paid for them. Add the cost basis so Wealthfolio can calculate gains/losses and returns.",
+        };
+    }
+
+    IssueCopy {
+        title: "Cost basis input needs review",
+        plural_title: "cost basis inputs need review",
+        message: "Some transactions or holdings are missing what you paid. Add the missing cost basis so gains/losses and returns can be calculated.",
     }
 }
 
@@ -498,14 +634,94 @@ fn build_unknown_performance_flow_issue(
     plural_title: &str,
     message: &str,
 ) -> HealthIssue {
-    let mut issue =
-        build_valuation_quality_issue(id_prefix, issues, severity, title, plural_title, message);
-    let mut query = serde_json::Map::new();
+    let mut data_keys: Vec<String> = issues
+        .iter()
+        .map(|i| {
+            format!(
+                "{}:{}",
+                i.record_id,
+                i.activity_date
+                    .map(|d| d.format("%Y-%m-%d").to_string())
+                    .unwrap_or_default()
+            )
+        })
+        .collect();
+    data_keys.sort();
+    let data_hash = compute_data_hash(&data_keys);
 
+    let affected_items: Vec<AffectedItem> = issues
+        .iter()
+        .map(|issue| {
+            let query = unknown_transfer_issue_query(issue);
+            let date = issue
+                .activity_date
+                .map(|date| date.format("%Y-%m-%d").to_string())
+                .unwrap_or_else(|| "unknown date".to_string());
+            AffectedItem {
+                id: issue.record_id.clone(),
+                name: format!("{} transfer on {}", issue.description, date),
+                symbol: None,
+                route: Some(activity_route_from_query(&query)),
+            }
+        })
+        .collect();
+
+    let details = issues
+        .iter()
+        .map(|issue| {
+            let date = issue
+                .activity_date
+                .map(|date| date.format("%Y-%m-%d").to_string())
+                .unwrap_or_else(|| "unknown date".to_string());
+            format!(
+                "{}\nDate: {}\nReview transfer transactions for this account and date.",
+                issue.description, date
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    let diagnostics: Vec<HealthDiagnostic> = issues
+        .iter()
+        .map(|issue| unknown_transfer_diagnostic(issue))
+        .collect();
+
+    let mut builder = HealthIssue::builder()
+        .id(format!("{}:{}", id_prefix, data_hash))
+        .severity(severity)
+        .category(HealthCategory::DataConsistency)
+        .title(if issues.len() == 1 {
+            title.to_string()
+        } else {
+            format!("{} {}", issues.len(), plural_title)
+        })
+        .message(message)
+        .affected_count(issues.len() as u32)
+        .navigate_action(NavigateAction {
+            route: "/activities".to_string(),
+            query: Some(unknown_transfer_review_query(issues)),
+            label: "Review Transactions".to_string(),
+        })
+        .diagnostics(diagnostics)
+        .data_hash(data_hash);
+
+    if !affected_items.is_empty() {
+        builder = builder.affected_items(affected_items);
+    }
+    if !details.is_empty() {
+        builder = builder.details(details);
+    }
+
+    builder.build()
+}
+
+fn unknown_transfer_review_query(issues: &[&ConsistencyIssueInfo]) -> serde_json::Value {
+    let mut query = serde_json::Map::new();
     query.insert(
         "types".to_string(),
         serde_json::json!("TRANSFER_IN,TRANSFER_OUT"),
     );
+    query.insert("healthContext".to_string(), serde_json::json!("activity"));
 
     let mut dates: Vec<_> = issues.iter().filter_map(|i| i.activity_date).collect();
     dates.sort_unstable();
@@ -529,12 +745,76 @@ fn build_unknown_performance_flow_issue(
         query.insert("account".to_string(), serde_json::json!(account_id));
     }
 
-    issue.navigate_action = Some(NavigateAction {
+    serde_json::Value::Object(query)
+}
+
+fn unknown_transfer_issue_query(
+    issue: &ConsistencyIssueInfo,
+) -> serde_json::Map<String, serde_json::Value> {
+    let mut query = serde_json::Map::new();
+    query.insert(
+        "types".to_string(),
+        serde_json::json!("TRANSFER_IN,TRANSFER_OUT"),
+    );
+    query.insert("healthContext".to_string(), serde_json::json!("activity"));
+    if let Some(account_id) = issue.account_id.as_ref() {
+        query.insert("account".to_string(), serde_json::json!(account_id));
+    }
+    if let Some(date) = issue.activity_date {
+        let date = date.format("%Y-%m-%d").to_string();
+        query.insert("from".to_string(), serde_json::json!(date.clone()));
+        query.insert("to".to_string(), serde_json::json!(date));
+    }
+    query
+}
+
+fn activity_route_from_query(query: &serde_json::Map<String, serde_json::Value>) -> String {
+    let params = query
+        .iter()
+        .filter_map(|(key, value)| {
+            let value = value.as_str()?;
+            Some(format!(
+                "{}={}",
+                urlencoding::encode(key),
+                urlencoding::encode(value)
+            ))
+        })
+        .collect::<Vec<_>>();
+    format!("/activities?{}", params.join("&"))
+}
+
+fn unknown_transfer_diagnostic(issue: &ConsistencyIssueInfo) -> HealthDiagnostic {
+    let query = unknown_transfer_issue_query(issue);
+    let route = activity_route_from_query(&query);
+    let navigate = NavigateAction {
         route: "/activities".to_string(),
         query: Some(serde_json::Value::Object(query)),
-        label: "View Activities".to_string(),
-    });
-    issue
+        label: "Review Transactions".to_string(),
+    };
+
+    let mut diagnostic = HealthDiagnostic::new(
+        "TRANSFER_DATE_NEEDS_REVIEW",
+        "Transfer needs review",
+        "Review the transfers on this date. Match the two transactions if money moved between your accounts, or mark it external if money entered or left your portfolio.",
+    )
+    .domain(DiagnosticDomain::Ledger)
+    .level(DiagnosticLevel::Source)
+    .entity(
+        HealthEntityRef::new("transferDate", issue.record_id.clone())
+            .label(issue.description.clone())
+            .route(route.clone()),
+    )
+    .evidence(Evidence::new("Transfer", issue.description.clone()).with_route(route))
+    .navigate(true, navigate);
+
+    if let Some(date) = issue.activity_date {
+        let date = date.format("%Y-%m-%d").to_string();
+        diagnostic = diagnostic
+            .date(date.clone())
+            .evidence(Evidence::new("Date", date));
+    }
+
+    diagnostic
 }
 
 fn build_valuation_quality_issue(
@@ -599,6 +879,11 @@ fn build_valuation_quality_issue(
         .collect::<Vec<_>>()
         .join("\n\n");
 
+    let diagnostics: Vec<HealthDiagnostic> = issues
+        .iter()
+        .filter_map(|i| valuation_diagnostic(i))
+        .collect();
+
     let mut builder = HealthIssue::builder()
         .id(format!("{}:{}", id_prefix, data_hash))
         .severity(severity)
@@ -618,7 +903,241 @@ fn build_valuation_quality_issue(
     if !details.is_empty() {
         builder = builder.details(details);
     }
+    if !diagnostics.is_empty() {
+        builder = builder.diagnostics(diagnostics);
+    }
     builder.build()
+}
+
+fn asset_quote_route(asset_id: &str, date: Option<&str>) -> String {
+    let encoded_asset_id = urlencoding::encode(asset_id);
+    match date {
+        Some(date) => format!(
+            "/holdings/{}?tab=quotes&healthContext=price&date={}",
+            encoded_asset_id,
+            urlencoding::encode(date)
+        ),
+        None => format!("/holdings/{encoded_asset_id}?tab=quotes&healthContext=price"),
+    }
+}
+
+fn asset_quote_navigate_action(asset_id: String, date: Option<&str>) -> NavigateAction {
+    let query = match date {
+        Some(date) => {
+            serde_json::json!({ "tab": "quotes", "healthContext": "price", "date": date })
+        }
+        None => serde_json::json!({ "tab": "quotes", "healthContext": "price" }),
+    };
+
+    NavigateAction {
+        route: format!("/holdings/{}", urlencoding::encode(&asset_id)),
+        query: Some(query),
+        label: "Add Price".to_string(),
+    }
+}
+
+/// Builds a structured diagnostic (root cause, evidence, ordered actions) for a
+/// classified valuation-quality issue. Returns `None` for issues without a
+/// classified `reason` so the UI falls back to the flat `details` rendering.
+fn valuation_diagnostic(issue: &ConsistencyIssueInfo) -> Option<HealthDiagnostic> {
+    let reason = issue.reason?;
+
+    let (title, explanation) = match reason {
+        ValuationIssueReason::MissingMarketQuote => (
+            "No price found",
+            "Wealthfolio is missing the exact market price for this holding on the affected date. \
+             It can carry forward the last available price, but syncing or adding the exact price keeps daily returns accurate. \
+             If this was a market holiday or the investment did not trade, dismiss this issue.",
+        ),
+        ValuationIssueReason::MissingManualValuation => (
+            "No value entered",
+            "This manual holding has no value entered for the affected date. Wealthfolio can carry forward the last value, but adding this date keeps daily returns accurate. If a separate value is not needed for this date, dismiss this issue.",
+        ),
+        ValuationIssueReason::MissingFxRate => (
+            "No exchange rate",
+            "An exchange rate is missing, so this holding cannot be converted to your base currency.",
+        ),
+        ValuationIssueReason::Unavailable => (
+            "Account value is missing",
+            "This account could not be valued on the affected date. Wealthfolio hides returns for that period instead of showing a misleading number.",
+        ),
+        ValuationIssueReason::Unknown => (
+            "Holding value needs review",
+            "At least one holding could not be valued on the affected date. Add the missing price or value to restore complete returns.",
+        ),
+        ValuationIssueReason::IncompleteBasisActivity => (
+            "Missing purchase price",
+            "This transaction has no price, so Wealthfolio cannot calculate what you paid or your gain/loss. \
+             Add the price you paid. If the shares were free, record them as a Transfer In.",
+        ),
+        ValuationIssueReason::IncompleteBasisSnapshot => (
+            "Missing cost basis",
+            "This holding has no cost basis, so Wealthfolio cannot calculate gain/loss. \
+             Add what you paid in the holdings entry.",
+        ),
+    };
+
+    let (domain, level) = match reason {
+        ValuationIssueReason::MissingMarketQuote | ValuationIssueReason::MissingManualValuation => {
+            (DiagnosticDomain::MarketData, DiagnosticLevel::Source)
+        }
+        ValuationIssueReason::MissingFxRate => (DiagnosticDomain::Fx, DiagnosticLevel::Source),
+        ValuationIssueReason::Unavailable | ValuationIssueReason::Unknown => {
+            (DiagnosticDomain::GeneratedData, DiagnosticLevel::Generated)
+        }
+        ValuationIssueReason::IncompleteBasisActivity
+        | ValuationIssueReason::IncompleteBasisSnapshot => {
+            (DiagnosticDomain::PerformanceInputs, DiagnosticLevel::Source)
+        }
+    };
+
+    let mut diagnostic = HealthDiagnostic::new(reason.code(), title, explanation)
+        .domain(domain)
+        .level(level);
+
+    if let Some(asset_id) = issue.asset_id.as_ref() {
+        let label = issue
+            .asset_symbol
+            .clone()
+            .map(|symbol| match issue.asset_name.as_ref() {
+                Some(name) => format!("{symbol} — {name}"),
+                None => symbol,
+            })
+            .unwrap_or_else(|| asset_id.clone());
+        let issue_date = issue
+            .activity_date
+            .map(|date| date.format("%Y-%m-%d").to_string());
+        let asset_route = match reason {
+            ValuationIssueReason::MissingMarketQuote
+            | ValuationIssueReason::MissingManualValuation => {
+                asset_quote_route(asset_id, issue_date.as_deref())
+            }
+            ValuationIssueReason::IncompleteBasisSnapshot => {
+                format!(
+                    "/holdings/{}?tab=snapshots&healthContext=basis",
+                    urlencoding::encode(asset_id)
+                )
+            }
+            ValuationIssueReason::IncompleteBasisActivity => {
+                format!(
+                    "/holdings/{}?tab=activities&healthContext=activity",
+                    urlencoding::encode(asset_id)
+                )
+            }
+            _ => format!("/holdings/{}", urlencoding::encode(asset_id)),
+        };
+        let evidence_label = match reason {
+            ValuationIssueReason::IncompleteBasisActivity => "Transaction",
+            _ => "Asset",
+        };
+        diagnostic = diagnostic
+            .evidence(Evidence::new(evidence_label, label.clone()).with_route(asset_route.clone()));
+        diagnostic = diagnostic.entity(
+            HealthEntityRef::new("asset", asset_id.clone())
+                .label(label)
+                .route(asset_route),
+        );
+    } else {
+        diagnostic = diagnostic.evidence(Evidence::new("Account", issue.description.clone()));
+    }
+
+    if let Some(account_id) = issue.account_id.as_ref() {
+        diagnostic = diagnostic.entity(
+            HealthEntityRef::new("account", account_id.clone()).label(issue.description.clone()),
+        );
+    }
+
+    if let Some(activity_id) = issue.activity_id.as_ref() {
+        diagnostic = diagnostic.entity(
+            HealthEntityRef::new("activity", activity_id.clone()).route(format!(
+                "/activities?activity={}&healthContext=activity",
+                urlencoding::encode(activity_id)
+            )),
+        );
+    }
+
+    if let Some(date) = issue.activity_date {
+        let label = match reason {
+            ValuationIssueReason::IncompleteBasisActivity => "Trade date",
+            _ => "Date",
+        };
+        let date = date.format("%Y-%m-%d").to_string();
+        diagnostic = diagnostic
+            .date(date.clone())
+            .evidence(Evidence::new(label, date));
+    }
+
+    match reason {
+        ValuationIssueReason::MissingMarketQuote => {
+            if let Some(asset_id) = issue.asset_id.clone() {
+                let issue_date = issue
+                    .activity_date
+                    .map(|date| date.format("%Y-%m-%d").to_string());
+                diagnostic = diagnostic
+                    .fix(true, FixAction::sync_prices(vec![asset_id.clone()]))
+                    .navigate(
+                        false,
+                        asset_quote_navigate_action(asset_id, issue_date.as_deref()),
+                    );
+            } else {
+                diagnostic = diagnostic.navigate(true, NavigateAction::to_market_data());
+            }
+        }
+        ValuationIssueReason::MissingManualValuation => {
+            if let Some(asset_id) = issue.asset_id.clone() {
+                let issue_date = issue
+                    .activity_date
+                    .map(|date| date.format("%Y-%m-%d").to_string());
+                diagnostic = diagnostic.navigate(
+                    true,
+                    asset_quote_navigate_action(asset_id, issue_date.as_deref()),
+                );
+            }
+        }
+        ValuationIssueReason::MissingFxRate => {
+            diagnostic = diagnostic.navigate(true, NavigateAction::to_market_data());
+        }
+        ValuationIssueReason::Unavailable | ValuationIssueReason::Unknown => {
+            diagnostic = diagnostic.navigate(true, NavigateAction::to_activities(None));
+            // Once the underlying prices/valuations are fixed, an account-scoped
+            // rebuild regenerates the affected history rows.
+            if let Some(account_id) = issue.account_id.clone() {
+                diagnostic =
+                    diagnostic.fix(false, FixAction::rebuild_account_history(vec![account_id]));
+            }
+        }
+        ValuationIssueReason::IncompleteBasisActivity => {
+            // Transaction-tracked: the acquiring activity lacks a cost basis.
+            // Prefer an exact deep-link to that activity; otherwise fall back to
+            // the asset's own activities tab (asset-scoped).
+            if let Some(activity_id) = issue.activity_id.clone() {
+                diagnostic = diagnostic.navigate(true, NavigateAction::to_activity(activity_id));
+            } else if let Some(asset_id) = issue.asset_id.clone() {
+                diagnostic =
+                    diagnostic.navigate(true, NavigateAction::to_asset_activities(asset_id));
+            } else {
+                diagnostic = diagnostic.navigate(true, NavigateAction::to_activities(None));
+            }
+            if let Some(account_id) = issue.account_id.clone() {
+                diagnostic =
+                    diagnostic.fix(false, FixAction::rebuild_account_history(vec![account_id]));
+            }
+        }
+        ValuationIssueReason::IncompleteBasisSnapshot => {
+            // Holdings-tracked: there is no transaction; edit the holdings
+            // snapshot's cost basis for the asset.
+            if let Some(asset_id) = issue.asset_id.clone() {
+                diagnostic =
+                    diagnostic.navigate(true, NavigateAction::to_asset_snapshots(asset_id));
+            }
+            if let Some(account_id) = issue.account_id.clone() {
+                diagnostic =
+                    diagnostic.fix(false, FixAction::rebuild_account_history(vec![account_id]));
+            }
+        }
+    }
+
+    Some(diagnostic)
 }
 
 impl Default for DataConsistencyCheck {
@@ -683,6 +1202,8 @@ mod tests {
             asset_name: None,
             quantity: None,
             proceeds: None,
+            reason: None,
+            activity_id: None,
         }];
 
         let issues = check.analyze(&issues_data, &ctx);
@@ -711,6 +1232,8 @@ mod tests {
             asset_name: None,
             quantity: None,
             proceeds: None,
+            reason: None,
+            activity_id: None,
         }];
 
         let issues = check.analyze(&issues_data, &ctx);
@@ -738,12 +1261,18 @@ mod tests {
             asset_name: None,
             quantity: None,
             proceeds: None,
+            reason: None,
+            activity_id: None,
         }];
 
         let issues = check.analyze(&issues_data, &ctx);
         assert_eq!(issues.len(), 1);
         assert_eq!(issues[0].severity, Severity::Info);
-        assert!(issues[0].fix_action.is_some());
+        // The legacy-classification finding routes to taxonomy settings rather
+        // than offering the old unimplemented per-asset classification fix action;
+        // the working migration lives on the ClassificationCheck finding.
+        assert!(issues[0].fix_action.is_none());
+        assert!(issues[0].navigate_action.is_some());
     }
 
     #[test]
@@ -767,6 +1296,8 @@ mod tests {
                 asset_name: None,
                 quantity: None,
                 proceeds: None,
+                reason: None,
+                activity_id: None,
             },
             ConsistencyIssueInfo {
                 issue_type: ConsistencyIssueType::OrphanActivityAccount,
@@ -783,6 +1314,8 @@ mod tests {
                 asset_name: None,
                 quantity: None,
                 proceeds: None,
+                reason: None,
+                activity_id: None,
             },
             ConsistencyIssueInfo {
                 issue_type: ConsistencyIssueType::NegativePosition,
@@ -799,6 +1332,8 @@ mod tests {
                 asset_name: None,
                 quantity: None,
                 proceeds: None,
+                reason: None,
+                activity_id: None,
             },
         ];
 
@@ -827,6 +1362,8 @@ mod tests {
             asset_name: None,
             quantity: None,
             proceeds: None,
+            reason: None,
+            activity_id: None,
         }];
 
         let issues = check.analyze(&issues_data, &ctx);
@@ -856,6 +1393,8 @@ mod tests {
             asset_name: Some("Apple Inc.".to_string()),
             quantity: Some(rust_decimal_macros::dec!(1)),
             proceeds: Some(rust_decimal_macros::dec!(291.10598755)),
+            reason: None,
+            activity_id: None,
         }];
 
         let issues = check.analyze(&issues_data, &ctx);
@@ -887,36 +1426,77 @@ mod tests {
         fn valuation_issue(
             issue_type: ConsistencyIssueType,
             record_id: &str,
+            reason: Option<ValuationIssueReason>,
         ) -> ConsistencyIssueInfo {
+            let is_basis_activity = reason == Some(ValuationIssueReason::IncompleteBasisActivity);
+            let activity_date = if record_id.ends_with("-2") {
+                chrono::NaiveDate::from_ymd_opt(2026, 6, 2).unwrap()
+            } else {
+                chrono::NaiveDate::from_ymd_opt(2026, 6, 1).unwrap()
+            };
             ConsistencyIssueInfo {
                 issue_type,
                 record_id: record_id.to_string(),
                 description: "TFSA".to_string(),
                 account_id: Some("acc_tfsa".to_string()),
-                asset_id: None,
+                asset_id: is_basis_activity.then(|| "asset_aapl".to_string()),
                 first_negative_date: None,
                 cash_balance: None,
                 total_value_at_date: None,
                 account_currency: None,
-                activity_date: Some(chrono::NaiveDate::from_ymd_opt(2026, 6, 1).unwrap()),
-                asset_symbol: None,
-                asset_name: None,
+                activity_date: Some(activity_date),
+                asset_symbol: is_basis_activity.then(|| "AAPL".to_string()),
+                asset_name: is_basis_activity.then(|| "Apple Inc.".to_string()),
                 quantity: None,
                 proceeds: None,
+                reason,
+                activity_id: is_basis_activity.then(|| record_id.to_string()),
             }
         }
 
         let check = DataConsistencyCheck::new();
         let ctx = HealthContext::new(HealthConfig::default(), "USD", 100_000.0);
         let issues_data = vec![
-            valuation_issue(ConsistencyIssueType::MissingGeneratedValuation, "missing-1"),
-            valuation_issue(ConsistencyIssueType::MissingGeneratedValuation, "missing-2"),
-            valuation_issue(ConsistencyIssueType::IncompleteValuationValue, "value-1"),
-            valuation_issue(ConsistencyIssueType::IncompleteValuationValue, "value-2"),
-            valuation_issue(ConsistencyIssueType::IncompleteValuationBasis, "basis-1"),
-            valuation_issue(ConsistencyIssueType::IncompleteValuationBasis, "basis-2"),
-            valuation_issue(ConsistencyIssueType::UnknownPerformanceFlowSource, "flow-1"),
-            valuation_issue(ConsistencyIssueType::UnknownPerformanceFlowSource, "flow-2"),
+            valuation_issue(
+                ConsistencyIssueType::MissingGeneratedValuation,
+                "missing-1",
+                None,
+            ),
+            valuation_issue(
+                ConsistencyIssueType::MissingGeneratedValuation,
+                "missing-2",
+                None,
+            ),
+            valuation_issue(
+                ConsistencyIssueType::IncompleteValuationValue,
+                "value-1",
+                None,
+            ),
+            valuation_issue(
+                ConsistencyIssueType::IncompleteValuationValue,
+                "value-2",
+                None,
+            ),
+            valuation_issue(
+                ConsistencyIssueType::IncompleteValuationBasis,
+                "basis-1",
+                Some(ValuationIssueReason::IncompleteBasisActivity),
+            ),
+            valuation_issue(
+                ConsistencyIssueType::IncompleteValuationBasis,
+                "basis-2",
+                Some(ValuationIssueReason::IncompleteBasisActivity),
+            ),
+            valuation_issue(
+                ConsistencyIssueType::UnknownPerformanceFlowSource,
+                "flow-1",
+                None,
+            ),
+            valuation_issue(
+                ConsistencyIssueType::UnknownPerformanceFlowSource,
+                "flow-2",
+                None,
+            ),
         ];
 
         let issues = check.analyze(&issues_data, &ctx);
@@ -929,19 +1509,19 @@ mod tests {
 
         assert_eq!(
             title_for("missing_generated_valuation:"),
-            Some("2 generated valuation rows are missing")
+            Some("2 daily account values are missing")
         );
         assert_eq!(
             title_for("incomplete_valuation_value:"),
-            Some("2 valuation rows have incomplete market value")
+            Some("2 prices or values are missing")
         );
         assert_eq!(
             title_for("incomplete_valuation_basis:"),
-            Some("2 positions have incomplete cost basis")
+            Some("2 transactions are missing purchase prices")
         );
         assert_eq!(
             title_for("unknown_performance_flow_source:"),
-            Some("2 valuation rows have unknown transfer classification")
+            Some("2 transfer dates need review")
         );
 
         let unknown_flow_issue = issues
@@ -970,6 +1550,43 @@ mod tests {
             navigate_query.get("to"),
             Some(&serde_json::json!("2026-06-01"))
         );
+        assert_eq!(
+            navigate_query.get("healthContext"),
+            Some(&serde_json::json!("activity"))
+        );
+        let transfer_diagnostics = unknown_flow_issue
+            .diagnostics
+            .as_ref()
+            .expect("transfer diagnostics");
+        assert_eq!(transfer_diagnostics.len(), 2);
+        assert!(transfer_diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code == "TRANSFER_DATE_NEEDS_REVIEW"));
+        assert!(transfer_diagnostics.iter().all(|diagnostic| diagnostic
+            .evidence
+            .iter()
+            .any(|evidence| evidence.label == "Transfer")));
+        let transfer_dates: Vec<_> = transfer_diagnostics
+            .iter()
+            .flat_map(|diagnostic| diagnostic.evidence.iter())
+            .filter(|evidence| evidence.label == "Date")
+            .map(|evidence| evidence.value.as_str())
+            .collect();
+        assert!(transfer_dates.contains(&"2026-06-01"));
+        assert!(transfer_dates.contains(&"2026-06-02"));
+        assert!(transfer_diagnostics
+            .iter()
+            .flat_map(|diagnostic| diagnostic.evidence.iter())
+            .filter(|evidence| evidence.label == "Transfer")
+            .filter_map(|evidence| evidence.route.as_deref())
+            .any(|route| route.contains("from=2026-06-02")));
+
+        let basis_issue = issues
+            .iter()
+            .find(|issue| issue.id.starts_with("incomplete_valuation_basis:"))
+            .expect("basis issue");
+        let diagnostic = &basis_issue.diagnostics.as_ref().expect("basis diagnostics")[0];
+        assert_eq!(diagnostic.evidence[0].label, "Transaction");
     }
 
     #[test]

--- a/crates/core/src/health/checks/fx_integrity.rs
+++ b/crates/core/src/health/checks/fx_integrity.rs
@@ -6,7 +6,10 @@ use async_trait::async_trait;
 use chrono::{DateTime, Duration, Utc};
 
 use crate::errors::Result;
-use crate::health::model::{AffectedItem, FixAction, HealthCategory, HealthIssue, Severity};
+use crate::health::model::{
+    AffectedItem, DiagnosticDomain, Evidence, HealthCategory, HealthDiagnostic, HealthEntityRef,
+    HealthIssue, NavigateAction, Severity,
+};
 use crate::health::traits::{HealthCheck, HealthContext};
 
 /// Data about a currency pair needed for FX checks.
@@ -120,7 +123,14 @@ impl FxIntegrityCheck {
                     )
                     .affected_count(count as u32)
                     .affected_mv_pct(mv_pct)
-                    .fix_action(FixAction::fetch_fx(pair_ids))
+                    .diagnostics(vec![fx_diagnostic(
+                        &missing_pairs,
+                        "MISSING_FX_RATE",
+                        "Missing exchange rate",
+                        "No exchange rate is on record for these currency pairs, so holdings in \
+                         those currencies can't be converted to your base currency.",
+                    )])
+                    .navigate_action(NavigateAction::to_market_data())
                     .affected_items(affected_items)
                     .data_hash(data_hash)
                     .build(),
@@ -174,7 +184,14 @@ impl FxIntegrityCheck {
                     )
                     .affected_count(count as u32)
                     .affected_mv_pct(mv_pct)
-                    .fix_action(FixAction::fetch_fx(pair_ids))
+                    .diagnostics(vec![fx_diagnostic(
+                        &stale_error_pairs,
+                        "STALE_FX_RATE",
+                        "Outdated exchange rate",
+                        "These exchange rates are more than 3 days old, so currency conversions \
+                         for the affected holdings may be inaccurate.",
+                    )])
+                    .navigate_action(NavigateAction::to_market_data())
                     .affected_items(affected_items)
                     .data_hash(data_hash)
                     .build(),
@@ -228,7 +245,14 @@ impl FxIntegrityCheck {
                     )
                     .affected_count(count as u32)
                     .affected_mv_pct(mv_pct)
-                    .fix_action(FixAction::fetch_fx(pair_ids))
+                    .diagnostics(vec![fx_diagnostic(
+                        &stale_warning_pairs,
+                        "STALE_FX_RATE",
+                        "Exchange rate update needed",
+                        "These exchange rates haven't been refreshed recently; conversions for the \
+                         affected holdings may drift until they are updated.",
+                    )])
+                    .navigate_action(NavigateAction::to_market_data())
                     .affected_items(affected_items)
                     .data_hash(data_hash)
                     .build(),
@@ -237,6 +261,34 @@ impl FxIntegrityCheck {
 
         issues
     }
+}
+
+/// Builds a structured diagnostic for an FX issue: one evidence row per pair
+/// (pair, rate freshness, affected market value) plus a navigation action to the
+/// market-data settings where rates are managed.
+fn fx_diagnostic(
+    pairs: &[&FxPairInfo],
+    code: &str,
+    title: &str,
+    explanation: &str,
+) -> HealthDiagnostic {
+    let mut diagnostic =
+        HealthDiagnostic::new(code, title, explanation).domain(DiagnosticDomain::Fx);
+    for pair in pairs {
+        let rate_state = match pair.latest_quote_time {
+            Some(ts) => format!("last rate {}", ts.format("%Y-%m-%d")),
+            None => "no rate on record".to_string(),
+        };
+        let label = format!("{} → {}", pair.from_currency, pair.to_currency);
+        let value = format!(
+            "{rate_state} · affects ~{:.0} in base currency",
+            pair.affected_mv
+        );
+        diagnostic = diagnostic
+            .entity(HealthEntityRef::new("currencyPair", pair.pair_id.clone()).label(label.clone()))
+            .evidence(Evidence::new(label, value));
+    }
+    diagnostic.navigate(true, NavigateAction::to_market_data())
 }
 
 impl Default for FxIntegrityCheck {
@@ -300,6 +352,18 @@ mod tests {
         assert_eq!(issues.len(), 1);
         assert_eq!(issues[0].severity, Severity::Error);
         assert_eq!(issues[0].category, HealthCategory::FxIntegrity);
+
+        // The old unimplemented FX fetch fix action must not be shown; the issue
+        // routes to market-data settings and carries a MISSING_FX_RATE diagnostic
+        // with per-pair evidence.
+        assert!(issues[0].fix_action.is_none());
+        assert!(issues[0].navigate_action.is_some());
+        let diagnostics = issues[0].diagnostics.as_ref().expect("fx diagnostics");
+        assert_eq!(diagnostics[0].code, "MISSING_FX_RATE");
+        assert!(diagnostics[0]
+            .evidence
+            .iter()
+            .any(|e| e.label.contains("EUR → USD")));
     }
 
     #[test]

--- a/crates/core/src/health/checks/mod.rs
+++ b/crates/core/src/health/checks/mod.rs
@@ -28,12 +28,12 @@ pub use transfer_integrity::TransferIntegrityCheck;
 // Re-export data types used by checks
 pub use account_configuration::UnconfiguredAccountInfo;
 pub use classification::{LegacyMigrationInfo, UnclassifiedAssetInfo};
-pub use data_consistency::{ConsistencyIssueInfo, ConsistencyIssueType};
+pub use data_consistency::{ConsistencyIssueInfo, ConsistencyIssueType, ValuationIssueReason};
 pub use fx_integrity::FxPairInfo;
 pub use price_staleness::AssetHoldingInfo;
 pub use quote_sync::QuoteSyncErrorInfo;
 pub use transfer_integrity::{InvalidTransferGroupInfo, TransferLegDetail};
 
 // Re-export data gathering functions
-pub use classification::gather_legacy_migration_status;
+pub use classification::{gather_legacy_migration_status, gather_unclassified_assets};
 pub use quote_sync::gather_quote_sync_errors;

--- a/crates/core/src/health/checks/price_staleness.rs
+++ b/crates/core/src/health/checks/price_staleness.rs
@@ -9,7 +9,10 @@ use chrono::{DateTime, Datelike, NaiveDate, Utc, Weekday};
 use std::collections::HashMap;
 
 use crate::errors::Result;
-use crate::health::model::{AffectedItem, FixAction, HealthCategory, HealthIssue, Severity};
+use crate::health::model::{
+    AffectedItem, DiagnosticDomain, Evidence, FixAction, HealthCategory, HealthDiagnostic,
+    HealthEntityRef, HealthIssue, NavigateAction, Severity,
+};
 use crate::health::traits::{HealthCheck, HealthContext};
 use crate::utils::time_utils;
 
@@ -141,6 +144,14 @@ impl PriceStalenessCheck {
                     .affected_count(count as u32)
                     .affected_mv_pct(0.0)
                     .affected_items(affected_items)
+                    .diagnostics(vec![price_diagnostic(
+                        &manual_without_value,
+                        latest_quote_times,
+                        "MISSING_MANUAL_VALUATION",
+                        "Missing manual valuation",
+                        "These are manual/custom holdings with no manual valuation entered, so \
+                         their market value can't be determined until you add a price.",
+                    )])
                     .details(details)
                     .data_hash(data_hash)
                     .build(),
@@ -224,6 +235,35 @@ impl PriceStalenessCheck {
             // Build details string listing affected assets
             let details = build_asset_details(&error_assets, latest_quote_times);
 
+            // Split into "no quote at all" (missing) vs "quote is stale" so each
+            // gets its own root-cause diagnostic.
+            let (missing_assets, stale_assets): (Vec<&AssetHoldingInfo>, Vec<&AssetHoldingInfo>) =
+                error_assets
+                    .iter()
+                    .copied()
+                    .partition(|a| !latest_quote_times.contains_key(&a.asset_id));
+            let mut diagnostics = Vec::new();
+            if !missing_assets.is_empty() {
+                diagnostics.push(price_diagnostic(
+                    &missing_assets,
+                    latest_quote_times,
+                    "MISSING_MARKET_QUOTE",
+                    "No market price",
+                    "These holdings have no market price on record, so their value can't be \
+                     computed. The symbol may be unresolved or the data provider has no data.",
+                ));
+            }
+            if !stale_assets.is_empty() {
+                diagnostics.push(price_diagnostic(
+                    &stale_assets,
+                    latest_quote_times,
+                    "STALE_MARKET_QUOTE",
+                    "Outdated price",
+                    "These prices are several days old, so portfolio value for the affected \
+                     holdings may be inaccurate until they are refreshed.",
+                ));
+            }
+
             let message = if missing_count > 0 {
                 "Unable to fetch market data for some holdings. This may be due to invalid symbols or provider issues. Your portfolio value may be inaccurate."
             } else {
@@ -241,6 +281,7 @@ impl PriceStalenessCheck {
                     .affected_mv_pct(mv_pct)
                     .affected_items(affected_items)
                     .fix_action(FixAction::sync_prices(asset_ids))
+                    .diagnostics(diagnostics)
                     .details(details)
                     .data_hash(data_hash)
                     .build(),
@@ -295,6 +336,14 @@ impl PriceStalenessCheck {
                     .affected_mv_pct(mv_pct)
                     .affected_items(affected_items)
                     .fix_action(FixAction::sync_prices(asset_ids))
+                    .diagnostics(vec![price_diagnostic(
+                        &warning_assets,
+                        latest_quote_times,
+                        "STALE_MARKET_QUOTE",
+                        "Price update needed",
+                        "These prices haven't been refreshed recently; portfolio value for the \
+                         affected holdings may drift until they are synced.",
+                    )])
                     .details(details)
                     .data_hash(data_hash)
                     .build(),
@@ -303,6 +352,76 @@ impl PriceStalenessCheck {
 
         issues
     }
+}
+
+/// Builds a structured diagnostic for a group of price-related holdings: one
+/// evidence row per asset (symbol, quote freshness, market value, deep-link) and
+/// an ordered action ladder (sync → market-data settings → add manual price).
+fn price_diagnostic(
+    assets: &[&AssetHoldingInfo],
+    latest_quote_times: &HashMap<String, DateTime<Utc>>,
+    code: &str,
+    title: &str,
+    explanation: &str,
+) -> HealthDiagnostic {
+    let mut diagnostic =
+        HealthDiagnostic::new(code, title, explanation).domain(DiagnosticDomain::MarketData);
+    for asset in assets {
+        let asset_route = format!(
+            "/holdings/{}?tab=quotes&healthContext=price",
+            urlencoding::encode(&asset.asset_id)
+        );
+        let asset_label = asset
+            .name
+            .as_ref()
+            .map(|name| format!("{} — {name}", asset.symbol))
+            .unwrap_or_else(|| asset.symbol.clone());
+        let quote_state = match latest_quote_times.get(&asset.asset_id) {
+            Some(ts) => format!("last quote {}", ts.format("%Y-%m-%d")),
+            None => "no quote on record".to_string(),
+        };
+        let value = format!(
+            "{} — {} · affects ~{:.0} in base currency",
+            asset.symbol, quote_state, asset.market_value
+        );
+        let label = asset.name.clone().unwrap_or_else(|| asset.symbol.clone());
+        diagnostic = diagnostic
+            .entity(
+                HealthEntityRef::new("asset", asset.asset_id.clone())
+                    .label(asset_label)
+                    .route(asset_route.clone()),
+            )
+            .evidence(Evidence::new(label, value).with_route(asset_route));
+    }
+
+    let asset_ids: Vec<String> = assets.iter().map(|a| a.asset_id.clone()).collect();
+
+    if code == "MISSING_MANUAL_VALUATION" {
+        // Manual holdings: primary is to open the price editor. For a single asset
+        // deep-link straight to its quotes tab; otherwise the market-data screen.
+        if let [single] = assets {
+            diagnostic = diagnostic.navigate(
+                true,
+                NavigateAction::to_asset_manual_quote(single.asset_id.clone()),
+            );
+        } else {
+            diagnostic = diagnostic.navigate(true, NavigateAction::to_market_data());
+        }
+        return diagnostic;
+    }
+
+    // Market-priced holdings: sync first, then settings to fix symbol/provider,
+    // then a manual/import fallback when the provider genuinely can't supply data.
+    diagnostic = diagnostic
+        .fix(true, FixAction::sync_prices(asset_ids))
+        .navigate(false, NavigateAction::to_market_data());
+    if let [single] = assets {
+        diagnostic = diagnostic.navigate(
+            false,
+            NavigateAction::to_asset_manual_quote(single.asset_id.clone()),
+        );
+    }
+    diagnostic
 }
 
 impl Default for PriceStalenessCheck {

--- a/crates/core/src/health/checks/quote_sync.rs
+++ b/crates/core/src/health/checks/quote_sync.rs
@@ -8,7 +8,8 @@ use std::collections::{HashMap, HashSet};
 use crate::assets::{AssetServiceTrait, QuoteMode};
 use crate::errors::Result;
 use crate::health::model::{
-    AffectedItem, FixAction, HealthCategory, HealthIssue, NavigateAction, Severity,
+    AffectedItem, DiagnosticDomain, Evidence, FixAction, HealthCategory, HealthDiagnostic,
+    HealthEntityRef, HealthIssue, NavigateAction, Severity,
 };
 use crate::health::traits::{HealthCheck, HealthContext};
 use crate::quotes::QuoteServiceTrait;
@@ -207,6 +208,7 @@ impl QuoteSyncCheck {
                     .affected_items(affected_items)
                     .fix_action(FixAction::retry_sync(asset_ids))
                     .navigate_action(NavigateAction::to_market_data())
+                    .diagnostics(vec![quote_sync_diagnostic(&persistent_errors)])
                     .details(details)
                     .data_hash(data_hash)
                     .build(),
@@ -250,6 +252,7 @@ impl QuoteSyncCheck {
                     .affected_mv_pct(mv_pct)
                     .affected_items(affected_items)
                     .fix_action(FixAction::retry_sync(asset_ids))
+                    .diagnostics(vec![quote_sync_diagnostic(&warning_errors)])
                     .details(details)
                     .data_hash(data_hash)
                     .build(),
@@ -258,6 +261,61 @@ impl QuoteSyncCheck {
 
         issues
     }
+}
+
+/// Builds a diagnostic for a group of quote-sync failures. Assets that have
+/// never returned a quote are classified as a symbol/provider problem
+/// (`INVALID_SYMBOL_OR_PROVIDER`); assets that synced before are a transient/
+/// provider sync failure (`QUOTE_SYNC_FAILED`). Evidence carries the failure
+/// count and (truncated) last provider error.
+fn quote_sync_diagnostic(errors: &[&QuoteSyncErrorInfo]) -> HealthDiagnostic {
+    let never_synced = errors.iter().all(|e| !e.has_synced_before);
+    let (code, title, explanation) = if never_synced {
+        (
+            "INVALID_SYMBOL_OR_PROVIDER",
+            "Symbol or provider problem",
+            "These assets have never returned a quote, which usually means the symbol is \
+             unresolved or the configured data provider can't price them. Check the symbol and \
+             provider in Market Data settings.",
+        )
+    } else {
+        (
+            "QUOTE_SYNC_FAILED",
+            "Price sync failing",
+            "These assets have repeatedly failed to sync a quote. This may be a temporary \
+             provider issue, or the symbol/provider may need correcting.",
+        )
+    };
+
+    let mut diagnostic =
+        HealthDiagnostic::new(code, title, explanation).domain(DiagnosticDomain::MarketData);
+    for error in errors {
+        let asset_route = format!(
+            "/holdings/{}?tab=quotes&healthContext=price",
+            urlencoding::encode(&error.asset_id)
+        );
+        let last_error = error
+            .last_error
+            .as_deref()
+            .map(|message| {
+                let truncated: String = message.chars().take(80).collect();
+                format!(" — {truncated}")
+            })
+            .unwrap_or_default();
+        let value = format!("{} failure(s){}", error.error_count, last_error);
+        diagnostic = diagnostic
+            .entity(
+                HealthEntityRef::new("asset", error.asset_id.clone())
+                    .label(error.symbol.clone())
+                    .route(asset_route.clone()),
+            )
+            .evidence(Evidence::new(error.symbol.clone(), value).with_route(asset_route));
+    }
+
+    let asset_ids: Vec<String> = errors.iter().map(|e| e.asset_id.clone()).collect();
+    diagnostic
+        .fix(true, FixAction::retry_sync(asset_ids))
+        .navigate(false, NavigateAction::to_market_data())
 }
 
 impl Default for QuoteSyncCheck {
@@ -358,6 +416,34 @@ mod tests {
         let issues = check.analyze(&sync_errors, &ctx);
         assert_eq!(issues.len(), 1);
         assert_eq!(issues[0].severity, Severity::Warning);
+
+        // Synced-before failures classify as a transient sync failure, and the
+        // evidence surfaces the failure count + provider error.
+        let diagnostics = issues[0].diagnostics.as_ref().expect("diagnostics");
+        assert_eq!(diagnostics[0].code, "QUOTE_SYNC_FAILED");
+        assert!(diagnostics[0].evidence[0].value.contains("Network timeout"));
+    }
+
+    #[test]
+    fn test_never_synced_classifies_as_invalid_symbol_or_provider() {
+        let check = QuoteSyncCheck::new();
+        let ctx = HealthContext::new(HealthConfig::default(), "USD", 100_000.0);
+
+        let sync_errors = vec![QuoteSyncErrorInfo {
+            asset_id: "SEC:BADSYM:XNAS".to_string(),
+            symbol: "BADSYM".to_string(),
+            error_count: 3,
+            last_error: Some("Symbol not found".to_string()),
+            market_value: 0.0,
+            has_synced_before: false,
+        }];
+
+        let issues = check.analyze(&sync_errors, &ctx);
+        assert_eq!(issues.len(), 1);
+        let diagnostics = issues[0].diagnostics.as_ref().expect("diagnostics");
+        assert_eq!(diagnostics[0].code, "INVALID_SYMBOL_OR_PROVIDER");
+        // Retry is the primary fix; market-data settings is the secondary nav.
+        assert!(diagnostics[0].actions[0].primary);
     }
 
     #[test]

--- a/crates/core/src/health/checks/transfer_integrity.rs
+++ b/crates/core/src/health/checks/transfer_integrity.rs
@@ -1,8 +1,9 @@
 //! Transfer integrity health check.
 //!
 //! Detects transfer groups that don't resolve to a valid pair (e.g. a transfer
-//! with only one recorded leg). Such groups have their flows treated as external,
-//! which silently distorts performance — so we surface them as actionable issues.
+//! with only one recorded leg). These can make returns look wrong if the app
+//! cannot tell whether money moved between owned accounts or entered/left the
+//! portfolio, so we surface them as actionable issues.
 //!
 //! The internal `group_id` is used only for identity / change-detection and is
 //! never shown to the user; the UI sees friendly per-leg transaction details.
@@ -13,7 +14,10 @@ use rust_decimal::Decimal;
 use serde_json::json;
 
 use crate::errors::Result;
-use crate::health::model::{AffectedItem, HealthCategory, HealthIssue, NavigateAction, Severity};
+use crate::health::model::{
+    AffectedItem, DiagnosticDomain, Evidence, HealthCategory, HealthDiagnostic, HealthEntityRef,
+    HealthIssue, NavigateAction, Severity,
+};
 use crate::health::traits::{HealthCheck, HealthContext};
 
 /// One leg of an invalid transfer group, with human-readable detail.
@@ -84,7 +88,7 @@ impl TransferIntegrityCheck {
             .iter()
             .flat_map(|g| g.legs.iter().map(|l| l.date))
             .collect();
-        let mut query = json!({ "types": "TRANSFER_IN,TRANSFER_OUT" });
+        let mut query = json!({ "types": "TRANSFER_IN,TRANSFER_OUT", "healthContext": "activity" });
         if let (Some(from), Some(to)) = (all_dates.iter().min(), all_dates.iter().max()) {
             query["from"] = json!(from.format("%Y-%m-%d").to_string());
             query["to"] = json!(to.format("%Y-%m-%d").to_string());
@@ -92,13 +96,13 @@ impl TransferIntegrityCheck {
         let navigate = NavigateAction {
             route: "/activities".to_string(),
             query: Some(query),
-            label: "Review transfers".to_string(),
+            label: "Review Transactions".to_string(),
         };
 
         let title = if count == 1 {
-            "Incomplete transfer detected".to_string()
+            "Transfer needs matching or confirmation".to_string()
         } else {
-            format!("{} incomplete transfers detected", count)
+            format!("{} transfers need matching or confirmation", count)
         };
 
         let mut builder = HealthIssue::builder()
@@ -107,10 +111,11 @@ impl TransferIntegrityCheck {
             .category(HealthCategory::DataConsistency)
             .title(title)
             .message(
-                "A transfer is unpaired or missing its matching leg, so its flow was treated as external and may distort returns. Pair it with the matching transfer, or mark it external if that is intended.",
+                "Some transfers are missing the other side of the move. Match the two transactions if this was between your accounts, or mark the transfer as external if money entered or left your portfolio.",
             )
             .affected_count(count as u32)
-            .navigate_action(navigate)
+            .navigate_action(navigate.clone())
+            .diagnostics(vec![transfer_diagnostic(groups, navigate)])
             .data_hash(data_hash);
         if !affected_items.is_empty() {
             builder = builder.affected_items(affected_items);
@@ -121,6 +126,56 @@ impl TransferIntegrityCheck {
 
         vec![builder.build()]
     }
+}
+
+fn transfer_diagnostic(
+    groups: &[InvalidTransferGroupInfo],
+    navigate: NavigateAction,
+) -> HealthDiagnostic {
+    let mut diagnostic = HealthDiagnostic::new(
+        "INVALID_TRANSFER_GROUP",
+        "Transfer needs review",
+        "This transfer is missing the other side of the move. Match the two transactions if it moved between your accounts, or mark it external if money entered or left your portfolio.",
+    )
+    .domain(DiagnosticDomain::Ledger)
+    .navigate(true, navigate);
+
+    let all_dates: Vec<NaiveDate> = groups
+        .iter()
+        .flat_map(|group| group.legs.iter().map(|leg| leg.date))
+        .collect();
+    if let (Some(from), Some(to)) = (all_dates.iter().min(), all_dates.iter().max()) {
+        diagnostic = diagnostic.date_range(
+            from.format("%Y-%m-%d").to_string(),
+            to.format("%Y-%m-%d").to_string(),
+        );
+    }
+
+    for group in groups {
+        diagnostic = diagnostic.entity(HealthEntityRef::new(
+            "transferGroup",
+            group.group_id.clone(),
+        ));
+        for leg in &group.legs {
+            let item = affected_item_for_leg(leg);
+            if let Some(route) = item.route.clone() {
+                diagnostic = diagnostic.entity(
+                    HealthEntityRef::new(
+                        "account",
+                        format!("{}:{}", leg.account_id, leg.activity_type),
+                    )
+                    .label(leg.account_name.clone())
+                    .route(route.clone()),
+                );
+                diagnostic =
+                    diagnostic.evidence(Evidence::new("Transaction", item.name).with_route(route));
+            } else {
+                diagnostic = diagnostic.evidence(Evidence::new("Transaction", item.name));
+            }
+        }
+    }
+
+    diagnostic
 }
 
 impl Default for TransferIntegrityCheck {
@@ -180,7 +235,7 @@ fn affected_item_for_leg(leg: &TransferLegDetail) -> AffectedItem {
         name: describe_leg(leg),
         symbol: None,
         route: Some(format!(
-            "/activities?account={}&from={}&to={}&types={}",
+            "/activities?account={}&from={}&to={}&types={}&healthContext=activity",
             urlencoding::encode(&leg.account_id),
             urlencoding::encode(&date),
             urlencoding::encode(&date),
@@ -192,14 +247,14 @@ fn affected_item_for_leg(leg: &TransferLegDetail) -> AffectedItem {
 fn format_group_details(group: &InvalidTransferGroupInfo) -> String {
     let when = match group.date_range() {
         Some((from, to)) if from == to => {
-            format!("Incomplete transfer on {}", from.format("%b %-d, %Y"))
+            format!("Transfer on {} needs review", from.format("%b %-d, %Y"))
         }
         Some((from, to)) => format!(
-            "Incomplete transfer between {} and {}",
+            "Transfer between {} and {} needs review",
             from.format("%b %-d, %Y"),
             to.format("%b %-d, %Y")
         ),
-        None => "Incomplete transfer".to_string(),
+        None => "Transfer needs review".to_string(),
     };
     let legs = group
         .legs
@@ -208,7 +263,7 @@ fn format_group_details(group: &InvalidTransferGroupInfo) -> String {
         .collect::<Vec<_>>()
         .join("\n");
     format!(
-        "{}:\n{}\n  → This transfer was treated as external; pair it or mark it external if intended.",
+        "{}:\n{}\n  → Match this with the other side of the transfer, or mark it external if money entered or left your portfolio.",
         when, legs
     )
 }
@@ -284,7 +339,7 @@ mod tests {
         assert_eq!(
             item.route.as_deref(),
             Some(
-                "/activities?account=acc_checking&from=2026-06-02&to=2026-06-02&types=TRANSFER_OUT"
+                "/activities?account=acc_checking&from=2026-06-02&to=2026-06-02&types=TRANSFER_OUT&healthContext=activity"
             )
         );
         // ...but the issue id (internal) still ties to the data hash for dismissal.

--- a/crates/core/src/health/mod.rs
+++ b/crates/core/src/health/mod.rs
@@ -58,8 +58,9 @@ mod tests;
 // Re-export commonly used types
 pub use errors::HealthError;
 pub use model::{
-    AffectedItem, FixAction, HealthCategory, HealthConfig, HealthIssue, HealthIssueBuilder,
-    HealthStatus, IssueDismissal, NavigateAction, Severity,
+    AffectedItem, DiagnosticAction, DiagnosticDomain, DiagnosticLevel, Evidence, FixAction,
+    HealthCategory, HealthConfig, HealthDateRange, HealthDiagnostic, HealthEntityRef, HealthImpact,
+    HealthIssue, HealthIssueBuilder, HealthStatus, IssueDismissal, NavigateAction, Severity,
 };
 pub use traits::{HealthCheck, HealthContext, HealthDismissalStore, HealthServiceTrait};
 
@@ -72,4 +73,6 @@ pub use fixes::{
 };
 
 // Re-export data gathering functions from checks
-pub use checks::{gather_legacy_migration_status, gather_quote_sync_errors};
+pub use checks::{
+    gather_legacy_migration_status, gather_quote_sync_errors, gather_unclassified_assets,
+};

--- a/crates/core/src/health/model.rs
+++ b/crates/core/src/health/model.rs
@@ -9,8 +9,8 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use sha2::{Digest, Sha256};
 use std::collections::HashMap;
-use std::hash::Hash;
 
 // =============================================================================
 // Severity
@@ -117,7 +117,7 @@ impl std::fmt::Display for HealthCategory {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct FixAction {
-    /// Unique identifier for the action type (e.g., "sync_prices", "fetch_fx")
+    /// Unique identifier for the action type (e.g., "sync_prices", "retry_sync")
     pub id: String,
     /// Human-readable button label (e.g., "Sync Prices")
     pub label: String,
@@ -135,29 +135,11 @@ impl FixAction {
         }
     }
 
-    /// Creates a new fix action for fetching FX rates.
-    pub fn fetch_fx(currency_pairs: Vec<String>) -> Self {
-        Self {
-            id: "fetch_fx".to_string(),
-            label: "Fetch Exchange Rates".to_string(),
-            payload: serde_json::json!(currency_pairs),
-        }
-    }
-
-    /// Creates a new fix action for migrating legacy classifications.
-    pub fn migrate_classifications(asset_ids: Vec<String>) -> Self {
-        Self {
-            id: "migrate_classifications".to_string(),
-            label: "Migrate Classifications".to_string(),
-            payload: serde_json::json!(asset_ids),
-        }
-    }
-
     /// Creates a new fix action for migrating all legacy classifications.
     pub fn migrate_legacy_classifications() -> Self {
         Self {
             id: "migrate_legacy_classifications".to_string(),
-            label: "Start Migration".to_string(),
+            label: "Migrate Classifications".to_string(),
             payload: serde_json::json!(null),
         }
     }
@@ -168,6 +150,17 @@ impl FixAction {
             id: "retry_sync".to_string(),
             label: "Retry Sync".to_string(),
             payload: serde_json::json!(asset_ids),
+        }
+    }
+
+    /// Creates a new fix action for rebuilding an account's generated history.
+    ///
+    /// Triggers a full snapshot recalculation scoped to the given accounts.
+    pub fn rebuild_account_history(account_ids: Vec<String>) -> Self {
+        Self {
+            id: "rebuild_account_history".to_string(),
+            label: "Rebuild History".to_string(),
+            payload: serde_json::json!(account_ids),
         }
     }
 }
@@ -188,7 +181,7 @@ pub struct NavigateAction {
     /// Optional query parameters for the route
     #[serde(skip_serializing_if = "Option::is_none")]
     pub query: Option<Value>,
-    /// Human-readable button label (e.g., "View Holdings")
+    /// Human-readable button label (e.g., "Review Holdings")
     pub label: String,
 }
 
@@ -245,13 +238,13 @@ impl AffectedItem {
     }
 
     /// Creates a new affected item for an asset with market data issues.
-    /// Links to the asset page with the market-data tab.
+    /// Links to the asset page's quotes tab (the manual-quote / price editor).
     pub fn asset_market_data(id: impl Into<String>, symbol: impl Into<String>) -> Self {
         let id_str = id.into();
         let symbol_str = symbol.into();
         Self {
             route: Some(format!(
-                "/holdings/{}?tab=market-data",
+                "/holdings/{}?tab=quotes&healthContext=price",
                 urlencoding::encode(&id_str)
             )),
             id: id_str,
@@ -287,8 +280,8 @@ impl NavigateAction {
     pub fn to_holdings(filter: Option<&str>) -> Self {
         Self {
             route: "/holdings".to_string(),
-            query: filter.map(|f| serde_json::json!({ "filter": f })),
-            label: "View Holdings".to_string(),
+            query: filter.map(|f| serde_json::json!({ "filter": f, "healthContext": "holding" })),
+            label: "Review Holdings".to_string(),
         }
     }
 
@@ -297,7 +290,7 @@ impl NavigateAction {
         Self {
             route: "/activities".to_string(),
             query: filter.map(|f| serde_json::json!({ "filter": f })),
-            label: "View Activities".to_string(),
+            label: "Review Transactions".to_string(),
         }
     }
 
@@ -306,7 +299,7 @@ impl NavigateAction {
         Self {
             route: "/settings/accounts".to_string(),
             query: None,
-            label: "View Accounts".to_string(),
+            label: "Review Accounts".to_string(),
         }
     }
 
@@ -314,8 +307,8 @@ impl NavigateAction {
     pub fn to_taxonomies() -> Self {
         Self {
             route: "/settings/taxonomies".to_string(),
-            query: None,
-            label: "View Classifications".to_string(),
+            query: Some(serde_json::json!({ "healthContext": "classification" })),
+            label: "Review Classifications".to_string(),
         }
     }
 
@@ -323,8 +316,8 @@ impl NavigateAction {
     pub fn to_market_data() -> Self {
         Self {
             route: "/settings/market-data".to_string(),
-            query: None,
-            label: "View Market Data".to_string(),
+            query: Some(serde_json::json!({ "healthContext": "marketData" })),
+            label: "Review Market Data".to_string(),
         }
     }
 
@@ -344,6 +337,490 @@ impl NavigateAction {
             query: None,
             label: "Configure Accounts".to_string(),
         }
+    }
+
+    /// Creates a navigate action to an asset's manual-quote editor (quotes tab).
+    pub fn to_asset_manual_quote(asset_id: impl Into<String>) -> Self {
+        let id = asset_id.into();
+        Self {
+            route: format!("/holdings/{}", urlencoding::encode(&id)),
+            query: Some(serde_json::json!({ "tab": "quotes", "healthContext": "price" })),
+            label: "Add Price".to_string(),
+        }
+    }
+
+    /// Creates a navigate action to an asset's holdings-snapshot editor
+    /// (snapshots tab), where cost basis is set for HOLDINGS-tracked accounts.
+    pub fn to_asset_snapshots(asset_id: impl Into<String>) -> Self {
+        let id = asset_id.into();
+        Self {
+            route: format!("/holdings/{}", urlencoding::encode(&id)),
+            query: Some(serde_json::json!({ "tab": "snapshots", "healthContext": "basis" })),
+            label: "Update Cost Basis".to_string(),
+        }
+    }
+
+    /// Creates a navigate action to an asset's activities tab — the asset-scoped
+    /// transaction list (the activities page itself cannot filter by asset).
+    pub fn to_asset_activities(asset_id: impl Into<String>) -> Self {
+        let id = asset_id.into();
+        Self {
+            route: format!("/holdings/{}", urlencoding::encode(&id)),
+            query: Some(serde_json::json!({ "tab": "activities", "healthContext": "activity" })),
+            label: "Review Transactions".to_string(),
+        }
+    }
+
+    /// Creates a navigate action to a single activity on the activities page.
+    /// The activities search filters by activity id server-side, so this pins the
+    /// list to exactly that transaction regardless of paging.
+    pub fn to_activity(activity_id: impl Into<String>) -> Self {
+        Self {
+            route: "/activities".to_string(),
+            query: Some(serde_json::json!({
+                "activity": activity_id.into(),
+                "healthContext": "activity"
+            })),
+            label: "Review Transaction".to_string(),
+        }
+    }
+}
+
+// =============================================================================
+// Diagnostics (root cause, evidence, ordered actions)
+// =============================================================================
+
+/// A wrapped fix or navigation action, tagged so the frontend can branch on `kind`.
+///
+/// Serializes flat with a `kind` discriminator, e.g.
+/// `{ "kind": "fix", "id": "sync_prices", "label": "Sync Prices", "payload": [...] }`
+/// or `{ "kind": "navigate", "route": "/settings/market-data", "label": "..." }`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase", tag = "kind")]
+pub enum ActionRef {
+    /// An automated fix action.
+    Fix {
+        #[serde(flatten)]
+        action: FixAction,
+    },
+    /// A manual navigation action.
+    Navigate {
+        #[serde(flatten)]
+        action: NavigateAction,
+    },
+}
+
+/// A single ordered action attached to a diagnostic.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct DiagnosticAction {
+    /// Whether this is the primary recommended action (styled prominently).
+    pub primary: bool,
+    /// The wrapped fix or navigate action (flattened with a `kind` discriminator).
+    #[serde(flatten)]
+    pub action: ActionRef,
+}
+
+/// A single supporting-evidence row for a diagnostic.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Evidence {
+    /// Short label (e.g., "Asset", "Date", "Last quote", "Currency pair").
+    pub label: String,
+    /// The evidence value (e.g., "AAPL — Apple Inc.", "2025-11-05").
+    pub value: String,
+    /// Optional deep-link route for this evidence row.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub route: Option<String>,
+}
+
+impl Evidence {
+    /// Creates an evidence row without a deep-link.
+    pub fn new(label: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            value: value.into(),
+            route: None,
+        }
+    }
+
+    /// Attaches a deep-link route to this evidence row.
+    pub fn with_route(mut self, route: impl Into<String>) -> Self {
+        self.route = Some(route.into());
+        self
+    }
+}
+
+// =============================================================================
+// Diagnostic metadata
+// =============================================================================
+
+/// Functional area that owns or best explains a diagnostic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum DiagnosticDomain {
+    #[default]
+    Unknown,
+    AccountSetup,
+    Ledger,
+    MarketData,
+    Fx,
+    Classification,
+    GeneratedData,
+    PerformanceInputs,
+}
+
+impl DiagnosticDomain {
+    fn as_fingerprint_part(self) -> &'static str {
+        match self {
+            Self::Unknown => "unknown",
+            Self::AccountSetup => "accountSetup",
+            Self::Ledger => "ledger",
+            Self::MarketData => "marketData",
+            Self::Fx => "fx",
+            Self::Classification => "classification",
+            Self::GeneratedData => "generatedData",
+            Self::PerformanceInputs => "performanceInputs",
+        }
+    }
+
+    fn from_category(category: HealthCategory) -> Self {
+        match category {
+            HealthCategory::PriceStaleness => Self::MarketData,
+            HealthCategory::FxIntegrity => Self::Fx,
+            HealthCategory::Classification => Self::Classification,
+            HealthCategory::DataConsistency => Self::Ledger,
+            HealthCategory::AccountConfiguration => Self::AccountSetup,
+            HealthCategory::SettingsConfiguration => Self::AccountSetup,
+        }
+    }
+}
+
+/// Whether the diagnostic points at user-entered source data, generated data, or
+/// a workflow/configuration state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum DiagnosticLevel {
+    #[default]
+    Source,
+    Generated,
+    Workflow,
+}
+
+impl DiagnosticLevel {
+    fn as_fingerprint_part(self) -> &'static str {
+        match self {
+            Self::Source => "source",
+            Self::Generated => "generated",
+            Self::Workflow => "workflow",
+        }
+    }
+}
+
+/// User-visible impact attached to a diagnostic.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct HealthImpact {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub affected_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub affected_mv_pct: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub amount: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub currency: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+impl HealthImpact {
+    pub fn from_issue(affected_count: u32, affected_mv_pct: Option<f64>) -> Option<Self> {
+        if affected_count == 0 && affected_mv_pct.unwrap_or_default() <= 0.0 {
+            return None;
+        }
+        Some(Self {
+            affected_count: (affected_count > 0).then_some(affected_count),
+            affected_mv_pct,
+            amount: None,
+            currency: None,
+            description: None,
+        })
+    }
+}
+
+/// A typed entity reference used to build stable diagnostic fingerprints and
+/// precise UI evidence.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub struct HealthEntityRef {
+    pub kind: String,
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub label: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub route: Option<String>,
+}
+
+impl HealthEntityRef {
+    pub fn new(kind: impl Into<String>, id: impl Into<String>) -> Self {
+        Self {
+            kind: kind.into(),
+            id: id.into(),
+            label: None,
+            route: None,
+        }
+    }
+
+    pub fn label(mut self, label: impl Into<String>) -> Self {
+        self.label = Some(label.into());
+        self
+    }
+
+    pub fn route(mut self, route: impl Into<String>) -> Self {
+        self.route = Some(route.into());
+        self
+    }
+}
+
+/// Inclusive date range associated with a diagnostic.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "camelCase")]
+pub struct HealthDateRange {
+    pub start: String,
+    pub end: String,
+}
+
+impl HealthDateRange {
+    pub fn new(start: impl Into<String>, end: impl Into<String>) -> Self {
+        Self {
+            start: start.into(),
+            end: end.into(),
+        }
+    }
+}
+
+/// A structured diagnostic explaining the root cause of (part of) a health issue,
+/// with supporting evidence and ordered remediation actions.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct HealthDiagnostic {
+    /// Stable identity for this concrete cause/scope.
+    #[serde(default)]
+    pub fingerprint: String,
+    /// Functional area that owns or best explains this diagnostic.
+    #[serde(default)]
+    pub domain: DiagnosticDomain,
+    /// Whether the cause is source data, generated data, or workflow state.
+    #[serde(default)]
+    pub level: DiagnosticLevel,
+    /// Severity for this specific cause.
+    #[serde(default)]
+    pub severity: Severity,
+    /// Stable machine code for the root cause (e.g., "MISSING_MARKET_QUOTE").
+    pub code: String,
+    /// Short human-friendly title for this root cause.
+    pub title: String,
+    /// Longer explanation of why this happened and its impact.
+    pub explanation: String,
+    /// Optional user-visible impact for this specific cause.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub impact: Option<HealthImpact>,
+    /// Typed entities used by the UI and fingerprinting.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub entities: Vec<HealthEntityRef>,
+    /// Optional primary date for this diagnostic (YYYY-MM-DD).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date: Option<String>,
+    /// Optional inclusive date range for this diagnostic.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date_range: Option<HealthDateRange>,
+    /// Supporting evidence rows.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence: Vec<Evidence>,
+    /// Ordered remediation actions (primary first by convention).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub actions: Vec<DiagnosticAction>,
+}
+
+impl HealthDiagnostic {
+    /// Creates a new diagnostic with no evidence or actions yet.
+    pub fn new(
+        code: impl Into<String>,
+        title: impl Into<String>,
+        explanation: impl Into<String>,
+    ) -> Self {
+        Self {
+            fingerprint: String::new(),
+            domain: DiagnosticDomain::Unknown,
+            level: DiagnosticLevel::Source,
+            severity: Severity::Info,
+            code: code.into(),
+            title: title.into(),
+            explanation: explanation.into(),
+            impact: None,
+            entities: Vec::new(),
+            date: None,
+            date_range: None,
+            evidence: Vec::new(),
+            actions: Vec::new(),
+        }
+    }
+
+    pub fn domain(mut self, domain: DiagnosticDomain) -> Self {
+        self.domain = domain;
+        self
+    }
+
+    pub fn level(mut self, level: DiagnosticLevel) -> Self {
+        self.level = level;
+        self
+    }
+
+    pub fn severity(mut self, severity: Severity) -> Self {
+        self.severity = severity;
+        self
+    }
+
+    pub fn impact(mut self, impact: HealthImpact) -> Self {
+        self.impact = Some(impact);
+        self
+    }
+
+    pub fn entity(mut self, entity: HealthEntityRef) -> Self {
+        self.entities.push(entity);
+        self
+    }
+
+    pub fn date(mut self, date: impl Into<String>) -> Self {
+        self.date = Some(date.into());
+        self
+    }
+
+    pub fn date_range(mut self, start: impl Into<String>, end: impl Into<String>) -> Self {
+        self.date_range = Some(HealthDateRange::new(start, end));
+        self
+    }
+
+    pub fn fingerprint(mut self, fingerprint: impl Into<String>) -> Self {
+        self.fingerprint = fingerprint.into();
+        self
+    }
+
+    /// Appends an evidence row.
+    pub fn evidence(mut self, evidence: Evidence) -> Self {
+        self.evidence.push(evidence);
+        self
+    }
+
+    /// Appends a fix action.
+    pub fn fix(mut self, primary: bool, action: FixAction) -> Self {
+        self.actions.push(DiagnosticAction {
+            primary,
+            action: ActionRef::Fix { action },
+        });
+        self
+    }
+
+    /// Appends a navigation action.
+    pub fn navigate(mut self, primary: bool, action: NavigateAction) -> Self {
+        self.actions.push(DiagnosticAction {
+            primary,
+            action: ActionRef::Navigate { action },
+        });
+        self
+    }
+
+    fn normalize_for_issue(
+        &mut self,
+        fallback_domain: DiagnosticDomain,
+        fallback_severity: Severity,
+        fallback_impact: Option<&HealthImpact>,
+    ) {
+        if self.domain == DiagnosticDomain::Unknown {
+            self.domain = fallback_domain;
+        }
+        if self.severity == Severity::Info && fallback_severity > Severity::Info {
+            self.severity = fallback_severity;
+        }
+        if self.impact.is_none() {
+            self.impact = fallback_impact.cloned();
+        }
+        if self.fingerprint.trim().is_empty() {
+            self.fingerprint = self.computed_fingerprint();
+        }
+    }
+
+    pub fn computed_fingerprint(&self) -> String {
+        let mut parts = vec![
+            format!("code={}", self.code),
+            format!("domain={}", self.domain.as_fingerprint_part()),
+            format!("level={}", self.level.as_fingerprint_part()),
+            format!("severity={}", self.severity.as_str()),
+        ];
+        if let Some(date) = &self.date {
+            parts.push(format!("date={date}"));
+        }
+        if let Some(range) = &self.date_range {
+            parts.push(format!("range={}:{}", range.start, range.end));
+        }
+        let mut entities: Vec<String> = self
+            .entities
+            .iter()
+            .map(|entity| format!("{}:{}", entity.kind, entity.id))
+            .collect();
+        entities.sort();
+        parts.extend(entities.into_iter().map(|value| format!("entity={value}")));
+
+        stable_hash(&parts.join("\n"))
+    }
+}
+
+fn stable_hash(value: &str) -> String {
+    let digest = Sha256::digest(value.as_bytes());
+    hex::encode(&digest[..8])
+}
+
+fn aggregate_diagnostic_hash(grouping_key: &str, diagnostics: &[HealthDiagnostic]) -> String {
+    let mut fingerprints: Vec<String> = diagnostics
+        .iter()
+        .map(|diagnostic| diagnostic.fingerprint.clone())
+        .collect();
+    fingerprints.sort();
+    stable_hash(&format!("{grouping_key}\n{}", fingerprints.join("\n")))
+}
+
+fn issue_grouping_key(id: &str) -> String {
+    id.rsplit_once(':')
+        .map(|(prefix, _)| prefix.to_string())
+        .unwrap_or_else(|| id.to_string())
+}
+
+fn diagnostic_code_from_grouping_key(grouping_key: &str) -> String {
+    grouping_key
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>()
+        .split('_')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("_")
+}
+
+fn default_level_for_category(category: HealthCategory, grouping_key: &str) -> DiagnosticLevel {
+    if grouping_key.contains("generated") || grouping_key.contains("valuation") {
+        return DiagnosticLevel::Generated;
+    }
+    match category {
+        HealthCategory::AccountConfiguration | HealthCategory::SettingsConfiguration => {
+            DiagnosticLevel::Workflow
+        }
+        _ => DiagnosticLevel::Source,
     }
 }
 
@@ -402,6 +879,11 @@ pub struct HealthIssue {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub affected_items: Option<Vec<AffectedItem>>,
 
+    /// Structured diagnostics (root cause, evidence, ordered actions).
+    /// When present, the UI renders these instead of the flat `details` string.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostics: Option<Vec<HealthDiagnostic>>,
+
     /// Hash of the underlying data that caused this issue.
     /// Used to detect when data changes after dismissal.
     pub data_hash: String,
@@ -431,6 +913,7 @@ pub struct HealthIssueBuilder {
     navigate_action: Option<NavigateAction>,
     details: Option<String>,
     affected_items: Option<Vec<AffectedItem>>,
+    diagnostics: Option<Vec<HealthDiagnostic>>,
     data_hash: Option<String>,
 }
 
@@ -490,6 +973,11 @@ impl HealthIssueBuilder {
         self
     }
 
+    pub fn diagnostics(mut self, diagnostics: Vec<HealthDiagnostic>) -> Self {
+        self.diagnostics = Some(diagnostics);
+        self
+    }
+
     pub fn data_hash(mut self, hash: impl Into<String>) -> Self {
         self.data_hash = Some(hash.into());
         self
@@ -501,19 +989,156 @@ impl HealthIssueBuilder {
     ///
     /// Panics if required fields (id, category, title, message, data_hash) are not set.
     pub fn build(self) -> HealthIssue {
+        let category = self.category.expect("category is required");
+        let raw_id = self.id.expect("id is required");
+        let grouping_key = issue_grouping_key(&raw_id);
+        let title = self.title.expect("title is required");
+        let message = self.message.expect("message is required");
+        let mut fix_action = self.fix_action;
+        let mut navigate_action = self.navigate_action;
+        let details = self.details;
+        let affected_items = self.affected_items;
+        let provided_data_hash = self.data_hash;
+
+        let fallback_domain = DiagnosticDomain::from_category(category);
+        let fallback_impact = HealthImpact::from_issue(self.affected_count, self.affected_mv_pct);
+        let mut diagnostics = self.diagnostics;
+        if diagnostics.is_none() {
+            let mut diagnostic = HealthDiagnostic::new(
+                diagnostic_code_from_grouping_key(&grouping_key),
+                title.clone(),
+                message.clone(),
+            )
+            .domain(fallback_domain)
+            .level(default_level_for_category(category, &grouping_key))
+            .severity(self.severity);
+
+            if let Some(impact) = fallback_impact.clone() {
+                diagnostic = diagnostic.impact(impact);
+            }
+            if let Some(hash) = provided_data_hash.as_ref() {
+                diagnostic =
+                    diagnostic.fingerprint(stable_hash(&format!("fallback:{grouping_key}:{hash}")));
+            }
+            if let Some(items) = affected_items.as_ref() {
+                for item in items {
+                    let mut entity = HealthEntityRef::new("affectedItem", item.id.clone())
+                        .label(item.name.clone());
+                    if let Some(route) = item.route.clone() {
+                        entity = entity.route(route.clone());
+                    }
+                    diagnostic = diagnostic.entity(entity);
+
+                    let value = item
+                        .symbol
+                        .as_ref()
+                        .map(|symbol| format!("{symbol} — {}", item.name))
+                        .unwrap_or_else(|| item.name.clone());
+                    let evidence = Evidence {
+                        label: "Item".to_string(),
+                        value,
+                        route: item.route.clone(),
+                    };
+                    diagnostic = diagnostic.evidence(evidence);
+                }
+            }
+            if let Some(action) = fix_action.clone() {
+                diagnostic = diagnostic.fix(true, action);
+            }
+            if let Some(action) = navigate_action.clone() {
+                diagnostic = diagnostic.navigate(fix_action.is_none(), action);
+            }
+            diagnostics = Some(vec![diagnostic]);
+        }
+        if let Some(diagnostics) = diagnostics.as_mut() {
+            for diagnostic in diagnostics.iter_mut() {
+                diagnostic.normalize_for_issue(
+                    fallback_domain,
+                    self.severity,
+                    fallback_impact.as_ref(),
+                );
+            }
+        }
+
+        let (id, data_hash) = if let Some(diagnostics) = diagnostics.as_ref() {
+            if diagnostics.is_empty() {
+                (raw_id, provided_data_hash.expect("data_hash is required"))
+            } else {
+                let aggregate_hash = aggregate_diagnostic_hash(&grouping_key, diagnostics);
+                (format!("{grouping_key}:{aggregate_hash}"), aggregate_hash)
+            }
+        } else {
+            (raw_id, provided_data_hash.expect("data_hash is required"))
+        };
+
+        if let Some(diagnostics) = diagnostics.as_ref().filter(|items| !items.is_empty()) {
+            let diagnostic_actions: Vec<&DiagnosticAction> = diagnostics
+                .iter()
+                .flat_map(|diagnostic| diagnostic.actions.iter())
+                .collect();
+            let primary_fix = diagnostic_actions
+                .iter()
+                .copied()
+                .filter(|action| action.primary)
+                .find_map(|action| match &action.action {
+                    ActionRef::Fix { action } => Some(action.clone()),
+                    _ => None,
+                })
+                .or_else(|| {
+                    diagnostic_actions
+                        .iter()
+                        .copied()
+                        .find_map(|action| match &action.action {
+                            ActionRef::Fix { action } => Some(action.clone()),
+                            _ => None,
+                        })
+                });
+            let primary_navigation = diagnostic_actions
+                .iter()
+                .copied()
+                .filter(|action| action.primary)
+                .find_map(|action| match &action.action {
+                    ActionRef::Navigate { action } => Some(action.clone()),
+                    _ => None,
+                })
+                .or_else(|| {
+                    diagnostic_actions
+                        .iter()
+                        .copied()
+                        .find_map(|action| match &action.action {
+                            ActionRef::Navigate { action } => Some(action.clone()),
+                            _ => None,
+                        })
+                });
+
+            if let Some(action) = primary_fix {
+                fix_action = Some(action);
+            }
+            if let Some(action) = primary_navigation {
+                navigate_action = Some(action);
+            }
+        }
+
+        let severity = diagnostics
+            .as_ref()
+            .and_then(|diagnostics| diagnostics.iter().map(|d| d.severity).max())
+            .filter(|diagnostic_severity| *diagnostic_severity > self.severity)
+            .unwrap_or(self.severity);
+
         HealthIssue {
-            id: self.id.expect("id is required"),
-            severity: self.severity,
-            category: self.category.expect("category is required"),
-            title: self.title.expect("title is required"),
-            message: self.message.expect("message is required"),
+            id,
+            severity,
+            category,
+            title,
+            message,
             affected_count: self.affected_count,
             affected_mv_pct: self.affected_mv_pct,
-            fix_action: self.fix_action,
-            navigate_action: self.navigate_action,
-            details: self.details,
-            affected_items: self.affected_items,
-            data_hash: self.data_hash.expect("data_hash is required"),
+            fix_action,
+            navigate_action,
+            details,
+            affected_items,
+            diagnostics,
+            data_hash,
             timestamp: Utc::now(),
         }
     }
@@ -783,8 +1408,11 @@ mod tests {
         assert_eq!(sync.id, "sync_prices");
         assert_eq!(sync.label, "Sync Prices");
 
-        let fx = FixAction::fetch_fx(vec!["EUR:USD".to_string()]);
-        assert_eq!(fx.id, "fetch_fx");
+        let retry = FixAction::retry_sync(vec!["AAPL".to_string()]);
+        assert_eq!(retry.id, "retry_sync");
+
+        let rebuild = FixAction::rebuild_account_history(vec!["acc_1".to_string()]);
+        assert_eq!(rebuild.id, "rebuild_account_history");
     }
 
     #[test]
@@ -811,6 +1439,221 @@ mod tests {
         let dismissal = IssueDismissal::new("price_stale:AAPL", "abc123");
         assert_eq!(dismissal.issue_id, "price_stale:AAPL");
         assert_eq!(dismissal.data_hash, "abc123");
+    }
+
+    #[test]
+    fn test_diagnostic_action_serialization_tagging() {
+        let fix = DiagnosticAction {
+            primary: true,
+            action: ActionRef::Fix {
+                action: FixAction::sync_prices(vec!["AAPL".to_string()]),
+            },
+        };
+        let json = serde_json::to_value(&fix).unwrap();
+        assert_eq!(json["kind"], "fix");
+        assert_eq!(json["primary"], true);
+        assert_eq!(json["id"], "sync_prices");
+
+        let nav = DiagnosticAction {
+            primary: false,
+            action: ActionRef::Navigate {
+                action: NavigateAction::to_market_data(),
+            },
+        };
+        let json = serde_json::to_value(&nav).unwrap();
+        assert_eq!(json["kind"], "navigate");
+        assert_eq!(json["route"], "/settings/market-data");
+
+        // Round-trips back to the same enum variant.
+        let parsed: DiagnosticAction = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed, nav);
+    }
+
+    #[test]
+    fn test_diagnostic_builder_and_issue_roundtrip() {
+        let diagnostic = HealthDiagnostic::new(
+            "MISSING_MARKET_QUOTE",
+            "No market price",
+            "AAPL has no quote on the affected dates, so returns are unavailable.",
+        )
+        .evidence(Evidence::new("Asset", "AAPL — Apple Inc.").with_route("/holdings/asset-1"))
+        .evidence(Evidence::new("Date", "2025-11-05"))
+        .fix(true, FixAction::sync_prices(vec!["asset-1".to_string()]))
+        .navigate(false, NavigateAction::to_asset_manual_quote("asset-1"));
+
+        assert_eq!(diagnostic.evidence.len(), 2);
+        assert_eq!(diagnostic.actions.len(), 2);
+        assert!(diagnostic.actions[0].primary);
+
+        let issue = HealthIssue::builder()
+            .id("incomplete_valuation_value:hash")
+            .severity(Severity::Warning)
+            .category(HealthCategory::DataConsistency)
+            .title("Valuation coverage is incomplete")
+            .message("msg")
+            .diagnostics(vec![diagnostic])
+            .data_hash("hash")
+            .build();
+
+        let json = serde_json::to_string(&issue).unwrap();
+        let parsed: HealthIssue = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.diagnostics.as_ref().unwrap().len(), 1);
+        assert_eq!(parsed.diagnostics.unwrap()[0].code, "MISSING_MARKET_QUOTE");
+    }
+
+    #[test]
+    fn test_diagnostic_fingerprint_ignores_copy_but_tracks_scope() {
+        let diagnostic = HealthDiagnostic::new(
+            "MISSING_MARKET_QUOTE",
+            "No market price",
+            "Original explanation.",
+        )
+        .domain(DiagnosticDomain::MarketData)
+        .entity(HealthEntityRef::new("asset", "asset-1").route("/holdings/asset-1"))
+        .evidence(Evidence::new("Asset", "AAPL — Apple Inc."));
+
+        let wording_changed = HealthDiagnostic::new(
+            "MISSING_MARKET_QUOTE",
+            "No price available",
+            "Reworded explanation.",
+        )
+        .domain(DiagnosticDomain::MarketData)
+        .entity(HealthEntityRef::new("asset", "asset-1").route("/new-route/asset-1"))
+        .evidence(Evidence::new("Holding", "Apple Inc."))
+        .navigate(
+            true,
+            NavigateAction {
+                route: "/new-route".to_string(),
+                query: Some(serde_json::json!({ "tab": "prices" })),
+                label: "Open".to_string(),
+            },
+        );
+
+        let scope_changed = HealthDiagnostic::new(
+            "MISSING_MARKET_QUOTE",
+            "No market price",
+            "Original explanation.",
+        )
+        .domain(DiagnosticDomain::MarketData)
+        .entity(HealthEntityRef::new("asset", "asset-2").route("/holdings/asset-2"));
+
+        assert_eq!(
+            diagnostic.computed_fingerprint(),
+            wording_changed.computed_fingerprint()
+        );
+        assert_ne!(
+            diagnostic.computed_fingerprint(),
+            scope_changed.computed_fingerprint()
+        );
+    }
+
+    #[test]
+    fn test_diagnostic_fingerprint_ignores_action_wiring() {
+        let first = HealthDiagnostic::new("MISSING_MARKET_QUOTE", "No price", "Missing quote")
+            .domain(DiagnosticDomain::MarketData)
+            .entity(HealthEntityRef::new("asset", "asset-1"))
+            .fix(true, FixAction::sync_prices(vec!["asset-a".to_string()]));
+        let second = HealthDiagnostic::new("MISSING_MARKET_QUOTE", "No price", "Missing quote")
+            .domain(DiagnosticDomain::MarketData)
+            .entity(HealthEntityRef::new("asset", "asset-1"))
+            .fix(true, FixAction::sync_prices(vec!["asset-b".to_string()]));
+
+        assert_eq!(first.computed_fingerprint(), second.computed_fingerprint());
+    }
+
+    #[test]
+    fn test_issue_identity_uses_sorted_diagnostic_fingerprints() {
+        let first = HealthDiagnostic::new("MISSING_MARKET_QUOTE", "No price", "Missing quote")
+            .fingerprint("fingerprint-a");
+        let second = HealthDiagnostic::new("MISSING_FX_RATE", "No FX", "Missing rate")
+            .fingerprint("fingerprint-b");
+
+        let issue_a = HealthIssue::builder()
+            .id("incomplete_valuation_value:old-hash")
+            .severity(Severity::Warning)
+            .category(HealthCategory::DataConsistency)
+            .title("Valuation coverage is incomplete")
+            .message("msg")
+            .diagnostics(vec![first.clone(), second.clone()])
+            .data_hash("old-hash")
+            .build();
+        let issue_b = HealthIssue::builder()
+            .id("incomplete_valuation_value:different-old-hash")
+            .severity(Severity::Warning)
+            .category(HealthCategory::DataConsistency)
+            .title("Valuation coverage wording changed")
+            .message("copy changed")
+            .diagnostics(vec![second, first])
+            .data_hash("different-old-hash")
+            .build();
+
+        assert_eq!(issue_a.id, issue_b.id);
+        assert_eq!(issue_a.data_hash, issue_b.data_hash);
+        assert!(issue_a.id.starts_with("incomplete_valuation_value:"));
+    }
+
+    #[test]
+    fn test_fallback_diagnostics_preserve_source_data_hash_identity() {
+        let unchanged_copy = HealthIssue::builder()
+            .id("timezone_invalid:old-hash")
+            .severity(Severity::Warning)
+            .category(HealthCategory::SettingsConfiguration)
+            .title("Configured timezone is invalid")
+            .message("Original copy")
+            .data_hash("source-hash")
+            .build();
+        let reworded = HealthIssue::builder()
+            .id("timezone_invalid:different-old-hash")
+            .severity(Severity::Warning)
+            .category(HealthCategory::SettingsConfiguration)
+            .title("Timezone setting needs review")
+            .message("Reworded copy")
+            .data_hash("source-hash")
+            .build();
+        let changed_source = HealthIssue::builder()
+            .id("timezone_invalid:new-old-hash")
+            .severity(Severity::Warning)
+            .category(HealthCategory::SettingsConfiguration)
+            .title("Configured timezone is invalid")
+            .message("Original copy")
+            .data_hash("changed-source-hash")
+            .build();
+
+        assert_eq!(unchanged_copy.id, reworded.id);
+        assert_ne!(unchanged_copy.id, changed_source.id);
+    }
+
+    #[test]
+    fn test_issue_actions_prefer_primary_diagnostic_actions() {
+        let diagnostic = HealthDiagnostic::new(
+            "INCOMPLETE_BASIS_ACTIVITY",
+            "Missing purchase price",
+            "A transaction is missing cost basis.",
+        )
+        .navigate(true, NavigateAction::to_activity("activity-1"));
+
+        let issue = HealthIssue::builder()
+            .id("incomplete_valuation_basis:old-hash")
+            .severity(Severity::Warning)
+            .category(HealthCategory::DataConsistency)
+            .title("Valuation basis is incomplete")
+            .message("msg")
+            .navigate_action(NavigateAction::to_activities(None))
+            .diagnostics(vec![diagnostic])
+            .data_hash("old-hash")
+            .build();
+
+        let navigate = issue.navigate_action.expect("navigate action");
+        assert_eq!(navigate.route, "/activities");
+        assert_eq!(navigate.label, "Review Transaction");
+        assert_eq!(navigate.query.unwrap()["activity"], "activity-1");
+    }
+
+    #[test]
+    fn test_manual_quote_navigate_action() {
+        let nav = NavigateAction::to_asset_manual_quote("asset-1");
+        assert_eq!(nav.route, "/holdings/asset-1");
+        assert_eq!(nav.query.unwrap()["tab"], "quotes");
     }
 
     #[test]

--- a/crates/core/src/health/service.rs
+++ b/crates/core/src/health/service.rs
@@ -4,7 +4,7 @@
 //! and handles fix actions.
 
 use async_trait::async_trait;
-use chrono::{Datelike, Duration, NaiveDate, Utc, Weekday};
+use chrono::{Duration, NaiveDate, Utc};
 use log::{debug, info, warn};
 use rust_decimal::Decimal;
 use std::collections::{HashMap, HashSet};
@@ -1141,9 +1141,6 @@ async fn gather_quote_date_gap_issues(
 
     for snapshots in snapshots_by_account.values() {
         for snapshot in snapshots {
-            if !is_market_weekday(snapshot.snapshot_date) {
-                continue;
-            }
             min_date = Some(min_date.map_or(snapshot.snapshot_date, |date| {
                 date.min(snapshot.snapshot_date)
             }));
@@ -1248,10 +1245,6 @@ fn quote_date_gap_issues_from_data(
         snapshots.sort_by_key(|snapshot| snapshot.snapshot_date);
 
         for snapshot in snapshots {
-            if !is_market_weekday(snapshot.snapshot_date) {
-                continue;
-            }
-
             let mut positions: Vec<_> = snapshot.positions.iter().collect();
             positions.sort_by_key(|(asset_id, _)| (*asset_id).clone());
             for (asset_id, position) in positions {
@@ -1307,10 +1300,6 @@ fn quote_date_gap_issues_from_data(
     }
 
     issues
-}
-
-fn is_market_weekday(date: NaiveDate) -> bool {
-    !matches!(date.weekday(), Weekday::Sat | Weekday::Sun)
 }
 
 fn market_calendar_key(asset: &Asset) -> Option<String> {
@@ -1690,13 +1679,13 @@ struct BasisSourceIssue {
     asset_id: String,
     /// The acquiring activity to fix (transactions-tracked only).
     activity_id: Option<String>,
-    /// Date the incomplete basis is observed (latest snapshot date).
+    /// Date the incomplete basis is observed.
     observed_date: NaiveDate,
     reason: ValuationIssueReason,
 }
 
-/// Detects incomplete cost basis at its source, from the latest snapshot per
-/// account. On a HOLDINGS-tracked account the cost lives on the snapshot
+/// Detects incomplete cost basis at its source. On a HOLDINGS-tracked account
+/// the cost lives on each snapshot
 /// position; on a TRANSACTIONS-tracked account it comes from the acquiring
 /// activity that opened the lot, so each unpriced lot is reported against its
 /// `source_activity_id` for a precise deep-link.
@@ -1762,36 +1751,37 @@ fn basis_source_issues_from_snapshots(
         ) {
             continue;
         }
-        let Some(latest) = snapshots_by_account[account_id].last() else {
-            continue;
-        };
         let account_name = account_name_map
             .get(account_id)
             .cloned()
             .unwrap_or_else(|| account_id.clone());
+        let mut snapshots: Vec<_> = snapshots_by_account[account_id].iter().collect();
+        snapshots.sort_by_key(|snapshot| snapshot.snapshot_date);
 
-        let mut positions: Vec<&Position> = latest
-            .positions
-            .values()
-            .filter(|position| !position.is_alternative && !position.quantity.is_zero())
-            .filter(|position| {
-                matches!(
-                    position.basis_status(),
-                    BasisStatus::Unknown | BasisStatus::PartialUnknown
-                )
-            })
-            .collect();
-        positions.sort_by(|a, b| a.asset_id.cmp(&b.asset_id));
+        for snapshot in snapshots {
+            let mut positions: Vec<&Position> = snapshot
+                .positions
+                .values()
+                .filter(|position| !position.is_alternative && !position.quantity.is_zero())
+                .filter(|position| {
+                    matches!(
+                        position.basis_status(),
+                        BasisStatus::Unknown | BasisStatus::PartialUnknown
+                    )
+                })
+                .collect();
+            positions.sort_by(|a, b| a.asset_id.cmp(&b.asset_id));
 
-        for position in positions {
-            raws.push(BasisSourceIssue {
-                account_id: account_id.clone(),
-                account_name: account_name.clone(),
-                asset_id: position.asset_id.clone(),
-                activity_id: None,
-                observed_date: latest.snapshot_date,
-                reason: ValuationIssueReason::IncompleteBasisSnapshot,
-            });
+            for position in positions {
+                raws.push(BasisSourceIssue {
+                    account_id: account_id.clone(),
+                    account_name: account_name.clone(),
+                    asset_id: position.asset_id.clone(),
+                    activity_id: None,
+                    observed_date: snapshot.snapshot_date,
+                    reason: ValuationIssueReason::IncompleteBasisSnapshot,
+                });
+            }
         }
     }
 
@@ -2678,6 +2668,50 @@ mod tests {
     }
 
     #[test]
+    fn missing_weekend_quote_date_is_reported_for_crypto() {
+        let saturday = NaiveDate::from_ymd_opt(2026, 6, 6).unwrap();
+        let snapshots_by_account = HashMap::from([(
+            "acc_crypto".to_string(),
+            vec![snapshot_with_positions(
+                "acc_crypto",
+                saturday,
+                HashMap::from([(
+                    "asset_btc".to_string(),
+                    position_with_basis_status("acc_crypto", "asset_btc", true),
+                )]),
+            )],
+        )]);
+        let account_names = HashMap::from([("acc_crypto".to_string(), "Crypto".to_string())]);
+        let latest_quote_times = HashMap::from([(
+            "asset_btc".to_string(),
+            Utc.with_ymd_and_hms(2026, 6, 8, 12, 0, 0).unwrap(),
+        )]);
+        let mut crypto = health_asset("asset_btc");
+        crypto.instrument_type = Some(InstrumentType::Crypto);
+        crypto.display_code = Some("BTC-USD".to_string());
+        crypto.instrument_symbol = Some("BTC-USD".to_string());
+        crypto.instrument_exchange_mic = None;
+        let assets_by_id = HashMap::from([("asset_btc".to_string(), crypto)]);
+
+        let issues = quote_date_gap_issues_from_data(
+            &snapshots_by_account,
+            &account_names,
+            &latest_quote_times,
+            &HashSet::new(),
+            &HashSet::new(),
+            &assets_by_id,
+        );
+
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].asset_id.as_deref(), Some("asset_btc"));
+        assert_eq!(issues[0].activity_date, Some(saturday));
+        assert_eq!(
+            issues[0].reason,
+            Some(crate::health::checks::ValuationIssueReason::MissingMarketQuote)
+        );
+    }
+
+    #[test]
     fn incomplete_basis_buy_without_price_is_flagged_and_deep_links_to_activity() {
         // Transaction-tracked acquisitions with no unit price yield zero-cost lots.
         let accounts = vec![health_account(
@@ -2777,6 +2811,46 @@ mod tests {
             && matches!(&a.action, crate::health::model::ActionRef::Navigate { action }
                 if action.route == "/holdings/asset_xyz"
                     && action.query.as_ref().is_some_and(|q| q["tab"] == "snapshots"))));
+    }
+
+    #[test]
+    fn incomplete_basis_holdings_reports_historical_snapshot_gap() {
+        let first_date = NaiveDate::from_ymd_opt(2026, 6, 1).unwrap();
+        let second_date = NaiveDate::from_ymd_opt(2026, 6, 2).unwrap();
+        let snapshots_by_account = HashMap::from([(
+            "acc_hold".to_string(),
+            vec![
+                snapshot_with_positions(
+                    "acc_hold",
+                    first_date,
+                    HashMap::from([(
+                        "asset_xyz".to_string(),
+                        position_with_basis_status("acc_hold", "asset_xyz", false),
+                    )]),
+                ),
+                snapshot_with_positions(
+                    "acc_hold",
+                    second_date,
+                    HashMap::from([(
+                        "asset_xyz".to_string(),
+                        position_with_basis_status("acc_hold", "asset_xyz", true),
+                    )]),
+                ),
+            ],
+        )]);
+        let account_names = HashMap::from([("acc_hold".to_string(), "Manual".to_string())]);
+        let account_tracking = HashMap::from([("acc_hold".to_string(), TrackingMode::Holdings)]);
+
+        let raws = basis_source_issues_from_snapshots(
+            &snapshots_by_account,
+            &account_names,
+            &account_tracking,
+        );
+
+        assert_eq!(raws.len(), 1);
+        assert_eq!(raws[0].asset_id, "asset_xyz");
+        assert_eq!(raws[0].observed_date, first_date);
+        assert!(raws[0].activity_id.is_none());
     }
 
     #[test]

--- a/crates/core/src/health/service.rs
+++ b/crates/core/src/health/service.rs
@@ -4,7 +4,7 @@
 //! and handles fix actions.
 
 use async_trait::async_trait;
-use chrono::{Duration, NaiveDate, Utc};
+use chrono::{Datelike, Duration, NaiveDate, Utc, Weekday};
 use log::{debug, info, warn};
 use rust_decimal::Decimal;
 use std::collections::{HashMap, HashSet};
@@ -14,14 +14,17 @@ use tokio::sync::RwLock;
 use crate::accounts::{
     account_types, is_liability_account_type, Account, AccountServiceTrait, TrackingMode,
 };
-use crate::activities::{Activity, ActivityServiceTrait, TransferPairResolution};
-use crate::assets::{Asset, AssetKind, AssetServiceTrait};
+use crate::activities::{
+    Activity, ActivityServiceTrait, TransferPairResolution, ACTIVITY_TYPE_BUY,
+    ACTIVITY_TYPE_TRANSFER_IN,
+};
+use crate::assets::{Asset, AssetKind, AssetServiceTrait, InstrumentType, QuoteMode};
 use crate::errors::Result;
 use crate::lots::LotRepositoryTrait;
 use crate::portfolio::economic_events::BasisStatus;
 use crate::portfolio::holdings::{HoldingType, HoldingsServiceTrait};
 use crate::portfolio::performance::is_external_transfer;
-use crate::portfolio::snapshot::{AccountStateSnapshot, SnapshotServiceTrait};
+use crate::portfolio::snapshot::{AccountStateSnapshot, Position, SnapshotServiceTrait};
 use crate::portfolio::valuation::{
     DailyAccountValuation, ExternalFlowSource, ValuationServiceTrait, ValuationStatus,
 };
@@ -34,6 +37,7 @@ use super::checks::{
     DataConsistencyCheck, FxIntegrityCheck, FxPairInfo, InvalidTransferGroupInfo,
     LegacyMigrationInfo, PriceStalenessCheck, QuoteSyncCheck, QuoteSyncErrorInfo,
     TransferIntegrityCheck, TransferLegDetail, UnclassifiedAssetInfo, UnconfiguredAccountInfo,
+    ValuationIssueReason,
 };
 use super::errors::HealthError;
 use super::model::{FixAction, HealthConfig, HealthIssue, HealthStatus, IssueDismissal};
@@ -382,6 +386,30 @@ impl HealthService {
                         .map(|k| (k, a.id))
                 })
                 .collect();
+            let fx_pair_asset_ids: HashSet<String> = fx_pair_mv
+                .keys()
+                .filter_map(|(from_ccy, to_ccy)| {
+                    let key_direct = format!("FX:{}/{}", from_ccy, to_ccy);
+                    let key_inverse = format!("FX:{}/{}", to_ccy, from_ccy);
+                    fx_asset_map
+                        .get(&key_direct)
+                        .or_else(|| fx_asset_map.get(&key_inverse))
+                        .cloned()
+                })
+                .collect();
+            let fx_latest_quote_times: HashMap<String, chrono::DateTime<Utc>> = if fx_pair_asset_ids
+                .is_empty()
+            {
+                HashMap::new()
+            } else {
+                let fx_pair_asset_id_list: Vec<String> = fx_pair_asset_ids.into_iter().collect();
+                quote_service
+                    .get_latest_quotes(&fx_pair_asset_id_list)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|(asset_id, quote)| (asset_id, quote.timestamp))
+                    .collect()
+            };
 
             fx_pair_mv
                 .iter()
@@ -392,12 +420,7 @@ impl HealthService {
                     let latest_quote_time = fx_asset_map
                         .get(&key_direct)
                         .or_else(|| fx_asset_map.get(&key_inverse))
-                        .and_then(|asset_id| {
-                            quote_service
-                                .get_latest_quotes(std::slice::from_ref(asset_id))
-                                .ok()
-                                .and_then(|q| q.into_values().next().map(|quote| quote.timestamp))
-                        });
+                        .and_then(|asset_id| fx_latest_quote_times.get(asset_id).copied());
 
                     FxPairInfo {
                         pair_id: format!("{}:{}", from_ccy, to_ccy),
@@ -409,7 +432,11 @@ impl HealthService {
                 })
                 .collect()
         };
-        let unclassified_assets: Vec<UnclassifiedAssetInfo> = Vec::new();
+        let unclassified_assets = super::gather_unclassified_assets(
+            asset_service.as_ref(),
+            taxonomy_service.as_ref(),
+            &holding_mv_map,
+        );
 
         // Detect accounts with negative portfolio balance in their history.
         // Exclude cash and credit-card accounts; card debt is an expected liability.
@@ -424,6 +451,10 @@ impl HealthService {
         let account_name_map: std::collections::HashMap<String, String> = accounts
             .iter()
             .map(|a| (a.id.clone(), a.name.clone()))
+            .collect();
+        let account_tracking_map: std::collections::HashMap<String, TrackingMode> = accounts
+            .iter()
+            .map(|a| (a.id.clone(), a.tracking_mode))
             .collect();
         let negative_balance_accounts = valuation_service
             .get_accounts_with_negative_balance(&account_ids)
@@ -453,6 +484,8 @@ impl HealthService {
                     asset_name: None,
                     quantity: None,
                     proceeds: None,
+                    reason: None,
+                    activity_id: None,
                 }
             })
             .collect();
@@ -490,6 +523,8 @@ impl HealthService {
                     asset_name: None,
                     quantity: None,
                     proceeds: None,
+                    reason: None,
+                    activity_id: None,
                 });
             }
         }
@@ -507,8 +542,12 @@ impl HealthService {
         // Detect invalid, incomplete, or unreviewed transfer flows across all
         // activities so the Health Center can surface them.
         let effective_timezone = effective_timezone(configured_timezone, client_timezone);
-        let invalid_transfer_groups = gather_invalid_transfer_groups(
-            activity_service.as_ref(),
+        let health_activities = activity_service.get_activities().unwrap_or_else(|e| {
+            warn!("Failed to load activities for Health checks: {}", e);
+            Vec::new()
+        });
+        let invalid_transfer_groups = invalid_transfer_groups_from_activities(
+            &health_activities,
             &account_name_map,
             effective_timezone,
         );
@@ -516,20 +555,31 @@ impl HealthService {
             valuation_service.as_ref(),
             snapshot_service.as_ref(),
             asset_service.as_ref(),
+            quote_service.as_ref(),
             &all_account_ids,
             &account_name_map,
+            &account_tracking_map,
+            &latest_quote_times,
         )
         .await;
         consistency_issues.extend(valuation_quality_issues);
         let missing_lot_disposal_sells = gather_missing_lot_disposal_sells(
-            activity_service.as_ref(),
             lot_repository.as_ref(),
             asset_service.as_ref(),
             &accounts,
+            &health_activities,
             effective_timezone,
         )
         .await;
         consistency_issues.extend(missing_lot_disposal_sells);
+        let incomplete_basis_trades = gather_incomplete_basis_trade_activities(
+            asset_service.as_ref(),
+            &accounts,
+            &health_activities,
+            effective_timezone,
+        )
+        .await;
+        consistency_issues.extend(incomplete_basis_trades);
 
         // Run checks with gathered data
         self.run_checks_with_data(
@@ -592,25 +642,6 @@ fn effective_timezone<'a>(
 /// Loads all activities and resolves transfer groups, returning the ones that
 /// don't form a valid pair, plus posted ungrouped transfers that are not
 /// explicitly marked as external.
-fn gather_invalid_transfer_groups(
-    activity_service: &dyn ActivityServiceTrait,
-    account_names: &HashMap<String, String>,
-    timezone: Option<&str>,
-) -> Vec<InvalidTransferGroupInfo> {
-    let activities = match activity_service.get_activities() {
-        Ok(activities) => activities,
-        Err(e) => {
-            warn!(
-                "Failed to load activities for transfer integrity check: {}",
-                e
-            );
-            return Vec::new();
-        }
-    };
-
-    invalid_transfer_groups_from_activities(&activities, account_names, timezone)
-}
-
 fn invalid_transfer_groups_from_activities(
     activities: &[Activity],
     account_names: &HashMap<String, String>,
@@ -671,10 +702,10 @@ fn invalid_transfer_groups_from_activities(
 }
 
 async fn gather_missing_lot_disposal_sells(
-    activity_service: &dyn ActivityServiceTrait,
     lot_repository: &dyn LotRepositoryTrait,
     asset_service: &dyn AssetServiceTrait,
     accounts: &[Account],
+    activities: &[Activity],
     timezone: Option<&str>,
 ) -> Vec<ConsistencyIssueInfo> {
     let eligible_accounts: HashMap<String, &Account> = accounts
@@ -693,17 +724,6 @@ async fn gather_missing_lot_disposal_sells(
     if eligible_accounts.is_empty() {
         return Vec::new();
     }
-
-    let activities = match activity_service.get_activities() {
-        Ok(activities) => activities,
-        Err(e) => {
-            warn!(
-                "Failed to load activities for missing lot disposal health check: {}",
-                e
-            );
-            return Vec::new();
-        }
-    };
 
     let sell_activities: Vec<&Activity> = activities
         .iter()
@@ -750,6 +770,8 @@ async fn gather_missing_lot_disposal_sells(
     let asset_ids: Vec<String> = sell_activities
         .iter()
         .filter_map(|activity| activity.asset_id.clone())
+        .collect::<HashSet<_>>()
+        .into_iter()
         .collect();
     let assets_by_id: HashMap<String, crate::assets::Asset> = asset_service
         .get_assets_by_asset_ids(&asset_ids)
@@ -767,7 +789,7 @@ async fn gather_missing_lot_disposal_sells(
 
     missing_lot_disposal_sells_from_data(
         accounts,
-        &activities,
+        activities,
         &disposal_activity_ids_by_account,
         &assets_by_id,
         timezone,
@@ -838,17 +860,166 @@ fn missing_lot_disposal_sells_from_data(
                 asset_name,
                 quantity: activity.quantity.map(|q| q.abs()),
                 proceeds: Some(proceeds),
+                reason: None,
+                activity_id: None,
             })
         })
         .collect()
 }
 
+/// Detects incomplete cost basis at the source for TRANSACTIONS-tracked accounts:
+/// a lot-creating acquisition with a positive quantity but no price. `add_lot` derives
+/// `cost_basis = qty * unit_price + fees` (ignoring `amount`), so a null/zero
+/// `unit_price` produces a zero-cost lot and thus an incomplete basis. Reported
+/// against the exact activity for a precise deep-link.
+async fn gather_incomplete_basis_trade_activities(
+    asset_service: &dyn AssetServiceTrait,
+    accounts: &[Account],
+    activities: &[Activity],
+    timezone: Option<&str>,
+) -> Vec<ConsistencyIssueInfo> {
+    let eligible_account_ids: HashSet<&str> = accounts
+        .iter()
+        .filter(|account| {
+            account.is_active
+                && !account.is_archived
+                && account.tracking_mode == TrackingMode::Transactions
+                && matches!(
+                    account.account_type.as_str(),
+                    account_types::SECURITIES | account_types::CRYPTOCURRENCY
+                )
+        })
+        .map(|account| account.id.as_str())
+        .collect();
+    if eligible_account_ids.is_empty() {
+        return Vec::new();
+    }
+
+    let asset_ids: Vec<String> = activities
+        .iter()
+        .filter(|activity| {
+            activity.is_posted()
+                && activity.asset_id.is_some()
+                && eligible_account_ids.contains(activity.account_id.as_str())
+                && is_lot_creating_basis_source(activity)
+                && activity
+                    .quantity
+                    .is_some_and(|qty| qty.is_sign_positive() && !qty.is_zero())
+                && activity.unit_price.is_none_or(|price| price.is_zero())
+        })
+        .filter_map(|activity| activity.asset_id.clone())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    if asset_ids.is_empty() {
+        return Vec::new();
+    }
+    let assets_by_id: HashMap<String, Asset> = asset_service
+        .get_assets_by_asset_ids(&asset_ids)
+        .await
+        .unwrap_or_else(|e| {
+            warn!(
+                "Failed to load assets for incomplete cost-basis health check: {}",
+                e
+            );
+            Vec::new()
+        })
+        .into_iter()
+        .map(|asset| (asset.id.clone(), asset))
+        .collect();
+
+    incomplete_basis_trade_activities_from_data(accounts, activities, &assets_by_id, timezone)
+}
+
+fn incomplete_basis_trade_activities_from_data(
+    accounts: &[Account],
+    activities: &[Activity],
+    assets_by_id: &HashMap<String, Asset>,
+    timezone: Option<&str>,
+) -> Vec<ConsistencyIssueInfo> {
+    let eligible_accounts: HashMap<String, &Account> = accounts
+        .iter()
+        .filter(|account| {
+            account.is_active
+                && !account.is_archived
+                && account.tracking_mode == TrackingMode::Transactions
+                && matches!(
+                    account.account_type.as_str(),
+                    account_types::SECURITIES | account_types::CRYPTOCURRENCY
+                )
+        })
+        .map(|account| (account.id.clone(), account))
+        .collect();
+
+    let tz = parse_user_timezone_or_default(timezone.unwrap_or_default());
+    activities
+        .iter()
+        .filter(|activity| {
+            activity.is_posted()
+                && activity.asset_id.is_some()
+                && eligible_accounts.contains_key(&activity.account_id)
+                && is_lot_creating_basis_source(activity)
+                // A positive-quantity acquisition with no price yields a zero-cost lot.
+                && activity
+                    .quantity
+                    .is_some_and(|qty| qty.is_sign_positive() && !qty.is_zero())
+                && activity.unit_price.is_none_or(|price| price.is_zero())
+        })
+        .filter_map(|activity| {
+            let account = eligible_accounts.get(&activity.account_id)?;
+            let asset_id = activity.asset_id.as_ref()?;
+            let asset = assets_by_id.get(asset_id);
+            let asset_symbol = asset
+                .and_then(|a| {
+                    a.display_code
+                        .clone()
+                        .or_else(|| a.instrument_symbol.clone())
+                })
+                .or_else(|| Some(asset_id.clone()));
+            let asset_name = asset.and_then(|a| a.name.clone());
+
+            Some(ConsistencyIssueInfo {
+                issue_type: super::checks::ConsistencyIssueType::IncompleteValuationBasis,
+                record_id: activity.id.clone(),
+                description: account.name.clone(),
+                account_id: Some(activity.account_id.clone()),
+                asset_id: Some(asset_id.clone()),
+                first_negative_date: None,
+                cash_balance: None,
+                total_value_at_date: None,
+                account_currency: Some(activity.currency.clone()),
+                activity_date: Some(activity_date_in_tz(activity.activity_date, tz)),
+                asset_symbol,
+                asset_name,
+                quantity: activity.quantity.map(|qty| qty.abs()),
+                proceeds: None,
+                reason: Some(ValuationIssueReason::IncompleteBasisActivity),
+                activity_id: Some(activity.id.clone()),
+            })
+        })
+        .collect()
+}
+
+fn is_lot_creating_basis_source(activity: &Activity) -> bool {
+    let activity_type = activity.effective_type();
+    if activity_type.eq_ignore_ascii_case(ACTIVITY_TYPE_BUY) {
+        return true;
+    }
+
+    activity_type.eq_ignore_ascii_case(ACTIVITY_TYPE_TRANSFER_IN)
+        && (activity.source_group_id.is_none() || is_external_transfer(activity))
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn gather_valuation_quality_issues(
     valuation_service: &dyn ValuationServiceTrait,
     snapshot_service: &dyn SnapshotServiceTrait,
     asset_service: &dyn AssetServiceTrait,
+    quote_service: &dyn QuoteServiceTrait,
     account_ids: &[String],
     account_name_map: &HashMap<String, String>,
+    account_tracking: &HashMap<String, TrackingMode>,
+    latest_quote_times: &HashMap<String, chrono::DateTime<Utc>>,
 ) -> Vec<ConsistencyIssueInfo> {
     if account_ids.is_empty() {
         return Vec::new();
@@ -870,16 +1041,538 @@ async fn gather_valuation_quality_issues(
     );
 
     issues.extend(
-        valuation_basis_issues_from_snapshots(
+        valuation_value_issues_from_snapshots(
             &histories,
             &snapshots_by_account,
             account_name_map,
+            asset_service,
+            latest_quote_times,
+        )
+        .await,
+    );
+
+    let quote_date_gaps = gather_quote_date_gap_issues(
+        &snapshots_by_account,
+        account_name_map,
+        latest_quote_times,
+        quote_service,
+        asset_service,
+    )
+    .await;
+    suppress_generic_value_issues(&mut issues, &quote_date_gaps);
+    let existing_precise_keys: HashSet<_> = issues
+        .iter()
+        .filter(|issue| {
+            issue.issue_type == super::checks::ConsistencyIssueType::IncompleteValuationValue
+                && matches!(
+                    issue.reason,
+                    Some(ValuationIssueReason::MissingMarketQuote)
+                        | Some(ValuationIssueReason::MissingManualValuation)
+                )
+        })
+        .filter_map(value_issue_key)
+        .collect();
+    issues.extend(quote_date_gaps.into_iter().filter(|issue| {
+        value_issue_key(issue).is_none_or(|key| !existing_precise_keys.contains(&key))
+    }));
+
+    issues.extend(
+        valuation_basis_issues_from_snapshots(
+            &snapshots_by_account,
+            account_name_map,
+            account_tracking,
             asset_service,
         )
         .await,
     );
 
     issues
+}
+
+fn value_issue_key(issue: &ConsistencyIssueInfo) -> Option<(String, String, NaiveDate)> {
+    Some((
+        issue.account_id.clone()?,
+        issue.asset_id.clone()?,
+        issue.activity_date?,
+    ))
+}
+
+fn value_issue_account_date(issue: &ConsistencyIssueInfo) -> Option<(String, NaiveDate)> {
+    Some((issue.account_id.clone()?, issue.activity_date?))
+}
+
+fn suppress_generic_value_issues(
+    issues: &mut Vec<ConsistencyIssueInfo>,
+    precise_issues: &[ConsistencyIssueInfo],
+) {
+    let precise_scopes: HashSet<_> = precise_issues
+        .iter()
+        .filter_map(value_issue_account_date)
+        .collect();
+
+    if precise_scopes.is_empty() {
+        return;
+    }
+
+    issues.retain(|issue| {
+        if issue.issue_type != super::checks::ConsistencyIssueType::IncompleteValuationValue {
+            return true;
+        }
+        if !matches!(
+            issue.reason,
+            Some(ValuationIssueReason::Unavailable) | Some(ValuationIssueReason::Unknown)
+        ) {
+            return true;
+        }
+        value_issue_account_date(issue).is_none_or(|scope| !precise_scopes.contains(&scope))
+    });
+}
+
+async fn gather_quote_date_gap_issues(
+    snapshots_by_account: &HashMap<String, Vec<AccountStateSnapshot>>,
+    account_name_map: &HashMap<String, String>,
+    latest_quote_times: &HashMap<String, chrono::DateTime<Utc>>,
+    quote_service: &dyn QuoteServiceTrait,
+    asset_service: &dyn AssetServiceTrait,
+) -> Vec<ConsistencyIssueInfo> {
+    let mut candidate_asset_ids = HashSet::new();
+    let mut min_date: Option<NaiveDate> = None;
+    let mut max_date: Option<NaiveDate> = None;
+
+    for snapshots in snapshots_by_account.values() {
+        for snapshot in snapshots {
+            if !is_market_weekday(snapshot.snapshot_date) {
+                continue;
+            }
+            min_date = Some(min_date.map_or(snapshot.snapshot_date, |date| {
+                date.min(snapshot.snapshot_date)
+            }));
+            max_date = Some(max_date.map_or(snapshot.snapshot_date, |date| {
+                date.max(snapshot.snapshot_date)
+            }));
+            for (asset_id, position) in &snapshot.positions {
+                if position.is_alternative
+                    || position.quantity.is_zero()
+                    || !latest_quote_times.contains_key(asset_id)
+                {
+                    continue;
+                }
+                candidate_asset_ids.insert(asset_id.clone());
+            }
+        }
+    }
+
+    let (Some(start), Some(end)) = (min_date, max_date) else {
+        return Vec::new();
+    };
+    if candidate_asset_ids.is_empty() {
+        return Vec::new();
+    }
+
+    let candidate_asset_id_list: Vec<String> = candidate_asset_ids.iter().cloned().collect();
+    let assets_by_id: HashMap<String, Asset> = asset_service
+        .get_assets_by_asset_ids(&candidate_asset_id_list)
+        .await
+        .unwrap_or_else(|error| {
+            warn!(
+                "Failed to load held assets for quote gap health check: {}",
+                error
+            );
+            Vec::new()
+        })
+        .into_iter()
+        .map(|asset| (asset.id.clone(), asset))
+        .collect();
+
+    let quote_scope_asset_ids: HashSet<String> = assets_by_id
+        .values()
+        .filter(|asset| market_calendar_key(asset).is_some())
+        .map(|asset| asset.id.clone())
+        .collect();
+    if quote_scope_asset_ids.is_empty() {
+        return Vec::new();
+    }
+
+    let quote_dates: HashSet<(String, NaiveDate)> = quote_service
+        .get_quotes_in_range(&quote_scope_asset_ids, start, end)
+        .unwrap_or_else(|error| {
+            warn!(
+                "Failed to load raw quotes for quote gap health check: {}",
+                error
+            );
+            Vec::new()
+        })
+        .into_iter()
+        .map(|quote| (quote.asset_id, quote.timestamp.date_naive()))
+        .collect();
+
+    let market_open_dates: HashSet<(String, NaiveDate)> = quote_dates
+        .iter()
+        .filter_map(|(asset_id, date)| {
+            assets_by_id
+                .get(asset_id)
+                .and_then(market_calendar_key)
+                .map(|key| (key, *date))
+        })
+        .collect();
+
+    quote_date_gap_issues_from_data(
+        snapshots_by_account,
+        account_name_map,
+        latest_quote_times,
+        &quote_dates,
+        &market_open_dates,
+        &assets_by_id,
+    )
+}
+
+fn quote_date_gap_issues_from_data(
+    snapshots_by_account: &HashMap<String, Vec<AccountStateSnapshot>>,
+    account_name_map: &HashMap<String, String>,
+    latest_quote_times: &HashMap<String, chrono::DateTime<Utc>>,
+    quote_dates: &HashSet<(String, NaiveDate)>,
+    market_open_dates: &HashSet<(String, NaiveDate)>,
+    assets_by_id: &HashMap<String, Asset>,
+) -> Vec<ConsistencyIssueInfo> {
+    let mut issues = Vec::new();
+    let mut seen = HashSet::new();
+
+    let mut account_ids: Vec<_> = snapshots_by_account.keys().collect();
+    account_ids.sort();
+    for account_id in account_ids {
+        let account_name = account_name_map
+            .get(account_id)
+            .cloned()
+            .unwrap_or_else(|| account_id.clone());
+        let mut snapshots: Vec<_> = snapshots_by_account[account_id].iter().collect();
+        snapshots.sort_by_key(|snapshot| snapshot.snapshot_date);
+
+        for snapshot in snapshots {
+            if !is_market_weekday(snapshot.snapshot_date) {
+                continue;
+            }
+
+            let mut positions: Vec<_> = snapshot.positions.iter().collect();
+            positions.sort_by_key(|(asset_id, _)| (*asset_id).clone());
+            for (asset_id, position) in positions {
+                if position.is_alternative
+                    || position.quantity.is_zero()
+                    || !latest_quote_times.contains_key(asset_id)
+                    || quote_dates.contains(&(asset_id.clone(), snapshot.snapshot_date))
+                {
+                    continue;
+                }
+
+                let Some(asset) = assets_by_id.get(asset_id) else {
+                    continue;
+                };
+                if matches!(asset.kind, AssetKind::Fx)
+                    || asset_is_manual(asset)
+                    || !market_was_open(asset, snapshot.snapshot_date, market_open_dates)
+                {
+                    continue;
+                }
+                if !seen.insert((account_id.clone(), asset_id.clone(), snapshot.snapshot_date)) {
+                    continue;
+                }
+
+                let symbol = asset
+                    .display_code
+                    .clone()
+                    .or_else(|| asset.instrument_symbol.clone())
+                    .unwrap_or_else(|| asset_id.clone());
+                issues.push(ConsistencyIssueInfo {
+                    issue_type: super::checks::ConsistencyIssueType::IncompleteValuationValue,
+                    record_id: format!(
+                        "quote_gap:{}:{}:{}",
+                        account_id, asset_id, snapshot.snapshot_date
+                    ),
+                    description: format!("{} in {}", symbol, account_name),
+                    account_id: Some(account_id.clone()),
+                    asset_id: Some(asset_id.clone()),
+                    first_negative_date: None,
+                    cash_balance: None,
+                    total_value_at_date: None,
+                    account_currency: Some(snapshot.currency.clone()),
+                    activity_date: Some(snapshot.snapshot_date),
+                    asset_symbol: Some(symbol),
+                    asset_name: asset.name.clone(),
+                    quantity: Some(position.quantity),
+                    proceeds: None,
+                    reason: Some(ValuationIssueReason::MissingMarketQuote),
+                    activity_id: None,
+                });
+            }
+        }
+    }
+
+    issues
+}
+
+fn is_market_weekday(date: NaiveDate) -> bool {
+    !matches!(date.weekday(), Weekday::Sat | Weekday::Sun)
+}
+
+fn market_calendar_key(asset: &Asset) -> Option<String> {
+    if asset.quote_mode != QuoteMode::Market || matches!(asset.kind, AssetKind::Fx) {
+        return None;
+    }
+    if matches!(asset.instrument_type, Some(InstrumentType::Crypto)) {
+        return Some("continuous:crypto".to_string());
+    }
+    asset
+        .instrument_exchange_mic
+        .as_deref()
+        .map(str::trim)
+        .filter(|mic| !mic.is_empty())
+        .map(|mic| format!("mic:{}", mic.to_ascii_uppercase()))
+}
+
+fn market_was_open(
+    asset: &Asset,
+    date: NaiveDate,
+    market_open_dates: &HashSet<(String, NaiveDate)>,
+) -> bool {
+    if matches!(asset.instrument_type, Some(InstrumentType::Crypto)) {
+        return true;
+    }
+    market_calendar_key(asset).is_some_and(|key| market_open_dates.contains(&(key, date)))
+}
+
+/// A held asset that could not be priced across one or more valuation dates.
+#[derive(Debug)]
+struct ValueAssetIssue {
+    account_id: String,
+    account_name: String,
+    asset_id: String,
+    first_date: NaiveDate,
+    last_date: NaiveDate,
+    valuation_days: usize,
+    unavailable: bool,
+}
+
+/// Classifies incomplete-market-value rows down to the specific unpriced
+/// asset(s) and their root cause, using the daily snapshots (held positions)
+/// and per-asset quote presence.
+///
+/// A held quotable position is treated as the culprit when the asset has no
+/// market quotes at all (`latest_quote_times` miss). The reason is then refined
+/// to `MissingManualValuation` for manual/custom assets, or `MissingMarketQuote`
+/// otherwise. Dates whose culprit cannot be pinned to a specific asset fall back
+/// to an account-level issue (`Unavailable` when nothing is priced, else
+/// `Unknown`).
+async fn valuation_value_issues_from_snapshots(
+    histories: &HashMap<String, Vec<DailyAccountValuation>>,
+    snapshots_by_account: &HashMap<String, Vec<AccountStateSnapshot>>,
+    account_name_map: &HashMap<String, String>,
+    asset_service: &dyn AssetServiceTrait,
+    latest_quote_times: &HashMap<String, chrono::DateTime<Utc>>,
+) -> Vec<ConsistencyIssueInfo> {
+    let (per_asset, account_fallbacks) = value_asset_issues_from_snapshots(
+        histories,
+        snapshots_by_account,
+        account_name_map,
+        latest_quote_times,
+    );
+
+    let asset_ids: Vec<String> = per_asset
+        .iter()
+        .map(|issue| issue.asset_id.clone())
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect();
+    let assets_by_id: HashMap<String, Asset> = if asset_ids.is_empty() {
+        HashMap::new()
+    } else {
+        asset_service
+            .get_assets_by_asset_ids(&asset_ids)
+            .await
+            .unwrap_or_else(|error| {
+                warn!(
+                    "Failed to load assets for incomplete market-value health check: {}",
+                    error
+                );
+                Vec::new()
+            })
+            .into_iter()
+            .map(|asset| (asset.id.clone(), asset))
+            .collect()
+    };
+
+    let mut issues = account_fallbacks;
+    issues.extend(
+        per_asset
+            .into_iter()
+            .map(|issue| value_asset_consistency_issue(issue, &assets_by_id)),
+    );
+    issues
+}
+
+/// Derives the per-asset unpriced culprits and the account-level fallbacks from
+/// snapshots + quote presence. Pure/sync so it can be unit-tested without an
+/// asset service; asset display + manual classification are applied later in
+/// [`value_asset_consistency_issue`].
+fn value_asset_issues_from_snapshots(
+    histories: &HashMap<String, Vec<DailyAccountValuation>>,
+    snapshots_by_account: &HashMap<String, Vec<AccountStateSnapshot>>,
+    account_name_map: &HashMap<String, String>,
+    latest_quote_times: &HashMap<String, chrono::DateTime<Utc>>,
+) -> (Vec<ValueAssetIssue>, Vec<ConsistencyIssueInfo>) {
+    let mut per_asset: HashMap<(String, String), ValueAssetIssue> = HashMap::new();
+    let mut account_fallbacks: Vec<ConsistencyIssueInfo> = Vec::new();
+
+    let mut account_ids: Vec<&String> = histories.keys().collect();
+    account_ids.sort();
+
+    for account_id in account_ids {
+        let history = &histories[account_id];
+        let account_name = account_name_map
+            .get(account_id)
+            .cloned()
+            .unwrap_or_else(|| account_id.clone());
+        let snapshots = snapshots_by_account.get(account_id);
+
+        let mut rows: Vec<&DailyAccountValuation> = history
+            .iter()
+            .filter(|row| row.value_status != ValuationStatus::Complete)
+            .collect();
+        rows.sort_by_key(|row| row.valuation_date);
+
+        let mut snapshot_idx = 0usize;
+        for row in rows {
+            let unavailable = row.value_status == ValuationStatus::Unavailable;
+
+            // Held quotable positions whose asset has no market quotes at all.
+            let positions_culprits: Vec<String> = match snapshots {
+                Some(snapshots) if !snapshots.is_empty() => {
+                    while snapshot_idx + 1 < snapshots.len()
+                        && snapshots[snapshot_idx + 1].snapshot_date <= row.valuation_date
+                    {
+                        snapshot_idx += 1;
+                    }
+                    if snapshots[snapshot_idx].snapshot_date > row.valuation_date {
+                        Vec::new()
+                    } else {
+                        snapshots[snapshot_idx]
+                            .positions
+                            .values()
+                            .filter(|position| {
+                                !position.is_alternative && !position.quantity.is_zero()
+                            })
+                            .map(|position| position.asset_id.clone())
+                            .filter(|asset_id| !latest_quote_times.contains_key(asset_id))
+                            .collect()
+                    }
+                }
+                _ => Vec::new(),
+            };
+
+            if positions_culprits.is_empty() {
+                // Cause not attributable to a specific held asset (e.g. missing
+                // FX, or a per-date gap for an asset that has quotes elsewhere).
+                let reason = if unavailable {
+                    ValuationIssueReason::Unavailable
+                } else {
+                    ValuationIssueReason::Unknown
+                };
+                account_fallbacks.push(valuation_quality_issue(
+                    super::checks::ConsistencyIssueType::IncompleteValuationValue,
+                    row,
+                    &account_name,
+                    Some(reason),
+                ));
+                continue;
+            }
+
+            for asset_id in positions_culprits {
+                per_asset
+                    .entry((account_id.clone(), asset_id.clone()))
+                    .and_modify(|issue| {
+                        issue.first_date = issue.first_date.min(row.valuation_date);
+                        issue.last_date = issue.last_date.max(row.valuation_date);
+                        issue.valuation_days += 1;
+                        issue.unavailable = issue.unavailable || unavailable;
+                    })
+                    .or_insert_with(|| ValueAssetIssue {
+                        account_id: account_id.clone(),
+                        account_name: account_name.clone(),
+                        asset_id,
+                        first_date: row.valuation_date,
+                        last_date: row.valuation_date,
+                        valuation_days: 1,
+                        unavailable,
+                    });
+            }
+        }
+    }
+
+    let mut per_asset: Vec<ValueAssetIssue> = per_asset.into_values().collect();
+    per_asset.sort_by(|a, b| {
+        a.account_id
+            .cmp(&b.account_id)
+            .then_with(|| a.asset_id.cmp(&b.asset_id))
+    });
+    (per_asset, account_fallbacks)
+}
+
+/// Labels a derived value-coverage issue with asset display info and classifies
+/// it as a missing manual valuation vs a missing market quote.
+fn value_asset_consistency_issue(
+    issue: ValueAssetIssue,
+    assets_by_id: &HashMap<String, Asset>,
+) -> ConsistencyIssueInfo {
+    let asset = assets_by_id.get(&issue.asset_id);
+    let symbol = asset
+        .and_then(|asset| asset.display_code.clone())
+        .unwrap_or_else(|| issue.asset_id.clone());
+    let asset_name = asset.and_then(|asset| asset.name.clone());
+    let is_manual = asset.map(asset_is_manual).unwrap_or(false);
+    let reason = if is_manual {
+        ValuationIssueReason::MissingManualValuation
+    } else {
+        ValuationIssueReason::MissingMarketQuote
+    };
+    let coverage = if issue.unavailable {
+        "unavailable"
+    } else {
+        "degraded"
+    };
+    let description = format!(
+        "{} in {} - {} from {} to {} ({} day(s))",
+        symbol,
+        issue.account_name,
+        coverage,
+        issue.first_date,
+        issue.last_date,
+        issue.valuation_days
+    );
+
+    ConsistencyIssueInfo {
+        issue_type: super::checks::ConsistencyIssueType::IncompleteValuationValue,
+        record_id: format!(
+            "{}:{}:{}:{}",
+            issue.account_id, issue.asset_id, issue.first_date, issue.last_date
+        ),
+        description,
+        account_id: Some(issue.account_id),
+        asset_id: Some(issue.asset_id),
+        first_negative_date: None,
+        cash_balance: None,
+        total_value_at_date: None,
+        account_currency: None,
+        activity_date: Some(issue.first_date),
+        asset_symbol: Some(symbol),
+        asset_name,
+        quantity: None,
+        proceeds: None,
+        reason: Some(reason),
+        activity_id: None,
+    }
+}
+
+/// Returns true when an asset is priced manually (no automatic market feed).
+fn asset_is_manual(asset: &Asset) -> bool {
+    asset.quote_mode == QuoteMode::Manual
 }
 
 fn valuation_snapshots_by_account(
@@ -966,15 +1659,10 @@ fn valuation_quality_issues_from_histories(
             }
         }
 
+        // Incomplete market-value rows are classified per-asset (with root cause)
+        // in `valuation_value_issues_from_snapshots`, which has snapshot + quote
+        // context. Here we only surface the flow-source classification.
         for row in history {
-            if row.value_status != ValuationStatus::Complete {
-                issues.push(valuation_quality_issue(
-                    super::checks::ConsistencyIssueType::IncompleteValuationValue,
-                    row,
-                    &account_name,
-                ));
-            }
-
             if matches!(
                 row.external_flow_source,
                 ExternalFlowSource::Unknown | ExternalFlowSource::UnknownBoundaryTransfer
@@ -983,6 +1671,7 @@ fn valuation_quality_issues_from_histories(
                     super::checks::ConsistencyIssueType::UnknownPerformanceFlowSource,
                     row,
                     &account_name,
+                    None,
                 ));
             }
         }
@@ -991,246 +1680,160 @@ fn valuation_quality_issues_from_histories(
     issues
 }
 
+/// A source-precise incomplete-cost-basis issue: either a specific acquiring
+/// activity (transactions-tracked) or a holdings snapshot position
+/// (holdings-tracked) that carries no cost basis.
 #[derive(Debug)]
-struct BasisAssetIssue {
+struct BasisSourceIssue {
     account_id: String,
     account_name: String,
     asset_id: String,
-    first_date: NaiveDate,
-    last_date: NaiveDate,
-    valuation_days: usize,
-    basis_status: BasisStatus,
+    /// The acquiring activity to fix (transactions-tracked only).
+    activity_id: Option<String>,
+    /// Date the incomplete basis is observed (latest snapshot date).
+    observed_date: NaiveDate,
+    reason: ValuationIssueReason,
 }
 
+/// Detects incomplete cost basis at its source, from the latest snapshot per
+/// account. On a HOLDINGS-tracked account the cost lives on the snapshot
+/// position; on a TRANSACTIONS-tracked account it comes from the acquiring
+/// activity that opened the lot, so each unpriced lot is reported against its
+/// `source_activity_id` for a precise deep-link.
 async fn valuation_basis_issues_from_snapshots(
-    histories: &HashMap<String, Vec<DailyAccountValuation>>,
     snapshots_by_account: &HashMap<String, Vec<AccountStateSnapshot>>,
     account_name_map: &HashMap<String, String>,
+    account_tracking: &HashMap<String, TrackingMode>,
     asset_service: &dyn AssetServiceTrait,
 ) -> Vec<ConsistencyIssueInfo> {
-    let basis_issues =
-        basis_asset_issues_from_snapshots(histories, snapshots_by_account, account_name_map);
+    let raws = basis_source_issues_from_snapshots(
+        snapshots_by_account,
+        account_name_map,
+        account_tracking,
+    );
 
-    let asset_ids: Vec<String> = basis_issues
+    let asset_ids: Vec<String> = raws
         .iter()
-        .map(|issue| issue.asset_id.clone())
+        .map(|raw| raw.asset_id.clone())
         .collect::<HashSet<_>>()
         .into_iter()
         .collect();
-    let assets_by_id: HashMap<String, Asset> = asset_service
-        .get_assets_by_asset_ids(&asset_ids)
-        .await
-        .unwrap_or_else(|error| {
-            warn!(
-                "Failed to load assets for incomplete cost-basis health check: {}",
-                error
-            );
-            Vec::new()
-        })
-        .into_iter()
-        .map(|asset| (asset.id.clone(), asset))
-        .collect();
+    let assets_by_id: HashMap<String, Asset> = if asset_ids.is_empty() {
+        HashMap::new()
+    } else {
+        asset_service
+            .get_assets_by_asset_ids(&asset_ids)
+            .await
+            .unwrap_or_else(|error| {
+                warn!(
+                    "Failed to load assets for incomplete cost-basis health check: {}",
+                    error
+                );
+                Vec::new()
+            })
+            .into_iter()
+            .map(|asset| (asset.id.clone(), asset))
+            .collect()
+    };
 
-    let mut issues: Vec<_> = basis_issues
-        .into_iter()
-        .map(|issue| basis_asset_consistency_issue(issue, &assets_by_id))
-        .collect();
-    issues.extend(unmapped_incomplete_basis_row_fallbacks(
-        histories,
-        snapshots_by_account,
-        account_name_map,
-    ));
-    issues
+    raws.into_iter()
+        .map(|raw| basis_source_consistency_issue(raw, &assets_by_id))
+        .collect()
 }
 
-fn basis_asset_issues_from_snapshots(
-    histories: &HashMap<String, Vec<DailyAccountValuation>>,
+/// Pure detection (sync, testable) for HOLDINGS-tracked accounts: a snapshot
+/// position with no cost basis. Transaction-tracked accounts are handled at the
+/// source by [`gather_incomplete_basis_trade_activities`], which points at the
+/// exact acquiring activity that lacks a price.
+fn basis_source_issues_from_snapshots(
     snapshots_by_account: &HashMap<String, Vec<AccountStateSnapshot>>,
     account_name_map: &HashMap<String, String>,
-) -> Vec<BasisAssetIssue> {
-    let mut issues: HashMap<(String, String), BasisAssetIssue> = HashMap::new();
+    account_tracking: &HashMap<String, TrackingMode>,
+) -> Vec<BasisSourceIssue> {
+    let mut raws: Vec<BasisSourceIssue> = Vec::new();
+    let mut account_ids: Vec<&String> = snapshots_by_account.keys().collect();
+    account_ids.sort();
 
-    for (account_id, history) in histories {
-        let Some(snapshots) = snapshots_by_account.get(account_id) else {
-            continue;
-        };
-        if snapshots.is_empty() {
+    for account_id in account_ids {
+        // Only holdings-tracked accounts derive cost basis from the snapshot.
+        if !matches!(
+            account_tracking.get(account_id),
+            Some(TrackingMode::Holdings)
+        ) {
             continue;
         }
-
+        let Some(latest) = snapshots_by_account[account_id].last() else {
+            continue;
+        };
         let account_name = account_name_map
             .get(account_id)
             .cloned()
             .unwrap_or_else(|| account_id.clone());
-        let mut rows: Vec<&DailyAccountValuation> = history
-            .iter()
-            .filter(|row| {
+
+        let mut positions: Vec<&Position> = latest
+            .positions
+            .values()
+            .filter(|position| !position.is_alternative && !position.quantity.is_zero())
+            .filter(|position| {
                 matches!(
-                    row.basis_status,
-                    BasisStatus::PartialUnknown | BasisStatus::Unknown
+                    position.basis_status(),
+                    BasisStatus::Unknown | BasisStatus::PartialUnknown
                 )
             })
             .collect();
-        rows.sort_by_key(|row| row.valuation_date);
+        positions.sort_by(|a, b| a.asset_id.cmp(&b.asset_id));
 
-        let mut snapshot_idx = 0usize;
-        for row in rows {
-            while snapshot_idx + 1 < snapshots.len()
-                && snapshots[snapshot_idx + 1].snapshot_date <= row.valuation_date
-            {
-                snapshot_idx += 1;
-            }
-            if snapshots[snapshot_idx].snapshot_date > row.valuation_date {
-                continue;
-            }
-
-            for position in snapshots[snapshot_idx].positions.values() {
-                let position_status = position.basis_status();
-                if !matches!(
-                    position_status,
-                    BasisStatus::PartialUnknown | BasisStatus::Unknown
-                ) {
-                    continue;
-                }
-
-                let key = (account_id.clone(), position.asset_id.clone());
-                issues
-                    .entry(key)
-                    .and_modify(|issue| {
-                        issue.first_date = issue.first_date.min(row.valuation_date);
-                        issue.last_date = issue.last_date.max(row.valuation_date);
-                        issue.valuation_days += 1;
-                        issue.basis_status = issue.basis_status.combine(position_status);
-                    })
-                    .or_insert_with(|| BasisAssetIssue {
-                        account_id: account_id.clone(),
-                        account_name: account_name.clone(),
-                        asset_id: position.asset_id.clone(),
-                        first_date: row.valuation_date,
-                        last_date: row.valuation_date,
-                        valuation_days: 1,
-                        basis_status: position_status,
-                    });
-            }
+        for position in positions {
+            raws.push(BasisSourceIssue {
+                account_id: account_id.clone(),
+                account_name: account_name.clone(),
+                asset_id: position.asset_id.clone(),
+                activity_id: None,
+                observed_date: latest.snapshot_date,
+                reason: ValuationIssueReason::IncompleteBasisSnapshot,
+            });
         }
     }
 
-    let mut issues: Vec<_> = issues.into_values().collect();
-    issues.sort_by(|a, b| {
-        a.account_name
-            .cmp(&b.account_name)
-            .then_with(|| a.asset_id.cmp(&b.asset_id))
-    });
-    issues
+    raws
 }
 
-fn basis_asset_consistency_issue(
-    issue: BasisAssetIssue,
+fn basis_source_consistency_issue(
+    raw: BasisSourceIssue,
     assets_by_id: &HashMap<String, Asset>,
 ) -> ConsistencyIssueInfo {
-    let asset = assets_by_id.get(&issue.asset_id);
+    let asset = assets_by_id.get(&raw.asset_id);
     let symbol = asset
         .and_then(|asset| asset.display_code.clone())
-        .unwrap_or_else(|| issue.asset_id.clone());
+        .unwrap_or_else(|| raw.asset_id.clone());
     let asset_name = asset.and_then(|asset| asset.name.clone());
-    let status = basis_status_display(issue.basis_status);
+
+    let record_id = match &raw.activity_id {
+        Some(activity_id) => format!("basis:{}:{}", raw.account_id, activity_id),
+        None => format!(
+            "basis:{}:{}:{}",
+            raw.account_id, raw.asset_id, raw.observed_date
+        ),
+    };
+    let description = format!("{} in {} - missing cost basis", symbol, raw.account_name);
 
     ConsistencyIssueInfo {
         issue_type: super::checks::ConsistencyIssueType::IncompleteValuationBasis,
-        record_id: format!(
-            "{}:{}:{}:{}",
-            issue.account_id, issue.asset_id, issue.first_date, issue.last_date
-        ),
-        description: format!(
-            "{} in {} - {} cost basis from {} to {} ({} valuation days)",
-            symbol,
-            issue.account_name,
-            status,
-            issue.first_date,
-            issue.last_date,
-            issue.valuation_days
-        ),
-        account_id: Some(issue.account_id),
-        asset_id: Some(issue.asset_id),
+        record_id,
+        description,
+        account_id: Some(raw.account_id),
+        asset_id: Some(raw.asset_id),
         first_negative_date: None,
         cash_balance: None,
         total_value_at_date: None,
         account_currency: None,
-        activity_date: Some(issue.first_date),
+        activity_date: Some(raw.observed_date),
         asset_symbol: Some(symbol),
         asset_name,
         quantity: None,
         proceeds: None,
-    }
-}
-
-fn unmapped_incomplete_basis_row_fallbacks(
-    histories: &HashMap<String, Vec<DailyAccountValuation>>,
-    snapshots_by_account: &HashMap<String, Vec<AccountStateSnapshot>>,
-    account_name_map: &HashMap<String, String>,
-) -> Vec<ConsistencyIssueInfo> {
-    let mut issues = Vec::new();
-    let mut account_ids: Vec<_> = histories.keys().collect();
-    account_ids.sort();
-
-    for account_id in account_ids {
-        let account_name = account_name_map
-            .get(account_id)
-            .cloned()
-            .unwrap_or_else(|| account_id.clone());
-        for row in histories
-            .get(account_id)
-            .into_iter()
-            .flatten()
-            .filter(|row| {
-                matches!(
-                    row.basis_status,
-                    BasisStatus::PartialUnknown | BasisStatus::Unknown
-                )
-            })
-        {
-            let maps_to_position_issue = snapshots_by_account
-                .get(account_id)
-                .and_then(|snapshots| latest_snapshot_on_or_before(snapshots, row.valuation_date))
-                .is_some_and(|snapshot| {
-                    snapshot.positions.values().any(|position| {
-                        matches!(
-                            position.basis_status(),
-                            BasisStatus::PartialUnknown | BasisStatus::Unknown
-                        )
-                    })
-                });
-            if maps_to_position_issue {
-                continue;
-            }
-
-            issues.push(valuation_quality_issue(
-                super::checks::ConsistencyIssueType::IncompleteValuationBasis,
-                row,
-                &account_name,
-            ));
-        }
-    }
-
-    issues
-}
-
-fn latest_snapshot_on_or_before(
-    snapshots: &[AccountStateSnapshot],
-    date: NaiveDate,
-) -> Option<&AccountStateSnapshot> {
-    snapshots
-        .iter()
-        .take_while(|snapshot| snapshot.snapshot_date <= date)
-        .last()
-}
-
-fn basis_status_display(status: BasisStatus) -> &'static str {
-    match status {
-        BasisStatus::Complete => "complete",
-        BasisStatus::PartialUnknown => "partial",
-        BasisStatus::Unknown => "missing",
-        BasisStatus::NotApplicable => "not applicable",
+        reason: Some(raw.reason),
+        activity_id: raw.activity_id,
     }
 }
 
@@ -1254,6 +1857,8 @@ fn missing_valuation_issue(
         asset_name: None,
         quantity: None,
         proceeds: None,
+        reason: None,
+        activity_id: None,
     }
 }
 
@@ -1261,6 +1866,7 @@ fn valuation_quality_issue(
     issue_type: super::checks::ConsistencyIssueType,
     row: &DailyAccountValuation,
     account_name: &str,
+    reason: Option<ValuationIssueReason>,
 ) -> ConsistencyIssueInfo {
     ConsistencyIssueInfo {
         issue_type,
@@ -1277,6 +1883,8 @@ fn valuation_quality_issue(
         asset_name: None,
         quantity: None,
         proceeds: None,
+        reason,
+        activity_id: None,
     }
 }
 
@@ -1408,24 +2016,6 @@ impl HealthServiceTrait for HealthService {
                 // TODO: Call quote sync service to refresh prices
                 // This will be wired up when integrating with the service context
                 warn!("{} fix action not yet implemented", action.id);
-                Ok(())
-            }
-            "fetch_fx" => {
-                // Parse currency pairs from payload
-                let _pairs: Vec<String> = serde_json::from_value(action.payload.clone())
-                    .map_err(|e| HealthError::invalid_payload(&action.id, e.to_string()))?;
-
-                // TODO: Call FX service to refresh rates
-                warn!("fetch_fx fix action not yet implemented");
-                Ok(())
-            }
-            "migrate_classifications" => {
-                // Parse asset IDs from payload
-                let _asset_ids: Vec<String> = serde_json::from_value(action.payload.clone())
-                    .map_err(|e| HealthError::invalid_payload(&action.id, e.to_string()))?;
-
-                // TODO: Call taxonomy service to migrate legacy data
-                warn!("migrate_classifications fix action not yet implemented");
                 Ok(())
             }
             _ => Err(HealthError::UnknownFixAction(action.id.clone()).into()),
@@ -1664,6 +2254,45 @@ mod tests {
         }
     }
 
+    fn buy_activity(
+        id: &str,
+        account_id: &str,
+        asset_id: &str,
+        unit_price: Option<Decimal>,
+    ) -> Activity {
+        let now = Utc.with_ymd_and_hms(2026, 6, 1, 2, 30, 0).unwrap();
+        Activity {
+            id: id.to_string(),
+            account_id: account_id.to_string(),
+            asset_id: Some(asset_id.to_string()),
+            activity_type: "BUY".to_string(),
+            activity_type_override: None,
+            source_type: None,
+            subtype: None,
+            status: ActivityStatus::Posted,
+            activity_date: now,
+            settlement_date: None,
+            quantity: Some(dec!(2)),
+            unit_price,
+            amount: None,
+            fee: None,
+            tax: None,
+            currency: "USD".to_string(),
+            fx_rate: None,
+            notes: None,
+            metadata: None,
+            source_system: Some("CSV".to_string()),
+            source_record_id: None,
+            source_group_id: None,
+            idempotency_key: None,
+            import_run_id: None,
+            is_user_modified: false,
+            needs_review: false,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
     fn health_asset(id: &str) -> Asset {
         let now = Utc.with_ymd_and_hms(2026, 6, 8, 12, 0, 0).unwrap();
         Asset {
@@ -1800,12 +2429,8 @@ mod tests {
         let consistency_issues =
             valuation_quality_issues_from_histories(&histories, None, &account_names);
 
-        assert!(consistency_issues.iter().any(|issue| {
-            issue.issue_type
-                == crate::health::checks::ConsistencyIssueType::IncompleteValuationValue
-                && issue.account_id.as_deref() == Some("acc_tfsa")
-                && issue.activity_date == Some(chrono::NaiveDate::from_ymd_opt(2026, 6, 1).unwrap())
-        }));
+        // The histories path surfaces the flow-source classification; incomplete
+        // market value is now classified per-asset in the snapshot-aware path.
         assert!(consistency_issues.iter().any(|issue| {
             issue.issue_type
                 == crate::health::checks::ConsistencyIssueType::UnknownPerformanceFlowSource
@@ -1816,23 +2441,19 @@ mod tests {
         let health_issues = check.analyze(&consistency_issues, &ctx);
 
         assert!(health_issues.iter().any(|issue| {
-            issue.id.starts_with("incomplete_valuation_value:")
-                && issue.details.as_deref().is_some_and(|details| {
-                    details.contains("TFSA") && details.contains("2026-06-01")
-                })
-        }));
-        assert!(health_issues.iter().any(|issue| {
             issue.id.starts_with("unknown_performance_flow_source:")
                 && issue.severity == crate::health::Severity::Error
         }));
     }
 
     #[test]
-    fn incomplete_basis_rows_are_reported_as_actionable_positions() {
+    fn incomplete_value_rows_are_classified_per_asset_with_diagnostics() {
+        // acc_tfsa holds a priced asset (asset_aapl) and an unpriced one
+        // (asset_xyz, absent from latest_quote_times) across two degraded days.
         let mut row_1 = valuation_row_on("acc_tfsa", NaiveDate::from_ymd_opt(2026, 6, 1).unwrap());
-        row_1.basis_status = BasisStatus::PartialUnknown;
+        row_1.value_status = ValuationStatus::PartialUnpriced;
         let mut row_2 = valuation_row_on("acc_tfsa", NaiveDate::from_ymd_opt(2026, 6, 2).unwrap());
-        row_2.basis_status = BasisStatus::PartialUnknown;
+        row_2.value_status = ValuationStatus::PartialUnpriced;
         let histories = HashMap::from([("acc_tfsa".to_string(), vec![row_1, row_2])]);
         let snapshots_by_account = HashMap::from([(
             "acc_tfsa".to_string(),
@@ -1845,6 +2466,150 @@ mod tests {
                         position_with_basis_status("acc_tfsa", "asset_aapl", false),
                     ),
                     (
+                        "asset_xyz".to_string(),
+                        position_with_basis_status("acc_tfsa", "asset_xyz", false),
+                    ),
+                ]),
+            )],
+        )]);
+        let account_names = HashMap::from([("acc_tfsa".to_string(), "TFSA".to_string())]);
+        // asset_aapl has a quote; asset_xyz does not.
+        let latest_quote_times = HashMap::from([("asset_aapl".to_string(), chrono::Utc::now())]);
+
+        let (per_asset, fallbacks) = value_asset_issues_from_snapshots(
+            &histories,
+            &snapshots_by_account,
+            &account_names,
+            &latest_quote_times,
+        );
+
+        assert!(fallbacks.is_empty());
+        assert_eq!(per_asset.len(), 1);
+        assert_eq!(per_asset[0].asset_id, "asset_xyz");
+        assert_eq!(per_asset[0].valuation_days, 2);
+
+        // A market-priced asset (not manual) → MissingMarketQuote + sync action.
+        let assets_by_id = HashMap::from([("asset_xyz".to_string(), health_asset("asset_xyz"))]);
+        let consistency_issue =
+            value_asset_consistency_issue(per_asset.into_iter().next().unwrap(), &assets_by_id);
+        assert_eq!(consistency_issue.asset_id.as_deref(), Some("asset_xyz"));
+        assert_eq!(
+            consistency_issue.reason,
+            Some(crate::health::checks::ValuationIssueReason::MissingMarketQuote)
+        );
+
+        let check = DataConsistencyCheck::new();
+        let ctx = HealthContext::new(HealthConfig::default(), "USD", 100_000.0);
+        let health_issues = check.analyze(&[consistency_issue], &ctx);
+
+        let issue = health_issues
+            .iter()
+            .find(|i| i.id.starts_with("incomplete_valuation_value:"))
+            .expect("incomplete value issue");
+        let diagnostics = issue.diagnostics.as_ref().expect("diagnostics present");
+        assert_eq!(diagnostics[0].code, "MISSING_MARKET_QUOTE");
+        assert!(diagnostics[0].actions.iter().any(|a| a.primary));
+        assert!(issue
+            .affected_items
+            .as_ref()
+            .is_some_and(|items| items.iter().any(|i| i.id == "asset_xyz")));
+    }
+
+    #[test]
+    fn missing_weekday_quote_date_is_reported_even_when_latest_quote_exists() {
+        let monday = NaiveDate::from_ymd_opt(2026, 6, 1).unwrap();
+        let tuesday = NaiveDate::from_ymd_opt(2026, 6, 2).unwrap();
+        let snapshots_by_account = HashMap::from([(
+            "acc_tfsa".to_string(),
+            vec![
+                snapshot_with_positions(
+                    "acc_tfsa",
+                    monday,
+                    HashMap::from([(
+                        "asset_aapl".to_string(),
+                        position_with_basis_status("acc_tfsa", "asset_aapl", true),
+                    )]),
+                ),
+                snapshot_with_positions(
+                    "acc_tfsa",
+                    tuesday,
+                    HashMap::from([(
+                        "asset_aapl".to_string(),
+                        position_with_basis_status("acc_tfsa", "asset_aapl", true),
+                    )]),
+                ),
+            ],
+        )]);
+        let account_names = HashMap::from([("acc_tfsa".to_string(), "TFSA".to_string())]);
+        let latest_quote_times = HashMap::from([(
+            "asset_aapl".to_string(),
+            Utc.with_ymd_and_hms(2026, 6, 8, 12, 0, 0).unwrap(),
+        )]);
+        // Monday has a direct quote; Tuesday was deleted. Latest quote still
+        // exists, so the old latest-quote-only Health path would stay silent.
+        // A peer quote on the same exchange proves Tuesday was a market day.
+        let quote_dates = HashSet::from([
+            ("asset_aapl".to_string(), monday),
+            ("asset_msft".to_string(), tuesday),
+        ]);
+        let market_open_dates = HashSet::from([("mic:XNAS".to_string(), tuesday)]);
+        let assets_by_id = HashMap::from([
+            ("asset_aapl".to_string(), health_asset("asset_aapl")),
+            ("asset_msft".to_string(), health_asset("asset_msft")),
+        ]);
+
+        let issues = quote_date_gap_issues_from_data(
+            &snapshots_by_account,
+            &account_names,
+            &latest_quote_times,
+            &quote_dates,
+            &market_open_dates,
+            &assets_by_id,
+        );
+
+        assert_eq!(issues.len(), 1);
+        assert_eq!(issues[0].asset_id.as_deref(), Some("asset_aapl"));
+        assert_eq!(issues[0].activity_date, Some(tuesday));
+        assert_eq!(
+            issues[0].reason,
+            Some(crate::health::checks::ValuationIssueReason::MissingMarketQuote)
+        );
+
+        let check = DataConsistencyCheck::new();
+        let ctx = HealthContext::new(HealthConfig::default(), "USD", 100_000.0);
+        let health_issues = check.analyze(&issues, &ctx);
+        let issue = health_issues
+            .iter()
+            .find(|issue| issue.id.starts_with("incomplete_valuation_value:"))
+            .expect("missing quote health issue");
+        let diagnostics = issue.diagnostics.as_ref().expect("diagnostics");
+        assert_eq!(diagnostics[0].code, "MISSING_MARKET_QUOTE");
+        assert!(diagnostics[0]
+            .evidence
+            .iter()
+            .any(|evidence| evidence.value == "2026-06-02"));
+        assert!(diagnostics[0].evidence.iter().any(|evidence| evidence
+            .route
+            .as_deref()
+            .is_some_and(|route| route.contains("date=2026-06-02"))));
+    }
+
+    #[test]
+    fn weekday_without_market_open_evidence_is_not_reported() {
+        // 2025-01-01 is a Wednesday, but US/Canadian markets are closed. Without
+        // an exchange-specific quote from another asset, this must not be flagged.
+        let new_years_day = NaiveDate::from_ymd_opt(2025, 1, 1).unwrap();
+        let snapshots_by_account = HashMap::from([(
+            "acc_tfsa".to_string(),
+            vec![snapshot_with_positions(
+                "acc_tfsa",
+                new_years_day,
+                HashMap::from([
+                    (
+                        "asset_aapl".to_string(),
+                        position_with_basis_status("acc_tfsa", "asset_aapl", true),
+                    ),
+                    (
                         "asset_msft".to_string(),
                         position_with_basis_status("acc_tfsa", "asset_msft", true),
                     ),
@@ -1852,97 +2617,206 @@ mod tests {
             )],
         )]);
         let account_names = HashMap::from([("acc_tfsa".to_string(), "TFSA".to_string())]);
+        let latest_quote_times = HashMap::from([
+            (
+                "asset_aapl".to_string(),
+                Utc.with_ymd_and_hms(2025, 1, 2, 12, 0, 0).unwrap(),
+            ),
+            (
+                "asset_msft".to_string(),
+                Utc.with_ymd_and_hms(2025, 1, 2, 12, 0, 0).unwrap(),
+            ),
+        ]);
+        let assets_by_id = HashMap::from([
+            ("asset_aapl".to_string(), health_asset("asset_aapl")),
+            ("asset_msft".to_string(), health_asset("asset_msft")),
+        ]);
 
-        let basis_issues =
-            basis_asset_issues_from_snapshots(&histories, &snapshots_by_account, &account_names);
-
-        assert_eq!(basis_issues.len(), 1);
-        assert_eq!(basis_issues[0].asset_id, "asset_aapl");
-        assert_eq!(
-            basis_issues[0].first_date,
-            NaiveDate::from_ymd_opt(2026, 6, 1).unwrap()
+        let issues = quote_date_gap_issues_from_data(
+            &snapshots_by_account,
+            &account_names,
+            &latest_quote_times,
+            &HashSet::new(),
+            &HashSet::new(),
+            &assets_by_id,
         );
-        assert_eq!(
-            basis_issues[0].last_date,
-            NaiveDate::from_ymd_opt(2026, 6, 2).unwrap()
-        );
-        assert_eq!(basis_issues[0].valuation_days, 2);
 
-        let assets_by_id = HashMap::from([("asset_aapl".to_string(), health_asset("asset_aapl"))]);
-        let consistency_issue =
-            basis_asset_consistency_issue(basis_issues.into_iter().next().unwrap(), &assets_by_id);
-
-        assert_eq!(
-            consistency_issue.issue_type,
-            crate::health::checks::ConsistencyIssueType::IncompleteValuationBasis
-        );
-        assert_eq!(consistency_issue.asset_id.as_deref(), Some("asset_aapl"));
-        assert!(consistency_issue
-            .description
-            .contains("AAPL in TFSA - missing cost basis from 2026-06-01 to 2026-06-02"));
-
-        let check = DataConsistencyCheck::new();
-        let ctx = HealthContext::new(HealthConfig::default(), "USD", 100_000.0);
-        let health_issues = check.analyze(&[consistency_issue], &ctx);
-
-        assert_eq!(health_issues.len(), 1);
-        assert_eq!(health_issues[0].title, "Cost basis coverage is incomplete");
-        assert_eq!(health_issues[0].affected_count, 1);
-        assert!(health_issues[0]
-            .affected_items
-            .as_ref()
-            .is_some_and(|items| items[0].symbol.as_deref() == Some("AAPL")));
+        assert!(issues.is_empty());
     }
 
     #[test]
-    fn incomplete_basis_fallback_keeps_unmapped_rows_when_other_rows_map_to_positions() {
-        let mut mapped_row =
-            valuation_row_on("acc_tfsa", NaiveDate::from_ymd_opt(2026, 6, 1).unwrap());
-        mapped_row.basis_status = BasisStatus::PartialUnknown;
-        let mut unmapped_row =
-            valuation_row_on("acc_margin", NaiveDate::from_ymd_opt(2026, 6, 2).unwrap());
-        unmapped_row.basis_status = BasisStatus::Unknown;
-        let histories = HashMap::from([
-            ("acc_tfsa".to_string(), vec![mapped_row]),
-            ("acc_margin".to_string(), vec![unmapped_row]),
-        ]);
+    fn missing_weekend_quote_date_is_not_reported() {
+        let saturday = NaiveDate::from_ymd_opt(2026, 6, 6).unwrap();
         let snapshots_by_account = HashMap::from([(
             "acc_tfsa".to_string(),
             vec![snapshot_with_positions(
                 "acc_tfsa",
-                NaiveDate::from_ymd_opt(2026, 6, 1).unwrap(),
+                saturday,
                 HashMap::from([(
                     "asset_aapl".to_string(),
-                    position_with_basis_status("acc_tfsa", "asset_aapl", false),
+                    position_with_basis_status("acc_tfsa", "asset_aapl", true),
                 )]),
             )],
         )]);
-        let account_names = HashMap::from([
-            ("acc_tfsa".to_string(), "TFSA".to_string()),
-            ("acc_margin".to_string(), "Margin".to_string()),
-        ]);
+        let account_names = HashMap::from([("acc_tfsa".to_string(), "TFSA".to_string())]);
+        let latest_quote_times = HashMap::from([(
+            "asset_aapl".to_string(),
+            Utc.with_ymd_and_hms(2026, 6, 8, 12, 0, 0).unwrap(),
+        )]);
+        let assets_by_id = HashMap::from([("asset_aapl".to_string(), health_asset("asset_aapl"))]);
 
-        let asset_issues =
-            basis_asset_issues_from_snapshots(&histories, &snapshots_by_account, &account_names);
-        let fallback_issues = unmapped_incomplete_basis_row_fallbacks(
-            &histories,
+        let issues = quote_date_gap_issues_from_data(
             &snapshots_by_account,
             &account_names,
+            &latest_quote_times,
+            &HashSet::new(),
+            &HashSet::new(),
+            &assets_by_id,
         );
 
-        assert_eq!(asset_issues.len(), 1);
-        assert_eq!(asset_issues[0].account_id, "acc_tfsa");
-        assert_eq!(fallback_issues.len(), 1);
-        assert_eq!(
-            fallback_issues[0].issue_type,
-            crate::health::checks::ConsistencyIssueType::IncompleteValuationBasis
+        assert!(issues.is_empty());
+    }
+
+    #[test]
+    fn incomplete_basis_buy_without_price_is_flagged_and_deep_links_to_activity() {
+        // Transaction-tracked acquisitions with no unit price yield zero-cost lots.
+        let accounts = vec![health_account(
+            "acc_tfsa",
+            account_types::SECURITIES,
+            TrackingMode::Transactions,
+        )];
+        let mut transfer_in_noprice =
+            buy_activity("transfer-in-noprice", "acc_tfsa", "asset_aapl", None);
+        transfer_in_noprice.activity_type = ACTIVITY_TYPE_TRANSFER_IN.to_string();
+        let activities = vec![
+            buy_activity("buy-noprice", "acc_tfsa", "asset_aapl", None),
+            buy_activity("buy-zero", "acc_tfsa", "asset_aapl", Some(dec!(0))),
+            transfer_in_noprice,
+            // A priced buy must NOT be flagged.
+            buy_activity("buy-priced", "acc_tfsa", "asset_aapl", Some(dec!(100))),
+        ];
+        let assets_by_id = HashMap::from([("asset_aapl".to_string(), health_asset("asset_aapl"))]);
+
+        let issues = incomplete_basis_trade_activities_from_data(
+            &accounts,
+            &activities,
+            &assets_by_id,
+            None,
         );
-        assert_eq!(fallback_issues[0].account_id.as_deref(), Some("acc_margin"));
+
+        // The null-price buy, 0-price buy, and unpaired transfer-in are flagged;
+        // the priced buy is not.
+        assert_eq!(issues.len(), 3);
+        let ids: Vec<&str> = issues.iter().map(|i| i.record_id.as_str()).collect();
+        assert!(ids.contains(&"buy-noprice"));
+        assert!(ids.contains(&"buy-zero"));
+        assert!(ids.contains(&"transfer-in-noprice"));
+        assert!(!ids.contains(&"buy-priced"));
+
+        let issue = issues
+            .iter()
+            .find(|i| i.record_id == "buy-noprice")
+            .unwrap()
+            .clone();
+        assert_eq!(issue.activity_id.as_deref(), Some("buy-noprice"));
         assert_eq!(
-            fallback_issues[0].activity_date,
-            Some(NaiveDate::from_ymd_opt(2026, 6, 2).unwrap())
+            issue.reason,
+            Some(crate::health::checks::ValuationIssueReason::IncompleteBasisActivity)
         );
-        assert!(fallback_issues[0].asset_id.is_none());
+
+        let check = DataConsistencyCheck::new();
+        let ctx = HealthContext::new(HealthConfig::default(), "USD", 100_000.0);
+        let health_issues = check.analyze(&[issue], &ctx);
+        let diagnostics = health_issues[0].diagnostics.as_ref().expect("diagnostics");
+        assert_eq!(diagnostics[0].code, "INCOMPLETE_BASIS_ACTIVITY");
+        // Primary action deep-links to the exact offending activity.
+        assert!(diagnostics[0].actions.iter().any(|a| a.primary
+            && matches!(&a.action, crate::health::model::ActionRef::Navigate { action }
+                if action.route == "/activities"
+                    && action.query.as_ref().is_some_and(|q| q["activity"] == "buy-noprice"))));
+    }
+
+    #[test]
+    fn incomplete_basis_holdings_routes_to_snapshot_editor() {
+        // Holdings-tracked account: cost basis lives on the snapshot (no lots).
+        let snapshots_by_account = HashMap::from([(
+            "acc_hold".to_string(),
+            vec![snapshot_with_positions(
+                "acc_hold",
+                NaiveDate::from_ymd_opt(2026, 6, 1).unwrap(),
+                HashMap::from([(
+                    "asset_xyz".to_string(),
+                    position_with_basis_status("acc_hold", "asset_xyz", false),
+                )]),
+            )],
+        )]);
+        let account_names = HashMap::from([("acc_hold".to_string(), "Manual".to_string())]);
+        let account_tracking = HashMap::from([("acc_hold".to_string(), TrackingMode::Holdings)]);
+
+        let raws = basis_source_issues_from_snapshots(
+            &snapshots_by_account,
+            &account_names,
+            &account_tracking,
+        );
+        assert_eq!(raws.len(), 1);
+        assert!(raws[0].activity_id.is_none());
+
+        let assets_by_id = HashMap::from([("asset_xyz".to_string(), health_asset("asset_xyz"))]);
+        let issue = basis_source_consistency_issue(raws.into_iter().next().unwrap(), &assets_by_id);
+        assert_eq!(
+            issue.reason,
+            Some(crate::health::checks::ValuationIssueReason::IncompleteBasisSnapshot)
+        );
+
+        let check = DataConsistencyCheck::new();
+        let ctx = HealthContext::new(HealthConfig::default(), "USD", 100_000.0);
+        let health_issues = check.analyze(&[issue], &ctx);
+        let diagnostics = health_issues[0].diagnostics.as_ref().expect("diagnostics");
+        assert_eq!(diagnostics[0].code, "INCOMPLETE_BASIS_SNAPSHOT");
+        assert!(diagnostics[0].actions.iter().any(|a| a.primary
+            && matches!(&a.action, crate::health::model::ActionRef::Navigate { action }
+                if action.route == "/holdings/asset_xyz"
+                    && action.query.as_ref().is_some_and(|q| q["tab"] == "snapshots"))));
+    }
+
+    #[test]
+    fn incomplete_basis_trade_scan_ignores_non_eligible_activities() {
+        // Holdings-tracked accounts are covered by the snapshot check, not the
+        // trade scan; SELLs and non-security accounts are never trades-without-cost.
+        let accounts = vec![
+            health_account(
+                "acc_hold",
+                account_types::SECURITIES,
+                TrackingMode::Holdings,
+            ),
+            health_account(
+                "acc_txn",
+                account_types::SECURITIES,
+                TrackingMode::Transactions,
+            ),
+        ];
+        let activities = vec![
+            // Holdings-tracked buy without price: excluded (wrong tracking mode).
+            buy_activity("hold-buy", "acc_hold", "asset_aapl", None),
+            // A sell is not an acquiring trade.
+            sell_activity("txn-sell", "acc_txn", "asset_aapl"),
+            {
+                let mut transfer_in =
+                    buy_activity("paired-transfer-in", "acc_txn", "asset_aapl", None);
+                transfer_in.activity_type = ACTIVITY_TYPE_TRANSFER_IN.to_string();
+                transfer_in.source_group_id = Some("paired-group".to_string());
+                transfer_in
+            },
+        ];
+        let assets_by_id = HashMap::from([("asset_aapl".to_string(), health_asset("asset_aapl"))]);
+
+        let issues = incomplete_basis_trade_activities_from_data(
+            &accounts,
+            &activities,
+            &assets_by_id,
+            None,
+        );
+        assert!(issues.is_empty());
     }
 
     #[test]

--- a/crates/core/src/limits/limits_service.rs
+++ b/crates/core/src/limits/limits_service.rs
@@ -339,6 +339,7 @@ mod tests {
             _: Option<NaiveDate>,
             _: Option<NaiveDate>,
             _: Option<Vec<String>>,
+            _: Option<Vec<String>>,
         ) -> Result<ActivitySearchResponse> {
             unimplemented!()
         }

--- a/crates/core/src/portfolio/holdings/holdings_service.rs
+++ b/crates/core/src/portfolio/holdings/holdings_service.rs
@@ -2189,6 +2189,7 @@ mod tests {
             _date_from: Option<NaiveDate>,
             _date_to: Option<NaiveDate>,
             _instrument_type_filter: Option<Vec<String>>,
+            _activity_id_filter: Option<Vec<String>>,
         ) -> Result<crate::activities::ActivitySearchResponse> {
             unimplemented!("unused in holdings service tests")
         }

--- a/crates/core/src/portfolio/performance/performance_service.rs
+++ b/crates/core/src/portfolio/performance/performance_service.rs
@@ -5990,6 +5990,7 @@ mod tests {
             _date_from: Option<NaiveDate>,
             _date_to: Option<NaiveDate>,
             _instrument_type_filter: Option<Vec<String>>,
+            _activity_id_filter: Option<Vec<String>>,
         ) -> Result<crate::activities::ActivitySearchResponse> {
             Err(errors::Error::Unexpected(
                 "TestActivityRepository::search_activities should not be called".to_string(),

--- a/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
+++ b/crates/core/src/portfolio/snapshot/snapshot_service_tests.rs
@@ -413,6 +413,7 @@ mod tests {
             _date_from: Option<NaiveDate>,
             _date_to: Option<NaiveDate>,
             _instrument_type_filter: Option<Vec<String>>,
+            _activity_id_filter: Option<Vec<String>>,
         ) -> AppResult<ActivitySearchResponse> {
             unimplemented!()
         }
@@ -650,6 +651,7 @@ mod tests {
             _date_from: Option<NaiveDate>,
             _date_to: Option<NaiveDate>,
             _instrument_type_filter: Option<Vec<String>>,
+            _activity_id_filter: Option<Vec<String>>,
         ) -> AppResult<ActivitySearchResponse> {
             unimplemented!()
         }

--- a/crates/core/src/quotes/service.rs
+++ b/crates/core/src/quotes/service.rs
@@ -3222,6 +3222,7 @@ mod tests {
             _date_from: Option<NaiveDate>,
             _date_to: Option<NaiveDate>,
             _instrument_type_filter: Option<Vec<String>>,
+            _activity_id_filter: Option<Vec<String>>,
         ) -> Result<crate::activities::ActivitySearchResponse> {
             unimplemented!("unused in this test")
         }

--- a/crates/spending/src/cash_activities/service.rs
+++ b/crates/spending/src/cash_activities/service.rs
@@ -1196,6 +1196,7 @@ mod tests {
             _: Option<chrono::NaiveDate>,
             _: Option<chrono::NaiveDate>,
             _: Option<Vec<String>>,
+            _: Option<Vec<String>>,
         ) -> wealthfolio_core::Result<ActivitySearchResponse> {
             unimplemented!()
         }

--- a/crates/spending/src/categorization_rules/service.rs
+++ b/crates/spending/src/categorization_rules/service.rs
@@ -684,6 +684,7 @@ mod tests {
             _: Option<NaiveDate>,
             _: Option<NaiveDate>,
             _: Option<Vec<String>>,
+            _: Option<Vec<String>>,
         ) -> wealthfolio_core::Result<ActivitySearchResponse> {
             unimplemented!()
         }

--- a/crates/spending/src/events/service.rs
+++ b/crates/spending/src/events/service.rs
@@ -531,6 +531,7 @@ mod tests {
             _: Option<chrono::NaiveDate>,
             _: Option<chrono::NaiveDate>,
             _: Option<Vec<String>>,
+            _: Option<Vec<String>>,
         ) -> wealthfolio_core::Result<ActivitySearchResponse> {
             unimplemented!()
         }

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -415,6 +415,7 @@ impl ActivityRepository {
         date_from_utc: Option<DateTime<Utc>>,
         date_to_utc_exclusive: Option<DateTime<Utc>>,
         instrument_type_filter: Option<Vec<String>>,
+        activity_id_filter: Option<Vec<String>>,
     ) -> Result<ActivitySearchResponse> {
         let mut conn = get_connection(&self.pool)?;
 
@@ -427,6 +428,9 @@ impl ActivityRepository {
                 .filter(accounts::is_archived.eq(false))
                 .into_boxed();
 
+            if let Some(ref activity_ids) = activity_id_filter {
+                query = query.filter(activities::id.eq_any(activity_ids));
+            }
             if let Some(ref account_ids) = account_id_filter {
                 query = query.filter(activities::account_id.eq_any(account_ids));
             }
@@ -671,6 +675,7 @@ impl ActivityRepositoryTrait for ActivityRepository {
         date_from: Option<NaiveDate>,      // Optional start date filter (inclusive)
         date_to: Option<NaiveDate>,        // Optional end date filter (inclusive)
         instrument_type_filter: Option<Vec<String>>, // Optional instrument_type filter
+        activity_id_filter: Option<Vec<String>>, // Optional exact activity-id filter
     ) -> Result<ActivitySearchResponse> {
         let date_from_utc = date_from.map(Self::naive_date_start_utc);
         let date_to_utc_exclusive = date_to
@@ -688,6 +693,7 @@ impl ActivityRepositoryTrait for ActivityRepository {
             date_from_utc,
             date_to_utc_exclusive,
             instrument_type_filter,
+            activity_id_filter,
         )
     }
 
@@ -704,6 +710,7 @@ impl ActivityRepositoryTrait for ActivityRepository {
         date_from_utc: Option<DateTime<Utc>>,
         date_to_utc_exclusive: Option<DateTime<Utc>>,
         instrument_type_filter: Option<Vec<String>>,
+        activity_id_filter: Option<Vec<String>>,
     ) -> Result<ActivitySearchResponse> {
         self.search_activities_with_utc_bounds(
             page,
@@ -716,6 +723,7 @@ impl ActivityRepositoryTrait for ActivityRepository {
             date_from_utc,
             date_to_utc_exclusive,
             instrument_type_filter,
+            activity_id_filter,
         )
     }
 
@@ -3081,11 +3089,32 @@ mod tests {
                 None,
                 None,
                 None,
+                None,
             )
             .expect("search by effective type");
         assert_eq!(filtered.data.len(), 1);
         assert_eq!(filtered.data[0].id, "broker-buy-override");
         assert_eq!(filtered.data[0].activity_type, "SELL");
+
+        // Server-side filter by exact activity id returns just that activity,
+        // regardless of other rows or paging.
+        let by_id = repo
+            .search_activities(
+                0,
+                10,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                Some(vec!["broker-dividend".to_string()]),
+            )
+            .expect("search by activity id");
+        assert_eq!(by_id.data.len(), 1);
+        assert_eq!(by_id.data[0].id, "broker-dividend");
 
         let sorted = repo
             .search_activities(
@@ -3098,6 +3127,7 @@ mod tests {
                     id: "activityType".to_string(),
                     desc: false,
                 }),
+                None,
                 None,
                 None,
                 None,
@@ -3118,6 +3148,7 @@ mod tests {
                 None,
                 None,
                 Some("InternalSecurityTransfer".to_string()),
+                None,
                 None,
                 None,
                 None,
@@ -3180,6 +3211,7 @@ mod tests {
                 None,
                 Some(date_from_utc),
                 Some(date_to_utc_exclusive),
+                None,
                 None,
             )
             .expect("search by utc range");

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wealthfolio-app",
   "private": true,
-  "version": "3.5.4",
+  "version": "3.6.0",
   "packageManager": "pnpm@10.33.4",
   "type": "module",
   "workspaces": [
@@ -62,7 +62,11 @@
   "pnpm": {
     "overrides": {
       "ip-address": "10.1.1",
-      "qs@<=6.15.1": "6.15.2"
+      "qs@<=6.15.1": "6.15.2",
+      "undici@>=7.0.0 <7.28.0": "7.28.0",
+      "@babel/core@<=7.29.0": "^7.29.6",
+      "hono@<4.12.25": "^4.12.25",
+      "esbuild@>=0.27.3 <0.28.1": "^0.28.1"
     }
   }
 }

--- a/packages/addon-dev-tools/package.json
+++ b/packages/addon-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/addon-dev-tools",
-  "version": "3.5.4",
+  "version": "3.6.0",
   "description": "Development tools for Wealthfolio addons - hot reload server and CLI",
   "main": "index.js",
   "bin": {

--- a/packages/addon-sdk/package.json
+++ b/packages/addon-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/addon-sdk",
-  "version": "3.5.4",
+  "version": "3.6.0",
   "type": "module",
   "description": "TypeScript SDK for building Wealthfolio addons with enhanced functionality and type safety",
   "main": "dist/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/ui",
-  "version": "3.5.4",
+  "version": "3.6.0",
   "type": "module",
   "description": "Wealthfolio UI components based on shadcn/ui and Tailwind CSS",
   "main": "dist/index.js",
@@ -115,6 +115,6 @@
     "shadcn": "^3.8.4",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3",
-    "vite": "^7.3.2"
+    "vite": "^7.3.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 overrides:
   ip-address: 10.1.1
   qs@<=6.15.1: 6.15.2
+  undici@>=7.0.0 <7.28.0: 7.28.0
+  '@babel/core@<=7.29.0': ^7.29.6
+  hono@<4.12.25: ^4.12.25
+  esbuild@>=0.27.3 <0.28.1: ^0.28.1
 
 importers:
 
@@ -101,7 +105,7 @@ importers:
         version: 0.5.19(tailwindcss@4.2.1)
       '@tailwindcss/vite':
         specifier: ^4.1.18
-        version: 4.2.1(vite@7.3.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 4.2.1(vite@7.3.6(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1))
       '@tanstack/react-query':
         specifier: ^5.90.20
         version: 5.90.21(react@19.2.4)
@@ -231,7 +235,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^5.1.4
-        version: 5.1.4(vite@7.3.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 5.1.4(vite@7.3.6(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1))
       '@vitest/coverage-v8':
         specifier: ^4.1.0
         version: 4.1.8(vitest@4.1.8)
@@ -260,11 +264,11 @@ importers:
         specifier: ^1.4.0
         version: 1.4.0
       vite:
-        specifier: ^7.3.2
-        version: 7.3.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)
+        specifier: ^7.3.6
+        version: 7.3.6(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)
       vitest:
         specifier: ^4.1.0
-        version: 4.1.8(@types/node@24.11.0)(@vitest/coverage-v8@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1))
+        version: 4.1.8(@types/node@24.11.0)(@vitest/coverage-v8@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))(vite@7.3.6(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1))
 
   packages/addon-dev-tools:
     dependencies:
@@ -469,8 +473,8 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
       vite:
-        specifier: ^7.3.2
-        version: 7.3.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)
+        specifier: ^7.3.6
+        version: 7.3.6(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)
 
 packages:
 
@@ -536,34 +540,42 @@ packages:
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.29.0':
-    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.29.0':
-    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/generator@7.29.1':
     resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-annotate-as-pure@7.27.3':
     resolution: {integrity: sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-compilation-targets@7.28.6':
-    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-create-class-features-plugin@7.28.6':
     resolution: {integrity: sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.29.6
 
   '@babel/helper-globals@7.28.0':
     resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-member-expression-to-functions@7.28.5':
@@ -574,11 +586,21 @@ packages:
     resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-module-transforms@7.28.6':
     resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.29.6
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.29.6
 
   '@babel/helper-optimise-call-expression@7.27.1':
     resolution: {integrity: sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==}
@@ -592,7 +614,7 @@ packages:
     resolution: {integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0
+      '@babel/core': ^7.29.6
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     resolution: {integrity: sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==}
@@ -618,8 +640,12 @@ packages:
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.28.6':
-    resolution: {integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==}
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.29.0':
@@ -636,43 +662,43 @@ packages:
     resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.29.6
 
   '@babel/plugin-syntax-typescript@7.28.6':
     resolution: {integrity: sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.29.6
 
   '@babel/plugin-transform-modules-commonjs@7.28.6':
     resolution: {integrity: sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.29.6
 
   '@babel/plugin-transform-react-jsx-self@7.27.1':
     resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.29.6
 
   '@babel/plugin-transform-react-jsx-source@7.27.1':
     resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.29.6
 
   '@babel/plugin-transform-typescript@7.28.6':
     resolution: {integrity: sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.29.6
 
   '@babel/preset-typescript@7.28.5':
     resolution: {integrity: sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': ^7.29.6
 
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
@@ -686,8 +712,16 @@ packages:
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/traverse@7.29.0':
     resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
@@ -753,158 +787,158 @@ packages:
   '@epic-web/invariant@1.0.0':
     resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
-  '@esbuild/aix-ppc64@0.27.7':
-    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.27.7':
-    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.27.7':
-    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.27.7':
-    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.27.7':
-    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.7':
-    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.27.7':
-    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.7':
-    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.27.7':
-    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.7':
-    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.7':
-    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.7':
-    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.7':
-    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.7':
-    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.7':
-    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.7':
-    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.7':
-    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.7':
-    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.27.7':
-    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.7':
-    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.27.7':
-    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.27.7':
-    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.27.7':
-    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.7':
-    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.7':
-    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1011,7 +1045,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: ^4.12.25
 
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
@@ -3231,7 +3265,7 @@ packages:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
-      esbuild: '>=0.18'
+      esbuild: ^0.28.1
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -3696,8 +3730,8 @@ packages:
   es-toolkit@1.44.0:
     resolution: {integrity: sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==}
 
-  esbuild@0.27.7:
-    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4091,8 +4125,8 @@ packages:
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
-  hono@4.12.23:
-    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
@@ -5877,8 +5911,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.3.0:
@@ -5999,8 +6033,8 @@ packages:
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
-  vite@7.3.2:
-    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -6318,19 +6352,19 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/compat-data@7.29.0': {}
+  '@babel/compat-data@7.29.7': {}
 
-  '@babel/core@7.29.0':
+  '@babel/core@7.29.7':
     dependencies:
-      '@babel/code-frame': 7.29.0
-      '@babel/generator': 7.29.1
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
-      '@babel/helpers': 7.28.6
-      '@babel/parser': 7.29.0
-      '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
@@ -6348,25 +6382,33 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
   '@babel/helper-annotate-as-pure@7.27.3':
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/helper-compilation-targets@7.28.6':
+  '@babel/helper-compilation-targets@7.29.7':
     dependencies:
-      '@babel/compat-data': 7.29.0
-      '@babel/helper-validator-option': 7.27.1
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
       browserslist: 4.28.1
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-create-class-features-plugin@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
       '@babel/traverse': 7.29.0
       semver: 6.3.1
@@ -6374,6 +6416,8 @@ snapshots:
       - supports-color
 
   '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-globals@7.29.7': {}
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
@@ -6389,12 +6433,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
       '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -6404,9 +6464,9 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
-  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/traverse': 7.29.0
@@ -6430,10 +6490,12 @@ snapshots:
 
   '@babel/helper-validator-option@7.27.1': {}
 
-  '@babel/helpers@7.28.6':
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
     dependencies:
-      '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.0':
     dependencies:
@@ -6443,53 +6505,53 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-typescript@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.7)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-typescript@7.28.5(@babel/core@7.29.0)':
+  '@babel/preset-typescript@7.28.5(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.7)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -6503,6 +6565,12 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
 
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
   '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -6511,6 +6579,18 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -6573,82 +6653,82 @@ snapshots:
 
   '@epic-web/invariant@1.0.0': {}
 
-  '@esbuild/aix-ppc64@0.27.7':
+  '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm64@0.27.7':
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
-  '@esbuild/android-arm@0.27.7':
+  '@esbuild/android-arm@0.28.1':
     optional: true
 
-  '@esbuild/android-x64@0.27.7':
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.7':
+  '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.7':
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.7':
+  '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.7':
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.7':
+  '@esbuild/linux-arm64@0.28.1':
     optional: true
 
-  '@esbuild/linux-arm@0.27.7':
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.7':
+  '@esbuild/linux-ia32@0.28.1':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.7':
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.7':
+  '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.7':
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.7':
+  '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.7':
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
-  '@esbuild/linux-x64@0.27.7':
+  '@esbuild/linux-x64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.7':
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.7':
+  '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.7':
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.7':
+  '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.7':
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.7':
+  '@esbuild/sunos-x64@0.28.1':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.7':
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.7':
+  '@esbuild/win32-ia32@0.28.1':
     optional: true
 
-  '@esbuild/win32-x64@0.27.7':
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.3(jiti@2.6.1))':
@@ -6758,9 +6838,9 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@hono/node-server@1.19.14(hono@4.12.23)':
+  '@hono/node-server@1.19.14(hono@4.12.27)':
     dependencies:
-      hono: 4.12.23
+      hono: 4.12.27
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.71.2(react@19.2.4))':
     dependencies:
@@ -6844,7 +6924,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.23)
+      '@hono/node-server': 1.19.14(hono@4.12.27)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -6854,7 +6934,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.5.0(express@5.2.1)
-      hono: 4.12.23
+      hono: 4.12.27
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -8780,12 +8860,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.1
 
-  '@tailwindcss/vite@4.2.1(vite@7.3.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1))':
+  '@tailwindcss/vite@4.2.1(vite@7.3.6(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1))':
     dependencies:
       '@tailwindcss/node': 4.2.1
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
-      vite: 7.3.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 7.3.6(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)
 
   '@tanstack/eslint-plugin-query@5.91.4(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -9192,15 +9272,15 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@5.1.4(vite@7.3.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1))':
+  '@vitejs/plugin-react@5.1.4(vite@7.3.6(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.7)
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 7.3.6(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9216,7 +9296,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@24.11.0)(@vitest/coverage-v8@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1))
+      vitest: 4.1.8(@types/node@24.11.0)(@vitest/coverage-v8@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))(vite@7.3.6(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -9227,14 +9307,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1))':
+  '@vitest/mocker@4.1.8(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))(vite@7.3.6(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.10(@types/node@24.11.0)(typescript@5.9.3)
-      vite: 7.3.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 7.3.6(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -9500,9 +9580,9 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
-  bundle-require@5.1.0(esbuild@0.27.7):
+  bundle-require@5.1.0(esbuild@0.28.1):
     dependencies:
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       load-tsconfig: 0.2.5
 
   bytes@3.1.2: {}
@@ -9965,34 +10045,34 @@ snapshots:
 
   es-toolkit@1.44.0: {}
 
-  esbuild@0.27.7:
+  esbuild@0.28.1:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.7
-      '@esbuild/android-arm': 0.27.7
-      '@esbuild/android-arm64': 0.27.7
-      '@esbuild/android-x64': 0.27.7
-      '@esbuild/darwin-arm64': 0.27.7
-      '@esbuild/darwin-x64': 0.27.7
-      '@esbuild/freebsd-arm64': 0.27.7
-      '@esbuild/freebsd-x64': 0.27.7
-      '@esbuild/linux-arm': 0.27.7
-      '@esbuild/linux-arm64': 0.27.7
-      '@esbuild/linux-ia32': 0.27.7
-      '@esbuild/linux-loong64': 0.27.7
-      '@esbuild/linux-mips64el': 0.27.7
-      '@esbuild/linux-ppc64': 0.27.7
-      '@esbuild/linux-riscv64': 0.27.7
-      '@esbuild/linux-s390x': 0.27.7
-      '@esbuild/linux-x64': 0.27.7
-      '@esbuild/netbsd-arm64': 0.27.7
-      '@esbuild/netbsd-x64': 0.27.7
-      '@esbuild/openbsd-arm64': 0.27.7
-      '@esbuild/openbsd-x64': 0.27.7
-      '@esbuild/openharmony-arm64': 0.27.7
-      '@esbuild/sunos-x64': 0.27.7
-      '@esbuild/win32-arm64': 0.27.7
-      '@esbuild/win32-ia32': 0.27.7
-      '@esbuild/win32-x64': 0.27.7
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -10485,7 +10565,7 @@ snapshots:
 
   headers-polyfill@4.0.3: {}
 
-  hono@4.12.23: {}
+  hono@4.12.27: {}
 
   html-encoding-sniffer@6.0.0(@noble/hashes@1.8.0):
     dependencies:
@@ -10794,7 +10874,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.0
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -12214,10 +12294,10 @@ snapshots:
   shadcn@3.8.5(@types/node@24.11.0)(typescript@5.9.3):
     dependencies:
       '@antfu/ni': 25.0.0
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.7
       '@babel/parser': 7.29.0
-      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.7)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.29.7)
       '@dotenvx/dotenvx': 1.52.0
       '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.76)
       '@types/validate-npm-package-name': 4.0.2
@@ -12524,12 +12604,12 @@ snapshots:
 
   tsup@8.5.1(jiti@2.6.1)(postcss@8.5.14)(typescript@5.9.3):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.7)
+      bundle-require: 5.1.0(esbuild@0.28.1)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
@@ -12628,7 +12708,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unicorn-magic@0.3.0: {}
 
@@ -12754,9 +12834,9 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite@7.3.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1):
+  vite@7.3.6(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1):
     dependencies:
-      esbuild: 0.27.7
+      esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.14
@@ -12768,10 +12848,10 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.31.1
 
-  vitest@4.1.8(@types/node@24.11.0)(@vitest/coverage-v8@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)):
+  vitest@4.1.8(@types/node@24.11.0)(@vitest/coverage-v8@4.1.8)(jsdom@28.1.0(@noble/hashes@1.8.0))(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))(vite@7.3.6(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))(vite@7.3.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1))
+      '@vitest/mocker': 4.1.8(msw@2.12.10(@types/node@24.11.0)(typescript@5.9.3))(vite@7.3.6(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -12788,7 +12868,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)
+      vite: 7.3.6(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.11.0


### PR DESCRIPTION
## Summary

Refactors Health Center around the simpler diagnostic model:

- `HealthDiagnostic` is the root-cause unit with stable fingerprints, domain/level/severity, optional impact/entities/date metadata, evidence, and ordered actions.
- `HealthIssue` remains the grouped API/UI row projection, with issue identity derived from sorted diagnostic fingerprints.
- `DiagnosticAction` keeps serialized `navigate` and `fix` action kinds while treating `fix` as a real job action only.

This PR also includes the existing branch dependency/security version bump commit to `3.6.0`.

## What changed

### Backend and diagnostics

- Converted price, quote sync, FX, classification, transfer, account setup, valuation quality, and data consistency checks to emit structured diagnostics.
- Added stable issue dismissal identity based on root-cause fields instead of wording, evidence labels, UI routes, or action wiring.
- Added precise diagnostics for missing quote dates, missing manual valuations, missing cost basis, transfer review dates, generated valuation gaps, quote sync failures, and classification/account setup issues.
- Added conservative quote-date gap detection that avoids holiday false positives by requiring same-market quote evidence before flagging missing market prices.
- Batched some Health data gathering paths to reduce repeated activity/FX lookups.
- Kept rebuild-history as a real async recalculation path and delayed Health cache clearing until recalculation completion.

### Navigation and contracts

- Added exact activity ID filtering through frontend URL parsing, command adapters, Tauri/web APIs, core service traits, and SQLite.
- Added Health deep-link context banners for activities, holdings, market data, taxonomies, and asset pages.
- Added asset quote deep-links with missing-date context where available.

### UX and copy

- Reworked the issue sheet to render each diagnostic's own title/explanation instead of reusing the first diagnostic for mixed causes.
- Grouped price-date diagnostics by investment, with missing-date summaries per asset.
- Improved retail-investor copy for missing prices, manual values, transfer review, purchase price/cost basis, and carried-forward price behavior.
- Added a warning-style asset price banner with `Refetch Prices` for provider-priced assets and manual-price guidance for manual assets.
- Removed the row-level quick fix when diagnostic-level actions exist so grouped issues do not accidentally run only the first diagnostic's fix.

## Why

The previous Health Center output mixed symptoms, grouped rows, and remediation actions too tightly. That made copy ambiguous, dismissal brittle, and navigation less useful. The new shape keeps a stable root-cause diagnostic underneath each grouped issue, so the UI can explain what happened, show the exact evidence, and either navigate to the right place or run a real job.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -q -p wealthfolio-core health::model`
- `cargo test -q -p wealthfolio-core health::service`
- `cargo test -q -p wealthfolio-spending`
- `cargo test -q -p wealthfolio-ai`
- `pnpm --filter frontend lint` (passes with existing warnings)
- `pnpm --filter frontend type-check`
- `pnpm --filter frontend test -- health-page issue-detail-sheet` (passes; existing jsdom `requestSubmit()` warning)
- `pnpm test` via CI subagent: 111 files / 990 tests passed
- `git diff --check`

## Notes for reviewers

- Quote-date gap detection intentionally prefers fewer false positives over catching every possible deleted quote. Sparse or one-asset portfolios may not flag every real missing trading-day price unless another held asset proves that market was open.
- This PR is draft by default so the full branch diff can be reviewed before marking ready.
