### PR TITLE
fix(addons): load web addons after login so sidebar items appear

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,15 +1,34 @@
 import { isWeb } from "@/adapters";
 import { setAddonQueryClient } from "@/addons/addons-runtime-context";
-import { AuthGate, AuthProvider } from "@/context/auth-context";
+import { loadAllAddons } from "@/addons/addons-loader";
+import { AuthGate, AuthProvider, useAuth } from "@/context/auth-context";
 import { EventDialogProvider } from "@/features/spending/components/event-dialog-provider";
 import { WealthfolioConnectProvider } from "@/features/wealthfolio-connect";
 import { SettingsProvider } from "@/lib/settings-provider";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@wealthfolio/ui";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { PrivacyProvider } from "./context/privacy-context";
 import { LoginPage } from "./pages/auth/login-page";
 import { AppRoutes } from "./routes";
+
+// In web mode, addon discovery requires an authenticated session, so addons
+// cannot be loaded at startup (see main.tsx). This loads them once the session
+// is authenticated. Desktop loads at startup and is handled in main.tsx.
+function AddonRuntimeLoader() {
+  const { isAuthenticated } = useAuth();
+  const loadedRef = useRef(false);
+
+  useEffect(() => {
+    if (!isWeb || !isAuthenticated || loadedRef.current) {
+      return;
+    }
+    loadedRef.current = true;
+    void loadAllAddons();
+  }, [isAuthenticated]);
+
+  return null;
+}
 
 function App() {
   const [queryClient] = useState(
@@ -40,6 +59,7 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <AuthProvider>
+        <AddonRuntimeLoader />
         <WealthfolioConnectProvider>
           <PrivacyProvider>
             <SettingsProvider>

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -32,8 +32,12 @@ if (import.meta.env.DEV) {
   });
 }
 
-// Load addons after context is injected
-loadAllAddons();
+// Load addons after context is injected. On web, addon discovery requires an
+// authenticated session, so loading is deferred until after login (handled by
+// AddonRuntimeLoader in App). On desktop there is no auth gate, so load now.
+if (isDesktop) {
+  loadAllAddons();
+}
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>


### PR DESCRIPTION
## Description

### Problem
In web mode, installed add-ons don't show up in the sidebar after logging in. The only workaround is to open Settings and disable/re-enable an add-on, after which the Add-ons nav item appears.

### Root cause

Addon discovery in web mode **requires an authenticated session**, but **add-ons were loaded before login**:

1. main.tsx called `loadAllAddons()` at module-load time — before the user authenticates.
2. In web mode this hits list_installed_addons, which the server rejects with no auth cookie. `discoverAddons()` catches the error and returns [], so no sidebar items get registered.
3. After login, AppRoutes mount and the sidebar reads `getDynamicNavItems()` → empty. Nothing re-triggers the load.
4. Toggling an add-on in Settings runs `reloadAllAddons()` while authenticated → add-ons load → nav items register. That's why the workaround "fixes" it.

Desktop is unaffected: there's no auth gate and Tauri's list_installed_addons needs no auth, so the startup load already works there.

### Fix

- main.tsx — gate the eager startup load to isDesktop (desktop behavior unchanged).
- App.tsx — add a web-only AddonRuntimeLoader that calls loadAllAddons() once isAuthenticated becomes true. A useRef guard makes it load exactly once and keeps it StrictMode-safe.

Covers all cases:

- Desktop → loads at startup (via main.tsx).
- Web with password/OIDC → loads right after login.
- Web with no auth required → isAuthenticated is true immediately, so it loads on mount.


## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
