### PR TITLE
Relax health stale price warning threshold

### DIFF
--- a/crates/core/src/health/checks/price_staleness.rs
+++ b/crates/core/src/health/checks/price_staleness.rs
@@ -63,7 +63,7 @@ impl PriceStalenessCheck {
         }
 
         // Convert hour thresholds to trading days
-        // 24 hours ≈ 1 trading day, 72 hours ≈ 3 trading days
+        // 48 hours ≈ 2 trading days, 72 hours ≈ 3 trading days by default
         let warning_trading_days = (ctx.config.price_stale_warning_hours / 24).max(1) as i64;
         let critical_trading_days = (ctx.config.price_stale_critical_hours / 24).max(1) as i64;
 
@@ -643,7 +643,7 @@ mod tests {
         }];
 
         // Quote from Monday Jan 15 (2 trading days ago: Tue, Wed)
-        // With default config (24h = 1 trading day warning), this should trigger warning
+        // With default config (48h = 2-trading-day warning), this should trigger warning
         let mut quote_times = HashMap::new();
         let monday = Utc.with_ymd_and_hms(2024, 1, 15, 16, 0, 0).unwrap();
         quote_times.insert("SEC:AAPL:XNAS".to_string(), monday);
@@ -731,18 +731,16 @@ mod tests {
         }];
 
         // Quote from Friday Jan 19 - only 1 trading day (Monday) has passed
-        // Default warning threshold is 1 trading day, so this is exactly at the threshold
-        // but not over it (we use >= so 1 >= 1 would trigger)
-        // Actually with the default 24h = 1 day threshold, 1 trading day should trigger warning
+        // Default warning threshold is 2 trading days, so this remains fresh.
         let mut quote_times = HashMap::new();
         let friday = Utc.with_ymd_and_hms(2024, 1, 19, 16, 0, 0).unwrap();
         quote_times.insert("SEC:AAPL:XNAS".to_string(), friday);
 
         let issues = check.analyze(&holdings, &quote_times, &ctx);
-        // 1 trading day has passed (Monday), warning threshold is 1 day
-        // So this will trigger a warning - which is correct behavior for Monday
-        assert_eq!(issues.len(), 1);
-        assert_eq!(issues[0].severity, Severity::Warning);
+        assert!(
+            issues.is_empty(),
+            "Friday quote should not be stale with relaxed warning threshold"
+        );
     }
 
     #[test]

--- a/crates/core/src/health/model.rs
+++ b/crates/core/src/health/model.rs
@@ -1274,7 +1274,7 @@ impl Default for HealthStatus {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct HealthConfig {
-    /// Hours after which a stale price triggers a Warning (default: 24)
+    /// Hours after which a stale price triggers a Warning (default: 48)
     pub price_stale_warning_hours: u32,
 
     /// Hours after which a stale price triggers an Error (default: 72)
@@ -1296,7 +1296,7 @@ pub struct HealthConfig {
 impl Default for HealthConfig {
     fn default() -> Self {
         Self {
-            price_stale_warning_hours: 24,
+            price_stale_warning_hours: 48,
             price_stale_critical_hours: 72,
             fx_stale_warning_hours: 24,
             fx_stale_critical_hours: 72,
@@ -1455,7 +1455,7 @@ mod tests {
     #[test]
     fn test_health_config_defaults() {
         let config = HealthConfig::default();
-        assert_eq!(config.price_stale_warning_hours, 24);
+        assert_eq!(config.price_stale_warning_hours, 48);
         assert_eq!(config.price_stale_critical_hours, 72);
         assert_eq!(config.mv_escalation_threshold, 0.30);
     }


### PR DESCRIPTION
## Summary

- Raises the default Health Center stale-price warning threshold from 24 hours to 48 hours.
- Updates stale-price tests so a Friday quote remains fresh after one Monday trading day, while the two-trading-day threshold still warns.
- Keeps the fix scoped to Health defaults and tests; no quote sync, market-clock resolver, frontend, API, or DB changes.

## Why

Monday pre-market and weekend quote availability can make current-session lag look actionable too early. Relaxing the warning threshold avoids noisy Health Center warnings for a single completed trading day while preserving the existing critical threshold.

## Review

- No blocking findings in the two-file diff.
- Existing `HealthConfig` is held in the health service default path, so changing `HealthConfig::default()` is the effective default behavior change.

## Validation

- `cargo fmt`
- `cargo check -p wealthfolio-core`
- `cargo clippy -p wealthfolio-core --all-targets -- -D warnings`
- `cargo test -p wealthfolio-core price_staleness`
- `cargo test -p wealthfolio-core test_health_config_defaults`
- `cargo test -p wealthfolio-core --lib`