### PR TITLE
addons: refine sandbox navigation and loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,26 @@ packages/addon-sdk/package-lock.json
 
 # Tauri generated
 apps/tauri/gen/schemas/
+apps/tauri/gen/android/.gradle/
+apps/tauri/gen/android/build/
+apps/tauri/gen/android/buildSrc/.gradle/
+apps/tauri/gen/android/buildSrc/.kotlin/
+apps/tauri/gen/android/buildSrc/build/
+apps/tauri/gen/android/app/build/
+apps/tauri/gen/android/tauri.settings.gradle
+apps/tauri/gen/android/app/tauri.build.gradle.kts
+apps/tauri/gen/android/app/tauri.properties
+apps/tauri/gen/android/app/proguard-tauri.pro
+apps/tauri/gen/android/app/src/main/assets/tauri.conf.json
+apps/tauri/gen/android/app/src/main/**/generated/
+apps/tauri/gen/android/app/src/main/jniLibs/**/*.so
+apps/tauri/gen/android/local.properties
+apps/tauri/gen/android/key.properties
+apps/tauri/gen/android/keystore.properties
+apps/tauri/gen/android/.tauri/
+apps/tauri/gen/android/.cxx/
+apps/tauri/gen/android/.externalNativeBuild/
+apps/tauri/gen/android/captures/
 
 # OS generated files
 .DS_Store

--- a/apps/frontend/addon-sandbox.html
+++ b/apps/frontend/addon-sandbox.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'none'; script-src 'self' 'unsafe-inline' blob: http://localhost:* http://127.0.0.1:* http://tauri.localhost https://tauri.localhost tauri: asset:; style-src 'self' 'unsafe-inline' http://localhost:* http://127.0.0.1:* http://tauri.localhost https://tauri.localhost tauri: asset:; img-src data: blob:; font-src 'self' data: blob: http://localhost:* http://127.0.0.1:* http://tauri.localhost https://tauri.localhost tauri: asset:; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'"
+    />
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+          sans-serif;
+      }
+
+      html,
+      body,
+      #addon-root {
+        min-height: 100%;
+        margin: 0;
+      }
+
+      body {
+        background: transparent;
+        color: inherit;
+      }
+
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="addon-root"></div>
+    <script type="module" src="/src/addons/iframe/addon-sandbox-entry.tsx"></script>
+  </body>
+</html>

--- a/apps/frontend/addon-sandbox.html
+++ b/apps/frontend/addon-sandbox.html
@@ -6,6 +6,30 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'none'; script-src 'self' 'unsafe-inline' blob: http://localhost:* http://127.0.0.1:* http://tauri.localhost https://tauri.localhost tauri: asset:; style-src 'self' 'unsafe-inline' http://localhost:* http://127.0.0.1:* http://tauri.localhost https://tauri.localhost tauri: asset:; img-src data: blob:; font-src 'self' data: blob: http://localhost:* http://127.0.0.1:* http://tauri.localhost https://tauri.localhost tauri: asset:; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'"
     />
+    <script>
+      (function () {
+        try {
+          var params = new URLSearchParams(window.location.hash.slice(1));
+          var themeClass = params.get("themeClass") === "dark" ? "dark" : "light";
+          var backgroundColor = params.get("backgroundColor");
+          var foregroundColor = params.get("foregroundColor");
+          document.documentElement.classList.add(themeClass);
+          document.documentElement.style.colorScheme = params.get("colorScheme") || themeClass;
+          if (backgroundColor) {
+            document.documentElement.style.setProperty(
+              "--addon-initial-background",
+              backgroundColor,
+            );
+          }
+          if (foregroundColor) {
+            document.documentElement.style.setProperty(
+              "--addon-initial-foreground",
+              foregroundColor,
+            );
+          }
+        } catch (e) {}
+      })();
+    </script>
     <style>
       :root {
         color-scheme: light dark;
@@ -26,8 +50,17 @@
         margin: 0;
       }
 
+      html {
+        background: var(--addon-initial-background, transparent);
+      }
+
       body {
-        background: transparent;
+        background: var(--addon-initial-background, transparent);
+        color: var(--addon-initial-foreground, inherit);
+      }
+
+      #addon-root {
+        background: inherit;
         color: inherit;
       }
 
@@ -39,6 +72,16 @@
     </style>
   </head>
   <body>
+    <script>
+      (function () {
+        try {
+          var fontClass = new URLSearchParams(window.location.hash.slice(1)).get("fontClass");
+          if (/^font-(mono|sans|serif)$/.test(fontClass)) {
+            document.body.classList.add(fontClass);
+          }
+        } catch (e) {}
+      })();
+    </script>
     <div id="addon-root"></div>
     <script type="module" src="/src/addons/iframe/addon-sandbox-entry.tsx"></script>
   </body>

--- a/apps/frontend/addon-sandbox.html
+++ b/apps/frontend/addon-sandbox.html
@@ -10,7 +10,12 @@
       :root {
         color-scheme: light dark;
         font-family:
-          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+          Inter,
+          ui-sans-serif,
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          "Segoe UI",
           sans-serif;
       }
 

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import { isWeb } from "@/adapters";
+import { setAddonQueryClient } from "@/addons/addons-runtime-context";
 import { AuthGate, AuthProvider } from "@/context/auth-context";
 import { EventDialogProvider } from "@/features/spending/components/event-dialog-provider";
 import { WealthfolioConnectProvider } from "@/features/wealthfolio-connect";
@@ -26,8 +27,7 @@ function App() {
 
   const isWebEnv = isWeb;
 
-  // Make QueryClient available globally for addons
-  window.__wealthfolio_query_client__ = queryClient;
+  setAddonQueryClient(queryClient as unknown as Parameters<typeof setAddonQueryClient>[0]);
 
   const routedContent = isWebEnv ? (
     <AuthGate fallback={<LoginPage />}>

--- a/apps/frontend/src/adapters/shared/addon-network.ts
+++ b/apps/frontend/src/adapters/shared/addon-network.ts
@@ -1,0 +1,12 @@
+import type { AddonNetworkRequest, AddonNetworkResponse } from "../types";
+import { invoke } from "./platform";
+
+export const addonNetworkRequest = async (
+  addonId: string,
+  request: AddonNetworkRequest,
+): Promise<AddonNetworkResponse> => {
+  return invoke<AddonNetworkResponse>("addon_network_request", {
+    addonId,
+    request,
+  });
+};

--- a/apps/frontend/src/adapters/shared/secrets.ts
+++ b/apps/frontend/src/adapters/shared/secrets.ts
@@ -12,3 +12,19 @@ export const getSecret = async (secretKey: string): Promise<string | null> => {
 export const deleteSecret = async (secretKey: string): Promise<void> => {
   return invoke<void>("delete_secret", { secretKey });
 };
+
+export const setAddonSecret = async (
+  addonId: string,
+  key: string,
+  secret: string,
+): Promise<void> => {
+  return invoke<void>("set_addon_secret", { addonId, key, secret });
+};
+
+export const getAddonSecret = async (addonId: string, key: string): Promise<string | null> => {
+  return invoke<string | null>("get_addon_secret", { addonId, key });
+};
+
+export const deleteAddonSecret = async (addonId: string, key: string): Promise<void> => {
+  return invoke<void>("delete_addon_secret", { addonId, key });
+};

--- a/apps/frontend/src/adapters/tauri/addons.ts
+++ b/apps/frontend/src/adapters/tauri/addons.ts
@@ -12,10 +12,12 @@ export const extractAddonZip = async (zipData: Uint8Array): Promise<ExtractedAdd
 export const installAddonZip = async (
   zipData: Uint8Array,
   enableAfterInstall?: boolean,
+  approvedNetworkHosts?: string[],
 ): Promise<AddonManifest> => {
   return await tauriInvoke<AddonManifest>("install_addon_zip", {
     zipData: Array.from(zipData),
     enableAfterInstall,
+    approvedNetworkHosts,
   });
 };
 
@@ -67,8 +69,9 @@ export const extractAddon = async (zipData: Uint8Array): Promise<ExtractedAddon>
 export const installAddon = async (
   zipData: Uint8Array,
   enableAfterInstall?: boolean,
+  approvedNetworkHosts?: string[],
 ): Promise<AddonManifest> => {
-  return installAddonZip(zipData, enableAfterInstall);
+  return installAddonZip(zipData, enableAfterInstall, approvedNetworkHosts);
 };
 
 export const getEnabledAddons = async (): Promise<ExtractedAddon[]> => {
@@ -95,10 +98,12 @@ export const downloadAddonForReview = async (addonId: string): Promise<Extracted
 export const installFromStaging = async (
   addonId: string,
   enableAfterInstall?: boolean,
+  approvedNetworkHosts?: string[],
 ): Promise<AddonManifest> => {
   return tauriInvoke<AddonManifest>("install_addon_from_staging", {
     addonId,
     enableAfterInstall,
+    approvedNetworkHosts,
   });
 };
 

--- a/apps/frontend/src/adapters/tauri/index.ts
+++ b/apps/frontend/src/adapters/tauri/index.ts
@@ -19,6 +19,8 @@ export type {
   AddonFile,
   AddonInstallResult,
   AddonManifest,
+  AddonNetworkRequest,
+  AddonNetworkResponse,
   AddonUpdateCheckResult,
   AddonUpdateInfo,
   AddonValidationResult,
@@ -116,6 +118,9 @@ export * from "../shared/exchange-rates";
 
 // Secrets Commands
 export * from "../shared/secrets";
+
+// Addon Network Commands
+export * from "../shared/addon-network";
 
 // Connect Commands (Broker + Device Sync + Auth)
 export * from "../shared/connect";

--- a/apps/frontend/src/adapters/types.ts
+++ b/apps/frontend/src/adapters/types.ts
@@ -101,6 +101,25 @@ export interface InstalledAddon {
   isZipAddon: boolean;
 }
 
+export interface AddonNetworkRequest {
+  url: string;
+  method?: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD";
+  headers?: Record<string, string>;
+  body?: string;
+  auth?: AddonNetworkAuth;
+}
+
+export interface AddonNetworkResponse {
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+export interface AddonNetworkAuth {
+  type: "bearer";
+  secretKey: string;
+}
+
 // Provider capabilities from backend
 export interface ProviderCapabilities {
   instruments: string;

--- a/apps/frontend/src/adapters/web/addons.ts
+++ b/apps/frontend/src/adapters/web/addons.ts
@@ -16,10 +16,12 @@ export const extractAddonZip = async (zipData: Uint8Array): Promise<ExtractedAdd
 export const installAddonZip = async (
   zipData: Uint8Array,
   enableAfterInstall?: boolean,
+  approvedNetworkHosts?: string[],
 ): Promise<AddonManifest> => {
   return await invoke<AddonManifest>("install_addon_zip", {
     zipData: Array.from(zipData),
     enableAfterInstall,
+    approvedNetworkHosts,
   });
 };
 
@@ -75,8 +77,9 @@ export const extractAddon = async (zipData: Uint8Array): Promise<ExtractedAddon>
 export const installAddon = async (
   zipData: Uint8Array,
   enableAfterInstall?: boolean,
+  approvedNetworkHosts?: string[],
 ): Promise<AddonManifest> => {
-  return installAddonZip(zipData, enableAfterInstall);
+  return installAddonZip(zipData, enableAfterInstall, approvedNetworkHosts);
 };
 
 export const getEnabledAddons = async (): Promise<ExtractedAddon[]> => {
@@ -106,10 +109,12 @@ export const downloadAddonForReview = async (addonId: string): Promise<Extracted
 export const installFromStaging = async (
   addonId: string,
   enableAfterInstall?: boolean,
+  approvedNetworkHosts?: string[],
 ): Promise<AddonManifest> => {
   return invoke<AddonManifest>("install_addon_from_staging", {
     addonId,
     enableAfterInstall,
+    approvedNetworkHosts,
   });
 };
 

--- a/apps/frontend/src/adapters/web/core.ts
+++ b/apps/frontend/src/adapters/web/core.ts
@@ -164,6 +164,10 @@ export const COMMANDS: CommandMap = {
   set_secret: { method: "POST", path: "/secrets" },
   get_secret: { method: "GET", path: "/secrets" },
   delete_secret: { method: "DELETE", path: "/secrets" },
+  set_addon_secret: { method: "POST", path: "/addons" },
+  get_addon_secret: { method: "GET", path: "/addons" },
+  delete_addon_secret: { method: "DELETE", path: "/addons" },
+  addon_network_request: { method: "POST", path: "/addons" },
   // Taxonomies
   get_taxonomies: { method: "GET", path: "/taxonomies" },
   get_taxonomy: { method: "GET", path: "/taxonomies" },
@@ -1104,6 +1108,33 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
       url += `?${params.toString()}`;
       break;
     }
+    case "set_addon_secret": {
+      const { addonId, key, secret } = payload as {
+        addonId: string;
+        key: string;
+        secret: string;
+      };
+      url += `/${encodeURIComponent(addonId)}/secrets`;
+      body = JSON.stringify({ key, secret });
+      break;
+    }
+    case "get_addon_secret":
+    case "delete_addon_secret": {
+      const { addonId, key } = payload as { addonId: string; key: string };
+      const params = new URLSearchParams();
+      params.set("key", key);
+      url += `/${encodeURIComponent(addonId)}/secrets?${params.toString()}`;
+      break;
+    }
+    case "addon_network_request": {
+      const { addonId, request } = payload as {
+        addonId: string;
+        request: unknown;
+      };
+      url += `/${encodeURIComponent(addonId)}/network/request`;
+      body = JSON.stringify({ request });
+      break;
+    }
     // Taxonomy commands
     case "get_taxonomies":
       break;
@@ -1496,13 +1527,14 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
     }
     // Addons
     case "install_addon_zip": {
-      const { zipData, enableAfterInstall } = payload as {
+      const { zipData, enableAfterInstall, approvedNetworkHosts } = payload as {
         zipData: Uint8Array | number[];
         enableAfterInstall?: boolean;
+        approvedNetworkHosts?: string[];
       };
       // Send compact base64 payload to avoid gigantic JSON arrays of numbers
       const zipDataB64 = toBase64(zipData);
-      body = JSON.stringify({ zipDataB64, enableAfterInstall });
+      body = JSON.stringify({ zipDataB64, enableAfterInstall, approvedNetworkHosts });
       break;
     }
     case "toggle_addon": {
@@ -1540,11 +1572,12 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
       break;
     }
     case "install_addon_from_staging": {
-      const { addonId, enableAfterInstall } = payload as {
+      const { addonId, enableAfterInstall, approvedNetworkHosts } = payload as {
         addonId: string;
         enableAfterInstall?: boolean;
+        approvedNetworkHosts?: string[];
       };
-      body = JSON.stringify({ addonId, enableAfterInstall });
+      body = JSON.stringify({ addonId, enableAfterInstall, approvedNetworkHosts });
       break;
     }
     case "clear_addon_staging": {

--- a/apps/frontend/src/adapters/web/index.ts
+++ b/apps/frontend/src/adapters/web/index.ts
@@ -13,6 +13,8 @@ export type {
   AddonFile,
   AddonInstallResult,
   AddonManifest,
+  AddonNetworkRequest,
+  AddonNetworkResponse,
   AddonUpdateCheckResult,
   AddonUpdateInfo,
   AddonValidationResult,
@@ -138,7 +140,17 @@ export {
 } from "../shared/goals";
 
 // Secrets Commands
-export { deleteSecret, getSecret, setSecret } from "../shared/secrets";
+export {
+  deleteAddonSecret,
+  deleteSecret,
+  getAddonSecret,
+  getSecret,
+  setAddonSecret,
+  setSecret,
+} from "../shared/secrets";
+
+// Addon Network Commands
+export { addonNetworkRequest } from "../shared/addon-network";
 
 // Taxonomy Commands
 export {

--- a/apps/frontend/src/addons/addons-core.ts
+++ b/apps/frontend/src/addons/addons-core.ts
@@ -1,12 +1,8 @@
 import { logger, getInstalledAddons, loadAddon as loadAddonRuntime } from "@/adapters";
-import {
-  createAddonContext,
-  getDynamicNavItems,
-  getDynamicRoutes,
-  triggerAllDisableCallbacks,
-} from "@/addons/addons-runtime-context";
-import type { AddonContext, AddonManifest } from "@wealthfolio/addon-sdk";
-import { ReactVersion, SDK_VERSION } from "@wealthfolio/addon-sdk";
+import { getDynamicNavItems, getDynamicRoutes } from "@/addons/addons-runtime-context";
+import { addonIframeManager, type AddonRuntimeHandle } from "@/addons/iframe/addon-iframe-manager";
+import type { AddonManifest } from "@wealthfolio/addon-sdk";
+import { SDK_VERSION } from "@wealthfolio/addon-sdk";
 
 interface AddonFile {
   path: string;
@@ -15,7 +11,7 @@ interface AddonFile {
 }
 
 // Store loaded addons for cleanup
-const loadedAddons = new Map<string, { disable?: () => void }>();
+const loadedAddons = new Map<string, AddonRuntimeHandle>();
 const loadedAddonIds = new Set<string>(); // Prevent re-loading already processed addons
 
 /**
@@ -60,8 +56,7 @@ function validateAddonCompatibility(manifest: AddonManifest): boolean {
 /**
  * Loads a single addon using Tauri commands
  */
-async function loadAddon(addonFile: AddonFile, _context: AddonContext): Promise<boolean> {
-  let blobUrl: string | null = null;
+async function loadAddon(addonFile: AddonFile): Promise<boolean> {
   try {
     // Check if this addon ID has already been loaded in the current session
     if (loadedAddonIds.has(addonFile.manifest.id)) {
@@ -102,89 +97,33 @@ async function loadAddon(addonFile: AddonFile, _context: AddonContext): Promise<
     const detectedFunctions = permissions.flatMap((p) =>
       p.functions.filter((f) => f.isDetected).map((f) => f.name),
     );
-    const detectedCategories = [...new Set(permissions.map((p) => p.category))];
+    const detectedCategories = [
+      ...new Set(
+        permissions
+          .filter((p) => p.functions.some((f) => f.isDeclared || f.isDetected))
+          .map((p) => p.category),
+      ),
+    ];
 
     logger.info(
       `Permissions for addon ${extractedAddon.metadata.id}: functions=[${detectedFunctions.join(",")}], categories=[${detectedCategories.join(",")}]`,
     );
 
-    // Runtime guards: Verify React singletons are available before addon execution
-    const g = globalThis as unknown as {
-      React?: { version?: string };
-      ReactDOM?: { createPortal?: unknown };
-    };
-    if (g.React?.version && g.React.version !== ReactVersion) {
-      logger.warn(`⚠️ React version mismatch: host=${g.React.version} sdk=${ReactVersion}`);
-    }
-
-    if (typeof g.ReactDOM?.createPortal !== "function") {
-      throw new Error(
-        "Host did not expose ReactDOM.createPortal. Portal-based UI components will not work.",
-      );
-    }
-
-    // Create a Blob and an object URL
-    const blob = new Blob([addonCode], { type: "text/javascript" });
-    blobUrl = URL.createObjectURL(blob);
-
-    // Dynamic import using the Blob URL
-    // The /* @vite-ignore */ comment might not be strictly necessary for blob URLs
-    // but can be kept if vite shows warnings during build.
-    const mod = await import(/* @vite-ignore */ blobUrl);
-
-    // Robustly resolve the addon's enable() regardless of bundle style
-    type EnableFn = ((ctx: AddonContext) => unknown) | null;
-    const asRecord = mod as unknown as Record<string, unknown> & {
-      default?: unknown;
-    };
-    const defaultObj = asRecord.default as
-      | ((ctx: AddonContext) => unknown)
-      | { enable?: (ctx: AddonContext) => unknown }
-      | undefined;
-    const enableFunction: EnableFn =
-      (typeof defaultObj === "function" ? defaultObj : null) ??
-      (defaultObj &&
-      typeof (defaultObj as { enable?: (ctx: AddonContext) => unknown }).enable === "function"
-        ? (defaultObj as { enable: (ctx: AddonContext) => unknown }).enable
-        : null) ??
-      (typeof asRecord.enable === "function"
-        ? (asRecord.enable as (ctx: AddonContext) => unknown)
-        : null) ??
-      (typeof (asRecord as Record<string, unknown>).PortfolioTrackerAddon === "function"
-        ? (asRecord as { PortfolioTrackerAddon: (ctx: AddonContext) => unknown })
-            .PortfolioTrackerAddon
-        : null) ??
-      (typeof (mod as unknown) === "function"
-        ? (mod as unknown as (ctx: AddonContext) => unknown)
-        : null);
-
-    if (!enableFunction) {
-      logger.error(
-        `❌ Addon ${extractedAddon.metadata.id} does not export a valid enable function. Available exports: ${Object.keys(mod).join(", ")}`,
-      );
-      return false;
-    }
-
-    // Create addon-specific context with scoped secrets
-    const addonSpecificContext = createAddonContext(extractedAddon.metadata.id);
-    const result = await enableFunction(addonSpecificContext);
-
-    // Store addon reference for potential cleanup
-    const typedResult = result as { disable?: () => void } | undefined;
-    loadedAddons.set(extractedAddon.metadata.id, {
-      disable: typeof typedResult?.disable === "function" ? typedResult.disable : undefined,
+    const handle = await addonIframeManager.startAddon({
+      addonId: extractedAddon.metadata.id,
+      code: addonCode,
+      files: extractedAddon.files,
+      manifest: extractedAddon.metadata,
+      permissions,
     });
+
+    loadedAddons.set(extractedAddon.metadata.id, handle);
     loadedAddonIds.add(extractedAddon.metadata.id); // Add to set after successful load and enablement
 
     return true;
   } catch (error) {
     logger.error(`Failed to load addon ${addonFile.manifest.id}: ${String(error)}`);
     return false;
-  } finally {
-    // Clean up the Blob URL
-    if (blobUrl) {
-      URL.revokeObjectURL(blobUrl);
-    }
   }
 }
 
@@ -210,7 +149,7 @@ export async function loadInstalledAddons(): Promise<void> {
   let loadedCount = 0;
   const loadPromises = enabledAddonFiles.map(async (addonFile) => {
     // Each addon gets its own context, but loadAddon creates its own internally
-    const success = await loadAddon(addonFile, {} as AddonContext);
+    const success = await loadAddon(addonFile);
     if (success) {
       loadedCount++;
     } else {
@@ -235,9 +174,7 @@ export function unloadAddon(addonId: string): void {
   const addon = loadedAddons.get(addonId);
   if (addon) {
     try {
-      if (addon.disable) {
-        addon.disable();
-      }
+      void addon.disable();
       loadedAddons.delete(addonId);
       loadedAddonIds.delete(addonId);
       logger.info(`🗑️ Unloaded addon: ${addonId}`);
@@ -253,9 +190,7 @@ export function unloadAddon(addonId: string): void {
 export function unloadAllAddons(): void {
   loadedAddons.forEach((addon, id) => {
     try {
-      if (addon.disable) {
-        addon.disable();
-      }
+      void addon.disable();
     } catch (error) {
       logger.error(`Error unloading addon ${id}: ${String(error)}`);
     }
@@ -263,9 +198,6 @@ export function unloadAllAddons(): void {
 
   loadedAddons.clear();
   loadedAddonIds.clear(); // Clear the set when unloading all
-
-  // Clear navigation items and routes from runtime context
-  triggerAllDisableCallbacks();
 }
 
 /**

--- a/apps/frontend/src/addons/addons-core.ts
+++ b/apps/frontend/src/addons/addons-core.ts
@@ -2,7 +2,7 @@ import { logger, getInstalledAddons, loadAddon as loadAddonRuntime } from "@/ada
 import { getDynamicNavItems, getDynamicRoutes } from "@/addons/addons-runtime-context";
 import { addonIframeManager, type AddonRuntimeHandle } from "@/addons/iframe/addon-iframe-manager";
 import type { AddonManifest } from "@wealthfolio/addon-sdk";
-import { SDK_VERSION } from "@wealthfolio/addon-sdk";
+import { HOST_DEPENDENCIES, SDK_VERSION } from "@wealthfolio/addon-sdk";
 
 interface AddonFile {
   path: string;
@@ -49,6 +49,13 @@ function validateAddonCompatibility(manifest: AddonManifest): boolean {
     logger.warn(
       `Addon ${manifest.id} declares SDK ${manifest.sdkVersion}; host is ${SDK_VERSION}. Proceeding with caution.`,
     );
+  }
+  for (const dependencyName of Object.keys(manifest.hostDependencies ?? {})) {
+    if (!Object.prototype.hasOwnProperty.call(HOST_DEPENDENCIES, dependencyName)) {
+      logger.warn(
+        `Addon ${manifest.id} declares unsupported host dependency '${dependencyName}'. It may need to bundle that package.`,
+      );
+    }
   }
   return true;
 }

--- a/apps/frontend/src/addons/addons-dev-mode.ts
+++ b/apps/frontend/src/addons/addons-dev-mode.ts
@@ -1,6 +1,7 @@
 import { logger } from "@/adapters";
 import { reloadAllAddons } from "@/addons/addons-core";
-import { createAddonContext } from "./addons-runtime-context";
+import type { AddonManifest } from "@wealthfolio/addon-sdk";
+import { addonIframeManager, type AddonRuntimeHandle } from "./iframe/addon-iframe-manager";
 
 interface DevModeConfig {
   enabled: boolean;
@@ -21,6 +22,7 @@ interface AddonDevServer {
 class AddonDevManager {
   private config: DevModeConfig;
   private devServers = new Map<string, AddonDevServer>();
+  private devAddons = new Map<string, AddonRuntimeHandle>();
   private watchInterval: number | null = null;
   private eventSource: EventSource | null = null;
 
@@ -185,40 +187,24 @@ class AddonDevManager {
   /**
    * Execute addon code in a sandboxed environment
    */
-  private async executeAddonCode(code: string, _manifest: unknown, addonId: string): Promise<void> {
+  private async executeAddonCode(
+    code: string,
+    manifest: Partial<AddonManifest> | null,
+    addonId: string,
+  ): Promise<void> {
     try {
-      // Runtime guard: Verify React singletons are available
-      const g = globalThis as unknown as { ReactDOM?: { createPortal?: unknown } };
-      if (typeof g.ReactDOM?.createPortal !== "function") {
-        throw new Error(
-          "Host did not expose ReactDOM.createPortal. Portal-based UI components will not work.",
-        );
-      }
-
-      // Create a blob URL for the addon code
-      const blob = new Blob([code], { type: "text/javascript" });
-      const blobUrl = URL.createObjectURL(blob);
-
-      // Import and execute the addon
-      const mod = await import(/* @vite-ignore */ blobUrl);
-
-      if (typeof mod.default === "function") {
-        // Create addon-specific context with scoped secrets
-        const addonSpecificContext = createAddonContext(addonId);
-        const addonInstance = mod.default(addonSpecificContext);
-
-        // Store for cleanup
-        if (addonInstance && typeof addonInstance.disable === "function") {
-          const g2 = globalThis as unknown as {
-            __DEV_ADDONS__?: Map<string, { disable?: () => void }>;
-          };
-          g2.__DEV_ADDONS__ = g2.__DEV_ADDONS__ ?? new Map();
-          g2.__DEV_ADDONS__.set(addonId, addonInstance);
-        }
-      }
-
-      // Cleanup blob URL
-      URL.revokeObjectURL(blobUrl);
+      const handle = await addonIframeManager.startAddon({
+        addonId,
+        code,
+        manifest: {
+          id: addonId,
+          name: manifest?.name ?? addonId,
+          version: manifest?.version ?? "0.0.0-dev",
+          ...manifest,
+        },
+        permissions: manifest?.permissions,
+      });
+      this.devAddons.set(addonId, handle);
     } catch (error) {
       logger.error(`Failed to execute addon code for ${addonId}: ${error}`);
       throw error;
@@ -279,18 +265,13 @@ class AddonDevManager {
   private async reloadAddon(addonId: string): Promise<void> {
     try {
       // Clean up existing instance
-      const devAddons = (
-        globalThis as unknown as {
-          __DEV_ADDONS__?: Map<string, { disable?: () => void }>;
-        }
-      ).__DEV_ADDONS__;
-      if (devAddons?.has(addonId)) {
-        const instance = devAddons.get(addonId);
-        if (instance?.disable) {
+      if (this.devAddons.has(addonId)) {
+        const instance = this.devAddons.get(addonId);
+        if (instance) {
           logger.info(`🧹 Cleaning up old instance of ${addonId}`);
-          instance.disable();
+          await instance.disable();
         }
-        devAddons.delete(addonId);
+        this.devAddons.delete(addonId);
       }
 
       // Also clean up from the main addon loader
@@ -351,7 +332,7 @@ class AddonDevManager {
    */
   private injectDevTools(): void {
     // Add development-specific APIs to a generic context
-    const devCtx = createAddonContext("dev-tools");
+    const devCtx = {};
     (
       devCtx as unknown as {
         dev?: {
@@ -382,20 +363,10 @@ class AddonDevManager {
       this.eventSource = null;
     }
 
-    // Clean up dev addon instances
-    const devAddons = (
-      globalThis as unknown as {
-        __DEV_ADDONS__?: Map<string, { disable?: () => void }>;
-      }
-    ).__DEV_ADDONS__;
-    if (devAddons) {
-      for (const [, instance] of devAddons) {
-        if (instance.disable) {
-          instance.disable();
-        }
-      }
-      devAddons.clear();
+    for (const [, instance] of this.devAddons) {
+      void instance.disable();
     }
+    this.devAddons.clear();
   }
 
   /**
@@ -464,11 +435,24 @@ export const addonDevManager = new AddonDevManager();
 
 // Make debugging tools available globally in development mode
 if (import.meta.env.DEV) {
-  // Make available globally for debugging (dev only)
-  (globalThis as unknown as { __ADDON_DEV__?: unknown }).__ADDON_DEV__ = addonDevManager;
-
-  // Add global helper functions (dev only)
-  (globalThis as unknown as { discoverAddons?: () => void }).discoverAddons = () =>
-    addonDevManager.discoverAndRegister();
-  (globalThis as unknown as { reloadAddons?: () => void }).reloadAddons = () => reloadAllAddons();
+  Object.defineProperties(globalThis, {
+    __ADDON_DEV__: {
+      configurable: true,
+      enumerable: false,
+      value: addonDevManager,
+      writable: false,
+    },
+    discoverAddons: {
+      configurable: true,
+      enumerable: false,
+      value: () => addonDevManager.discoverAndRegister(),
+      writable: false,
+    },
+    reloadAddons: {
+      configurable: true,
+      enumerable: false,
+      value: () => reloadAllAddons(),
+      writable: false,
+    },
+  });
 }

--- a/apps/frontend/src/addons/addons-runtime-context.test.ts
+++ b/apps/frontend/src/addons/addons-runtime-context.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearAddonRegistrations,
+  getDynamicRoutes,
+  registerAddonNavItem,
+  registerAddonRoute,
+} from "./addons-runtime-context";
+
+describe("addons runtime route policy", () => {
+  afterEach(() => {
+    clearAddonRegistrations("evil-addon");
+    clearAddonRegistrations("swingfolio-addon");
+  });
+
+  it("allows routes under the add-on slug without the addon suffix", () => {
+    registerAddonNavItem("swingfolio-addon", {
+      id: "swingfolio",
+      label: "Swingfolio",
+      route: "/addons/swingfolio",
+    });
+    registerAddonRoute("swingfolio-addon", {
+      path: "/addons/swingfolio/settings",
+      routeId: "/addons/swingfolio/settings",
+    });
+
+    expect(getDynamicRoutes()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          addonId: "swingfolio-addon",
+          href: "/addons/swingfolio/settings",
+        }),
+      ]),
+    );
+  });
+
+  it("blocks an add-on from self-authorizing another add-on namespace", () => {
+    expect(() =>
+      registerAddonNavItem("evil-addon", {
+        id: "victim",
+        label: "Victim",
+        route: "/addon/victim-addon",
+      }),
+    ).toThrow("cannot register sidebar route");
+
+    expect(() =>
+      registerAddonRoute("evil-addon", {
+        path: "/addon/victim-addon/dashboard",
+        routeId: "/addon/victim-addon/dashboard",
+      }),
+    ).toThrow("cannot register route");
+  });
+});

--- a/apps/frontend/src/addons/addons-runtime-context.ts
+++ b/apps/frontend/src/addons/addons-runtime-context.ts
@@ -1,9 +1,7 @@
-import type { AddonContext, SidebarItemHandle } from "@wealthfolio/addon-sdk";
-import React from "react";
+import type { AddonContext, Permission, SidebarItemConfig } from "@wealthfolio/addon-sdk";
 import { toast } from "sonner";
-import { createSDKHostAPIBridge } from "./type-bridge";
+import { createPermissionGuard, createSDKHostAPIBridge, type PermissionGuard } from "./type-bridge";
 
-// Import all command functions
 import {
   logger,
   checkActivitiesImport,
@@ -18,6 +16,7 @@ import {
   createAccount,
   getAccounts,
   updateAccount,
+  addonNetworkRequest,
 } from "@/adapters";
 import {
   addExchangeRate,
@@ -73,324 +72,421 @@ import {
   listenPortfolioUpdateStart,
 } from "@/adapters";
 import {
-  deleteSecret,
-  getSecret,
-  setSecret,
+  deleteAddonSecret,
+  getAddonSecret,
+  setAddonSecret,
   backupDatabase,
   getSettings,
   updateSettings,
 } from "@/adapters";
 
-// Store for dynamically added navigation items
-interface NavItem {
-  icon: React.ReactNode | string;
+export interface DynamicNavItem {
+  icon?: string;
   title: string;
   href: string;
-  onClick?: () => void;
   order: number;
   id: string;
+  addonId: string;
 }
-const dynamicNavItems = new Map<string, NavItem>();
-const disableCallbacks = new Set<() => void>();
 
-// Store for dynamically added routes
-const dynamicRoutes = new Map<string, React.LazyExoticComponent<React.ComponentType<unknown>>>();
+export interface DynamicRouteEntry {
+  path: string;
+  href: string;
+  addonId: string;
+  routeId: string;
+  title?: string;
+}
 
-// Navigation update listeners
+interface QueryClientLike {
+  invalidateQueries: (opts: { queryKey: string[]; exact?: boolean }) => unknown;
+  refetchQueries: (opts: { queryKey: string[]; exact?: boolean }) => unknown;
+}
+
+const dynamicNavItems = new Map<string, DynamicNavItem>();
+const dynamicRoutes = new Map<string, DynamicRouteEntry>();
+const disableCallbacks = new Map<string, Set<() => void>>();
 const navigationUpdateListeners = new Set<() => void>();
 
-// Function to notify navigation update listeners
+let hostNavigate: ((route: string) => void) | undefined;
+let hostQueryClient: QueryClientLike | undefined;
+
+function navigateWithoutReload(route: string) {
+  const targetUrl = new URL(route, window.location.href);
+  if (targetUrl.origin !== window.location.origin) {
+    console.warn(`Blocked addon navigation to external URL: ${route}`);
+    return;
+  }
+
+  const normalizedRoute = `${targetUrl.pathname}${targetUrl.search}${targetUrl.hash}`;
+  window.history.pushState(null, "", normalizedRoute);
+  const popStateEvent =
+    typeof PopStateEvent === "function" ? new PopStateEvent("popstate") : new Event("popstate");
+  window.dispatchEvent(popStateEvent);
+}
+
+export function setAddonNavigationHandler(navigate: (route: string) => void) {
+  hostNavigate = navigate;
+}
+
+export function clearAddonNavigationHandler(navigate: (route: string) => void) {
+  if (hostNavigate === navigate) {
+    hostNavigate = undefined;
+  }
+}
+
+export function setAddonQueryClient(queryClient: QueryClientLike) {
+  hostQueryClient = queryClient;
+}
+
 function notifyNavigationUpdate() {
   navigationUpdateListeners.forEach((listener) => listener());
 }
 
-// Public API for getting dynamic navigation items
+function scopedKey(addonId: string, id: string) {
+  return `${addonId}:${id}`;
+}
+
+function cleanRoutePath(path: string) {
+  const routeOnly = path.trim().split(/[?#]/, 1)[0] ?? "";
+  const withSlash = routeOnly.startsWith("/") ? routeOnly : `/${routeOnly}`;
+  return withSlash.length > 1 && withSlash.endsWith("/") ? withSlash.slice(0, -1) : withSlash;
+}
+
+function toRouterPath(href: string) {
+  return href.replace(/^\/+/, "");
+}
+
+function cleanRouteNamespace(namespace: string) {
+  return namespace.trim().replace(/^\/+|\/+$/g, "");
+}
+
+function isPathWithinRoutePrefix(path: string, prefix: string) {
+  const href = cleanRoutePath(path);
+  const cleanPrefix = cleanRoutePath(prefix);
+  return href === cleanPrefix || href.startsWith(`${cleanPrefix}/`);
+}
+
+function isAddonRouteNamespaceAllowed(addonId: string, path: string, aliases: string[] = []) {
+  const href = cleanRoutePath(path);
+  const namespaces = [addonId, ...aliases].map(cleanRouteNamespace).filter(Boolean);
+
+  return namespaces.some(
+    (namespace) =>
+      href === `/addon/${namespace}` ||
+      href.startsWith(`/addon/${namespace}/`) ||
+      href === `/addons/${namespace}` ||
+      href.startsWith(`/addons/${namespace}/`),
+  );
+}
+
+function hasRegisteredAddonNavPrefix(addonId: string, path: string) {
+  return Array.from(dynamicNavItems.values()).some(
+    (item) => item.addonId === addonId && isPathWithinRoutePrefix(path, item.href),
+  );
+}
+
+export function isAddonRoutePathAllowed(addonId: string, path: string) {
+  return isAddonRouteNamespaceAllowed(addonId, path);
+}
+
+export function registerAddonNavItem(addonId: string, cfg: SidebarItemConfig) {
+  const itemId = String(cfg.id || "").trim();
+  const label = String(cfg.label || "").trim();
+  if (!itemId || !label) {
+    throw new Error("Addon sidebar items require a non-empty id and label");
+  }
+
+  const href = cleanRoutePath(cfg.route || `/addon/${addonId}`);
+  if (!isAddonRouteNamespaceAllowed(addonId, href, [itemId])) {
+    throw new Error(`Addon '${addonId}' cannot register sidebar route '${href}'`);
+  }
+
+  dynamicNavItems.set(scopedKey(addonId, itemId), {
+    addonId,
+    href,
+    icon: typeof cfg.icon === "string" ? cfg.icon : undefined,
+    id: scopedKey(addonId, itemId),
+    order: typeof cfg.order === "number" ? cfg.order : 999,
+    title: label,
+  });
+  notifyNavigationUpdate();
+}
+
+export function removeAddonNavItem(addonId: string, itemId: string) {
+  dynamicNavItems.delete(scopedKey(addonId, itemId));
+  notifyNavigationUpdate();
+}
+
+export function registerAddonRoute(
+  addonId: string,
+  route: { path: string; routeId: string; title?: string },
+) {
+  const routeId = String(route.routeId || "").trim();
+  if (!routeId) {
+    throw new Error("Addon routes require a non-empty routeId");
+  }
+
+  const href = cleanRoutePath(route.path);
+  if (!isAddonRoutePathAllowed(addonId, href) && !hasRegisteredAddonNavPrefix(addonId, href)) {
+    throw new Error(`Addon '${addonId}' cannot register route '${href}'`);
+  }
+
+  dynamicRoutes.set(scopedKey(addonId, routeId), {
+    addonId,
+    href,
+    path: toRouterPath(href),
+    routeId,
+    title: route.title,
+  });
+  notifyNavigationUpdate();
+}
+
+export function removeAddonRoute(addonId: string, routeId: string) {
+  dynamicRoutes.delete(scopedKey(addonId, routeId));
+  notifyNavigationUpdate();
+}
+
+export function clearAddonRegistrations(addonId: string) {
+  let changed = false;
+
+  for (const [key, item] of dynamicNavItems) {
+    if (item.addonId === addonId) {
+      dynamicNavItems.delete(key);
+      changed = true;
+    }
+  }
+
+  for (const [key, route] of dynamicRoutes) {
+    if (route.addonId === addonId) {
+      dynamicRoutes.delete(key);
+      changed = true;
+    }
+  }
+
+  const callbacks = disableCallbacks.get(addonId);
+  if (callbacks) {
+    callbacks.forEach((cb) => {
+      try {
+        cb();
+      } catch (error) {
+        console.error("Error in addon disable callback:", error);
+      }
+    });
+    disableCallbacks.delete(addonId);
+  }
+
+  if (changed) {
+    notifyNavigationUpdate();
+  }
+}
+
 export function getDynamicNavItems() {
   return Array.from(dynamicNavItems.values()).sort((a, b) => a.order - b.order);
 }
 
-// Public API for getting dynamic routes
 export function getDynamicRoutes() {
-  return Array.from(dynamicRoutes.entries()).map(([path, component]) => ({
-    path,
-    component,
-  }));
+  return Array.from(dynamicRoutes.values()).sort((a, b) => a.path.localeCompare(b.path));
 }
 
-// Public API for subscribing to navigation updates
 export function subscribeToNavigationUpdates(callback: () => void) {
   navigationUpdateListeners.add(callback);
   return () => navigationUpdateListeners.delete(callback);
 }
 
-// Public API for triggering navigation updates
 export function triggerNavigationUpdate() {
   notifyNavigationUpdate();
 }
 
-// Public API for triggering all disable callbacks
 export function triggerAllDisableCallbacks() {
-  disableCallbacks.forEach((cb) => {
-    try {
-      cb();
-    } catch (error) {
-      console.error("Error in addon disable callback:", error);
-    }
-  });
-  disableCallbacks.clear();
+  Array.from(disableCallbacks.keys()).forEach(clearAddonRegistrations);
   dynamicNavItems.clear();
   dynamicRoutes.clear();
   notifyNavigationUpdate();
 }
 
-// Create addon-scoped secret functions
-function createAddonScopedSecrets(addonId: string) {
-  const addonPrefix = `addon_${addonId}_`;
-
+function createAddonScopedSecrets(addonId: string, guard: PermissionGuard) {
   return {
     set: async (key: string, value: string): Promise<void> => {
-      const scopedKey = `${addonPrefix}${key}`;
-      return setSecret(scopedKey, value);
+      guard.assertCanUse("secrets", "set");
+      return setAddonSecret(addonId, key, value);
     },
     get: async (key: string): Promise<string | null> => {
-      const scopedKey = `${addonPrefix}${key}`;
-      return getSecret(scopedKey);
+      guard.assertCanUse("secrets", "get");
+      return getAddonSecret(addonId, key);
     },
     delete: async (key: string): Promise<void> => {
-      const scopedKey = `${addonPrefix}${key}`;
-      return deleteSecret(scopedKey);
+      guard.assertCanUse("secrets", "delete");
+      return deleteAddonSecret(addonId, key);
     },
   };
 }
 
-// Create context factory function for addon-specific contexts
-export function createAddonContext(addonId: string): AddonContext {
+export function createAddonHostAPI(
+  addonId: string,
+  permissions?: Permission[],
+): AddonContext["api"] {
+  const permissionGuard = createPermissionGuard(addonId, permissions);
+  const baseAPI = createSDKHostAPIBridge(
+    {
+      getHoldings: (accountId: string) => getHoldings({ type: "account", accountId }),
+      getActivities,
+      getAccounts,
+
+      getExchangeRates,
+      updateExchangeRate,
+      addExchangeRate,
+
+      getContributionLimit,
+      createContributionLimit,
+      updateContributionLimit,
+      calculateDepositsForLimit,
+
+      getGoals,
+      createGoal,
+      updateGoal,
+      getGoalFunding,
+      saveGoalFunding,
+
+      searchTicker,
+      fetchDividends,
+      syncHistoryQuotes,
+      getAssetProfile,
+      updateAssetProfile,
+      updateQuoteMode,
+      updateQuote,
+      syncMarketData,
+      getQuoteHistory,
+      getMarketDataProviders,
+
+      updatePortfolio,
+      recalculatePortfolio,
+      getIncomeSummary: () => getIncomeSummary(undefined),
+      getHistoricalValuations: (accountId?: string, startDate?: string, endDate?: string) =>
+        getHistoricalValuations(
+          accountId ? { type: "account", accountId } : { type: "all" },
+          startDate,
+          endDate,
+        ),
+      getLatestValuations,
+      calculatePerformanceHistory,
+      calculatePerformanceSummary,
+      calculateAccountsSimplePerformance,
+      getHolding,
+
+      getSettings,
+      updateSettings,
+      backupDatabase,
+
+      createAccount,
+      updateAccount,
+
+      searchActivities,
+      createActivity,
+      updateActivity,
+      saveActivities,
+
+      openCsvFileDialog,
+      openFileSaveDialog,
+
+      listenImportFileDropHover,
+      listenImportFileDrop,
+      listenImportFileDropCancelled,
+
+      listenPortfolioUpdateStart,
+      listenPortfolioUpdateComplete,
+      listenPortfolioUpdateError,
+      listenMarketSyncStart,
+      listenMarketSyncComplete,
+
+      importActivities,
+      checkActivitiesImport,
+      getAccountImportMapping,
+      saveAccountImportMapping,
+
+      getSnapshots,
+      getSnapshotByDate,
+      saveManualHoldings,
+      checkHoldingsImport,
+      importHoldingsCsv,
+      deleteSnapshot,
+
+      logError: logger.error,
+      logInfo: logger.info,
+      logWarn: logger.warn,
+      logTrace: logger.trace,
+      logDebug: logger.debug,
+
+      navigateToRoute: async (route: string) => {
+        if (hostNavigate) {
+          hostNavigate(route);
+        } else {
+          navigateWithoutReload(route);
+        }
+      },
+
+      getQueryClient: () => undefined,
+      invalidateQueries: (queryKey: string | string[]) => {
+        hostQueryClient?.invalidateQueries({
+          queryKey: Array.isArray(queryKey) ? queryKey : [queryKey],
+          exact: false,
+        });
+      },
+      refetchQueries: (queryKey: string | string[]) => {
+        hostQueryClient?.refetchQueries({
+          queryKey: Array.isArray(queryKey) ? queryKey : [queryKey],
+          exact: false,
+        });
+      },
+
+      addonNetworkRequest: (request) => addonNetworkRequest(addonId, request),
+
+      toastSuccess: (message: string) => toast.success(message),
+      toastError: (message: string) => toast.error(message),
+      toastWarning: (message: string) => toast.warning(message),
+      toastInfo: (message: string) => toast.info(message),
+    },
+    addonId,
+    permissionGuard,
+  );
+
   return {
+    ...baseAPI,
+    secrets: createAddonScopedSecrets(addonId, permissionGuard),
+  };
+}
+
+export function createAddonContext(addonId: string, permissions?: Permission[]): AddonContext {
+  const permissionGuard = createPermissionGuard(addonId, permissions);
+
+  return {
+    ui: {
+      root: document.createElement("div"),
+    },
     sidebar: {
-      addItem: (cfg: {
-        id: string;
-        label: string;
-        icon?: React.ReactNode;
-        route?: string;
-        order?: number;
-        onClick?: () => void;
-      }): SidebarItemHandle => {
-        // Create navigation item
-        const navItem = {
-          icon: cfg.icon ?? '<Icons.Circle className="h-5 w-5" />',
-          title: cfg.label,
-          href: cfg.route ?? "#",
-          onClick: cfg.onClick,
-          order: cfg.order ?? 999,
-          id: cfg.id,
-        };
-
-        // Store the navigation item
-        dynamicNavItems.set(cfg.id, navItem);
-
-        // Notify listeners that navigation has changed
-        notifyNavigationUpdate();
+      addItem: (cfg) => {
+        permissionGuard.assertCanUse("ui", "sidebar.addItem");
+        registerAddonNavItem(addonId, cfg);
 
         return {
-          remove: () => {
-            dynamicNavItems.delete(cfg.id);
-            notifyNavigationUpdate();
-          },
+          remove: () => removeAddonNavItem(addonId, cfg.id),
         };
       },
     },
     router: {
-      add: (r: {
-        path: string;
-        component: React.LazyExoticComponent<React.ComponentType<unknown>>;
-      }): void => {
-        // Store the route component
-        dynamicRoutes.set(r.path, r.component);
-
-        // Notify listeners that routes have changed
-        notifyNavigationUpdate();
+      add: (route) => {
+        permissionGuard.assertCanUse("ui", "router.add");
+        registerAddonRoute(addonId, {
+          path: route.path,
+          routeId: route.id ?? route.path,
+          title: route.title,
+        });
       },
     },
-    onDisable: (cb: () => void): void => {
-      disableCallbacks.add(cb);
+    onDisable: (cb) => {
+      const callbacks = disableCallbacks.get(addonId) ?? new Set<() => void>();
+      callbacks.add(cb);
+      disableCallbacks.set(addonId, callbacks);
     },
-    api: (() => {
-      const baseAPI = createSDKHostAPIBridge(
-        {
-          // Core data access
-          getHoldings: (accountId: string) => getHoldings({ type: "account", accountId }),
-          getActivities: getActivities,
-          getAccounts: getAccounts,
-
-          // Exchange rates
-          getExchangeRates,
-          updateExchangeRate,
-          addExchangeRate,
-
-          // Contribution limits
-          getContributionLimit,
-          createContributionLimit,
-          updateContributionLimit,
-          calculateDepositsForLimit,
-
-          // Goals
-          getGoals,
-          createGoal,
-          updateGoal,
-          getGoalFunding,
-          saveGoalFunding,
-
-          // Market data
-          searchTicker,
-          fetchDividends,
-          syncHistoryQuotes,
-          getAssetProfile,
-          updateAssetProfile,
-          updateQuoteMode,
-          updateQuote,
-          syncMarketData,
-          getQuoteHistory,
-          getMarketDataProviders,
-
-          // Portfolio
-          updatePortfolio,
-          recalculatePortfolio,
-          getIncomeSummary: () => getIncomeSummary(undefined),
-          getHistoricalValuations: (accountId?: string, startDate?: string, endDate?: string) =>
-            getHistoricalValuations(
-              accountId ? { type: "account", accountId } : { type: "all" },
-              startDate,
-              endDate,
-            ),
-          getLatestValuations,
-          calculatePerformanceHistory,
-          calculatePerformanceSummary,
-          calculateAccountsSimplePerformance,
-          getHolding,
-
-          // Settings
-          getSettings,
-          updateSettings,
-          backupDatabase,
-
-          // Account management
-          createAccount,
-          updateAccount,
-
-          // Activity management
-          searchActivities,
-          createActivity,
-          updateActivity,
-          saveActivities,
-
-          // File operations
-          openCsvFileDialog,
-          openFileSaveDialog,
-
-          // Event listeners - Import
-          listenImportFileDropHover,
-          listenImportFileDrop,
-          listenImportFileDropCancelled,
-
-          // Event listeners - Portfolio
-          listenPortfolioUpdateStart,
-          listenPortfolioUpdateComplete,
-          listenPortfolioUpdateError,
-          listenMarketSyncStart,
-          listenMarketSyncComplete,
-
-          // Activity import
-          importActivities,
-          checkActivitiesImport,
-          getAccountImportMapping,
-          saveAccountImportMapping,
-
-          // Snapshots
-          getSnapshots,
-          getSnapshotByDate,
-          saveManualHoldings,
-          checkHoldingsImport,
-          importHoldingsCsv,
-          deleteSnapshot,
-
-          // Logger functions
-          logError: logger.error,
-          logInfo: logger.info,
-          logWarn: logger.warn,
-          logTrace: logger.trace,
-          logDebug: logger.debug,
-
-          // Navigation functions
-          navigateToRoute: async (route: string) => {
-            // Use the browser's navigation API through React Router
-            const navigate = (
-              window as unknown as { __wealthfolio_navigate__?: (r: string) => void }
-            ).__wealthfolio_navigate__;
-            if (navigate) {
-              navigate(route);
-            } else {
-              // Fallback: change the URL directly
-              window.location.hash = route;
-            }
-          },
-
-          // Query functions
-          getQueryClient: () => {
-            interface QueryClientLike {
-              invalidateQueries: (opts: { queryKey: string[] }) => unknown;
-              refetchQueries: (opts: { queryKey: string[] }) => unknown;
-            }
-            return (window as unknown as { __wealthfolio_query_client__?: QueryClientLike })
-              .__wealthfolio_query_client__;
-          },
-          invalidateQueries: (queryKey: string | string[]) => {
-            interface QueryClientLike {
-              invalidateQueries: (opts: { queryKey: string[]; exact?: boolean }) => unknown;
-            }
-            const queryClient = (
-              window as unknown as { __wealthfolio_query_client__?: QueryClientLike }
-            ).__wealthfolio_query_client__;
-            if (queryClient) {
-              queryClient.invalidateQueries({
-                queryKey: Array.isArray(queryKey) ? queryKey : [queryKey],
-                exact: false,
-              });
-            }
-          },
-          refetchQueries: (queryKey: string | string[]) => {
-            interface QueryClientLike {
-              refetchQueries: (opts: { queryKey: string[]; exact?: boolean }) => unknown;
-            }
-            const queryClient = (
-              window as unknown as { __wealthfolio_query_client__?: QueryClientLike }
-            ).__wealthfolio_query_client__;
-            if (queryClient) {
-              queryClient.refetchQueries({
-                queryKey: Array.isArray(queryKey) ? queryKey : [queryKey],
-                exact: false,
-              });
-            }
-          },
-
-          // Toast functions (backed by host's sonner instance)
-          toastSuccess: (message: string) => toast.success(message),
-          toastError: (message: string) => toast.error(message),
-          toastWarning: (message: string) => toast.warning(message),
-          toastInfo: (message: string) => toast.info(message),
-        },
-        addonId,
-      );
-
-      // Add the secrets API manually (without `any`)
-      const apiWithSecrets = {
-        ...baseAPI,
-        secrets: createAddonScopedSecrets(addonId),
-      };
-
-      return apiWithSecrets;
-    })(),
+    api: createAddonHostAPI(addonId, permissions),
   };
 }
-
-// Note: We intentionally do not set a global context to ensure proper secret isolation.
-// Each addon receives its own scoped context via the enable(ctx: AddonContext) function parameter.

--- a/apps/frontend/src/addons/addons-runtime-context.ts
+++ b/apps/frontend/src/addons/addons-runtime-context.ts
@@ -179,6 +179,12 @@ function isAddonRouteNamespaceAllowed(addonId: string, path: string, aliases: st
   );
 }
 
+function getAddonRouteNamespaceFromPath(path: string) {
+  const href = cleanRoutePath(path);
+  const match = /^\/addons?\/([^/?#]+)/.exec(href);
+  return match?.[1];
+}
+
 function hasRegisteredAddonNavPrefix(addonId: string, path: string) {
   return Array.from(dynamicNavItems.values()).some(
     (item) => item.addonId === addonId && isPathWithinRoutePrefix(path, item.href),
@@ -227,7 +233,12 @@ export function registerAddonRoute(
   }
 
   const href = cleanRoutePath(route.path);
-  if (!isAddonRoutePathAllowed(addonId, href) && !hasRegisteredAddonNavPrefix(addonId, href)) {
+  const routeNamespace = getAddonRouteNamespaceFromPath(href);
+  const aliases = [routeId, routeNamespace].filter((alias): alias is string => Boolean(alias));
+  if (
+    !isAddonRouteNamespaceAllowed(addonId, href, aliases) &&
+    !hasRegisteredAddonNavPrefix(addonId, href)
+  ) {
     throw new Error(`Addon '${addonId}' cannot register route '${href}'`);
   }
 

--- a/apps/frontend/src/addons/addons-runtime-context.ts
+++ b/apps/frontend/src/addons/addons-runtime-context.ts
@@ -106,6 +106,7 @@ const dynamicNavItems = new Map<string, DynamicNavItem>();
 const dynamicRoutes = new Map<string, DynamicRouteEntry>();
 const disableCallbacks = new Map<string, Set<() => void>>();
 const navigationUpdateListeners = new Set<() => void>();
+const ADDON_ID_SUFFIX = "-addon";
 
 let hostNavigate: ((route: string) => void) | undefined;
 let hostQueryClient: QueryClientLike | undefined;
@@ -160,6 +161,14 @@ function cleanRouteNamespace(namespace: string) {
   return namespace.trim().replace(/^\/+|\/+$/g, "");
 }
 
+function getOwnedAddonRouteNamespaces(addonId: string) {
+  const cleanAddonId = cleanRouteNamespace(addonId);
+  const addonSlug = cleanAddonId.endsWith(ADDON_ID_SUFFIX)
+    ? cleanAddonId.slice(0, -ADDON_ID_SUFFIX.length)
+    : cleanAddonId;
+  return Array.from(new Set([cleanAddonId, addonSlug].filter(Boolean)));
+}
+
 function isPathWithinRoutePrefix(path: string, prefix: string) {
   const href = cleanRoutePath(path);
   const cleanPrefix = cleanRoutePath(prefix);
@@ -168,7 +177,9 @@ function isPathWithinRoutePrefix(path: string, prefix: string) {
 
 function isAddonRouteNamespaceAllowed(addonId: string, path: string, aliases: string[] = []) {
   const href = cleanRoutePath(path);
-  const namespaces = [addonId, ...aliases].map(cleanRouteNamespace).filter(Boolean);
+  const namespaces = [...getOwnedAddonRouteNamespaces(addonId), ...aliases]
+    .map(cleanRouteNamespace)
+    .filter(Boolean);
 
   return namespaces.some(
     (namespace) =>
@@ -177,12 +188,6 @@ function isAddonRouteNamespaceAllowed(addonId: string, path: string, aliases: st
       href === `/addons/${namespace}` ||
       href.startsWith(`/addons/${namespace}/`),
   );
-}
-
-function getAddonRouteNamespaceFromPath(path: string) {
-  const href = cleanRoutePath(path);
-  const match = /^\/addons?\/([^/?#]+)/.exec(href);
-  return match?.[1];
 }
 
 function hasRegisteredAddonNavPrefix(addonId: string, path: string) {
@@ -203,7 +208,7 @@ export function registerAddonNavItem(addonId: string, cfg: SidebarItemConfig) {
   }
 
   const href = cleanRoutePath(cfg.route || `/addon/${addonId}`);
-  if (!isAddonRouteNamespaceAllowed(addonId, href, [itemId])) {
+  if (!isAddonRoutePathAllowed(addonId, href)) {
     throw new Error(`Addon '${addonId}' cannot register sidebar route '${href}'`);
   }
 
@@ -233,12 +238,7 @@ export function registerAddonRoute(
   }
 
   const href = cleanRoutePath(route.path);
-  const routeNamespace = getAddonRouteNamespaceFromPath(href);
-  const aliases = [routeId, routeNamespace].filter((alias): alias is string => Boolean(alias));
-  if (
-    !isAddonRouteNamespaceAllowed(addonId, href, aliases) &&
-    !hasRegisteredAddonNavPrefix(addonId, href)
-  ) {
+  if (!isAddonRoutePathAllowed(addonId, href) && !hasRegisteredAddonNavPrefix(addonId, href)) {
     throw new Error(`Addon '${addonId}' cannot register route '${href}'`);
   }
 

--- a/apps/frontend/src/addons/iframe/addon-iframe-manager.ts
+++ b/apps/frontend/src/addons/iframe/addon-iframe-manager.ts
@@ -1,0 +1,481 @@
+import type { AddonManifest, Permission, SidebarItemConfig } from "@wealthfolio/addon-sdk";
+import type { AddonFile } from "@/adapters/types";
+import {
+  clearAddonRegistrations,
+  createAddonHostAPI,
+  registerAddonNavItem,
+  registerAddonRoute,
+  removeAddonNavItem,
+  removeAddonRoute,
+} from "@/addons/addons-runtime-context";
+import { logger } from "@/adapters";
+import { createPermissionGuard, type PermissionGuard } from "../type-bridge";
+
+const CHANNEL = "wealthfolio:addon-sandbox:v1";
+const LOAD_TIMEOUT_MS = 10_000;
+
+interface StartAddonInput {
+  addonId: string;
+  manifest: AddonManifest;
+  code: string;
+  files?: AddonFile[];
+  permissions?: Permission[];
+}
+
+export interface AddonRouteLocation {
+  pathname: string;
+  search: string;
+  hash: string;
+  params: Record<string, string | undefined>;
+}
+
+export interface AddonRuntimeHandle {
+  disable(): Promise<void>;
+}
+
+interface Runtime {
+  addonId: string;
+  nonce: string;
+  iframe: HTMLIFrameElement;
+  code: string;
+  files: AddonFile[];
+  api: unknown;
+  activeContainer?: HTMLElement;
+  activeRoute?: {
+    location: AddonRouteLocation;
+    routeId: string;
+  };
+  isLoaded: boolean;
+  permissionGuard: PermissionGuard;
+  routeRenderTimer?: number;
+  subscriptions: Map<string, () => Promise<void> | void>;
+  resolveLoad: (handle: AddonRuntimeHandle) => void;
+  rejectLoad: (error: Error) => void;
+  loadTimer: number;
+}
+
+interface SandboxMessage {
+  channel?: string;
+  addonId?: string;
+  nonce?: string;
+  type?: string;
+  requestId?: string;
+  method?: string;
+  args?: unknown[];
+  item?: SidebarItemConfig;
+  itemId?: string;
+  route?: {
+    path?: string;
+    routeId?: string;
+    title?: string;
+  };
+  routeId?: string;
+  subscriptionId?: string;
+  error?: string;
+}
+
+function createNonce() {
+  return crypto.randomUUID?.() ?? `${Date.now().toString(36)}-${Math.random().toString(36)}`;
+}
+
+function createSandboxUrl(addonId: string, nonce: string) {
+  const basePath = import.meta.env.BASE_URL || "/";
+  const sandboxUrl = new URL(
+    `${basePath.replace(/\/?$/, "/")}addon-sandbox.html`,
+    window.location.href,
+  );
+  sandboxUrl.hash = new URLSearchParams({ addonId, nonce }).toString();
+  return sandboxUrl.toString();
+}
+
+function makeRequestId() {
+  return crypto.randomUUID?.() ?? Math.random().toString(36).slice(2);
+}
+
+function formatUnknownError(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === "string") {
+    return error;
+  }
+  if (typeof error === "number" || typeof error === "boolean" || typeof error === "bigint") {
+    return String(error);
+  }
+  if (typeof error === "symbol") {
+    return error.description ?? "Symbol";
+  }
+  if (typeof error === "function") {
+    return error.name || "Function";
+  }
+  if (error === null || error === undefined) {
+    return undefined;
+  }
+  return JSON.stringify(error) ?? "Unknown error";
+}
+
+function getParkingRoot() {
+  let root = document.getElementById("addon-sandbox-parking");
+  if (!root) {
+    root = document.createElement("div");
+    root.id = "addon-sandbox-parking";
+    root.setAttribute("aria-hidden", "true");
+    Object.assign(root.style, {
+      height: "0",
+      overflow: "hidden",
+      position: "absolute",
+      width: "0",
+    });
+    document.body.appendChild(root);
+  }
+  return root;
+}
+
+function getProperty(target: unknown, key: string): unknown {
+  if (typeof target !== "object" || target === null) {
+    return undefined;
+  }
+  return (target as Record<string, unknown>)[key];
+}
+
+function getMethod(target: unknown, methodPath: string) {
+  const parts = methodPath.split(".").filter(Boolean);
+  let current = target;
+
+  for (const part of parts) {
+    current = getProperty(current, part);
+  }
+
+  if (typeof current !== "function") {
+    throw new Error(`Unknown addon host API method '${methodPath}'`);
+  }
+
+  return current as (...args: unknown[]) => unknown;
+}
+
+export class AddonIframeManager {
+  private runtimes = new Map<string, Runtime>();
+  private listening = false;
+
+  async startAddon(input: StartAddonInput): Promise<AddonRuntimeHandle> {
+    await this.stopAddon(input.addonId);
+    this.ensureListener();
+
+    const nonce = createNonce();
+    const sandboxUrl = createSandboxUrl(input.addonId, nonce);
+
+    const iframe = document.createElement("iframe");
+    iframe.title = `${input.manifest.name || input.addonId} add-on sandbox`;
+    iframe.setAttribute("sandbox", "allow-scripts");
+    iframe.referrerPolicy = "no-referrer";
+    Object.assign(iframe.style, {
+      border: "0",
+      display: "block",
+      height: "100%",
+      width: "100%",
+    });
+
+    const credentiallessFrame = iframe as HTMLIFrameElement & { credentialless?: boolean };
+    if ("credentialless" in credentiallessFrame) {
+      credentiallessFrame.credentialless = true;
+    }
+
+    const loadPromise = new Promise<AddonRuntimeHandle>((resolve, reject) => {
+      const runtime: Runtime = {
+        addonId: input.addonId,
+        api: createAddonHostAPI(input.addonId, input.permissions),
+        code: input.code,
+        files: input.files ?? [],
+        iframe,
+        isLoaded: false,
+        loadTimer: window.setTimeout(() => {
+          reject(new Error(`Timed out loading addon '${input.addonId}'`));
+          void this.stopAddon(input.addonId);
+        }, LOAD_TIMEOUT_MS),
+        nonce,
+        permissionGuard: createPermissionGuard(input.addonId, input.permissions),
+        rejectLoad: reject,
+        resolveLoad: resolve,
+        subscriptions: new Map(),
+      };
+      this.runtimes.set(input.addonId, runtime);
+    });
+
+    getParkingRoot().appendChild(iframe);
+    iframe.src = sandboxUrl;
+
+    return loadPromise.finally(() => {
+      const runtime = this.runtimes.get(input.addonId);
+      if (runtime) {
+        clearTimeout(runtime.loadTimer);
+      }
+    });
+  }
+
+  attachRoute(addonId: string, container: HTMLElement) {
+    const runtime = this.runtimes.get(addonId);
+    if (!runtime) {
+      throw new Error(`Addon '${addonId}' is not loaded`);
+    }
+
+    runtime.activeContainer = container;
+    if (runtime.iframe.parentElement !== container) {
+      container.appendChild(runtime.iframe);
+    }
+    runtime.iframe.style.height = "100%";
+    runtime.iframe.style.minHeight = "calc(100vh - 96px)";
+    runtime.iframe.style.width = "100%";
+    this.renderActiveRoute(runtime);
+  }
+
+  updateRoute(addonId: string, routeId: string, location: AddonRouteLocation) {
+    const runtime = this.runtimes.get(addonId);
+    if (!runtime) {
+      throw new Error(`Addon '${addonId}' is not loaded`);
+    }
+
+    runtime.activeRoute = { routeId, location };
+    this.renderActiveRoute(runtime);
+  }
+
+  detachRoute(addonId: string, container?: HTMLElement) {
+    const runtime = this.runtimes.get(addonId);
+    if (!runtime) {
+      return;
+    }
+    if (container && runtime.activeContainer !== container) {
+      return;
+    }
+
+    runtime.activeContainer = undefined;
+    runtime.activeRoute = undefined;
+    getParkingRoot().appendChild(runtime.iframe);
+  }
+
+  async stopAddon(addonId: string) {
+    const runtime = this.runtimes.get(addonId);
+    if (!runtime) {
+      clearAddonRegistrations(addonId);
+      return;
+    }
+
+    this.post(runtime, "disable");
+    clearTimeout(runtime.loadTimer);
+    if (runtime.routeRenderTimer) {
+      clearTimeout(runtime.routeRenderTimer);
+    }
+    runtime.rejectLoad(new Error(`Addon '${addonId}' was unloaded before it finished loading`));
+    for (const unsubscribe of runtime.subscriptions.values()) {
+      try {
+        await unsubscribe();
+      } catch (error) {
+        logger.warn(`Failed to remove addon event subscription: ${String(error)}`);
+      }
+    }
+    runtime.subscriptions.clear();
+    runtime.iframe.remove();
+    this.runtimes.delete(addonId);
+    clearAddonRegistrations(addonId);
+  }
+
+  private ensureListener() {
+    if (this.listening) {
+      return;
+    }
+    window.addEventListener("message", this.handleMessage);
+    this.listening = true;
+  }
+
+  private handleMessage = (event: MessageEvent) => {
+    const message = event.data as SandboxMessage;
+    if (message?.channel !== CHANNEL || !message.addonId || !message.nonce) {
+      return;
+    }
+
+    const runtime = this.runtimes.get(message.addonId);
+    if (runtime?.nonce !== message.nonce) {
+      return;
+    }
+
+    void this.dispatchMessage(runtime, message);
+  };
+
+  private async dispatchMessage(runtime: Runtime, message: SandboxMessage) {
+    try {
+      switch (message.type) {
+        case "ready":
+          runtime.isLoaded = false;
+          this.post(runtime, "loadAddon", {
+            code: runtime.code,
+            files: runtime.files,
+          });
+          break;
+        case "loaded":
+          runtime.isLoaded = true;
+          runtime.resolveLoad({
+            disable: () => this.stopAddon(runtime.addonId),
+          });
+          this.renderActiveRoute(runtime);
+          break;
+        case "loadError": {
+          const error = new Error(message.error || `Failed to load addon '${runtime.addonId}'`);
+          runtime.rejectLoad(error);
+          await this.stopAddon(runtime.addonId);
+          break;
+        }
+        case "runtimeError":
+          logger.error(`Addon '${runtime.addonId}' runtime error: ${message.error || "unknown"}`);
+          break;
+        case "api":
+          await this.handleApiCall(runtime, message);
+          break;
+        case "eventSubscribe":
+          await this.handleEventSubscribe(runtime, message);
+          break;
+        case "eventUnsubscribe":
+          await this.handleEventUnsubscribe(runtime, message);
+          break;
+        case "sidebar.addItem":
+          this.handleSidebarAdd(runtime, message);
+          break;
+        case "sidebar.removeItem":
+          this.handleSidebarRemove(runtime, message);
+          break;
+        case "router.add":
+          this.handleRouterAdd(runtime, message);
+          break;
+        case "router.remove":
+          this.handleRouterRemove(runtime, message);
+          break;
+        default:
+          break;
+      }
+    } catch (error) {
+      if (message.requestId) {
+        this.respond(runtime, message.requestId, false, undefined, error);
+      } else {
+        logger.error(`Addon '${runtime.addonId}' message failed: ${String(error)}`);
+      }
+    }
+  }
+
+  private async handleApiCall(runtime: Runtime, message: SandboxMessage) {
+    if (!message.requestId || !message.method) {
+      return;
+    }
+    const method = getMethod(runtime.api, message.method);
+    const result = await method(...(message.args ?? []));
+    this.respond(runtime, message.requestId, true, result);
+  }
+
+  private async handleEventSubscribe(runtime: Runtime, message: SandboxMessage) {
+    if (!message.requestId || !message.method) {
+      return;
+    }
+
+    const method = getMethod(runtime.api, message.method);
+    const subscriptionId = makeRequestId();
+    const unlisten = (await method((event: unknown) => {
+      this.post(runtime, "event", { subscriptionId, payload: event });
+    })) as () => Promise<void> | void;
+    runtime.subscriptions.set(subscriptionId, unlisten);
+    this.respond(runtime, message.requestId, true, { subscriptionId });
+  }
+
+  private async handleEventUnsubscribe(runtime: Runtime, message: SandboxMessage) {
+    if (!message.requestId || !message.subscriptionId) {
+      return;
+    }
+    const unlisten = runtime.subscriptions.get(message.subscriptionId);
+    if (unlisten) {
+      await unlisten();
+      runtime.subscriptions.delete(message.subscriptionId);
+    }
+    this.respond(runtime, message.requestId, true, undefined);
+  }
+
+  private handleSidebarAdd(runtime: Runtime, message: SandboxMessage) {
+    if (!message.requestId || !message.item) {
+      return;
+    }
+    runtime.permissionGuard.assertCanUse("ui", "sidebar.addItem");
+    registerAddonNavItem(runtime.addonId, message.item);
+    this.respond(runtime, message.requestId, true, undefined);
+  }
+
+  private handleSidebarRemove(runtime: Runtime, message: SandboxMessage) {
+    if (!message.requestId || !message.itemId) {
+      return;
+    }
+    removeAddonNavItem(runtime.addonId, message.itemId);
+    this.respond(runtime, message.requestId, true, undefined);
+  }
+
+  private handleRouterAdd(runtime: Runtime, message: SandboxMessage) {
+    if (!message.requestId || !message.route?.path || !message.route.routeId) {
+      return;
+    }
+    runtime.permissionGuard.assertCanUse("ui", "router.add");
+    registerAddonRoute(runtime.addonId, {
+      path: message.route.path,
+      routeId: message.route.routeId,
+      title: message.route.title,
+    });
+    this.respond(runtime, message.requestId, true, undefined);
+  }
+
+  private handleRouterRemove(runtime: Runtime, message: SandboxMessage) {
+    if (!message.requestId || !message.routeId) {
+      return;
+    }
+    removeAddonRoute(runtime.addonId, message.routeId);
+    this.respond(runtime, message.requestId, true, undefined);
+  }
+
+  private respond(
+    runtime: Runtime,
+    requestId: string,
+    ok: boolean,
+    result?: unknown,
+    error?: unknown,
+  ) {
+    this.post(runtime, "rpcResponse", {
+      error: formatUnknownError(error),
+      ok,
+      requestId,
+      result,
+    });
+  }
+
+  private post(runtime: Runtime, type: string, payload: Record<string, unknown> = {}) {
+    runtime.iframe.contentWindow?.postMessage(
+      {
+        addonId: runtime.addonId,
+        channel: CHANNEL,
+        nonce: runtime.nonce,
+        type,
+        ...payload,
+      },
+      "*",
+    );
+  }
+
+  private renderActiveRoute(runtime: Runtime) {
+    if (!runtime.isLoaded || !runtime.activeContainer || !runtime.activeRoute) {
+      return;
+    }
+
+    if (runtime.routeRenderTimer) {
+      clearTimeout(runtime.routeRenderTimer);
+    }
+
+    runtime.routeRenderTimer = window.setTimeout(() => {
+      if (!runtime.isLoaded || !runtime.activeContainer || !runtime.activeRoute) {
+        return;
+      }
+      this.post(runtime, "renderRoute", runtime.activeRoute);
+    }, 0);
+  }
+}
+
+export const addonIframeManager = new AddonIframeManager();

--- a/apps/frontend/src/addons/iframe/addon-iframe-manager.ts
+++ b/apps/frontend/src/addons/iframe/addon-iframe-manager.ts
@@ -9,10 +9,12 @@ import {
   removeAddonRoute,
 } from "@/addons/addons-runtime-context";
 import { logger } from "@/adapters";
+import { collectAddonThemeSnapshot, type AddonThemeSnapshot } from "./addon-sandbox-theme";
 import { createPermissionGuard, type PermissionGuard } from "../type-bridge";
 
 const CHANNEL = "wealthfolio:addon-sandbox:v1";
 const LOAD_TIMEOUT_MS = 10_000;
+const ROUTE_RENDER_TIMEOUT_MS = 10_000;
 
 interface StartAddonInput {
   addonId: string;
@@ -28,6 +30,14 @@ export interface AddonRouteLocation {
   hash: string;
   params: Record<string, string | undefined>;
 }
+
+export type AddonRouteRenderStatus =
+  | { status: "idle"; routeKey?: string }
+  | { status: "rendering"; cold: boolean; routeKey: string }
+  | { status: "rendered"; routeKey: string }
+  | { status: "error"; error: string; routeKey?: string };
+
+type AddonRouteStatusListener = (status: AddonRouteRenderStatus) => void;
 
 export interface AddonRuntimeHandle {
   disable(): Promise<void>;
@@ -46,8 +56,12 @@ interface Runtime {
     routeId: string;
   };
   isLoaded: boolean;
+  lastRenderedRouteKey?: string;
   permissionGuard: PermissionGuard;
+  activeRouteRequestId?: string;
   routeRenderTimer?: number;
+  routeRenderTimeout?: number;
+  routeStatusListeners: Set<AddonRouteStatusListener>;
   subscriptions: Map<string, () => Promise<void> | void>;
   resolveLoad: (handle: AddonRuntimeHandle) => void;
   rejectLoad: (error: Error) => void;
@@ -78,13 +92,24 @@ function createNonce() {
   return crypto.randomUUID?.() ?? `${Date.now().toString(36)}-${Math.random().toString(36)}`;
 }
 
-function createSandboxUrl(addonId: string, nonce: string) {
+function createSandboxUrl(addonId: string, nonce: string, theme: AddonThemeSnapshot) {
   const basePath = import.meta.env.BASE_URL || "/";
   const sandboxUrl = new URL(
     `${basePath.replace(/\/?$/, "/")}addon-sandbox.html`,
     window.location.href,
   );
-  sandboxUrl.hash = new URLSearchParams({ addonId, nonce }).toString();
+  const params = new URLSearchParams({
+    addonId,
+    backgroundColor: theme.backgroundColor,
+    colorScheme: theme.colorScheme,
+    foregroundColor: theme.foregroundColor,
+    nonce,
+    themeClass: theme.themeClass,
+  });
+  if (theme.fontClass) {
+    params.set("fontClass", theme.fontClass);
+  }
+  sandboxUrl.hash = params.toString();
   return sandboxUrl.toString();
 }
 
@@ -112,6 +137,25 @@ function formatUnknownError(error: unknown) {
     return undefined;
   }
   return JSON.stringify(error) ?? "Unknown error";
+}
+
+function createRouteRenderKey(routeId: string, location: AddonRouteLocation) {
+  const params = Object.entries(location.params)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value ?? "")}`)
+    .join("&");
+  return [routeId, location.pathname, location.search, location.hash, params].join("\n");
+}
+
+function clearPendingRouteRender(runtime: Runtime) {
+  if (runtime.routeRenderTimer) {
+    clearTimeout(runtime.routeRenderTimer);
+    runtime.routeRenderTimer = undefined;
+  }
+  if (runtime.routeRenderTimeout) {
+    clearTimeout(runtime.routeRenderTimeout);
+    runtime.routeRenderTimeout = undefined;
+  }
 }
 
 function getParkingRoot() {
@@ -255,13 +299,17 @@ function getMethod(target: unknown, methodPath: string, allowedMethods: Set<stri
 export class AddonIframeManager {
   private runtimes = new Map<string, Runtime>();
   private listening = false;
+  private themeObserver?: MutationObserver;
+  private themeUpdateFrame?: number;
 
   async startAddon(input: StartAddonInput): Promise<AddonRuntimeHandle> {
     await this.stopAddon(input.addonId);
     this.ensureListener();
+    this.ensureThemeObserver();
 
     const nonce = createNonce();
-    const sandboxUrl = createSandboxUrl(input.addonId, nonce);
+    const initialTheme = collectAddonThemeSnapshot();
+    const sandboxUrl = createSandboxUrl(input.addonId, nonce, initialTheme);
 
     const iframe = document.createElement("iframe");
     iframe.title = `${input.manifest.name || input.addonId} add-on sandbox`;
@@ -269,8 +317,11 @@ export class AddonIframeManager {
     iframe.referrerPolicy = "no-referrer";
     Object.assign(iframe.style, {
       border: "0",
+      backgroundColor: "transparent",
+      colorScheme: initialTheme.colorScheme,
       display: "block",
       height: "100%",
+      visibility: "hidden",
       width: "100%",
     });
 
@@ -295,6 +346,7 @@ export class AddonIframeManager {
         permissionGuard: createPermissionGuard(input.addonId, input.permissions),
         rejectLoad: reject,
         resolveLoad: resolve,
+        routeStatusListeners: new Set(),
         subscriptions: new Map(),
       };
       this.runtimes.set(input.addonId, runtime);
@@ -311,6 +363,43 @@ export class AddonIframeManager {
     });
   }
 
+  getRouteStatus(
+    addonId: string,
+    routeId: string,
+    location: AddonRouteLocation,
+  ): AddonRouteRenderStatus {
+    const runtime = this.runtimes.get(addonId);
+    const routeKey = createRouteRenderKey(routeId, location);
+    if (!runtime) {
+      return { error: `Addon '${addonId}' is not loaded`, routeKey, status: "error" };
+    }
+    if (runtime.lastRenderedRouteKey === routeKey) {
+      return { routeKey, status: "rendered" };
+    }
+    if (runtime.activeRouteRequestId) {
+      return { cold: !runtime.lastRenderedRouteKey, routeKey, status: "rendering" };
+    }
+    return { routeKey, status: "idle" };
+  }
+
+  subscribeRouteStatus(addonId: string, listener: AddonRouteStatusListener) {
+    const runtime = this.runtimes.get(addonId);
+    if (!runtime) {
+      return () => undefined;
+    }
+    runtime.routeStatusListeners.add(listener);
+    return () => {
+      runtime.routeStatusListeners.delete(listener);
+    };
+  }
+
+  retryRoute(addonId: string) {
+    const runtime = this.runtimes.get(addonId);
+    if (runtime) {
+      this.renderActiveRoute(runtime);
+    }
+  }
+
   attachRoute(addonId: string, container: HTMLElement) {
     const runtime = this.runtimes.get(addonId);
     if (!runtime) {
@@ -318,13 +407,13 @@ export class AddonIframeManager {
     }
 
     runtime.activeContainer = container;
+    runtime.iframe.style.visibility = runtime.lastRenderedRouteKey ? "visible" : "hidden";
     if (runtime.iframe.parentElement !== container) {
       container.appendChild(runtime.iframe);
     }
     runtime.iframe.style.height = "100%";
     runtime.iframe.style.minHeight = "calc(100vh - 96px)";
     runtime.iframe.style.width = "100%";
-    this.renderActiveRoute(runtime);
   }
 
   updateRoute(addonId: string, routeId: string, location: AddonRouteLocation) {
@@ -347,7 +436,8 @@ export class AddonIframeManager {
     }
 
     runtime.activeContainer = undefined;
-    runtime.activeRoute = undefined;
+    runtime.activeRouteRequestId = undefined;
+    clearPendingRouteRender(runtime);
     getParkingRoot().appendChild(runtime.iframe);
   }
 
@@ -360,9 +450,8 @@ export class AddonIframeManager {
 
     this.post(runtime, "disable");
     clearTimeout(runtime.loadTimer);
-    if (runtime.routeRenderTimer) {
-      clearTimeout(runtime.routeRenderTimer);
-    }
+    runtime.activeRouteRequestId = undefined;
+    clearPendingRouteRender(runtime);
     runtime.rejectLoad(new Error(`Addon '${addonId}' was unloaded before it finished loading`));
     for (const unsubscribe of runtime.subscriptions.values()) {
       try {
@@ -375,6 +464,7 @@ export class AddonIframeManager {
     runtime.iframe.remove();
     this.runtimes.delete(addonId);
     clearAddonRegistrations(addonId);
+    this.stopThemeObserverIfIdle();
   }
 
   private ensureListener() {
@@ -410,6 +500,7 @@ export class AddonIframeManager {
           this.post(runtime, "loadAddon", {
             code: runtime.code,
             files: runtime.files,
+            theme: collectAddonThemeSnapshot(),
           });
           break;
         case "loaded":
@@ -427,6 +518,12 @@ export class AddonIframeManager {
         }
         case "runtimeError":
           logger.error(`Addon '${runtime.addonId}' runtime error: ${message.error || "unknown"}`);
+          break;
+        case "routeRendered":
+          this.handleRouteRendered(runtime, message);
+          break;
+        case "routeRenderError":
+          this.handleRouteRenderError(runtime, message);
           break;
         case "api":
           await this.handleApiCall(runtime, message);
@@ -534,6 +631,45 @@ export class AddonIframeManager {
     this.respond(runtime, message.requestId, true, undefined);
   }
 
+  private handleRouteRendered(runtime: Runtime, message: SandboxMessage) {
+    if (!message.requestId || message.requestId !== runtime.activeRouteRequestId) {
+      return;
+    }
+
+    const route = runtime.activeRoute;
+    const routeKey = route ? createRouteRenderKey(route.routeId, route.location) : undefined;
+    runtime.activeRouteRequestId = undefined;
+    clearPendingRouteRender(runtime);
+    if (routeKey) {
+      runtime.lastRenderedRouteKey = routeKey;
+      runtime.iframe.style.visibility = "visible";
+      this.emitRouteStatus(runtime, { routeKey, status: "rendered" });
+    }
+  }
+
+  private handleRouteRenderError(runtime: Runtime, message: SandboxMessage) {
+    if (!message.requestId || message.requestId !== runtime.activeRouteRequestId) {
+      return;
+    }
+
+    const route = runtime.activeRoute;
+    const routeKey = route ? createRouteRenderKey(route.routeId, route.location) : undefined;
+    runtime.activeRouteRequestId = undefined;
+    clearPendingRouteRender(runtime);
+    runtime.iframe.style.visibility = runtime.lastRenderedRouteKey ? "visible" : "hidden";
+    this.emitRouteStatus(runtime, {
+      error: message.error || `Failed to render add-on route '${route?.routeId ?? "unknown"}'`,
+      routeKey,
+      status: "error",
+    });
+  }
+
+  private emitRouteStatus(runtime: Runtime, status: AddonRouteRenderStatus) {
+    for (const listener of runtime.routeStatusListeners) {
+      listener(status);
+    }
+  }
+
   private respond(
     runtime: Runtime,
     requestId: string,
@@ -562,21 +698,97 @@ export class AddonIframeManager {
     );
   }
 
+  private ensureThemeObserver() {
+    if (this.themeObserver) {
+      return;
+    }
+
+    this.themeObserver = new MutationObserver(this.scheduleThemeBroadcast);
+    this.themeObserver.observe(document.documentElement, {
+      attributeFilter: ["class", "style"],
+      attributes: true,
+    });
+    this.themeObserver.observe(document.body, {
+      attributeFilter: ["class"],
+      attributes: true,
+    });
+  }
+
+  private stopThemeObserverIfIdle() {
+    if (this.runtimes.size > 0) {
+      return;
+    }
+
+    this.themeObserver?.disconnect();
+    this.themeObserver = undefined;
+    if (this.themeUpdateFrame) {
+      cancelAnimationFrame(this.themeUpdateFrame);
+      this.themeUpdateFrame = undefined;
+    }
+  }
+
+  private scheduleThemeBroadcast = () => {
+    if (this.themeUpdateFrame) {
+      return;
+    }
+
+    this.themeUpdateFrame = requestAnimationFrame(() => {
+      this.themeUpdateFrame = undefined;
+      this.broadcastTheme();
+    });
+  };
+
+  private broadcastTheme() {
+    const theme = collectAddonThemeSnapshot();
+    for (const runtime of this.runtimes.values()) {
+      this.post(runtime, "themeUpdate", { theme });
+    }
+  }
+
   private renderActiveRoute(runtime: Runtime) {
     if (!runtime.isLoaded || !runtime.activeContainer || !runtime.activeRoute) {
       return;
     }
 
-    if (runtime.routeRenderTimer) {
-      clearTimeout(runtime.routeRenderTimer);
-    }
+    const route = runtime.activeRoute;
+    const routeKey = createRouteRenderKey(route.routeId, route.location);
+    const requestId = makeRequestId();
+
+    clearPendingRouteRender(runtime);
+    runtime.activeRouteRequestId = requestId;
+    const hasRenderedContent = Boolean(runtime.lastRenderedRouteKey);
+    runtime.iframe.style.visibility = hasRenderedContent ? "visible" : "hidden";
+    this.emitRouteStatus(runtime, {
+      cold: !hasRenderedContent,
+      routeKey,
+      status: "rendering",
+    });
 
     runtime.routeRenderTimer = window.setTimeout(() => {
-      if (!runtime.isLoaded || !runtime.activeContainer || !runtime.activeRoute) {
+      if (
+        !runtime.isLoaded ||
+        !runtime.activeContainer ||
+        runtime.activeRoute !== route ||
+        runtime.activeRouteRequestId !== requestId
+      ) {
         return;
       }
-      this.post(runtime, "renderRoute", runtime.activeRoute);
+      this.post(runtime, "renderRoute", { ...route, requestId });
     }, 0);
+
+    runtime.routeRenderTimeout = window.setTimeout(() => {
+      if (runtime.activeRouteRequestId !== requestId) {
+        return;
+      }
+      runtime.activeRouteRequestId = undefined;
+      clearPendingRouteRender(runtime);
+      runtime.iframe.style.visibility = runtime.lastRenderedRouteKey ? "visible" : "hidden";
+      this.emitRouteStatus(runtime, {
+        error: `Timed out rendering add-on route '${route.routeId}'`,
+        routeKey,
+        status: "error",
+      });
+    }, ROUTE_RENDER_TIMEOUT_MS);
   }
 }
 

--- a/apps/frontend/src/addons/iframe/addon-iframe-manager.ts
+++ b/apps/frontend/src/addons/iframe/addon-iframe-manager.ts
@@ -15,6 +15,7 @@ import { createPermissionGuard, type PermissionGuard } from "../type-bridge";
 const CHANNEL = "wealthfolio:addon-sandbox:v1";
 const LOAD_TIMEOUT_MS = 10_000;
 const ROUTE_RENDER_TIMEOUT_MS = 10_000;
+const DISABLE_TIMEOUT_MS = 1_000;
 
 interface StartAddonInput {
   addonId: string;
@@ -63,6 +64,7 @@ interface Runtime {
   routeRenderTimeout?: number;
   routeStatusListeners: Set<AddonRouteStatusListener>;
   subscriptions: Map<string, () => Promise<void> | void>;
+  disableAck?: () => void;
   resolveLoad: (handle: AddonRuntimeHandle) => void;
   rejectLoad: (error: Error) => void;
   loadTimer: number;
@@ -163,12 +165,11 @@ function getParkingRoot() {
   if (!root) {
     root = document.createElement("div");
     root.id = "addon-sandbox-parking";
-    root.setAttribute("aria-hidden", "true");
     Object.assign(root.style, {
-      height: "0",
-      overflow: "hidden",
-      position: "absolute",
-      width: "0",
+      inset: "0",
+      overflow: "visible",
+      pointerEvents: "none",
+      position: "fixed",
     });
     document.body.appendChild(root);
   }
@@ -299,6 +300,8 @@ function getMethod(target: unknown, methodPath: string, allowedMethods: Set<stri
 export class AddonIframeManager {
   private runtimes = new Map<string, Runtime>();
   private listening = false;
+  private frameLayoutUpdateFrame?: number;
+  private layoutListening = false;
   private themeObserver?: MutationObserver;
   private themeUpdateFrame?: number;
 
@@ -320,9 +323,13 @@ export class AddonIframeManager {
       backgroundColor: "transparent",
       colorScheme: initialTheme.colorScheme,
       display: "block",
-      height: "100%",
+      height: "0",
+      left: "0",
+      pointerEvents: "none",
+      position: "fixed",
+      top: "0",
       visibility: "hidden",
-      width: "100%",
+      width: "0",
     });
 
     const credentiallessFrame = iframe as HTMLIFrameElement & { credentialless?: boolean };
@@ -408,12 +415,8 @@ export class AddonIframeManager {
 
     runtime.activeContainer = container;
     runtime.iframe.style.visibility = runtime.lastRenderedRouteKey ? "visible" : "hidden";
-    if (runtime.iframe.parentElement !== container) {
-      container.appendChild(runtime.iframe);
-    }
-    runtime.iframe.style.height = "100%";
-    runtime.iframe.style.minHeight = "calc(100vh - 96px)";
-    runtime.iframe.style.width = "100%";
+    this.ensureLayoutListener();
+    this.updateFrameBounds(runtime);
   }
 
   updateRoute(addonId: string, routeId: string, location: AddonRouteLocation) {
@@ -438,7 +441,8 @@ export class AddonIframeManager {
     runtime.activeContainer = undefined;
     runtime.activeRouteRequestId = undefined;
     clearPendingRouteRender(runtime);
-    getParkingRoot().appendChild(runtime.iframe);
+    this.hideFrame(runtime);
+    this.stopLayoutListenerIfIdle();
   }
 
   async stopAddon(addonId: string) {
@@ -448,11 +452,45 @@ export class AddonIframeManager {
       return;
     }
 
-    this.post(runtime, "disable");
     clearTimeout(runtime.loadTimer);
     runtime.activeRouteRequestId = undefined;
     clearPendingRouteRender(runtime);
     runtime.rejectLoad(new Error(`Addon '${addonId}' was unloaded before it finished loading`));
+
+    const disabled = runtime.isLoaded ? this.waitForDisable(runtime) : Promise.resolve(true);
+    this.post(runtime, "disable");
+    if (!(await disabled)) {
+      logger.warn(`Timed out waiting for addon '${addonId}' to disable`);
+    }
+
+    await this.clearSubscriptions(runtime);
+    this.hideFrame(runtime);
+    runtime.iframe.remove();
+    this.runtimes.delete(addonId);
+    clearAddonRegistrations(addonId);
+    this.stopLayoutListenerIfIdle();
+    this.stopThemeObserverIfIdle();
+  }
+
+  private waitForDisable(runtime: Runtime) {
+    return new Promise<boolean>((resolve) => {
+      let ack: () => void = () => undefined;
+      const timer = window.setTimeout(() => {
+        if (runtime.disableAck === ack) {
+          runtime.disableAck = undefined;
+        }
+        resolve(false);
+      }, DISABLE_TIMEOUT_MS);
+
+      ack = () => {
+        clearTimeout(timer);
+        resolve(true);
+      };
+      runtime.disableAck = ack;
+    });
+  }
+
+  private async clearSubscriptions(runtime: Runtime) {
     for (const unsubscribe of runtime.subscriptions.values()) {
       try {
         await unsubscribe();
@@ -461,10 +499,89 @@ export class AddonIframeManager {
       }
     }
     runtime.subscriptions.clear();
-    runtime.iframe.remove();
-    this.runtimes.delete(addonId);
-    clearAddonRegistrations(addonId);
-    this.stopThemeObserverIfIdle();
+  }
+
+  private async resetRuntimeForReload(runtime: Runtime) {
+    runtime.isLoaded = false;
+    runtime.lastRenderedRouteKey = undefined;
+    runtime.activeRouteRequestId = undefined;
+    clearPendingRouteRender(runtime);
+    runtime.iframe.style.visibility = "hidden";
+    await this.clearSubscriptions(runtime);
+    clearAddonRegistrations(runtime.addonId);
+  }
+
+  private ensureLayoutListener() {
+    if (this.layoutListening) {
+      return;
+    }
+    window.addEventListener("resize", this.scheduleFrameLayoutUpdate);
+    window.addEventListener("scroll", this.scheduleFrameLayoutUpdate, true);
+    this.layoutListening = true;
+  }
+
+  private stopLayoutListenerIfIdle() {
+    if (Array.from(this.runtimes.values()).some((runtime) => runtime.activeContainer)) {
+      return;
+    }
+    if (!this.layoutListening) {
+      return;
+    }
+    window.removeEventListener("resize", this.scheduleFrameLayoutUpdate);
+    window.removeEventListener("scroll", this.scheduleFrameLayoutUpdate, true);
+    this.layoutListening = false;
+    if (this.frameLayoutUpdateFrame) {
+      cancelAnimationFrame(this.frameLayoutUpdateFrame);
+      this.frameLayoutUpdateFrame = undefined;
+    }
+  }
+
+  private scheduleFrameLayoutUpdate = () => {
+    if (this.frameLayoutUpdateFrame) {
+      return;
+    }
+
+    this.frameLayoutUpdateFrame = requestAnimationFrame(() => {
+      this.frameLayoutUpdateFrame = undefined;
+      for (const runtime of this.runtimes.values()) {
+        if (runtime.activeContainer) {
+          this.updateFrameBounds(runtime);
+        }
+      }
+    });
+  };
+
+  private hideFrame(runtime: Runtime) {
+    Object.assign(runtime.iframe.style, {
+      height: "0",
+      left: "0",
+      minHeight: "0",
+      pointerEvents: "none",
+      top: "0",
+      visibility: "hidden",
+      width: "0",
+    });
+  }
+
+  private updateFrameBounds(runtime: Runtime) {
+    const container = runtime.activeContainer;
+    if (!container?.isConnected) {
+      this.hideFrame(runtime);
+      return;
+    }
+
+    const rect = container.getBoundingClientRect();
+    const width = Math.max(rect.width, 0);
+    const height = Math.max(rect.height, 0);
+    Object.assign(runtime.iframe.style, {
+      height: `${height}px`,
+      left: `${rect.left}px`,
+      minHeight: "0",
+      pointerEvents:
+        runtime.iframe.style.visibility === "visible" && width > 0 && height > 0 ? "auto" : "none",
+      top: `${rect.top}px`,
+      width: `${width}px`,
+    });
   }
 
   private ensureListener() {
@@ -496,7 +613,7 @@ export class AddonIframeManager {
     try {
       switch (message.type) {
         case "ready":
-          runtime.isLoaded = false;
+          await this.resetRuntimeForReload(runtime);
           this.post(runtime, "loadAddon", {
             code: runtime.code,
             files: runtime.files,
@@ -518,6 +635,10 @@ export class AddonIframeManager {
         }
         case "runtimeError":
           logger.error(`Addon '${runtime.addonId}' runtime error: ${message.error || "unknown"}`);
+          break;
+        case "disabled":
+          runtime.disableAck?.();
+          runtime.disableAck = undefined;
           break;
         case "routeRendered":
           this.handleRouteRendered(runtime, message);
@@ -643,6 +764,7 @@ export class AddonIframeManager {
     if (routeKey) {
       runtime.lastRenderedRouteKey = routeKey;
       runtime.iframe.style.visibility = "visible";
+      this.updateFrameBounds(runtime);
       this.emitRouteStatus(runtime, { routeKey, status: "rendered" });
     }
   }
@@ -758,6 +880,7 @@ export class AddonIframeManager {
     runtime.activeRouteRequestId = requestId;
     const hasRenderedContent = Boolean(runtime.lastRenderedRouteKey);
     runtime.iframe.style.visibility = hasRenderedContent ? "visible" : "hidden";
+    this.updateFrameBounds(runtime);
     this.emitRouteStatus(runtime, {
       cold: !hasRenderedContent,
       routeKey,
@@ -783,6 +906,7 @@ export class AddonIframeManager {
       runtime.activeRouteRequestId = undefined;
       clearPendingRouteRender(runtime);
       runtime.iframe.style.visibility = runtime.lastRenderedRouteKey ? "visible" : "hidden";
+      this.updateFrameBounds(runtime);
       this.emitRouteStatus(runtime, {
         error: `Timed out rendering add-on route '${route.routeId}'`,
         routeKey,

--- a/apps/frontend/src/addons/iframe/addon-iframe-manager.ts
+++ b/apps/frontend/src/addons/iframe/addon-iframe-manager.ts
@@ -131,15 +131,114 @@ function getParkingRoot() {
   return root;
 }
 
+const ALLOWED_API_METHODS = new Set([
+  "accounts.getAll",
+  "accounts.create",
+  "portfolio.getHoldings",
+  "portfolio.getHolding",
+  "portfolio.update",
+  "portfolio.recalculate",
+  "portfolio.getIncomeSummary",
+  "portfolio.getHistoricalValuations",
+  "portfolio.getLatestValuations",
+  "activities.getAll",
+  "activities.search",
+  "activities.create",
+  "activities.update",
+  "activities.saveMany",
+  "activities.import",
+  "activities.checkImport",
+  "activities.getImportMapping",
+  "activities.saveImportMapping",
+  "market.searchTicker",
+  "market.syncHistory",
+  "market.sync",
+  "market.getProviders",
+  "market.fetchDividends",
+  "assets.getProfile",
+  "assets.updateProfile",
+  "assets.updateQuoteMode",
+  "quotes.update",
+  "quotes.getHistory",
+  "performance.calculateHistory",
+  "performance.calculateSummary",
+  "performance.calculateAccountsSimple",
+  "exchangeRates.getAll",
+  "exchangeRates.update",
+  "exchangeRates.add",
+  "contributionLimits.getAll",
+  "contributionLimits.create",
+  "contributionLimits.update",
+  "contributionLimits.calculateDeposits",
+  "goals.getAll",
+  "goals.create",
+  "goals.update",
+  "goals.getFunding",
+  "goals.saveFunding",
+  "goals.getAllocations",
+  "goals.updateAllocations",
+  "settings.get",
+  "settings.update",
+  "settings.backupDatabase",
+  "files.openCsvDialog",
+  "files.openSaveDialog",
+  "snapshots.getAll",
+  "snapshots.getByDate",
+  "snapshots.save",
+  "snapshots.checkImport",
+  "snapshots.importSnapshots",
+  "snapshots.delete",
+  "navigation.navigate",
+  "query.invalidateQueries",
+  "query.refetchQueries",
+  "network.request",
+  "secrets.set",
+  "secrets.get",
+  "secrets.delete",
+  "toast.success",
+  "toast.error",
+  "toast.warning",
+  "toast.info",
+  "logger.error",
+  "logger.info",
+  "logger.warn",
+  "logger.trace",
+  "logger.debug",
+]);
+
+const ALLOWED_EVENT_METHODS = new Set([
+  "events.import.onDropHover",
+  "events.import.onDrop",
+  "events.import.onDropCancelled",
+  "events.portfolio.onUpdateStart",
+  "events.portfolio.onUpdateComplete",
+  "events.portfolio.onUpdateError",
+  "events.market.onSyncStart",
+  "events.market.onSyncComplete",
+]);
+
+const FORBIDDEN_METHOD_PARTS = new Set(["__proto__", "constructor", "prototype"]);
+
 function getProperty(target: unknown, key: string): unknown {
   if (typeof target !== "object" || target === null) {
+    return undefined;
+  }
+  if (!Object.prototype.hasOwnProperty.call(target, key)) {
     return undefined;
   }
   return (target as Record<string, unknown>)[key];
 }
 
-function getMethod(target: unknown, methodPath: string) {
+function getMethod(target: unknown, methodPath: string, allowedMethods: Set<string>) {
+  if (!allowedMethods.has(methodPath)) {
+    throw new Error(`Unknown addon host API method '${methodPath}'`);
+  }
+
   const parts = methodPath.split(".").filter(Boolean);
+  if (parts.length === 0 || parts.some((part) => FORBIDDEN_METHOD_PARTS.has(part))) {
+    throw new Error(`Unknown addon host API method '${methodPath}'`);
+  }
+
   let current = target;
 
   for (const part of parts) {
@@ -296,6 +395,9 @@ export class AddonIframeManager {
     if (runtime?.nonce !== message.nonce) {
       return;
     }
+    if (event.source !== runtime.iframe.contentWindow) {
+      return;
+    }
 
     void this.dispatchMessage(runtime, message);
   };
@@ -363,7 +465,7 @@ export class AddonIframeManager {
     if (!message.requestId || !message.method) {
       return;
     }
-    const method = getMethod(runtime.api, message.method);
+    const method = getMethod(runtime.api, message.method, ALLOWED_API_METHODS);
     const result = await method(...(message.args ?? []));
     this.respond(runtime, message.requestId, true, result);
   }
@@ -373,7 +475,7 @@ export class AddonIframeManager {
       return;
     }
 
-    const method = getMethod(runtime.api, message.method);
+    const method = getMethod(runtime.api, message.method, ALLOWED_EVENT_METHODS);
     const subscriptionId = makeRequestId();
     const unlisten = (await method((event: unknown) => {
       this.post(runtime, "event", { subscriptionId, payload: event });

--- a/apps/frontend/src/addons/iframe/addon-iframe-manager.ts
+++ b/apps/frontend/src/addons/iframe/addon-iframe-manager.ts
@@ -65,6 +65,7 @@ interface Runtime {
   routeStatusListeners: Set<AddonRouteStatusListener>;
   subscriptions: Map<string, () => Promise<void> | void>;
   disableAck?: () => void;
+  stopPromise?: Promise<void>;
   resolveLoad: (handle: AddonRuntimeHandle) => void;
   rejectLoad: (error: Error) => void;
   loadTimer: number;
@@ -451,23 +452,29 @@ export class AddonIframeManager {
       clearAddonRegistrations(addonId);
       return;
     }
+    runtime.stopPromise ??= this.stopRuntime(runtime);
+    await runtime.stopPromise;
+  }
 
+  private async stopRuntime(runtime: Runtime) {
     clearTimeout(runtime.loadTimer);
     runtime.activeRouteRequestId = undefined;
     clearPendingRouteRender(runtime);
-    runtime.rejectLoad(new Error(`Addon '${addonId}' was unloaded before it finished loading`));
+    runtime.rejectLoad(
+      new Error(`Addon '${runtime.addonId}' was unloaded before it finished loading`),
+    );
 
     const disabled = runtime.isLoaded ? this.waitForDisable(runtime) : Promise.resolve(true);
     this.post(runtime, "disable");
     if (!(await disabled)) {
-      logger.warn(`Timed out waiting for addon '${addonId}' to disable`);
+      logger.warn(`Timed out waiting for addon '${runtime.addonId}' to disable`);
     }
 
     await this.clearSubscriptions(runtime);
     this.hideFrame(runtime);
     runtime.iframe.remove();
-    this.runtimes.delete(addonId);
-    clearAddonRegistrations(addonId);
+    this.runtimes.delete(runtime.addonId);
+    clearAddonRegistrations(runtime.addonId);
     this.stopLayoutListenerIfIdle();
     this.stopThemeObserverIfIdle();
   }
@@ -671,10 +678,11 @@ export class AddonIframeManager {
           break;
       }
     } catch (error) {
+      logger.error(
+        `Addon '${runtime.addonId}' message '${message.type ?? "unknown"}' failed: ${String(error)}`,
+      );
       if (message.requestId) {
         this.respond(runtime, message.requestId, false, undefined, error);
-      } else {
-        logger.error(`Addon '${runtime.addonId}' message failed: ${String(error)}`);
       }
     }
   }

--- a/apps/frontend/src/addons/iframe/addon-iframe-route.tsx
+++ b/apps/frontend/src/addons/iframe/addon-iframe-route.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useRef } from "react";
+import { useLocation, useParams } from "react-router-dom";
+import { addonIframeManager } from "./addon-iframe-manager";
+
+interface AddonIframeRouteProps {
+  addonId: string;
+  routeId: string;
+}
+
+export function AddonIframeRoute({ addonId, routeId }: AddonIframeRouteProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const location = useLocation();
+  const params = useParams();
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return undefined;
+    }
+
+    addonIframeManager.attachRoute(addonId, container);
+
+    return () => {
+      addonIframeManager.detachRoute(addonId, container);
+    };
+  }, [addonId]);
+
+  useEffect(() => {
+    addonIframeManager.updateRoute(addonId, routeId, {
+      hash: location.hash,
+      params,
+      pathname: location.pathname,
+      search: location.search,
+    });
+  }, [addonId, routeId, location.hash, location.pathname, location.search, params]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="min-h-[calc(100vh-96px)] w-full overflow-hidden"
+      data-addon-id={addonId}
+      data-addon-route-id={routeId}
+    />
+  );
+}

--- a/apps/frontend/src/addons/iframe/addon-iframe-route.tsx
+++ b/apps/frontend/src/addons/iframe/addon-iframe-route.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef } from "react";
+import { useLayoutEffect, useRef, useState } from "react";
 import { useLocation, useParams } from "react-router-dom";
-import { addonIframeManager } from "./addon-iframe-manager";
+import { cn } from "@/lib/utils";
+import { addonIframeManager, type AddonRouteRenderStatus } from "./addon-iframe-manager";
 
 interface AddonIframeRouteProps {
   addonId: string;
@@ -11,35 +12,94 @@ export function AddonIframeRoute({ addonId, routeId }: AddonIframeRouteProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
   const params = useParams();
+  const [routeStatus, setRouteStatus] = useState<AddonRouteRenderStatus>({ status: "idle" });
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const container = containerRef.current;
     if (!container) {
       return undefined;
     }
 
+    const unsubscribe = addonIframeManager.subscribeRouteStatus(addonId, setRouteStatus);
     addonIframeManager.attachRoute(addonId, container);
 
     return () => {
+      unsubscribe();
       addonIframeManager.detachRoute(addonId, container);
     };
   }, [addonId]);
 
-  useEffect(() => {
-    addonIframeManager.updateRoute(addonId, routeId, {
+  useLayoutEffect(() => {
+    const routeLocation = {
       hash: location.hash,
       params,
       pathname: location.pathname,
       search: location.search,
-    });
+    };
+    setRouteStatus(addonIframeManager.getRouteStatus(addonId, routeId, routeLocation));
+    addonIframeManager.updateRoute(addonId, routeId, routeLocation);
   }, [addonId, routeId, location.hash, location.pathname, location.search, params]);
 
+  const isColdLoading = routeStatus.status === "rendering" && routeStatus.cold;
+  const isError = routeStatus.status === "error";
+
+  return (
+    <div className="relative min-h-[calc(100vh-96px)] w-full overflow-hidden">
+      <div
+        ref={containerRef}
+        className={cn(
+          "min-h-[calc(100vh-96px)] w-full overflow-hidden transition-opacity duration-150",
+          isColdLoading && "opacity-0",
+        )}
+        data-addon-id={addonId}
+        data-addon-route-id={routeId}
+      />
+      {isColdLoading ? <AddonRouteSkeleton /> : null}
+      {isError ? (
+        <AddonRouteError
+          error={routeStatus.error}
+          onRetry={() => addonIframeManager.retryRoute(addonId)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+function AddonRouteSkeleton() {
   return (
     <div
-      ref={containerRef}
-      className="min-h-[calc(100vh-96px)] w-full overflow-hidden"
-      data-addon-id={addonId}
-      data-addon-route-id={routeId}
-    />
+      className="bg-background text-foreground absolute inset-0 px-6 py-5"
+      aria-label="Loading add-on"
+      aria-live="polite"
+    >
+      <div className="space-y-6">
+        <div className="bg-muted h-9 w-72 max-w-full animate-pulse rounded-md" />
+        <div className="bg-muted h-5 w-[min(28rem,70%)] animate-pulse rounded-md" />
+        <div className="grid gap-4 md:grid-cols-3">
+          <div className="bg-muted/80 h-28 animate-pulse rounded-md" />
+          <div className="bg-muted/80 h-28 animate-pulse rounded-md" />
+          <div className="bg-muted/80 h-28 animate-pulse rounded-md" />
+        </div>
+        <div className="bg-muted/60 h-64 animate-pulse rounded-md" />
+      </div>
+    </div>
+  );
+}
+
+function AddonRouteError({ error, onRetry }: { error: string; onRetry: () => void }) {
+  return (
+    <div className="bg-background/95 text-foreground absolute inset-0 px-6 py-5">
+      <div className="border-border bg-card max-w-xl rounded-md border p-4 shadow-sm">
+        <h2 className="text-lg font-semibold">Add-on view failed to load</h2>
+        <p className="text-muted-foreground mt-2 text-sm">{error}</p>
+        <button
+          type="button"
+          className="bg-primary text-primary-foreground hover:bg-primary/90 mt-4 rounded-md px-3 py-2 text-sm font-medium"
+          onClick={onRetry}
+        >
+          Retry
+        </button>
+      </div>
+    </div>
   );
 }

--- a/apps/frontend/src/addons/iframe/addon-sandbox-entry.tsx
+++ b/apps/frontend/src/addons/iframe/addon-sandbox-entry.tsx
@@ -4,6 +4,15 @@ import * as React from "react";
 import * as ReactDOMClient from "react-dom/client";
 import { QueryClient } from "@tanstack/react-query";
 import { createHostDependencyModuleUrl, isHostDependencySpecifier } from "./host-dependencies";
+import {
+  clearAddonStyles,
+  createCssModuleSource,
+  installAddonCssFiles,
+  installAddonStyle,
+  isCssFile,
+  type SandboxAddonFile,
+} from "./addon-sandbox-styles";
+import { applyHostTheme, type AddonThemeSnapshot } from "./addon-sandbox-theme";
 
 const CHANNEL = "wealthfolio:addon-sandbox:v1";
 
@@ -22,6 +31,7 @@ interface RouteLocation {
 interface RouteRenderContext {
   root: HTMLElement;
   location: RouteLocation;
+  onRendered?: () => void;
 }
 
 interface LegacyRouteConfig {
@@ -30,12 +40,6 @@ interface LegacyRouteConfig {
   title?: unknown;
   render?: unknown;
   component?: unknown;
-}
-
-interface SandboxAddonFile {
-  name: string;
-  content: string;
-  isMain?: boolean;
 }
 
 interface SandboxMessage {
@@ -53,6 +57,7 @@ interface SandboxMessage {
   error?: string;
   subscriptionId?: string;
   payload?: unknown;
+  theme?: AddonThemeSnapshot;
 }
 
 type RouteRenderer = (context: RouteRenderContext) => Promise<void> | void;
@@ -87,6 +92,12 @@ function callHost(type: string, payload: Record<string, unknown> = {}) {
   return new Promise((resolve, reject) => {
     pending.set(requestId, { resolve, reject });
     post(type, { requestId, ...payload });
+  });
+}
+
+function waitForNextPaint() {
+  return new Promise<void>((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
   });
 }
 
@@ -134,14 +145,20 @@ function getModuleBasename(path: string) {
 
 function createAddonModuleRegistry(code: string, files: SandboxAddonFile[] = []) {
   const sources = new Map<string, { path: string; source: string }>();
+  const cssSources = new Map<string, { path: string; source: string }>();
   const mainFile = files.find((file) => file.isMain) ?? files.find((file) => file.content === code);
   const mainPath = normalizeModulePath(mainFile?.name ?? "addon.js");
 
   for (const file of files) {
-    if (!file.name.endsWith(".js")) {
+    const path = normalizeModulePath(file.name);
+    if (isCssFile(path)) {
+      cssSources.set(path, { path, source: file.content });
+      cssSources.set(getModuleBasename(path), { path, source: file.content });
       continue;
     }
-    const path = normalizeModulePath(file.name);
+    if (!path.endsWith(".js")) {
+      continue;
+    }
     const source = stripSourceMapReferences(file.content);
     sources.set(path, { path, source });
     sources.set(getModuleBasename(path), { path, source });
@@ -157,6 +174,22 @@ function createAddonModuleRegistry(code: string, files: SandboxAddonFile[] = [])
     }
 
     const resolvedPath = resolveModulePath(importerPath, specifier);
+    const cssEntry =
+      cssSources.get(resolvedPath) ?? cssSources.get(getModuleBasename(resolvedPath));
+    if (cssEntry) {
+      const cssUrlKey = `css:${cssSources.has(resolvedPath) ? resolvedPath : getModuleBasename(resolvedPath)}`;
+      let cssModuleUrl = objectUrls.get(cssUrlKey);
+      if (!cssModuleUrl) {
+        cssModuleUrl = URL.createObjectURL(
+          new Blob([createCssModuleSource(cssEntry.path, cssEntry.source)], {
+            type: "text/javascript",
+          }),
+        );
+        objectUrls.set(cssUrlKey, cssModuleUrl);
+      }
+      return cssModuleUrl;
+    }
+
     const moduleEntry = sources.get(resolvedPath) ?? sources.get(getModuleBasename(resolvedPath));
     if (!moduleEntry) {
       return specifier;
@@ -184,6 +217,7 @@ function createAddonModuleRegistry(code: string, files: SandboxAddonFile[] = [])
 
   Object.assign(globalThis, {
     __wealthfolioImport: importModule,
+    __wealthfolioInstallAddonStyle: installAddonStyle,
   });
 
   return {
@@ -330,52 +364,73 @@ function getAddonQueryClient() {
 }
 
 function createApiProxy(path: string[] = []): unknown {
-  return new Proxy(function addonApiProxy() {}, {
-    get(_target, key) {
-      if (key === "then" || typeof key === "symbol") {
-        return undefined;
-      }
-      return createApiProxy([...path, String(key)]);
+  return new Proxy(
+    function addonApiProxy() {
+      return undefined;
     },
-    apply(_target, _thisArg, args: unknown[]) {
-      const method = path.join(".");
-      if (method === "query.getClient") {
-        return getAddonQueryClient();
-      }
-      if (method.startsWith("events.") && typeof args[0] === "function") {
-        const callback = args[0] as (payload: unknown) => void;
-        return callHost("eventSubscribe", { method }).then((value) => {
-          const { subscriptionId } = value as { subscriptionId: string };
-          eventCallbacks.set(subscriptionId, callback);
-          return () => {
-            eventCallbacks.delete(subscriptionId);
-            return callHost("eventUnsubscribe", { subscriptionId });
-          };
-        });
-      }
-      assertCloneable(args);
-      const result = callHost("api", { method, args });
-      if (method.startsWith("logger.") || method.startsWith("toast.")) {
-        result.catch((error: unknown) => console.error(error));
-        return undefined;
-      }
-      return result;
+    {
+      get(_target, key) {
+        if (key === "then" || typeof key === "symbol") {
+          return undefined;
+        }
+        return createApiProxy([...path, String(key)]);
+      },
+      apply(_target, _thisArg, args: unknown[]) {
+        const method = path.join(".");
+        if (method === "query.getClient") {
+          return getAddonQueryClient();
+        }
+        if (method.startsWith("events.") && typeof args[0] === "function") {
+          const callback = args[0] as (payload: unknown) => void;
+          return callHost("eventSubscribe", { method }).then((value) => {
+            const { subscriptionId } = value as { subscriptionId: string };
+            eventCallbacks.set(subscriptionId, callback);
+            return () => {
+              eventCallbacks.delete(subscriptionId);
+              return callHost("eventUnsubscribe", { subscriptionId });
+            };
+          });
+        }
+        assertCloneable(args);
+        const result = callHost("api", { method, args });
+        if (method.startsWith("logger.") || method.startsWith("toast.")) {
+          result.catch((error: unknown) => console.error(error));
+          return undefined;
+        }
+        return result;
+      },
     },
-  });
+  );
+}
+
+export function RouteRenderCommit({ onRendered }: { onRendered?: () => void }) {
+  React.useEffect(() => {
+    onRendered?.();
+  }, [onRendered]);
+  return null;
 }
 
 function createReactRouteRenderer(component: unknown): RouteRenderer {
-  return ({ root: routeRoot }) => {
+  return ({ root: routeRoot, onRendered }) => {
     const Component = component as React.ElementType;
     reactRouteRoot ??= ReactDOMClient.createRoot(routeRoot);
     const reactRoot = reactRouteRoot;
-    reactRoot.render(
-      React.createElement(
-        React.Suspense,
-        { fallback: React.createElement("div", null, "Loading add-on...") },
-        React.createElement(Component),
-      ),
-    );
+    return new Promise<void>((resolve) => {
+      const handleRendered = () => {
+        onRendered?.();
+        resolve();
+      };
+      React.startTransition(() => {
+        reactRoot.render(
+          React.createElement(
+            React.Suspense,
+            { fallback: null },
+            React.createElement(Component),
+            React.createElement(RouteRenderCommit, { onRendered: handleRendered }),
+          ),
+        );
+      });
+    });
   };
 }
 
@@ -397,6 +452,10 @@ function stringFromPrimitive(value: unknown): string | undefined {
   return undefined;
 }
 
+function iconNameFromUnknown(value: unknown): string | undefined {
+  return stringFromPrimitive(value);
+}
+
 function normalizeRoute(route: LegacyRouteConfig) {
   const path = stringFromPrimitive(route.path) ?? "";
   const routeId = (stringFromPrimitive(route.id) ?? path) || crypto.randomUUID?.() || "";
@@ -412,10 +471,11 @@ function createContext() {
     ui: { root },
     sidebar: {
       addItem(cfg: Record<string, unknown>) {
+        const id = stringFromPrimitive(cfg?.id) ?? "";
         const item = {
-          id: stringFromPrimitive(cfg?.id) ?? "",
+          id,
           label: stringFromPrimitive(cfg?.label) ?? "",
-          icon: typeof cfg?.icon === "string" ? cfg.icon : undefined,
+          icon: iconNameFromUnknown(cfg?.icon),
           route: typeof cfg?.route === "string" ? cfg.route : undefined,
           order: typeof cfg?.order === "number" ? cfg.order : undefined,
         };
@@ -476,6 +536,7 @@ function resolveEnable(mod: Record<string, unknown>) {
 }
 
 async function loadAddon(code: string, files: SandboxAddonFile[] = []) {
+  installAddonCssFiles(files);
   const moduleRegistry = createAddonModuleRegistry(code, files);
   addonModuleUrls = moduleRegistry.objectUrls;
   addonCodeUrl = moduleRegistry.mainUrl;
@@ -498,9 +559,17 @@ async function renderRoute(routeId: string, location: RouteLocation) {
   if (!route) {
     unmountReactRouteRoot();
     root.textContent = "Addon route is not available.";
-    return;
+    throw new Error(`Addon route '${routeId}' is not available`);
   }
-  await route({ root, location });
+
+  let didRender = false;
+  const markRendered = () => {
+    didRender = true;
+  };
+  await route({ root, location, onRendered: markRendered });
+  if (!didRender) {
+    await waitForNextPaint();
+  }
 }
 
 async function disableAddon() {
@@ -528,6 +597,7 @@ async function disableAddon() {
     }
   }
   addonModuleUrls.clear();
+  clearAddonStyles();
   root.replaceChildren();
 }
 
@@ -541,12 +611,7 @@ window.addEventListener("unhandledrejection", (event) => {
 
 window.addEventListener("message", (event: MessageEvent<SandboxMessage>) => {
   const message = event.data;
-  if (
-    !message ||
-    message.channel !== CHANNEL ||
-    message.addonId !== ADDON_ID ||
-    message.nonce !== NONCE
-  ) {
+  if (message?.channel !== CHANNEL || message.addonId !== ADDON_ID || message.nonce !== NONCE) {
     return;
   }
 
@@ -572,21 +637,36 @@ window.addEventListener("message", (event: MessageEvent<SandboxMessage>) => {
     return;
   }
 
+  if (message.type === "themeUpdate") {
+    applyHostTheme(message.theme);
+    return;
+  }
+
   void (async () => {
     try {
       if (message.type === "loadAddon" && typeof message.code === "string") {
+        applyHostTheme(message.theme);
         await loadAddon(message.code, message.files);
         post("loaded");
       } else if (message.type === "renderRoute" && message.routeId && message.location) {
         await renderRoute(message.routeId, message.location);
+        post("routeRendered", { requestId: message.requestId });
       } else if (message.type === "disable") {
         await disableAddon();
         post("disabled");
       }
     } catch (error) {
-      post("loadError", {
-        error: error instanceof Error ? error.message : String(error),
-      });
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      if (message.type === "renderRoute") {
+        post("routeRenderError", {
+          error: errorMessage,
+          requestId: message.requestId,
+        });
+      } else {
+        post("loadError", {
+          error: errorMessage,
+        });
+      }
     }
   })();
 });

--- a/apps/frontend/src/addons/iframe/addon-sandbox-entry.tsx
+++ b/apps/frontend/src/addons/iframe/addon-sandbox-entry.tsx
@@ -1,0 +1,548 @@
+import "@/globals.css";
+
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import * as ReactDOMClient from "react-dom/client";
+import { QueryClient } from "@tanstack/react-query";
+
+const CHANNEL = "wealthfolio:addon-sandbox:v1";
+
+interface PendingCall {
+  resolve: (value: unknown) => void;
+  reject: (reason?: unknown) => void;
+}
+
+interface RouteLocation {
+  pathname: string;
+  search: string;
+  hash: string;
+  params: Record<string, string | undefined>;
+}
+
+interface RouteRenderContext {
+  root: HTMLElement;
+  location: RouteLocation;
+}
+
+interface LegacyRouteConfig {
+  id?: unknown;
+  path?: unknown;
+  title?: unknown;
+  render?: unknown;
+  component?: unknown;
+}
+
+interface SandboxAddonFile {
+  name: string;
+  content: string;
+  isMain?: boolean;
+}
+
+interface SandboxMessage {
+  channel?: string;
+  addonId?: string;
+  nonce?: string;
+  type?: string;
+  requestId?: string;
+  code?: string;
+  files?: SandboxAddonFile[];
+  routeId?: string;
+  location?: RouteLocation;
+  ok?: boolean;
+  result?: unknown;
+  error?: string;
+  subscriptionId?: string;
+  payload?: unknown;
+}
+
+type RouteRenderer = (context: RouteRenderContext) => Promise<void> | void;
+
+const init = new URLSearchParams(window.location.hash.slice(1));
+const ADDON_ID = init.get("addonId") ?? "";
+const NONCE = init.get("nonce") ?? "";
+const rootElement = document.getElementById("addon-root");
+const routes = new Map<string, RouteRenderer>();
+const pending = new Map<string, PendingCall>();
+const disableCallbacks = new Set<() => Promise<void> | void>();
+const eventCallbacks = new Map<string, (payload: unknown) => void>();
+let addonDisable: (() => Promise<void> | void) | undefined;
+let addonCodeUrl: string | undefined;
+let addonQueryClient: QueryClient | undefined;
+let addonModuleUrls = new Map<string, string>();
+let reactRouteRoot: ReactDOMClient.Root | undefined;
+
+Object.assign(globalThis, {
+  React,
+  ReactDOM,
+  ReactDOMClient,
+});
+
+if (!ADDON_ID || !NONCE || !rootElement) {
+  throw new Error("Invalid addon sandbox bootstrap parameters");
+}
+
+const root = rootElement;
+
+function post(type: string, payload: Record<string, unknown> = {}) {
+  parent.postMessage({ channel: CHANNEL, addonId: ADDON_ID, nonce: NONCE, type, ...payload }, "*");
+}
+
+function callHost(type: string, payload: Record<string, unknown> = {}) {
+  const requestId = crypto.randomUUID?.() ?? Math.random().toString(36).slice(2);
+  return new Promise((resolve, reject) => {
+    pending.set(requestId, { resolve, reject });
+    post(type, { requestId, ...payload });
+  });
+}
+
+function normalizeModulePath(path: string) {
+  return path.replace(/\\/g, "/").replace(/^\/+/, "");
+}
+
+function dirname(path: string) {
+  const normalizedPath = normalizeModulePath(path);
+  const index = normalizedPath.lastIndexOf("/");
+  return index === -1 ? "" : normalizedPath.slice(0, index);
+}
+
+function resolveModulePath(importerPath: string, specifier: string) {
+  const normalizedSpecifier = normalizeModulePath(specifier);
+  if (!normalizedSpecifier.startsWith(".")) {
+    return normalizedSpecifier;
+  }
+
+  const basePath = dirname(importerPath);
+  const parts = `${basePath}/${normalizedSpecifier}`.split("/");
+  const resolved: string[] = [];
+  for (const part of parts) {
+    if (!part || part === ".") {
+      continue;
+    }
+    if (part === "..") {
+      resolved.pop();
+    } else {
+      resolved.push(part);
+    }
+  }
+  return resolved.join("/");
+}
+
+function stripSourceMapReferences(code: string) {
+  return code.replace(/\/\/# sourceMappingURL=.*/g, "");
+}
+
+function rewriteDynamicImports(importerPath: string, code: string) {
+  return stripSourceMapReferences(code).replace(
+    /\bimport\s*\(/g,
+    `globalThis.__wealthfolioImport(${JSON.stringify(importerPath)}, `,
+  );
+}
+
+function getModuleBasename(path: string) {
+  const normalizedPath = normalizeModulePath(path);
+  const index = normalizedPath.lastIndexOf("/");
+  return index === -1 ? normalizedPath : normalizedPath.slice(index + 1);
+}
+
+function createAddonModuleRegistry(code: string, files: SandboxAddonFile[] = []) {
+  const sources = new Map<string, string>();
+  const mainFile = files.find((file) => file.isMain) ?? files.find((file) => file.content === code);
+  const mainPath = normalizeModulePath(mainFile?.name ?? "addon.js");
+
+  for (const file of files) {
+    if (!file.name.endsWith(".js")) {
+      continue;
+    }
+    const path = normalizeModulePath(file.name);
+    const source = rewriteDynamicImports(path, file.content);
+    sources.set(path, source);
+    sources.set(getModuleBasename(path), source);
+  }
+
+  sources.set(mainPath, rewriteDynamicImports(mainPath, code));
+
+  const objectUrls = new Map<string, string>();
+  const importModule = (importerPath: string, specifier: string) => {
+    const resolvedPath = resolveModulePath(importerPath, specifier);
+    const source = sources.get(resolvedPath) ?? sources.get(getModuleBasename(resolvedPath));
+    if (!source) {
+      return import(/* @vite-ignore */ specifier);
+    }
+
+    const urlKey = sources.has(resolvedPath) ? resolvedPath : getModuleBasename(resolvedPath);
+    let moduleUrl = objectUrls.get(urlKey);
+    if (!moduleUrl) {
+      moduleUrl = URL.createObjectURL(new Blob([source], { type: "text/javascript" }));
+      objectUrls.set(urlKey, moduleUrl);
+    }
+    return import(/* @vite-ignore */ moduleUrl);
+  };
+
+  Object.assign(globalThis, {
+    __wealthfolioImport: importModule,
+  });
+
+  return {
+    mainPath,
+    objectUrls,
+    source: sources.get(mainPath) ?? rewriteDynamicImports(mainPath, code),
+  };
+}
+
+function findAnchor(target: EventTarget | null) {
+  if (!(target instanceof Element)) {
+    return null;
+  }
+  return target.closest<HTMLAnchorElement>("a[href]");
+}
+
+function toInternalRoute(rawHref: string) {
+  if (!rawHref || rawHref.startsWith("#")) {
+    return null;
+  }
+
+  const currentUrl = new URL(window.location.href);
+  const targetUrl = new URL(rawHref, currentUrl);
+  if (targetUrl.origin !== currentUrl.origin) {
+    return null;
+  }
+
+  return `${targetUrl.pathname}${targetUrl.search}${targetUrl.hash}`;
+}
+
+document.addEventListener("click", (event) => {
+  if (event.defaultPrevented || event.button !== 0) {
+    return;
+  }
+  if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+    return;
+  }
+
+  const anchor = findAnchor(event.target);
+  if (!anchor || anchor.hasAttribute("download")) {
+    return;
+  }
+  const target = anchor.getAttribute("target");
+  if (target && target !== "_self") {
+    return;
+  }
+
+  const route = toInternalRoute(anchor.getAttribute("href") ?? "");
+  if (!route || route.startsWith("/addon-sandbox.html")) {
+    return;
+  }
+
+  event.preventDefault();
+  callHost("api", { method: "navigation.navigate", args: [route] }).catch((error: unknown) =>
+    console.error(error),
+  );
+});
+
+function assertCloneable(value: unknown) {
+  if (typeof structuredClone !== "function") {
+    return;
+  }
+  structuredClone(value);
+}
+
+function toHostQueryKey(value: unknown): string | string[] | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  if (Array.isArray(value) && value.every((item) => typeof item === "string")) {
+    return value;
+  }
+
+  if (typeof value === "object" && value !== null && "queryKey" in value) {
+    return toHostQueryKey((value as { queryKey?: unknown }).queryKey);
+  }
+
+  return undefined;
+}
+
+function mirrorHostQueryCall(
+  method: "query.invalidateQueries" | "query.refetchQueries",
+  args: unknown[],
+) {
+  const queryKey = toHostQueryKey(args[0]);
+  if (!queryKey) {
+    return;
+  }
+
+  callHost("api", { method, args: [queryKey] }).catch((error: unknown) => console.error(error));
+}
+
+function getAddonQueryClient() {
+  if (!addonQueryClient) {
+    addonQueryClient = new QueryClient();
+    const client = addonQueryClient as unknown as {
+      invalidateQueries: (...args: unknown[]) => Promise<unknown>;
+      refetchQueries: (...args: unknown[]) => Promise<unknown>;
+    };
+    const invalidateQueries = client.invalidateQueries.bind(client);
+    const refetchQueries = client.refetchQueries.bind(client);
+
+    client.invalidateQueries = (...args: unknown[]) => {
+      mirrorHostQueryCall("query.invalidateQueries", args);
+      return invalidateQueries(...args);
+    };
+    client.refetchQueries = (...args: unknown[]) => {
+      mirrorHostQueryCall("query.refetchQueries", args);
+      return refetchQueries(...args);
+    };
+  }
+
+  return addonQueryClient;
+}
+
+function createApiProxy(path: string[] = []): unknown {
+  return new Proxy(function addonApiProxy() {}, {
+    get(_target, key) {
+      if (key === "then" || typeof key === "symbol") {
+        return undefined;
+      }
+      return createApiProxy([...path, String(key)]);
+    },
+    apply(_target, _thisArg, args: unknown[]) {
+      const method = path.join(".");
+      if (method === "query.getClient") {
+        return getAddonQueryClient();
+      }
+      if (method.startsWith("events.") && typeof args[0] === "function") {
+        const callback = args[0] as (payload: unknown) => void;
+        return callHost("eventSubscribe", { method }).then((value) => {
+          const { subscriptionId } = value as { subscriptionId: string };
+          eventCallbacks.set(subscriptionId, callback);
+          return () => {
+            eventCallbacks.delete(subscriptionId);
+            return callHost("eventUnsubscribe", { subscriptionId });
+          };
+        });
+      }
+      assertCloneable(args);
+      const result = callHost("api", { method, args });
+      if (method.startsWith("logger.") || method.startsWith("toast.")) {
+        result.catch((error: unknown) => console.error(error));
+        return undefined;
+      }
+      return result;
+    },
+  });
+}
+
+function createReactRouteRenderer(component: unknown): RouteRenderer {
+  return ({ root: routeRoot }) => {
+    const Component = component as React.ElementType;
+    reactRouteRoot ??= ReactDOMClient.createRoot(routeRoot);
+    const reactRoot = reactRouteRoot;
+    reactRoot.render(
+      React.createElement(
+        React.Suspense,
+        { fallback: React.createElement("div", null, "Loading add-on...") },
+        React.createElement(Component),
+      ),
+    );
+  };
+}
+
+function unmountReactRouteRoot() {
+  if (!reactRouteRoot) {
+    return;
+  }
+  reactRouteRoot.unmount();
+  reactRouteRoot = undefined;
+}
+
+function normalizeRoute(route: LegacyRouteConfig) {
+  const path = String(route.path || "");
+  const routeId = String(route.id || path || crypto.randomUUID?.() || "");
+  return {
+    path,
+    routeId,
+    title: typeof route.title === "string" ? route.title : undefined,
+  };
+}
+
+function createContext() {
+  return {
+    ui: { root },
+    sidebar: {
+      addItem(cfg: Record<string, unknown>) {
+        const item = {
+          id: String(cfg?.id ?? ""),
+          label: String(cfg?.label ?? ""),
+          icon: typeof cfg?.icon === "string" ? cfg.icon : undefined,
+          route: typeof cfg?.route === "string" ? cfg.route : undefined,
+          order: typeof cfg?.order === "number" ? cfg.order : undefined,
+        };
+        callHost("sidebar.addItem", { item }).catch((error: unknown) => console.error(error));
+        return {
+          remove() {
+            return callHost("sidebar.removeItem", { itemId: item.id });
+          },
+        };
+      },
+    },
+    router: {
+      add(route: LegacyRouteConfig) {
+        const normalizedRoute = normalizeRoute(route);
+        if (typeof route?.render === "function") {
+          routes.set(normalizedRoute.routeId, async (context) => {
+            unmountReactRouteRoot();
+            await (route.render as RouteRenderer)(context);
+          });
+        } else if (route?.component) {
+          routes.set(normalizedRoute.routeId, createReactRouteRenderer(route.component));
+        } else {
+          throw new Error("Sandboxed addon routes must provide render(context) or component");
+        }
+        callHost("router.add", { route: normalizedRoute }).catch((error: unknown) =>
+          console.error(error),
+        );
+      },
+    },
+    onDisable(callback: unknown) {
+      if (typeof callback === "function") {
+        disableCallbacks.add(callback as () => Promise<void> | void);
+      }
+    },
+    api: createApiProxy(),
+  };
+}
+
+function resolveEnable(mod: Record<string, unknown>) {
+  const defaultExport = mod?.default;
+  if (typeof defaultExport === "function") {
+    return defaultExport;
+  }
+  if (
+    defaultExport &&
+    typeof defaultExport === "object" &&
+    typeof (defaultExport as { enable?: unknown }).enable === "function"
+  ) {
+    return (defaultExport as { enable: unknown }).enable;
+  }
+  if (typeof mod?.enable === "function") {
+    return mod.enable;
+  }
+  if (typeof mod?.PortfolioTrackerAddon === "function") {
+    return mod.PortfolioTrackerAddon;
+  }
+  return null;
+}
+
+async function loadAddon(code: string, files: SandboxAddonFile[] = []) {
+  const moduleRegistry = createAddonModuleRegistry(code, files);
+  addonModuleUrls = moduleRegistry.objectUrls;
+  addonCodeUrl = URL.createObjectURL(new Blob([moduleRegistry.source], { type: "text/javascript" }));
+  const mod = (await import(/* @vite-ignore */ addonCodeUrl)) as Record<string, unknown>;
+  const enable = resolveEnable(mod);
+  if (!enable) {
+    throw new Error("Addon does not export an enable(context) function");
+  }
+  const result = await (enable as (context: unknown) => Promise<unknown> | unknown)(createContext());
+  addonDisable =
+    result &&
+    typeof result === "object" &&
+    typeof (result as { disable?: unknown }).disable === "function"
+      ? ((result as { disable: () => Promise<void> | void }).disable)
+      : undefined;
+}
+
+async function renderRoute(routeId: string, location: RouteLocation) {
+  const route = routes.get(routeId);
+  if (!route) {
+    unmountReactRouteRoot();
+    root.textContent = "Addon route is not available.";
+    return;
+  }
+  await route({ root, location });
+}
+
+async function disableAddon() {
+  for (const callback of Array.from(disableCallbacks).reverse()) {
+    await callback();
+  }
+  disableCallbacks.clear();
+  if (addonDisable) {
+    await addonDisable();
+    addonDisable = undefined;
+  }
+  unmountReactRouteRoot();
+  routes.clear();
+  eventCallbacks.clear();
+  addonQueryClient?.clear();
+  addonQueryClient = undefined;
+  if (addonCodeUrl) {
+    URL.revokeObjectURL(addonCodeUrl);
+    addonCodeUrl = undefined;
+  }
+  for (const moduleUrl of addonModuleUrls.values()) {
+    URL.revokeObjectURL(moduleUrl);
+  }
+  addonModuleUrls.clear();
+  root.replaceChildren();
+}
+
+window.addEventListener("error", (event) => {
+  post("runtimeError", { error: event.message || String(event.error) });
+});
+
+window.addEventListener("unhandledrejection", (event) => {
+  post("runtimeError", { error: String(event.reason) });
+});
+
+window.addEventListener("message", (event: MessageEvent<SandboxMessage>) => {
+  const message = event.data;
+  if (
+    !message ||
+    message.channel !== CHANNEL ||
+    message.addonId !== ADDON_ID ||
+    message.nonce !== NONCE
+  ) {
+    return;
+  }
+
+  if (message.type === "rpcResponse") {
+    const callbacks = pending.get(message.requestId ?? "");
+    if (!callbacks) {
+      return;
+    }
+    pending.delete(message.requestId ?? "");
+    if (message.ok) {
+      callbacks.resolve(message.result);
+    } else {
+      callbacks.reject(new Error(message.error || "Addon host call failed"));
+    }
+    return;
+  }
+
+  if (message.type === "event") {
+    const callback = eventCallbacks.get(message.subscriptionId ?? "");
+    if (callback) {
+      callback(message.payload);
+    }
+    return;
+  }
+
+  void (async () => {
+    try {
+      if (message.type === "loadAddon" && typeof message.code === "string") {
+        await loadAddon(message.code, message.files);
+        post("loaded");
+      } else if (message.type === "renderRoute" && message.routeId && message.location) {
+        await renderRoute(message.routeId, message.location);
+      } else if (message.type === "disable") {
+        await disableAddon();
+        post("disabled");
+      }
+    } catch (error) {
+      post("loadError", {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  })();
+});
+
+post("ready");

--- a/apps/frontend/src/addons/iframe/addon-sandbox-entry.tsx
+++ b/apps/frontend/src/addons/iframe/addon-sandbox-entry.tsx
@@ -148,12 +148,30 @@ function createAddonModuleRegistry(code: string, files: SandboxAddonFile[] = [])
   const cssSources = new Map<string, { path: string; source: string }>();
   const mainFile = files.find((file) => file.isMain) ?? files.find((file) => file.content === code);
   const mainPath = normalizeModulePath(mainFile?.name ?? "addon.js");
+  const moduleBasenameCounts = new Map<string, number>();
+  const cssBasenameCounts = new Map<string, number>();
+
+  for (const file of files) {
+    const path = normalizeModulePath(file.name);
+    if (isCssFile(path)) {
+      const basename = getModuleBasename(path);
+      cssBasenameCounts.set(basename, (cssBasenameCounts.get(basename) ?? 0) + 1);
+      continue;
+    }
+    if (path.endsWith(".js")) {
+      const basename = getModuleBasename(path);
+      moduleBasenameCounts.set(basename, (moduleBasenameCounts.get(basename) ?? 0) + 1);
+    }
+  }
 
   for (const file of files) {
     const path = normalizeModulePath(file.name);
     if (isCssFile(path)) {
       cssSources.set(path, { path, source: file.content });
-      cssSources.set(getModuleBasename(path), { path, source: file.content });
+      const basename = getModuleBasename(path);
+      if (cssBasenameCounts.get(basename) === 1) {
+        cssSources.set(basename, { path, source: file.content });
+      }
       continue;
     }
     if (!path.endsWith(".js")) {
@@ -161,7 +179,10 @@ function createAddonModuleRegistry(code: string, files: SandboxAddonFile[] = [])
     }
     const source = stripSourceMapReferences(file.content);
     sources.set(path, { path, source });
-    sources.set(getModuleBasename(path), { path, source });
+    const basename = getModuleBasename(path);
+    if (moduleBasenameCounts.get(basename) === 1) {
+      sources.set(basename, { path, source });
+    }
   }
 
   sources.set(mainPath, { path: mainPath, source: stripSourceMapReferences(code) });
@@ -232,13 +253,24 @@ function rewriteStaticImportSpecifiers(
   code: string,
   resolveSpecifier: ModuleSpecifierResolver,
 ) {
-  return code.replace(
-    /(\b(?:import|export)\s+(?:[^'"]*?\s+from\s*)?)(["'])([^"']+)\2/g,
+  const rewrite = (match: string, prefix: string, quote: string, specifier: string) => {
+    if (!isHostDependencySpecifier(specifier) && !specifier.startsWith(".")) {
+      return match;
+    }
+    return `${prefix}${quote}${resolveSpecifier(importerPath, specifier)}${quote}`;
+  };
+
+  const withFromImports = code.replace(
+    /(\b(?:import|export)\s*[^'"]*?\bfrom\s*)(["'])([^"']+)\2/g,
     (match, prefix: string, quote: string, specifier: string) => {
-      if (!isHostDependencySpecifier(specifier) && !specifier.startsWith(".")) {
-        return match;
-      }
-      return `${prefix}${quote}${resolveSpecifier(importerPath, specifier)}${quote}`;
+      return rewrite(match, prefix, quote, specifier);
+    },
+  );
+
+  return withFromImports.replace(
+    /(\bimport\s*)(["'])([^"']+)\2/g,
+    (match, prefix: string, quote: string, specifier: string) => {
+      return rewrite(match, prefix, quote, specifier);
     },
   );
 }
@@ -500,9 +532,11 @@ function createContext() {
         } else {
           throw new Error("Sandboxed addon routes must provide render(context) or component");
         }
-        callHost("router.add", { route: normalizedRoute }).catch((error: unknown) =>
-          console.error(error),
-        );
+        return callHost("router.add", { route: normalizedRoute }).catch((error: unknown) => {
+          routes.delete(normalizedRoute.routeId);
+          console.error(error);
+          throw error;
+        });
       },
     },
     onDisable(callback: unknown) {
@@ -644,16 +678,22 @@ window.addEventListener("message", (event: MessageEvent<SandboxMessage>) => {
 
   void (async () => {
     try {
-      if (message.type === "loadAddon" && typeof message.code === "string") {
+      if (message.type === "disable") {
+        try {
+          await disableAddon();
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+          post("runtimeError", { error: errorMessage });
+        } finally {
+          post("disabled");
+        }
+      } else if (message.type === "loadAddon" && typeof message.code === "string") {
         applyHostTheme(message.theme);
         await loadAddon(message.code, message.files);
         post("loaded");
       } else if (message.type === "renderRoute" && message.routeId && message.location) {
         await renderRoute(message.routeId, message.location);
         post("routeRendered", { requestId: message.requestId });
-      } else if (message.type === "disable") {
-        await disableAddon();
-        post("disabled");
       }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);

--- a/apps/frontend/src/addons/iframe/addon-sandbox-entry.tsx
+++ b/apps/frontend/src/addons/iframe/addon-sandbox-entry.tsx
@@ -3,10 +3,7 @@ import "@/globals.css";
 import * as React from "react";
 import * as ReactDOMClient from "react-dom/client";
 import { QueryClient } from "@tanstack/react-query";
-import {
-  createHostDependencyModuleUrl,
-  isHostDependencySpecifier,
-} from "./host-dependencies";
+import { createHostDependencyModuleUrl, isHostDependencySpecifier } from "./host-dependencies";
 
 const CHANNEL = "wealthfolio:addon-sandbox:v1";
 
@@ -390,9 +387,19 @@ function unmountReactRouteRoot() {
   reactRouteRoot = undefined;
 }
 
+function stringFromPrimitive(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  return undefined;
+}
+
 function normalizeRoute(route: LegacyRouteConfig) {
-  const path = String(route.path || "");
-  const routeId = String(route.id || path || crypto.randomUUID?.() || "");
+  const path = stringFromPrimitive(route.path) ?? "";
+  const routeId = (stringFromPrimitive(route.id) ?? path) || crypto.randomUUID?.() || "";
   return {
     path,
     routeId,
@@ -406,8 +413,8 @@ function createContext() {
     sidebar: {
       addItem(cfg: Record<string, unknown>) {
         const item = {
-          id: String(cfg?.id ?? ""),
-          label: String(cfg?.label ?? ""),
+          id: stringFromPrimitive(cfg?.id) ?? "",
+          label: stringFromPrimitive(cfg?.label) ?? "",
           icon: typeof cfg?.icon === "string" ? cfg.icon : undefined,
           route: typeof cfg?.route === "string" ? cfg.route : undefined,
           order: typeof cfg?.order === "number" ? cfg.order : undefined,
@@ -477,12 +484,12 @@ async function loadAddon(code: string, files: SandboxAddonFile[] = []) {
   if (!enable) {
     throw new Error("Addon does not export an enable(context) function");
   }
-  const result = await (enable as (context: unknown) => Promise<unknown> | unknown)(createContext());
+  const result = await (enable as (context: unknown) => unknown)(createContext());
   addonDisable =
     result &&
     typeof result === "object" &&
     typeof (result as { disable?: unknown }).disable === "function"
-      ? ((result as { disable: () => Promise<void> | void }).disable)
+      ? (result as { disable: () => Promise<void> | void }).disable
       : undefined;
 }
 

--- a/apps/frontend/src/addons/iframe/addon-sandbox-entry.tsx
+++ b/apps/frontend/src/addons/iframe/addon-sandbox-entry.tsx
@@ -445,7 +445,10 @@ export function RouteRenderCommit({ onRendered }: { onRendered?: () => void }) {
 function createReactRouteRenderer(component: unknown): RouteRenderer {
   return ({ root: routeRoot, onRendered }) => {
     const Component = component as React.ElementType;
-    reactRouteRoot ??= ReactDOMClient.createRoot(routeRoot);
+    if (!reactRouteRoot) {
+      routeRoot.replaceChildren();
+      reactRouteRoot = ReactDOMClient.createRoot(routeRoot);
+    }
     const reactRoot = reactRouteRoot;
     return new Promise<void>((resolve) => {
       const handleRendered = () => {

--- a/apps/frontend/src/addons/iframe/addon-sandbox-entry.tsx
+++ b/apps/frontend/src/addons/iframe/addon-sandbox-entry.tsx
@@ -1,9 +1,12 @@
 import "@/globals.css";
 
 import * as React from "react";
-import * as ReactDOM from "react-dom";
 import * as ReactDOMClient from "react-dom/client";
 import { QueryClient } from "@tanstack/react-query";
+import {
+  createHostDependencyModuleUrl,
+  isHostDependencySpecifier,
+} from "./host-dependencies";
 
 const CHANNEL = "wealthfolio:addon-sandbox:v1";
 
@@ -56,6 +59,7 @@ interface SandboxMessage {
 }
 
 type RouteRenderer = (context: RouteRenderContext) => Promise<void> | void;
+type ModuleSpecifierResolver = (importerPath: string, specifier: string) => string;
 
 const init = new URLSearchParams(window.location.hash.slice(1));
 const ADDON_ID = init.get("addonId") ?? "";
@@ -70,12 +74,6 @@ let addonCodeUrl: string | undefined;
 let addonQueryClient: QueryClient | undefined;
 let addonModuleUrls = new Map<string, string>();
 let reactRouteRoot: ReactDOMClient.Root | undefined;
-
-Object.assign(globalThis, {
-  React,
-  ReactDOM,
-  ReactDOMClient,
-});
 
 if (!ADDON_ID || !NONCE || !rootElement) {
   throw new Error("Invalid addon sandbox bootstrap parameters");
@@ -131,13 +129,6 @@ function stripSourceMapReferences(code: string) {
   return code.replace(/\/\/# sourceMappingURL=.*/g, "");
 }
 
-function rewriteDynamicImports(importerPath: string, code: string) {
-  return stripSourceMapReferences(code).replace(
-    /\bimport\s*\(/g,
-    `globalThis.__wealthfolioImport(${JSON.stringify(importerPath)}, `,
-  );
-}
-
 function getModuleBasename(path: string) {
   const normalizedPath = normalizeModulePath(path);
   const index = normalizedPath.lastIndexOf("/");
@@ -145,7 +136,7 @@ function getModuleBasename(path: string) {
 }
 
 function createAddonModuleRegistry(code: string, files: SandboxAddonFile[] = []) {
-  const sources = new Map<string, string>();
+  const sources = new Map<string, { path: string; source: string }>();
   const mainFile = files.find((file) => file.isMain) ?? files.find((file) => file.content === code);
   const mainPath = normalizeModulePath(mainFile?.name ?? "addon.js");
 
@@ -154,28 +145,44 @@ function createAddonModuleRegistry(code: string, files: SandboxAddonFile[] = [])
       continue;
     }
     const path = normalizeModulePath(file.name);
-    const source = rewriteDynamicImports(path, file.content);
-    sources.set(path, source);
-    sources.set(getModuleBasename(path), source);
+    const source = stripSourceMapReferences(file.content);
+    sources.set(path, { path, source });
+    sources.set(getModuleBasename(path), { path, source });
   }
 
-  sources.set(mainPath, rewriteDynamicImports(mainPath, code));
+  sources.set(mainPath, { path: mainPath, source: stripSourceMapReferences(code) });
 
   const objectUrls = new Map<string, string>();
-  const importModule = (importerPath: string, specifier: string) => {
+  const resolveModuleSpecifier = (importerPath: string, specifier: string) => {
+    const hostModuleUrl = createHostDependencyModuleUrl(specifier, objectUrls);
+    if (hostModuleUrl) {
+      return hostModuleUrl;
+    }
+
     const resolvedPath = resolveModulePath(importerPath, specifier);
-    const source = sources.get(resolvedPath) ?? sources.get(getModuleBasename(resolvedPath));
-    if (!source) {
-      return import(/* @vite-ignore */ specifier);
+    const moduleEntry = sources.get(resolvedPath) ?? sources.get(getModuleBasename(resolvedPath));
+    if (!moduleEntry) {
+      return specifier;
     }
 
     const urlKey = sources.has(resolvedPath) ? resolvedPath : getModuleBasename(resolvedPath);
     let moduleUrl = objectUrls.get(urlKey);
     if (!moduleUrl) {
-      moduleUrl = URL.createObjectURL(new Blob([source], { type: "text/javascript" }));
+      moduleUrl = URL.createObjectURL(
+        new Blob(
+          [rewriteModuleSpecifiers(moduleEntry.path, moduleEntry.source, resolveModuleSpecifier)],
+          {
+            type: "text/javascript",
+          },
+        ),
+      );
       objectUrls.set(urlKey, moduleUrl);
     }
-    return import(/* @vite-ignore */ moduleUrl);
+    return moduleUrl;
+  };
+
+  const importModule = (importerPath: string, specifier: string) => {
+    return import(/* @vite-ignore */ resolveModuleSpecifier(importerPath, specifier));
   };
 
   Object.assign(globalThis, {
@@ -184,9 +191,38 @@ function createAddonModuleRegistry(code: string, files: SandboxAddonFile[] = [])
 
   return {
     mainPath,
+    mainUrl: resolveModuleSpecifier(mainPath, mainPath),
     objectUrls,
-    source: sources.get(mainPath) ?? rewriteDynamicImports(mainPath, code),
   };
+}
+
+function rewriteStaticImportSpecifiers(
+  importerPath: string,
+  code: string,
+  resolveSpecifier: ModuleSpecifierResolver,
+) {
+  return code.replace(
+    /(\b(?:import|export)\s+(?:[^'"]*?\s+from\s*)?)(["'])([^"']+)\2/g,
+    (match, prefix: string, quote: string, specifier: string) => {
+      if (!isHostDependencySpecifier(specifier) && !specifier.startsWith(".")) {
+        return match;
+      }
+      return `${prefix}${quote}${resolveSpecifier(importerPath, specifier)}${quote}`;
+    },
+  );
+}
+
+function rewriteModuleSpecifiers(
+  importerPath: string,
+  code: string,
+  resolveSpecifier: ModuleSpecifierResolver,
+) {
+  const withStaticImports = rewriteStaticImportSpecifiers(importerPath, code, resolveSpecifier);
+
+  return withStaticImports.replace(
+    /\bimport\s*\(/g,
+    `globalThis.__wealthfolioImport(${JSON.stringify(importerPath)}, `,
+  );
 }
 
 function findAnchor(target: EventTarget | null) {
@@ -435,7 +471,7 @@ function resolveEnable(mod: Record<string, unknown>) {
 async function loadAddon(code: string, files: SandboxAddonFile[] = []) {
   const moduleRegistry = createAddonModuleRegistry(code, files);
   addonModuleUrls = moduleRegistry.objectUrls;
-  addonCodeUrl = URL.createObjectURL(new Blob([moduleRegistry.source], { type: "text/javascript" }));
+  addonCodeUrl = moduleRegistry.mainUrl;
   const mod = (await import(/* @vite-ignore */ addonCodeUrl)) as Record<string, unknown>;
   const enable = resolveEnable(mod);
   if (!enable) {
@@ -474,12 +510,15 @@ async function disableAddon() {
   eventCallbacks.clear();
   addonQueryClient?.clear();
   addonQueryClient = undefined;
+  const mainModuleUrl = addonCodeUrl;
   if (addonCodeUrl) {
     URL.revokeObjectURL(addonCodeUrl);
     addonCodeUrl = undefined;
   }
   for (const moduleUrl of addonModuleUrls.values()) {
-    URL.revokeObjectURL(moduleUrl);
+    if (moduleUrl !== mainModuleUrl) {
+      URL.revokeObjectURL(moduleUrl);
+    }
   }
   addonModuleUrls.clear();
   root.replaceChildren();

--- a/apps/frontend/src/addons/iframe/addon-sandbox-styles.test.ts
+++ b/apps/frontend/src/addons/iframe/addon-sandbox-styles.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { installFakeAddonDom } from "@/test/fake-addon-dom";
+import {
+  clearAddonStyles,
+  createCssModuleSource,
+  installAddonCssFiles,
+  installAddonStyle,
+  isCssFile,
+} from "./addon-sandbox-styles";
+
+function addonStyleElements() {
+  return Array.from(
+    document.head.querySelectorAll<HTMLStyleElement>("style[data-wealthfolio-addon-style]"),
+  );
+}
+
+afterEach(() => {
+  clearAddonStyles();
+});
+
+describe("addon sandbox styles", () => {
+  beforeEach(() => {
+    installFakeAddonDom();
+  });
+
+  it("detects css assets case-insensitively", () => {
+    expect(isCssFile("dist/style.css")).toBe(true);
+    expect(isCssFile("dist/theme.CSS")).toBe(true);
+    expect(isCssFile("dist/addon.js")).toBe(false);
+  });
+
+  it("injects extracted addon css files and ignores non-css files", () => {
+    installAddonCssFiles([
+      { content: "export default {}", isMain: true, name: "dist/addon.js" },
+      { content: ".addon-card { color: red; }", name: "dist/style.css" },
+    ]);
+
+    const styles = addonStyleElements();
+    expect(styles).toHaveLength(1);
+    expect(styles[0]?.getAttribute("data-wealthfolio-addon-style")).toBe("dist/style.css");
+    expect(styles[0]?.textContent).toContain(".addon-card");
+  });
+
+  it("upserts css imports without duplicating style tags", () => {
+    installAddonStyle("dist/style.css", ".addon-card { color: red; }");
+    installAddonStyle("dist/style.css", ".addon-card { color: green; }");
+
+    const styles = addonStyleElements();
+    expect(styles).toHaveLength(1);
+    expect(styles[0]?.textContent).toContain("green");
+  });
+
+  it("creates a side-effect module for native css imports", () => {
+    const source = createCssModuleSource("dist/style.css", ".addon-card { color: red; }");
+
+    expect(source).toContain("__wealthfolioInstallAddonStyle");
+    expect(source).toContain("dist/style.css");
+    expect(source).toContain("export default css");
+  });
+});

--- a/apps/frontend/src/addons/iframe/addon-sandbox-styles.ts
+++ b/apps/frontend/src/addons/iframe/addon-sandbox-styles.ts
@@ -1,0 +1,55 @@
+export interface SandboxAddonFile {
+  name: string;
+  content: string;
+  isMain?: boolean;
+}
+
+const ADDON_STYLE_ATTRIBUTE = "data-wealthfolio-addon-style";
+
+export function isCssFile(path: string) {
+  return path.toLowerCase().endsWith(".css");
+}
+
+function findAddonStyleElement(path: string) {
+  return Array.from(
+    document.head.querySelectorAll<HTMLStyleElement>(`style[${ADDON_STYLE_ATTRIBUTE}]`),
+  ).find((element) => element.getAttribute(ADDON_STYLE_ATTRIBUTE) === path);
+}
+
+export function installAddonStyle(path: string, css: string) {
+  let styleElement = findAddonStyleElement(path);
+  if (!styleElement) {
+    styleElement = document.createElement("style");
+    styleElement.setAttribute(ADDON_STYLE_ATTRIBUTE, path);
+    document.head.appendChild(styleElement);
+  }
+  styleElement.textContent = css;
+}
+
+export function installAddonCssFiles(files: SandboxAddonFile[] = []) {
+  clearAddonStyles();
+  for (const file of files) {
+    if (isCssFile(file.name) && file.content.trim()) {
+      installAddonStyle(file.name, file.content);
+    }
+  }
+}
+
+export function clearAddonStyles() {
+  for (const styleElement of document.head.querySelectorAll<HTMLStyleElement>(
+    `style[${ADDON_STYLE_ATTRIBUTE}]`,
+  )) {
+    styleElement.remove();
+  }
+}
+
+export function createCssModuleSource(path: string, css: string) {
+  return `
+const css = ${JSON.stringify(css)};
+const installAddonStyle = globalThis.__wealthfolioInstallAddonStyle;
+if (typeof installAddonStyle === "function") {
+  installAddonStyle(${JSON.stringify(path)}, css);
+}
+export default css;
+`;
+}

--- a/apps/frontend/src/addons/iframe/addon-sandbox-theme.test.ts
+++ b/apps/frontend/src/addons/iframe/addon-sandbox-theme.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment node
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { installFakeAddonDom } from "@/test/fake-addon-dom";
+import { applyHostTheme, collectAddonThemeSnapshot } from "./addon-sandbox-theme";
+
+afterEach(() => {
+  applyHostTheme({ cssVariables: {} });
+  document.documentElement.className = "";
+  document.documentElement.removeAttribute("style");
+  document.body.className = "";
+  document.body.removeAttribute("style");
+});
+
+describe("addon sandbox theme bridge", () => {
+  beforeEach(() => {
+    installFakeAddonDom();
+  });
+
+  it("collects app mode, font, color scheme, and css variables from the host document", () => {
+    document.documentElement.classList.add("overflow-x-hidden", "dark");
+    document.documentElement.style.colorScheme = "dark";
+    document.documentElement.style.setProperty("--background", "black");
+    document.documentElement.style.setProperty("--foreground", "white");
+    document.body.classList.add("overflow-x-hidden", "font-serif");
+    document.body.style.backgroundColor = "rgb(0, 0, 0)";
+    document.body.style.color = "rgb(255, 255, 255)";
+    document.body.style.fontFamily = "Merriweather, serif";
+
+    const theme = collectAddonThemeSnapshot();
+
+    expect(theme.backgroundColor).toBe("rgb(0, 0, 0)");
+    expect(theme.themeClass).toBe("dark");
+    expect(theme.colorScheme).toBe("dark");
+    expect(theme.foregroundColor).toBe("rgb(255, 255, 255)");
+    expect(theme.fontClass).toBe("font-serif");
+    expect(theme.fontFamily).toContain("Merriweather");
+    expect(theme.cssVariables).toMatchObject({
+      "--background": "black",
+      "--foreground": "white",
+    });
+  });
+
+  it("applies host theme updates and removes stale host css variables", () => {
+    document.documentElement.classList.add("dark", "app-lockdown");
+    document.body.classList.add("font-mono");
+
+    applyHostTheme({
+      colorScheme: "light",
+      cssVariables: { "--background": "white", "--old-token": "remove-me" },
+      fontClass: "font-sans",
+      fontFamily: "Inter, sans-serif",
+      themeClass: "light",
+    });
+    applyHostTheme({
+      colorScheme: "dark",
+      cssVariables: { "--background": "black" },
+      fontClass: "font-serif",
+      fontFamily: "Merriweather, serif",
+      themeClass: "dark",
+    });
+
+    expect(document.documentElement.classList.contains("app-lockdown")).toBe(true);
+    expect(document.documentElement.classList.contains("light")).toBe(false);
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.documentElement.style.colorScheme).toBe("dark");
+    expect(document.documentElement.style.getPropertyValue("--background")).toBe("black");
+    expect(document.documentElement.style.getPropertyValue("--old-token")).toBe("");
+    expect(document.body.classList.contains("font-mono")).toBe(false);
+    expect(document.body.classList.contains("font-serif")).toBe(true);
+    expect(document.body.style.fontFamily).toContain("Merriweather");
+  });
+});

--- a/apps/frontend/src/addons/iframe/addon-sandbox-theme.ts
+++ b/apps/frontend/src/addons/iframe/addon-sandbox-theme.ts
@@ -1,0 +1,76 @@
+export interface AddonThemeSnapshot {
+  backgroundColor: string;
+  colorScheme: string;
+  cssVariables: Record<string, string>;
+  fontClass?: string;
+  fontFamily: string;
+  foregroundColor: string;
+  themeClass: "light" | "dark";
+}
+
+const FONT_CLASSES = ["font-mono", "font-sans", "font-serif"] as const;
+const appliedHostCssVariables = new Set<string>();
+
+export function collectAddonThemeSnapshot(): AddonThemeSnapshot {
+  const rootStyle = getComputedStyle(document.documentElement);
+  const bodyStyle = getComputedStyle(document.body);
+  const themeClass = document.documentElement.classList.contains("dark") ? "dark" : "light";
+  const cssVariables: Record<string, string> = {};
+
+  for (let index = 0; index < rootStyle.length; index += 1) {
+    const propertyName = rootStyle.item(index);
+    if (propertyName.startsWith("--")) {
+      cssVariables[propertyName] = rootStyle.getPropertyValue(propertyName).trim();
+    }
+  }
+
+  return {
+    backgroundColor: bodyStyle.backgroundColor || rootStyle.backgroundColor || "transparent",
+    colorScheme: rootStyle.colorScheme || themeClass,
+    cssVariables,
+    fontClass: FONT_CLASSES.find((className) => document.body.classList.contains(className)),
+    fontFamily: bodyStyle.fontFamily || rootStyle.fontFamily,
+    foregroundColor: bodyStyle.color || rootStyle.color || "inherit",
+    themeClass,
+  };
+}
+
+export function applyHostTheme(theme?: Partial<AddonThemeSnapshot>) {
+  if (!theme) {
+    return;
+  }
+
+  const htmlElement = document.documentElement;
+  if (theme.themeClass) {
+    htmlElement.classList.remove("light", "dark");
+    htmlElement.classList.add(theme.themeClass);
+  }
+  if (theme.colorScheme) {
+    htmlElement.style.colorScheme = theme.colorScheme;
+  }
+
+  document.body.classList.remove(...FONT_CLASSES);
+  if (theme.fontClass && FONT_CLASSES.includes(theme.fontClass as (typeof FONT_CLASSES)[number])) {
+    document.body.classList.add(theme.fontClass);
+  }
+  if (theme.fontFamily) {
+    document.body.style.fontFamily = theme.fontFamily;
+  }
+
+  const nextCssVariables = new Set(Object.keys(theme.cssVariables ?? {}));
+  for (const propertyName of appliedHostCssVariables) {
+    if (!nextCssVariables.has(propertyName)) {
+      htmlElement.style.removeProperty(propertyName);
+    }
+  }
+  for (const [propertyName, value] of Object.entries(theme.cssVariables ?? {})) {
+    if (propertyName.startsWith("--")) {
+      htmlElement.style.setProperty(propertyName, value);
+    }
+  }
+
+  appliedHostCssVariables.clear();
+  for (const propertyName of nextCssVariables) {
+    appliedHostCssVariables.add(propertyName);
+  }
+}

--- a/apps/frontend/src/addons/iframe/host-dependencies.ts
+++ b/apps/frontend/src/addons/iframe/host-dependencies.ts
@@ -1,0 +1,115 @@
+import * as ReactQuery from "@tanstack/react-query";
+import * as AddonSDK from "@wealthfolio/addon-sdk";
+import * as AddonSDKGoalProgress from "@wealthfolio/addon-sdk/goal-progress";
+import * as AddonSDKHostDependencies from "@wealthfolio/addon-sdk/host-dependencies";
+import * as AddonSDKManifest from "@wealthfolio/addon-sdk/manifest";
+import * as AddonSDKPermissions from "@wealthfolio/addon-sdk/permissions";
+import * as AddonSDKQueryKeys from "@wealthfolio/addon-sdk/query-keys";
+import * as AddonSDKUtils from "@wealthfolio/addon-sdk/utils";
+import * as WealthfolioUI from "@wealthfolio/ui";
+import * as WealthfolioUIChart from "@wealthfolio/ui/chart";
+import * as DateFns from "date-fns";
+import * as LucideReact from "lucide-react";
+import * as React from "react";
+import * as ReactJSXDevRuntime from "react/jsx-dev-runtime";
+import * as ReactJSXRuntime from "react/jsx-runtime";
+import * as ReactDOM from "react-dom";
+import * as ReactDOMClient from "react-dom/client";
+import * as Recharts from "recharts";
+
+interface HostDependencyModule {
+  defaultExport?: unknown;
+  module: Record<string, unknown>;
+}
+
+declare global {
+  // Host-provided ESM bridge used by generated blob modules in the sandbox.
+  // eslint-disable-next-line no-var
+  var __wealthfolioHostModules: Record<string, HostDependencyModule> | undefined;
+}
+
+const emptyModule: Record<string, unknown> = {};
+
+const HOST_DEPENDENCIES: Record<string, HostDependencyModule> = {
+  "@tanstack/react-query": { module: ReactQuery },
+  "@wealthfolio/addon-sdk": { module: AddonSDK },
+  "@wealthfolio/addon-sdk/goal-progress": { module: AddonSDKGoalProgress },
+  "@wealthfolio/addon-sdk/host-api": { module: emptyModule },
+  "@wealthfolio/addon-sdk/host-dependencies": { module: AddonSDKHostDependencies },
+  "@wealthfolio/addon-sdk/manifest": { module: AddonSDKManifest },
+  "@wealthfolio/addon-sdk/permissions": { module: AddonSDKPermissions },
+  "@wealthfolio/addon-sdk/query-keys": { module: AddonSDKQueryKeys },
+  "@wealthfolio/addon-sdk/types": { module: emptyModule },
+  "@wealthfolio/addon-sdk/utils": { module: AddonSDKUtils },
+  "@wealthfolio/ui": { module: WealthfolioUI },
+  "@wealthfolio/ui/chart": { module: WealthfolioUIChart },
+  "date-fns": { module: DateFns },
+  "lucide-react": { module: LucideReact },
+  react: { defaultExport: React, module: React },
+  "react-dom": { defaultExport: ReactDOM, module: ReactDOM },
+  "react-dom/client": { defaultExport: ReactDOMClient, module: ReactDOMClient },
+  "react/jsx-dev-runtime": { module: ReactJSXDevRuntime },
+  "react/jsx-runtime": { module: ReactJSXRuntime },
+  recharts: { module: Recharts },
+};
+
+const validExportName = /^[$A-Z_a-z][$\w]*$/;
+
+Object.assign(globalThis, {
+  React,
+  ReactDOM,
+  ReactDOMClient,
+  __wealthfolioHostModules: HOST_DEPENDENCIES,
+});
+
+export const HOST_DEPENDENCY_VERSION_RANGES = {
+  "@tanstack/react-query": "^5.90.0",
+  "@wealthfolio/addon-sdk": "^3.6.0",
+  "@wealthfolio/ui": "^3.6.0",
+  "date-fns": "^4.1.0",
+  "lucide-react": "^0.561.0",
+  react: "^19.2.0",
+  "react-dom": "^19.2.0",
+  recharts: "^3.7.0",
+} as const;
+
+export function isHostDependencySpecifier(specifier: string) {
+  return Object.prototype.hasOwnProperty.call(HOST_DEPENDENCIES, specifier);
+}
+
+export function createHostDependencyModuleUrl(
+  specifier: string,
+  objectUrls: Map<string, string>,
+) {
+  const module = HOST_DEPENDENCIES[specifier];
+  if (!module) {
+    return undefined;
+  }
+
+  const urlKey = `host:${specifier}`;
+  const existingUrl = objectUrls.get(urlKey);
+  if (existingUrl) {
+    return existingUrl;
+  }
+
+  const namedExports = Object.keys(module.module)
+    .filter((name) => name !== "default" && validExportName.test(name))
+    .sort()
+    .map((name) => `export const ${name} = module[${JSON.stringify(name)}];`)
+    .join("\n");
+
+  const source = `
+const hostModule = globalThis.__wealthfolioHostModules?.[${JSON.stringify(specifier)}];
+if (!hostModule) {
+  throw new Error("Host dependency is not available: ${specifier}");
+}
+const module = hostModule.module;
+const defaultExport = hostModule.defaultExport ?? module.default ?? module;
+export default defaultExport;
+${namedExports}
+`;
+
+  const url = URL.createObjectURL(new Blob([source], { type: "text/javascript" }));
+  objectUrls.set(urlKey, url);
+  return url;
+}

--- a/apps/frontend/src/addons/iframe/host-dependencies.ts
+++ b/apps/frontend/src/addons/iframe/host-dependencies.ts
@@ -77,10 +77,7 @@ export function isHostDependencySpecifier(specifier: string) {
   return Object.prototype.hasOwnProperty.call(HOST_DEPENDENCIES, specifier);
 }
 
-export function createHostDependencyModuleUrl(
-  specifier: string,
-  objectUrls: Map<string, string>,
-) {
+export function createHostDependencyModuleUrl(specifier: string, objectUrls: Map<string, string>) {
   const module = HOST_DEPENDENCIES[specifier];
   if (!module) {
     return undefined;

--- a/apps/frontend/src/addons/type-bridge.test.ts
+++ b/apps/frontend/src/addons/type-bridge.test.ts
@@ -1,5 +1,5 @@
 import { vi, describe, it, expect } from "vitest";
-import { createSDKHostAPIBridge, type InternalHostAPI } from "./type-bridge";
+import { createPermissionGuard, createSDKHostAPIBridge, type InternalHostAPI } from "./type-bridge";
 
 describe("Addon Type Bridge", () => {
   describe("createSDKHostAPIBridge", () => {
@@ -68,6 +68,135 @@ describe("Addon Type Bridge", () => {
 
       // Should fallback to default addon ID for empty string
       expect(mockLogInfo).toHaveBeenCalledWith("[unknown-addon] test message");
+    });
+
+    it("should enforce granted function permissions", () => {
+      const mockGetHoldings = vi.fn();
+      const mockUpdateSettings = vi.fn();
+      const guard = createPermissionGuard("test-addon", [
+        {
+          category: "portfolio",
+          purpose: "Portfolio access",
+          functions: [{ name: "getHoldings", isDeclared: true, isDetected: false }],
+        },
+      ]);
+
+      const sdkAPI = createSDKHostAPIBridge(
+        {
+          getHoldings: mockGetHoldings,
+          updateSettings: mockUpdateSettings,
+          logError: vi.fn(),
+          logInfo: vi.fn(),
+          logWarn: vi.fn(),
+          logTrace: vi.fn(),
+          logDebug: vi.fn(),
+        } as unknown as InternalHostAPI,
+        "test-addon",
+        guard,
+      );
+
+      sdkAPI.portfolio.getHoldings("account-1");
+
+      expect(mockGetHoldings).toHaveBeenCalledWith("account-1");
+      expect(() => sdkAPI.settings.update({})).toThrow(
+        "Addon 'test-addon' is not allowed to call settings.update",
+      );
+    });
+
+    it("should allow legacy addon navigation when router permission is granted", () => {
+      const guard = createPermissionGuard("test-addon", [
+        {
+          category: "ui",
+          purpose: "Navigation",
+          functions: [{ name: "router.add", isDeclared: true, isDetected: false }],
+        },
+      ]);
+
+      expect(guard.canUse("ui", "navigation.navigate")).toBe(true);
+    });
+
+    it("should not expose the raw QueryClient", () => {
+      const sdkAPI = createSDKHostAPIBridge(
+        {
+          logError: vi.fn(),
+          logInfo: vi.fn(),
+          logWarn: vi.fn(),
+          logTrace: vi.fn(),
+          logDebug: vi.fn(),
+        } as unknown as InternalHostAPI,
+        "test-addon",
+      );
+
+      expect(() => sdkAPI.query.getClient()).toThrow(
+        "Direct QueryClient access is not available to addons",
+      );
+    });
+
+    it("should require secrets.use for network auth injection", async () => {
+      const mockAddonNetworkRequest = vi.fn();
+      const networkOnlyGuard = createPermissionGuard("test-addon", [
+        {
+          category: "network",
+          purpose: "Network access",
+          functions: [{ name: "request", isDeclared: true, isDetected: false }],
+        },
+      ]);
+
+      const networkOnlyAPI = createSDKHostAPIBridge(
+        {
+          addonNetworkRequest: mockAddonNetworkRequest,
+          logError: vi.fn(),
+          logInfo: vi.fn(),
+          logWarn: vi.fn(),
+          logTrace: vi.fn(),
+          logDebug: vi.fn(),
+        } as unknown as InternalHostAPI,
+        "test-addon",
+        networkOnlyGuard,
+      );
+
+      expect(() =>
+        networkOnlyAPI.network.request({
+          url: "https://api.example.com/v1",
+          auth: { type: "bearer", secretKey: "api-token" },
+        }),
+      ).toThrow("Addon 'test-addon' is not allowed to call secrets.use");
+      expect(mockAddonNetworkRequest).not.toHaveBeenCalled();
+
+      const authGuard = createPermissionGuard("test-addon", [
+        {
+          category: "network",
+          purpose: "Network access",
+          functions: [{ name: "request", isDeclared: true, isDetected: false }],
+        },
+        {
+          category: "secrets",
+          purpose: "Use network secrets",
+          functions: [{ name: "use", isDeclared: true, isDetected: false }],
+        },
+      ]);
+      const authAPI = createSDKHostAPIBridge(
+        {
+          addonNetworkRequest: mockAddonNetworkRequest,
+          logError: vi.fn(),
+          logInfo: vi.fn(),
+          logWarn: vi.fn(),
+          logTrace: vi.fn(),
+          logDebug: vi.fn(),
+        } as unknown as InternalHostAPI,
+        "test-addon",
+        authGuard,
+      );
+
+      await authAPI.network.request({
+        url: "https://api.example.com/v1",
+        auth: { type: "bearer", secretKey: "api-token" },
+      });
+
+      expect(mockAddonNetworkRequest).toHaveBeenCalledWith({
+        url: "https://api.example.com/v1",
+        auth: { type: "bearer", secretKey: "api-token" },
+      });
     });
   });
 });

--- a/apps/frontend/src/addons/type-bridge.test.ts
+++ b/apps/frontend/src/addons/type-bridge.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { vi, describe, it, expect } from "vitest";
 import { createPermissionGuard, createSDKHostAPIBridge, type InternalHostAPI } from "./type-bridge";
 
@@ -127,6 +129,20 @@ describe("Addon Type Bridge", () => {
         },
       ]);
 
+      expect(guard.canUse("ui", "navigation.navigate")).toBe(true);
+    });
+
+    it("should support legacy string function permissions from raw manifests", () => {
+      const guard = createPermissionGuard("test-addon", [
+        {
+          category: "ui",
+          purpose: "Navigation",
+          functions: ["sidebar.addItem", "router.add"],
+        },
+      ] as unknown as Parameters<typeof createPermissionGuard>[1]);
+
+      expect(guard.canUse("ui", "sidebar.addItem")).toBe(true);
+      expect(guard.canUse("ui", "router.add")).toBe(true);
       expect(guard.canUse("ui", "navigation.navigate")).toBe(true);
     });
 

--- a/apps/frontend/src/addons/type-bridge.test.ts
+++ b/apps/frontend/src/addons/type-bridge.test.ts
@@ -146,6 +146,19 @@ describe("Addon Type Bridge", () => {
       expect(guard.canUse("ui", "navigation.navigate")).toBe(true);
     });
 
+    it("should treat missing isDeclared as declared for object function permissions", () => {
+      const guard = createPermissionGuard("test-addon", [
+        {
+          category: "ui",
+          purpose: "Navigation",
+          functions: [{ name: "router.add" }],
+        },
+      ] as unknown as Parameters<typeof createPermissionGuard>[1]);
+
+      expect(guard.canUse("ui", "router.add")).toBe(true);
+      expect(guard.canUse("ui", "navigation.navigate")).toBe(true);
+    });
+
     it("should not expose the raw QueryClient", () => {
       const sdkAPI = createSDKHostAPIBridge(
         {

--- a/apps/frontend/src/addons/type-bridge.test.ts
+++ b/apps/frontend/src/addons/type-bridge.test.ts
@@ -103,6 +103,21 @@ describe("Addon Type Bridge", () => {
       );
     });
 
+    it("should not grant detected-only function permissions", () => {
+      const guard = createPermissionGuard("test-addon", [
+        {
+          category: "secrets",
+          purpose: "Secrets access",
+          functions: [{ name: "use", isDeclared: false, isDetected: true }],
+        },
+      ]);
+
+      expect(guard.canUse("secrets", "use")).toBe(false);
+      expect(() => guard.assertCanUse("secrets", "use")).toThrow(
+        "Addon 'test-addon' is not allowed to call secrets.use",
+      );
+    });
+
     it("should allow legacy addon navigation when router permission is granted", () => {
       const guard = createPermissionGuard("test-addon", [
         {

--- a/apps/frontend/src/addons/type-bridge.ts
+++ b/apps/frontend/src/addons/type-bridge.ts
@@ -219,6 +219,7 @@ export interface InternalHostAPI {
 }
 
 type SDKApiWithoutSecrets = Omit<SDKHostAPI, "secrets">;
+type PermissionFunctionInput = Permission["functions"][number] | string;
 
 export interface PermissionGuard {
   canUse(category: string, functionName: string): boolean;
@@ -232,8 +233,10 @@ export function createPermissionGuard(
   const allowed = new Set<string>();
 
   for (const permission of permissions ?? []) {
-    for (const fn of permission.functions ?? []) {
-      if (fn.isDeclared) {
+    for (const fn of (permission.functions ?? []) as PermissionFunctionInput[]) {
+      if (typeof fn === "string") {
+        allowed.add(`${permission.category}:${fn}`);
+      } else if (fn.isDeclared) {
         allowed.add(`${permission.category}:${fn.name}`);
       }
     }

--- a/apps/frontend/src/addons/type-bridge.ts
+++ b/apps/frontend/src/addons/type-bridge.ts
@@ -44,6 +44,9 @@ import type {
   Goal as SDKGoal,
   GoalAllocation as SDKGoalAllocation,
   HostAPI as SDKHostAPI,
+  NetworkRequest as SDKNetworkRequest,
+  NetworkResponse as SDKNetworkResponse,
+  Permission,
 } from "@wealthfolio/addon-sdk";
 
 /**
@@ -205,11 +208,90 @@ export interface InternalHostAPI {
   invalidateQueries(queryKey: string | string[]): void;
   refetchQueries(queryKey: string | string[]): void;
 
+  // Network functions
+  addonNetworkRequest(request: SDKNetworkRequest): Promise<SDKNetworkResponse>;
+
   // Toast functions
   toastSuccess(message: string): void;
   toastError(message: string): void;
   toastWarning(message: string): void;
   toastInfo(message: string): void;
+}
+
+type SDKApiWithoutSecrets = Omit<SDKHostAPI, "secrets">;
+
+export interface PermissionGuard {
+  canUse(category: string, functionName: string): boolean;
+  assertCanUse(category: string, functionName: string): void;
+}
+
+export function createPermissionGuard(
+  addonId: string,
+  permissions: Permission[] | undefined,
+): PermissionGuard {
+  const allowed = new Set<string>();
+
+  for (const permission of permissions ?? []) {
+    for (const fn of permission.functions ?? []) {
+      if (fn.isDeclared || fn.isDetected) {
+        allowed.add(`${permission.category}:${fn.name}`);
+      }
+    }
+  }
+
+  const legacyUiNavigationAllowed = allowed.has("ui:router.add");
+  const isAllowed = (category: string, functionName: string) =>
+    allowed.has(`${category}:${functionName}`) ||
+    (category === "ui" &&
+      functionName === "navigation.navigate" &&
+      legacyUiNavigationAllowed);
+
+  return {
+    canUse: isAllowed,
+    assertCanUse: (category: string, functionName: string) => {
+      if (!isAllowed(category, functionName)) {
+        throw new Error(`Addon '${addonId}' is not allowed to call ${category}.${functionName}`);
+      }
+    },
+  };
+}
+
+function guardNamespace<T extends Record<string, unknown>>(
+  namespace: T,
+  category: string,
+  guard?: PermissionGuard,
+): T {
+  if (!guard) {
+    return namespace;
+  }
+
+  return Object.fromEntries(
+    Object.entries(namespace).map(([functionName, value]) => [
+      functionName,
+      typeof value === "function"
+        ? (...args: unknown[]) => {
+            guard.assertCanUse(category, functionName);
+            return (value as (...innerArgs: unknown[]) => unknown)(...args);
+          }
+        : value,
+    ]),
+  ) as T;
+}
+
+function guardEventsNamespace<T extends SDKApiWithoutSecrets["events"]>(
+  namespace: T,
+  guard?: PermissionGuard,
+): T {
+  if (!guard) {
+    return namespace;
+  }
+
+  return Object.fromEntries(
+    Object.entries(namespace).map(([eventGroup, handlers]) => [
+      eventGroup,
+      guardNamespace(handlers as Record<string, unknown>, "events", guard),
+    ]),
+  ) as unknown as T;
 }
 
 /**
@@ -219,7 +301,8 @@ export interface InternalHostAPI {
 export function createSDKHostAPIBridge(
   internalAPI: InternalHostAPI,
   addonId?: string,
-): Omit<SDKHostAPI, "secrets"> {
+  guard?: PermissionGuard,
+): SDKApiWithoutSecrets {
   // Create logger with addon prefix
   const createAddonLogger = (prefix: string) => ({
     error: (message: string) => internalAPI.logError(`[${prefix}] ${message}`),
@@ -309,12 +392,16 @@ export function createSDKHostAPIBridge(
     );
   };
 
-  return {
-    accounts: {
+  const accounts = guardNamespace(
+    {
       getAll: internalAPI.getAccounts,
       create: internalAPI.createAccount,
     },
-    portfolio: {
+    "accounts",
+    guard,
+  );
+  const portfolio = guardNamespace(
+    {
       getHoldings: internalAPI.getHoldings,
       getHolding: internalAPI.getHolding,
       update: internalAPI.updatePortfolio,
@@ -323,7 +410,11 @@ export function createSDKHostAPIBridge(
       getHistoricalValuations: internalAPI.getHistoricalValuations,
       getLatestValuations: internalAPI.getLatestValuations,
     },
-    activities: {
+    "portfolio",
+    guard,
+  );
+  const activities = guardNamespace(
+    {
       getAll: internalAPI.getActivities,
       search: internalAPI.searchActivities,
       create: internalAPI.createActivity,
@@ -338,57 +429,97 @@ export function createSDKHostAPIBridge(
       getImportMapping: internalAPI.getAccountImportMapping,
       saveImportMapping: internalAPI.saveAccountImportMapping,
     },
-    market: {
+    "activities",
+    guard,
+  );
+  const market = guardNamespace(
+    {
       searchTicker: internalAPI.searchTicker,
       syncHistory: internalAPI.syncHistoryQuotes,
       sync: internalAPI.syncMarketData,
       getProviders: internalAPI.getMarketDataProviders,
       fetchDividends: internalAPI.fetchDividends,
     },
-    assets: {
+    "market-data",
+    guard,
+  );
+  const assets = guardNamespace(
+    {
       getProfile: internalAPI.getAssetProfile,
       updateProfile: internalAPI.updateAssetProfile,
       updateQuoteMode: internalAPI.updateQuoteMode,
     },
-    quotes: {
+    "assets",
+    guard,
+  );
+  const quotes = guardNamespace(
+    {
       update: internalAPI.updateQuote,
       getHistory: internalAPI.getQuoteHistory,
     },
-    performance: {
+    "quotes",
+    guard,
+  );
+  const performance = guardNamespace(
+    {
       calculateHistory: internalAPI.calculatePerformanceHistory,
       calculateSummary: internalAPI.calculatePerformanceSummary,
       calculateAccountsSimple: internalAPI.calculateAccountsSimplePerformance,
     },
-    exchangeRates: {
+    "performance",
+    guard,
+  );
+  const exchangeRates = guardNamespace(
+    {
       getAll: internalAPI.getExchangeRates,
       update: internalAPI.updateExchangeRate,
       add: internalAPI.addExchangeRate,
     },
-    contributionLimits: {
+    "currency",
+    guard,
+  );
+  const contributionLimits = guardNamespace(
+    {
       getAll: internalAPI.getContributionLimit,
       create: internalAPI.createContributionLimit,
       update: internalAPI.updateContributionLimit,
       calculateDeposits: internalAPI.calculateDepositsForLimit,
     },
-    goals: {
+    "contribution-limits",
+    guard,
+  );
+  const goals = guardNamespace(
+    {
       getAll: async () => (await internalAPI.getGoals()).map(toSDKGoal),
-      create: async (goal) => toSDKGoal(await internalAPI.createGoal(goal)),
-      update: async (goal) => toSDKGoal(await internalAPI.updateGoal(goal)),
+      create: async (goal: unknown) => toSDKGoal(await internalAPI.createGoal(goal)),
+      update: async (goal: SDKGoal) => toSDKGoal(await internalAPI.updateGoal(goal)),
       getFunding: getGoalFunding,
       saveFunding: saveGoalFunding,
       getAllocations: getGoalAllocations,
       updateAllocations: updateGoalAllocations,
     },
-    settings: {
+    "financial-planning",
+    guard,
+  );
+  const settings = guardNamespace(
+    {
       get: internalAPI.getSettings,
       update: internalAPI.updateSettings,
       backupDatabase: internalAPI.backupDatabase,
     },
-    files: {
+    "settings",
+    guard,
+  );
+  const files = guardNamespace(
+    {
       openCsvDialog: internalAPI.openCsvFileDialog,
       openSaveDialog: internalAPI.openFileSaveDialog,
     },
-    snapshots: {
+    "files",
+    guard,
+  );
+  const snapshots = guardNamespace(
+    {
       getAll: internalAPI.getSnapshots,
       getByDate: internalAPI.getSnapshotByDate,
       save: internalAPI.saveManualHoldings,
@@ -396,10 +527,12 @@ export function createSDKHostAPIBridge(
       importSnapshots: internalAPI.importHoldingsCsv,
       delete: internalAPI.deleteSnapshot,
     },
+    "snapshots",
+    guard,
+  );
 
-    logger: createAddonLogger(addonId || "unknown-addon"),
-
-    events: {
+  const events = guardEventsNamespace(
+    {
       import: {
         onDropHover: internalAPI.listenImportFileDropHover,
         onDrop: internalAPI.listenImportFileDrop,
@@ -415,16 +548,59 @@ export function createSDKHostAPIBridge(
         onSyncComplete: internalAPI.listenMarketSyncComplete,
       },
     },
+    guard,
+  );
+  const requestNetwork = (request: SDKNetworkRequest) => {
+    guard?.assertCanUse("network", "request");
+    if (request.auth) {
+      guard?.assertCanUse("secrets", "use");
+    }
+    return internalAPI.addonNetworkRequest(request);
+  };
+
+  return {
+    accounts: accounts as unknown as SDKApiWithoutSecrets["accounts"],
+    portfolio: portfolio as unknown as SDKApiWithoutSecrets["portfolio"],
+    activities: activities as unknown as SDKApiWithoutSecrets["activities"],
+    market: market as unknown as SDKApiWithoutSecrets["market"],
+    assets: assets as unknown as SDKApiWithoutSecrets["assets"],
+    quotes: quotes as unknown as SDKApiWithoutSecrets["quotes"],
+    performance: performance as unknown as SDKApiWithoutSecrets["performance"],
+    exchangeRates: exchangeRates as unknown as SDKApiWithoutSecrets["exchangeRates"],
+    contributionLimits: contributionLimits as unknown as SDKApiWithoutSecrets["contributionLimits"],
+    goals: goals as unknown as SDKApiWithoutSecrets["goals"],
+    settings: settings as unknown as SDKApiWithoutSecrets["settings"],
+    files: files as unknown as SDKApiWithoutSecrets["files"],
+    snapshots: snapshots as unknown as SDKApiWithoutSecrets["snapshots"],
+
+    logger: createAddonLogger(addonId || "unknown-addon"),
+
+    events: events as unknown as SDKApiWithoutSecrets["events"],
 
     navigation: {
-      navigate: internalAPI.navigateToRoute,
+      navigate: async (route: string) => {
+        guard?.assertCanUse("ui", "navigation.navigate");
+        return internalAPI.navigateToRoute(route);
+      },
     },
 
     query: {
-      getClient: internalAPI.getQueryClient,
-      invalidateQueries: internalAPI.invalidateQueries,
-      refetchQueries: internalAPI.refetchQueries,
+      getClient: () => {
+        throw new Error("Direct QueryClient access is not available to addons");
+      },
+      invalidateQueries: (queryKey: string | string[]) => {
+        guard?.assertCanUse("query", "invalidateQueries");
+        return internalAPI.invalidateQueries(queryKey);
+      },
+      refetchQueries: (queryKey: string | string[]) => {
+        guard?.assertCanUse("query", "refetchQueries");
+        return internalAPI.refetchQueries(queryKey);
+      },
     },
+
+    network: {
+      request: requestNetwork,
+    } as unknown as SDKApiWithoutSecrets["network"],
 
     toast: {
       success: internalAPI.toastSuccess,

--- a/apps/frontend/src/addons/type-bridge.ts
+++ b/apps/frontend/src/addons/type-bridge.ts
@@ -233,7 +233,7 @@ export function createPermissionGuard(
 
   for (const permission of permissions ?? []) {
     for (const fn of permission.functions ?? []) {
-      if (fn.isDeclared || fn.isDetected) {
+      if (fn.isDeclared) {
         allowed.add(`${permission.category}:${fn.name}`);
       }
     }
@@ -242,9 +242,7 @@ export function createPermissionGuard(
   const legacyUiNavigationAllowed = allowed.has("ui:router.add");
   const isAllowed = (category: string, functionName: string) =>
     allowed.has(`${category}:${functionName}`) ||
-    (category === "ui" &&
-      functionName === "navigation.navigate" &&
-      legacyUiNavigationAllowed);
+    (category === "ui" && functionName === "navigation.navigate" && legacyUiNavigationAllowed);
 
   return {
     canUse: isAllowed,

--- a/apps/frontend/src/addons/type-bridge.ts
+++ b/apps/frontend/src/addons/type-bridge.ts
@@ -236,7 +236,7 @@ export function createPermissionGuard(
     for (const fn of (permission.functions ?? []) as PermissionFunctionInput[]) {
       if (typeof fn === "string") {
         allowed.add(`${permission.category}:${fn}`);
-      } else if (fn.isDeclared) {
+      } else if (typeof fn.name === "string" && fn.isDeclared !== false) {
         allowed.add(`${permission.category}:${fn.name}`);
       }
     }

--- a/apps/frontend/src/components/app-launcher.tsx
+++ b/apps/frontend/src/components/app-launcher.tsx
@@ -17,6 +17,7 @@ import { useSettingsContext } from "@/lib/settings-provider";
 import { Account } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { useNavigation } from "@/pages/layouts/navigation/app-navigation";
+import { resolveNavigationIcon } from "@/pages/layouts/navigation/navigation-icons";
 import { useNavigationMode } from "@/pages/layouts/navigation/navigation-mode-context";
 import {
   Command,
@@ -35,7 +36,7 @@ import {
   SheetTitle,
   type Icon,
 } from "@wealthfolio/ui";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 interface RecentItem {
@@ -61,7 +62,7 @@ interface LauncherAccountItem {
 interface LauncherActionItem {
   title: string;
   href: string;
-  icon?: React.ReactNode;
+  icon?: ReactNode;
   keywords?: string[];
   label?: string;
   disabled?: boolean;
@@ -598,24 +599,7 @@ export function AppLauncher() {
     filteredAccounts.length > 0 ||
     showRecent;
 
-  const renderIcon = (icon?: React.ReactNode) => {
-    if (!icon) {
-      return null;
-    }
-
-    if (React.isValidElement<{ className?: string }>(icon)) {
-      return React.cloneElement(icon, {
-        className: [iconClassName, icon.props.className].filter(Boolean).join(" "),
-      });
-    }
-
-    if (typeof icon === "function") {
-      const IconComponent = icon as React.ComponentType<{ className?: string }>;
-      return <IconComponent className={iconClassName} />;
-    }
-
-    return <span className={iconClassName}>{icon}</span>;
-  };
+  const renderIcon = (icon?: ReactNode) => resolveNavigationIcon(icon, iconClassName);
 
   const commandContent = (
     <>

--- a/apps/frontend/src/hooks/use-navigation-event-listener.ts
+++ b/apps/frontend/src/hooks/use-navigation-event-listener.ts
@@ -1,6 +1,10 @@
 import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { listenNavigateToRoute } from "@/adapters";
+import {
+  clearAddonNavigationHandler,
+  setAddonNavigationHandler,
+} from "@/addons/addons-runtime-context";
 
 const useNavigationEventListener = () => {
   const navigate = useNavigate();
@@ -10,8 +14,7 @@ const useNavigationEventListener = () => {
       return;
     };
 
-    // Make navigate function available globally for addons
-    window.__wealthfolio_navigate__ = navigate;
+    setAddonNavigationHandler(navigate);
 
     const setupNavigationListener = async () => {
       const handleNavigateToRoute = (event: { payload: { route: string } }) => {
@@ -32,8 +35,7 @@ const useNavigationEventListener = () => {
       });
 
     return () => {
-      // Clean up global reference
-      delete window.__wealthfolio_navigate__;
+      clearAddonNavigationHandler(navigate);
       cleanup();
     };
   }, [navigate]);

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -1,6 +1,5 @@
 import { isDesktop, getPlatform } from "@/adapters";
 import React from "react";
-import * as ReactDOMLegacy from "react-dom";
 import ReactDOM from "react-dom/client";
 import { debugAddonState, isAddonDevModeEnabled, loadAllAddons } from "./addons/addons-loader";
 import "./addons/addons-runtime-context";
@@ -21,13 +20,14 @@ if (isAddonDevModeEnabled) {
   });
 }
 
-// Expose React and ReactDOM globally for addons
-// ReactDOM/client only has createRoot/hydrateRoot, but addons need createPortal from react-dom
-window.React = React;
-window.ReactDOM = ReactDOMLegacy;
-
-// Make debug function available globally for debugging
-globalThis.debugAddons = debugAddonState;
+if (import.meta.env.DEV) {
+  Object.defineProperty(globalThis, "debugAddons", {
+    configurable: true,
+    enumerable: false,
+    value: debugAddonState,
+    writable: false,
+  });
+}
 
 // Load addons after context is injected
 loadAllAddons();

--- a/apps/frontend/src/pages/layouts/app-layout.tsx
+++ b/apps/frontend/src/pages/layouts/app-layout.tsx
@@ -6,7 +6,6 @@ import { UpdateDialog } from "@/components/update-dialog";
 import { PortfolioSyncProvider } from "@/context/portfolio-sync-context";
 import { useActiveAppSyncTrigger } from "@/features/devices-sync/hooks/use-active-app-sync-trigger";
 import { usePostLoginConnectSync } from "@/features/wealthfolio-connect/hooks";
-import useNavigationEventListener from "@/hooks/use-navigation-event-listener";
 import { useIsMobileViewport, usePlatform } from "@/hooks/use-platform";
 import { useSettings } from "@/hooks/use-settings";
 import { cn } from "@/lib/utils";
@@ -44,9 +43,12 @@ const AppLayoutContent = () => {
   const launchBarHeight =
     !shouldUseMobileNavigation && isLaunchBar && !isFocusMode ? "56px" : undefined;
   const isAppShellReady = isSettingsReady && !!settings?.onboardingCompleted;
+  const pageScrollKey =
+    location.pathname.startsWith("/addon/") || location.pathname.startsWith("/addons/")
+      ? location.pathname.split("/").slice(0, 3).join("/")
+      : location.pathname;
 
   const areGlobalEventsReady = useGlobalEventListener();
-  useNavigationEventListener();
   useActiveAppSyncTrigger({ enabled: isTauri, requireWindowFocusForInterval: !isMobile });
   usePostLoginConnectSync({ enabled: areGlobalEventsReady && isAppShellReady });
 
@@ -107,7 +109,7 @@ const AppLayoutContent = () => {
               <MobileNavigationContainer key={location.pathname} />
             ) : (
               <PageScrollContainer
-                key={location.pathname}
+                key={pageScrollKey}
                 withMobileNavOffset={shouldUseBottomNavigation}
               >
                 <Outlet />

--- a/apps/frontend/src/pages/layouts/app-layout.tsx
+++ b/apps/frontend/src/pages/layouts/app-layout.tsx
@@ -45,7 +45,7 @@ const AppLayoutContent = () => {
   const isAppShellReady = isSettingsReady && !!settings?.onboardingCompleted;
   const pageScrollKey =
     location.pathname.startsWith("/addon/") || location.pathname.startsWith("/addons/")
-      ? location.pathname.split("/").slice(0, 3).join("/")
+      ? "/addons"
       : location.pathname;
 
   const areGlobalEventsReady = useGlobalEventListener();
@@ -106,7 +106,7 @@ const AppLayoutContent = () => {
               className="draggable pointer-events-auto absolute inset-x-0 top-0 z-50 h-6 cursor-grab opacity-0"
             ></div>
             {shouldUseMobileNavigation ? (
-              <MobileNavigationContainer key={location.pathname} />
+              <MobileNavigationContainer key={pageScrollKey} />
             ) : (
               <PageScrollContainer
                 key={pageScrollKey}

--- a/apps/frontend/src/pages/layouts/navigation/addon-navigation-pins.ts
+++ b/apps/frontend/src/pages/layouts/navigation/addon-navigation-pins.ts
@@ -1,0 +1,60 @@
+import { usePersistentState } from "@/hooks/use-persistent-state";
+import { useCallback, useMemo } from "react";
+
+export interface AddonNavPinItem {
+  id?: string;
+  href: string;
+}
+
+export const PINNED_ADDON_NAV_STORAGE_KEY = "wealthfolio:pinned-addon-nav-items";
+export const PINNED_ADDON_NAV_CONFIGURED_STORAGE_KEY =
+  "wealthfolio:pinned-addon-nav-items-configured";
+
+export function getAddonNavPinKey(item: AddonNavPinItem) {
+  return item.id ?? item.href;
+}
+
+export function useAddonNavigationPins() {
+  const [pinnedAddonIds, setPinnedAddonIds] = usePersistentState<string[]>(
+    PINNED_ADDON_NAV_STORAGE_KEY,
+    [],
+  );
+  const [hasConfiguredAddonPins, setHasConfiguredAddonPins] = usePersistentState<boolean>(
+    PINNED_ADDON_NAV_CONFIGURED_STORAGE_KEY,
+    false,
+  );
+
+  const pinnedAddonIdSet = useMemo(() => new Set(pinnedAddonIds), [pinnedAddonIds]);
+
+  const isAddonPinned = useCallback(
+    (item: AddonNavPinItem) => pinnedAddonIdSet.has(getAddonNavPinKey(item)),
+    [pinnedAddonIdSet],
+  );
+
+  const setAddonPinned = useCallback(
+    (item: AddonNavPinItem, pinned: boolean) => {
+      const itemId = getAddonNavPinKey(item);
+      setHasConfiguredAddonPins(true);
+
+      setPinnedAddonIds((currentIds) => {
+        const isPinned = currentIds.includes(itemId);
+
+        if (pinned) {
+          return isPinned ? currentIds : [...currentIds, itemId];
+        }
+
+        return isPinned ? currentIds.filter((id) => id !== itemId) : currentIds;
+      });
+    },
+    [setHasConfiguredAddonPins, setPinnedAddonIds],
+  );
+
+  return {
+    hasConfiguredAddonPins,
+    isAddonPinned,
+    pinnedAddonIds,
+    pinnedAddonIdSet,
+    setAddonPinned,
+    setPinnedAddonIds,
+  };
+}

--- a/apps/frontend/src/pages/layouts/navigation/app-navigation.tsx
+++ b/apps/frontend/src/pages/layouts/navigation/app-navigation.tsx
@@ -1,8 +1,10 @@
 import { getDynamicNavItems, subscribeToNavigationUpdates } from "@/addons/addons-runtime-context";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { getAddonNavPinKey, useAddonNavigationPins } from "./addon-navigation-pins";
 
 export interface NavLink {
+  id?: string;
   title: string;
   href: string;
   icon?: ReactNode;
@@ -14,6 +16,9 @@ export interface NavigationProps {
   primary: NavLink[];
   secondary?: NavLink[];
   addons?: NavLink[];
+  addonMenuItems?: NavLink[];
+  pinnedAddons?: NavLink[];
+  setAddonPinned?: (item: NavLink, pinned: boolean) => void;
 }
 
 const staticNavigation: NavigationProps = {
@@ -73,6 +78,8 @@ const staticNavigation: NavigationProps = {
 
 export function useNavigation() {
   const [dynamicItems, setDynamicItems] = useState<NavigationProps["addons"]>([]);
+  const { hasConfiguredAddonPins, pinnedAddonIdSet, setAddonPinned, setPinnedAddonIds } =
+    useAddonNavigationPins();
 
   // Subscribe to navigation updates from addons
   useEffect(() => {
@@ -95,11 +102,34 @@ export function useNavigation() {
   // Spending lives entirely on the dashboard tab (and its deep-linked pages);
   // no top-level nav entry. Combine static navigation items with addons.
   const primary = [...staticNavigation.primary];
+  const addons = useMemo(() => dynamicItems ?? [], [dynamicItems]);
 
+  useEffect(() => {
+    if (hasConfiguredAddonPins || addons.length !== 1) {
+      return;
+    }
+
+    const onlyAddonId = getAddonNavPinKey(addons[0]);
+    setPinnedAddonIds((currentIds) =>
+      currentIds.includes(onlyAddonId) ? currentIds : [...currentIds, onlyAddonId],
+    );
+  }, [addons, hasConfiguredAddonPins, setPinnedAddonIds]);
+
+  const pinnedAddons = useMemo(
+    () => addons.filter((item) => pinnedAddonIdSet.has(getAddonNavPinKey(item))),
+    [addons, pinnedAddonIdSet],
+  );
+  const addonMenuItems = useMemo(
+    () => addons.filter((item) => !pinnedAddonIdSet.has(getAddonNavPinKey(item))),
+    [addons, pinnedAddonIdSet],
+  );
   const navigation: NavigationProps = {
     primary,
     secondary: staticNavigation.secondary,
-    addons: dynamicItems,
+    addons,
+    addonMenuItems,
+    pinnedAddons,
+    setAddonPinned,
   };
 
   return navigation;

--- a/apps/frontend/src/pages/layouts/navigation/app-navigation.tsx
+++ b/apps/frontend/src/pages/layouts/navigation/app-navigation.tsx
@@ -1,11 +1,11 @@
 import { getDynamicNavItems, subscribeToNavigationUpdates } from "@/addons/addons-runtime-context";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 
 export interface NavLink {
   title: string;
   href: string;
-  icon?: React.ReactNode;
+  icon?: ReactNode;
   keywords?: string[];
   label?: string; // Optional descriptive label for launcher/search
 }

--- a/apps/frontend/src/pages/layouts/navigation/app-sidebar.tsx
+++ b/apps/frontend/src/pages/layouts/navigation/app-sidebar.tsx
@@ -26,6 +26,7 @@ const modKey = isAppleDevice() ? "⌘" : "Ctrl";
 export function AppSidebar({ navigation }: AppSidebarProps) {
   const [collapsed, setCollapsed] = useState(true);
   const { logout, requiresAuth } = useAuth();
+  const addonMenuItems = navigation?.addonMenuItems ?? navigation?.addons ?? [];
 
   return (
     <div
@@ -120,8 +121,21 @@ export function AppSidebar({ navigation }: AppSidebarProps) {
                   <NavItem key={item.title} item={item} collapsed={collapsed} />
                 ))}
 
-                {navigation?.addons && navigation.addons.length > 0 && (
-                  <AddonsMenu addons={navigation.addons} collapsed={collapsed} />
+                {navigation?.pinnedAddons?.map((item) => (
+                  <PinnedAddonNavItem
+                    key={item.id ?? item.href}
+                    item={item}
+                    collapsed={collapsed}
+                    onSetPinned={navigation.setAddonPinned}
+                  />
+                ))}
+
+                {addonMenuItems.length > 0 && (
+                  <AddonsMenu
+                    addons={addonMenuItems}
+                    collapsed={collapsed}
+                    onSetPinned={navigation.setAddonPinned}
+                  />
                 )}
               </nav>
             </div>
@@ -180,6 +194,45 @@ export function AppSidebar({ navigation }: AppSidebarProps) {
   );
 }
 
+interface PinnedAddonNavItemProps {
+  item: NavLink;
+  collapsed: boolean;
+  onSetPinned?: (item: NavLink, pinned: boolean) => void;
+}
+
+function PinnedAddonNavItem({ item, collapsed, onSetPinned }: PinnedAddonNavItemProps) {
+  if (collapsed || !onSetPinned) {
+    return <NavItem item={item} collapsed={collapsed} />;
+  }
+
+  return (
+    <div className="group relative">
+      <NavItem item={item} collapsed={collapsed} className="pr-10" />
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="hover:bg-accent pointer-events-none absolute right-1 top-1/2 z-10 h-8 w-8 -translate-y-1/2 rounded-full opacity-0 transition-opacity focus:pointer-events-auto focus:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100"
+            title={`${item.title} options`}
+            aria-label={`${item.title} options`}
+          >
+            <Icons.MoreHorizontal className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent side="bottom" align="start" className="w-48">
+          <DropdownMenuItem onClick={() => onSetPinned(item, false)}>
+            <Icons.PinOff className="mr-2 h-4 w-4" />
+            Unpin from sidebar
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
 interface NavItemProps {
   item: NavLink;
   collapsed: boolean;
@@ -228,14 +281,16 @@ function NavItem({ item, collapsed, className, ...props }: NavItemProps) {
 interface AddonsMenuProps {
   addons: NavLink[];
   collapsed: boolean;
+  onSetPinned?: (item: NavLink, pinned: boolean) => void;
 }
 
-function AddonsMenu({ addons, collapsed }: AddonsMenuProps) {
+function AddonsMenu({ addons, collapsed, onSetPinned }: AddonsMenuProps) {
   const location = useLocation();
+  const [open, setOpen] = useState(false);
   const hasActiveAddon = addons.some((addon) => isPathActive(location.pathname, addon.href));
 
   return (
-    <DropdownMenu>
+    <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
         <Button
           variant={hasActiveAddon ? "secondary" : "ghost"}
@@ -258,27 +313,70 @@ function AddonsMenu({ addons, collapsed }: AddonsMenuProps) {
           </span>
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent side={collapsed ? "right" : "bottom"} align="start" className="w-56">
+      <DropdownMenuContent
+        side={collapsed ? "right" : "bottom"}
+        align="start"
+        className="w-max min-w-56 max-w-[calc(100vw-2rem)]"
+      >
         {addons.map((addon) => {
           const isActive = isPathActive(location.pathname, addon.href);
+          const pinAddon = () => {
+            onSetPinned?.(addon, true);
+            setOpen(false);
+          };
+
           return (
-            <DropdownMenuItem key={addon.href} asChild>
-              <Link
-                to={addon.href}
-                className={cn(
-                  "flex h-12 w-full cursor-pointer items-center gap-3 px-3 py-3",
-                  isActive && "bg-secondary",
-                )}
+            <div
+              key={addon.id ?? addon.href}
+              className={cn(
+                "hover:bg-accent focus-within:bg-accent group flex h-12 items-center rounded-sm transition-colors",
+                isActive && "bg-secondary",
+              )}
+            >
+              <DropdownMenuItem
+                asChild
+                className="h-12 min-w-0 flex-1 gap-3 px-3 py-3 text-sm font-medium"
               >
-                <span
-                  aria-hidden="true"
-                  className="flex size-5 shrink-0 items-center justify-center"
+                <Link to={addon.href} onClick={() => setOpen(false)}>
+                  <span
+                    aria-hidden="true"
+                    className="flex size-5 shrink-0 items-center justify-center"
+                  >
+                    {resolveNavigationIcon(addon.icon, "h-5 w-5")}
+                  </span>
+                  <span className="whitespace-nowrap">{addon.title}</span>
+                </Link>
+              </DropdownMenuItem>
+              {onSetPinned && (
+                <button
+                  type="button"
+                  className="hover:bg-background focus:bg-background group-hover:bg-background hover:ring-border focus:ring-border group-hover:ring-border mr-1 flex size-8 shrink-0 items-center justify-center rounded-full opacity-0 outline-none transition-[background-color,box-shadow,opacity] hover:ring-1 focus:opacity-100 focus:ring-1 group-hover:opacity-100 group-hover:ring-1"
+                  title="Pin to sidebar"
+                  aria-label={`Pin ${addon.title} to sidebar`}
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    pinAddon();
+                  }}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    pinAddon();
+                  }}
+                  onKeyDown={(event) => {
+                    if (event.key !== "Enter" && event.key !== " ") {
+                      return;
+                    }
+
+                    event.preventDefault();
+                    event.stopPropagation();
+                    pinAddon();
+                  }}
                 >
-                  {resolveNavigationIcon(addon.icon, "h-5 w-5")}
-                </span>
-                <span className="text-sm font-medium">{addon.title}</span>
-              </Link>
-            </DropdownMenuItem>
+                  <Icons.Pin className="h-4 w-4" />
+                </button>
+              )}
+            </div>
           );
         })}
       </DropdownMenuContent>

--- a/apps/frontend/src/pages/layouts/navigation/app-sidebar.tsx
+++ b/apps/frontend/src/pages/layouts/navigation/app-sidebar.tsx
@@ -15,6 +15,7 @@ import { useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { type NavLink, type NavigationProps, isPathActive } from "./app-navigation";
 import { ConnectNavItem } from "./connect-nav-item";
+import { resolveNavigationIcon } from "./navigation-icons";
 
 interface AppSidebarProps {
   navigation: NavigationProps;
@@ -208,7 +209,7 @@ function NavItem({ item, collapsed, className, ...props }: NavItemProps) {
         aria-current={isActive ? "page" : undefined}
         {...props}
       >
-        <span aria-hidden="true">{item.icon ?? <Icons.ArrowRight className="h-5 w-5" />}</span>
+        <span aria-hidden="true">{resolveNavigationIcon(item.icon, "h-5 w-5")}</span>
 
         <span
           className={cn({
@@ -273,7 +274,7 @@ function AddonsMenu({ addons, collapsed }: AddonsMenuProps) {
                   aria-hidden="true"
                   className="flex size-5 shrink-0 items-center justify-center"
                 >
-                  {addon.icon ?? <Icons.ArrowRight className="h-5 w-5" />}
+                  {resolveNavigationIcon(addon.icon, "h-5 w-5")}
                 </span>
                 <span className="text-sm font-medium">{addon.title}</span>
               </Link>

--- a/apps/frontend/src/pages/layouts/navigation/floating-navigation-bar.tsx
+++ b/apps/frontend/src/pages/layouts/navigation/floating-navigation-bar.tsx
@@ -4,7 +4,7 @@ import { useAggregatedSyncStatus } from "@/features/wealthfolio-connect/hooks";
 import { cn } from "@/lib/utils";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger, Icons } from "@wealthfolio/ui";
 import { motion } from "motion/react";
-import { useCallback, useId, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useId, useState, type ReactNode } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { type NavigationProps, isPathActive } from "./app-navigation";
 import { resolveNavigationIcon } from "./navigation-icons";
@@ -17,11 +17,10 @@ export function FloatingNavigationBar({ navigation }: FloatingNavigationBarProps
   const location = useLocation();
   const navigate = useNavigate();
   const [overflowOpen, setOverflowOpen] = useState(false);
-  const [addonsOpen, setAddonsOpen] = useState(false);
   const uniqueId = useId();
   const { status: syncStatus } = useAggregatedSyncStatus();
   const baseButtonClass =
-    "text-foreground relative z-10 flex h-11 w-full items-center justify-center rounded-full transition-colors";
+    "text-foreground relative z-10 flex size-11 shrink-0 items-center justify-center rounded-full transition-colors";
 
   const handleNavigation = useCallback(
     (href: string, isActive: boolean) => {
@@ -35,25 +34,15 @@ export function FloatingNavigationBar({ navigation }: FloatingNavigationBarProps
 
   const primaryItems = navigation?.primary ?? [];
   const secondaryItems = navigation?.secondary ?? [];
-  const addonItems = navigation?.addons ?? [];
+  const pinnedAddonItems = navigation?.pinnedAddons ?? [];
+  const addonMenuItems = navigation?.addonMenuItems ?? navigation?.addons ?? [];
 
-  const baseItems = useMemo(
-    () => [...primaryItems, ...secondaryItems],
-    [primaryItems, secondaryItems],
-  );
-  const launcherColumn = 1;
-  const connectColumn = 1;
-  const visibleCount = 7;
+  const baseItems = [...primaryItems, ...pinnedAddonItems, ...secondaryItems];
+  const visibleCount = 15;
   const visibleItems = baseItems.slice(0, visibleCount);
   const overflowItems = baseItems.slice(visibleCount);
-  const hasOverflow = overflowItems.length > 0;
-  const hasAddons = addonItems.length > 0;
-  const columnCount =
-    visibleItems.length +
-    launcherColumn +
-    connectColumn +
-    (hasOverflow ? 1 : 0) +
-    (hasAddons ? 1 : 0);
+  const moreItems = [...overflowItems, ...addonMenuItems];
+  const hasMoreItems = moreItems.length > 0;
 
   return (
     <div className="pointer-events-none fixed inset-x-0 bottom-0 z-40">
@@ -62,16 +51,11 @@ export function FloatingNavigationBar({ navigation }: FloatingNavigationBarProps
           variant="floating"
           intensity="subtle"
           className={cn(
-            "pointer-events-auto w-full px-1 py-1.5",
+            "scrollbar-hide pointer-events-auto w-fit max-w-[calc(100vw-2rem)] overflow-x-auto px-1 py-1.5",
             "h-[var(--mobile-nav-ui-height)]",
-            "max-w-md",
           )}
         >
-          <nav
-            aria-label="Floating navigation"
-            className="grid place-items-center items-center gap-0"
-            style={{ gridTemplateColumns: `repeat(${columnCount}, minmax(0, 1fr))` }}
-          >
+          <nav aria-label="Floating navigation" className="flex items-center gap-0">
             {visibleItems.map((item) => {
               const isActive = isPathActive(location.pathname, item.href);
               return (
@@ -159,11 +143,11 @@ export function FloatingNavigationBar({ navigation }: FloatingNavigationBarProps
                 <SyncStatusIcon status={syncStatus} className="size-6" />
               </span>
             </Link>
-            {hasOverflow && (
+            {hasMoreItems && (
               <DropdownMenu open={overflowOpen} onOpenChange={setOverflowOpen}>
                 <DropdownMenuTrigger asChild>
                   <button aria-label="More navigation" className={baseButtonClass}>
-                    {overflowItems.some((item) => isPathActive(location.pathname, item.href)) && (
+                    {moreItems.some((item) => isPathActive(location.pathname, item.href)) && (
                       <motion.div
                         layoutId={`floating-nav-indicator-${uniqueId}`}
                         className="absolute inset-0 -z-10 rounded-full border border-black/10 bg-black/5 shadow-sm dark:border-white/10 dark:bg-white/10"
@@ -189,7 +173,7 @@ export function FloatingNavigationBar({ navigation }: FloatingNavigationBarProps
                   sideOffset={16}
                   className="mb-0 mr-0 flex w-48 flex-col gap-1 border-0 bg-transparent p-0 shadow-none ring-0 ring-offset-0"
                 >
-                  {overflowItems.map((item) => {
+                  {moreItems.map((item) => {
                     const isActive = isPathActive(location.pathname, item.href);
                     return (
                       <LiquidGlass key={item.href} variant="floating" intensity="subtle">
@@ -198,61 +182,6 @@ export function FloatingNavigationBar({ navigation }: FloatingNavigationBarProps
                           onClick={() => {
                             handleNavigation(item.href, isActive);
                             setOverflowOpen(false);
-                          }}
-                          aria-current={isActive ? "page" : undefined}
-                          className="relative z-10 flex w-full items-center gap-3 rounded-full px-3 py-2 text-sm"
-                        >
-                          <span className="flex size-6 shrink-0 items-center justify-center">
-                            {renderIcon(item.icon)}
-                          </span>
-                          <span className="truncate text-left">{item.title}</span>
-                        </Link>
-                      </LiquidGlass>
-                    );
-                  })}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            )}
-
-            {hasAddons && (
-              <DropdownMenu open={addonsOpen} onOpenChange={setAddonsOpen}>
-                <DropdownMenuTrigger asChild>
-                  <button aria-label="Add-ons" className={baseButtonClass}>
-                    {addonItems.some((item) => isPathActive(location.pathname, item.href)) && (
-                      <motion.div
-                        layoutId={`floating-nav-indicator-${uniqueId}`}
-                        className="absolute inset-0 -z-10 rounded-full border border-black/10 bg-black/5 shadow-sm dark:border-white/10 dark:bg-white/10"
-                        initial={false}
-                        transition={{
-                          type: "spring",
-                          stiffness: 400,
-                          damping: 30,
-                        }}
-                      />
-                    )}
-                    <span
-                      className="relative flex size-7 shrink-0 items-center justify-center outline-none"
-                      aria-hidden="true"
-                    >
-                      <Icons.Addons className="size-5" />
-                    </span>
-                  </button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent
-                  side="top"
-                  align="end"
-                  sideOffset={16}
-                  className="mb-0 mr-0 flex w-48 flex-col gap-1 border-0 bg-transparent p-0 shadow-none ring-0 ring-offset-0"
-                >
-                  {addonItems.map((item) => {
-                    const isActive = isPathActive(location.pathname, item.href);
-                    return (
-                      <LiquidGlass key={item.href} variant="floating" intensity="subtle">
-                        <Link
-                          to={item.href}
-                          onClick={() => {
-                            handleNavigation(item.href, isActive);
-                            setAddonsOpen(false);
                           }}
                           aria-current={isActive ? "page" : undefined}
                           className="relative z-10 flex w-full items-center gap-3 rounded-full px-3 py-2 text-sm"

--- a/apps/frontend/src/pages/layouts/navigation/floating-navigation-bar.tsx
+++ b/apps/frontend/src/pages/layouts/navigation/floating-navigation-bar.tsx
@@ -4,9 +4,10 @@ import { useAggregatedSyncStatus } from "@/features/wealthfolio-connect/hooks";
 import { cn } from "@/lib/utils";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger, Icons } from "@wealthfolio/ui";
 import { motion } from "motion/react";
-import React, { useCallback, useId, useMemo, useState } from "react";
+import { useCallback, useId, useMemo, useState, type ReactNode } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { type NavigationProps, isPathActive } from "./app-navigation";
+import { resolveNavigationIcon } from "./navigation-icons";
 
 interface FloatingNavigationBarProps {
   navigation: NavigationProps;
@@ -30,22 +31,7 @@ export function FloatingNavigationBar({ navigation }: FloatingNavigationBarProps
     [navigate],
   );
 
-  const renderIcon = useCallback((icon?: React.ReactNode) => {
-    if (!icon) {
-      return <Icons.ArrowRight className="size-6" />;
-    }
-
-    if (React.isValidElement<{ className?: string }>(icon)) {
-      return icon.props.className ? icon : React.cloneElement(icon, { className: "size-6" });
-    }
-
-    if (typeof icon === "function") {
-      const IconComponent = icon as React.ComponentType<{ className?: string }>;
-      return <IconComponent className="size-6" />;
-    }
-
-    return <span className="size-6">{icon}</span>;
-  }, []);
+  const renderIcon = useCallback((icon?: ReactNode) => resolveNavigationIcon(icon, "size-6"), []);
 
   const primaryItems = navigation?.primary ?? [];
   const secondaryItems = navigation?.secondary ?? [];

--- a/apps/frontend/src/pages/layouts/navigation/mobile-navbar.tsx
+++ b/apps/frontend/src/pages/layouts/navigation/mobile-navbar.tsx
@@ -3,20 +3,11 @@ import { SyncStatusIcon } from "@/features/wealthfolio-connect/components/sync-s
 import { useAggregatedSyncStatus } from "@/features/wealthfolio-connect/hooks";
 import { useHapticFeedback } from "@/hooks/use-haptic-feedback";
 import { cn } from "@/lib/utils";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-  Icons,
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-} from "@wealthfolio/ui";
+import { Icons, Sheet, SheetContent, SheetTitle } from "@wealthfolio/ui";
 import { motion } from "motion/react";
 import { useCallback, useId, useState, type ReactNode } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
-import { type NavigationProps, isPathActive } from "./app-navigation";
+import { type NavLink, type NavigationProps, isPathActive } from "./app-navigation";
 import { resolveNavigationIcon } from "./navigation-icons";
 
 interface MobileNavBarProps {
@@ -27,7 +18,6 @@ export function MobileNavBar({ navigation }: MobileNavBarProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
-  const [addonsSheetOpen, setAddonsSheetOpen] = useState(false);
   const { triggerHaptic } = useHapticFeedback();
   const uniqueId = useId();
   const { status: syncStatus } = useAggregatedSyncStatus();
@@ -47,7 +37,10 @@ export function MobileNavBar({ navigation }: MobileNavBarProps) {
 
   const primaryItems = navigation?.primary ?? [];
   const secondaryItems = navigation?.secondary ?? [];
-  const addonItems = navigation?.addons ?? [];
+  const pinnedAddonItems = navigation?.pinnedAddons ?? [];
+  const addonMenuItems = navigation?.addonMenuItems ?? navigation?.addons ?? [];
+  const directPinnedAddonItems = pinnedAddonItems.slice(0, 1);
+  const overflowPinnedAddonItems = pinnedAddonItems.slice(1);
 
   const searchItem = {
     title: "Search",
@@ -55,12 +48,25 @@ export function MobileNavBar({ navigation }: MobileNavBarProps) {
     icon: <Icons.Search2 className="size-6" />,
   };
 
-  const visibleItems = [primaryItems[0], primaryItems[1], searchItem].filter(Boolean);
+  const visibleItems = [
+    primaryItems[0],
+    primaryItems[1],
+    ...directPinnedAddonItems,
+    searchItem,
+  ].filter(Boolean);
 
-  const menuItems = [...primaryItems.slice(2), ...secondaryItems];
-
-  const hasMenu = menuItems.length > 0 || addonItems.length > 0;
-  const hasAddons = addonItems.length > 0;
+  const addonItems = [...overflowPinnedAddonItems, ...addonMenuItems];
+  const standardMenuItems: NavLink[] = [
+    ...primaryItems.slice(2),
+    ...secondaryItems,
+    {
+      title: "Connect",
+      href: "/connect",
+      icon: <SyncStatusIcon status={syncStatus} className="size-6" />,
+    },
+  ];
+  const moreItems = [...standardMenuItems, ...addonItems];
+  const hasMenu = moreItems.length > 0;
   const columnCount = visibleItems.length + (hasMenu ? 1 : 0);
 
   return (
@@ -131,137 +137,124 @@ export function MobileNavBar({ navigation }: MobileNavBarProps) {
             })}
 
             {hasMenu && (
-              <DropdownMenu open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
-                <DropdownMenuTrigger asChild>
-                  <button
-                    onClick={triggerHaptic}
-                    aria-label="More options"
-                    className="text-foreground relative z-10 flex h-14 w-full items-center justify-center rounded-full transition-colors"
-                  >
-                    {(menuItems.some((item) => isPathActive(location.pathname, item.href)) ||
-                      addonItems.some((item) => isPathActive(location.pathname, item.href))) && (
-                      <motion.div
-                        layoutId={`mobile-nav-indicator-${uniqueId}`}
-                        className="absolute inset-0 -z-10 rounded-full border border-black/10 bg-black/5 shadow-sm dark:border-white/10 dark:bg-white/10"
-                        initial={false}
-                        transition={{
-                          type: "spring",
-                          stiffness: 400,
-                          damping: 30,
-                        }}
-                      />
-                    )}
-                    <span
-                      className="relative flex size-7 shrink-0 items-center justify-center outline-none"
-                      aria-hidden="true"
-                    >
-                      <Icons.CirclesFour className="size-6" />
-                    </span>
-                  </button>
-                </DropdownMenuTrigger>
-
-                <DropdownMenuContent
-                  side="top"
-                  align="end"
-                  sideOffset={16}
-                  className="w-42 mb-0 mr-0 flex flex-col gap-1 border-0 bg-transparent p-0 shadow-none ring-0 ring-offset-0"
+              <button
+                onClick={() => {
+                  triggerHaptic();
+                  setMobileMenuOpen(true);
+                }}
+                aria-label="More options"
+                className="text-foreground relative z-10 flex h-14 w-full items-center justify-center rounded-full transition-colors"
+              >
+                {moreItems.some((item) => isPathActive(location.pathname, item.href)) && (
+                  <motion.div
+                    layoutId={`mobile-nav-indicator-${uniqueId}`}
+                    className="absolute inset-0 -z-10 rounded-full border border-black/10 bg-black/5 shadow-sm dark:border-white/10 dark:bg-white/10"
+                    initial={false}
+                    transition={{
+                      type: "spring",
+                      stiffness: 400,
+                      damping: 30,
+                    }}
+                  />
+                )}
+                <span
+                  className="relative flex size-7 shrink-0 items-center justify-center outline-none"
+                  aria-hidden="true"
                 >
-                  {menuItems.map((item) => {
-                    const isActive = isPathActive(location.pathname, item.href);
-                    return (
-                      <LiquidGlass key={item.href} variant="floating" intensity="subtle">
-                        <Link
-                          to={item.href}
-                          onClick={() => {
-                            handleNavigation(item.href, isActive);
-                            setMobileMenuOpen(false);
-                          }}
-                          aria-current={isActive ? "page" : undefined}
-                          className="relative z-10 flex w-full items-center gap-3 rounded-full px-3 py-2 text-sm"
-                        >
-                          <span className="flex size-6 shrink-0 items-center justify-center">
-                            {renderIcon(item.icon)}
-                          </span>
-                          <span className="truncate text-left">{item.title}</span>
-                        </Link>
-                      </LiquidGlass>
-                    );
-                  })}
-
-                  {/* Connect with status icon */}
-                  <LiquidGlass variant="floating" intensity="subtle">
-                    <Link
-                      to="/connect"
-                      onClick={() => {
-                        const isActive = isPathActive(location.pathname, "/connect");
-                        handleNavigation("/connect", isActive);
-                        setMobileMenuOpen(false);
-                      }}
-                      aria-current={
-                        isPathActive(location.pathname, "/connect") ? "page" : undefined
-                      }
-                      className="relative z-10 flex w-full items-center gap-3 rounded-full px-3 py-2 text-sm"
-                    >
-                      <span className="flex size-6 shrink-0 items-center justify-center">
-                        <SyncStatusIcon status={syncStatus} className="size-5" />
-                      </span>
-                      <span className="truncate text-left">Connect</span>
-                    </Link>
-                  </LiquidGlass>
-
-                  {hasAddons && (
-                    <LiquidGlass variant="floating" intensity="subtle">
-                      <button
-                        onClick={() => {
-                          triggerHaptic();
-                          setMobileMenuOpen(false);
-                          setAddonsSheetOpen(true);
-                        }}
-                        className="relative z-10 flex w-full items-center gap-3 rounded-full px-3 py-2 text-sm"
-                      >
-                        <span className="flex size-6 shrink-0 items-center justify-center">
-                          <Icons.Addons className="size-5" />
-                        </span>
-                        <span className="truncate text-left">Add-ons</span>
-                      </button>
-                    </LiquidGlass>
-                  )}
-                </DropdownMenuContent>
-              </DropdownMenu>
+                  <Icons.CirclesFour className="size-6" />
+                </span>
+              </button>
             )}
           </nav>
         </LiquidGlass>
       </div>
 
-      {/* Add-ons Sheet */}
-      <Sheet open={addonsSheetOpen} onOpenChange={setAddonsSheetOpen}>
-        <SheetContent side="bottom" className="px-4 pb-8">
-          <SheetHeader>
-            <SheetTitle>Add-ons</SheetTitle>
-          </SheetHeader>
-          <div className="mt-4 flex flex-col gap-2">
-            {addonItems.map((item) => {
-              const isActive = isPathActive(location.pathname, item.href);
-              return (
-                <Link
-                  key={item.href}
-                  to={item.href}
-                  onClick={() => {
-                    handleNavigation(item.href, isActive);
-                    setAddonsSheetOpen(false);
-                  }}
-                  className={cn(
-                    "flex h-12 items-center gap-3 rounded-lg px-4 transition-colors",
-                    isActive ? "bg-secondary" : "hover:bg-secondary/50",
-                  )}
-                >
-                  <span className="flex size-5 shrink-0 items-center justify-center">
-                    {renderIcon(item.icon)}
-                  </span>
-                  <span className="text-base font-medium">{item.title}</span>
-                </Link>
-              );
-            })}
+      <Sheet open={mobileMenuOpen} onOpenChange={setMobileMenuOpen}>
+        <SheetContent
+          side="bottom"
+          showCloseButton={false}
+          className="bg-background inset-x-4 bottom-4 max-h-[min(82vh,720px)] overflow-hidden rounded-[2rem] border-0 px-0 pb-[calc(env(safe-area-inset-bottom,0px)+1.25rem)] pt-0 shadow-2xl"
+        >
+          <div className="bg-muted mx-auto mt-4 h-1.5 w-14 rounded-full" />
+          <div className="flex items-center justify-between px-8 pb-4 pt-7">
+            <SheetTitle className="text-2xl font-semibold">More</SheetTitle>
+            <button
+              type="button"
+              onClick={() => setMobileMenuOpen(false)}
+              className="bg-muted text-foreground hover:bg-muted/80 flex size-11 items-center justify-center rounded-full transition-colors"
+              aria-label="Close more menu"
+            >
+              <Icons.Close className="size-5" />
+            </button>
+          </div>
+
+          <div className="scrollbar-hide max-h-[calc(min(82vh,720px)-7rem)] overflow-y-auto px-8">
+            <div className="divide-border/70 divide-y">
+              {standardMenuItems.map((item) => {
+                const isActive = isPathActive(location.pathname, item.href);
+
+                return (
+                  <Link
+                    key={item.href}
+                    to={item.href}
+                    onClick={() => {
+                      handleNavigation(item.href, isActive);
+                      setMobileMenuOpen(false);
+                    }}
+                    aria-current={isActive ? "page" : undefined}
+                    className={cn(
+                      "group flex h-16 items-center gap-4 transition-colors",
+                      isActive ? "text-primary" : "text-foreground",
+                    )}
+                  >
+                    <span className="flex size-7 shrink-0 items-center justify-center">
+                      {renderIcon(item.icon)}
+                    </span>
+                    <span className="min-w-0 flex-1 truncate text-lg font-semibold">
+                      {item.title}
+                    </span>
+                    <Icons.ChevronRight className="text-muted-foreground/50 size-5 shrink-0 transition-transform group-hover:translate-x-0.5" />
+                  </Link>
+                );
+              })}
+            </div>
+
+            {addonItems.length > 0 && (
+              <div className="pt-6">
+                <div className="text-muted-foreground pb-3 text-xs font-semibold uppercase tracking-[0.35em]">
+                  Add-ons
+                </div>
+                <div className="divide-border/70 divide-y">
+                  {addonItems.map((item) => {
+                    const isActive = isPathActive(location.pathname, item.href);
+
+                    return (
+                      <Link
+                        key={item.href}
+                        to={item.href}
+                        onClick={() => {
+                          handleNavigation(item.href, isActive);
+                          setMobileMenuOpen(false);
+                        }}
+                        aria-current={isActive ? "page" : undefined}
+                        className={cn(
+                          "group flex h-16 items-center gap-4 transition-colors",
+                          isActive ? "text-primary" : "text-foreground",
+                        )}
+                      >
+                        <span className="flex size-7 shrink-0 items-center justify-center">
+                          {renderIcon(item.icon)}
+                        </span>
+                        <span className="min-w-0 flex-1 truncate text-lg font-semibold">
+                          {item.title}
+                        </span>
+                        <Icons.ChevronRight className="text-muted-foreground/50 size-5 shrink-0 transition-transform group-hover:translate-x-0.5" />
+                      </Link>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
           </div>
         </SheetContent>
       </Sheet>

--- a/apps/frontend/src/pages/layouts/navigation/mobile-navbar.tsx
+++ b/apps/frontend/src/pages/layouts/navigation/mobile-navbar.tsx
@@ -14,9 +14,10 @@ import {
   SheetTitle,
 } from "@wealthfolio/ui";
 import { motion } from "motion/react";
-import React, { useCallback, useId, useState } from "react";
+import { useCallback, useId, useState, type ReactNode } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { type NavigationProps, isPathActive } from "./app-navigation";
+import { resolveNavigationIcon } from "./navigation-icons";
 
 interface MobileNavBarProps {
   navigation: NavigationProps;
@@ -42,22 +43,7 @@ export function MobileNavBar({ navigation }: MobileNavBarProps) {
     [triggerHaptic, navigate],
   );
 
-  const renderIcon = useCallback((icon?: React.ReactNode) => {
-    if (!icon) {
-      return <Icons.ArrowRight className="size-6" />;
-    }
-
-    if (React.isValidElement<{ className?: string }>(icon)) {
-      return icon.props.className ? icon : React.cloneElement(icon, { className: "size-6" });
-    }
-
-    if (typeof icon === "function") {
-      const IconComponent = icon as React.ComponentType<{ className?: string }>;
-      return <IconComponent className="size-6" />;
-    }
-
-    return <span className="size-6">{icon}</span>;
-  }, []);
+  const renderIcon = useCallback((icon?: ReactNode) => resolveNavigationIcon(icon, "size-6"), []);
 
   const primaryItems = navigation?.primary ?? [];
   const secondaryItems = navigation?.secondary ?? [];

--- a/apps/frontend/src/pages/layouts/navigation/navigation-icons.tsx
+++ b/apps/frontend/src/pages/layouts/navigation/navigation-icons.tsx
@@ -4,27 +4,48 @@ import React from "react";
 const addonIconMap = {
   addon: Icons.Addons,
   addons: Icons.Addons,
+  barchart: Icons.BarChart,
   blocks: Icons.Blocks,
+  calendar: Icons.Calendar,
+  calendardots: Icons.CalendarDots,
+  calendardays: Icons.Calendar,
+  calendaricon: Icons.CalendarIcon,
   chart: Icons.Insight,
+  chartbar: Icons.ChartBar,
+  chartline: Icons.TrendingUp,
   dashboard: Icons.Dashboard,
+  fee: Icons.Invoice,
+  fees: Icons.Invoice,
   goal: Icons.Goal,
   goals: Icons.Goals,
   holdings: Icons.Holdings,
+  invoice: Icons.Invoice,
+  puzzle: Icons.PuzzlePiece,
+  puzzlepiece: Icons.PuzzlePiece,
+  receipt: Icons.ReceiptDuotone,
+  receipttext: Icons.ReceiptText,
   settings: Icons.Settings,
+  target: Icons.Target,
+  trading: Icons.TrendingUp,
+  trendingup: Icons.TrendingUp,
   wallet: Icons.Wallet,
 } satisfies Record<string, React.ComponentType<{ className?: string }>>;
 
+function normalizeIconKey(icon: string) {
+  return icon.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
 export function resolveNavigationIcon(icon: React.ReactNode, className: string) {
   if (!icon) {
-    return <Icons.ArrowRight className={className} />;
+    return <Icons.PuzzlePiece className={className} />;
   }
 
   if (typeof icon === "string") {
-    const IconComponent = addonIconMap[icon.toLowerCase() as keyof typeof addonIconMap];
+    const IconComponent = addonIconMap[normalizeIconKey(icon) as keyof typeof addonIconMap];
     return IconComponent ? (
       <IconComponent className={className} />
     ) : (
-      <Icons.Addons className={className} />
+      <Icons.PuzzlePiece className={className} />
     );
   }
 
@@ -37,5 +58,5 @@ export function resolveNavigationIcon(icon: React.ReactNode, className: string) 
     return <IconComponent className={className} />;
   }
 
-  return <Icons.ArrowRight className={className} />;
+  return <Icons.PuzzlePiece className={className} />;
 }

--- a/apps/frontend/src/pages/layouts/navigation/navigation-icons.tsx
+++ b/apps/frontend/src/pages/layouts/navigation/navigation-icons.tsx
@@ -1,0 +1,41 @@
+import { Icons } from "@wealthfolio/ui/components/ui/icons";
+import React from "react";
+
+const addonIconMap = {
+  addon: Icons.Addons,
+  addons: Icons.Addons,
+  blocks: Icons.Blocks,
+  chart: Icons.Insight,
+  dashboard: Icons.Dashboard,
+  goal: Icons.Goal,
+  goals: Icons.Goals,
+  holdings: Icons.Holdings,
+  settings: Icons.Settings,
+  wallet: Icons.Wallet,
+} satisfies Record<string, React.ComponentType<{ className?: string }>>;
+
+export function resolveNavigationIcon(icon: React.ReactNode, className: string) {
+  if (!icon) {
+    return <Icons.ArrowRight className={className} />;
+  }
+
+  if (typeof icon === "string") {
+    const IconComponent = addonIconMap[icon.toLowerCase() as keyof typeof addonIconMap];
+    return IconComponent ? (
+      <IconComponent className={className} />
+    ) : (
+      <Icons.Addons className={className} />
+    );
+  }
+
+  if (React.isValidElement<{ className?: string }>(icon)) {
+    return icon.props.className ? icon : React.cloneElement(icon, { className });
+  }
+
+  if (typeof icon === "function") {
+    const IconComponent = icon as React.ComponentType<{ className?: string }>;
+    return <IconComponent className={className} />;
+  }
+
+  return <Icons.ArrowRight className={className} />;
+}

--- a/apps/frontend/src/pages/settings/addons/addon-settings.tsx
+++ b/apps/frontend/src/pages/settings/addons/addon-settings.tsx
@@ -1,3 +1,5 @@
+import { getDynamicNavItems, subscribeToNavigationUpdates } from "@/addons/addons-runtime-context";
+import { useAddonNavigationPins } from "@/pages/layouts/navigation/addon-navigation-pins";
 import { PermissionDialog } from "@/pages/settings/addons/components/addon-permission-dialog";
 import { AddonStoreBrowser } from "@/pages/settings/addons/components/addon-store-browser";
 import { AddonUpdateCard } from "@/pages/settings/addons/components/addon-update-card";
@@ -16,9 +18,12 @@ import {
   TabsContent,
   TabsList,
   TabsTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from "@wealthfolio/ui";
 import { useToast } from "@wealthfolio/ui/components/ui/use-toast";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { SettingsHeader } from "../settings-header";
 import { useAddonActions } from "./hooks/use-addon-actions";
 import { useAddonUpdates } from "./hooks/use-addon-updates";
@@ -30,6 +35,8 @@ export default function AddonSettingsPage() {
     addonId?: string;
     addonName?: string;
   }>({ open: false });
+  const [addonNavItems, setAddonNavItems] = useState(() => getDynamicNavItems());
+  const { isAddonPinned, setAddonPinned } = useAddonNavigationPins();
 
   const {
     installedAddons,
@@ -61,6 +68,30 @@ export default function AddonSettingsPage() {
   });
 
   const { toast } = useToast();
+
+  useEffect(() => {
+    const updateAddonNavItems = () => {
+      setAddonNavItems(getDynamicNavItems());
+    };
+
+    updateAddonNavItems();
+    const unsubscribe = subscribeToNavigationUpdates(updateAddonNavItems);
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  const addonNavItemsByAddonId = useMemo(() => {
+    const itemsByAddonId = new Map<string, (typeof addonNavItems)[number]>();
+
+    addonNavItems.forEach((item) => {
+      if (!itemsByAddonId.has(item.addonId)) {
+        itemsByAddonId.set(item.addonId, item);
+      }
+    });
+
+    return itemsByAddonId;
+  }, [addonNavItems]);
 
   const handleCheckUpdates = async () => {
     try {
@@ -307,163 +338,201 @@ export default function AddonSettingsPage() {
               </EmptyPlaceholder>
             ) : (
               <div className="space-y-3">
-                {installedAddons.map((addon) => (
-                  <div
-                    key={addon.metadata.id}
-                    className={`group rounded-lg border p-4 transition-all duration-200 sm:p-6 ${
-                      addon.metadata.enabled
-                        ? "bg-card hover:bg-accent/30 hover:shadow-md"
-                        : "bg-muted/30 border-dashed opacity-75 hover:opacity-90"
-                    }`}
-                  >
-                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                      <div className="min-w-0 flex-1 space-y-2 sm:space-y-3">
-                        {/* Header section with name and version */}
-                        <div className="flex flex-wrap items-center gap-2">
-                          <div className="flex items-center gap-2">
+                {installedAddons.map((addon) => {
+                  const addonNavItem = addonNavItemsByAddonId.get(addon.metadata.id);
+                  const isPinned = addonNavItem ? isAddonPinned(addonNavItem) : false;
+
+                  return (
+                    <div
+                      key={addon.metadata.id}
+                      className={`group rounded-lg border p-4 transition-all duration-200 sm:p-6 ${
+                        addon.metadata.enabled
+                          ? "bg-card hover:bg-accent/30 hover:shadow-md"
+                          : "bg-muted/30 border-dashed opacity-75 hover:opacity-90"
+                      }`}
+                    >
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                        <div className="min-w-0 flex-1 space-y-2 sm:space-y-3">
+                          {/* Header section with name and version */}
+                          <div className="flex flex-wrap items-center gap-2">
+                            <div className="flex items-center gap-2">
+                              {!addon.metadata.enabled && (
+                                <Icons.PauseCircle className="text-muted-foreground/60 h-5 w-5 flex-shrink-0" />
+                              )}
+                              <h4
+                                className={`truncate text-sm font-semibold md:text-lg ${
+                                  addon.metadata.enabled ? "" : "text-muted-foreground"
+                                }`}
+                              >
+                                {addon.metadata.name}
+                              </h4>
+                            </div>
+                            <Badge
+                              variant="outline"
+                              className="text-muted-foreground shrink-0 text-xs"
+                            >
+                              v{addon.metadata.version}
+                            </Badge>
                             {!addon.metadata.enabled && (
-                              <Icons.PauseCircle className="text-muted-foreground/60 h-5 w-5 flex-shrink-0" />
+                              <Badge
+                                variant="secondary"
+                                className="bg-warning/10 text-warning border-warning/20 shrink-0 text-xs"
+                              >
+                                <Icons.AlertCircle className="mr-1 h-3 w-3" />
+                                Disabled
+                              </Badge>
                             )}
-                            <h4
-                              className={`truncate text-sm font-semibold md:text-lg ${
-                                addon.metadata.enabled ? "" : "text-muted-foreground"
+                          </div>
+
+                          {/* Description */}
+                          {addon.metadata.description && (
+                            <p
+                              className={`text-xs leading-relaxed sm:text-sm ${
+                                addon.metadata.enabled
+                                  ? "text-muted-foreground"
+                                  : "text-muted-foreground/70"
                               }`}
                             >
-                              {addon.metadata.name}
-                            </h4>
-                          </div>
-                          <Badge
-                            variant="outline"
-                            className="text-muted-foreground shrink-0 text-xs"
-                          >
-                            v{addon.metadata.version}
-                          </Badge>
-                          {!addon.metadata.enabled && (
-                            <Badge
-                              variant="secondary"
-                              className="bg-warning/10 text-warning border-warning/20 shrink-0 text-xs"
+                              {addon.metadata.description}
+                            </p>
+                          )}
+
+                          {/* Author info */}
+                          {addon.metadata.author && (
+                            <div
+                              className={`flex items-center gap-2 text-xs sm:text-sm ${
+                                addon.metadata.enabled
+                                  ? "text-muted-foreground"
+                                  : "text-muted-foreground/70"
+                              }`}
                             >
-                              <Icons.AlertCircle className="mr-1 h-3 w-3" />
-                              Disabled
-                            </Badge>
+                              <Icons.Users className="h-4 w-4 flex-shrink-0" />
+                              <span className="truncate">By {addon.metadata.author}</span>
+                            </div>
                           )}
                         </div>
 
-                        {/* Description */}
-                        {addon.metadata.description && (
-                          <p
-                            className={`text-xs leading-relaxed sm:text-sm ${
-                              addon.metadata.enabled
-                                ? "text-muted-foreground"
-                                : "text-muted-foreground/70"
-                            }`}
-                          >
-                            {addon.metadata.description}
-                          </p>
-                        )}
+                        {/* Controls section */}
+                        <div className="flex items-center justify-between gap-2 sm:ml-6 sm:justify-normal">
+                          <div className="flex items-center gap-2">
+                            {/* Permissions button */}
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => handleViewPermissions(addon)}
+                              className="text-muted-foreground hover:bg-accent hover:text-foreground h-9 w-9 p-0 sm:opacity-0 sm:transition-opacity sm:group-hover:opacity-100"
+                            >
+                              <Icons.Eye className="h-4 w-4" />
+                              <span className="sr-only">View permissions</span>
+                            </Button>
 
-                        {/* Author info */}
-                        {addon.metadata.author && (
-                          <div
-                            className={`flex items-center gap-2 text-xs sm:text-sm ${
-                              addon.metadata.enabled
-                                ? "text-muted-foreground"
-                                : "text-muted-foreground/70"
-                            }`}
-                          >
-                            <Icons.Users className="h-4 w-4 flex-shrink-0" />
-                            <span className="truncate">By {addon.metadata.author}</span>
+                            {/* Rating button */}
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() =>
+                                handleRateAddon(addon.metadata.id, addon.metadata.name)
+                              }
+                              className="text-muted-foreground hover:bg-accent hover:text-foreground h-9 w-9 p-0 sm:opacity-0 sm:transition-opacity sm:group-hover:opacity-100"
+                            >
+                              <Icons.Star className="h-4 w-4" />
+                              <span className="sr-only">Rate addon</span>
+                            </Button>
+
+                            {/* Delete button with confirmation */}
+                            <DeleteConfirm
+                              deleteConfirmTitle="Remove Addon"
+                              deleteConfirmMessage={
+                                <div className="space-y-2">
+                                  <p>
+                                    Are you sure you want to remove{" "}
+                                    <strong>{addon.metadata.name}</strong>?
+                                  </p>
+                                  <p className="text-muted-foreground text-sm">
+                                    This action cannot be undone. The addon will be completely
+                                    removed from your system.
+                                  </p>
+                                </div>
+                              }
+                              handleDeleteConfirm={() => handleUninstallAddon(addon.metadata.id)}
+                              isPending={false}
+                              button={
+                                <Button
+                                  variant="outline"
+                                  size="sm"
+                                  className="text-muted-foreground hover:bg-destructive/10 hover:text-destructive h-9 w-9 p-0 sm:opacity-0 sm:transition-opacity sm:group-hover:opacity-100"
+                                >
+                                  <Icons.Trash className="h-4 w-4" />
+                                  <span className="sr-only">Remove addon</span>
+                                </Button>
+                              }
+                            />
+
+                            {addon.metadata.enabled && addonNavItem && (
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <Button
+                                    variant={isPinned ? "default" : "outline"}
+                                    size="sm"
+                                    onClick={() => setAddonPinned(addonNavItem, !isPinned)}
+                                    className={
+                                      isPinned
+                                        ? "h-9 w-9 p-0"
+                                        : "text-muted-foreground hover:bg-accent hover:text-foreground h-9 w-9 p-0"
+                                    }
+                                    aria-label={
+                                      isPinned
+                                        ? `Unpin ${addon.metadata.name} from navigation`
+                                        : `Pin ${addon.metadata.name} to navigation`
+                                    }
+                                  >
+                                    {isPinned ? (
+                                      <Icons.PinOff className="h-4 w-4" />
+                                    ) : (
+                                      <Icons.Pin className="h-4 w-4" />
+                                    )}
+                                  </Button>
+                                </TooltipTrigger>
+                                <TooltipContent side="bottom">
+                                  {isPinned ? "Unpin from navigation" : "Pin to navigation"}
+                                </TooltipContent>
+                              </Tooltip>
+                            )}
+
+                            {/* Enable/Disable Switch */}
+                            <Switch
+                              id={`addon-${addon.metadata.id}`}
+                              checked={addon.metadata.enabled}
+                              onCheckedChange={(checked) =>
+                                handleToggleAddon(addon.metadata.id, !checked)
+                              }
+                              className="data-[state=checked]:bg-green-600"
+                              disabled={togglingAddonId === addon.metadata.id}
+                            />
                           </div>
-                        )}
-                      </div>
-
-                      {/* Controls section */}
-                      <div className="flex items-center justify-between gap-2 sm:ml-6 sm:justify-normal">
-                        <div className="flex items-center gap-2">
-                          {/* Permissions button */}
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => handleViewPermissions(addon)}
-                            className="text-muted-foreground hover:bg-accent hover:text-foreground h-9 w-9 p-0 sm:opacity-0 sm:transition-opacity sm:group-hover:opacity-100"
-                          >
-                            <Icons.Eye className="h-4 w-4" />
-                            <span className="sr-only">View permissions</span>
-                          </Button>
-
-                          {/* Rating button */}
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => handleRateAddon(addon.metadata.id, addon.metadata.name)}
-                            className="text-muted-foreground hover:bg-accent hover:text-foreground h-9 w-9 p-0 sm:opacity-0 sm:transition-opacity sm:group-hover:opacity-100"
-                          >
-                            <Icons.Star className="h-4 w-4" />
-                            <span className="sr-only">Rate addon</span>
-                          </Button>
-
-                          {/* Delete button with confirmation */}
-                          <DeleteConfirm
-                            deleteConfirmTitle="Remove Addon"
-                            deleteConfirmMessage={
-                              <div className="space-y-2">
-                                <p>
-                                  Are you sure you want to remove{" "}
-                                  <strong>{addon.metadata.name}</strong>?
-                                </p>
-                                <p className="text-muted-foreground text-sm">
-                                  This action cannot be undone. The addon will be completely removed
-                                  from your system.
-                                </p>
-                              </div>
-                            }
-                            handleDeleteConfirm={() => handleUninstallAddon(addon.metadata.id)}
-                            isPending={false}
-                            button={
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                className="text-muted-foreground hover:bg-destructive/10 hover:text-destructive h-9 w-9 p-0 sm:opacity-0 sm:transition-opacity sm:group-hover:opacity-100"
-                              >
-                                <Icons.Trash className="h-4 w-4" />
-                                <span className="sr-only">Remove addon</span>
-                              </Button>
-                            }
-                          />
-
-                          {/* Enable/Disable Switch */}
-                          <Switch
-                            id={`addon-${addon.metadata.id}`}
-                            checked={addon.metadata.enabled}
-                            onCheckedChange={(checked) =>
-                              handleToggleAddon(addon.metadata.id, !checked)
-                            }
-                            className="data-[state=checked]:bg-green-600"
-                            disabled={togglingAddonId === addon.metadata.id}
-                          />
                         </div>
                       </div>
+
+                      {/* Update Card - Show if update is available */}
+                      {(() => {
+                        const updateResult = getUpdateResult(addon.metadata.id);
+                        return updateResult?.updateInfo.updateAvailable ? (
+                          <div className="mt-3">
+                            <AddonUpdateCard
+                              addonId={addon.metadata.id}
+                              addonName={addon.metadata.name}
+                              updateInfo={updateResult.updateInfo}
+                              onUpdateComplete={() => handleUpdateComplete(addon.metadata.id)}
+                              disabled={togglingAddonId === addon.metadata.id}
+                              enableAfterInstall={addon.metadata.enabled ?? true}
+                              approvedNetworkHosts={addon.metadata.network?.approvedHosts ?? []}
+                            />
+                          </div>
+                        ) : null;
+                      })()}
                     </div>
-
-                    {/* Update Card - Show if update is available */}
-                    {(() => {
-                      const updateResult = getUpdateResult(addon.metadata.id);
-                      return updateResult?.updateInfo.updateAvailable ? (
-                        <div className="mt-3">
-                          <AddonUpdateCard
-                            addonId={addon.metadata.id}
-                            addonName={addon.metadata.name}
-                            updateInfo={updateResult.updateInfo}
-                            onUpdateComplete={() => handleUpdateComplete(addon.metadata.id)}
-                            disabled={togglingAddonId === addon.metadata.id}
-                            enableAfterInstall={addon.metadata.enabled ?? true}
-                            approvedNetworkHosts={addon.metadata.network?.approvedHosts ?? []}
-                          />
-                        </div>
-                      ) : null;
-                    })()}
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             )}
           </div>

--- a/apps/frontend/src/pages/settings/addons/addon-settings.tsx
+++ b/apps/frontend/src/pages/settings/addons/addon-settings.tsx
@@ -456,6 +456,8 @@ export default function AddonSettingsPage() {
                             updateInfo={updateResult.updateInfo}
                             onUpdateComplete={() => handleUpdateComplete(addon.metadata.id)}
                             disabled={togglingAddonId === addon.metadata.id}
+                            enableAfterInstall={addon.metadata.enabled ?? true}
+                            approvedNetworkHosts={addon.metadata.network?.approvedHosts ?? []}
                           />
                         </div>
                       ) : null;
@@ -478,16 +480,22 @@ export default function AddonSettingsPage() {
       {/* Permission Dialog */}
       <PermissionDialog
         open={permissionDialog.open}
-        onOpenChange={(open) => setPermissionDialog({ ...permissionDialog, open })}
+        onOpenChange={(open) => {
+          if (!open && permissionDialog.open) {
+            void permissionDialog.onCancel?.();
+          }
+          setPermissionDialog({ ...permissionDialog, open });
+        }}
         manifest={permissionDialog.manifest}
         declaredPermissions={permissionDialog.permissions || []}
         riskLevel={permissionDialog.riskLevel || "low"}
-        onApprove={() => {
+        onApprove={(approvedNetworkHosts) => {
           if (permissionDialog.onApprove) {
-            permissionDialog.onApprove();
+            void permissionDialog.onApprove(approvedNetworkHosts);
           }
         }}
         onDeny={() => {
+          void permissionDialog.onCancel?.();
           setPermissionDialog({ open: false });
           toast({
             title: "Installation cancelled",

--- a/apps/frontend/src/pages/settings/addons/components/addon-function-names.ts
+++ b/apps/frontend/src/pages/settings/addons/components/addon-function-names.ts
@@ -55,6 +55,9 @@ export const FUNCTION_DISPLAY_NAMES: Record<string, string> = {
   "performance.calculateAccountsSimple": "Calculate basic account performance",
 
   // ExchangeRatesAPI functions
+  "currency.getAll": "View exchange rates",
+  "currency.update": "Update currency rates",
+  "currency.add": "Add new exchange rates",
   "exchangeRates.getAll": "View exchange rates",
   "exchangeRates.update": "Update currency rates",
   "exchangeRates.add": "Add new exchange rates",
@@ -107,6 +110,7 @@ export const FUNCTION_DISPLAY_NAMES: Record<string, string> = {
   "ui.sidebar.addItem": "Add navigation items",
   "ui.router.add": "Add new pages",
   "ui.navigation.navigate": "Navigate within the app",
+  "ui.onDisable": "Run cleanup when disabled",
 
   // Network broker
   "network.request": "Send brokered network requests",

--- a/apps/frontend/src/pages/settings/addons/components/addon-function-names.ts
+++ b/apps/frontend/src/pages/settings/addons/components/addon-function-names.ts
@@ -86,6 +86,7 @@ export const FUNCTION_DISPLAY_NAMES: Record<string, string> = {
   // SecretsAPI functions
   "secrets.get": "Retrieve stored credentials",
   "secrets.set": "Store secure credentials",
+  "secrets.use": "Use stored credentials for brokered requests",
   "secrets.delete": "Remove stored credentials",
 
   // EventsAPI functions - Import events
@@ -105,6 +106,10 @@ export const FUNCTION_DISPLAY_NAMES: Record<string, string> = {
   // UI functions (addon extensions) - these use dotted notation in backend detection
   "ui.sidebar.addItem": "Add navigation items",
   "ui.router.add": "Add new pages",
+  "ui.navigation.navigate": "Navigate within the app",
+
+  // Network broker
+  "network.request": "Send brokered network requests",
 };
 
 /**

--- a/apps/frontend/src/pages/settings/addons/components/addon-permission-dialog.tsx
+++ b/apps/frontend/src/pages/settings/addons/components/addon-permission-dialog.tsx
@@ -1,5 +1,6 @@
 import { Badge } from "@wealthfolio/ui/components/ui/badge";
 import { Button } from "@wealthfolio/ui/components/ui/button";
+import { Checkbox } from "@wealthfolio/ui/components/ui/checkbox";
 import {
   Dialog,
   DialogContent,
@@ -16,6 +17,7 @@ import type {
   RiskLevel,
 } from "@wealthfolio/addon-sdk";
 import { AlertFeedback } from "@wealthfolio/ui";
+import { useEffect, useMemo, useState } from "react";
 import { PermissionCategoriesDisplay } from "./permission-categories-display";
 
 interface PermissionDialogProps {
@@ -25,7 +27,7 @@ interface PermissionDialogProps {
   detectedCategories?: PermissionCategory[];
   declaredPermissions?: Permission[];
   riskLevel: RiskLevel;
-  onApprove: () => void;
+  onApprove: (approvedNetworkHosts: string[]) => void;
   onDeny: () => void;
   isViewOnly?: boolean;
 }
@@ -52,6 +54,33 @@ export function PermissionDialog({
   onDeny,
   isViewOnly = false,
 }: PermissionDialogProps) {
+  const networkHosts = useMemo(() => {
+    const hosts = manifest?.network?.allowedHosts ?? [];
+    return Array.from(new Set(hosts.map((host) => host.trim()).filter(Boolean))).sort();
+  }, [manifest]);
+  const defaultApprovedNetworkHosts = useMemo(() => {
+    const approvedHosts = manifest?.network?.approvedHosts ?? [];
+    return approvedHosts.filter((host) => networkHosts.includes(host));
+  }, [manifest, networkHosts]);
+  const [approvedNetworkHosts, setApprovedNetworkHosts] = useState<string[]>(
+    defaultApprovedNetworkHosts,
+  );
+
+  useEffect(() => {
+    if (open) {
+      setApprovedNetworkHosts(defaultApprovedNetworkHosts);
+    }
+  }, [defaultApprovedNetworkHosts, open]);
+
+  const toggleNetworkHost = (host: string, checked: boolean | "indeterminate") => {
+    setApprovedNetworkHosts((current) => {
+      if (checked === true) {
+        return Array.from(new Set([...current, host])).sort();
+      }
+      return current.filter((currentHost) => currentHost !== host);
+    });
+  };
+
   // Safety check - don't render if manifest is missing
   if (!manifest) {
     return null;
@@ -115,11 +144,43 @@ export function PermissionDialog({
           <div className="flex-1 overflow-auto">
             <PermissionCategoriesDisplay permissions={permissionsToDisplay} />
           </div>
+
+          {networkHosts.length > 0 && (
+            <div className="space-y-3 rounded-md border p-4">
+              <div className="flex items-center gap-2">
+                <Icons.Globe className="text-muted-foreground h-4 w-4" />
+                <h3 className="text-sm font-medium">Network hosts</h3>
+              </div>
+              <div className="grid gap-2 sm:grid-cols-2">
+                {networkHosts.map((host) => {
+                  const checked = approvedNetworkHosts.includes(host);
+                  return (
+                    <label
+                      key={host}
+                      className="flex min-w-0 items-center gap-3 rounded-md border px-3 py-2 text-sm"
+                    >
+                      <Checkbox
+                        checked={checked}
+                        disabled={isViewOnly}
+                        onCheckedChange={(value) => toggleNetworkHost(host, value)}
+                      />
+                      <span className="min-w-0 flex-1 truncate font-mono text-xs">{host}</span>
+                      {isViewOnly && (
+                        <Badge variant={checked ? "default" : "outline"} className="shrink-0">
+                          {checked ? "Approved" : "Denied"}
+                        </Badge>
+                      )}
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+          )}
         </div>
 
         <DialogFooter className="gap-3">
           {isViewOnly ? (
-            <Button onClick={onApprove}>
+            <Button onClick={() => onApprove(approvedNetworkHosts)}>
               <Icons.Check className="mr-2 h-4 w-4" />
               Close
             </Button>
@@ -129,7 +190,7 @@ export function PermissionDialog({
                 <Icons.Close className="mr-2 h-4 w-4" />
                 Deny Installation
               </Button>
-              <Button onClick={onApprove}>
+              <Button onClick={() => onApprove(approvedNetworkHosts)}>
                 <Icons.Check className="mr-2 h-4 w-4" />
                 Approve & Install
               </Button>

--- a/apps/frontend/src/pages/settings/addons/components/addon-store-browser.tsx
+++ b/apps/frontend/src/pages/settings/addons/components/addon-store-browser.tsx
@@ -370,12 +370,20 @@ export function AddonStoreBrowser({ installedAddonIds, onInstallSuccess }: Addon
       {/* Permission Dialog */}
       <PermissionDialog
         open={permissionDialog.open}
-        onOpenChange={(open) => setPermissionDialog({ ...permissionDialog, open })}
+        onOpenChange={(open) => {
+          if (!open && permissionDialog.open) {
+            void permissionDialog.onCancel?.();
+          }
+          setPermissionDialog({ ...permissionDialog, open });
+        }}
         manifest={permissionDialog.manifest}
         declaredPermissions={permissionDialog.permissions || []}
         riskLevel={permissionDialog.riskLevel || "low"}
         onApprove={permissionDialog.onApprove || (() => undefined)}
-        onDeny={() => setPermissionDialog({ open: false })}
+        onDeny={() => {
+          void permissionDialog.onCancel?.();
+          setPermissionDialog({ open: false });
+        }}
       />
     </div>
   );

--- a/apps/frontend/src/pages/settings/addons/components/addon-update-card.tsx
+++ b/apps/frontend/src/pages/settings/addons/components/addon-update-card.tsx
@@ -1,12 +1,14 @@
 import { reloadAllAddons } from "@/addons/addons-core";
-import { updateAddon } from "@/adapters";
+import { clearAddonStaging, downloadAddonForReview, installFromStaging } from "@/adapters";
+import type { ExtractedAddon } from "@/adapters";
 import { ExternalLink } from "@/components/external-link";
 import { Badge } from "@wealthfolio/ui/components/ui/badge";
 import { Button } from "@wealthfolio/ui/components/ui/button";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
 import { useToast } from "@wealthfolio/ui/components/ui/use-toast";
-import type { AddonUpdateInfo } from "@wealthfolio/addon-sdk";
+import type { AddonUpdateInfo, Permission, RiskLevel } from "@wealthfolio/addon-sdk";
 import { useState } from "react";
+import { PermissionDialog } from "./addon-permission-dialog";
 
 interface AddonUpdateCardProps {
   addonId: string;
@@ -14,6 +16,8 @@ interface AddonUpdateCardProps {
   updateInfo: AddonUpdateInfo;
   onUpdateComplete?: () => void;
   disabled?: boolean;
+  enableAfterInstall?: boolean;
+  approvedNetworkHosts?: string[];
 }
 
 export function AddonUpdateCard({
@@ -22,10 +26,50 @@ export function AddonUpdateCard({
   updateInfo,
   onUpdateComplete,
   disabled = false,
+  enableAfterInstall = true,
+  approvedNetworkHosts = [],
 }: AddonUpdateCardProps) {
   const [isUpdating, setIsUpdating] = useState(false);
+  const [permissionReview, setPermissionReview] = useState<{
+    open: boolean;
+    addon?: ExtractedAddon;
+    permissions: Permission[];
+    riskLevel: RiskLevel;
+  }>({
+    open: false,
+    permissions: [],
+    riskLevel: "low",
+  });
   const { toast } = useToast();
   const addonDetailUrl = `https://wealthfolio.app/addons/${encodeURIComponent(addonId)}`;
+
+  const calculateRiskLevel = (permissions: Permission[]): RiskLevel => {
+    const hasHighRiskCategories = permissions.some((perm) =>
+      ["accounts", "activities", "settings"].includes(perm.category),
+    );
+    const hasMediumRiskCategories = permissions.some((perm) =>
+      ["portfolio", "files", "financial-planning"].includes(perm.category),
+    );
+
+    return hasHighRiskCategories ? "high" : hasMediumRiskCategories ? "medium" : "low";
+  };
+
+  const withCurrentNetworkApprovals = (extractedAddon: ExtractedAddon): ExtractedAddon => {
+    const allowedHosts = extractedAddon.metadata.network?.allowedHosts ?? [];
+    if (!extractedAddon.metadata.network) {
+      return extractedAddon;
+    }
+    return {
+      ...extractedAddon,
+      metadata: {
+        ...extractedAddon.metadata,
+        network: {
+          ...extractedAddon.metadata.network,
+          approvedHosts: approvedNetworkHosts.filter((host) => allowedHosts.includes(host)),
+        },
+      },
+    };
+  };
 
   const handleUpdate = async () => {
     if (!updateInfo.downloadUrl) {
@@ -40,9 +84,32 @@ export function AddonUpdateCard({
     try {
       setIsUpdating(true);
 
-      await updateAddon(addonId);
+      const extractedAddon = withCurrentNetworkApprovals(await downloadAddonForReview(addonId));
+      const permissions = extractedAddon.metadata.permissions || [];
+      setPermissionReview({
+        open: true,
+        addon: extractedAddon,
+        permissions,
+        riskLevel: calculateRiskLevel(permissions),
+      });
+    } catch (error) {
+      console.error("Error preparing addon update:", error);
+      toast({
+        title: "Update failed",
+        description: error instanceof Error ? error.message : "Failed to prepare addon update",
+        variant: "destructive",
+      });
+    } finally {
+      setIsUpdating(false);
+    }
+  };
 
-      // Reload addons to apply the update
+  const handleApproveUpdate = async (approvedHosts: string[]) => {
+    try {
+      setPermissionReview((current) => ({ ...current, open: false }));
+      setIsUpdating(true);
+
+      await installFromStaging(addonId, enableAfterInstall, approvedHosts);
       await reloadAllAddons();
 
       toast({
@@ -53,6 +120,11 @@ export function AddonUpdateCard({
       onUpdateComplete?.();
     } catch (error) {
       console.error("Error updating addon:", error);
+      try {
+        await clearAddonStaging(addonId);
+      } catch (cleanupError) {
+        console.error("Failed to clear staging after update failure:", cleanupError);
+      }
       toast({
         title: "Update failed",
         description: error instanceof Error ? error.message : "Failed to update addon",
@@ -61,6 +133,23 @@ export function AddonUpdateCard({
     } finally {
       setIsUpdating(false);
     }
+  };
+
+  const handleDenyUpdate = async () => {
+    setPermissionReview({ open: false, permissions: [], riskLevel: "low" });
+    try {
+      await clearAddonStaging(addonId);
+    } catch (error) {
+      console.error("Failed to clear staging after update denial:", error);
+    }
+  };
+
+  const handleReviewOpenChange = (open: boolean) => {
+    if (!open && permissionReview.open) {
+      void handleDenyUpdate();
+      return;
+    }
+    setPermissionReview((current) => ({ ...current, open }));
   };
 
   const getUpdateBadgeVariant = () => {
@@ -80,74 +169,86 @@ export function AddonUpdateCard({
   }
 
   return (
-    <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-950/20">
-      <div className="flex items-start justify-between">
-        <div className="flex-1 space-y-2">
-          <div className="flex items-center gap-2">
-            <Icons.ArrowUp className="h-4 w-4 text-amber-600 dark:text-amber-400" />
-            <h4 className="font-medium text-amber-900 dark:text-amber-100">Update Available</h4>
-            {getUpdateBadgeText() && (
-              <Badge variant={getUpdateBadgeVariant()} className="text-xs">
-                {getUpdateBadgeText()}
-              </Badge>
-            )}
-          </div>
+    <>
+      <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-800 dark:bg-amber-950/20">
+        <div className="flex items-start justify-between">
+          <div className="flex-1 space-y-2">
+            <div className="flex items-center gap-2">
+              <Icons.ArrowUp className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+              <h4 className="font-medium text-amber-900 dark:text-amber-100">Update Available</h4>
+              {getUpdateBadgeText() && (
+                <Badge variant={getUpdateBadgeVariant()} className="text-xs">
+                  {getUpdateBadgeText()}
+                </Badge>
+              )}
+            </div>
 
-          <div className="text-sm text-amber-800 dark:text-amber-200">
-            <p>
-              {updateInfo.currentVersion} →{" "}
-              <span className="font-medium">{updateInfo.latestVersion}</span>
-            </p>
-            {updateInfo.releaseDate && (
-              <p className="text-xs opacity-80">
-                Released: {new Date(updateInfo.releaseDate).toLocaleDateString()}
+            <div className="text-sm text-amber-800 dark:text-amber-200">
+              <p>
+                {updateInfo.currentVersion} →{" "}
+                <span className="font-medium">{updateInfo.latestVersion}</span>
+              </p>
+              {updateInfo.releaseDate && (
+                <p className="text-xs opacity-80">
+                  Released: {new Date(updateInfo.releaseDate).toLocaleDateString()}
+                </p>
+              )}
+            </div>
+
+            {updateInfo.releaseNotes && (
+              <p className="line-clamp-2 text-sm text-amber-700 dark:text-amber-300">
+                {updateInfo.releaseNotes}
               </p>
             )}
           </div>
 
-          {updateInfo.releaseNotes && (
-            <p className="line-clamp-2 text-sm text-amber-700 dark:text-amber-300">
-              {updateInfo.releaseNotes}
-            </p>
-          )}
-        </div>
-
-        <div className="ml-4 flex items-center gap-2">
-          {(updateInfo.releaseNotes || updateInfo.changelogUrl) && (
-            <Button variant="ghost" size="sm" asChild>
-              <ExternalLink href={addonDetailUrl}>
-                <span className="inline-flex items-center">
-                  <Icons.FileText className="mr-1 h-3 w-3" />
-                  Release Notes
-                </span>
-              </ExternalLink>
-            </Button>
-          )}
-
-          <Button onClick={handleUpdate} disabled={isUpdating || disabled} size="sm">
-            {isUpdating ? (
-              <>
-                <Icons.Loader className="mr-1 h-3 w-3 animate-spin" />
-                Updating...
-              </>
-            ) : (
-              <>
-                <Icons.Download className="mr-1 h-3 w-3" />
-                Update
-              </>
+          <div className="ml-4 flex items-center gap-2">
+            {(updateInfo.releaseNotes || updateInfo.changelogUrl) && (
+              <Button variant="ghost" size="sm" asChild>
+                <ExternalLink href={addonDetailUrl}>
+                  <span className="inline-flex items-center">
+                    <Icons.FileText className="mr-1 h-3 w-3" />
+                    Release Notes
+                  </span>
+                </ExternalLink>
+              </Button>
             )}
-          </Button>
+
+            <Button onClick={handleUpdate} disabled={isUpdating || disabled} size="sm">
+              {isUpdating ? (
+                <>
+                  <Icons.Loader className="mr-1 h-3 w-3 animate-spin" />
+                  Updating...
+                </>
+              ) : (
+                <>
+                  <Icons.Download className="mr-1 h-3 w-3" />
+                  Update
+                </>
+              )}
+            </Button>
+          </div>
         </div>
+
+        {updateInfo.minWealthfolioVersion && (
+          <div className="mt-3 rounded-md bg-amber-100 p-2 dark:bg-amber-900/20">
+            <p className="text-xs text-amber-800 dark:text-amber-200">
+              <Icons.Info className="mr-1 inline h-3 w-3" />
+              Requires Wealthfolio {updateInfo.minWealthfolioVersion} or later
+            </p>
+          </div>
+        )}
       </div>
 
-      {updateInfo.minWealthfolioVersion && (
-        <div className="mt-3 rounded-md bg-amber-100 p-2 dark:bg-amber-900/20">
-          <p className="text-xs text-amber-800 dark:text-amber-200">
-            <Icons.Info className="mr-1 inline h-3 w-3" />
-            Requires Wealthfolio {updateInfo.minWealthfolioVersion} or later
-          </p>
-        </div>
-      )}
-    </div>
+      <PermissionDialog
+        open={permissionReview.open}
+        onOpenChange={handleReviewOpenChange}
+        manifest={permissionReview.addon?.metadata}
+        declaredPermissions={permissionReview.permissions}
+        riskLevel={permissionReview.riskLevel}
+        onApprove={handleApproveUpdate}
+        onDeny={handleDenyUpdate}
+      />
+    </>
   );
 }

--- a/apps/frontend/src/pages/settings/addons/hooks/use-addon-actions.ts
+++ b/apps/frontend/src/pages/settings/addons/hooks/use-addon-actions.ts
@@ -23,7 +23,7 @@ interface PermissionDialogState {
   permissions?: Permission[];
   riskLevel?: RiskLevel;
   fileData?: Uint8Array;
-  onApprove?: () => void;
+  onApprove?: (approvedNetworkHosts: string[]) => void | Promise<void>;
   onCancel?: () => void;
 }
 
@@ -163,28 +163,25 @@ export function useAddonActions() {
         permissions,
         riskLevel,
         fileData,
-        onApprove: async () => {
+        onApprove: async (approvedNetworkHosts) => {
           setPermissionDialog({ open: false });
-          await performAddonInstallation(fileData);
+          await performAddonInstallation(fileData, approvedNetworkHosts);
         },
       });
     } catch (error) {
       console.error("Error analyzing addon permissions:", error);
-      // If permission analysis fails, show warning and allow user to proceed
       toast({
         title: "Permission analysis failed",
-        description: "Could not analyze addon permissions. Install at your own risk.",
+        description:
+          error instanceof Error ? error.message : "Could not analyze addon permissions.",
         variant: "destructive",
       });
-
-      // Still allow installation but with warning
-      await performAddonInstallation(fileData);
     }
   };
 
   const handleShowPermissionDialog = (
     extractedAddon: ExtractedAddon,
-    onApprove: () => Promise<void>,
+    onApprove: (approvedNetworkHosts: string[]) => Promise<void>,
   ) => {
     // Calculate risk level based on permissions
     const permissions = extractedAddon.metadata.permissions || [];
@@ -196,10 +193,10 @@ export function useAddonActions() {
       manifest: extractedAddon.metadata,
       permissions,
       riskLevel,
-      onApprove: async () => {
+      onApprove: async (approvedNetworkHosts) => {
         setPermissionDialog({ open: false });
         try {
-          await onApprove();
+          await onApprove(approvedNetworkHosts);
           // Invalidate and refetch installed addons query
           queryClient.invalidateQueries({ queryKey: [QueryKeys.INSTALLED_ADDONS] });
           await reloadAllAddons();
@@ -229,10 +226,10 @@ export function useAddonActions() {
     });
   };
 
-  const performAddonInstallation = async (fileData: Uint8Array) => {
+  const performAddonInstallation = async (fileData: Uint8Array, approvedNetworkHosts: string[]) => {
     try {
       // Install the ZIP addon persistently
-      const metadata = await installAddon(fileData, true);
+      const metadata = await installAddon(fileData, true, approvedNetworkHosts);
 
       // Invalidate and refetch installed addons query
       queryClient.invalidateQueries({ queryKey: [QueryKeys.INSTALLED_ADDONS] });

--- a/apps/frontend/src/pages/settings/addons/hooks/use-addon-store.ts
+++ b/apps/frontend/src/pages/settings/addons/hooks/use-addon-store.ts
@@ -51,7 +51,7 @@ export function useAddonStore() {
       enableAfterInstall = true,
       onShowPermissionDialog?: (
         extractedAddon: ExtractedAddon,
-        onApprove: () => Promise<void>,
+        onApprove: (approvedNetworkHosts: string[]) => Promise<void>,
       ) => void,
     ) => {
       if (!onShowPermissionDialog) {
@@ -69,9 +69,9 @@ export function useAddonStore() {
         const extractedAddon = await downloadAddonForReview(listing.id);
 
         // Show permission dialog with pre-analyzed addon
-        onShowPermissionDialog(extractedAddon, async () => {
+        onShowPermissionDialog(extractedAddon, async (approvedNetworkHosts) => {
           // Install from staging after permission approval
-          await installFromStaging(listing.id, enableAfterInstall);
+          await installFromStaging(listing.id, enableAfterInstall, approvedNetworkHosts);
           // Invalidate installed addons cache to refresh the list
           queryClient.invalidateQueries({ queryKey: [QueryKeys.INSTALLED_ADDONS] });
         });

--- a/apps/frontend/src/routes.tsx
+++ b/apps/frontend/src/routes.tsx
@@ -1,13 +1,19 @@
-import { Suspense, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 
 import { AppLayout } from "@/pages/layouts/app-layout";
 import { OnboardingLayout } from "@/pages/layouts/onboarding-layout";
 import SettingsLayout from "@/pages/settings/settings-layout";
 
-import { getDynamicRoutes, subscribeToNavigationUpdates } from "@/addons/addons-runtime-context";
+import {
+  getDynamicRoutes,
+  subscribeToNavigationUpdates,
+  type DynamicRouteEntry,
+} from "@/addons/addons-runtime-context";
+import { AddonIframeRoute } from "@/addons/iframe/addon-iframe-route";
 import AuthCallbackPage from "@/features/wealthfolio-connect/pages/auth-callback-page";
 import ConnectPage from "@/features/wealthfolio-connect/pages/connect-page";
+import useNavigationEventListener from "@/hooks/use-navigation-event-listener";
 import ActivityManagerPage from "@/pages/activity/activity-manager-page";
 import ActivityPage from "@/pages/activity/activity-page";
 import ActivityImportPage from "@/pages/activity/import/activity-import-page";
@@ -49,10 +55,13 @@ import GoalNewPage from "@/features/goals/pages/goal-new-page";
 import GoalDetailPage from "@/features/goals/pages/goal-detail-page";
 import GoalRetirementGuidePage from "@/features/goals/pages/goal-retirement-guide-page";
 
+function NavigationEventBridge() {
+  useNavigationEventListener();
+  return null;
+}
+
 export function AppRoutes() {
-  const [dynamicRoutes, setDynamicRoutes] = useState<
-    { path: string; component: React.LazyExoticComponent<React.ComponentType<unknown>> }[]
-  >([]);
+  const [dynamicRoutes, setDynamicRoutes] = useState<DynamicRouteEntry[]>([]);
 
   // Subscribe to dynamic route updates
   useEffect(() => {
@@ -73,6 +82,7 @@ export function AppRoutes() {
 
   return (
     <BrowserRouter>
+      <NavigationEventBridge />
       <Routes>
         {/* QR Scanner - No layout for fullscreen camera access */}
         {/* <Route path="/qr-scanner" element={<QRScannerPage />} /> */}
@@ -112,17 +122,11 @@ export function AppRoutes() {
           <Route path="spending/insights" element={<SpendingInsightsPage />} />
           <Route path="spending/budget" element={<SpendingBudgetPage />} />
           {/* Dynamic addon routes */}
-          {dynamicRoutes.map(({ path, component: Component }) => (
+          {dynamicRoutes.map(({ path, addonId, routeId }) => (
             <Route
-              key={path}
+              key={`${addonId}:${routeId}`}
               path={path}
-              element={
-                <Suspense
-                  fallback={<div className="flex h-64 items-center justify-center">Loading...</div>}
-                >
-                  <Component />
-                </Suspense>
-              }
+              element={<AddonIframeRoute addonId={addonId} routeId={routeId} />}
             />
           ))}
           <Route path="settings" element={<SettingsLayout />}>

--- a/apps/frontend/src/test/fake-addon-dom.ts
+++ b/apps/frontend/src/test/fake-addon-dom.ts
@@ -1,0 +1,141 @@
+class FakeClassList {
+  private classes = new Set<string>();
+
+  add(...classNames: string[]) {
+    for (const className of classNames) {
+      this.classes.add(className);
+    }
+  }
+
+  remove(...classNames: string[]) {
+    for (const className of classNames) {
+      this.classes.delete(className);
+    }
+  }
+
+  contains(className: string) {
+    return this.classes.has(className);
+  }
+
+  setFromString(value: string) {
+    this.classes = new Set(value.split(/\s+/).filter(Boolean));
+  }
+
+  toString() {
+    return Array.from(this.classes).join(" ");
+  }
+}
+
+class FakeStyle {
+  backgroundColor = "";
+  color = "";
+  colorScheme = "";
+  fontFamily = "";
+  private properties = new Map<string, string>();
+
+  get length() {
+    return this.propertyNames.length;
+  }
+
+  item(index: number) {
+    return this.propertyNames[index] ?? "";
+  }
+
+  setProperty(propertyName: string, value: string) {
+    this.properties.set(propertyName, value);
+  }
+
+  getPropertyValue(propertyName: string) {
+    return this.properties.get(propertyName) ?? "";
+  }
+
+  removeProperty(propertyName: string) {
+    this.properties.delete(propertyName);
+  }
+
+  private get propertyNames() {
+    return Array.from(this.properties.keys());
+  }
+}
+
+class FakeElement {
+  readonly classList = new FakeClassList();
+  style = new FakeStyle();
+  textContent = "";
+  private attributes = new Map<string, string>();
+  private parent?: FakeHead;
+
+  get className() {
+    return this.classList.toString();
+  }
+
+  set className(value: string) {
+    this.classList.setFromString(value);
+  }
+
+  setAttribute(name: string, value: string) {
+    this.attributes.set(name, value);
+  }
+
+  getAttribute(name: string) {
+    return this.attributes.get(name) ?? null;
+  }
+
+  removeAttribute(name: string) {
+    if (name === "style") {
+      this.style = new FakeStyle();
+      return;
+    }
+    this.attributes.delete(name);
+  }
+
+  attachTo(parent: FakeHead) {
+    this.parent = parent;
+  }
+
+  remove() {
+    this.parent?.removeChild(this);
+  }
+}
+
+class FakeHead {
+  private children: FakeElement[] = [];
+
+  appendChild(element: FakeElement) {
+    element.attachTo(this);
+    this.children.push(element);
+  }
+
+  removeChild(element: FakeElement) {
+    this.children = this.children.filter((child) => child !== element);
+  }
+
+  querySelectorAll(_selector: string) {
+    return this.children.filter((element) => element.getAttribute("data-wealthfolio-addon-style"));
+  }
+}
+
+class FakeDocument {
+  readonly documentElement = new FakeElement();
+  readonly body = new FakeElement();
+  readonly head = new FakeHead();
+
+  createElement(_tagName: string) {
+    return new FakeElement();
+  }
+}
+
+export function installFakeAddonDom() {
+  const document = new FakeDocument();
+
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: document,
+  });
+  Object.defineProperty(globalThis, "getComputedStyle", {
+    configurable: true,
+    value: (element: FakeElement) => element.style,
+  });
+
+  return document;
+}

--- a/apps/frontend/src/types/global.d.ts
+++ b/apps/frontend/src/types/global.d.ts
@@ -1,26 +1,19 @@
 // Global ambient type declarations to avoid `any` for globals
-import type { QueryClient } from '@tanstack/react-query';
-
 declare global {
   interface Window {
     // Tauri global injected by the desktop runtime
     __TAURI__?: unknown;
-
-    // Exposed for addon integration
-    __wealthfolio_query_client__?: QueryClient;
-    __wealthfolio_navigate__?: (route: string) => void;
-
-    // Dev helpers and framework singletons made available at runtime
-    React?: unknown;
-    ReactDOM?: unknown;
-    __ADDON_DEV__?: unknown;
-    __DEV_ADDONS__?: Map<string, unknown>;
   }
 
   // Additional globals (available in dev)
   // eslint-disable-next-line no-var
+  var __ADDON_DEV__: unknown;
+  // eslint-disable-next-line no-var
   var debugAddons: unknown;
+  // eslint-disable-next-line no-var
+  var discoverAddons: unknown;
+  // eslint-disable-next-line no-var
+  var reloadAddons: unknown;
 }
 
 export {};
-

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -64,6 +64,9 @@ export default defineConfig({
     port: Number.isFinite(devPort) ? devPort : 1420,
     strictPort: true,
     host: host ? "0.0.0.0" : false,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+    },
     hmr: host
       ? {
           protocol: "ws",
@@ -83,6 +86,12 @@ export default defineConfig({
   build: {
     // Output to project root's dist folder (for Tauri)
     outDir: "../../dist",
+    rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, "index.html"),
+        "addon-sandbox": path.resolve(__dirname, "addon-sandbox.html"),
+      },
+    },
     // Tauri uses Chromium on Windows and WebKit on macOS and Linux
     // Keep target unset to use modern defaults for desktop WebView engines.
     // don't minify for debug builds

--- a/apps/server/src/api.rs
+++ b/apps/server/src/api.rs
@@ -8,7 +8,17 @@ use crate::{
     oidc,
 };
 use axum::middleware;
-use axum::{routing::get, Json, Router};
+use axum::{
+    body::Body,
+    http::{
+        header::{HeaderName, HeaderValue},
+        Request,
+    },
+    middleware::Next,
+    response::Response,
+    routing::get,
+    Json, Router,
+};
 use tower_governor::{governor::GovernorConfigBuilder, GovernorLayer};
 use tower_http::{
     cors::{Any, CorsLayer},
@@ -21,6 +31,7 @@ use utoipa::OpenApi;
 
 mod accounts;
 mod activities;
+mod addon_network;
 mod addons;
 mod agent_access;
 mod ai_chat;
@@ -73,6 +84,39 @@ pub async fn readyz() -> &'static str {
 )]
 pub struct ApiDoc;
 
+const SERVER_CSP: &str = "default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://wealthfolio.app https://auth.wealthfolio.app https://connect.wealthfolio.app https://connect-staging.wealthfolio.app; frame-src 'self' blob: about:; child-src 'self' blob: about:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; worker-src 'self' blob:";
+const ADDON_SANDBOX_CSP: &str = "default-src 'none'; script-src 'self' 'unsafe-inline' blob:; style-src 'self' 'unsafe-inline'; img-src data: blob:; font-src 'self' data: blob:; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'";
+
+pub async fn security_headers(request: Request<Body>, next: Next) -> Response {
+    let path = request.uri().path().to_string();
+    let mut response = next.run(request).await;
+    let headers = response.headers_mut();
+    let csp = if path.ends_with("/addon-sandbox.html") {
+        ADDON_SANDBOX_CSP
+    } else {
+        SERVER_CSP
+    };
+    headers.insert(
+        HeaderName::from_static("content-security-policy"),
+        HeaderValue::from_static(csp),
+    );
+    if !path.starts_with("/api/") && !path.starts_with("/mcp") {
+        headers.insert(
+            HeaderName::from_static("access-control-allow-origin"),
+            HeaderValue::from_static("*"),
+        );
+    }
+    headers.insert(
+        HeaderName::from_static("x-content-type-options"),
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
+        HeaderName::from_static("referrer-policy"),
+        HeaderValue::from_static("no-referrer"),
+    );
+    response
+}
+
 #[allow(deprecated)]
 pub fn app_router(state: Arc<AppState>, config: &Config) -> Router {
     let cors = if config.cors_allow.iter().any(|o| o == "*") {
@@ -108,6 +152,7 @@ pub fn app_router(state: Arc<AppState>, config: &Config) -> Router {
         .merge(market_data::router())
         .merge(assets::router())
         .merge(secrets::router())
+        .merge(addon_network::router())
         .merge(limits::router())
         .merge(addons::router())
         .merge(taxonomies::router())

--- a/apps/server/src/api/addon_network.rs
+++ b/apps/server/src/api/addon_network.rs
@@ -1,0 +1,45 @@
+use std::sync::Arc;
+
+use crate::{error::ApiResult, main_lib::AppState};
+use axum::{
+    extract::{Path, State},
+    routing::post,
+    Json, Router,
+};
+use wealthfolio_core::addons::network::{
+    resolve_addon_network_auth_header, AddonNetworkRequest, AddonNetworkResponse,
+};
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AddonNetworkBody {
+    request: AddonNetworkRequest,
+}
+
+async fn addon_network_request(
+    State(state): State<Arc<AppState>>,
+    Path(addon_id): Path<String>,
+    Json(body): Json<AddonNetworkBody>,
+) -> ApiResult<Json<AddonNetworkResponse>> {
+    let mut request = body.request;
+    let injected_authorization = resolve_addon_network_auth_header(
+        &addon_id,
+        request.auth.as_ref(),
+        state.secret_store.as_ref(),
+    )
+    .map_err(crate::error::ApiError::BadRequest)?;
+    request.injected_authorization = injected_authorization;
+    let response = state
+        .addon_service
+        .addon_network_request(&addon_id, request)
+        .await
+        .map_err(crate::error::ApiError::BadRequest)?;
+    Ok(Json(response))
+}
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new().route(
+        "/addons/{addon_id}/network/request",
+        post(addon_network_request),
+    )
+}

--- a/apps/server/src/api/addon_network.rs
+++ b/apps/server/src/api/addon_network.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use crate::{error::ApiResult, main_lib::AppState};
+use crate::{
+    error::{ApiError, ApiResult},
+    main_lib::AppState,
+};
 use axum::{
     extract::{Path, State},
     routing::post,
@@ -16,24 +19,35 @@ struct AddonNetworkBody {
     request: AddonNetworkRequest,
 }
 
+fn ensure_addon_network_auth(state: &AppState) -> ApiResult<()> {
+    if state.auth.is_none() {
+        return Err(ApiError::Unauthorized(
+            "Addon network broker requires authentication".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
 async fn addon_network_request(
     State(state): State<Arc<AppState>>,
     Path(addon_id): Path<String>,
     Json(body): Json<AddonNetworkBody>,
 ) -> ApiResult<Json<AddonNetworkResponse>> {
+    ensure_addon_network_auth(&state)?;
     let mut request = body.request;
     let injected_authorization = resolve_addon_network_auth_header(
         &addon_id,
         request.auth.as_ref(),
         state.secret_store.as_ref(),
     )
-    .map_err(crate::error::ApiError::BadRequest)?;
+    .map_err(ApiError::BadRequest)?;
     request.injected_authorization = injected_authorization;
     let response = state
         .addon_service
         .addon_network_request(&addon_id, request)
         .await
-        .map_err(crate::error::ApiError::BadRequest)?;
+        .map_err(ApiError::BadRequest)?;
     Ok(Json(response))
 }
 

--- a/apps/server/src/api/addons.rs
+++ b/apps/server/src/api/addons.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use crate::{error::ApiResult, main_lib::AppState};
+use crate::{
+    error::{ApiError, ApiResult},
+    main_lib::AppState,
+};
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
@@ -20,6 +23,8 @@ struct InstallZipBody {
     zip_data_b64: Option<String>,
     #[serde(rename = "enableAfterInstall")]
     enable_after_install: Option<bool>,
+    #[serde(rename = "approvedNetworkHosts")]
+    approved_network_hosts: Option<Vec<String>>,
 }
 
 #[derive(serde::Deserialize)]
@@ -28,14 +33,28 @@ struct AddonIdBody {
     addon_id: String,
 }
 
+fn ensure_addon_management_auth(state: &AppState) -> ApiResult<()> {
+    if state.auth.is_none() {
+        return Err(ApiError::Unauthorized(
+            "Addon management requires authentication".to_string(),
+        ));
+    }
+    Ok(())
+}
+
 async fn install_addon_zip_web(
     State(state): State<Arc<AppState>>,
     Json(body): Json<InstallZipBody>,
 ) -> ApiResult<Json<AddonManifest>> {
+    ensure_addon_management_auth(&state)?;
     let zip_bytes = decode_zip_data(body.zip_data, body.zip_data_b64)?;
     let metadata = state
         .addon_service
-        .install_addon_zip(zip_bytes, body.enable_after_install.unwrap_or(true))
+        .install_addon_zip(
+            zip_bytes,
+            body.enable_after_install.unwrap_or(true),
+            body.approved_network_hosts.unwrap_or_default(),
+        )
         .await
         .map_err(|e| anyhow::anyhow!(e))?;
     Ok(Json(metadata))
@@ -55,6 +74,7 @@ async fn check_addon_update_web(
     State(state): State<Arc<AppState>>,
     Json(body): Json<AddonIdBody>,
 ) -> ApiResult<Json<AddonUpdateCheckResult>> {
+    ensure_addon_management_auth(&state)?;
     let result = state
         .addon_service
         .check_addon_update(&body.addon_id)
@@ -66,6 +86,7 @@ async fn check_addon_update_web(
 async fn check_all_addon_updates_web(
     State(state): State<Arc<AppState>>,
 ) -> ApiResult<Json<Vec<AddonUpdateCheckResult>>> {
+    ensure_addon_management_auth(&state)?;
     let results = state
         .addon_service
         .check_all_addon_updates()
@@ -85,6 +106,7 @@ async fn toggle_addon_web(
     State(state): State<Arc<AppState>>,
     Json(body): Json<ToggleBody>,
 ) -> ApiResult<StatusCode> {
+    ensure_addon_management_auth(&state)?;
     state
         .addon_service
         .toggle_addon(&body.addon_id, body.enabled)
@@ -96,6 +118,7 @@ async fn uninstall_addon_web(
     Path(id): Path<String>,
     State(state): State<Arc<AppState>>,
 ) -> ApiResult<StatusCode> {
+    ensure_addon_management_auth(&state)?;
     state
         .addon_service
         .uninstall_addon(&id)
@@ -137,6 +160,7 @@ async fn extract_addon_zip_web(
     State(state): State<Arc<AppState>>,
     Json(body): Json<ExtractBody>,
 ) -> ApiResult<Json<ExtractedAddon>> {
+    ensure_addon_management_auth(&state)?;
     let zip_bytes = decode_zip_data(body.zip_data, body.zip_data_b64)?;
     let extracted = state
         .addon_service
@@ -170,6 +194,7 @@ async fn submit_addon_rating_web(
     State(state): State<Arc<AppState>>,
     Json(body): Json<SubmitRatingBody>,
 ) -> ApiResult<Json<serde_json::Value>> {
+    ensure_addon_management_auth(&state)?;
     let resp = state
         .addon_service
         .submit_rating(&body.addon_id, body.rating, body.review)
@@ -199,6 +224,7 @@ async fn download_addon_to_staging_web(
     State(state): State<Arc<AppState>>,
     Json(body): Json<StagingDownloadBody>,
 ) -> ApiResult<Json<ExtractedAddon>> {
+    ensure_addon_management_auth(&state)?;
     let extracted = state
         .addon_service
         .download_addon_to_staging(&body.addon_id)
@@ -213,12 +239,15 @@ struct InstallFromStagingBody {
     addon_id: String,
     #[serde(rename = "enableAfterInstall")]
     enable_after_install: Option<bool>,
+    #[serde(rename = "approvedNetworkHosts")]
+    approved_network_hosts: Option<Vec<String>>,
 }
 
 async fn update_addon_from_store_by_id_web(
     State(state): State<Arc<AppState>>,
     Json(body): Json<AddonIdBody>,
 ) -> ApiResult<Json<AddonManifest>> {
+    ensure_addon_management_auth(&state)?;
     let metadata = state
         .addon_service
         .update_addon_from_store(&body.addon_id)
@@ -231,9 +260,14 @@ async fn install_addon_from_staging_web(
     State(state): State<Arc<AppState>>,
     Json(body): Json<InstallFromStagingBody>,
 ) -> ApiResult<Json<AddonManifest>> {
+    ensure_addon_management_auth(&state)?;
     let metadata = state
         .addon_service
-        .install_addon_from_staging(&body.addon_id, body.enable_after_install.unwrap_or(true))
+        .install_addon_from_staging(
+            &body.addon_id,
+            body.enable_after_install.unwrap_or(true),
+            body.approved_network_hosts.unwrap_or_default(),
+        )
         .await
         .map_err(|e| anyhow::anyhow!(e))?;
     Ok(Json(metadata))
@@ -243,6 +277,7 @@ async fn clear_addon_staging_web(
     State(state): State<Arc<AppState>>,
     Query(rq): Query<RatingsQuery>,
 ) -> ApiResult<StatusCode> {
+    ensure_addon_management_auth(&state)?;
     state
         .addon_service
         .clear_staging(rq.addon_id.as_deref())
@@ -285,7 +320,7 @@ pub fn router() -> Router<Arc<AppState>> {
         )
         .route(
             "/addons/store/ratings",
-            post(submit_addon_rating_web).get(get_addon_ratings_web),
+            get(get_addon_ratings_web).post(submit_addon_rating_web),
         )
         .route("/addons/store/check-update", post(check_addon_update_web))
         .route("/addons/store/check-all", post(check_all_addon_updates_web))

--- a/apps/server/src/api/secrets.rs
+++ b/apps/server/src/api/secrets.rs
@@ -2,11 +2,12 @@ use std::sync::Arc;
 
 use crate::{error::ApiResult, main_lib::AppState};
 use axum::{
-    extract::{Query, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     routing::post,
     Json, Router,
 };
+use wealthfolio_core::secrets::addon_secret_service_id;
 
 #[derive(serde::Deserialize)]
 struct SecretSetBody {
@@ -47,9 +48,60 @@ async fn delete_secret(
     Ok(StatusCode::NO_CONTENT)
 }
 
+#[derive(serde::Deserialize)]
+struct AddonSecretSetBody {
+    key: String,
+    secret: String,
+}
+
+async fn set_addon_secret(
+    State(state): State<Arc<AppState>>,
+    Path(addon_id): Path<String>,
+    Json(body): Json<AddonSecretSetBody>,
+) -> ApiResult<StatusCode> {
+    let service_id = addon_secret_service_id(&addon_id, &body.key)
+        .map_err(crate::error::ApiError::BadRequest)?;
+    state.secret_store.set_secret(&service_id, &body.secret)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+#[derive(serde::Deserialize)]
+struct AddonSecretQuery {
+    key: String,
+}
+
+async fn get_addon_secret(
+    State(state): State<Arc<AppState>>,
+    Path(addon_id): Path<String>,
+    Query(q): Query<AddonSecretQuery>,
+) -> ApiResult<Json<Option<String>>> {
+    let service_id =
+        addon_secret_service_id(&addon_id, &q.key).map_err(crate::error::ApiError::BadRequest)?;
+    let val = state.secret_store.get_secret(&service_id)?;
+    Ok(Json(val))
+}
+
+async fn delete_addon_secret(
+    State(state): State<Arc<AppState>>,
+    Path(addon_id): Path<String>,
+    Query(q): Query<AddonSecretQuery>,
+) -> ApiResult<StatusCode> {
+    let service_id =
+        addon_secret_service_id(&addon_id, &q.key).map_err(crate::error::ApiError::BadRequest)?;
+    state.secret_store.delete_secret(&service_id)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
 pub fn router() -> Router<Arc<AppState>> {
-    Router::new().route(
-        "/secrets",
-        post(set_secret).get(get_secret).delete(delete_secret),
-    )
+    Router::new()
+        .route(
+            "/secrets",
+            post(set_secret).get(get_secret).delete(delete_secret),
+        )
+        .route(
+            "/addons/{addon_id}/secrets",
+            post(set_addon_secret)
+                .get(get_addon_secret)
+                .delete(delete_addon_secret),
+        )
 }

--- a/apps/server/src/api/secrets.rs
+++ b/apps/server/src/api/secrets.rs
@@ -10,7 +10,9 @@ use axum::{
     routing::post,
     Json, Router,
 };
-use wealthfolio_core::secrets::{addon_secret_service_id, validate_unscoped_secret_service_id};
+use wealthfolio_core::secrets::{
+    addon_secret_service_id, legacy_addon_secret_service_id, validate_unscoped_secret_service_id,
+};
 
 fn ensure_secret_api_auth(state: &AppState) -> ApiResult<()> {
     if state.auth.is_none() {
@@ -80,7 +82,10 @@ async fn set_addon_secret(
 ) -> ApiResult<StatusCode> {
     ensure_secret_api_auth(&state)?;
     let service_id = addon_secret_service_id(&addon_id, &body.key).map_err(ApiError::BadRequest)?;
+    let legacy_service_id =
+        legacy_addon_secret_service_id(&addon_id, &body.key).map_err(ApiError::BadRequest)?;
     state.secret_store.set_secret(&service_id, &body.secret)?;
+    state.secret_store.delete_secret(&legacy_service_id)?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -96,7 +101,17 @@ async fn get_addon_secret(
 ) -> ApiResult<Json<Option<String>>> {
     ensure_secret_api_auth(&state)?;
     let service_id = addon_secret_service_id(&addon_id, &q.key).map_err(ApiError::BadRequest)?;
-    let val = state.secret_store.get_secret(&service_id)?;
+    if let Some(value) = state.secret_store.get_secret(&service_id)? {
+        return Ok(Json(Some(value)));
+    }
+
+    let legacy_service_id =
+        legacy_addon_secret_service_id(&addon_id, &q.key).map_err(ApiError::BadRequest)?;
+    let val = state.secret_store.get_secret(&legacy_service_id)?;
+    if let Some(secret) = val.as_deref() {
+        state.secret_store.set_secret(&service_id, secret)?;
+        state.secret_store.delete_secret(&legacy_service_id)?;
+    }
     Ok(Json(val))
 }
 
@@ -107,7 +122,10 @@ async fn delete_addon_secret(
 ) -> ApiResult<StatusCode> {
     ensure_secret_api_auth(&state)?;
     let service_id = addon_secret_service_id(&addon_id, &q.key).map_err(ApiError::BadRequest)?;
+    let legacy_service_id =
+        legacy_addon_secret_service_id(&addon_id, &q.key).map_err(ApiError::BadRequest)?;
     state.secret_store.delete_secret(&service_id)?;
+    state.secret_store.delete_secret(&legacy_service_id)?;
     Ok(StatusCode::NO_CONTENT)
 }
 

--- a/apps/server/src/api/secrets.rs
+++ b/apps/server/src/api/secrets.rs
@@ -1,13 +1,26 @@
 use std::sync::Arc;
 
-use crate::{error::ApiResult, main_lib::AppState};
+use crate::{
+    error::{ApiError, ApiResult},
+    main_lib::AppState,
+};
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
     routing::post,
     Json, Router,
 };
-use wealthfolio_core::secrets::addon_secret_service_id;
+use wealthfolio_core::secrets::{addon_secret_service_id, validate_unscoped_secret_service_id};
+
+fn ensure_secret_api_auth(state: &AppState) -> ApiResult<()> {
+    if state.auth.is_none() {
+        return Err(ApiError::Unauthorized(
+            "Secrets API requires authentication".to_string(),
+        ));
+    }
+
+    Ok(())
+}
 
 #[derive(serde::Deserialize)]
 struct SecretSetBody {
@@ -20,6 +33,8 @@ async fn set_secret(
     State(state): State<Arc<AppState>>,
     Json(body): Json<SecretSetBody>,
 ) -> ApiResult<StatusCode> {
+    ensure_secret_api_auth(&state)?;
+    validate_unscoped_secret_service_id(&body.secret_key).map_err(ApiError::BadRequest)?;
     state
         .secret_store
         .set_secret(&body.secret_key, &body.secret)?;
@@ -36,6 +51,8 @@ async fn get_secret(
     State(state): State<Arc<AppState>>,
     Query(q): Query<SecretQuery>,
 ) -> ApiResult<Json<Option<String>>> {
+    ensure_secret_api_auth(&state)?;
+    validate_unscoped_secret_service_id(&q.secret_key).map_err(ApiError::BadRequest)?;
     let val = state.secret_store.get_secret(&q.secret_key)?;
     Ok(Json(val))
 }
@@ -44,6 +61,8 @@ async fn delete_secret(
     State(state): State<Arc<AppState>>,
     Query(q): Query<SecretQuery>,
 ) -> ApiResult<StatusCode> {
+    ensure_secret_api_auth(&state)?;
+    validate_unscoped_secret_service_id(&q.secret_key).map_err(ApiError::BadRequest)?;
     state.secret_store.delete_secret(&q.secret_key)?;
     Ok(StatusCode::NO_CONTENT)
 }
@@ -59,8 +78,8 @@ async fn set_addon_secret(
     Path(addon_id): Path<String>,
     Json(body): Json<AddonSecretSetBody>,
 ) -> ApiResult<StatusCode> {
-    let service_id = addon_secret_service_id(&addon_id, &body.key)
-        .map_err(crate::error::ApiError::BadRequest)?;
+    ensure_secret_api_auth(&state)?;
+    let service_id = addon_secret_service_id(&addon_id, &body.key).map_err(ApiError::BadRequest)?;
     state.secret_store.set_secret(&service_id, &body.secret)?;
     Ok(StatusCode::NO_CONTENT)
 }
@@ -75,8 +94,8 @@ async fn get_addon_secret(
     Path(addon_id): Path<String>,
     Query(q): Query<AddonSecretQuery>,
 ) -> ApiResult<Json<Option<String>>> {
-    let service_id =
-        addon_secret_service_id(&addon_id, &q.key).map_err(crate::error::ApiError::BadRequest)?;
+    ensure_secret_api_auth(&state)?;
+    let service_id = addon_secret_service_id(&addon_id, &q.key).map_err(ApiError::BadRequest)?;
     let val = state.secret_store.get_secret(&service_id)?;
     Ok(Json(val))
 }
@@ -86,8 +105,8 @@ async fn delete_addon_secret(
     Path(addon_id): Path<String>,
     Query(q): Query<AddonSecretQuery>,
 ) -> ApiResult<StatusCode> {
-    let service_id =
-        addon_secret_service_id(&addon_id, &q.key).map_err(crate::error::ApiError::BadRequest)?;
+    ensure_secret_api_auth(&state)?;
+    let service_id = addon_secret_service_id(&addon_id, &q.key).map_err(ApiError::BadRequest)?;
     state.secret_store.delete_secret(&service_id)?;
     Ok(StatusCode::NO_CONTENT)
 }

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -13,7 +13,8 @@ mod oidc;
 mod scheduler;
 mod secrets;
 
-use api::app_router;
+use api::{app_router, security_headers};
+use axum::middleware;
 use config::Config;
 use main_lib::{build_state, init_tracing};
 use tower_http::services::{ServeDir, ServeFile};
@@ -124,7 +125,9 @@ async fn main() -> anyhow::Result<()> {
     let static_dir = std::path::PathBuf::from(&config.static_dir);
     let index_file = static_dir.join("index.html");
     let static_service = ServeDir::new(static_dir).fallback(ServeFile::new(index_file));
-    let router = app_router(state, &config).fallback_service(static_service);
+    let router = app_router(state, &config)
+        .fallback_service(static_service)
+        .layer(middleware::from_fn(security_headers));
     if let Some(ref auth) = config.auth {
         tracing::info!(
             "Authentication enabled, cookie secure policy: {}",

--- a/apps/tauri/capabilities/desktop.json
+++ b/apps/tauri/capabilities/desktop.json
@@ -13,29 +13,22 @@
   "permissions": [
     "core:default",
     "fs:allow-read-file",
-    "fs:allow-write-file",
-    "fs:allow-read-dir",
     "fs:allow-copy-file",
-    "fs:allow-mkdir",
     "fs:allow-remove",
-    "fs:allow-remove",
-    "fs:allow-rename",
     "fs:allow-exists",
     {
       "identifier": "fs:scope",
       "allow": [
-        "$APPDATA/**"
+        "$APPDATA/pending-exports/**"
       ]
     },
     "core:window:allow-start-dragging",
     "core:window:allow-set-fullscreen",
     "core:window:allow-is-fullscreen",
-    "shell:allow-open",
     "dialog:allow-open",
     "dialog:allow-save",
     "fs:default",
     "dialog:default",
-    "shell:default",
     "deep-link:default",
     "core:app:allow-set-app-theme",
     "core:window:allow-set-theme",

--- a/apps/tauri/src/commands/addon.rs
+++ b/apps/tauri/src/commands/addon.rs
@@ -1,4 +1,3 @@
-use std::fs;
 use std::sync::Arc;
 use tauri::Manager;
 use tauri::{AppHandle, State};
@@ -6,127 +5,45 @@ use tauri::{AppHandle, State};
 // Import addon modules
 use crate::context::ServiceContext;
 use wealthfolio_core::addons::{
-    self, AddonManifest, AddonUpdateCheckResult, AddonUpdateInfo, ExtractedAddon, InstalledAddon,
+    self, AddonManifest, AddonService, AddonServiceTrait, AddonUpdateCheckResult, AddonUpdateInfo,
+    ExtractedAddon, InstalledAddon,
 };
+
+fn addon_service(
+    app_handle: &AppHandle,
+    instance_id: impl Into<String>,
+) -> Result<AddonService, String> {
+    let app_data_dir = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {}", e))?;
+
+    Ok(AddonService::new(app_data_dir, instance_id))
+}
 
 #[tauri::command]
 pub async fn install_addon_zip(
     app_handle: AppHandle,
     zip_data: Vec<u8>,
     enable_after_install: Option<bool>,
+    approved_network_hosts: Option<Vec<String>>,
+    state: State<'_, Arc<ServiceContext>>,
 ) -> Result<AddonManifest, String> {
-    let app_data_dir = app_handle
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {}", e))?
-        .to_str()
-        .ok_or("Failed to convert app data dir path to string")?
-        .to_string();
-
-    let extracted = addons::extract_addon_zip_internal(zip_data)?;
-    let addon_id = extracted.metadata.id.clone();
-
-    // Create addon directory
-    let addon_dir = addons::get_addon_path(&app_data_dir, &addon_id)?;
-    if addon_dir.exists() {
-        fs::remove_dir_all(&addon_dir)
-            .map_err(|e| format!("Failed to remove existing addon directory: {}", e))?;
-    }
-    fs::create_dir_all(&addon_dir)
-        .map_err(|e| format!("Failed to create addon directory: {}", e))?;
-
-    // Write all addon files
-    for file in &extracted.files {
-        let relative_path = addons::validated_addon_archive_path(&file.name)?;
-        let file_path = addon_dir.join(relative_path);
-        if let Some(parent) = file_path.parent() {
-            fs::create_dir_all(parent)
-                .map_err(|e| format!("Failed to create file directory: {}", e))?;
-        }
-        fs::write(&file_path, &file.content)
-            .map_err(|e| format!("Failed to write addon file {}: {}", file.name, e))?;
-    }
-
-    // Convert to installed manifest with runtime fields and use the merged permissions
-    let metadata = extracted
-        .metadata
-        .to_installed(enable_after_install.unwrap_or(true))?;
-
-    let manifest_path = addon_dir.join("manifest.json");
-    let manifest_json = serde_json::to_string_pretty(&metadata)
-        .map_err(|e| format!("Failed to serialize manifest: {}", e))?;
-    fs::write(&manifest_path, manifest_json)
-        .map_err(|e| format!("Failed to write manifest: {}", e))?;
-
-    Ok(metadata)
+    addon_service(&app_handle, state.instance_id.as_str())?
+        .install_addon_zip(
+            zip_data,
+            enable_after_install.unwrap_or(true),
+            approved_network_hosts.unwrap_or_default(),
+        )
+        .await
 }
 
 #[tauri::command]
-pub async fn list_installed_addons(app_handle: AppHandle) -> Result<Vec<InstalledAddon>, String> {
-    let app_data_dir = app_handle
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {}", e))?
-        .to_str()
-        .ok_or("Failed to convert app data dir path to string")?
-        .to_string();
-
-    let addons_dir = addons::ensure_addons_directory(&app_data_dir)?;
-    let mut installed_addons = Vec::new();
-
-    if !addons_dir.exists() {
-        return Ok(installed_addons);
-    }
-
-    // Read addon directories
-    let entries =
-        fs::read_dir(&addons_dir).map_err(|e| format!("Failed to read addons directory: {}", e))?;
-
-    for entry in entries {
-        let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
-        let addon_dir = entry.path();
-
-        if !addon_dir.is_dir() {
-            continue;
-        }
-
-        let manifest_path = addon_dir.join("manifest.json");
-        if !manifest_path.exists() {
-            continue;
-        }
-
-        // Read manifest
-        let manifest_content = match fs::read_to_string(&manifest_path) {
-            Ok(content) => content,
-            Err(e) => {
-                log::error!("Failed to read manifest file {:?}: {}", manifest_path, e);
-                continue;
-            }
-        };
-
-        let metadata: AddonManifest = match serde_json::from_str(&manifest_content) {
-            Ok(metadata) => metadata,
-            Err(e) => {
-                log::error!("Failed to parse manifest {:?}: {}", manifest_path, e);
-                log::error!("Manifest content: {}", manifest_content);
-                continue;
-            }
-        };
-
-        // Determine if it's a ZIP addon (has multiple files)
-        let files_count = fs::read_dir(&addon_dir)
-            .map_err(|e| format!("Failed to count addon files: {}", e))?
-            .count();
-        let is_zip_addon = files_count > 2; // More than manifest.json and main file
-
-        installed_addons.push(InstalledAddon {
-            metadata,
-            file_path: addon_dir.to_string_lossy().to_string(),
-            is_zip_addon,
-        });
-    }
-
-    Ok(installed_addons)
+pub async fn list_installed_addons(
+    app_handle: AppHandle,
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<Vec<InstalledAddon>, String> {
+    addon_service(&app_handle, state.instance_id.as_str())?.list_installed_addons()
 }
 
 #[tauri::command]
@@ -134,144 +51,37 @@ pub async fn toggle_addon(
     app_handle: AppHandle,
     addon_id: String,
     enabled: bool,
+    state: State<'_, Arc<ServiceContext>>,
 ) -> Result<(), String> {
-    let app_data_dir = app_handle
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {}", e))?
-        .to_str()
-        .ok_or("Failed to convert app data dir path to string")?
-        .to_string();
-
-    let addon_dir = addons::get_addon_path(&app_data_dir, &addon_id)?;
-    let manifest_path = addon_dir.join("manifest.json");
-
-    if !manifest_path.exists() {
-        return Err("Addon not found".to_string());
-    }
-
-    // Read current manifest
-    let manifest_content = fs::read_to_string(&manifest_path)
-        .map_err(|e| format!("Failed to read manifest file: {}", e))?;
-    let mut metadata: AddonManifest = serde_json::from_str(&manifest_content)
-        .map_err(|e| format!("Failed to parse manifest: {}", e))?;
-
-    // Update enabled status
-    metadata.enabled = Some(enabled);
-
-    // Write back manifest
-    let manifest_json = serde_json::to_string_pretty(&metadata)
-        .map_err(|e| format!("Failed to serialize manifest: {}", e))?;
-    fs::write(&manifest_path, manifest_json)
-        .map_err(|e| format!("Failed to write manifest: {}", e))?;
-
-    Ok(())
+    addon_service(&app_handle, state.instance_id.as_str())?.toggle_addon(&addon_id, enabled)
 }
 
 #[tauri::command]
-pub async fn uninstall_addon(app_handle: AppHandle, addon_id: String) -> Result<(), String> {
-    let app_data_dir = app_handle
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {}", e))?
-        .to_str()
-        .ok_or("Failed to convert app data dir path to string")?
-        .to_string();
-
-    let addon_dir = addons::get_addon_path(&app_data_dir, &addon_id)?;
-
-    if !addon_dir.exists() {
-        return Err("Addon not found".to_string());
-    }
-
-    fs::remove_dir_all(&addon_dir)
-        .map_err(|e| format!("Failed to remove addon directory: {}", e))?;
-
-    Ok(())
+pub async fn uninstall_addon(
+    app_handle: AppHandle,
+    addon_id: String,
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<(), String> {
+    addon_service(&app_handle, state.instance_id.as_str())?
+        .uninstall_addon(&addon_id)
+        .await
 }
 
 #[tauri::command]
 pub async fn load_addon_for_runtime(
     app_handle: AppHandle,
     addon_id: String,
+    state: State<'_, Arc<ServiceContext>>,
 ) -> Result<ExtractedAddon, String> {
-    let app_data_dir = app_handle
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {}", e))?
-        .to_str()
-        .ok_or("Failed to convert app data dir path to string")?
-        .to_string();
-
-    let addon_dir = addons::get_addon_path(&app_data_dir, &addon_id)?;
-    let manifest_path = addon_dir.join("manifest.json");
-
-    if !manifest_path.exists() {
-        return Err("Addon not found".to_string());
-    }
-
-    // Read manifest
-    let manifest_content = fs::read_to_string(&manifest_path)
-        .map_err(|e| format!("Failed to read manifest file: {}", e))?;
-    let metadata: AddonManifest = serde_json::from_str(&manifest_content)
-        .map_err(|e| format!("Failed to parse manifest: {}", e))?;
-
-    if !metadata.is_enabled() {
-        return Err("Addon is disabled".to_string());
-    }
-
-    // Read addon files recursively
-    let mut files = Vec::new();
-    addons::read_addon_files_recursive(&addon_dir, &addon_dir, &mut files)?;
-
-    // Set the is_main flag based on metadata.main
-    let main_file = metadata.get_main()?;
-    for file in &mut files {
-        // Normalize path separators for comparison (convert backslashes to forward slashes)
-        let normalized_file_name = file.name.replace('\\', "/");
-        let normalized_main_file = main_file.replace('\\', "/");
-
-        file.is_main = normalized_file_name == normalized_main_file
-            || normalized_file_name.ends_with(&normalized_main_file);
-    }
-
-    // Verify that we found the main file
-    let main_file_found = files.iter().any(|f| f.is_main);
-    if !main_file_found {
-        return Err(format!(
-            "Main addon file '{}' not found. Available files: {}",
-            main_file,
-            files
-                .iter()
-                .map(|f| f.name.as_str())
-                .collect::<Vec<_>>()
-                .join(", ")
-        ));
-    }
-
-    Ok(ExtractedAddon { metadata, files })
+    addon_service(&app_handle, state.instance_id.as_str())?.load_addon_for_runtime(&addon_id)
 }
 
 #[tauri::command]
 pub async fn get_enabled_addons_on_startup(
     app_handle: AppHandle,
+    state: State<'_, Arc<ServiceContext>>,
 ) -> Result<Vec<ExtractedAddon>, String> {
-    let installed_addons = list_installed_addons(app_handle.clone()).await?;
-    let mut enabled_addons = Vec::new();
-
-    for installed in installed_addons {
-        if installed.metadata.is_enabled() {
-            match load_addon_for_runtime(app_handle.clone(), installed.metadata.id).await {
-                Ok(addon) => enabled_addons.push(addon),
-                Err(e) => {
-                    log::warn!("Failed to load addon {}: {}", installed.metadata.name, e);
-                    continue;
-                }
-            }
-        }
-    }
-
-    Ok(enabled_addons)
+    addon_service(&app_handle, state.instance_id.as_str())?.get_enabled_addons_on_startup()
 }
 
 // Legacy function for backward compatibility
@@ -311,6 +121,7 @@ pub async fn check_addon_update(
                     latest_version: "unknown".to_string(),
                     update_available: false,
                     download_url: None,
+                    sha256: None,
                     release_notes: None,
                     release_date: None,
                     changelog_url: None,
@@ -330,9 +141,9 @@ pub async fn check_all_addon_updates(
     app_handle: AppHandle,
     state: State<'_, Arc<ServiceContext>>,
 ) -> Result<Vec<AddonUpdateCheckResult>, String> {
-    let installed_addons = list_installed_addons(app_handle.clone()).await?;
     let mut results = Vec::new();
     let instance_id = state.instance_id.as_str();
+    let installed_addons = addon_service(&app_handle, instance_id)?.list_installed_addons()?;
 
     for addon in installed_addons {
         match addons::check_addon_update_from_api(
@@ -357,6 +168,7 @@ pub async fn check_all_addon_updates(
                         latest_version: "unknown".to_string(),
                         update_available: false,
                         download_url: None,
+                        sha256: None,
                         release_notes: None,
                         release_date: None,
                         changelog_url: None,
@@ -381,40 +193,9 @@ pub async fn update_addon_from_store_by_id(
     state: State<'_, Arc<ServiceContext>>,
 ) -> Result<AddonManifest, String> {
     let instance_id = state.instance_id.as_str();
-
-    // Download the addon package using the new download API
-    let zip_data = addons::download_addon_from_store(&addon_id, instance_id)
+    addon_service(&app_handle, instance_id.to_string())?
+        .update_addon_from_store(&addon_id)
         .await
-        .map_err(|e| format!("Failed to download addon: {}", e))?;
-
-    // Get the current addon state before updating
-    let app_data_dir = app_handle
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {}", e))?
-        .to_str()
-        .ok_or("Failed to convert app data dir path to string")?
-        .to_string();
-
-    let addon_dir = addons::get_addon_path(&app_data_dir, &addon_id)?;
-    let was_enabled =
-        if let Ok(manifest_content) = fs::read_to_string(addon_dir.join("manifest.json")) {
-            if let Ok(metadata) = serde_json::from_str::<AddonManifest>(&manifest_content) {
-                metadata.enabled.unwrap_or(false)
-            } else {
-                false
-            }
-        } else {
-            false
-        };
-
-    // Uninstall the old version first
-    uninstall_addon(app_handle.clone(), addon_id.clone()).await?;
-
-    // Install the new version, preserving the enabled state
-    let new_metadata = install_addon_zip(app_handle, zip_data, Some(was_enabled)).await?;
-
-    Ok(new_metadata)
 }
 
 /// Fetch available addons from the store
@@ -433,31 +214,10 @@ pub async fn download_addon_to_staging(
     addon_id: String,
     state: State<'_, Arc<ServiceContext>>,
 ) -> Result<ExtractedAddon, String> {
-    let app_data_dir = app_handle
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {}", e))?
-        .to_str()
-        .ok_or("Failed to convert app data dir path to string")?
-        .to_string();
-
     let instance_id = state.instance_id.as_str();
-
-    // Download addon data
-    let zip_data = addons::download_addon_from_store(&addon_id, instance_id)
+    addon_service(&app_handle, instance_id.to_string())?
+        .download_addon_to_staging(&addon_id)
         .await
-        .map_err(|e| {
-            // Clean up any partial staging on download failure
-            let _ = addons::remove_addon_from_staging(&addon_id, &app_data_dir);
-            format!("Failed to download addon: {}", e)
-        })?;
-
-    // Save to staging directory with validation
-    let _staged_path = addons::save_addon_to_staging(&addon_id, &app_data_dir, &zip_data)
-        .map_err(|e| format!("Failed to stage addon: {}", e))?;
-
-    // Extract and analyze permissions
-    addons::extract_addon_zip_internal(zip_data)
 }
 
 /// Install addon from staging directory after permission approval
@@ -466,25 +226,16 @@ pub async fn install_addon_from_staging(
     app_handle: AppHandle,
     addon_id: String,
     enable_after_install: Option<bool>,
+    approved_network_hosts: Option<Vec<String>>,
+    state: State<'_, Arc<ServiceContext>>,
 ) -> Result<AddonManifest, String> {
-    let app_data_dir = app_handle
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {}", e))?
-        .to_str()
-        .ok_or("Failed to convert app data dir path to string")?
-        .to_string();
-
-    // Load addon from staging
-    let zip_data = addons::load_addon_from_staging(&addon_id, &app_data_dir)?;
-
-    // Install the addon
-    let result = install_addon_zip(app_handle, zip_data, enable_after_install).await;
-
-    // Clean up staging regardless of install success/failure
-    let _ = addons::remove_addon_from_staging(&addon_id, &app_data_dir);
-
-    result
+    addon_service(&app_handle, state.instance_id.as_str())?
+        .install_addon_from_staging(
+            &addon_id,
+            enable_after_install.unwrap_or(true),
+            approved_network_hosts.unwrap_or_default(),
+        )
+        .await
 }
 
 /// Clear specific addon from staging or entire staging directory
@@ -492,19 +243,9 @@ pub async fn install_addon_from_staging(
 pub async fn clear_addon_staging(
     app_handle: AppHandle,
     addon_id: Option<String>,
+    state: State<'_, Arc<ServiceContext>>,
 ) -> Result<(), String> {
-    let app_data_dir = app_handle
-        .path()
-        .app_data_dir()
-        .map_err(|e| format!("Failed to get app data dir: {}", e))?
-        .to_str()
-        .ok_or("Failed to convert app data dir path to string")?
-        .to_string();
-
-    match addon_id {
-        Some(id) => addons::remove_addon_from_staging(&id, &app_data_dir),
-        None => addons::clear_staging_directory(&app_data_dir),
-    }
+    addon_service(&app_handle, state.instance_id.as_str())?.clear_staging(addon_id.as_deref())
 }
 
 /// Submit or update a rating for an addon

--- a/apps/tauri/src/commands/addon_network.rs
+++ b/apps/tauri/src/commands/addon_network.rs
@@ -1,0 +1,29 @@
+use std::sync::Arc;
+
+use crate::secret_store::KeyringSecretStore;
+use tauri::{AppHandle, Manager, State};
+use wealthfolio_core::addons::network::{
+    resolve_addon_network_auth_header, AddonNetworkRequest, AddonNetworkResponse,
+};
+use wealthfolio_core::addons::{AddonService, AddonServiceTrait};
+
+use crate::context::ServiceContext;
+
+#[tauri::command]
+pub async fn addon_network_request(
+    app_handle: AppHandle,
+    state: State<'_, Arc<ServiceContext>>,
+    addon_id: String,
+    mut request: AddonNetworkRequest,
+) -> Result<AddonNetworkResponse, String> {
+    let app_data_dir = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {}", e))?;
+    let injected_authorization =
+        resolve_addon_network_auth_header(&addon_id, request.auth.as_ref(), &KeyringSecretStore)?;
+    request.injected_authorization = injected_authorization;
+    AddonService::new(app_data_dir, state.instance_id.as_str())
+        .addon_network_request(&addon_id, request)
+        .await
+}

--- a/apps/tauri/src/commands/mod.rs
+++ b/apps/tauri/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod account;
 pub mod activity;
 pub mod addon;
+pub mod addon_network;
 pub mod ai_chat;
 pub mod ai_providers;
 pub mod allocation_targets;

--- a/apps/tauri/src/commands/secrets.rs
+++ b/apps/tauri/src/commands/secrets.rs
@@ -1,7 +1,7 @@
 use crate::{context::ServiceContext, secret_store::KeyringSecretStore};
 use std::sync::Arc;
-use tauri::State;
-use wealthfolio_core::secrets::SecretStore;
+use tauri::{AppHandle, State};
+use wealthfolio_core::secrets::{addon_secret_service_id, SecretStore};
 
 #[tauri::command]
 pub async fn set_secret(
@@ -31,5 +31,45 @@ pub async fn delete_secret(
 ) -> Result<(), String> {
     KeyringSecretStore
         .delete_secret(&secret_key)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn set_addon_secret(
+    addon_id: String,
+    key: String,
+    secret: String,
+    _app: AppHandle,
+    _state: State<'_, Arc<ServiceContext>>,
+) -> Result<(), String> {
+    let service_id = addon_secret_service_id(&addon_id, &key)?;
+    KeyringSecretStore
+        .set_secret(&service_id, &secret)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn get_addon_secret(
+    addon_id: String,
+    key: String,
+    _app: AppHandle,
+    _state: State<'_, Arc<ServiceContext>>,
+) -> Result<Option<String>, String> {
+    let service_id = addon_secret_service_id(&addon_id, &key)?;
+    KeyringSecretStore
+        .get_secret(&service_id)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn delete_addon_secret(
+    addon_id: String,
+    key: String,
+    _app: AppHandle,
+    _state: State<'_, Arc<ServiceContext>>,
+) -> Result<(), String> {
+    let service_id = addon_secret_service_id(&addon_id, &key)?;
+    KeyringSecretStore
+        .delete_secret(&service_id)
         .map_err(|e| e.to_string())
 }

--- a/apps/tauri/src/commands/secrets.rs
+++ b/apps/tauri/src/commands/secrets.rs
@@ -2,7 +2,8 @@ use crate::{context::ServiceContext, secret_store::KeyringSecretStore};
 use std::sync::Arc;
 use tauri::{AppHandle, State};
 use wealthfolio_core::secrets::{
-    addon_secret_service_id, validate_unscoped_secret_service_id, SecretStore,
+    addon_secret_service_id, legacy_addon_secret_service_id, validate_unscoped_secret_service_id,
+    SecretStore,
 };
 
 #[tauri::command]
@@ -48,8 +49,12 @@ pub async fn set_addon_secret(
     _state: State<'_, Arc<ServiceContext>>,
 ) -> Result<(), String> {
     let service_id = addon_secret_service_id(&addon_id, &key)?;
+    let legacy_service_id = legacy_addon_secret_service_id(&addon_id, &key)?;
     KeyringSecretStore
         .set_secret(&service_id, &secret)
+        .map_err(|e| e.to_string())?;
+    KeyringSecretStore
+        .delete_secret(&legacy_service_id)
         .map_err(|e| e.to_string())
 }
 
@@ -61,9 +66,26 @@ pub async fn get_addon_secret(
     _state: State<'_, Arc<ServiceContext>>,
 ) -> Result<Option<String>, String> {
     let service_id = addon_secret_service_id(&addon_id, &key)?;
-    KeyringSecretStore
+    if let Some(secret) = KeyringSecretStore
         .get_secret(&service_id)
-        .map_err(|e| e.to_string())
+        .map_err(|e| e.to_string())?
+    {
+        return Ok(Some(secret));
+    }
+
+    let legacy_service_id = legacy_addon_secret_service_id(&addon_id, &key)?;
+    let legacy_secret = KeyringSecretStore
+        .get_secret(&legacy_service_id)
+        .map_err(|e| e.to_string())?;
+    if let Some(secret) = legacy_secret.as_deref() {
+        KeyringSecretStore
+            .set_secret(&service_id, secret)
+            .map_err(|e| e.to_string())?;
+        KeyringSecretStore
+            .delete_secret(&legacy_service_id)
+            .map_err(|e| e.to_string())?;
+    }
+    Ok(legacy_secret)
 }
 
 #[tauri::command]
@@ -74,7 +96,11 @@ pub async fn delete_addon_secret(
     _state: State<'_, Arc<ServiceContext>>,
 ) -> Result<(), String> {
     let service_id = addon_secret_service_id(&addon_id, &key)?;
+    let legacy_service_id = legacy_addon_secret_service_id(&addon_id, &key)?;
     KeyringSecretStore
         .delete_secret(&service_id)
+        .map_err(|e| e.to_string())?;
+    KeyringSecretStore
+        .delete_secret(&legacy_service_id)
         .map_err(|e| e.to_string())
 }

--- a/apps/tauri/src/commands/secrets.rs
+++ b/apps/tauri/src/commands/secrets.rs
@@ -1,7 +1,9 @@
 use crate::{context::ServiceContext, secret_store::KeyringSecretStore};
 use std::sync::Arc;
 use tauri::{AppHandle, State};
-use wealthfolio_core::secrets::{addon_secret_service_id, SecretStore};
+use wealthfolio_core::secrets::{
+    addon_secret_service_id, validate_unscoped_secret_service_id, SecretStore,
+};
 
 #[tauri::command]
 pub async fn set_secret(
@@ -9,6 +11,7 @@ pub async fn set_secret(
     secret: String,
     _state: State<'_, Arc<ServiceContext>>, // keep signature consistent
 ) -> Result<(), String> {
+    validate_unscoped_secret_service_id(&secret_key)?;
     KeyringSecretStore
         .set_secret(&secret_key, &secret)
         .map_err(|e| e.to_string())
@@ -19,6 +22,7 @@ pub async fn get_secret(
     secret_key: String,
     _state: State<'_, Arc<ServiceContext>>,
 ) -> Result<Option<String>, String> {
+    validate_unscoped_secret_service_id(&secret_key)?;
     KeyringSecretStore
         .get_secret(&secret_key)
         .map_err(|e| e.to_string())
@@ -29,6 +33,7 @@ pub async fn delete_secret(
     secret_key: String,
     _state: State<'_, Arc<ServiceContext>>,
 ) -> Result<(), String> {
+    validate_unscoped_secret_service_id(&secret_key)?;
     KeyringSecretStore
         .delete_secret(&secret_key)
         .map_err(|e| e.to_string())

--- a/apps/tauri/src/lib.rs
+++ b/apps/tauri/src/lib.rs
@@ -619,6 +619,10 @@ pub fn run() {
             commands::secrets::set_secret,
             commands::secrets::get_secret,
             commands::secrets::delete_secret,
+            commands::secrets::set_addon_secret,
+            commands::secrets::get_addon_secret,
+            commands::secrets::delete_addon_secret,
+            commands::addon_network::addon_network_request,
             // Provider settings commands
             commands::providers_settings::get_market_data_providers_settings,
             commands::providers_settings::update_market_data_provider_settings,

--- a/apps/tauri/tauri.conf.json
+++ b/apps/tauri/tauri.conf.json
@@ -62,7 +62,7 @@
     }
   },
   "app": {
-    "withGlobalTauri": true,
+    "withGlobalTauri": false,
     "windows": [
       {
         "dragDropEnabled": false,
@@ -77,7 +77,8 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://wealthfolio.app https://auth.wealthfolio.app https://connect.wealthfolio.app https://connect-staging.wealthfolio.app; frame-src 'self' blob: about:; child-src 'self' blob: about:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; worker-src 'self' blob:",
+      "devCsp": "default-src 'self' http://localhost:1420; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: http://localhost:1420; style-src 'self' 'unsafe-inline' http://localhost:1420; img-src 'self' data: blob: https: http://localhost:1420; font-src 'self' data: http://localhost:1420; connect-src 'self' http://localhost:1420 ws://localhost:1420 http://localhost:3001 https://wealthfolio.app https://auth.wealthfolio.app https://connect.wealthfolio.app https://connect-staging.wealthfolio.app; frame-src 'self' blob: about:; child-src 'self' blob: about:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; worker-src 'self' blob:"
     }
   }
 }

--- a/crates/core/src/addons/addon_traits.rs
+++ b/crates/core/src/addons/addon_traits.rs
@@ -2,6 +2,7 @@
 
 use async_trait::async_trait;
 
+use super::network::{AddonNetworkRequest, AddonNetworkResponse};
 use super::{AddonManifest, AddonUpdateCheckResult, ExtractedAddon, InstalledAddon};
 
 /// Service trait for addon business logic operations.
@@ -12,12 +13,14 @@ pub trait AddonServiceTrait: Send + Sync {
         &self,
         zip_data: Vec<u8>,
         enable_after_install: bool,
+        approved_network_hosts: Vec<String>,
     ) -> Result<AddonManifest, String>;
 
     async fn install_addon_from_staging(
         &self,
         addon_id: &str,
         enable_after_install: bool,
+        approved_network_hosts: Vec<String>,
     ) -> Result<AddonManifest, String>;
 
     async fn uninstall_addon(&self, addon_id: &str) -> Result<(), String>;
@@ -35,6 +38,13 @@ pub trait AddonServiceTrait: Send + Sync {
     async fn check_all_addon_updates(&self) -> Result<Vec<AddonUpdateCheckResult>, String>;
 
     async fn update_addon_from_store(&self, addon_id: &str) -> Result<AddonManifest, String>;
+
+    // Brokered network operations
+    async fn addon_network_request(
+        &self,
+        addon_id: &str,
+        request: AddonNetworkRequest,
+    ) -> Result<AddonNetworkResponse, String>;
 
     // Toggle operation
     fn toggle_addon(&self, addon_id: &str, enabled: bool) -> Result<(), String>;

--- a/crates/core/src/addons/mod.rs
+++ b/crates/core/src/addons/mod.rs
@@ -1,5 +1,6 @@
 mod addon_traits;
 pub mod models;
+pub mod network;
 pub mod service;
 
 pub use addon_traits::AddonServiceTrait;

--- a/crates/core/src/addons/models.rs
+++ b/crates/core/src/addons/models.rs
@@ -29,6 +29,14 @@ pub struct AddonPermission {
     pub purpose: String,
 }
 
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct AddonNetworkAccess {
+    pub allowed_hosts: Vec<String>,
+    #[serde(default)]
+    pub approved_hosts: Vec<String>,
+}
+
 /// Unified addon manifest structure that handles both development and runtime scenarios
 /// This represents both what developers write in their manifest.json and installed addon metadata
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
@@ -52,6 +60,7 @@ pub struct AddonManifest {
     pub min_wealthfolio_version: Option<String>,
     pub keywords: Option<Vec<String>>,
     pub icon: Option<String>,
+    pub network: Option<AddonNetworkAccess>,
 
     // Runtime fields (only present after installation)
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -113,6 +122,7 @@ pub struct InstalledAddon {
 pub struct AddonStoreListing {
     pub metadata: AddonManifest,
     pub download_url: String,
+    pub sha256: Option<String>,
     pub downloads: Option<u32>,
     pub rating: Option<f32>,
     pub review_count: Option<u32>,
@@ -130,6 +140,7 @@ pub struct AddonUpdateInfo {
     pub latest_version: String,
     pub update_available: bool,
     pub download_url: Option<String>,
+    pub sha256: Option<String>,
     pub release_notes: Option<String>,
     pub release_date: Option<String>,
     pub changelog_url: Option<String>,

--- a/crates/core/src/addons/models.rs
+++ b/crates/core/src/addons/models.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -61,6 +62,8 @@ pub struct AddonManifest {
     pub keywords: Option<Vec<String>>,
     pub icon: Option<String>,
     pub network: Option<AddonNetworkAccess>,
+    #[serde(rename = "hostDependencies")]
+    pub host_dependencies: Option<BTreeMap<String, String>>,
 
     // Runtime fields (only present after installation)
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/core/src/addons/network.rs
+++ b/crates/core/src/addons/network.rs
@@ -1,0 +1,399 @@
+use std::{
+    collections::BTreeMap,
+    net::{IpAddr, SocketAddr},
+    time::Duration,
+};
+
+use reqwest::{
+    header::{HeaderName, AUTHORIZATION},
+    Method,
+};
+use serde::{Deserialize, Serialize};
+use tokio::net::lookup_host;
+use url::Url;
+
+use super::validate_addon_id;
+use crate::secrets::{addon_secret_service_id, SecretStore};
+
+const MAX_REQUEST_BODY_BYTES: usize = 1024 * 1024;
+const MAX_RESPONSE_BODY_BYTES: usize = 2 * 1024 * 1024;
+const REQUEST_TIMEOUT_SECS: u64 = 10;
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AddonNetworkAuth {
+    #[serde(rename = "type")]
+    pub auth_type: String,
+    pub secret_key: String,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AddonNetworkRequest {
+    pub url: String,
+    pub method: Option<String>,
+    pub headers: Option<BTreeMap<String, String>>,
+    pub body: Option<String>,
+    pub auth: Option<AddonNetworkAuth>,
+    #[serde(skip)]
+    pub injected_authorization: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AddonNetworkResponse {
+    pub status: u16,
+    pub headers: BTreeMap<String, String>,
+    pub body: String,
+}
+
+pub async fn perform_addon_network_request(
+    addon_id: &str,
+    allowed_hosts: &[String],
+    request: AddonNetworkRequest,
+) -> Result<AddonNetworkResponse, String> {
+    validate_addon_id(addon_id)?;
+    let url = validate_url(&request.url, allowed_hosts)?;
+    let host = url
+        .host_str()
+        .ok_or_else(|| "Addon network URL must include a host".to_string())?
+        .to_string();
+    let resolved_addresses = resolve_public_addresses(&url).await?;
+    let method = validate_method(request.method.as_deref().unwrap_or("GET"))?;
+    let body = request.body.unwrap_or_default();
+    if body.len() > MAX_REQUEST_BODY_BYTES {
+        return Err("Addon network request body is too large".to_string());
+    }
+
+    let client = reqwest::Client::builder()
+        .redirect(reqwest::redirect::Policy::none())
+        .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+        .resolve_to_addrs(&host, &resolved_addresses)
+        .build()
+        .map_err(|e| e.to_string())?;
+
+    let mut builder = client.request(method, url);
+    for (name, value) in request.headers.unwrap_or_default() {
+        if is_authorization_header(&name) {
+            return Err(
+                "Addon network Authorization header must use request.auth.secretKey".to_string(),
+            );
+        }
+        if is_blocked_request_header(&name) {
+            continue;
+        }
+        let header_name = HeaderName::from_bytes(name.as_bytes())
+            .map_err(|_| format!("Invalid request header '{name}'"))?;
+        builder = builder.header(header_name, value);
+    }
+    if let Some(authorization) = request.injected_authorization {
+        builder = builder.header(AUTHORIZATION, authorization);
+    }
+
+    if !body.is_empty() {
+        builder = builder.body(body);
+    }
+
+    let response = builder.send().await.map_err(|e| e.to_string())?;
+    let status = response.status().as_u16();
+    let mut headers = BTreeMap::new();
+    for (name, value) in response.headers() {
+        let name = name.as_str();
+        if is_blocked_response_header(name) {
+            continue;
+        }
+        if let Ok(value) = value.to_str() {
+            headers.insert(name.to_string(), value.to_string());
+        }
+    }
+
+    if response.content_length().unwrap_or_default() > MAX_RESPONSE_BODY_BYTES as u64 {
+        return Err("Addon network response body is too large".to_string());
+    }
+    let body = response.bytes().await.map_err(|e| e.to_string())?;
+    if body.len() > MAX_RESPONSE_BODY_BYTES {
+        return Err("Addon network response body is too large".to_string());
+    }
+
+    Ok(AddonNetworkResponse {
+        status,
+        headers,
+        body: String::from_utf8_lossy(&body).to_string(),
+    })
+}
+
+pub fn resolve_addon_network_auth_header(
+    addon_id: &str,
+    auth: Option<&AddonNetworkAuth>,
+    secret_store: &dyn SecretStore,
+) -> Result<Option<String>, String> {
+    validate_addon_id(addon_id)?;
+    let Some(auth) = auth else {
+        return Ok(None);
+    };
+    if auth.auth_type != "bearer" {
+        return Err("Addon network auth type is not supported".to_string());
+    }
+    let service_id = addon_secret_service_id(addon_id, &auth.secret_key)?;
+    let secret = secret_store
+        .get_secret(&service_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| "Addon network auth secret was not found".to_string())?;
+    if secret.trim().is_empty() {
+        return Err("Addon network auth secret is empty".to_string());
+    }
+    Ok(Some(format!("Bearer {}", secret)))
+}
+
+fn validate_url(url: &str, allowed_hosts: &[String]) -> Result<Url, String> {
+    let parsed = Url::parse(url).map_err(|_| "Invalid addon network URL".to_string())?;
+    if parsed.scheme() != "https" {
+        return Err("Addon network requests must use HTTPS".to_string());
+    }
+
+    if parsed.username() != "" || parsed.password().is_some() {
+        return Err("Addon network URLs cannot include credentials".to_string());
+    }
+
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| "Addon network URL must include a host".to_string())?
+        .to_ascii_lowercase();
+
+    if is_blocked_host(&host) {
+        return Err("Addon network host is not allowed".to_string());
+    }
+
+    if !allowed_hosts
+        .iter()
+        .any(|allowed| host_matches_allowed(&host, allowed))
+    {
+        return Err(format!("Addon network host '{host}' is not approved"));
+    }
+
+    Ok(parsed)
+}
+
+fn validate_method(method: &str) -> Result<Method, String> {
+    match method.to_ascii_uppercase().as_str() {
+        "GET" => Ok(Method::GET),
+        "POST" => Ok(Method::POST),
+        "PUT" => Ok(Method::PUT),
+        "PATCH" => Ok(Method::PATCH),
+        "DELETE" => Ok(Method::DELETE),
+        "HEAD" => Ok(Method::HEAD),
+        _ => Err("Addon network method is not allowed".to_string()),
+    }
+}
+
+fn host_matches_allowed(host: &str, allowed: &str) -> bool {
+    let allowed = allowed.trim().trim_end_matches('.').to_ascii_lowercase();
+    if let Some(suffix) = allowed.strip_prefix("*.") {
+        host.ends_with(&format!(".{suffix}")) && host != suffix
+    } else {
+        host == allowed
+    }
+}
+
+fn is_blocked_host(host: &str) -> bool {
+    if matches!(host, "localhost" | "ip6-localhost" | "ip6-loopback")
+        || host.ends_with(".localhost")
+        || host.ends_with(".local")
+    {
+        return true;
+    }
+
+    match parse_ip_host(host) {
+        Ok(ip) => is_blocked_ip(ip),
+        Err(_) => false,
+    }
+}
+
+fn parse_ip_host(host: &str) -> Result<IpAddr, std::net::AddrParseError> {
+    host.trim_start_matches('[')
+        .trim_end_matches(']')
+        .parse::<IpAddr>()
+}
+
+fn is_blocked_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => {
+            ip.is_private()
+                || ip.is_loopback()
+                || ip.is_link_local()
+                || ip.is_broadcast()
+                || ip.is_documentation()
+                || ip.is_unspecified()
+                || ip.octets() == [169, 254, 169, 254]
+        }
+        IpAddr::V6(ip) => {
+            ip.is_loopback()
+                || ip.is_unspecified()
+                || ip.is_unique_local()
+                || ip.is_unicast_link_local()
+        }
+    }
+}
+
+async fn resolve_public_addresses(url: &Url) -> Result<Vec<SocketAddr>, String> {
+    let host = url
+        .host_str()
+        .ok_or_else(|| "Addon network URL must include a host".to_string())?;
+    let port = url
+        .port_or_known_default()
+        .ok_or_else(|| "Addon network URL must include a port".to_string())?;
+
+    if let Ok(ip) = parse_ip_host(host) {
+        if is_blocked_ip(ip) {
+            return Err("Addon network host resolves to a private address".to_string());
+        }
+        return Ok(vec![SocketAddr::new(ip, port)]);
+    }
+
+    let addresses = lookup_host((host, port))
+        .await
+        .map_err(|_| "Addon network host could not be resolved".to_string())?;
+
+    let mut resolved = Vec::new();
+    for address in addresses {
+        if is_blocked_ip(address.ip()) {
+            return Err("Addon network host resolves to a private address".to_string());
+        }
+        resolved.push(address);
+    }
+
+    if resolved.is_empty() {
+        return Err("Addon network host could not be resolved".to_string());
+    }
+
+    Ok(resolved)
+}
+
+fn is_blocked_request_header(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "connection"
+            | "content-length"
+            | "cookie"
+            | "host"
+            | "origin"
+            | "proxy-authorization"
+            | "referer"
+            | "te"
+            | "trailer"
+            | "transfer-encoding"
+            | "upgrade"
+    )
+}
+
+fn is_authorization_header(name: &str) -> bool {
+    name.eq_ignore_ascii_case("authorization")
+}
+
+fn is_blocked_response_header(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "set-cookie" | "set-cookie2" | "transfer-encoding"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Result;
+    use std::collections::BTreeMap;
+
+    struct TestSecretStore {
+        secrets: BTreeMap<String, String>,
+    }
+
+    impl SecretStore for TestSecretStore {
+        fn set_secret(&self, _service: &str, _secret: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn get_secret(&self, service: &str) -> Result<Option<String>> {
+            Ok(self.secrets.get(service).cloned())
+        }
+
+        fn delete_secret(&self, _service: &str) -> Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn validates_allowed_hosts() {
+        assert!(validate_url("https://api.example.com/v1", &["api.example.com".into()]).is_ok());
+        assert!(validate_url("https://x.example.com/v1", &["*.example.com".into()]).is_ok());
+        assert!(validate_url("https://example.com/v1", &["*.example.com".into()]).is_err());
+        assert!(validate_url("http://api.example.com/v1", &["api.example.com".into()]).is_err());
+        assert!(validate_url("https://127.0.0.1/v1", &["127.0.0.1".into()]).is_err());
+        assert!(validate_url("https://[::1]/v1", &["::1".into()]).is_err());
+        assert!(validate_url("https://localhost/v1", &["localhost".into()]).is_err());
+    }
+
+    #[test]
+    fn blocks_private_and_metadata_addresses() {
+        assert!(is_blocked_ip("127.0.0.1".parse().unwrap()));
+        assert!(is_blocked_ip("10.0.0.1".parse().unwrap()));
+        assert!(is_blocked_ip("169.254.169.254".parse().unwrap()));
+        assert!(is_blocked_ip("::1".parse().unwrap()));
+        assert!(is_blocked_ip("fd00::1".parse().unwrap()));
+        assert!(!is_blocked_ip("8.8.8.8".parse().unwrap()));
+        assert!(!is_blocked_ip("2606:4700:4700::1111".parse().unwrap()));
+    }
+
+    #[test]
+    fn resolves_bearer_auth_from_addon_scoped_secret() {
+        let store = TestSecretStore {
+            secrets: BTreeMap::from([(
+                "addon:example-addon:api-token".to_string(),
+                "secret-token".to_string(),
+            )]),
+        };
+        let header = resolve_addon_network_auth_header(
+            "example-addon",
+            Some(&AddonNetworkAuth {
+                auth_type: "bearer".to_string(),
+                secret_key: "api-token".to_string(),
+            }),
+            &store,
+        )
+        .unwrap();
+
+        assert_eq!(header, Some("Bearer secret-token".to_string()));
+    }
+
+    #[test]
+    fn rejects_invalid_network_auth_requests() {
+        let store = TestSecretStore {
+            secrets: BTreeMap::new(),
+        };
+
+        assert!(resolve_addon_network_auth_header(
+            "example-addon",
+            Some(&AddonNetworkAuth {
+                auth_type: "basic".to_string(),
+                secret_key: "api-token".to_string(),
+            }),
+            &store,
+        )
+        .is_err());
+        assert!(resolve_addon_network_auth_header(
+            "example-addon",
+            Some(&AddonNetworkAuth {
+                auth_type: "bearer".to_string(),
+                secret_key: "ApiToken".to_string(),
+            }),
+            &store,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn recognizes_raw_authorization_headers() {
+        assert!(is_authorization_header("Authorization"));
+        assert!(is_authorization_header("authorization"));
+        assert!(!is_authorization_header("X-Authorization"));
+    }
+}

--- a/crates/core/src/addons/network.rs
+++ b/crates/core/src/addons/network.rs
@@ -13,11 +13,15 @@ use tokio::net::lookup_host;
 use url::Url;
 
 use super::validate_addon_id;
-use crate::secrets::{addon_secret_service_id, SecretStore};
+use crate::secrets::{addon_secret_service_id, legacy_addon_secret_service_id, SecretStore};
 
 const MAX_REQUEST_BODY_BYTES: usize = 1024 * 1024;
 const MAX_RESPONSE_BODY_BYTES: usize = 2 * 1024 * 1024;
 const REQUEST_TIMEOUT_SECS: u64 = 10;
+
+fn validate_addon_runtime_id(addon_id: &str) -> Result<(), String> {
+    validate_addon_id(&addon_id.to_ascii_lowercase())
+}
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -52,7 +56,7 @@ pub async fn perform_addon_network_request(
     allowed_hosts: &[String],
     request: AddonNetworkRequest,
 ) -> Result<AddonNetworkResponse, String> {
-    validate_addon_id(addon_id)?;
+    validate_addon_runtime_id(addon_id)?;
     let url = validate_url(&request.url, allowed_hosts)?;
     let host = url
         .host_str()
@@ -131,7 +135,7 @@ pub fn resolve_addon_network_auth_header(
     auth: Option<&AddonNetworkAuth>,
     secret_store: &dyn SecretStore,
 ) -> Result<Option<String>, String> {
-    validate_addon_id(addon_id)?;
+    validate_addon_runtime_id(addon_id)?;
     let Some(auth) = auth else {
         return Ok(None);
     };
@@ -139,10 +143,17 @@ pub fn resolve_addon_network_auth_header(
         return Err("Addon network auth type is not supported".to_string());
     }
     let service_id = addon_secret_service_id(addon_id, &auth.secret_key)?;
-    let secret = secret_store
+    let legacy_service_id = legacy_addon_secret_service_id(addon_id, &auth.secret_key)?;
+    let secret = match secret_store
         .get_secret(&service_id)
         .map_err(|e| e.to_string())?
-        .ok_or_else(|| "Addon network auth secret was not found".to_string())?;
+    {
+        Some(secret) => secret,
+        None => secret_store
+            .get_secret(&legacy_service_id)
+            .map_err(|e| e.to_string())?
+            .ok_or_else(|| "Addon network auth secret was not found".to_string())?,
+    };
     if secret.trim().is_empty() {
         return Err("Addon network auth secret is empty".to_string());
     }
@@ -366,6 +377,27 @@ mod tests {
         .unwrap();
 
         assert_eq!(header, Some("Bearer secret-token".to_string()));
+    }
+
+    #[test]
+    fn resolves_bearer_auth_from_legacy_addon_secret() {
+        let store = TestSecretStore {
+            secrets: BTreeMap::from([(
+                "addon_example-addon_apitoken".to_string(),
+                "legacy-token".to_string(),
+            )]),
+        };
+        let header = resolve_addon_network_auth_header(
+            "example-addon",
+            Some(&AddonNetworkAuth {
+                auth_type: "bearer".to_string(),
+                secret_key: "ApiToken".to_string(),
+            }),
+            &store,
+        )
+        .unwrap();
+
+        assert_eq!(header, Some("Bearer legacy-token".to_string()));
     }
 
     #[test]

--- a/crates/core/src/addons/network.rs
+++ b/crates/core/src/addons/network.rs
@@ -110,9 +110,13 @@ pub async fn perform_addon_network_request(
     if response.content_length().unwrap_or_default() > MAX_RESPONSE_BODY_BYTES as u64 {
         return Err("Addon network response body is too large".to_string());
     }
-    let body = response.bytes().await.map_err(|e| e.to_string())?;
-    if body.len() > MAX_RESPONSE_BODY_BYTES {
-        return Err("Addon network response body is too large".to_string());
+    let mut response = response;
+    let mut body = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(|e| e.to_string())? {
+        if body.len().saturating_add(chunk.len()) > MAX_RESPONSE_BODY_BYTES {
+            return Err("Addon network response body is too large".to_string());
+        }
+        body.extend_from_slice(&chunk);
     }
 
     Ok(AddonNetworkResponse {

--- a/crates/core/src/addons/service.rs
+++ b/crates/core/src/addons/service.rs
@@ -360,7 +360,12 @@ pub fn detect_addon_permissions(addon_files: &[AddonFile]) -> Vec<AddonPermissio
         (
             "ui",
             "ui",
-            vec!["sidebar.addItem", "router.add", "navigation.navigate"],
+            vec![
+                "sidebar.addItem",
+                "router.add",
+                "navigation.navigate",
+                "onDisable",
+            ],
             "User interface and navigation",
         ),
     ];
@@ -439,6 +444,8 @@ pub fn detect_addon_permissions(addon_files: &[AddonFile]) -> Vec<AddonPermissio
                     // Special patterns for non-API functions
                     let simple_patterns = if *category == "ui" {
                         vec![
+                            format!(".{}(", function), // ctx.onDisable( or minified e.onDisable(
+                            format!("{}(", function),  // onDisable(
                             format!("ctx.{}(", function), // ctx.onDisable(
                         ]
                     } else {

--- a/crates/core/src/addons/service.rs
+++ b/crates/core/src/addons/service.rs
@@ -1,14 +1,32 @@
 use std::fs;
-use std::io::Read;
+use std::io::{Read, Write};
 use std::path::{Component, Path, PathBuf};
 
 use async_trait::async_trait;
+use serde_json::json;
 
 use super::addon_traits::AddonServiceTrait;
 use super::models::*;
+use super::network::{perform_addon_network_request, AddonNetworkRequest, AddonNetworkResponse};
 
 // Constants
 pub const ADDON_STORE_API_BASE_URL: &str = "https://wealthfolio.app/api/addons";
+const MAX_ADDON_ARCHIVE_ENTRIES: usize = 256;
+const MAX_ADDON_ARCHIVE_FILE_SIZE: u64 = 5 * 1024 * 1024;
+const MAX_ADDON_ARCHIVE_TOTAL_SIZE: u64 = 25 * 1024 * 1024;
+const MAX_ADDON_ARCHIVE_COMPRESSED_SIZE: usize = 50 * 1024 * 1024;
+
+#[derive(Clone)]
+struct AddonArchiveFile {
+    name: String,
+    content: Vec<u8>,
+    is_main: bool,
+}
+
+struct ExtractedAddonArchive {
+    metadata: AddonManifest,
+    files: Vec<AddonArchiveFile>,
+}
 
 /// Helper function to create a request with common headers
 fn create_request_with_headers(
@@ -83,8 +101,39 @@ pub fn ensure_addons_directory(base_dir: impl AsRef<Path>) -> Result<PathBuf, St
     Ok(addons_dir)
 }
 
+pub fn validate_addon_id(addon_id: &str) -> Result<(), String> {
+    if addon_id.is_empty() {
+        return Err("Invalid addon id: id is empty".to_string());
+    }
+    if addon_id.len() > 64 {
+        return Err("Invalid addon id: id must be 64 characters or fewer".to_string());
+    }
+    if addon_id == "." || addon_id == ".." || addon_id.chars().all(|c| c == '.') {
+        return Err("Invalid addon id: dot-only ids are not allowed".to_string());
+    }
+    if addon_id == "staging" {
+        return Err("Invalid addon id: 'staging' is reserved".to_string());
+    }
+
+    let mut chars = addon_id.chars();
+    let Some(first) = chars.next() else {
+        return Err("Invalid addon id: id is empty".to_string());
+    };
+    if !first.is_ascii_lowercase() && !first.is_ascii_digit() {
+        return Err("Invalid addon id: id must start with a lowercase letter or digit".to_string());
+    }
+
+    if !chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '.' | '_' | '-'))
+    {
+        return Err("Invalid addon id: use lowercase letters, digits, '.', '_' or '-'".to_string());
+    }
+
+    Ok(())
+}
+
 /// Get addon directory path for a specific addon
 pub fn get_addon_path(base_dir: impl AsRef<Path>, addon_id: &str) -> Result<PathBuf, String> {
+    validate_addon_id(addon_id)?;
     let addons_dir = ensure_addons_directory(base_dir)?;
     Ok(addons_dir.join(addon_id))
 }
@@ -262,7 +311,7 @@ pub fn detect_addon_permissions(addon_files: &[AddonFile]) -> Vec<AddonPermissio
         (
             "secrets",
             "secrets",
-            vec!["set", "get", "delete"],
+            vec!["set", "get", "use", "delete"],
             "Access to secure storage for addon secrets",
         ),
         (
@@ -297,9 +346,21 @@ pub fn detect_addon_permissions(addon_files: &[AddonFile]) -> Vec<AddonPermissio
             "Access to application events",
         ),
         (
+            "query",
+            "query",
+            vec!["invalidateQueries", "refetchQueries"],
+            "Access to refresh host application data",
+        ),
+        (
+            "network",
+            "network",
+            vec!["request"],
+            "Access to declared external HTTPS hosts",
+        ),
+        (
             "ui",
             "ui",
-            vec!["sidebar.addItem", "router.add"],
+            vec!["sidebar.addItem", "router.add", "navigation.navigate"],
             "User interface and navigation",
         ),
     ];
@@ -444,6 +505,16 @@ pub fn detect_addon_permissions(addon_files: &[AddonFile]) -> Vec<AddonPermissio
                 }
             }
         }
+
+        if file.content.contains(".network.request(")
+            && file.content.contains("auth")
+            && file.content.contains("secretKey")
+        {
+            category_functions
+                .entry("secrets".to_string())
+                .or_default()
+                .push("use".to_string());
+        }
     }
 
     // Create permission objects for each category with detected functions
@@ -493,16 +564,99 @@ pub fn detect_addon_permissions(addon_files: &[AddonFile]) -> Vec<AddonPermissio
     detected_permissions
 }
 
-pub fn extract_addon_zip_internal(zip_data: Vec<u8>) -> Result<ExtractedAddon, String> {
+fn merge_detected_permissions(
+    declared_permissions: Option<&[AddonPermission]>,
+    detected_permissions: Vec<AddonPermission>,
+) -> Vec<AddonPermission> {
+    let mut merged_permissions = Vec::new();
+
+    if let Some(declared_permissions) = declared_permissions {
+        for permission in declared_permissions {
+            merged_permissions.push(AddonPermission {
+                category: permission.category.clone(),
+                functions: permission.functions.clone(),
+                purpose: permission.purpose.clone(),
+            });
+        }
+    }
+
+    for detected_permission in detected_permissions {
+        if let Some(existing) = merged_permissions
+            .iter_mut()
+            .find(|permission| permission.category == detected_permission.category)
+        {
+            for detected_function in &detected_permission.functions {
+                if let Some(existing_function) = existing
+                    .functions
+                    .iter_mut()
+                    .find(|function| function.name == detected_function.name)
+                {
+                    existing_function.is_detected = true;
+                    existing_function.detected_at = detected_function.detected_at.clone();
+                } else {
+                    existing.functions.push(detected_function.clone());
+                }
+            }
+        } else {
+            merged_permissions.push(detected_permission);
+        }
+    }
+
+    merged_permissions
+}
+
+fn archive_file_to_addon_file(file: AddonArchiveFile) -> AddonFile {
+    AddonFile {
+        name: file.name,
+        content: String::from_utf8(file.content).unwrap_or_default(),
+        is_main: file.is_main,
+    }
+}
+
+fn archive_files_to_text_files(files: &[AddonArchiveFile]) -> Vec<AddonFile> {
+    files
+        .iter()
+        .filter_map(|file| {
+            String::from_utf8(file.content.clone())
+                .ok()
+                .map(|content| AddonFile {
+                    name: file.name.clone(),
+                    content,
+                    is_main: file.is_main,
+                })
+        })
+        .collect()
+}
+
+fn extract_addon_zip_archive(zip_data: Vec<u8>) -> Result<ExtractedAddonArchive, String> {
     use std::io::Cursor;
     use zip::ZipArchive;
 
+    if zip_data.is_empty() {
+        return Err("ZIP addon data is empty".to_string());
+    }
+    if zip_data.len() > MAX_ADDON_ARCHIVE_COMPRESSED_SIZE {
+        return Err(format!(
+            "ZIP addon is too large: {} bytes exceeds {} byte limit",
+            zip_data.len(),
+            MAX_ADDON_ARCHIVE_COMPRESSED_SIZE
+        ));
+    }
+
     let cursor = Cursor::new(zip_data);
     let mut archive = ZipArchive::new(cursor).map_err(|e| format!("Failed to read ZIP: {}", e))?;
+    if archive.len() > MAX_ADDON_ARCHIVE_ENTRIES {
+        return Err(format!(
+            "ZIP addon has too many entries: {} exceeds {} entry limit",
+            archive.len(),
+            MAX_ADDON_ARCHIVE_ENTRIES
+        ));
+    }
 
     let mut files = Vec::new();
     let mut manifest_json: Option<String> = None;
     let mut main_file: Option<String> = None;
+    let mut total_uncompressed_size = 0u64;
 
     // Extract all files from ZIP
     for i in 0..archive.len() {
@@ -516,14 +670,48 @@ pub fn extract_addon_zip_internal(zip_data: Vec<u8>) -> Result<ExtractedAddon, S
 
         let file_name = file.name().to_string();
         validated_addon_archive_path(&file_name)?;
-        let mut contents = String::new();
 
-        file.read_to_string(&mut contents)
+        if file_name.ends_with(".map") {
+            log::debug!("Skipping addon source map '{}'", file_name);
+            continue;
+        }
+
+        let file_size = file.size();
+        if file_size > MAX_ADDON_ARCHIVE_FILE_SIZE {
+            return Err(format!(
+                "ZIP addon file '{}' is too large: {} bytes exceeds {} byte limit",
+                file_name, file_size, MAX_ADDON_ARCHIVE_FILE_SIZE
+            ));
+        }
+        total_uncompressed_size = total_uncompressed_size
+            .checked_add(file_size)
+            .ok_or_else(|| "ZIP addon uncompressed size overflowed".to_string())?;
+        if total_uncompressed_size > MAX_ADDON_ARCHIVE_TOTAL_SIZE {
+            return Err(format!(
+                "ZIP addon uncompressed size is too large: {} bytes exceeds {} byte limit",
+                total_uncompressed_size, MAX_ADDON_ARCHIVE_TOTAL_SIZE
+            ));
+        }
+
+        let mut contents = Vec::with_capacity(file_size.min(MAX_ADDON_ARCHIVE_FILE_SIZE) as usize);
+        let bytes_read = file
+            .by_ref()
+            .take(MAX_ADDON_ARCHIVE_FILE_SIZE + 1)
+            .read_to_end(&mut contents)
             .map_err(|e| format!("Failed to read file {}: {}", file_name, e))?;
+        if bytes_read as u64 > MAX_ADDON_ARCHIVE_FILE_SIZE {
+            return Err(format!(
+                "ZIP addon file '{}' exceeds {} byte limit",
+                file_name, MAX_ADDON_ARCHIVE_FILE_SIZE
+            ));
+        }
 
         // Check for manifest.json
         if file_name == "manifest.json" || file_name.ends_with("/manifest.json") {
-            manifest_json = Some(contents.clone());
+            manifest_json = Some(
+                String::from_utf8(contents.clone())
+                    .map_err(|e| format!("Failed to read manifest.json as UTF-8: {}", e))?,
+            );
         }
 
         // Check for main addon file (fallback detection)
@@ -537,7 +725,7 @@ pub fn extract_addon_zip_internal(zip_data: Vec<u8>) -> Result<ExtractedAddon, S
             main_file = Some(file_name.clone());
         }
 
-        files.push(AddonFile {
+        files.push(AddonArchiveFile {
             name: file_name,
             content: contents,
             is_main: false, // Will be set correctly after parsing manifest.json
@@ -576,8 +764,9 @@ pub fn extract_addon_zip_internal(zip_data: Vec<u8>) -> Result<ExtractedAddon, S
         "Starting permission detection for extracted addon: {}",
         metadata.id
     );
-    log::debug!("Number of files to analyze: {}", files.len());
-    for file in &files {
+    let permission_files = archive_files_to_text_files(&files);
+    log::debug!("Number of files to analyze: {}", permission_files.len());
+    for file in &permission_files {
         log::debug!(
             "File: {} (size: {} chars, is_main: {})",
             file.name,
@@ -586,7 +775,7 @@ pub fn extract_addon_zip_internal(zip_data: Vec<u8>) -> Result<ExtractedAddon, S
         );
     }
 
-    let detected_permissions = detect_addon_permissions(&files);
+    let detected_permissions = detect_addon_permissions(&permission_files);
     log::debug!(
         "Permission detection completed for extracted addon: {}",
         metadata.id
@@ -596,59 +785,8 @@ pub fn extract_addon_zip_internal(zip_data: Vec<u8>) -> Result<ExtractedAddon, S
         detected_permissions.len()
     );
 
-    // Merge declared and detected permissions (same logic as install_addon_zip)
-    let mut merged_permissions = Vec::new();
-
-    // First, add all declared permissions with their original flags preserved
-    if let Some(declared_perms) = &metadata.permissions {
-        for perm in declared_perms {
-            // Clone the permission and preserve all function flags
-            let mut cloned_functions = Vec::new();
-            for func in &perm.functions {
-                cloned_functions.push(FunctionPermission {
-                    name: func.name.clone(),
-                    is_declared: func.is_declared,
-                    is_detected: func.is_detected,
-                    detected_at: func.detected_at.clone(),
-                });
-            }
-
-            merged_permissions.push(AddonPermission {
-                category: perm.category.clone(),
-                functions: cloned_functions,
-                purpose: perm.purpose.clone(),
-            });
-        }
-    }
-
-    // Then, add detected permissions and merge with declared ones
-    for detected_perm in detected_permissions {
-        // Check if this category already exists in declared permissions
-        if let Some(existing) = merged_permissions
-            .iter_mut()
-            .find(|p| p.category == detected_perm.category)
-        {
-            // Merge detected functions with declared functions
-            for detected_func in &detected_perm.functions {
-                // Check if this function already exists in declared functions
-                if let Some(existing_func) = existing
-                    .functions
-                    .iter_mut()
-                    .find(|f| f.name == detected_func.name)
-                {
-                    // Mark existing declared function as also detected
-                    existing_func.is_detected = true;
-                    existing_func.detected_at = detected_func.detected_at.clone();
-                } else {
-                    // Add new detected function
-                    existing.functions.push(detected_func.clone());
-                }
-            }
-        } else {
-            // Add as detected-only permission category
-            merged_permissions.push(detected_perm);
-        }
-    }
+    let merged_permissions =
+        merge_detected_permissions(metadata.permissions.as_deref(), detected_permissions);
 
     // Create a metadata copy with merged permissions for the extracted addon
     let mut metadata_with_merged_permissions = metadata;
@@ -676,9 +814,21 @@ pub fn extract_addon_zip_internal(zip_data: Vec<u8>) -> Result<ExtractedAddon, S
         }
     }
 
-    Ok(ExtractedAddon {
+    Ok(ExtractedAddonArchive {
         metadata: metadata_with_merged_permissions,
         files,
+    })
+}
+
+pub fn extract_addon_zip_internal(zip_data: Vec<u8>) -> Result<ExtractedAddon, String> {
+    let extracted = extract_addon_zip_archive(zip_data)?;
+    Ok(ExtractedAddon {
+        metadata: extracted.metadata,
+        files: extracted
+            .files
+            .into_iter()
+            .map(archive_file_to_addon_file)
+            .collect(),
     })
 }
 
@@ -717,10 +867,54 @@ pub fn parse_manifest_json_metadata(manifest_content: &str) -> Result<AddonManif
             .collect()
     });
     let icon = raw_manifest["icon"].as_str().map(|s| s.to_string());
+    let network = if let Some(network_value) = raw_manifest.get("network") {
+        if network_value.is_null() {
+            None
+        } else {
+            let mut allowed_hosts = network_value["allowedHosts"]
+                .as_array()
+                .ok_or("Missing or invalid 'network.allowedHosts' field in manifest")?
+                .iter()
+                .map(|host| {
+                    host.as_str()
+                        .map(|s| s.trim().trim_end_matches('.').to_ascii_lowercase())
+                        .filter(|s| !s.is_empty() && s.len() <= 253)
+                        .ok_or("Invalid network allowed host in manifest")
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+            allowed_hosts.sort();
+            allowed_hosts.dedup();
+            let mut approved_hosts = network_value["approvedHosts"]
+                .as_array()
+                .map(|hosts| {
+                    hosts
+                        .iter()
+                        .filter_map(|host| {
+                            host.as_str()
+                                .map(|s| s.trim().trim_end_matches('.').to_ascii_lowercase())
+                        })
+                        .filter(|host| allowed_hosts.contains(host))
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            approved_hosts.sort();
+            approved_hosts.dedup();
+            Some(AddonNetworkAccess {
+                allowed_hosts,
+                approved_hosts,
+            })
+        }
+    } else {
+        None
+    };
 
     // Validate required fields
     if main.is_none() {
         return Err("Missing 'main' field in manifest.json".to_string());
+    }
+    validate_addon_id(&id)?;
+    if let Some(main_path) = &main {
+        validated_addon_archive_path(main_path)?;
     }
 
     // Handle permissions - convert from legacy string array format to new FunctionPermission format
@@ -803,6 +997,7 @@ pub fn parse_manifest_json_metadata(manifest_content: &str) -> Result<AddonManif
         min_wealthfolio_version,
         keywords,
         icon,
+        network,
         installed_at: None,
         updated_at: None,
         source: None,
@@ -839,8 +1034,31 @@ pub fn read_addon_files_recursive(
                 .map_err(|e| format!("Failed to get relative path: {}", e))?;
             let relative_path_str = relative_path.to_string_lossy().to_string();
 
-            let content = fs::read_to_string(&file_path)
+            if relative_path_str.ends_with(".map") {
+                log::debug!("Skipping addon source map '{}'", relative_path_str);
+                continue;
+            }
+
+            let metadata = fs::metadata(&file_path).map_err(|e| {
+                format!("Failed to read file metadata {}: {}", relative_path_str, e)
+            })?;
+            if metadata.len() > MAX_ADDON_ARCHIVE_FILE_SIZE {
+                return Err(format!(
+                    "Addon file '{}' is too large: {} bytes exceeds {} byte limit",
+                    relative_path_str,
+                    metadata.len(),
+                    MAX_ADDON_ARCHIVE_FILE_SIZE
+                ));
+            }
+            let bytes = fs::read(&file_path)
                 .map_err(|e| format!("Failed to read file {}: {}", relative_path_str, e))?;
+            let content = match String::from_utf8(bytes) {
+                Ok(content) => content,
+                Err(_) => {
+                    log::debug!("Skipping non-UTF-8 addon asset '{}'", relative_path_str);
+                    continue;
+                }
+            };
 
             files.push(AddonFile {
                 name: relative_path_str,
@@ -859,6 +1077,7 @@ pub async fn check_addon_update_from_api(
     current_version: &str,
     instance_id: Option<&str>,
 ) -> Result<AddonUpdateCheckResult, String> {
+    validate_addon_id(addon_id)?;
     let api_url = format!(
         "{}/update-check?addonId={}&currentVersion={}",
         ADDON_STORE_API_BASE_URL, addon_id, current_version
@@ -879,6 +1098,28 @@ pub async fn check_addon_update_from_api(
 
 /// Download addon package from URL
 pub async fn download_addon_package(download_url: &str) -> Result<Vec<u8>, String> {
+    download_addon_package_verified(download_url, None).await
+}
+
+pub fn verify_addon_package_sha256(zip_data: &[u8], expected_sha256: &str) -> Result<(), String> {
+    let expected = expected_sha256.trim().to_ascii_lowercase();
+    if expected.len() != 64 || !expected.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err("Invalid addon package SHA-256 digest".to_string());
+    }
+
+    use sha2::{Digest, Sha256};
+    let actual = hex::encode(Sha256::digest(zip_data));
+    if actual != expected {
+        return Err("Addon package SHA-256 digest did not match".to_string());
+    }
+
+    Ok(())
+}
+
+pub async fn download_addon_package_verified(
+    download_url: &str,
+    expected_sha256: Option<&str>,
+) -> Result<Vec<u8>, String> {
     log::info!("Downloading addon package from URL: {}", download_url);
 
     let client = reqwest::Client::new();
@@ -942,6 +1183,14 @@ pub async fn download_addon_package(download_url: &str) -> Result<Vec<u8>, Strin
         download_url
     );
 
+    if let Some(expected_sha256) = expected_sha256 {
+        verify_addon_package_sha256(&zip_data, expected_sha256)?;
+        log::info!(
+            "Verified SHA-256 digest for addon package: {}",
+            download_url
+        );
+    }
+
     Ok(zip_data)
 }
 
@@ -978,6 +1227,7 @@ pub async fn download_addon_from_store(
     addon_id: &str,
     instance_id: &str,
 ) -> Result<Vec<u8>, String> {
+    validate_addon_id(addon_id)?;
     let download_api_url = format!("{}/{}/download", ADDON_STORE_API_BASE_URL, addon_id);
 
     log::info!(
@@ -1059,6 +1309,10 @@ pub async fn download_addon_from_store(
             .get("downloadUrl")
             .and_then(|v| v.as_str())
             .ok_or("Download API response missing downloadUrl field")?;
+        let expected_sha256 = download_response
+            .get("sha256")
+            .or_else(|| download_response.get("checksumSha256"))
+            .and_then(|v| v.as_str());
 
         log::info!(
             "Got download URL for addon '{}': {}",
@@ -1067,9 +1321,14 @@ pub async fn download_addon_from_store(
         );
 
         // Now download the actual file
-        return download_addon_package(actual_download_url).await;
+        return download_addon_package_verified(actual_download_url, expected_sha256).await;
     } else {
         log::debug!("Response is binary data, treating as direct ZIP download");
+        let expected_sha256 = response
+            .headers()
+            .get("x-addon-sha256")
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string);
 
         // Download the addon package directly (GET request returns the file)
         let zip_data = response
@@ -1104,6 +1363,11 @@ pub async fn download_addon_from_store(
             }
         }
 
+        if let Some(expected_sha256) = expected_sha256 {
+            verify_addon_package_sha256(&zip_data, &expected_sha256)?;
+            log::info!("Verified SHA-256 digest for addon '{}'", addon_id);
+        }
+
         Ok(zip_data)
     }
 }
@@ -1114,12 +1378,19 @@ pub fn save_addon_to_staging(
     base_dir: impl AsRef<Path>,
     zip_data: &[u8],
 ) -> Result<PathBuf, String> {
+    validate_addon_id(addon_id)?;
     let staging_dir = get_staging_directory(base_dir)?;
     let staged_file_path = staging_dir.join(format!("{}.zip", addon_id));
 
     // Validate zip data before saving
     if zip_data.is_empty() {
         return Err("Cannot stage empty addon data".to_string());
+    }
+    if zip_data.len() > MAX_ADDON_ARCHIVE_COMPRESSED_SIZE {
+        return Err(format!(
+            "Cannot stage addon data larger than {} bytes",
+            MAX_ADDON_ARCHIVE_COMPRESSED_SIZE
+        ));
     }
 
     log::debug!(
@@ -1208,6 +1479,7 @@ pub fn load_addon_from_staging(
     addon_id: &str,
     base_dir: impl AsRef<Path>,
 ) -> Result<Vec<u8>, String> {
+    validate_addon_id(addon_id)?;
     let staging_dir = get_staging_directory(base_dir)?;
     let staged_file_path = staging_dir.join(format!("{}.zip", addon_id));
 
@@ -1232,6 +1504,7 @@ pub fn load_addon_from_staging(
 
 /// Remove specific addon from staging
 pub fn remove_addon_from_staging(addon_id: &str, base_dir: impl AsRef<Path>) -> Result<(), String> {
+    validate_addon_id(addon_id)?;
     let staging_dir = get_staging_directory(base_dir)?;
     let staged_file_path = staging_dir.join(format!("{}.zip", addon_id));
 
@@ -1315,6 +1588,7 @@ pub async fn submit_addon_rating(
     review: Option<String>,
     instance_id: &str,
 ) -> Result<serde_json::Value, String> {
+    validate_addon_id(addon_id)?;
     if !(1..=5).contains(&rating) {
         return Err("Rating must be between 1 and 5".to_string());
     }
@@ -1408,7 +1682,11 @@ impl AddonService {
             .ok_or_else(|| format!("Addon manifest not found in {}", addon_dir.display()))
     }
 
-    fn write_addon_files(&self, addon_dir: &Path, files: &[AddonFile]) -> Result<(), String> {
+    fn write_addon_archive_files(
+        &self,
+        addon_dir: &Path,
+        files: &[AddonArchiveFile],
+    ) -> Result<(), String> {
         for file in files {
             let relative_path = validated_addon_archive_path(&file.name)?;
             let file_path = addon_dir.join(relative_path);
@@ -1430,6 +1708,160 @@ impl AddonService {
             .map_err(|e| format!("Failed to write manifest: {}", e))?;
         Ok(())
     }
+
+    fn enabled_manifest_for_addon(&self, addon_id: &str) -> Result<AddonManifest, String> {
+        let addon_dir = get_addon_path(&self.addons_root, addon_id)?;
+        let manifest = self.read_manifest_or_error(&addon_dir)?;
+        if !manifest.is_enabled() {
+            return Err("Addon is disabled".to_string());
+        }
+        Ok(manifest)
+    }
+
+    fn manifest_allows_function(
+        manifest: &AddonManifest,
+        category: &str,
+        function_name: &str,
+    ) -> bool {
+        manifest
+            .permissions
+            .as_ref()
+            .map(|permissions| {
+                permissions.iter().any(|permission| {
+                    permission.category == category
+                        && permission.functions.iter().any(|function| {
+                            function.name == function_name
+                                && (function.is_declared || function.is_detected)
+                        })
+                })
+            })
+            .unwrap_or(false)
+    }
+
+    fn write_network_audit_entry(
+        &self,
+        addon_id: &str,
+        request: &AddonNetworkRequest,
+        result: &Result<AddonNetworkResponse, String>,
+    ) -> Result<(), String> {
+        let audit_path = ensure_addons_directory(&self.addons_root)?.join("network-audit.jsonl");
+        let parsed_url = url::Url::parse(&request.url).ok();
+        let method = request
+            .method
+            .as_deref()
+            .unwrap_or("GET")
+            .to_ascii_uppercase();
+        let entry = match result {
+            Ok(response) => json!({
+                "timestamp": chrono::Utc::now().to_rfc3339(),
+                "addonId": addon_id,
+                "method": method,
+                "scheme": parsed_url.as_ref().map(|url| url.scheme()),
+                "host": parsed_url.as_ref().and_then(|url| url.host_str()),
+                "port": parsed_url.as_ref().and_then(|url| url.port_or_known_default()),
+                "allowed": true,
+                "status": response.status,
+                "responseBytes": response.body.len(),
+            }),
+            Err(error) => json!({
+                "timestamp": chrono::Utc::now().to_rfc3339(),
+                "addonId": addon_id,
+                "method": method,
+                "scheme": parsed_url.as_ref().map(|url| url.scheme()),
+                "host": parsed_url.as_ref().and_then(|url| url.host_str()),
+                "port": parsed_url.as_ref().and_then(|url| url.port_or_known_default()),
+                "allowed": false,
+                "errorCode": Self::classify_network_error(error),
+            }),
+        };
+
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&audit_path)
+            .map_err(|e| format!("Failed to open addon network audit log: {}", e))?;
+        serde_json::to_writer(&mut file, &entry)
+            .map_err(|e| format!("Failed to serialize addon network audit entry: {}", e))?;
+        writeln!(file).map_err(|e| format!("Failed to write addon network audit entry: {}", e))?;
+        Ok(())
+    }
+
+    fn audit_network_request(
+        &self,
+        addon_id: &str,
+        request: &AddonNetworkRequest,
+        result: &Result<AddonNetworkResponse, String>,
+    ) {
+        if let Err(error) = self.write_network_audit_entry(addon_id, request, result) {
+            log::warn!("Failed to write addon network audit entry: {}", error);
+        }
+    }
+
+    fn classify_network_error(error: &str) -> &'static str {
+        if error.contains("disabled") {
+            "addon_disabled"
+        } else if error.contains("Invalid addon id") {
+            "invalid_addon_id"
+        } else if error.contains("not approved") || error.contains("not declared") {
+            "host_not_approved"
+        } else if error.contains("not allowed to use network auth") {
+            "network_auth_permission_denied"
+        } else if error.contains("must use HTTPS") {
+            "https_required"
+        } else if error.contains("credentials") {
+            "url_credentials"
+        } else if error.contains("method") {
+            "method_not_allowed"
+        } else if error.contains("not allowed") {
+            "blocked_host"
+        } else if error.contains("could not be resolved") {
+            "dns_resolution_failed"
+        } else if error.contains("private address") {
+            "private_address_resolution"
+        } else if error.contains("too large") {
+            "size_limit_exceeded"
+        } else {
+            "request_failed"
+        }
+    }
+
+    fn apply_network_approvals(
+        mut manifest: AddonManifest,
+        approved_network_hosts: &[String],
+    ) -> AddonManifest {
+        if let Some(network) = manifest.network.as_mut() {
+            let requested = network.allowed_hosts.clone();
+            network.approved_hosts = approved_network_hosts
+                .iter()
+                .map(|host| host.trim().trim_end_matches('.').to_ascii_lowercase())
+                .filter(|host| requested.contains(host))
+                .collect();
+            network.approved_hosts.sort();
+            network.approved_hosts.dedup();
+        }
+        manifest
+    }
+
+    fn preserve_existing_network_approvals(
+        mut manifest: AddonManifest,
+        previous: Option<&AddonManifest>,
+    ) -> AddonManifest {
+        if let Some(network) = manifest.network.as_mut() {
+            let allowed_hosts = network.allowed_hosts.clone();
+            let previous_approved = previous
+                .and_then(|m| m.network.as_ref())
+                .map(|network| network.approved_hosts.as_slice())
+                .unwrap_or(&[]);
+            network.approved_hosts = previous_approved
+                .iter()
+                .filter(|host| allowed_hosts.contains(host))
+                .cloned()
+                .collect();
+            network.approved_hosts.sort();
+            network.approved_hosts.dedup();
+        }
+        manifest
+    }
 }
 
 #[async_trait]
@@ -1438,8 +1870,9 @@ impl AddonServiceTrait for AddonService {
         &self,
         zip_data: Vec<u8>,
         enable_after_install: bool,
+        approved_network_hosts: Vec<String>,
     ) -> Result<AddonManifest, String> {
-        let extracted = extract_addon_zip_internal(zip_data)?;
+        let extracted = extract_addon_zip_archive(zip_data)?;
         let addon_id = extracted.metadata.id.clone();
         let addon_dir = get_addon_path(&self.addons_root, &addon_id)?;
 
@@ -1450,9 +1883,12 @@ impl AddonServiceTrait for AddonService {
         fs::create_dir_all(&addon_dir)
             .map_err(|e| format!("Failed to create addon directory: {}", e))?;
 
-        self.write_addon_files(&addon_dir, &extracted.files)?;
+        self.write_addon_archive_files(&addon_dir, &extracted.files)?;
 
-        let metadata = extracted.metadata.to_installed(enable_after_install)?;
+        let metadata = Self::apply_network_approvals(
+            extracted.metadata.to_installed(enable_after_install)?,
+            &approved_network_hosts,
+        );
         self.write_manifest(&addon_dir, &metadata)?;
 
         Ok(metadata)
@@ -1462,9 +1898,23 @@ impl AddonServiceTrait for AddonService {
         &self,
         addon_id: &str,
         enable_after_install: bool,
+        approved_network_hosts: Vec<String>,
     ) -> Result<AddonManifest, String> {
         let zip = load_addon_from_staging(addon_id, &self.addons_root)?;
-        let extracted = extract_addon_zip_internal(zip)?;
+        let extracted = match extract_addon_zip_archive(zip) {
+            Ok(extracted) => extracted,
+            Err(err) => {
+                let _ = remove_addon_from_staging(addon_id, &self.addons_root);
+                return Err(err);
+            }
+        };
+        if extracted.metadata.id != addon_id {
+            let _ = remove_addon_from_staging(addon_id, &self.addons_root);
+            return Err(format!(
+                "Staged addon id mismatch: requested '{}', manifest contains '{}'",
+                addon_id, extracted.metadata.id
+            ));
+        }
         let addon_dir = get_addon_path(&self.addons_root, &extracted.metadata.id)?;
 
         if addon_dir.exists() {
@@ -1474,9 +1924,12 @@ impl AddonServiceTrait for AddonService {
         fs::create_dir_all(&addon_dir)
             .map_err(|e| format!("Failed to create addon directory: {}", e))?;
 
-        self.write_addon_files(&addon_dir, &extracted.files)?;
+        self.write_addon_archive_files(&addon_dir, &extracted.files)?;
 
-        let metadata = extracted.metadata.to_installed(enable_after_install)?;
+        let metadata = Self::apply_network_approvals(
+            extracted.metadata.to_installed(enable_after_install)?,
+            &approved_network_hosts,
+        );
         self.write_manifest(&addon_dir, &metadata)?;
 
         // Clean staging file
@@ -1507,9 +1960,13 @@ impl AddonServiceTrait for AddonService {
                 if !dir.is_dir() {
                     continue;
                 }
-                let manifest = match self.read_manifest_if_exists(&dir)? {
-                    Some(m) => m,
-                    None => continue,
+                let manifest = match self.read_manifest_if_exists(&dir) {
+                    Ok(Some(m)) => m,
+                    Ok(None) => continue,
+                    Err(err) => {
+                        log::error!("Skipping invalid addon manifest in {:?}: {}", dir, err);
+                        continue;
+                    }
                 };
                 let files_count = fs::read_dir(&dir)
                     .map_err(|e| format!("Failed to count addon files: {}", e))?
@@ -1548,10 +2005,14 @@ impl AddonServiceTrait for AddonService {
             return Err("Main addon file not found".to_string());
         }
 
-        Ok(ExtractedAddon {
-            metadata: manifest,
-            files,
-        })
+        let detected_permissions = detect_addon_permissions(&files);
+        let mut metadata = manifest;
+        metadata.permissions = Some(merge_detected_permissions(
+            metadata.permissions.as_deref(),
+            detected_permissions,
+        ));
+
+        Ok(ExtractedAddon { metadata, files })
     }
 
     fn get_enabled_addons_on_startup(&self) -> Result<Vec<ExtractedAddon>, String> {
@@ -1587,9 +2048,13 @@ impl AddonServiceTrait for AddonService {
                 if !dir.is_dir() {
                     continue;
                 }
-                let manifest = match self.read_manifest_if_exists(&dir)? {
-                    Some(m) => m,
-                    None => continue,
+                let manifest = match self.read_manifest_if_exists(&dir) {
+                    Ok(Some(m)) => m,
+                    Ok(None) => continue,
+                    Err(err) => {
+                        log::error!("Skipping invalid addon manifest in {:?}: {}", dir, err);
+                        continue;
+                    }
                 };
                 let addon_id = manifest.id.clone();
                 match check_addon_update_from_api(
@@ -1609,6 +2074,7 @@ impl AddonServiceTrait for AddonService {
                                 latest_version: "unknown".to_string(),
                                 update_available: false,
                                 download_url: None,
+                                sha256: None,
                                 release_notes: None,
                                 release_date: None,
                                 changelog_url: None,
@@ -1627,13 +2093,20 @@ impl AddonServiceTrait for AddonService {
 
     async fn update_addon_from_store(&self, addon_id: &str) -> Result<AddonManifest, String> {
         let addon_dir = get_addon_path(&self.addons_root, addon_id)?;
-        let was_enabled = self
-            .read_manifest_if_exists(&addon_dir)?
+        let previous_manifest = self.read_manifest_if_exists(&addon_dir)?;
+        let was_enabled = previous_manifest
+            .as_ref()
             .and_then(|m| m.enabled)
             .unwrap_or(false);
 
         let zip_data = download_addon_from_store(addon_id, &self.instance_id).await?;
-        let extracted = extract_addon_zip_internal(zip_data)?;
+        let extracted = extract_addon_zip_archive(zip_data)?;
+        if extracted.metadata.id != addon_id {
+            return Err(format!(
+                "Downloaded addon id mismatch: requested '{}', manifest contains '{}'",
+                addon_id, extracted.metadata.id
+            ));
+        }
 
         if addon_dir.exists() {
             fs::remove_dir_all(&addon_dir)
@@ -1642,12 +2115,40 @@ impl AddonServiceTrait for AddonService {
         fs::create_dir_all(&addon_dir)
             .map_err(|e| format!("Failed to create addon directory: {}", e))?;
 
-        self.write_addon_files(&addon_dir, &extracted.files)?;
+        self.write_addon_archive_files(&addon_dir, &extracted.files)?;
 
-        let metadata = extracted.metadata.to_installed(was_enabled)?;
+        let metadata = Self::preserve_existing_network_approvals(
+            extracted.metadata.to_installed(was_enabled)?,
+            previous_manifest.as_ref(),
+        );
         self.write_manifest(&addon_dir, &metadata)?;
 
         Ok(metadata)
+    }
+
+    async fn addon_network_request(
+        &self,
+        addon_id: &str,
+        request: AddonNetworkRequest,
+    ) -> Result<AddonNetworkResponse, String> {
+        let result = match self.enabled_manifest_for_addon(addon_id) {
+            Ok(manifest) => {
+                if (request.auth.is_some() || request.injected_authorization.is_some())
+                    && !Self::manifest_allows_function(&manifest, "secrets", "use")
+                {
+                    Err("Addon is not allowed to use network auth secrets".to_string())
+                } else {
+                    let approved_hosts = manifest
+                        .network
+                        .map(|network| network.approved_hosts)
+                        .unwrap_or_default();
+                    perform_addon_network_request(addon_id, &approved_hosts, request.clone()).await
+                }
+            }
+            Err(error) => Err(error),
+        };
+        self.audit_network_request(addon_id, &request, &result);
+        result
     }
 
     fn toggle_addon(&self, addon_id: &str, enabled: bool) -> Result<(), String> {
@@ -1662,6 +2163,13 @@ impl AddonServiceTrait for AddonService {
         let zip = download_addon_from_store(addon_id, &self.instance_id).await?;
         let _staged_path = save_addon_to_staging(addon_id, &self.addons_root, &zip)?;
         let extracted = extract_addon_zip_internal(zip)?;
+        if extracted.metadata.id != addon_id {
+            let _ = remove_addon_from_staging(addon_id, &self.addons_root);
+            return Err(format!(
+                "Downloaded addon id mismatch: requested '{}', manifest contains '{}'",
+                addon_id, extracted.metadata.id
+            ));
+        }
         Ok(extracted)
     }
 

--- a/crates/core/src/addons/service.rs
+++ b/crates/core/src/addons/service.rs
@@ -841,6 +841,17 @@ pub fn extract_addon_zip_internal(zip_data: Vec<u8>) -> Result<ExtractedAddon, S
 }
 
 pub fn parse_manifest_json_metadata(manifest_content: &str) -> Result<AddonManifest, String> {
+    parse_manifest_json_metadata_with_options(manifest_content, true)
+}
+
+fn parse_installed_manifest_json_metadata(manifest_content: &str) -> Result<AddonManifest, String> {
+    parse_manifest_json_metadata_with_options(manifest_content, false)
+}
+
+fn parse_manifest_json_metadata_with_options(
+    manifest_content: &str,
+    enforce_canonical_id: bool,
+) -> Result<AddonManifest, String> {
     // First, parse as a raw JSON value to handle the legacy format
     let raw_manifest: serde_json::Value = serde_json::from_str(manifest_content)
         .map_err(|e| format!("Invalid manifest.json: {}", e))?;
@@ -929,7 +940,11 @@ pub fn parse_manifest_json_metadata(manifest_content: &str) -> Result<AddonManif
     if main.is_none() {
         return Err("Missing 'main' field in manifest.json".to_string());
     }
-    validate_addon_id(&id)?;
+    if enforce_canonical_id {
+        validate_addon_id(&id)?;
+    } else {
+        validate_addon_id(&id.to_ascii_lowercase())?;
+    }
     if let Some(main_path) = &main {
         validated_addon_archive_path(main_path)?;
     }
@@ -1697,7 +1712,7 @@ impl AddonService {
         }
         let content = fs::read_to_string(&manifest_path)
             .map_err(|e| format!("Failed to read manifest {}: {}", manifest_path.display(), e))?;
-        let manifest = parse_manifest_json_metadata(&content).map_err(|e| {
+        let manifest = parse_installed_manifest_json_metadata(&content).map_err(|e| {
             format!(
                 "Failed to parse manifest {}: {}",
                 manifest_path.display(),
@@ -1710,6 +1725,44 @@ impl AddonService {
     fn read_manifest_or_error(&self, addon_dir: &Path) -> Result<AddonManifest, String> {
         self.read_manifest_if_exists(addon_dir)?
             .ok_or_else(|| format!("Addon manifest not found in {}", addon_dir.display()))
+    }
+
+    fn find_installed_addon_dir_by_manifest_id(&self, addon_id: &str) -> Result<PathBuf, String> {
+        let addons_dir = ensure_addons_directory(&self.addons_root)?;
+        for entry in fs::read_dir(&addons_dir)
+            .map_err(|e| format!("Failed to read addons directory: {}", e))?
+        {
+            let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
+            let dir = entry.path();
+            if !dir.is_dir() || Self::is_hidden_addon_dir(&dir) {
+                continue;
+            }
+            let manifest = match self.read_manifest_if_exists(&dir) {
+                Ok(Some(manifest)) => manifest,
+                Ok(None) => continue,
+                Err(err) => {
+                    log::warn!("Skipping invalid addon manifest in {:?}: {}", dir, err);
+                    continue;
+                }
+            };
+            if manifest.id == addon_id {
+                return Ok(dir);
+            }
+        }
+
+        Err("Addon not found".to_string())
+    }
+
+    fn existing_addon_dir(&self, addon_id: &str) -> Result<PathBuf, String> {
+        if validate_addon_id(addon_id).is_ok() {
+            self.recover_incomplete_replacement_for_addon(addon_id)?;
+            let addon_dir = get_addon_path(&self.addons_root, addon_id)?;
+            if addon_dir.exists() {
+                return Ok(addon_dir);
+            }
+        }
+
+        self.find_installed_addon_dir_by_manifest_id(addon_id)
     }
 
     fn write_addon_archive_files(
@@ -1914,8 +1967,7 @@ impl AddonService {
     }
 
     fn enabled_manifest_for_addon(&self, addon_id: &str) -> Result<AddonManifest, String> {
-        self.recover_incomplete_replacement_for_addon(addon_id)?;
-        let addon_dir = get_addon_path(&self.addons_root, addon_id)?;
+        let addon_dir = self.existing_addon_dir(addon_id)?;
         let manifest = self.read_manifest_or_error(&addon_dir)?;
         if !manifest.is_enabled() {
             return Err("Addon is disabled".to_string());
@@ -2179,8 +2231,7 @@ impl AddonServiceTrait for AddonService {
     }
 
     async fn uninstall_addon(&self, addon_id: &str) -> Result<(), String> {
-        self.recover_incomplete_replacement_for_addon(addon_id)?;
-        let addon_dir = get_addon_path(&self.addons_root, addon_id)?;
+        let addon_dir = self.existing_addon_dir(addon_id)?;
         if !addon_dir.exists() {
             return Err("Addon not found".to_string());
         }
@@ -2228,8 +2279,7 @@ impl AddonServiceTrait for AddonService {
     }
 
     fn load_addon_for_runtime(&self, addon_id: &str) -> Result<ExtractedAddon, String> {
-        self.recover_incomplete_replacement_for_addon(addon_id)?;
-        let addon_dir = get_addon_path(&self.addons_root, addon_id)?;
+        let addon_dir = self.existing_addon_dir(addon_id)?;
         let manifest = self.read_manifest_or_error(&addon_dir)?;
 
         if !manifest.is_enabled() {
@@ -2273,8 +2323,7 @@ impl AddonServiceTrait for AddonService {
     }
 
     async fn check_addon_update(&self, addon_id: &str) -> Result<AddonUpdateCheckResult, String> {
-        self.recover_incomplete_replacement_for_addon(addon_id)?;
-        let addon_dir = get_addon_path(&self.addons_root, addon_id)?;
+        let addon_dir = self.existing_addon_dir(addon_id)?;
         let manifest = self.read_manifest_or_error(&addon_dir)?;
         check_addon_update_from_api(addon_id, &manifest.version, Some(&self.instance_id)).await
     }
@@ -2340,8 +2389,7 @@ impl AddonServiceTrait for AddonService {
     }
 
     async fn update_addon_from_store(&self, addon_id: &str) -> Result<AddonManifest, String> {
-        self.recover_incomplete_replacement_for_addon(addon_id)?;
-        let addon_dir = get_addon_path(&self.addons_root, addon_id)?;
+        let addon_dir = self.existing_addon_dir(addon_id)?;
         let previous_manifest = self.read_manifest_if_exists(&addon_dir)?;
         let was_enabled = previous_manifest
             .as_ref()
@@ -2396,7 +2444,7 @@ impl AddonServiceTrait for AddonService {
     }
 
     fn toggle_addon(&self, addon_id: &str, enabled: bool) -> Result<(), String> {
-        let addon_dir = get_addon_path(&self.addons_root, addon_id)?;
+        let addon_dir = self.existing_addon_dir(addon_id)?;
         let mut manifest = self.read_manifest_or_error(&addon_dir)?;
         manifest.enabled = Some(enabled);
         self.write_manifest(&addon_dir, &manifest)?;

--- a/crates/core/src/addons/service.rs
+++ b/crates/core/src/addons/service.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::fs;
 use std::io::{Read, Write};
 use std::path::{Component, Path, PathBuf};
@@ -444,8 +445,8 @@ pub fn detect_addon_permissions(addon_files: &[AddonFile]) -> Vec<AddonPermissio
                     // Special patterns for non-API functions
                     let simple_patterns = if *category == "ui" {
                         vec![
-                            format!(".{}(", function), // ctx.onDisable( or minified e.onDisable(
-                            format!("{}(", function),  // onDisable(
+                            format!(".{}(", function),    // ctx.onDisable( or minified e.onDisable(
+                            format!("{}(", function),     // onDisable(
                             format!("ctx.{}(", function), // ctx.onDisable(
                         ]
                     } else {
@@ -749,7 +750,7 @@ fn extract_addon_zip_archive(zip_data: Vec<u8>) -> Result<ExtractedAddonArchive,
     // Now set the is_main flag correctly based on the metadata.main path
     let main_file = metadata.get_main()?;
     for file in &mut files {
-        file.is_main = file.name == main_file || file.name.ends_with(main_file);
+        file.is_main = archive_path_matches_manifest_main(&file.name, main_file);
     }
 
     // Verify that we found the main file
@@ -1114,8 +1115,22 @@ pub async fn check_addon_update_from_api(
 }
 
 /// Download addon package from URL
-pub async fn download_addon_package(download_url: &str) -> Result<Vec<u8>, String> {
-    download_addon_package_verified(download_url, None).await
+pub async fn download_addon_package(
+    download_url: &str,
+    expected_sha256: &str,
+) -> Result<Vec<u8>, String> {
+    download_addon_package_verified(download_url, expected_sha256).await
+}
+
+pub(crate) fn archive_path_matches_manifest_main(file_name: &str, main_file: &str) -> bool {
+    let file_name = file_name.replace('\\', "/");
+    let main_file = main_file.replace('\\', "/");
+    let main_file = main_file.trim_start_matches('/');
+    if main_file.is_empty() {
+        return false;
+    }
+
+    file_name == main_file || file_name.ends_with(&format!("/{main_file}"))
 }
 
 pub fn verify_addon_package_sha256(zip_data: &[u8], expected_sha256: &str) -> Result<(), String> {
@@ -1135,7 +1150,7 @@ pub fn verify_addon_package_sha256(zip_data: &[u8], expected_sha256: &str) -> Re
 
 pub async fn download_addon_package_verified(
     download_url: &str,
-    expected_sha256: Option<&str>,
+    expected_sha256: &str,
 ) -> Result<Vec<u8>, String> {
     log::info!("Downloading addon package from URL: {}", download_url);
 
@@ -1200,13 +1215,11 @@ pub async fn download_addon_package_verified(
         download_url
     );
 
-    if let Some(expected_sha256) = expected_sha256 {
-        verify_addon_package_sha256(&zip_data, expected_sha256)?;
-        log::info!(
-            "Verified SHA-256 digest for addon package: {}",
-            download_url
-        );
-    }
+    verify_addon_package_sha256(&zip_data, expected_sha256)?;
+    log::info!(
+        "Verified SHA-256 digest for addon package: {}",
+        download_url
+    );
 
     Ok(zip_data)
 }
@@ -1329,7 +1342,8 @@ pub async fn download_addon_from_store(
         let expected_sha256 = download_response
             .get("sha256")
             .or_else(|| download_response.get("checksumSha256"))
-            .and_then(|v| v.as_str());
+            .and_then(|v| v.as_str())
+            .ok_or("Download API response missing SHA-256 digest")?;
 
         log::info!(
             "Got download URL for addon '{}': {}",
@@ -1345,7 +1359,8 @@ pub async fn download_addon_from_store(
             .headers()
             .get("x-addon-sha256")
             .and_then(|v| v.to_str().ok())
-            .map(str::to_string);
+            .ok_or("Download response missing x-addon-sha256 header")?
+            .to_string();
 
         // Download the addon package directly (GET request returns the file)
         let zip_data = response
@@ -1380,10 +1395,8 @@ pub async fn download_addon_from_store(
             }
         }
 
-        if let Some(expected_sha256) = expected_sha256 {
-            verify_addon_package_sha256(&zip_data, &expected_sha256)?;
-            log::info!("Verified SHA-256 digest for addon '{}'", addon_id);
-        }
+        verify_addon_package_sha256(&zip_data, &expected_sha256)?;
+        log::info!("Verified SHA-256 digest for addon '{}'", addon_id);
 
         Ok(zip_data)
     }
@@ -1726,7 +1739,182 @@ impl AddonService {
         Ok(())
     }
 
+    fn hidden_artifact_dirs(&self, addon_id: &str, kind: &str) -> Result<Vec<PathBuf>, String> {
+        validate_addon_id(addon_id)?;
+        let addons_dir = ensure_addons_directory(&self.addons_root)?;
+        let prefix = format!(".{addon_id}.{kind}-");
+        let mut dirs = Vec::new();
+
+        for entry in fs::read_dir(&addons_dir)
+            .map_err(|e| format!("Failed to read addons directory: {}", e))?
+        {
+            let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            if name.starts_with(&prefix) {
+                dirs.push(path);
+            }
+        }
+
+        dirs.sort();
+        Ok(dirs)
+    }
+
+    fn cleanup_replacement_artifacts(&self, addon_id: &str) {
+        for kind in ["tmp", "backup"] {
+            let Ok(dirs) = self.hidden_artifact_dirs(addon_id, kind) else {
+                continue;
+            };
+            for dir in dirs {
+                if let Err(error) = fs::remove_dir_all(&dir) {
+                    log::warn!("Failed to remove stale addon artifact {:?}: {}", dir, error);
+                }
+            }
+        }
+    }
+
+    fn addon_id_from_backup_dir_name(name: &str) -> Option<&str> {
+        let without_dot = name.strip_prefix('.')?;
+        let (addon_id, _) = without_dot.rsplit_once(".backup-")?;
+        validate_addon_id(addon_id).ok()?;
+        Some(addon_id)
+    }
+
+    fn is_hidden_addon_dir(dir: &Path) -> bool {
+        dir.file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with('.'))
+    }
+
+    fn recover_incomplete_replacement_for_addon(&self, addon_id: &str) -> Result<(), String> {
+        let addon_dir = get_addon_path(&self.addons_root, addon_id)?;
+        if addon_dir.exists() {
+            self.cleanup_replacement_artifacts(addon_id);
+            return Ok(());
+        }
+
+        let backup_dirs = self.hidden_artifact_dirs(addon_id, "backup")?;
+        for backup_dir in backup_dirs.into_iter().rev() {
+            let manifest = match self.read_manifest_if_exists(&backup_dir) {
+                Ok(Some(manifest)) => manifest,
+                Ok(None) => continue,
+                Err(error) => {
+                    log::warn!(
+                        "Skipping invalid addon backup manifest in {:?}: {}",
+                        backup_dir,
+                        error
+                    );
+                    continue;
+                }
+            };
+            if manifest.id != addon_id {
+                log::warn!(
+                    "Skipping addon backup {:?}: manifest id '{}' does not match '{}'",
+                    backup_dir,
+                    manifest.id,
+                    addon_id
+                );
+                continue;
+            }
+
+            fs::rename(&backup_dir, &addon_dir)
+                .map_err(|e| format!("Failed to restore addon backup '{}': {}", addon_id, e))?;
+            self.cleanup_replacement_artifacts(addon_id);
+            return Ok(());
+        }
+
+        Ok(())
+    }
+
+    fn recover_incomplete_replacements(&self) -> Result<(), String> {
+        let addons_dir = ensure_addons_directory(&self.addons_root)?;
+        let mut addon_ids = Vec::new();
+
+        for entry in fs::read_dir(&addons_dir)
+            .map_err(|e| format!("Failed to read addons directory: {}", e))?
+        {
+            let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            if let Some(addon_id) = Self::addon_id_from_backup_dir_name(name) {
+                addon_ids.push(addon_id.to_string());
+            }
+        }
+
+        addon_ids.sort();
+        addon_ids.dedup();
+        for addon_id in addon_ids {
+            self.recover_incomplete_replacement_for_addon(&addon_id)?;
+        }
+
+        Ok(())
+    }
+
+    fn replace_addon_directory(
+        &self,
+        addon_id: &str,
+        files: &[AddonArchiveFile],
+        metadata: &AddonManifest,
+    ) -> Result<(), String> {
+        let addon_dir = get_addon_path(&self.addons_root, addon_id)?;
+        let addons_dir = ensure_addons_directory(&self.addons_root)?;
+        let nonce = uuid::Uuid::new_v4();
+        let temp_dir = addons_dir.join(format!(".{addon_id}.tmp-{nonce}"));
+        let backup_dir = addons_dir.join(format!(".{addon_id}.backup-{nonce}"));
+
+        if temp_dir.exists() {
+            fs::remove_dir_all(&temp_dir)
+                .map_err(|e| format!("Failed to clear temporary addon directory: {}", e))?;
+        }
+        fs::create_dir_all(&temp_dir)
+            .map_err(|e| format!("Failed to create temporary addon directory: {}", e))?;
+
+        let write_result = (|| -> Result<(), String> {
+            self.write_addon_archive_files(&temp_dir, files)?;
+            self.write_manifest(&temp_dir, metadata)?;
+            Ok(())
+        })();
+
+        if let Err(err) = write_result {
+            let _ = fs::remove_dir_all(&temp_dir);
+            return Err(err);
+        }
+
+        let had_existing_addon = addon_dir.exists();
+        if had_existing_addon {
+            fs::rename(&addon_dir, &backup_dir)
+                .map_err(|e| format!("Failed to move existing addon aside: {}", e))?;
+        }
+
+        match fs::rename(&temp_dir, &addon_dir) {
+            Ok(()) => {
+                if had_existing_addon {
+                    let _ = fs::remove_dir_all(&backup_dir);
+                }
+                Ok(())
+            }
+            Err(err) => {
+                let _ = fs::remove_dir_all(&temp_dir);
+                if had_existing_addon && backup_dir.exists() {
+                    let _ = fs::rename(&backup_dir, &addon_dir);
+                }
+                Err(format!("Failed to install addon directory: {}", err))
+            }
+        }
+    }
+
     fn enabled_manifest_for_addon(&self, addon_id: &str) -> Result<AddonManifest, String> {
+        self.recover_incomplete_replacement_for_addon(addon_id)?;
         let addon_dir = get_addon_path(&self.addons_root, addon_id)?;
         let manifest = self.read_manifest_or_error(&addon_dir)?;
         if !manifest.is_enabled() {
@@ -1746,13 +1934,69 @@ impl AddonService {
             .map(|permissions| {
                 permissions.iter().any(|permission| {
                     permission.category == category
-                        && permission.functions.iter().any(|function| {
-                            function.name == function_name
-                                && (function.is_declared || function.is_detected)
-                        })
+                        && permission
+                            .functions
+                            .iter()
+                            .any(|function| function.name == function_name && function.is_declared)
                 })
             })
             .unwrap_or(false)
+    }
+
+    fn manifest_permission_keys(manifest: &AddonManifest) -> BTreeSet<String> {
+        manifest
+            .permissions
+            .as_ref()
+            .map(|permissions| {
+                permissions
+                    .iter()
+                    .flat_map(|permission| {
+                        permission
+                            .functions
+                            .iter()
+                            .filter(|function| function.is_declared || function.is_detected)
+                            .map(|function| format!("{}.{}", permission.category, function.name))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn ensure_update_does_not_add_permissions(
+        previous: Option<&AddonManifest>,
+        next: &AddonManifest,
+    ) -> Result<(), String> {
+        let Some(previous) = previous else {
+            return Ok(());
+        };
+
+        let previous_permissions = Self::manifest_permission_keys(previous);
+        let next_permissions = Self::manifest_permission_keys(next);
+        let added_permissions = next_permissions
+            .difference(&previous_permissions)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        if added_permissions.is_empty() {
+            return Ok(());
+        }
+
+        let preview = added_permissions
+            .iter()
+            .take(8)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ");
+        let suffix = if added_permissions.len() > 8 {
+            format!(" and {} more", added_permissions.len() - 8)
+        } else {
+            String::new()
+        };
+
+        Err(format!(
+            "Addon update adds new permissions and requires reinstall approval: {}{}",
+            preview, suffix
+        ))
     }
 
     fn write_network_audit_entry(
@@ -1891,22 +2135,11 @@ impl AddonServiceTrait for AddonService {
     ) -> Result<AddonManifest, String> {
         let extracted = extract_addon_zip_archive(zip_data)?;
         let addon_id = extracted.metadata.id.clone();
-        let addon_dir = get_addon_path(&self.addons_root, &addon_id)?;
-
-        if addon_dir.exists() {
-            fs::remove_dir_all(&addon_dir)
-                .map_err(|e| format!("Failed to remove existing addon: {}", e))?;
-        }
-        fs::create_dir_all(&addon_dir)
-            .map_err(|e| format!("Failed to create addon directory: {}", e))?;
-
-        self.write_addon_archive_files(&addon_dir, &extracted.files)?;
-
         let metadata = Self::apply_network_approvals(
             extracted.metadata.to_installed(enable_after_install)?,
             &approved_network_hosts,
         );
-        self.write_manifest(&addon_dir, &metadata)?;
+        self.replace_addon_directory(&addon_id, &extracted.files, &metadata)?;
 
         Ok(metadata)
     }
@@ -1932,22 +2165,12 @@ impl AddonServiceTrait for AddonService {
                 addon_id, extracted.metadata.id
             ));
         }
-        let addon_dir = get_addon_path(&self.addons_root, &extracted.metadata.id)?;
-
-        if addon_dir.exists() {
-            fs::remove_dir_all(&addon_dir)
-                .map_err(|e| format!("Failed to remove existing addon: {}", e))?;
-        }
-        fs::create_dir_all(&addon_dir)
-            .map_err(|e| format!("Failed to create addon directory: {}", e))?;
-
-        self.write_addon_archive_files(&addon_dir, &extracted.files)?;
-
+        let installed_addon_id = extracted.metadata.id.clone();
         let metadata = Self::apply_network_approvals(
             extracted.metadata.to_installed(enable_after_install)?,
             &approved_network_hosts,
         );
-        self.write_manifest(&addon_dir, &metadata)?;
+        self.replace_addon_directory(&installed_addon_id, &extracted.files, &metadata)?;
 
         // Clean staging file
         let _ = remove_addon_from_staging(addon_id, &self.addons_root);
@@ -1956,6 +2179,7 @@ impl AddonServiceTrait for AddonService {
     }
 
     async fn uninstall_addon(&self, addon_id: &str) -> Result<(), String> {
+        self.recover_incomplete_replacement_for_addon(addon_id)?;
         let addon_dir = get_addon_path(&self.addons_root, addon_id)?;
         if !addon_dir.exists() {
             return Err("Addon not found".to_string());
@@ -1965,6 +2189,7 @@ impl AddonServiceTrait for AddonService {
     }
 
     fn list_installed_addons(&self) -> Result<Vec<InstalledAddon>, String> {
+        self.recover_incomplete_replacements()?;
         let addons_dir = ensure_addons_directory(&self.addons_root)?;
         let mut installed = Vec::new();
 
@@ -1975,6 +2200,9 @@ impl AddonServiceTrait for AddonService {
                 let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
                 let dir = entry.path();
                 if !dir.is_dir() {
+                    continue;
+                }
+                if Self::is_hidden_addon_dir(&dir) {
                     continue;
                 }
                 let manifest = match self.read_manifest_if_exists(&dir) {
@@ -2000,6 +2228,7 @@ impl AddonServiceTrait for AddonService {
     }
 
     fn load_addon_for_runtime(&self, addon_id: &str) -> Result<ExtractedAddon, String> {
+        self.recover_incomplete_replacement_for_addon(addon_id)?;
         let addon_dir = get_addon_path(&self.addons_root, addon_id)?;
         let manifest = self.read_manifest_or_error(&addon_dir)?;
 
@@ -2012,10 +2241,7 @@ impl AddonServiceTrait for AddonService {
 
         let main_file = manifest.get_main()?;
         for f in &mut files {
-            let normalized_name = f.name.replace('\\', "/");
-            let normalized_main = main_file.replace('\\', "/");
-            f.is_main =
-                normalized_name == normalized_main || normalized_name.ends_with(&normalized_main);
+            f.is_main = archive_path_matches_manifest_main(&f.name, main_file);
         }
 
         if !files.iter().any(|f| f.is_main) {
@@ -2047,12 +2273,14 @@ impl AddonServiceTrait for AddonService {
     }
 
     async fn check_addon_update(&self, addon_id: &str) -> Result<AddonUpdateCheckResult, String> {
+        self.recover_incomplete_replacement_for_addon(addon_id)?;
         let addon_dir = get_addon_path(&self.addons_root, addon_id)?;
         let manifest = self.read_manifest_or_error(&addon_dir)?;
         check_addon_update_from_api(addon_id, &manifest.version, Some(&self.instance_id)).await
     }
 
     async fn check_all_addon_updates(&self) -> Result<Vec<AddonUpdateCheckResult>, String> {
+        self.recover_incomplete_replacements()?;
         let addons_dir = ensure_addons_directory(&self.addons_root)?;
         let mut results = Vec::new();
 
@@ -2063,6 +2291,9 @@ impl AddonServiceTrait for AddonService {
                 let entry = entry.map_err(|e| format!("Failed to read directory entry: {}", e))?;
                 let dir = entry.path();
                 if !dir.is_dir() {
+                    continue;
+                }
+                if Self::is_hidden_addon_dir(&dir) {
                     continue;
                 }
                 let manifest = match self.read_manifest_if_exists(&dir) {
@@ -2109,6 +2340,7 @@ impl AddonServiceTrait for AddonService {
     }
 
     async fn update_addon_from_store(&self, addon_id: &str) -> Result<AddonManifest, String> {
+        self.recover_incomplete_replacement_for_addon(addon_id)?;
         let addon_dir = get_addon_path(&self.addons_root, addon_id)?;
         let previous_manifest = self.read_manifest_if_exists(&addon_dir)?;
         let was_enabled = previous_manifest
@@ -2124,21 +2356,16 @@ impl AddonServiceTrait for AddonService {
                 addon_id, extracted.metadata.id
             ));
         }
-
-        if addon_dir.exists() {
-            fs::remove_dir_all(&addon_dir)
-                .map_err(|e| format!("Failed to remove addon directory: {}", e))?;
-        }
-        fs::create_dir_all(&addon_dir)
-            .map_err(|e| format!("Failed to create addon directory: {}", e))?;
-
-        self.write_addon_archive_files(&addon_dir, &extracted.files)?;
+        Self::ensure_update_does_not_add_permissions(
+            previous_manifest.as_ref(),
+            &extracted.metadata,
+        )?;
 
         let metadata = Self::preserve_existing_network_approvals(
             extracted.metadata.to_installed(was_enabled)?,
             previous_manifest.as_ref(),
         );
-        self.write_manifest(&addon_dir, &metadata)?;
+        self.replace_addon_directory(addon_id, &extracted.files, &metadata)?;
 
         Ok(metadata)
     }

--- a/crates/core/src/addons/service.rs
+++ b/crates/core/src/addons/service.rs
@@ -1167,6 +1167,13 @@ pub async fn download_addon_package_verified(
     download_url: &str,
     expected_sha256: &str,
 ) -> Result<Vec<u8>, String> {
+    download_addon_package_with_optional_sha256(download_url, Some(expected_sha256)).await
+}
+
+async fn download_addon_package_with_optional_sha256(
+    download_url: &str,
+    expected_sha256: Option<&str>,
+) -> Result<Vec<u8>, String> {
     log::info!("Downloading addon package from URL: {}", download_url);
 
     let client = reqwest::Client::new();
@@ -1230,11 +1237,18 @@ pub async fn download_addon_package_verified(
         download_url
     );
 
-    verify_addon_package_sha256(&zip_data, expected_sha256)?;
-    log::info!(
-        "Verified SHA-256 digest for addon package: {}",
-        download_url
-    );
+    if let Some(expected_sha256) = expected_sha256 {
+        verify_addon_package_sha256(&zip_data, expected_sha256)?;
+        log::info!(
+            "Verified SHA-256 digest for addon package: {}",
+            download_url
+        );
+    } else {
+        log::warn!(
+            "Addon package download from '{}' did not include a SHA-256 digest; skipping package verification",
+            download_url
+        );
+    }
 
     Ok(zip_data)
 }
@@ -1358,7 +1372,7 @@ pub async fn download_addon_from_store(
             .get("sha256")
             .or_else(|| download_response.get("checksumSha256"))
             .and_then(|v| v.as_str())
-            .ok_or("Download API response missing SHA-256 digest")?;
+            .map(str::to_string);
 
         log::info!(
             "Got download URL for addon '{}': {}",
@@ -1367,15 +1381,18 @@ pub async fn download_addon_from_store(
         );
 
         // Now download the actual file
-        return download_addon_package_verified(actual_download_url, expected_sha256).await;
+        return download_addon_package_with_optional_sha256(
+            actual_download_url,
+            expected_sha256.as_deref(),
+        )
+        .await;
     } else {
         log::debug!("Response is binary data, treating as direct ZIP download");
         let expected_sha256 = response
             .headers()
             .get("x-addon-sha256")
             .and_then(|v| v.to_str().ok())
-            .ok_or("Download response missing x-addon-sha256 header")?
-            .to_string();
+            .map(str::to_string);
 
         // Download the addon package directly (GET request returns the file)
         let zip_data = response
@@ -1410,8 +1427,15 @@ pub async fn download_addon_from_store(
             }
         }
 
-        verify_addon_package_sha256(&zip_data, &expected_sha256)?;
-        log::info!("Verified SHA-256 digest for addon '{}'", addon_id);
+        if let Some(expected_sha256) = expected_sha256 {
+            verify_addon_package_sha256(&zip_data, &expected_sha256)?;
+            log::info!("Verified SHA-256 digest for addon '{}'", addon_id);
+        } else {
+            log::warn!(
+                "Download response for addon '{}' did not include x-addon-sha256; skipping package verification",
+                addon_id
+            );
+        }
 
         Ok(zip_data)
     }

--- a/crates/core/src/addons/service.rs
+++ b/crates/core/src/addons/service.rs
@@ -867,6 +867,15 @@ pub fn parse_manifest_json_metadata(manifest_content: &str) -> Result<AddonManif
             .collect()
     });
     let icon = raw_manifest["icon"].as_str().map(|s| s.to_string());
+    let host_dependencies = raw_manifest["hostDependencies"].as_object().map(|deps| {
+        deps.iter()
+            .filter_map(|(name, version)| {
+                version
+                    .as_str()
+                    .map(|version| (name.clone(), version.to_string()))
+            })
+            .collect()
+    });
     let network = if let Some(network_value) = raw_manifest.get("network") {
         if network_value.is_null() {
             None
@@ -998,6 +1007,7 @@ pub fn parse_manifest_json_metadata(manifest_content: &str) -> Result<AddonManif
         keywords,
         icon,
         network,
+        host_dependencies,
         installed_at: None,
         updated_at: None,
         source: None,

--- a/crates/core/src/addons/tests.rs
+++ b/crates/core/src/addons/tests.rs
@@ -1,19 +1,28 @@
 use crate::addons::models::*;
+use crate::addons::network::{AddonNetworkAuth, AddonNetworkRequest};
 use crate::addons::service::*;
 use std::io::Write;
 use zip::write::SimpleFileOptions;
 
 fn build_test_addon_zip(entries: &[(&str, &str)]) -> Vec<u8> {
+    build_test_addon_zip_owned(
+        entries
+            .iter()
+            .map(|(name, content)| (name.to_string(), content.as_bytes().to_vec()))
+            .collect(),
+    )
+}
+
+fn build_test_addon_zip_owned(entries: Vec<(String, Vec<u8>)>) -> Vec<u8> {
     let mut cursor = std::io::Cursor::new(Vec::new());
     {
         let mut zip = zip::ZipWriter::new(&mut cursor);
         let options = SimpleFileOptions::default();
 
         for (name, content) in entries {
-            zip.start_file(name, options)
+            zip.start_file(&name, options)
                 .expect("failed to start zip file");
-            zip.write_all(content.as_bytes())
-                .expect("failed to write zip file");
+            zip.write_all(&content).expect("failed to write zip file");
         }
 
         zip.finish().expect("failed to finish zip");
@@ -275,6 +284,7 @@ fn test_addon_manifest_to_installed() {
         min_wealthfolio_version: None,
         keywords: None,
         icon: None,
+        network: None,
         installed_at: None,
         updated_at: None,
         source: None,
@@ -305,6 +315,7 @@ fn test_addon_manifest_get_main() {
         min_wealthfolio_version: None,
         keywords: None,
         icon: None,
+        network: None,
         installed_at: None,
         updated_at: None,
         source: None,
@@ -329,6 +340,7 @@ fn test_addon_manifest_get_main() {
         min_wealthfolio_version: None,
         keywords: None,
         icon: None,
+        network: None,
         installed_at: None,
         updated_at: None,
         source: None,
@@ -754,6 +766,115 @@ fn test_extract_addon_zip_accepts_valid_nested_paths() {
     );
 }
 
+#[test]
+fn test_validate_addon_id_rejects_traversal_and_reserved_names() {
+    for addon_id in [
+        "",
+        ".",
+        "..",
+        "...",
+        "../evil",
+        "evil/path",
+        "evil\\path",
+        "Staging",
+        "staging",
+        "-starts-with-dash",
+    ] {
+        assert!(
+            validate_addon_id(addon_id).is_err(),
+            "addon id '{addon_id}' should be rejected"
+        );
+    }
+
+    for addon_id in ["a", "test-addon", "addon_1", "addon.name"] {
+        assert!(
+            validate_addon_id(addon_id).is_ok(),
+            "addon id '{addon_id}' should be accepted"
+        );
+    }
+}
+
+#[test]
+fn test_parse_manifest_rejects_invalid_addon_id() {
+    let err = parse_manifest_json_metadata(
+        r#"{"id":"../../evil","name":"Evil","version":"1.0.0","main":"addon.js"}"#,
+    )
+    .expect_err("manifest id traversal should be rejected");
+
+    assert!(err.contains("Invalid addon id"));
+}
+
+#[test]
+fn test_extract_addon_zip_rejects_too_many_entries() {
+    let mut entries = vec![
+        (
+            "manifest.json".to_string(),
+            br#"{"id":"test-addon","name":"Test Addon","version":"1.0.0","main":"addon.js"}"#
+                .to_vec(),
+        ),
+        ("addon.js".to_string(), b"console.log('ok');".to_vec()),
+    ];
+    for i in 0..256 {
+        entries.push((format!("helpers/{i}.js"), b"export {};".to_vec()));
+    }
+
+    let err = match extract_addon_zip_internal(build_test_addon_zip_owned(entries)) {
+        Ok(_) => panic!("zip with too many entries should be rejected"),
+        Err(err) => err,
+    };
+
+    assert!(err.contains("too many entries"));
+}
+
+#[test]
+fn test_extract_addon_zip_rejects_large_file() {
+    let large_content = vec![b'a'; 5 * 1024 * 1024 + 1];
+    let zip_data = build_test_addon_zip_owned(vec![
+        (
+            "manifest.json".to_string(),
+            br#"{"id":"test-addon","name":"Test Addon","version":"1.0.0","main":"addon.js"}"#
+                .to_vec(),
+        ),
+        ("addon.js".to_string(), large_content),
+    ]);
+
+    let err = match extract_addon_zip_internal(zip_data) {
+        Ok(_) => panic!("zip with an oversized file should be rejected"),
+        Err(err) => err,
+    };
+
+    assert!(err.contains("too large"));
+}
+
+#[test]
+fn test_extract_addon_zip_skips_large_source_map() {
+    let large_source_map = vec![b'a'; 5 * 1024 * 1024 + 1];
+    let zip_data = build_test_addon_zip_owned(vec![
+        (
+            "manifest.json".to_string(),
+            br#"{"id":"test-addon","name":"Test Addon","version":"1.0.0","main":"dist/addon.js"}"#
+                .to_vec(),
+        ),
+        (
+            "dist/addon.js".to_string(),
+            b"export default function enable() {}".to_vec(),
+        ),
+        ("dist/addon.js.map".to_string(), large_source_map),
+    ]);
+
+    let extracted = extract_addon_zip_internal(zip_data)
+        .expect("zip with an oversized source map should still extract");
+
+    assert!(
+        extracted.files.iter().any(|file| file.name == "dist/addon.js"),
+        "runtime JS should be preserved"
+    );
+    assert!(
+        extracted.files.iter().all(|file| !file.name.ends_with(".map")),
+        "source maps should not be installed as runtime files"
+    );
+}
+
 #[cfg(test)]
 mod service_tests {
     use super::*;
@@ -874,7 +995,7 @@ mod service_tests {
         ]);
 
         let service = AddonService::new(&temp_dir, "test-instance");
-        let result = service.install_addon_zip(zip_data, true).await;
+        let result = service.install_addon_zip(zip_data, true, vec![]).await;
         let addon_dir = temp_dir.join("addons").join("test-addon");
 
         assert!(result.is_err(), "unsafe zip install should fail");
@@ -888,6 +1009,229 @@ mod service_tests {
         assert!(
             !addon_dir.exists(),
             "addon directory should not be populated on failed install"
+        );
+
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[tokio::test]
+    async fn test_install_addon_zip_rejects_malicious_manifest_id() {
+        let temp_dir = env::temp_dir().join("wealthfolio_test_addon_id_traversal");
+        if temp_dir.exists() {
+            std::fs::remove_dir_all(&temp_dir).ok();
+        }
+
+        let zip_data = build_test_addon_zip(&[
+            (
+                "manifest.json",
+                r#"{"id":"../../evil","name":"Evil","version":"1.0.0","main":"addon.js"}"#,
+            ),
+            ("addon.js", "console.log('bad');"),
+        ]);
+
+        let service = AddonService::new(&temp_dir, "test-instance");
+        let result = service.install_addon_zip(zip_data, true, vec![]).await;
+
+        assert!(result.is_err(), "malicious manifest id should fail install");
+        assert!(
+            !temp_dir.join("evil").exists(),
+            "install must not write outside the addon root"
+        );
+
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[tokio::test]
+    async fn test_install_addon_zip_persists_only_approved_network_hosts() {
+        let temp_dir = env::temp_dir().join("wealthfolio_test_addon_network_approvals");
+        if temp_dir.exists() {
+            std::fs::remove_dir_all(&temp_dir).ok();
+        }
+
+        let zip_data = build_test_addon_zip(&[
+            (
+                "manifest.json",
+                r#"{
+                    "id":"network-addon",
+                    "name":"Network Addon",
+                    "version":"1.0.0",
+                    "main":"addon.js",
+                    "network": {
+                        "allowedHosts": ["api.example.com", "quotes.example.com"]
+                    }
+                }"#,
+            ),
+            ("addon.js", "console.log('ok');"),
+        ]);
+
+        let service = AddonService::new(&temp_dir, "test-instance");
+        let manifest = service
+            .install_addon_zip(
+                zip_data,
+                true,
+                vec![
+                    "api.example.com".to_string(),
+                    "unrequested.example.com".to_string(),
+                ],
+            )
+            .await
+            .expect("network addon should install");
+
+        let network = manifest
+            .network
+            .expect("network policy should be preserved");
+        assert_eq!(network.allowed_hosts.len(), 2);
+        assert_eq!(network.approved_hosts, vec!["api.example.com".to_string()]);
+
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[tokio::test]
+    async fn test_network_auth_requires_secrets_use_permission() {
+        let temp_dir = env::temp_dir().join("wealthfolio_test_network_auth_permission");
+        if temp_dir.exists() {
+            std::fs::remove_dir_all(&temp_dir).ok();
+        }
+
+        let addon_dir = temp_dir.join("addons").join("network-addon");
+        std::fs::create_dir_all(&addon_dir).expect("addon dir should be created");
+        std::fs::write(
+            addon_dir.join("manifest.json"),
+            r#"{
+                "id":"network-addon",
+                "name":"Network Addon",
+                "version":"1.0.0",
+                "main":"addon.js",
+                "enabled": true,
+                "permissions": [
+                    {
+                        "category":"network",
+                        "purpose":"Network access",
+                        "functions":[{"name":"request","isDeclared":true,"isDetected":false}]
+                    }
+                ],
+                "network": {
+                    "allowedHosts": ["api.example.com"],
+                    "approvedHosts": ["api.example.com"]
+                }
+            }"#,
+        )
+        .expect("manifest should be written");
+        std::fs::write(addon_dir.join("addon.js"), "console.log('ok');")
+            .expect("addon should be written");
+
+        let service = AddonService::new(&temp_dir, "test-instance");
+        let result = service
+            .addon_network_request(
+                "network-addon",
+                AddonNetworkRequest {
+                    url: "https://api.example.com/v1".to_string(),
+                    method: Some("GET".to_string()),
+                    headers: None,
+                    body: None,
+                    auth: Some(AddonNetworkAuth {
+                        auth_type: "bearer".to_string(),
+                        secret_key: "api-token".to_string(),
+                    }),
+                    injected_authorization: Some("Bearer secret-token".to_string()),
+                },
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert!(result
+            .err()
+            .unwrap_or_default()
+            .contains("not allowed to use network auth"));
+
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[tokio::test]
+    async fn test_install_and_runtime_load_allow_binary_assets() {
+        let temp_dir = env::temp_dir().join("wealthfolio_test_binary_addon_asset");
+        if temp_dir.exists() {
+            std::fs::remove_dir_all(&temp_dir).ok();
+        }
+
+        let zip_data = build_test_addon_zip_owned(vec![
+            (
+                "manifest.json".to_string(),
+                br#"{"id":"binary-addon","name":"Binary Addon","version":"1.0.0","main":"addon.js"}"#
+                    .to_vec(),
+            ),
+            (
+                "addon.js".to_string(),
+                b"export default function enable() {}".to_vec(),
+            ),
+            ("assets/icon.bin".to_string(), vec![0, 159, 146, 150]),
+        ]);
+
+        let service = AddonService::new(&temp_dir, "test-instance");
+        service
+            .install_addon_zip(zip_data, true, vec![])
+            .await
+            .expect("binary asset addon should install");
+
+        let loaded = service
+            .load_addon_for_runtime("binary-addon")
+            .expect("runtime load should skip binary assets and keep JS");
+
+        assert!(
+            loaded
+                .files
+                .iter()
+                .any(|file| file.name == "addon.js" && file.is_main),
+            "main JS file should still be available at runtime"
+        );
+        assert!(
+            temp_dir
+                .join("addons")
+                .join("binary-addon")
+                .join("assets")
+                .join("icon.bin")
+                .exists(),
+            "binary asset should be written to disk"
+        );
+
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[tokio::test]
+    async fn test_install_from_staging_rejects_manifest_id_mismatch() {
+        let temp_dir = env::temp_dir().join("wealthfolio_test_staging_id_mismatch");
+        if temp_dir.exists() {
+            std::fs::remove_dir_all(&temp_dir).ok();
+        }
+
+        let zip_data = build_test_addon_zip(&[
+            (
+                "manifest.json",
+                r#"{"id":"actual-addon","name":"Actual","version":"1.0.0","main":"addon.js"}"#,
+            ),
+            ("addon.js", "console.log('ok');"),
+        ]);
+
+        save_addon_to_staging("requested-addon", &temp_dir, &zip_data)
+            .expect("staging should save requested id");
+
+        let service = AddonService::new(&temp_dir, "test-instance");
+        let result = service
+            .install_addon_from_staging("requested-addon", true, vec![])
+            .await;
+
+        assert!(result.is_err(), "staging id mismatch should fail");
+        assert!(
+            !temp_dir
+                .join("addons")
+                .join("staging")
+                .join("requested-addon.zip")
+                .exists(),
+            "mismatched staged zip should be removed"
+        );
+        assert!(
+            !temp_dir.join("addons").join("actual-addon").exists(),
+            "mismatched addon should not be installed"
         );
 
         std::fs::remove_dir_all(&temp_dir).ok();

--- a/crates/core/src/addons/tests.rs
+++ b/crates/core/src/addons/tests.rs
@@ -102,6 +102,10 @@ export default function enable(ctx: AddonContext) {
         ui_functions.contains(&"router.add"),
         "router.add should be detected in hello world"
     );
+    assert!(
+        ui_functions.contains(&"onDisable"),
+        "onDisable should be detected in hello world"
+    );
 
     // Should NOT detect portfolio or market-data functions
     let portfolio_permission = detected_permissions
@@ -170,6 +174,10 @@ fn test_detect_addon_permissions() {
     assert!(
         ui_functions.contains(&"router.add"),
         "router.add should be detected"
+    );
+    assert!(
+        ui_functions.contains(&"onDisable"),
+        "onDisable should be detected"
     );
 
     // Should detect portfolio functions

--- a/crates/core/src/addons/tests.rs
+++ b/crates/core/src/addons/tests.rs
@@ -1192,6 +1192,60 @@ mod service_tests {
     }
 
     #[tokio::test]
+    async fn test_legacy_manifest_id_addon_can_load_toggle_and_uninstall() {
+        let temp_dir = env::temp_dir().join("wealthfolio_test_legacy_addon_id");
+        if temp_dir.exists() {
+            std::fs::remove_dir_all(&temp_dir).ok();
+        }
+
+        let service = AddonService::new(&temp_dir, "test-instance");
+        let addon_dir = temp_dir.join("addons").join("LegacyAddon");
+        std::fs::create_dir_all(&addon_dir).expect("addon dir should be created");
+        std::fs::write(
+            addon_dir.join("manifest.json"),
+            r#"{
+                "id": "LegacyAddon",
+                "name": "Legacy Addon",
+                "version": "1.0.0",
+                "main": "addon.js",
+                "enabled": true
+            }"#,
+        )
+        .expect("manifest should be written");
+        std::fs::write(
+            addon_dir.join("addon.js"),
+            "export default function enable() {}",
+        )
+        .expect("addon should be written");
+
+        let loaded = service
+            .load_addon_for_runtime("LegacyAddon")
+            .expect("legacy installed addon should load by manifest id");
+        assert_eq!(loaded.metadata.id, "LegacyAddon");
+
+        service
+            .toggle_addon("LegacyAddon", false)
+            .expect("legacy installed addon should toggle");
+        let manifest: AddonManifest = serde_json::from_str(
+            &std::fs::read_to_string(addon_dir.join("manifest.json"))
+                .expect("manifest should still be readable"),
+        )
+        .expect("manifest should parse");
+        assert_eq!(manifest.enabled, Some(false));
+
+        service
+            .uninstall_addon("LegacyAddon")
+            .await
+            .expect("legacy installed addon should uninstall");
+        assert!(
+            !addon_dir.exists(),
+            "legacy addon directory should be removed"
+        );
+
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[tokio::test]
     async fn test_install_addon_zip_rejects_unsafe_paths_without_writing_files() {
         let temp_dir = env::temp_dir().join("wealthfolio_test_addon_zip_traversal");
         if temp_dir.exists() {

--- a/crates/core/src/addons/tests.rs
+++ b/crates/core/src/addons/tests.rs
@@ -285,6 +285,7 @@ fn test_addon_manifest_to_installed() {
         keywords: None,
         icon: None,
         network: None,
+        host_dependencies: None,
         installed_at: None,
         updated_at: None,
         source: None,
@@ -316,6 +317,7 @@ fn test_addon_manifest_get_main() {
         keywords: None,
         icon: None,
         network: None,
+        host_dependencies: None,
         installed_at: None,
         updated_at: None,
         source: None,
@@ -341,6 +343,7 @@ fn test_addon_manifest_get_main() {
         keywords: None,
         icon: None,
         network: None,
+        host_dependencies: None,
         installed_at: None,
         updated_at: None,
         source: None,
@@ -663,6 +666,39 @@ fn test_parse_manifest_json_metadata_service() {
     assert_eq!(permissions[0].functions[0].name, "showNotification");
     assert!(permissions[0].functions[0].is_declared);
     assert!(!permissions[0].functions[0].is_detected);
+}
+
+#[test]
+fn test_parse_manifest_json_metadata_service_preserves_host_dependencies() {
+    let manifest_json = r#"
+    {
+        "id": "host-deps-addon",
+        "name": "Host Deps Addon",
+        "version": "1.0.0",
+        "main": "dist/addon.js",
+        "hostDependencies": {
+            "react": "^19.2.0",
+            "react-dom": "^19.2.0",
+            "@wealthfolio/ui": "^3.6.0"
+        }
+    }
+    "#;
+
+    let manifest = parse_manifest_json_metadata(manifest_json).unwrap();
+    let host_dependencies = manifest.host_dependencies.unwrap();
+
+    assert_eq!(
+        host_dependencies.get("react").map(String::as_str),
+        Some("^19.2.0")
+    );
+    assert_eq!(
+        host_dependencies.get("react-dom").map(String::as_str),
+        Some("^19.2.0")
+    );
+    assert_eq!(
+        host_dependencies.get("@wealthfolio/ui").map(String::as_str),
+        Some("^3.6.0")
+    );
 }
 
 #[test]

--- a/crates/core/src/addons/tests.rs
+++ b/crates/core/src/addons/tests.rs
@@ -32,6 +32,73 @@ fn build_test_addon_zip_owned(entries: Vec<(String, Vec<u8>)>) -> Vec<u8> {
 }
 
 #[test]
+fn test_archive_path_matches_manifest_main_requires_component_boundary() {
+    assert!(archive_path_matches_manifest_main("addon.js", "addon.js"));
+    assert!(archive_path_matches_manifest_main(
+        "package/dist/addon.js",
+        "dist/addon.js"
+    ));
+    assert!(!archive_path_matches_manifest_main(
+        "package/dist/not-addon.js",
+        "addon.js"
+    ));
+    assert!(!archive_path_matches_manifest_main("addon.js", ""));
+}
+
+#[test]
+fn test_update_permission_escalation_requires_reinstall_approval() {
+    let previous = AddonManifest {
+        id: "test-addon".to_string(),
+        name: "Test Addon".to_string(),
+        version: "1.0.0".to_string(),
+        description: None,
+        author: None,
+        sdk_version: None,
+        main: Some("addon.js".to_string()),
+        enabled: Some(true),
+        permissions: Some(vec![AddonPermission {
+            category: "ui".to_string(),
+            purpose: "User interface".to_string(),
+            functions: vec![FunctionPermission {
+                name: "router.add".to_string(),
+                is_declared: true,
+                is_detected: false,
+                detected_at: None,
+            }],
+        }]),
+        homepage: None,
+        repository: None,
+        license: None,
+        min_wealthfolio_version: None,
+        keywords: None,
+        icon: None,
+        network: None,
+        host_dependencies: None,
+        installed_at: None,
+        updated_at: None,
+        source: None,
+        size: None,
+    };
+    let mut next = previous.clone();
+    next.version = "1.1.0".to_string();
+    next.permissions.as_mut().unwrap().push(AddonPermission {
+        category: "secrets".to_string(),
+        purpose: "Secrets".to_string(),
+        functions: vec![FunctionPermission {
+            name: "use".to_string(),
+            is_declared: true,
+            is_detected: false,
+            detected_at: None,
+        }],
+    });
+
+    let result = AddonService::ensure_update_does_not_add_permissions(Some(&previous), &next);
+
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("secrets.use"));
+}
+
+#[test]
 fn test_detect_addon_permissions_hello_world() {
     // Test with actual hello world addon content
     let hello_world_content = r#"
@@ -910,11 +977,17 @@ fn test_extract_addon_zip_skips_large_source_map() {
         .expect("zip with an oversized source map should still extract");
 
     assert!(
-        extracted.files.iter().any(|file| file.name == "dist/addon.js"),
+        extracted
+            .files
+            .iter()
+            .any(|file| file.name == "dist/addon.js"),
         "runtime JS should be preserved"
     );
     assert!(
-        extracted.files.iter().all(|file| !file.name.ends_with(".map")),
+        extracted
+            .files
+            .iter()
+            .all(|file| !file.name.ends_with(".map")),
         "source maps should not be installed as runtime files"
     );
 }
@@ -1019,6 +1092,102 @@ mod service_tests {
         assert!(permissions[0].functions[0].is_declared);
 
         // Clean up
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    fn test_list_installed_addons_skips_and_cleans_replacement_artifacts() {
+        let temp_dir = env::temp_dir().join("wealthfolio_test_artifact_skip");
+        if temp_dir.exists() {
+            std::fs::remove_dir_all(&temp_dir).ok();
+        }
+
+        let service = AddonService::new(&temp_dir, "test-instance");
+        let addons_dir = temp_dir.join("addons");
+        let addon_dir = addons_dir.join("artifact-addon");
+        let backup_dir = addons_dir.join(".artifact-addon.backup-test");
+        let temp_install_dir = addons_dir.join(".artifact-addon.tmp-test");
+        std::fs::create_dir_all(&addon_dir).expect("addon dir should be created");
+        std::fs::create_dir_all(&backup_dir).expect("backup dir should be created");
+        std::fs::create_dir_all(&temp_install_dir).expect("tmp dir should be created");
+
+        let manifest_json = r#"{
+            "id": "artifact-addon",
+            "name": "Artifact Addon",
+            "version": "1.0.0",
+            "main": "addon.js",
+            "enabled": true
+        }"#;
+        for dir in [&addon_dir, &backup_dir, &temp_install_dir] {
+            std::fs::write(dir.join("manifest.json"), manifest_json)
+                .expect("manifest should be written");
+            std::fs::write(dir.join("addon.js"), "console.log('ok');")
+                .expect("addon should be written");
+        }
+
+        let installed = service
+            .list_installed_addons()
+            .expect("installed addons should list");
+
+        assert_eq!(installed.len(), 1);
+        assert_eq!(installed[0].metadata.id, "artifact-addon");
+        assert!(
+            !backup_dir.exists(),
+            "stale backup should be cleaned when canonical addon exists"
+        );
+        assert!(
+            !temp_install_dir.exists(),
+            "stale temp install dir should be cleaned when canonical addon exists"
+        );
+
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    fn test_list_installed_addons_restores_backup_after_interrupted_replacement() {
+        let temp_dir = env::temp_dir().join("wealthfolio_test_artifact_restore");
+        if temp_dir.exists() {
+            std::fs::remove_dir_all(&temp_dir).ok();
+        }
+
+        let service = AddonService::new(&temp_dir, "test-instance");
+        let addons_dir = temp_dir.join("addons");
+        let addon_dir = addons_dir.join("recover-addon");
+        let backup_dir = addons_dir.join(".recover-addon.backup-test");
+        let temp_install_dir = addons_dir.join(".recover-addon.tmp-test");
+        std::fs::create_dir_all(&backup_dir).expect("backup dir should be created");
+        std::fs::create_dir_all(&temp_install_dir).expect("tmp dir should be created");
+
+        let manifest_json = r#"{
+            "id": "recover-addon",
+            "name": "Recover Addon",
+            "version": "1.0.0",
+            "main": "addon.js",
+            "enabled": true
+        }"#;
+        for dir in [&backup_dir, &temp_install_dir] {
+            std::fs::write(dir.join("manifest.json"), manifest_json)
+                .expect("manifest should be written");
+            std::fs::write(dir.join("addon.js"), "console.log('ok');")
+                .expect("addon should be written");
+        }
+
+        let installed = service
+            .list_installed_addons()
+            .expect("installed addons should recover backup");
+
+        assert_eq!(installed.len(), 1);
+        assert_eq!(installed[0].metadata.id, "recover-addon");
+        assert!(
+            addon_dir.exists(),
+            "backup should be restored to canonical path"
+        );
+        assert!(!backup_dir.exists(), "restored backup dir should be gone");
+        assert!(
+            !temp_install_dir.exists(),
+            "stale temp install dir should be cleaned after restore"
+        );
+
         std::fs::remove_dir_all(&temp_dir).ok();
     }
 
@@ -1152,6 +1321,72 @@ mod service_tests {
                         "category":"network",
                         "purpose":"Network access",
                         "functions":[{"name":"request","isDeclared":true,"isDetected":false}]
+                    }
+                ],
+                "network": {
+                    "allowedHosts": ["api.example.com"],
+                    "approvedHosts": ["api.example.com"]
+                }
+            }"#,
+        )
+        .expect("manifest should be written");
+        std::fs::write(addon_dir.join("addon.js"), "console.log('ok');")
+            .expect("addon should be written");
+
+        let service = AddonService::new(&temp_dir, "test-instance");
+        let result = service
+            .addon_network_request(
+                "network-addon",
+                AddonNetworkRequest {
+                    url: "https://api.example.com/v1".to_string(),
+                    method: Some("GET".to_string()),
+                    headers: None,
+                    body: None,
+                    auth: Some(AddonNetworkAuth {
+                        auth_type: "bearer".to_string(),
+                        secret_key: "api-token".to_string(),
+                    }),
+                    injected_authorization: Some("Bearer secret-token".to_string()),
+                },
+            )
+            .await;
+
+        assert!(result.is_err());
+        assert!(result
+            .err()
+            .unwrap_or_default()
+            .contains("not allowed to use network auth"));
+
+        std::fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[tokio::test]
+    async fn test_network_auth_rejects_detected_only_secrets_use_permission() {
+        let temp_dir = env::temp_dir().join("wealthfolio_test_detected_only_network_auth");
+        if temp_dir.exists() {
+            std::fs::remove_dir_all(&temp_dir).ok();
+        }
+
+        let addon_dir = temp_dir.join("addons").join("network-addon");
+        std::fs::create_dir_all(&addon_dir).expect("addon dir should be created");
+        std::fs::write(
+            addon_dir.join("manifest.json"),
+            r#"{
+                "id":"network-addon",
+                "name":"Network Addon",
+                "version":"1.0.0",
+                "main":"addon.js",
+                "enabled": true,
+                "permissions": [
+                    {
+                        "category":"network",
+                        "purpose":"Network access",
+                        "functions":[{"name":"request","isDeclared":true,"isDetected":false}]
+                    },
+                    {
+                        "category":"secrets",
+                        "purpose":"Secrets access",
+                        "functions":[{"name":"use","isDeclared":false,"isDetected":true}]
                     }
                 ],
                 "network": {

--- a/crates/core/src/secrets/mod.rs
+++ b/crates/core/src/secrets/mod.rs
@@ -1,3 +1,4 @@
+use crate::addons::validate_addon_id;
 use crate::errors::Result;
 
 /// Prefix applied to all secret identifiers to avoid collisions with other
@@ -10,6 +11,34 @@ pub fn format_service_id(service: &str) -> String {
     format!("{}{}", SERVICE_PREFIX, service.to_lowercase())
 }
 
+pub fn validate_addon_secret_key(key: &str) -> std::result::Result<(), String> {
+    if key.is_empty() {
+        return Err("Addon secret key cannot be empty".to_string());
+    }
+
+    if key.len() > 128 {
+        return Err("Addon secret key cannot exceed 128 characters".to_string());
+    }
+
+    if !key
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '.' | '_' | '-'))
+    {
+        return Err(
+            "Addon secret key may only contain lowercase ASCII letters, digits, '.', '_' and '-'"
+                .to_string(),
+        );
+    }
+
+    Ok(())
+}
+
+pub fn addon_secret_service_id(addon_id: &str, key: &str) -> std::result::Result<String, String> {
+    validate_addon_id(addon_id)?;
+    validate_addon_secret_key(key)?;
+    Ok(format!("addon:{}:{}", addon_id, key))
+}
+
 /// Platform-agnostic contract for storing provider secrets. Concrete
 /// implementations live in the platform crates (e.g. the Tauri desktop app or
 /// the self-hosted web server) so the core crate remains focused on business
@@ -18,4 +47,21 @@ pub trait SecretStore: Send + Sync {
     fn set_secret(&self, service: &str, secret: &str) -> Result<()>;
     fn get_secret(&self, service: &str) -> Result<Option<String>>;
     fn delete_secret(&self, service: &str) -> Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn addon_secret_service_id_scopes_and_validates_keys() {
+        assert_eq!(
+            addon_secret_service_id("example-addon", "api_key").unwrap(),
+            "addon:example-addon:api_key"
+        );
+
+        assert!(addon_secret_service_id("../bad", "api_key").is_err());
+        assert!(addon_secret_service_id("example-addon", "../token").is_err());
+        assert!(addon_secret_service_id("example-addon", "ApiKey").is_err());
+    }
 }

--- a/crates/core/src/secrets/mod.rs
+++ b/crates/core/src/secrets/mod.rs
@@ -11,7 +11,7 @@ pub fn format_service_id(service: &str) -> String {
     format!("{}{}", SERVICE_PREFIX, service.to_lowercase())
 }
 
-pub fn validate_addon_secret_key(key: &str) -> std::result::Result<(), String> {
+pub fn normalize_addon_secret_key(key: &str) -> std::result::Result<String, String> {
     if key.is_empty() {
         return Err("Addon secret key cannot be empty".to_string());
     }
@@ -22,15 +22,24 @@ pub fn validate_addon_secret_key(key: &str) -> std::result::Result<(), String> {
 
     if !key
         .chars()
-        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '.' | '_' | '-'))
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
     {
         return Err(
-            "Addon secret key may only contain lowercase ASCII letters, digits, '.', '_' and '-'"
-                .to_string(),
+            "Addon secret key may only contain ASCII letters, digits, '.', '_' and '-'".to_string(),
         );
     }
 
-    Ok(())
+    Ok(key.to_ascii_lowercase())
+}
+
+pub fn validate_addon_secret_key(key: &str) -> std::result::Result<(), String> {
+    normalize_addon_secret_key(key).map(|_| ())
+}
+
+fn normalize_addon_secret_addon_id(addon_id: &str) -> std::result::Result<String, String> {
+    let addon_id = addon_id.to_ascii_lowercase();
+    validate_addon_id(&addon_id)?;
+    Ok(addon_id)
 }
 
 pub fn validate_unscoped_secret_service_id(service: &str) -> std::result::Result<(), String> {
@@ -46,9 +55,18 @@ pub fn validate_unscoped_secret_service_id(service: &str) -> std::result::Result
 }
 
 pub fn addon_secret_service_id(addon_id: &str, key: &str) -> std::result::Result<String, String> {
-    validate_addon_id(addon_id)?;
-    validate_addon_secret_key(key)?;
+    let addon_id = normalize_addon_secret_addon_id(addon_id)?;
+    let key = normalize_addon_secret_key(key)?;
     Ok(format!("addon:{}:{}", addon_id, key))
+}
+
+pub fn legacy_addon_secret_service_id(
+    addon_id: &str,
+    key: &str,
+) -> std::result::Result<String, String> {
+    let addon_id = normalize_addon_secret_addon_id(addon_id)?;
+    let key = normalize_addon_secret_key(key)?;
+    Ok(format!("addon_{}_{}", addon_id, key))
 }
 
 /// Platform-agnostic contract for storing provider secrets. Concrete
@@ -71,10 +89,21 @@ mod tests {
             addon_secret_service_id("example-addon", "api_key").unwrap(),
             "addon:example-addon:api_key"
         );
+        assert_eq!(
+            addon_secret_service_id("example-addon", "ApiKey").unwrap(),
+            "addon:example-addon:apikey"
+        );
+        assert_eq!(
+            legacy_addon_secret_service_id("example-addon", "ApiKey").unwrap(),
+            "addon_example-addon_apikey"
+        );
+        assert_eq!(
+            addon_secret_service_id("Example-Addon", "ApiKey").unwrap(),
+            "addon:example-addon:apikey"
+        );
 
         assert!(addon_secret_service_id("../bad", "api_key").is_err());
         assert!(addon_secret_service_id("example-addon", "../token").is_err());
-        assert!(addon_secret_service_id("example-addon", "ApiKey").is_err());
     }
 
     #[test]

--- a/crates/core/src/secrets/mod.rs
+++ b/crates/core/src/secrets/mod.rs
@@ -33,6 +33,18 @@ pub fn validate_addon_secret_key(key: &str) -> std::result::Result<(), String> {
     Ok(())
 }
 
+pub fn validate_unscoped_secret_service_id(service: &str) -> std::result::Result<(), String> {
+    if service.trim().is_empty() {
+        return Err("Secret service id cannot be empty".to_string());
+    }
+
+    if service.to_ascii_lowercase().starts_with("addon:") {
+        return Err("Addon-scoped secrets must use the addon secret API".to_string());
+    }
+
+    Ok(())
+}
+
 pub fn addon_secret_service_id(addon_id: &str, key: &str) -> std::result::Result<String, String> {
     validate_addon_id(addon_id)?;
     validate_addon_secret_key(key)?;
@@ -63,5 +75,13 @@ mod tests {
         assert!(addon_secret_service_id("../bad", "api_key").is_err());
         assert!(addon_secret_service_id("example-addon", "../token").is_err());
         assert!(addon_secret_service_id("example-addon", "ApiKey").is_err());
+    }
+
+    #[test]
+    fn validate_unscoped_secret_service_id_rejects_addon_namespace() {
+        assert!(validate_unscoped_secret_service_id("market-data-provider").is_ok());
+        assert!(validate_unscoped_secret_service_id("").is_err());
+        assert!(validate_unscoped_secret_service_id("addon:example-addon:api_key").is_err());
+        assert!(validate_unscoped_secret_service_id("ADDON:example-addon:api_key").is_err());
     }
 }

--- a/docs/addon-security-architecture-review.md
+++ b/docs/addon-security-architecture-review.md
@@ -1,0 +1,726 @@
+# Addon System — Security & Architecture Review
+
+Status: Draft for review (rev. 2 — SOTA + code re-verification pass) Scope:
+`packages/addon-sdk`, `apps/frontend/src/addons`,
+`apps/frontend/src/pages/settings/addons`, `crates/core/src/addons`,
+`apps/tauri/src/commands/addon.rs`, `apps/server/src/api/addons.rs`,
+`apps/tauri/tauri.conf.json`, `apps/tauri/capabilities/` Applies to: Tauri
+desktop/mobile app **and** the Axum web/server mode.
+
+This document consolidates two independent reviews of the addon system, verified
+against the current code, and lays out the recommended target architecture for
+both platforms. Revision 2 adds finding S12 (desktop `withGlobalTauri` + `fs`
+capability exposure) found during a re-verification pass, corrects the S10
+citations to the actual assignment sites, benchmarks the recommendations against
+current SOTA (Figma, VS Code, Chrome MV3, MetaMask Snaps, and Tauri's own
+Isolation Pattern / v2 capabilities), and hedges the import-map and ShadowRealm
+maturity claims.
+
+---
+
+## 1. Executive summary
+
+The addon system is functional and has good developer ergonomics, but its
+security posture is **Obsidian-level: excellent DX, effectively zero
+isolation.** Addons are untrusted third-party JavaScript that execute in the
+main application realm with the same privileges as first-party app code. The
+permission system is **advisory only** — it is displayed to the user but never
+enforced at runtime — and the Content-Security-Policy is disabled, so a
+malicious or compromised addon can read every piece of financial data and secret
+in the app and exfiltrate it to any server with a single `fetch()`.
+
+On desktop the exposure is **worse than "same privileges as app code"**: because
+`withGlobalTauri` is enabled and the Tauri filesystem capability is scoped to
+the whole `$APPDATA/**` tree, addon code can bypass the HostAPI entirely and
+read, overwrite, or delete the SQLite database, other addons' files, and secret
+storage directly (S12). The brokered ~90-function API is not the ceiling of what
+an addon can reach — it is a convenience layered over unrestricted access.
+
+None of this is exotic; addon/plugin isolation is a solved problem across the
+industry — Figma (sandboxed realm + iframe UI), VS Code (out-of-process
+extension host), Chrome extensions (declared host allowlists), and, most
+directly relevant, MetaMask Snaps (untrusted third-party plugins in a financial
+app, isolated with SES/Compartments). The work here is host-side plumbing, not
+novel security research. Tauri itself ships two mechanisms that are currently
+unused: the **Isolation Pattern** (sandboxed-iframe IPC broker) and the **v2
+capabilities/ACL** system.
+
+The single highest-leverage principle: **treat addons as untrusted and give them
+a capability-scoped, brokered API behind a real isolation boundary — the same
+design for Tauri and web.**
+
+### Findings at a glance
+
+| #   | Issue                                                                | Severity | Type             | Verified location                                                     |
+| --- | -------------------------------------------------------------------- | -------- | ---------------- | --------------------------------------------------------------------- |
+| S1  | No runtime permission enforcement — full API handed to every addon   | Critical | Architecture     | `addons-runtime-context.ts:167–392`                                   |
+| S2  | No sandboxing — addons execute in host JS realm                      | Critical | Architecture     | `addons-core.ts:126–133`                                              |
+| S3  | CSP disabled (`"csp": null`)                                         | Critical | Configuration    | `apps/tauri/tauri.conf.json` security block                           |
+| S4  | Backend cannot verify addon identity; secret scoping is JS-only      | High     | Architecture     | `addons-runtime-context.ts:147–164`, `commands/addon.rs`              |
+| S5  | Static permission analysis trivially bypassable                      | High     | Design           | `crates/core/src/addons/service.rs:150–494`                           |
+| S6  | Path traversal via unvalidated `addon_id`                            | High     | Input validation | `service.rs:87–90`, all `get_addon_path` callers                      |
+| S7  | Install proceeds on permission-analysis failure                      | Medium   | Logic            | `use-addon-actions.ts:171–182`                                        |
+| S8  | Server mode: addons are global + auth optional (multi-tenant unsafe) | Medium   | Architecture     | `apps/server/src/api.rs:92,144–151`, `api/addons.rs`                  |
+| S9  | Dev mode fetches & executes remote code from localhost:3001          | Medium   | Dev security     | `addons-dev-mode.ts:42–83,144–226,327–347`                            |
+| S10 | Global state exposed on `window`                                     | Medium   | Architecture     | `main.tsx:26–27`, `App.tsx:30`, `use-navigation-event-listener.ts`    |
+| S11 | No ZIP extraction limits (zip bomb / OOM)                            | Low→Med  | Input validation | `service.rs:496–545`                                                  |
+| S12 | Desktop config grants addons direct filesystem + IPC access          | Critical | Configuration    | `tauri.conf.json:65` (`withGlobalTauri`), `capabilities/desktop.json` |
+
+> Severity note: S6 and S11 were rated "Low" in the original review. On closer
+> reading `addon_id` flows from the attacker-controlled manifest **and** from
+> raw command/HTTP arguments into `fs::remove_dir_all`, and the web server
+> exposes those paths remotely, so S6 is raised to **High**. S11 is raised to
+> **Low→Medium** because `read_to_string` over unbounded entries is both a DoS
+> and a functional bug (binary assets break). **S12 is new to this revision**
+> (surfaced during the code re-verification pass): on desktop, `withGlobalTauri`
+> plus the filesystem capability scope give addon code a data-access path that
+> is strictly _worse_ than the ~90-function HostAPI, and it is the concrete
+> mechanism behind S2 and S4 rather than a theoretical one — hence **Critical**.
+
+---
+
+## 2. Architecture overview (how it works today)
+
+1. **Package format.** An addon is a ZIP containing `manifest.json` (id, name,
+   version, `main`, declared `permissions`) and a JS bundle.
+2. **Install (Rust).** The backend extracts the ZIP, runs substring-based static
+   analysis on the JS to _detect_ which host-API functions are used, and merges
+   detected vs declared permissions into the stored manifest. Files are written
+   to `<app_data>/addons/<id>/`.
+3. **Approval (Frontend).** A permission dialog (`addon-permission-dialog.tsx`)
+   shows the merged permissions and a coarse risk label, then the user approves
+   or denies.
+4. **Runtime load (Frontend).** `load_addon_for_runtime` returns the main file
+   **as a string**; the loader strips the sourcemap comment, wraps the code in a
+   `Blob`, `createObjectURL`s it, and `import()`s the blob URL — executing the
+   code in the host window.
+5. **Context injection.** The addon's `enable(ctx)` is called with an
+   `AddonContext` whose `ctx.api` is a bridge (`type-bridge.ts`) to ~90 host
+   functions (portfolio, activities, accounts, settings, secrets, files, market
+   data, etc.), plus `sidebar.addItem`, `router.add`, `onDisable`, and scoped
+   `secrets`.
+
+Both the Tauri IPC layer (`commands/addon.rs`) and the Axum server
+(`api/addons.rs`) expose the same operations. The web runtime path is identical
+to desktop except the transport is HTTP instead of Tauri `invoke`.
+
+Two desktop-config facts compound the above and are load-bearing for S2/S4/S12:
+`tauri.conf.json` sets `"withGlobalTauri": true`, injecting `window.__TAURI__`
+into every script in the webview; and `capabilities/desktop.json` grants
+`fs:allow-read-file`/`write-file`/`remove` scoped to `$APPDATA/**` plus
+`shell:allow-open`. App-defined `#[tauri::command]`s are not gated by the
+capability ACL at all — capabilities govern core/plugin commands, not custom
+ones — so every addon/secret command is freely invokable from the webview.
+
+The load boundary — the fact that step 4 runs addon code **in the same realm as
+the host** — is the root cause of S1, S2, S4, S10, and S12 simultaneously.
+
+---
+
+## 3. Detailed findings
+
+### S1 — Critical: Permissions are informational only; no runtime enforcement
+
+`createAddonContext()` (`addons-runtime-context.ts:167`) builds the **full**
+`HostAPI` bridge for every addon regardless of what was declared or approved:
+
+```ts
+// Every addon receives the same complete API — nothing is filtered by grant:
+api: createSDKHostAPIBridge(
+  {
+    getHoldings,
+    getActivities,
+    getAccounts,
+    getExchangeRates,
+    updateSettings,
+    backupDatabase,
+    createActivity,
+    updateActivity,
+    importActivities,
+    openCsvFileDialog,
+    openFileSaveDialog,
+    setSecret,
+    getSecret,
+    deleteSecret,
+    // ...everything
+  },
+  addonId,
+);
+```
+
+**Impact.** An addon that declares only `portfolio.getHoldings` can call
+`settings.update()`, `activities.create()`, `accounts.create()`,
+`backupDatabase()`, or any other function. The permission dialog is purely
+cosmetic. Detection (`is_detected`) and declaration (`is_declared`) flags are
+computed and stored, but nothing reads them to gate the API surface.
+
+### S2 — Critical: No sandboxing — addons run in the host's JS context
+
+`addons-core.ts:126`:
+
+```ts
+const blob = new Blob([addonCode], { type: "text/javascript" });
+blobUrl = URL.createObjectURL(blob);
+const mod = await import(/* @vite-ignore */ blobUrl);
+```
+
+This runs addon code in the same origin, window, and DOM as the host. A
+malicious addon can:
+
+- Read `window.__wealthfolio_query_client__` to read/invalidate/refetch any
+  cache entry.
+- Call `window.__wealthfolio_navigate__` to redirect the user.
+- Reach `window.React` / `window.ReactDOM` to inject arbitrary UI anywhere.
+- On desktop, reach the Tauri IPC directly via `window.__TAURI__` (exposed by
+  `withGlobalTauri: true`) to call **any** command, bypassing the HostAPI
+  entirely — including the filesystem plugin (see S12).
+- Read/modify DOM, `localStorage`, `sessionStorage`, cookies.
+- Monkey-patch any global (`fetch`, `XMLHttpRequest`) to intercept traffic.
+
+The `ctx` object handed to `enable()` is not a boundary — it is a convenience.
+Ignoring it grants no less access. On desktop it grants strictly _more_ access
+than the HostAPI (S12).
+
+### S3 — Critical: CSP is disabled
+
+`apps/tauri/tauri.conf.json` sets:
+
+```json
+"security": { "csp": null }
+```
+
+With no Content-Security-Policy, addon code has unrestricted ability to:
+
+- `fetch()`/`XHR` to **any** external host → one-line exfiltration of the entire
+  portfolio and all secrets.
+- Load remote scripts.
+- Use `eval()` / `new Function()`.
+
+This is the highest-leverage single fix. Even without a full sandbox, a strict
+`connect-src` allowlist neutralizes the _impact_ of S1/S2 by preventing data
+from leaving the machine.
+
+### S4 — High: Backend cannot verify addon identity; secret scoping is JS-only
+
+Secret isolation is implemented purely in JS via a key prefix
+(`addons-runtime-context.ts:147`):
+
+```ts
+function createAddonScopedSecrets(addonId: string) {
+  const addonPrefix = `addon_${addonId}_`;
+  return {
+    set: (key, value) => setSecret(`${addonPrefix}${key}`, value), // raw invoke
+    get: (key) => getSecret(`${addonPrefix}${key}`),
+    delete: (key) => deleteSecret(`${addonPrefix}${key}`),
+  };
+}
+```
+
+Because all addons share the JS realm (S2), any addon can call
+`setSecret("addon_OTHER_ID_apiKey", ...)` or
+`getSecret("addon_OTHER_ID_apiKey")` directly. On desktop this is not
+hypothetical: `window.__TAURI__.core.invoke("get_secret", { key })` reaches the
+command directly (S12), for any addon's key. The Tauri/server commands receive
+raw parameters with **no caller identity**, so the backend cannot validate
+scope. The prefix is a naming convention, not a security boundary.
+
+### S5 — High: Static analysis is trivially bypassable
+
+Permission detection (`service.rs:150–494`) is substring matching:
+
+```rust
+let api_patterns = vec![
+    format!("api.{}.{}(", api_category, function),
+    format!(".api.{}.{}(", api_category, function),
+    format!("ctx.api.{}.{}(", api_category, function),
+];
+```
+
+Bypasses (any one suffices):
+
+- Bracket access: `ctx.api["settings"]["update"]()`
+- Reference capture: `const fn = ctx.api.settings.update; fn()`
+- Dynamic dispatch: `ctx.api[cat][method]()`
+- Minification/obfuscation renaming
+- `eval()` / `new Function()` to build calls at runtime
+- Reaching the Tauri IPC directly instead of the HostAPI
+
+It also produces false positives (a comment or unrelated string containing the
+pattern), and, because of S1, it changes nothing at runtime regardless of
+accuracy. Detection is at best a UI hint, never a control.
+
+### S6 — High: Path traversal via unvalidated `addon_id`
+
+`service.rs:87`:
+
+```rust
+pub fn get_addon_path(base_dir: impl AsRef<Path>, addon_id: &str) -> Result<PathBuf, String> {
+    let addons_dir = ensure_addons_directory(base_dir)?;
+    Ok(addons_dir.join(addon_id))   // no validation
+}
+```
+
+`validated_addon_archive_path` guards only the **file names inside** the ZIP —
+never the `addon_id` used as the directory name. `addon_id` originates from (a)
+the attacker-controlled manifest `id` and (b) raw command/HTTP arguments
+(`uninstall_addon`, `toggle_addon`, `load_addon_for_runtime`). Consequences:
+
+- Install with `"id": "../../../../some/path"` writes addon files outside the
+  addons tree.
+- `uninstall_addon("../../some/path")` → `fs::remove_dir_all` on an arbitrary
+  directory.
+- `toggle`/`load` read and rewrite `manifest.json` outside the tree.
+
+On the web server these are remotely reachable (auth-gated when auth is
+configured — see S8). Fix: validate `addon_id` against a strict charset at every
+entry point.
+
+### S7 — Medium: Install proceeds on permission-analysis failure
+
+`use-addon-actions.ts:171`:
+
+```ts
+} catch (error) {
+  toast({ title: "Permission analysis failed", ... });
+  // Still allow installation but with warning
+  await performAddonInstallation(fileData);
+}
+```
+
+If permission extraction throws (e.g. a deliberately malformed manifest), the
+addon is installed anyway behind a toast. A malicious addon can intentionally
+trip this path to skip the permission surface entirely. Fail closed instead.
+
+### S8 — Medium: Server mode is multi-tenant unsafe; auth is optional
+
+The Axum server has a single `addon_service` over a single `addons_root`
+(`WF_ADDONS_DIR`, `config.rs:67`). `get_enabled_addons_on_startup` returns the
+same addon set to **every** connected user. In any shared/multi-user deployment,
+one user installing an addon runs it in every other user's browser, against
+their data and their authenticated session. Additionally, addon routes are
+behind JWT only when `state.auth.is_some()` (`api.rs:92,144`); a server started
+without auth exposes all addon install/uninstall/toggle endpoints
+unauthenticated.
+
+### S9 — Medium: Dev mode fetches and executes remote code without verification
+
+`addons-dev-mode.ts` auto-discovers a dev server on `localhost:3001`, then
+fetches and executes its JS:
+
+```ts
+const addonResponse = await fetch(`${devServer.url}/addon.js`);
+const addonCode = await addonResponse.text();
+await this.executeAddonCode(addonCode, manifest, addonId); // Blob import
+```
+
+It also opens `new EventSource("http://localhost:3001/addon-updates")` for hot
+reload. No integrity checks; any local process can serve on that port and inject
+code into a dev build. Gated behind `import.meta.env.DEV`, so it is
+developer-machine-only — but it is a real supply-chain vector for developers.
+Ensure it can never be present in a production bundle and document the risk.
+
+### S10 — Medium: Global state pollution
+
+Sensitive objects are reachable by any script on the page, including addons:
+
+- `window.__wealthfolio_query_client__` — full React Query client
+- `window.__wealthfolio_navigate__` — router navigation
+- `window.React` / `window.ReactDOM` — framework singletons
+- `window.__ADDON_DEV__`, `window.__DEV_ADDONS__`, `globalThis.discoverAddons`,
+  `globalThis.reloadAddons` (dev mode)
+
+These are ambient authority. They should be non-enumerable, closured, or
+replaced by the RPC broker (below).
+
+### S11 — Low→Medium: No ZIP extraction limits
+
+`extract_addon_zip_internal` (`service.rs:496`) reads every entry with
+`read_to_string` into memory with no cap on total uncompressed size, entry
+count, or per-file size — a zip-bomb / OOM vector. Because it uses
+`read_to_string`, it is _also_ a functional bug: any binary asset (icon, font,
+wasm) fails to extract or is corrupted. Read as bytes and enforce limits.
+
+### S12 — Critical: Desktop config grants addons direct filesystem + IPC access
+
+This is the finding that makes the desktop threat model concretely worse than
+"addon has the same privileges as app code." Two configuration facts combine:
+
+- **`"withGlobalTauri": true`** (`tauri.conf.json:65`) injects the
+  `window.__TAURI__` bridge into every script in the webview, addon blobs
+  included. The host app itself does **not** use this global — it calls `invoke`
+  exclusively through `@tauri-apps/api` module imports (verified:
+  `adapters/tauri/core.ts` and 5 other files; zero references to
+  `window.__TAURI__` in app code) — so the global is gratuitous attack surface
+  that can be turned off with no app changes.
+- **Filesystem capability scoped to
+  `$APPDATA/**`** (`capabilities/desktop.json`): `fs:allow-read-file`, `fs:allow-write-file`, `fs:allow-remove`, `fs:allow-rename`, plus `shell:allow-open`. That scope contains the SQLite database (`app.db`),
+  every installed addon's files, and secret storage.
+
+Combined, an addon can do the following without touching the HostAPI:
+
+```js
+// Directly, from inside an addon blob, on desktop:
+const { readFile, writeFile, remove } = window.__TAURI__.fs;
+await readFile("$APPDATA/app.db"); // exfiltrate the whole DB
+await remove("$APPDATA/addons/<other-addon>", { recursive: true });
+await window.__TAURI__.core.invoke("get_secret", {
+  key: "addon_OTHER_ID_apiKey",
+});
+```
+
+The Tauri v2 capability ACL does not mitigate this: capabilities gate core and
+plugin commands, but app-defined `#[tauri::command]`s (install, uninstall,
+`get_secret`, etc.) are invokable from the main window regardless of the
+capability file. So the ACL that exists provides **no** boundary against addon
+code, and the `fs` plugin grant is a direct read/write primitive over all app
+data.
+
+Web mode is not affected by `withGlobalTauri`/`fs` (no Tauri bridge), but the
+equivalent there is the authenticated session (S8): an addon inherits the user's
+cookies/JWT and can call every protected `/api/*` route.
+
+Fixes are cheap and independent of the isolation work: set
+`withGlobalTauri: false`, and tighten the `fs` scope to the minimum the app
+needs (ideally not the whole `$APPDATA/**`), or accept the scope and rely on
+Tier 1 isolation to keep addons out of the webview's ambient authority.
+
+---
+
+## 4. Non-security architecture & code-quality issues
+
+These do not have CVEs but drive the security debt and maintenance cost.
+
+- **Duplication across three surfaces.** Install/extract/write logic exists in
+  `AddonService` **and** is re-inlined in `commands/addon.rs` (the Tauri command
+  reimplements extraction and file writing rather than calling the service).
+  This is why a fix in one path (e.g. `write_addon_files` validation) doesn't
+  cover the other. Collapse to a single `AddonService` consumed by thin
+  Tauri/server wrappers.
+- **Permission table lives in 3 places** —
+  `packages/addon-sdk/src/permissions.ts` (`PERMISSION_CATEGORIES`),
+  `service.rs` (`permission_patterns`), and the frontend risk lists in
+  `use-addon-actions.ts` (`calculateRiskLevel`). They drift. Establish one
+  source of truth (ideally code-generated).
+- **`type-bridge.ts` hand-maps ~90 functions** between "internal" and "SDK"
+  shapes (436 lines). Every new host function touches the adapter,
+  `InternalHostAPI`, the bridge, and `permissions`. High friction, easy to
+  desync.
+- **Fragile `enable()` resolution.** `addons-core.ts:144` tries five bundle
+  shapes including a hardcoded `PortfolioTrackerAddon` name — an
+  example-specific hack leaked into the loader. Standardize on one entry
+  contract (`export default function enable(ctx)`).
+- **Lifecycle is best-effort.** A blob module can register
+  timers/listeners/portals that `disable()` won't reliably clean up; nav/route
+  maps are global singletons. "Disable" does not guarantee the addon stops
+  running.
+- **Silent failure swallowing** (`catch {}`, `let _ = ...`, install-on-failure)
+  throughout.
+- **`enabled` defaults to `true`** (`models.rs:91`,
+  `is_enabled → unwrap_or(true)`): a manifest with no `enabled` field auto-runs.
+
+---
+
+## 5. Target architecture
+
+### How comparable systems solve this (SOTA)
+
+The recommendations below are not speculative — every major plugin platform has
+converged on "untrusted code behind an enforced boundary," differing mainly in
+_which_ boundary:
+
+| System             | Logic isolation                       | UI                         | Host access                           |
+| ------------------ | ------------------------------------- | -------------------------- | ------------------------------------- |
+| **Figma**          | Sandboxed JS realm (no DOM)           | Sandboxed iframe           | `postMessage` to a typed API          |
+| **VS Code**        | Separate OS process (extension host)  | Declarative API + Webviews | RPC; no direct DOM access             |
+| **Chrome (MV3)**   | Isolated world / service worker       | Own pages                  | Declared `host_permissions` allowlist |
+| **MetaMask Snaps** | SES `Compartment` (hardened JS)       | Constrained UI schema      | Capability-gated RPC methods          |
+| **Obsidian**       | **None** — same thread, full `window` | Direct DOM                 | Everything (this is today's model)    |
+
+Wealthfolio is currently at the **Obsidian** row: best DX, zero isolation. The
+Chrome model informs the Tier 2 network broker; the Figma/Snaps models inform
+the Tier 1 isolation choice. None of this requires inventing anything new.
+
+Adopt in tiers, ordered by return on effort. Tier 0 is shippable in days and
+removes most real-world impact; Tier 1 is the correct long-term isolation model;
+Tier 2 hardens supply chain and multi-tenancy.
+
+### Tier 0 — Stop the bleeding (no architecture change)
+
+1. **Strict CSP** in `tauri.conf.json` and as server response headers. The
+   critical directive is a tight `connect-src` allowlist (`'self'` +
+   `https://wealthfolio.app`) so addons cannot exfiltrate. Constrain
+   `script-src` to `'self' blob:`. Note the residual: allowing `blob:` in
+   `script-src` is what keeps the current loader working, but it also means CSP
+   does **not** constrain addon _code execution_ — only its network egress. The
+   `connect-src` allowlist is doing the real work here; full script isolation
+   waits for Tier 1. (S3)
+2. **Set `withGlobalTauri: false`** and tighten the `fs` capability scope below
+   `$APPDATA/**`. The host app doesn't use the global bridge, so this is a
+   no-app-change removal of a direct filesystem/IPC primitive from addon reach.
+   (S12)
+3. **Validate `addon_id`** with a strict regex — e.g.
+   `^[a-z0-9][a-z0-9._-]{0,63}$`, explicitly rejecting `.`-only, `..`, `/`, `\`
+   — at every service/command/route entry. (S6)
+4. **Enforce approved permissions when building `ctx.api`.** Store the granted
+   category set in the manifest; have `createAddonContext` include **only**
+   granted namespaces and return `undefined`/throw for the rest. This makes the
+   dialog meaningful without any sandbox work. (S1, partially S5)
+5. **ZIP limits + byte reads.** Cap entry count, per-file size, and total
+   uncompressed size; read entries as bytes. (S11)
+6. **Fail closed on analysis failure** — deny install, don't fall through. (S7)
+7. **De-globalize** the `__wealthfolio_*`, `React`, and `ReactDOM` handles
+   behind a non-enumerable closured accessor. (S10)
+
+### Tier 1 — Real isolation: sandboxed iframe + postMessage RPC broker
+
+Run each addon in a **sandboxed `<iframe sandbox="allow-scripts">`** (UI addons)
+or a **Web Worker** (headless), with **no direct host access**. The host exposes
+the API over `postMessage` RPC. The RPC router becomes the **single enforcement
+point**: it checks the calling addon's granted capabilities per call, validates
+arguments, and rate-limits.
+
+```
+Addon iframe                         Host SPA
+────────────                         ──────────────────────────────
+ctx.api.portfolio.getHoldings()  ──postMessage──►  RPC broker
+                                                    ├─ verify addon identity (iframe origin)
+                                                    ├─ check granted capability
+                                                    ├─ validate args
+                                                    └─ call local adapter (invoke) / HTTP
+                                     ◄──postMessage── result
+```
+
+Why this is the right model for **both** platforms:
+
+- Addon code cannot touch `window`, the Tauri IPC, secrets, or other addons.
+- Permissions are **actually enforced** at the broker — deny by capability, not
+  detected by substring. S1, S4, S5, S10, and S12 collapse into "the broker is
+  the only door" — the iframe has no `window.__TAURI__`, no `fs` plugin, and no
+  host globals.
+- Identical design in Tauri and web — the broker just dispatches to the local
+  adapter (`invoke`) or to HTTP.
+- Backend identity is solved: the broker attaches the verified addon id to every
+  brokered call, so Rust can scope secrets server-side (an addon physically
+  cannot name another addon's secret).
+
+**Layout model.** Only the _content slot_ is the iframe; the host still renders
+the sidebar, header, and routes. See §6 for the UX analysis — SPA navigation,
+toasts, and query invalidation are preserved because they already go through the
+`ctx.api` bridge; the iframe just makes that indirection explicit.
+
+**Alternative isolation mechanisms** (for reference):
+
+| Approach                | Isolation       | DX   | Notes                                                                   |
+| ----------------------- | --------------- | ---- | ----------------------------------------------------------------------- |
+| Same context (current)  | None            | Best | Addon can access `window`, crash host                                   |
+| Sandboxed iframe        | Strong DOM + JS | Good | Figma's model for plugin UI                                             |
+| Web Worker              | Strong JS       | Poor | No DOM; awkward for React UI                                            |
+| SES / Compartments      | Strong JS       | Good | MetaMask Snaps' model; same-realm, no iframe; `endo`/`ses` runtime      |
+| Separate Tauri WebView  | Process-level   | Good | Tauri supports `WebviewWindow` natively                                 |
+| Tauri Isolation Pattern | IPC broker      | Good | Native Tauri feature; sandboxed iframe validates every IPC message      |
+| ShadowRealm             | Strong JS       | Fair | TC39 proposal, stalled; **no shipping browser support** — not near-term |
+
+Recommendation: **sandboxed iframe** for UI addons (Figma model), **Web Worker**
+for headless/background addons. If a future direction wants same-realm isolation
+without an iframe (better DX for React), **SES/Compartments** is the proven path
+— it is exactly how MetaMask Snaps runs untrusted third-party plugins in a
+financial product. On the IPC side specifically, enabling Tauri's **Isolation
+Pattern** is a native, lower-effort complement that validates every
+webview→backend message through a sandboxed broker iframe.
+
+> Naming note: the repo already contains `apps/frontend/src/lockdown.ts`, but it
+> is a **UI** lockdown (disables context menu, copy/cut/select-all) and is
+> unrelated to Agoric SES `lockdown()`. Don't confuse the two when evaluating
+> the SES option.
+
+### Tier 2 — Network broker, supply chain, multi-tenancy
+
+**Network access via a host-brokered, manifest-allowlisted proxy
+(Chrome-extension model).** Rather than let addons `fetch()` freely (blocked by
+the Tier 0 CSP anyway), give them an explicit `ctx.api.http` whose requests are
+validated against a declared host allowlist and executed by the Rust backend
+(which is also CORS-free):
+
+Manifest declares network permissions:
+
+```json
+{
+  "permissions": [
+    {
+      "category": "http",
+      "hosts": [
+        "https://gdcdyn.interactivebrokers.com/*",
+        "https://www.interactivebrokers.com/*"
+      ],
+      "purpose": "Fetch Flex Query statements from IBKR API"
+    }
+  ]
+}
+```
+
+Tauri command proxies and validates:
+
+```rust
+#[tauri::command]
+async fn addon_http_request(
+    addon_id: String,          // supplied by the broker, not the addon
+    url: String,
+    method: String,
+    headers: HashMap<String, String>,
+    body: Option<String>,
+) -> Result<HttpResponse, String> {
+    let manifest = get_addon_manifest(&addon_id)?;
+    if !manifest.allows_host(&url) {
+        return Err("URL not in addon's allowed hosts".into());
+    }
+    let resp = reqwest::Client::new()
+        .request(method.parse()?, &url)
+        .headers(headers)
+        .body(body.unwrap_or_default())
+        .send().await?;
+    Ok(HttpResponse { status: resp.status().as_u16(), /* headers, body */ })
+}
+```
+
+SDK surface: `ctx.api.http.request(url, options)`. The allowed domains appear in
+the permission dialog for user transparency. This is standard Tauri plumbing;
+the design is not the hard part.
+
+**Supply chain.** Sign addon packages (publisher key), verify signature +
+integrity hash on install, and surface verified-publisher status in the dialog.
+Removes blind trust in the download channel (`download_addon_from_store`
+currently trusts TLS + backend only).
+
+**Multi-tenancy (server mode).** Namespace `addons_root` per user, or make addon
+management explicitly admin-only and document that addons run for all users.
+Make auth **mandatory** for addon mutation routes rather than silently open when
+`auth` is `None`. (S8)
+
+### Module sharing (bundle size, orthogonal to isolation)
+
+Addons currently rely on host globals for `React`/`ReactDOM`/UI. Two better
+options:
+
+- **Import maps** (browser-native): the host declares `react`,
+  `@wealthfolio/ui`, `@tanstack/react-query` → addon ESM bundles just `import`
+  them and the browser resolves to the host copy. Zero addon-side config;
+  bundles drop from ~1.8 MB to ~100–200 KB. Works cleanly with the iframe model
+  (inject the import map into the iframe document before the addon loads).
+  **WebView caveat:** import maps need a recent engine — Safari 16.4+ (macOS
+  WKWebView), a recent WebKitGTK (Linux), and any WebView2 (Windows, Chromium).
+  Older macOS/Linux system webviews silently won't resolve them, so verify the
+  minimum-supported OS/webview before relying on this. If coverage is a problem,
+  a build-time `externals` mapping to a single host-provided global is the
+  fallback (roughly what exists today, but explicit).
+- **Module Federation v2** (Rspack/Webpack): singleton negotiation at runtime;
+  powerful for large micro-frontend ecosystems but significant tooling overhead.
+  Overkill here.
+
+Recommendation: **import maps**, short term, independently of the isolation
+work.
+
+---
+
+## 6. UX analysis of the iframe model (navigation, chrome, redirects)
+
+A common concern: does sandboxing cost the SPA feel — cross-app navigation,
+redirects to native pages, toasts? For the content-slot iframe model, **almost
+nothing is lost**, because the host stays in charge of routing and chrome.
+
+**Layout.** Only the page body is the iframe:
+
+```
+┌─────────────────────────────────────────────────┐
+│  Host SPA                                        │
+│  ┌──────────┐  ┌──────────────────────────────┐ │
+│  │ Sidebar  │  │  Content area                │ │
+│  │ (host)   │  │  ┌────────────────────────┐  │ │
+│  │ nav works│  │  │  <iframe> addon body   │  │ │
+│  └──────────┘  │  └────────────────────────┘  │ │
+│                └──────────────────────────────┘ │
+└─────────────────────────────────────────────────┘
+```
+
+**Preserved for free** (already routed through `ctx.api` today): SPA navigation
+via host `<NavLink>`, `navigateToRoute`, toasts, query invalidation, layout
+chrome.
+
+**Cross-app navigation from an addon** (e.g. addon → asset detail page) works
+unchanged. The addon does not navigate itself — it _asks_ the host to navigate;
+the host owns the router:
+
+```
+Addon iframe                          Host SPA
+ctx.api.navigateToRoute('/assets/AAPL')
+   └─postMessage──►  navigate('/assets/AAPL')
+                      React Router navigates
+                      addon iframe unmounts
+                      asset detail page renders
+```
+
+The only change is the call travels through `postMessage` instead of touching
+`window.__wealthfolio_navigate__` directly — **the addon code does not change.**
+UX is identical to clicking any host link.
+
+**Needs explicit re-bridging** when moving to an iframe:
+
+| Concern                      | Today                | With iframe                                            |
+| ---------------------------- | -------------------- | ------------------------------------------------------ |
+| CSS theme vars               | shared automatically | inject into iframe document on mount + on theme change |
+| Privacy/balance-blur context | shared React context | `postMessage` on change                                |
+| Query cache                  | same `QueryClient`   | already brokered                                       |
+| Keyboard shortcuts           | app-wide             | can break at iframe boundary; delegate                 |
+| Focus management             | native               | explicit `tabindex`/focus delegation                   |
+
+CSS variables are the biggest item — inject the host's theme vars (or full
+`<style>`) into `iframe.contentDocument` on mount and whenever the theme
+changes. Figma does exactly this.
+
+**Genuinely harder cases** (only affect addons that render _outside_ their
+slot): full-app overlay modals, drag-drop crossing the iframe boundary, tooltips
+that overflow and get clipped. A full-page content addon (e.g. a dividend
+tracker) hits none of these. Provide host-brokered primitives (a
+`ctx.ui.openModal`, a toast API — already present) for the cases that need to
+escape the slot.
+
+---
+
+## 7. Prioritized remediation roadmap
+
+| Priority | Item                                                                | Addresses                | Effort   |
+| -------- | ------------------------------------------------------------------- | ------------------------ | -------- |
+| **P0**   | Strict CSP with `connect-src` allowlist                             | S3, mitigates S1/S2      | Low      |
+| **P0**   | `withGlobalTauri: false` + tighten `fs` capability scope            | S12                      | Low      |
+| **P0**   | Validate `addon_id` at every entry point                            | S6                       | Low      |
+| **P0**   | Enforce approved permissions when building `ctx.api`                | S1, part of S5           | Low–Med  |
+| **P0**   | Fail closed on permission-analysis failure                          | S7                       | Low      |
+| **P1**   | ZIP entry/size limits; read bytes not `String`                      | S11                      | Low      |
+| **P1**   | Consolidate to a single `AddonService`; delete duplicate Tauri path | §4                       | Med      |
+| **P1**   | De-globalize `__wealthfolio_*` / `React` / `ReactDOM` handles       | S10                      | Low      |
+| **P1**   | Per-user addon roots + mandatory auth (server)                      | S8                       | Med      |
+| **P1**   | Enable Tauri Isolation Pattern (IPC broker)                         | S4, S12                  | Low–Med  |
+| **P2**   | Sandboxed iframe/Worker + `postMessage` RPC broker                  | S1, S2, S4, S5, S10, S12 | High     |
+| **P2**   | Host-brokered `ctx.api.http` with manifest host allowlist           | network access           | Med      |
+| **P2**   | Package signing + verified publishers                               | S5 (trust), supply chain | Med–High |
+| **P3**   | Import maps for shared modules (bundle size)                        | DX / size                | Low–Med  |
+| **P3**   | Single source of truth for the permission table                     | §4                       | Med      |
+
+The **P0** items are small, self-contained, and independently shippable;
+together they convert the permission system from cosmetic to enforced, remove
+the direct filesystem/IPC primitive from addon reach on desktop (S12), and close
+the exfiltration and traversal holes without touching the isolation model.
+
+---
+
+## 8. Open questions
+
+1. **Is web/server mode intended for multi-user deployments?** Determines the
+   urgency of S8 (per-user addon roots vs. admin-only).
+2. **Must addons render React directly into the host tree today,** or is the
+   content-slot iframe model acceptable? This decides whether we can reach Tier
+   1 or are constrained to Tier 0/1 enforcement only.
+3. **Is there an addon store backend we control** that could host
+   signatures/publisher keys for Tier 2 signing?
+4. **What is the compatibility commitment to already-published addons?** Runtime
+   permission enforcement (P0 #3) and the iframe model (P2) are potentially
+   breaking for addons that reach outside `ctx`.

--- a/packages/addon-dev-tools/templates/addon.tsx.template
+++ b/packages/addon-dev-tools/templates/addon.tsx.template
@@ -1,4 +1,4 @@
-import React from 'react';
+import { createRoot, type Root } from 'react-dom/client';
 import type { AddonContext } from '@wealthfolio/addon-sdk';
 import { Card, CardContent, Icons } from '@wealthfolio/ui';
 
@@ -18,28 +18,34 @@ function AddonExample({ ctx }: { ctx: AddonContext }) {
 }
 
 export default function enable(ctx: AddonContext) {
+  let root: Root | null = null;
+
   // Add a sidebar item
   const sidebarItem = ctx.sidebar.addItem({
     id: '{{addonId}}',
     label: '{{addonName}}',
-    icon: <Icons.Blocks className="h-5 w-5" />,
+    icon: 'blocks',
     route: '/addon/{{addonId}}',
     order: 100,
   });
 
   // Add a route
-  const Wrapper = () => <AddonExample ctx={ctx} />;
   ctx.router.add({
     path: '/addon/{{addonId}}',
-    component: React.lazy(() => Promise.resolve({ default: Wrapper })),
+    render: ({ root: routeRoot }) => {
+      root ??= createRoot(routeRoot);
+      root.render(<AddonExample ctx={ctx} />);
+    },
   });
 
   // Cleanup on disable
   ctx.onDisable(() => {
     try {
       sidebarItem.remove();
+      root?.unmount();
+      root = null;
     } catch (err) {
-      ctx.api.logger.error('Failed to remove sidebar item:', err);
+      ctx.api.logger.error(`Failed to remove sidebar item: ${String(err)}`);
     }
   });
 }

--- a/packages/addon-dev-tools/templates/manifest.json.template
+++ b/packages/addon-dev-tools/templates/manifest.json.template
@@ -21,8 +21,8 @@
   "permissions": [
     {
       "category": "ui",
-      "functions": ["sidebar.addItem"],
-      "purpose": "Add navigation items to the sidebar"
+      "functions": ["sidebar.addItem", "router.add"],
+      "purpose": "Add navigation items and pages"
     }
   ],
   "keywords": ["wealthfolio", "addon"],

--- a/packages/addon-dev-tools/templates/manifest.json.template
+++ b/packages/addon-dev-tools/templates/manifest.json.template
@@ -5,8 +5,19 @@
   "description": "{{description}}",
   "author": "{{author}}",
   "main": "dist/addon.js",
-  "sdkVersion": "1.0.0",
+  "sdkVersion": "3.6.0",
+  "minWealthfolioVersion": "3.6.0",
   "enabled": true,
+  "hostDependencies": {
+    "@tanstack/react-query": "^5.90.0",
+    "@wealthfolio/addon-sdk": "^3.6.0",
+    "@wealthfolio/ui": "^3.6.0",
+    "date-fns": "^4.1.0",
+    "lucide-react": "^0.561.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "recharts": "^3.7.0"
+  },
   "permissions": [
     {
       "category": "ui",

--- a/packages/addon-dev-tools/templates/package.json.template
+++ b/packages/addon-dev-tools/templates/package.json.template
@@ -11,7 +11,7 @@
     "dev": "vite build --watch",
     "dev:server": "wealthfolio dev",
     "clean": "rm -rf dist",
-    "package": "mkdir -p dist && zip -r dist/$npm_package_name-$npm_package_version.zip manifest.json dist/ assets/ README.md",
+    "package": "mkdir -p dist && find dist -name '*.map' -delete && zip -r dist/$npm_package_name-$npm_package_version.zip manifest.json dist/ assets/ README.md -x '*.map'",
     "bundle": "pnpm clean && pnpm build && pnpm package",
     "lint": "tsc --noEmit",
     "type-check": "tsc --noEmit"
@@ -29,7 +29,6 @@
     "@types/react": "^19.1.1",
     "@types/react-dom": "^19.1.1",
     "@vitejs/plugin-react": "^5.0.2",
-    "rollup-plugin-external-globals": "^0.13.0",
     "tailwindcss": "^4.1.13",
     "typescript": "^5.9.2",
     "vite": "^7.1.5"

--- a/packages/addon-dev-tools/templates/package.json.template
+++ b/packages/addon-dev-tools/templates/package.json.template
@@ -16,19 +16,31 @@
     "lint": "tsc --noEmit",
     "type-check": "tsc --noEmit"
   },
-  "dependencies": {
-    "@wealthfolio/addon-sdk": "^2.0.0",
-    "@wealthfolio/ui": "^2.0.0",
-    "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+  "peerDependencies": {
+    "@tanstack/react-query": "^5.90.0",
+    "@wealthfolio/addon-sdk": "^3.6.0",
+    "@wealthfolio/ui": "^3.6.0",
+    "date-fns": "^4.1.0",
+    "lucide-react": "^0.561.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "recharts": "^3.7.0"
   },
   "devDependencies": {
+    "@tanstack/react-query": "^5.90.20",
     "@tailwindcss/vite": "^4.1.13",
-    "@wealthfolio/addon-dev-tools": "^2.0.0",
+    "@wealthfolio/addon-dev-tools": "^3.6.0",
+    "@wealthfolio/addon-sdk": "^3.6.0",
+    "@wealthfolio/ui": "^3.6.0",
     "@types/node": "^20.0.0",
-    "@types/react": "^19.1.1",
-    "@types/react-dom": "^19.1.1",
+    "@types/react": "^19.2.13",
+    "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.0.2",
+    "date-fns": "^4.1.0",
+    "lucide-react": "^0.561.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "recharts": "^3.7.0",
     "tailwindcss": "^4.1.13",
     "typescript": "^5.9.2",
     "vite": "^7.1.5"

--- a/packages/addon-dev-tools/templates/vite.config.ts.template
+++ b/packages/addon-dev-tools/templates/vite.config.ts.template
@@ -1,7 +1,6 @@
 import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
-import externalGlobals from 'rollup-plugin-external-globals';
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
@@ -13,21 +12,6 @@ export default defineConfig({
       entry: 'src/addon.tsx',
       fileName: () => 'addon.js',
       formats: ['es'],
-    },
-    rollupOptions: {
-      external: ['react', 'react-dom'],
-      plugins: [
-        externalGlobals({
-          react: 'React',
-          'react-dom': 'ReactDOM'
-        })
-      ],
-      output: {
-        globals: {
-          react: 'React',
-          'react-dom': 'ReactDOM',
-        },
-      },
     },
     outDir: 'dist',
     minify: false,

--- a/packages/addon-dev-tools/templates/vite.config.ts.template
+++ b/packages/addon-dev-tools/templates/vite.config.ts.template
@@ -2,6 +2,29 @@ import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
 
+const hostProvidedDependencies = [
+  '@tanstack/react-query',
+  '@wealthfolio/addon-sdk',
+  '@wealthfolio/addon-sdk/goal-progress',
+  '@wealthfolio/addon-sdk/host-api',
+  '@wealthfolio/addon-sdk/host-dependencies',
+  '@wealthfolio/addon-sdk/manifest',
+  '@wealthfolio/addon-sdk/permissions',
+  '@wealthfolio/addon-sdk/query-keys',
+  '@wealthfolio/addon-sdk/types',
+  '@wealthfolio/addon-sdk/utils',
+  '@wealthfolio/ui',
+  '@wealthfolio/ui/chart',
+  'date-fns',
+  'lucide-react',
+  'react',
+  'react-dom',
+  'react-dom/client',
+  'react/jsx-dev-runtime',
+  'react/jsx-runtime',
+  'recharts',
+];
+
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   define: {
@@ -14,8 +37,11 @@ export default defineConfig({
       formats: ['es'],
     },
     outDir: 'dist',
-    minify: false,
+    minify: true,
     sourcemap: false,
+    rollupOptions: {
+      external: hostProvidedDependencies,
+    },
     watch: {
       // Watch mode options for better hot reloading
       include: ['src/**'],

--- a/packages/addon-sdk/README.md
+++ b/packages/addon-sdk/README.md
@@ -258,11 +258,11 @@ const enable: AddonEnableFunction = (context) => {
   const addedItems: Array<{ remove: () => void }> = [];
 
   try {
-    // Add sidebar navigation item with icon from UI library
+    // Add sidebar navigation item with a host-supported icon token
     const sidebarItem = context.sidebar.addItem({
       id: 'investment-fees-tracker',
       label: 'Fee Tracker',
-      icon: <Icons.Invoice className="h-5 w-5" />,
+      icon: 'receipt',
       route: '/addons/investment-fees-tracker',
       order: 200
     });
@@ -726,7 +726,8 @@ Add an item to the application sidebar.
 
 - `config.id` (string): Unique identifier
 - `config.label` (string): Display text
-- `config.icon` (string | ReactNode): Icon name or component
+- `config.icon` (string): Host-supported icon token, such as `receipt`,
+  `chart-bar`, or `calendar-dots`
 - `config.route` (string): Navigation route
 - `config.order` (number): Display order (optional)
 - `config.onClick` (function): Click handler (optional)

--- a/packages/addon-sdk/package.json
+++ b/packages/addon-sdk/package.json
@@ -14,9 +14,33 @@
       "import": "./dist/types.js",
       "types": "./dist/src/types.d.ts"
     },
+    "./host-api": {
+      "import": "./dist/host-api.js",
+      "types": "./dist/src/host-api.d.ts"
+    },
+    "./host-dependencies": {
+      "import": "./dist/host-dependencies.js",
+      "types": "./dist/src/host-dependencies.d.ts"
+    },
+    "./manifest": {
+      "import": "./dist/manifest.js",
+      "types": "./dist/src/manifest.d.ts"
+    },
     "./permissions": {
       "import": "./dist/permissions.js",
       "types": "./dist/src/permissions.d.ts"
+    },
+    "./query-keys": {
+      "import": "./dist/query-keys.js",
+      "types": "./dist/src/query-keys.d.ts"
+    },
+    "./utils": {
+      "import": "./dist/utils.js",
+      "types": "./dist/src/utils.d.ts"
+    },
+    "./goal-progress": {
+      "import": "./dist/goal-progress.js",
+      "types": "./dist/src/goal-progress.d.ts"
     }
   },
   "files": [

--- a/packages/addon-sdk/src/host-api.ts
+++ b/packages/addon-sdk/src/host-api.ts
@@ -722,6 +722,32 @@ export interface QueryAPI {
   refetchQueries(queryKey: string | string[]): void;
 }
 
+export interface NetworkRequest {
+  url: string;
+  method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD';
+  headers?: Record<string, string>;
+  body?: string;
+  auth?: NetworkAuth;
+}
+
+export interface NetworkResponse {
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+}
+
+export interface NetworkAuth {
+  type: 'bearer';
+  secretKey: string;
+}
+
+export interface NetworkAPI {
+  /**
+   * Send a brokered HTTPS request to a host declared in the addon manifest.
+   */
+  request(request: NetworkRequest): Promise<NetworkResponse>;
+}
+
 /**
  * Snapshot management APIs
  * For accounts using HOLDINGS tracking mode
@@ -804,6 +830,9 @@ export interface HostAPI {
 
   /** React Query operations */
   query: QueryAPI;
+
+  /** Brokered external network operations */
+  network: NetworkAPI;
 
   /** Toast notification operations */
   toast: ToastAPI;

--- a/packages/addon-sdk/src/host-dependencies.ts
+++ b/packages/addon-sdk/src/host-dependencies.ts
@@ -1,0 +1,10 @@
+export const HOST_DEPENDENCIES = {
+  '@tanstack/react-query': '^5.90.0',
+  '@wealthfolio/addon-sdk': '^3.6.0',
+  '@wealthfolio/ui': '^3.6.0',
+  'date-fns': '^4.1.0',
+  'lucide-react': '^0.561.0',
+  react: '^19.2.0',
+  'react-dom': '^19.2.0',
+  recharts: '^3.7.0',
+} as const;

--- a/packages/addon-sdk/src/index.ts
+++ b/packages/addon-sdk/src/index.ts
@@ -13,6 +13,9 @@
 export type {
   AddonContext,
   AddonEnableFunction,
+  AddonRouteLocation,
+  AddonRouteRenderContext,
+  AddonRouteRenderer,
   EventCallback,
   RouteConfig,
   RouterManager,
@@ -27,6 +30,10 @@ export type {
   ActivitySearchFilters,
   ActivitySort,
   HostAPI,
+  NetworkAuth,
+  NetworkAPI,
+  NetworkRequest,
+  NetworkResponse,
   SnapshotsAPI,
   ToastAPI,
   DividendEvent,
@@ -85,35 +92,24 @@ export {
 // Goal progress calculation
 export { calculateGoalProgress } from './goal-progress';
 
-// -----------------------------------------------------------------------------
-// Framework version contract
-// -----------------------------------------------------------------------------
-
 /**
- * React version guaranteed by the host application. Addons may assert against
- * this at runtime if they rely on a particular React feature set.
+ * React version used by the Wealthfolio add-on template. Add-ons run in a
+ * sandboxed iframe and must bundle their own React runtime instead of reading
+ * React from the host window.
  */
 export const ReactVersion = '19.1.1';
 
 /**
  * Addons receive their context as a parameter to the enable() function.
- * Each addon gets its own isolated context with scoped secret storage.
+ * Each addon gets its own isolated iframe context with scoped host APIs.
  *
  * Example:
  * export default function enable(ctx: AddonContext) {
  *   // Use ctx.api.secrets.set/get/delete for secure storage
  *   // Use ctx.sidebar.addItem() to add navigation
- *   // Use ctx.router.add() to register routes
+ *   // Use ctx.router.add() with a render callback to register routes
  * }
  */
-
-interface HostGlobals {
-  React: typeof import('react');
-  ReactDOM: typeof import('react-dom');
-}
-const hostGlobals = window as unknown as Partial<HostGlobals>;
-export const React = hostGlobals.React!;
-export const ReactDOM = hostGlobals.ReactDOM!;
 
 // Version
 export { SDK_VERSION } from './version';

--- a/packages/addon-sdk/src/index.ts
+++ b/packages/addon-sdk/src/index.ts
@@ -50,6 +50,7 @@ export type * from './data-types';
 // Manifest and metadata types
 export type {
   AddonFile,
+  AddonHostDependencies,
   AddonInstallResult,
   AddonManifest,
   AddonStoreListing,
@@ -93,11 +94,12 @@ export {
 export { calculateGoalProgress } from './goal-progress';
 
 /**
- * React version used by the Wealthfolio add-on template. Add-ons run in a
- * sandboxed iframe and must bundle their own React runtime instead of reading
- * React from the host window.
+ * React version provided by the Wealthfolio add-on sandbox for host-externalized
+ * add-ons.
  */
-export const ReactVersion = '19.1.1';
+export const ReactVersion = '19.2.4';
+
+export { HOST_DEPENDENCIES } from './host-dependencies';
 
 /**
  * Addons receive their context as a parameter to the enable() function.

--- a/packages/addon-sdk/src/manifest.ts
+++ b/packages/addon-sdk/src/manifest.ts
@@ -4,6 +4,11 @@
 
 import type { Permission } from './permissions';
 
+export interface AddonNetworkAccess {
+  allowedHosts: string[];
+  approvedHosts?: string[];
+}
+
 /**
  * Unified addon manifest structure that handles both development and runtime scenarios
  * This represents both what developers write in their manifest.json and installed addon metadata
@@ -40,6 +45,8 @@ export interface AddonManifest {
   keywords?: string[];
   /** Addon icon (base64 or relative path) */
   icon?: string;
+  /** Network hosts this addon may reach through the host broker */
+  network?: AddonNetworkAccess;
 
   // Runtime fields (only present after installation)
   /** Installation timestamp in ISO format */
@@ -154,6 +161,8 @@ export interface AddonUpdateInfo {
   updateAvailable: boolean;
   /** Download URL for the update */
   downloadUrl?: string;
+  /** Optional SHA-256 digest for the update package bytes */
+  sha256?: string;
   /** Release notes for the latest version */
   releaseNotes?: string;
   /** Release date of the latest version */
@@ -188,6 +197,8 @@ export interface AddonStoreListing {
   metadata: AddonManifest;
   /** Download URL */
   downloadUrl: string;
+  /** Optional SHA-256 digest for the package bytes */
+  sha256?: string;
   /** Number of downloads */
   downloads?: number;
   /** Average rating */

--- a/packages/addon-sdk/src/manifest.ts
+++ b/packages/addon-sdk/src/manifest.ts
@@ -9,6 +9,8 @@ export interface AddonNetworkAccess {
   approvedHosts?: string[];
 }
 
+export type AddonHostDependencies = Record<string, string>;
+
 /**
  * Unified addon manifest structure that handles both development and runtime scenarios
  * This represents both what developers write in their manifest.json and installed addon metadata
@@ -47,6 +49,8 @@ export interface AddonManifest {
   icon?: string;
   /** Network hosts this addon may reach through the host broker */
   network?: AddonNetworkAccess;
+  /** Host-provided packages this addon imports instead of bundling */
+  hostDependencies?: AddonHostDependencies;
 
   // Runtime fields (only present after installation)
   /** Installation timestamp in ISO format */

--- a/packages/addon-sdk/src/permissions.ts
+++ b/packages/addon-sdk/src/permissions.ts
@@ -219,7 +219,7 @@ export const PERMISSION_CATEGORIES: PermissionCategory[] = [
     id: 'ui',
     name: 'User Interface',
     description: 'Access to modify navigation and add UI components',
-    functions: ['sidebar.addItem', 'router.add', 'navigation.navigate'],
+    functions: ['sidebar.addItem', 'router.add', 'navigation.navigate', 'onDisable'],
     riskLevel: 'low',
   },
 ];

--- a/packages/addon-sdk/src/permissions.ts
+++ b/packages/addon-sdk/src/permissions.ts
@@ -167,7 +167,7 @@ export const PERMISSION_CATEGORIES: PermissionCategory[] = [
     id: 'secrets',
     name: 'Secrets Management',
     description: 'Access to secure storage for addon secrets',
-    functions: ['set', 'get', 'delete'],
+    functions: ['set', 'get', 'use', 'delete'],
     riskLevel: 'high',
   },
   {
@@ -201,10 +201,25 @@ export const PERMISSION_CATEGORIES: PermissionCategory[] = [
     riskLevel: 'low',
   },
   {
+    id: 'query',
+    name: 'Query Cache',
+    description: 'Access to refresh host application data',
+    functions: ['invalidateQueries', 'refetchQueries'],
+    riskLevel: 'low',
+  },
+  {
+    id: 'network',
+    name: 'Network Access',
+    description:
+      'Access to declared external HTTPS hosts through the host network broker',
+    functions: ['request'],
+    riskLevel: 'high',
+  },
+  {
     id: 'ui',
     name: 'User Interface',
     description: 'Access to modify navigation and add UI components',
-    functions: ['sidebar.addItem', 'router.add'],
+    functions: ['sidebar.addItem', 'router.add', 'navigation.navigate'],
     riskLevel: 'low',
   },
 ];

--- a/packages/addon-sdk/src/types.ts
+++ b/packages/addon-sdk/src/types.ts
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { HostAPI } from './host-api';
 
 /**
@@ -21,24 +20,51 @@ export interface SidebarItemConfig {
   id: string;
   /** Display text for the sidebar item */
   label: string;
-  /** Optional icon name or React component */
-  icon?: string | React.ReactNode;
+  /** Optional host-supported icon name */
+  icon?: string;
   /** Optional route to navigate to when clicked */
   route?: string;
   /** Optional ordering priority (lower numbers appear first) */
   order?: number;
-  /** Optional click handler (if no route provided) */
-  onClick?: () => void;
 }
+
+/**
+ * Route location supplied by the host when an addon route is rendered.
+ */
+export interface AddonRouteLocation {
+  pathname: string;
+  search: string;
+  hash: string;
+  params: Record<string, string | undefined>;
+}
+
+/**
+ * Context supplied to addon route render functions.
+ */
+export interface AddonRouteRenderContext {
+  root: HTMLElement;
+  location: AddonRouteLocation;
+}
+
+/**
+ * Render callback for iframe-hosted addon routes.
+ */
+export type AddonRouteRenderer = (
+  context: AddonRouteRenderContext,
+) => void | Promise<void>;
 
 /**
  * Configuration for adding a route
  */
 export interface RouteConfig {
+  /** Optional stable route identifier */
+  id?: string;
   /** Route path pattern */
   path: string;
-  /** Lazy-loaded React component */
-  component: React.LazyExoticComponent<React.ComponentType<unknown>>;
+  /** Optional label for diagnostics */
+  title?: string;
+  /** Render inside the addon's sandboxed iframe */
+  render: AddonRouteRenderer;
 }
 
 /**
@@ -78,6 +104,11 @@ export type UnlistenFn = () => void;
  * Main addon context interface providing access to Wealthfolio APIs
  */
 export interface AddonContext {
+  /** UI primitives owned by the addon's sandboxed iframe */
+  ui: {
+    /** Root element for addon-rendered content */
+    root: HTMLElement;
+  };
   /** Sidebar management */
   sidebar: SidebarManager;
   /** Router management */

--- a/packages/addon-sdk/src/utils.ts
+++ b/packages/addon-sdk/src/utils.ts
@@ -3,6 +3,7 @@
  */
 
 import type { AddonManifest, AddonValidationResult } from './manifest';
+import { HOST_DEPENDENCIES } from './host-dependencies';
 import { SDK_VERSION } from './version';
 
 /**
@@ -40,6 +41,19 @@ export function validateManifest(manifest: AddonManifest): AddonValidationResult
 
   if (!manifest.main) {
     warnings.push('Main entry point not specified, defaulting to "addon.js"');
+  }
+
+  if (manifest.hostDependencies) {
+    Object.entries(manifest.hostDependencies).forEach(([name, version]) => {
+      if (!version) {
+        errors.push(`Host dependency ${name}: version range is required`);
+      }
+      if (!Object.prototype.hasOwnProperty.call(HOST_DEPENDENCIES, name)) {
+        warnings.push(
+          `Host dependency ${name} is not provided by Wealthfolio and should be bundled`,
+        );
+      }
+    });
   }
 
   // Validate permissions if present

--- a/packages/addon-sdk/tsup.config.ts
+++ b/packages/addon-sdk/tsup.config.ts
@@ -2,9 +2,15 @@ import { defineConfig } from 'tsup';
 
 export default defineConfig({
   entry: {
+    'goal-progress': 'src/goal-progress.ts',
+    'host-dependencies': 'src/host-dependencies.ts',
+    'host-api': 'src/host-api.ts',
     index: 'src/index.ts',
-    types: 'src/types.ts',
+    manifest: 'src/manifest.ts',
     permissions: 'src/permissions.ts',
+    'query-keys': 'src/query-keys.ts',
+    types: 'src/types.ts',
+    utils: 'src/utils.ts',
   },
   format: ['esm'],
   dts: false,

--- a/packages/ui/src/components/ui/icons.tsx
+++ b/packages/ui/src/components/ui/icons.tsx
@@ -176,6 +176,7 @@ import {
 import type { ComponentType, CSSProperties } from "react";
 
 // Phosphor icons - deep imports for optimal tree shaking with Vite
+import { CalendarDotsIcon } from "@phosphor-icons/react/dist/csr/CalendarDots";
 import { CarProfileIcon } from "@phosphor-icons/react/dist/csr/CarProfile";
 import { ClockCounterClockwiseIcon } from "@phosphor-icons/react/dist/csr/ClockCounterClockwise";
 import { CoinsIcon } from "@phosphor-icons/react/dist/csr/Coins";
@@ -188,6 +189,8 @@ import { EyeIcon } from "@phosphor-icons/react/dist/csr/Eye";
 import { EyeSlashIcon } from "@phosphor-icons/react/dist/csr/EyeSlash";
 import { GarageIcon } from "@phosphor-icons/react/dist/csr/Garage";
 import { HouseIcon } from "@phosphor-icons/react/dist/csr/House";
+import { PuzzlePieceIcon } from "@phosphor-icons/react/dist/csr/PuzzlePiece";
+import { ReceiptIcon } from "@phosphor-icons/react/dist/csr/Receipt";
 import { SketchLogoIcon } from "@phosphor-icons/react/dist/csr/SketchLogo";
 import { SparkleIcon } from "@phosphor-icons/react/dist/csr/Sparkle";
 import { TagIcon } from "@phosphor-icons/react/dist/csr/Tag";
@@ -715,6 +718,15 @@ const IconsInternal = {
   ),
 
   // Phosphor icons
+  CalendarDots: ({ size, className, style, color }: IconProps) => (
+    <CalendarDotsIcon size={size} weight="duotone" className={className} style={style} color={color} />
+  ),
+  PuzzlePiece: ({ size, className, style, color }: IconProps) => (
+    <PuzzlePieceIcon size={size} weight="regular" className={className} style={style} color={color} />
+  ),
+  ReceiptDuotone: ({ size, className, style, color }: IconProps) => (
+    <ReceiptIcon size={size} weight="duotone" className={className} style={style} color={color} />
+  ),
   Devices: ({ size, className, style, color }: IconProps) => (
     <DevicesIcon size={size} weight="duotone" className={className} style={style} color={color} />
   ),
@@ -894,10 +906,12 @@ export type IconName =
   | "ArrowRightLeft"
   | "ArrowLeftRight"
   | "Receipt"
+  | "ReceiptDuotone"
   | "ReceiptText"
   | "Percent"
   | "Store"
   | "Package"
+  | "PuzzlePiece"
   | "Star"
   | "Shield"
   | "ShieldAlert"
@@ -950,6 +964,7 @@ export type IconName =
   | "UserSwitch"
   // Additional icons for UI components
   | "Baseline"
+  | "CalendarDots"
   | "CalendarIcon"
   | "CaseSensitive"
   | "CheckSquare"


### PR DESCRIPTION
## Summary

- harden the add-on sandbox/runtime path with brokered route rendering, theme propagation, CSS asset support, and host-owned loading/error states
- refine add-on navigation across sidebar, floating, mobile, and settings pin controls
- add sandbox style/theme tests and document the updated SDK expectations

## Why

The add-on iframe flow could flash a light/blank page during route changes, lose styling when add-ons shipped extracted CSS, and had inconsistent navigation/pinning behavior across desktop and mobile surfaces.

## Validation

- `pnpm lint`
- `pnpm --filter frontend type-check`
- `pnpm --filter frontend test src/addons/iframe/addon-sandbox-theme.test.ts --run`
