### PR TITLE
Mobile activity form parity, dashboard chart backdrop, and a11y fixes

### DIFF
--- a/apps/frontend/src/addons/addon-runtime-loader.test.tsx
+++ b/apps/frontend/src/addons/addon-runtime-loader.test.tsx
@@ -1,0 +1,73 @@
+import { render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AddonRuntimeLoader } from "./addon-runtime-loader";
+
+const authMock = vi.hoisted(() => ({
+  state: {
+    isAuthenticated: false,
+    statusLoading: false,
+  },
+}));
+
+const addonLoaderMock = vi.hoisted(() => ({
+  loadAllAddons: vi.fn(),
+}));
+
+vi.mock("@/context/auth-context", () => ({
+  useAuth: () => authMock.state,
+}));
+
+vi.mock("./addons-loader", () => ({
+  loadAllAddons: addonLoaderMock.loadAllAddons,
+}));
+
+describe("AddonRuntimeLoader", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authMock.state = {
+      isAuthenticated: false,
+      statusLoading: false,
+    };
+    addonLoaderMock.loadAllAddons.mockResolvedValue(undefined);
+  });
+
+  it("loads once after auth status resolves and authentication is ready", async () => {
+    const { rerender } = render(<AddonRuntimeLoader />);
+
+    expect(addonLoaderMock.loadAllAddons).not.toHaveBeenCalled();
+
+    authMock.state = {
+      isAuthenticated: true,
+      statusLoading: true,
+    };
+    rerender(<AddonRuntimeLoader />);
+
+    expect(addonLoaderMock.loadAllAddons).not.toHaveBeenCalled();
+
+    authMock.state = {
+      isAuthenticated: false,
+      statusLoading: false,
+    };
+    rerender(<AddonRuntimeLoader />);
+
+    expect(addonLoaderMock.loadAllAddons).not.toHaveBeenCalled();
+
+    authMock.state = {
+      isAuthenticated: true,
+      statusLoading: false,
+    };
+    rerender(<AddonRuntimeLoader />);
+
+    await waitFor(() => {
+      expect(addonLoaderMock.loadAllAddons).toHaveBeenCalledTimes(1);
+    });
+
+    authMock.state = {
+      isAuthenticated: true,
+      statusLoading: false,
+    };
+    rerender(<AddonRuntimeLoader />);
+
+    expect(addonLoaderMock.loadAllAddons).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/frontend/src/addons/addon-runtime-loader.tsx
+++ b/apps/frontend/src/addons/addon-runtime-loader.tsx
@@ -1,17 +1,20 @@
+import { useAuth } from "@/context/auth-context";
 import { useEffect } from "react";
 import { loadAllAddons } from "./addons-loader";
 
 let hasStartedAddonRuntime = false;
 
 export function AddonRuntimeLoader() {
+  const { isAuthenticated, statusLoading } = useAuth();
+
   useEffect(() => {
-    if (hasStartedAddonRuntime) {
+    if (statusLoading || !isAuthenticated || hasStartedAddonRuntime) {
       return;
     }
 
     hasStartedAddonRuntime = true;
     void loadAllAddons();
-  }, []);
+  }, [statusLoading, isAuthenticated]);
 
   return null;
 }

--- a/apps/frontend/src/i18n/locales/de/activity.json
+++ b/apps/frontend/src/i18n/locales/de/activity.json
@@ -644,6 +644,7 @@
     "err_transfer_amount_currencies": "Transferbetrag und Währungen sind erforderlich.",
     "err_link_before_internal": "Verwenden Sie Transfer verknüpfen..., um diesen bestehenden Transfer zu koppeln, bevor Sie ihn als intern speichern.",
     "err_internal_securities_both_legs": "Die Bearbeitung eines internen Wertpapiertransfers erfordert beide Seiten.",
+    "add_details": "Transaktionsdetails eingeben",
     "update_details": "Transaktionsdetails aktualisieren"
   },
   "table_symbol": "Symbol",

--- a/apps/frontend/src/i18n/locales/en/activity.json
+++ b/apps/frontend/src/i18n/locales/en/activity.json
@@ -749,6 +749,7 @@
     "err_transfer_amount_currencies": "Transfer amount and currencies are required.",
     "err_link_before_internal": "Use Link transfer... to pair this existing transfer before saving it as internal.",
     "err_internal_securities_both_legs": "Editing an internal securities transfer requires both legs.",
+    "add_details": "Enter the transaction details",
     "update_details": "Update transaction details"
   },
   "import": {

--- a/apps/frontend/src/i18n/locales/es/activity.json
+++ b/apps/frontend/src/i18n/locales/es/activity.json
@@ -749,6 +749,7 @@
     "err_transfer_amount_currencies": "El importe y las monedas de la transferencia son obligatorios.",
     "err_link_before_internal": "Usa Vincular transferencia... para emparejar esta transferencia existente antes de guardarla como interna.",
     "err_internal_securities_both_legs": "Editar una transferencia interna de valores requiere ambas partes.",
+    "add_details": "Introduce los detalles de la transacción",
     "update_details": "Actualizar los detalles de la transacción"
   },
   "import": {

--- a/apps/frontend/src/i18n/locales/fr/activity.json
+++ b/apps/frontend/src/i18n/locales/fr/activity.json
@@ -749,6 +749,7 @@
     "err_transfer_amount_currencies": "Le montant et les devises du transfert sont requis.",
     "err_link_before_internal": "Utilisez Lier le transfert... pour associer ce transfert existant avant de l'enregistrer comme interne.",
     "err_internal_securities_both_legs": "La modification d'un transfert de titres interne nécessite les deux volets.",
+    "add_details": "Saisissez les détails de la transaction",
     "update_details": "Mettre à jour les détails de la transaction"
   },
   "import": {

--- a/apps/frontend/src/i18n/locales/zh/activity.json
+++ b/apps/frontend/src/i18n/locales/zh/activity.json
@@ -749,6 +749,7 @@
     "err_transfer_amount_currencies": "转账金额和货币为必填项。",
     "err_link_before_internal": "请使用“关联转账……”配对此现有转账，然后再将其保存为内部转账。",
     "err_internal_securities_both_legs": "编辑内部证券转账需要转账双方。",
+    "add_details": "输入交易详情",
     "update_details": "更新交易详情"
   },
   "import": {

--- a/apps/frontend/src/pages/activity/components/forms/fields/option-contract-fields.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/fields/option-contract-fields.tsx
@@ -1,8 +1,9 @@
 import TickerSearchInput from "@/components/ticker-search";
 import { buildOccSymbol, parseOccSymbol } from "@/lib/occ-symbol";
 import type { SymbolSearchResult } from "@/lib/types";
-import { normalizeCurrency } from "@/lib/utils";
+import { cn, normalizeCurrency } from "@/lib/utils";
 import { resolveSymbolQuote } from "@/adapters";
+import { motion } from "motion/react";
 import { Input } from "@wealthfolio/ui/components/ui/input";
 import {
   DatePickerInput,
@@ -12,7 +13,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@wealthfolio/ui";
-import { useEffect, useRef } from "react";
+import { useEffect, useId, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { useFormContext, type FieldPath, type FieldValues } from "react-hook-form";
 
@@ -43,6 +44,7 @@ export function OptionContractFields<TFieldValues extends FieldValues = FieldVal
 }: OptionContractFieldsProps<TFieldValues>) {
   const { t } = useTranslation(["activity"]);
   const { control, setValue, getValues, watch } = useFormContext<TFieldValues>();
+  const optionTypeId = useId();
   const latestResolveRequestId = useRef(0);
   const needsCurrencyConfirmation = useRef(false);
   const provisionalCurrency = useRef<string | undefined>(undefined);
@@ -189,59 +191,75 @@ export function OptionContractFields<TFieldValues extends FieldValues = FieldVal
         )}
       />
 
-      {/* Call / Put — full-width toggle, prominent */}
+      {/* Call / Put — segmented control matching the Stock/Option/Bond tabs */}
       <FormField
         control={control}
         name={optionTypeName}
-        render={({ field }) => (
-          <FormItem>
-            <FormControl>
-              <div className="bg-muted grid grid-cols-2 gap-1 rounded-lg p-1">
-                <button
-                  type="button"
-                  onClick={() => field.onChange("CALL")}
-                  className={`flex cursor-pointer items-center justify-center gap-2 rounded-md py-2.5 text-sm font-medium transition-colors ${
-                    field.value === "CALL"
-                      ? "bg-background text-foreground shadow-sm"
-                      : "text-muted-foreground hover:text-foreground"
-                  }`}
-                >
-                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" className="shrink-0">
-                    <path
-                      d="M2 12L6 6L10 9L14 3"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                  {t("activity:form.option_call")}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => field.onChange("PUT")}
-                  className={`flex cursor-pointer items-center justify-center gap-2 rounded-md py-2.5 text-sm font-medium transition-colors ${
-                    field.value === "PUT"
-                      ? "bg-background text-foreground shadow-sm"
-                      : "text-muted-foreground hover:text-foreground"
-                  }`}
-                >
-                  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" className="shrink-0">
-                    <path
-                      d="M2 4L6 10L10 7L14 13"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                  {t("activity:form.option_put")}
-                </button>
-              </div>
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        )}
+        render={({ field }) => {
+          const optionTypes = [
+            {
+              value: "CALL",
+              label: t("activity:form.option_call"),
+              iconPath: "M2 12L6 6L10 9L14 3",
+            },
+            {
+              value: "PUT",
+              label: t("activity:form.option_put"),
+              iconPath: "M2 4L6 10L10 7L14 13",
+            },
+          ] as const;
+          return (
+            <FormItem>
+              <FormControl>
+                <div className="bg-muted relative flex items-center gap-1 rounded-lg p-1">
+                  {optionTypes.map((option) => {
+                    const isSelected = field.value === option.value;
+                    return (
+                      <button
+                        key={option.value}
+                        type="button"
+                        onClick={() => field.onChange(option.value)}
+                        className={cn(
+                          "relative z-10 flex flex-1 cursor-pointer select-none items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors",
+                          "focus-visible:ring-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+                          isSelected
+                            ? "text-foreground"
+                            : "text-muted-foreground hover:text-foreground",
+                        )}
+                      >
+                        {isSelected && (
+                          <motion.div
+                            layoutId={`option-type-indicator-${optionTypeId}`}
+                            className="bg-background absolute inset-0 -z-10 rounded-md shadow-sm"
+                            initial={false}
+                            transition={{ type: "spring", stiffness: 400, damping: 30 }}
+                          />
+                        )}
+                        <svg
+                          width="16"
+                          height="16"
+                          viewBox="0 0 16 16"
+                          fill="none"
+                          className="shrink-0"
+                        >
+                          <path
+                            d={option.iconPath}
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                        </svg>
+                        <span>{option.label}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          );
+        }}
       />
 
       {/* Strike Price + Expiration Date */}

--- a/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
@@ -217,6 +217,13 @@ function validateTradeFields(
     if (!data.optionType) {
       return { field: "optionType", message: t("activity:form.err_option_type_required") };
     }
+    // Require an explicit Open/Close choice — matches the desktop option form.
+    if (
+      data.subtype !== ACTIVITY_SUBTYPES.POSITION_OPEN &&
+      data.subtype !== ACTIVITY_SUBTYPES.POSITION_CLOSE
+    ) {
+      return { field: "subtype", message: t("activity:form.err_open_or_close") };
+    }
   } else {
     if (!(data.assetId as string)?.trim()) {
       return { field: "assetId", message: t("activity:form.err_select_security") };

--- a/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/mobile-activity-form.tsx
@@ -863,8 +863,14 @@ export function MobileActivityForm({
                 ))}
               </div>
             )}
-            {activity?.id && (
+            {activity?.id ? (
               <SheetDescription>{t("activity:mobile_form.update_details")}</SheetDescription>
+            ) : (
+              // Always describe the dialog for a11y; the add flow shows step dots
+              // instead of visible description text, so keep it screen-reader only.
+              <SheetDescription className="sr-only">
+                {t("activity:mobile_form.add_details")}
+              </SheetDescription>
             )}
           </div>
         </SheetHeader>

--- a/apps/frontend/src/pages/activity/components/mobile-forms/mobile-details-step.tsx
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/mobile-details-step.tsx
@@ -9,6 +9,8 @@ import {
   SymbolSearch,
   AssetTypeSelector,
   OptionContractFields,
+  PositionIntentSelector,
+  StockTradeIntentSelector,
   type AssetType,
   type AccountSelectOption,
 } from "../forms/fields";
@@ -284,6 +286,9 @@ export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileD
       setValue("quoteMode" as any, QuoteMode.MARKET);
       setValue("assetKind" as any, undefined);
     }
+    // Reset the trade intent (Sell Short / Buy to Cover / option Open-Close) so
+    // a stale subtype never carries across asset types.
+    setValue("subtype" as any, null);
     setValue("assetId" as any, "");
     setValue("existingAssetId" as any, undefined);
     setValue("exchangeMic" as any, undefined);
@@ -755,6 +760,20 @@ export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileD
 
           {hasValueFields && (
             <FormSection title={detailsTitle}>
+              {/* Trade intent — Sell/Sell Short (stock), Open/Close (option). Bonds have none. */}
+              {isBuyOrSell && !isBond && (
+                <div className="-mt-1">
+                  {isOption ? (
+                    <PositionIntentSelector control={control as any} name={"subtype" as any} />
+                  ) : (
+                    <StockTradeIntentSelector
+                      control={control as any}
+                      name={"subtype" as any}
+                      side={activityType === ActivityType.SELL ? "sell" : "buy"}
+                    />
+                  )}
+                </div>
+              )}
               {/* Quantity and Unit Price */}
               {needsQuantity && (
                 <>

--- a/apps/frontend/src/pages/activity/components/mobile-forms/mobile-details-step.tsx
+++ b/apps/frontend/src/pages/activity/components/mobile-forms/mobile-details-step.tsx
@@ -444,7 +444,8 @@ export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileD
         : t("activity:form.label_price");
 
   // Toggle shown in the "Asset & Account" card header: transfer mode for
-  // transfers, asset type (Stock/Option/Bond) for buy/sell.
+  // transfers. Asset type (Stock/Option/Bond) renders as a full-width row
+  // inside the section instead (see below).
   const headerAction = isTransfer ? (
     <AnimatedToggleGroup
       items={transferModeItems}
@@ -453,13 +454,18 @@ export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileD
       size="sm"
       rounded="lg"
     />
-  ) : isBuyOrSell && !isEditing ? (
-    <AssetTypeSelector
-      control={control as any}
-      name={"assetType" as any}
-      onValueChange={handleAssetTypeChange}
-    />
   ) : null;
+
+  // Stock/Option/Bond selector — full-width segmented control on mobile.
+  const assetTypeSelector =
+    isBuyOrSell && !isEditing ? (
+      <AssetTypeSelector
+        control={control as any}
+        name={"assetType" as any}
+        onValueChange={handleAssetTypeChange}
+        className="w-full"
+      />
+    ) : null;
 
   const detailsTitle = isBuyOrSell
     ? t("activity:form.section_trade")
@@ -524,6 +530,7 @@ export function MobileDetailsStep({ accounts, activityType, isEditing }: MobileD
       <ScrollArea>
         <div className="form-mobile-spacing pb-4">
           <FormSection title={t("activity:form.section_asset_account")} action={headerAction}>
+            {assetTypeSelector}
             {/* External checkbox + direction (transfers) */}
             {isTransfer && (
               <div className="flex items-center gap-4">

--- a/apps/frontend/src/pages/dashboard/dashboard-content.tsx
+++ b/apps/frontend/src/pages/dashboard/dashboard-content.tsx
@@ -242,8 +242,8 @@ export function DashboardContent() {
       <div
         className={`bg-linear-to-t flex grow flex-col ${
           isNegative
-            ? "from-destructive/30 via-destructive/15 to-transparent"
-            : "from-success/30 via-success/15 to-transparent"
+            ? "from-destructive/15 via-destructive/8 to-transparent"
+            : "from-success/15 via-success/8 to-transparent"
         }`}
       >
         <div className="h-[280px]">

--- a/apps/frontend/src/pages/dashboard/dashboard-content.tsx
+++ b/apps/frontend/src/pages/dashboard/dashboard-content.tsx
@@ -5,7 +5,7 @@ import { useCurrentValuation } from "@/hooks/use-current-account-valuations";
 import { useHoldings } from "@/hooks/use-holdings";
 import { useValuationHistory } from "@/hooks/use-valuation-history";
 import { HoldingType, isAlternativeAssetKind } from "@/lib/constants";
-import { performanceSummaryReturn, performancePeriodPnl } from "@/lib/performance";
+import { performancePeriodPnl, performanceSummaryReturn } from "@/lib/performance";
 import { QueryKeys } from "@/lib/query-keys";
 import { useSettingsContext } from "@/lib/settings-provider";
 import { DateRange, TimePeriod } from "@/lib/types";
@@ -240,13 +240,14 @@ export function DashboardContent() {
       </div>
 
       <div
-        className={`bg-linear-to-t flex grow flex-col ${
-          isNegative
-            ? "from-destructive/15 via-destructive/8 to-transparent"
-            : "from-success/15 via-success/8 to-transparent"
-        }`}
+        className="flex grow flex-col"
+        style={{
+          backgroundImage: isNegative
+            ? `linear-gradient(to top, color-mix(in srgb, var(--destructive) 30%, transparent), color-mix(in srgb, var(--destructive) 15%, transparent) 50%, transparent 100%)`
+            : `linear-gradient(to top, color-mix(in srgb, var(--success) 30%, transparent), color-mix(in srgb, var(--success) 15%, transparent) 50%, transparent 100%)`,
+        }}
       >
-        <div className="h-[280px]">
+        <div className="h-70">
           <HistoryChart
             data={chartData}
             isLoading={isValuationHistoryLoading}
@@ -255,7 +256,7 @@ export function DashboardContent() {
             netContributionMaxDomainSpanRatio={chartNetContributionMaxDomainSpanRatio}
           />
           {valuationHistory && chartData.length > 0 && (
-            <div className="flex w-full -translate-y-6 justify-center">
+            <div className="flex w-full justify-center">
               <IntervalSelector
                 className="pointer-events-auto relative z-20 w-full max-w-screen-sm sm:max-w-screen-md md:max-w-2xl lg:max-w-3xl"
                 onIntervalSelect={handleIntervalSelect}
@@ -268,7 +269,7 @@ export function DashboardContent() {
           )}
         </div>
 
-        <div className="grow px-4 pb-[var(--mobile-nav-total-offset)] pt-12 md:px-6 md:pb-6 md:pt-6 lg:px-10 lg:pb-8 lg:pt-8">
+        <div className="grow px-4 pb-[var(--mobile-nav-total-offset)] pt-14 md:px-6 md:pb-6 md:pt-12 lg:px-10 lg:pb-8 lg:pt-14">
           <div className="grid grid-cols-1 gap-8 lg:grid-cols-3 lg:gap-20">
             <div className="lg:col-span-2">
               <AccountsSummary

--- a/apps/frontend/src/pages/settings/addons/components/addon-permission-dialog.tsx
+++ b/apps/frontend/src/pages/settings/addons/components/addon-permission-dialog.tsx
@@ -120,13 +120,7 @@ export function PermissionDialog({
               </div>
             </div>
           </DialogTitle>
-          <DialogDescription className="space-y-2">
-            <div className="text-muted-foreground text-sm">
-              {manifest.description && (
-                <p className="text-muted-foreground text-sm">{manifest.description}</p>
-              )}
-            </div>
-          </DialogDescription>
+          <DialogDescription>{manifest.description}</DialogDescription>
         </DialogHeader>
 
         <div className="flex-1 space-y-6 overflow-hidden">


### PR DESCRIPTION
## Summary

A batch of mobile activity-form parity fixes, a dashboard chart-backdrop polish, and two accessibility corrections — prep work toward 3.6.

## Changes

### Mobile activity form

- **Asset-type tabs fit the width.** The Stock / Option / Bond selector now spans the card as a full-width segmented row instead of a content-width control wrapped in the section header.
- **Call / Put matches the top tabs.** Reworked the toggle in the shared `OptionContractFields` to use the same `flex-1` segmented style with an animated sliding indicator (applies to desktop buy/sell too, for consistency).
- **Trade-intent parity with desktop.** The mobile Trade section was missing the intent controls the desktop forms have — added them via the shared components:
  - Stocks: **Sell / Sell Short** (and **Buy / Buy to Cover**) via `StockTradeIntentSelector`.
  - Options: **Open / Close** via `PositionIntentSelector`, now required at submit (matching the desktop `superRefine`), and `subtype` is reset on asset-type change so a stale intent can't carry across types.

### Dashboard chart backdrop

- Aligned the Investments chart backdrop with the Net Worth tab: restored the `to top` `color-mix` gradient (keeps the bottom tint, adapts to light/dark themes) and dropped the `-translate-y-6` that pulled the period selector into the chart's dark bottom edge, which had produced a muddy dark band at the seam. Matched Net Worth's content padding.

### Accessibility

- **Invalid `<p>` nesting** in the addon permission dialog — `DialogDescription` (a `<p>`) wrapped a `<div>`/`<p>`; removed the redundant wrapper.
- **Missing dialog description** in the mobile Add Activity sheet — the add flow rendered no `SheetDescription` (only edit did), triggering Radix's `aria-describedby` warning. Added a screen-reader-only description (new `add_details` string across all locales).

### Addons

- `fix(addons): wait for auth status before loading` — defers addon loading until auth status resolves.

## Testing

- `pnpm type-check` ✅ · `pnpm lint` (0 errors) ✅ · Prettier ✅
- Frontend unit tests: 322 passing ✅
- Verified live in a browser (mobile + desktop viewports, dark theme): full-width tabs, Call/Put toggle, Sell/Sell Short and Open/Close intents, the resolved a11y warnings, and the dashboard backdrop.

## Notes

- The Call/Put restyle and the invalid-`<p>` fix touch shared components, so they also affect the desktop forms and the add-ons settings screen — intended, for consistency/correctness.
- The dashboard backdrop still scales with content height (identical to the Net Worth tab it now mirrors); can be decoupled into a fixed-height glow later if desired.
