### PR TITLE
Addon SDK 3.6.1: changelog backfill, hand-deposit icon, sandbox theme fix

### DIFF
--- a/apps/frontend/public/addon-sandbox.css
+++ b/apps/frontend/public/addon-sandbox.css
@@ -26,13 +26,21 @@ body,
   margin: 0;
 }
 
+/*
+ * Prefer the LIVE host theme token (--background / --foreground): applyHostTheme
+ * re-copies these into the sandbox on every theme apply, so they track the
+ * current theme. --addon-initial-* is a one-time snapshot taken at addon start
+ * and is never refreshed on its own — using it directly leaves a stale (often
+ * dark) background when the app resolves its real theme after the snapshot.
+ * Keep it only as the pre-loadAddon fallback.
+ */
 html {
-  background: var(--addon-initial-background, transparent);
+  background: var(--background, var(--addon-initial-background, transparent));
 }
 
 body {
-  background: var(--addon-initial-background, transparent);
-  color: var(--addon-initial-foreground, inherit);
+  background: var(--background, var(--addon-initial-background, transparent));
+  color: var(--foreground, var(--addon-initial-foreground, inherit));
 }
 
 #addon-root {

--- a/apps/frontend/src/addons/iframe/addon-sandbox-theme.ts
+++ b/apps/frontend/src/addons/iframe/addon-sandbox-theme.ts
@@ -49,6 +49,16 @@ export function applyHostTheme(theme?: Partial<AddonThemeSnapshot>) {
     htmlElement.style.colorScheme = theme.colorScheme;
   }
 
+  // Refresh the snapshot fallbacks too. These are seeded once from URL params at
+  // addon start (before the app's real theme resolves), so without this they can
+  // stay stuck on a dark startup value even after the app settles on light.
+  if (theme.backgroundColor) {
+    htmlElement.style.setProperty("--addon-initial-background", theme.backgroundColor);
+  }
+  if (theme.foregroundColor) {
+    htmlElement.style.setProperty("--addon-initial-foreground", theme.foregroundColor);
+  }
+
   document.body.classList.remove(...FONT_CLASSES);
   if (theme.fontClass && FONT_CLASSES.includes(theme.fontClass as (typeof FONT_CLASSES)[number])) {
     document.body.classList.add(theme.fontClass);

--- a/packages/addon-sdk/CHANGELOG.md
+++ b/packages/addon-sdk/CHANGELOG.md
@@ -4,6 +4,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.1] - 2026-07-06
+
+Follow-up to the v3.6 sandbox release: sidebar icons are now a typed, curated
+set. See the
+[v3.5 → v3.6 migration guide](../../docs/addons/addon-migration-guide-v3.5-to-v3.6.md).
+
+### Breaking
+
+- **`SidebarItemConfig.icon`** is now a typed `AddonIconName` (was `string`).
+  Names outside the curated set fail type-checking; unknown or omitted names
+  render a neutral `caret-right` fallback at runtime.
+
+### Added
+
+- `AddonIconName` type and `ADDON_ICON_NAMES` — the curated set of duotone
+  Phosphor sidebar icon names, exported from the package entry point.
+
 ## [3.6.0] - 2026-07-04
 
 Addons now run in an isolated sandbox iframe. This is a **breaking** release for
@@ -19,10 +36,9 @@ addons that register routes. See the
 - **React exports removed**: the SDK no longer re-exports `React` / `ReactDOM`
   from host globals. Import from `react` / `react-dom/client`; mark them
   `external` in your build.
-- **`SidebarItemConfig`**: `icon` is now a typed `AddonIconName` (one of a
-  curated set of duotone Phosphor icons the host bundles) — `React.ReactNode`
-  icons and the `onClick` handler were removed. Use `route`. Unknown/omitted
-  names render a neutral `caret-right` fallback.
+- **`SidebarItemConfig`**: `icon` is now a host-supported icon name (`string`)
+  instead of a `React.ReactNode`, and the `onClick` handler was removed — use
+  `route`.
 - **React** guaranteed version bumped 19.1.1 → 19.2.4.
 
 ### Added
@@ -30,14 +46,178 @@ addons that register routes. See the
 - `HOST_DEPENDENCIES` export — the versioned packages the sandbox provides
   (react, react-dom, @tanstack/react-query, @wealthfolio/ui, date-fns,
   lucide-react, recharts).
-- `AddonIconName` type and `ADDON_ICON_NAMES` list — the 80 supported sidebar
-  icon names.
 - Brokered networking: `ctx.api.network.request()` with manifest-declared
   `network.allowedHosts` and bearer auth resolved from scoped secret storage
   (`NetworkAPI`, `NetworkRequest`, `NetworkResponse`, `NetworkAuth`).
 - Manifest fields: `minWealthfolioVersion`, `hostDependencies`, `network`,
   `sha256`. `AddonHostDependencies` type.
 - Addon SDK tax fields on activity/data types (#1188).
+
+## [3.5.1] - 2026-06-09
+
+Also includes the unpublished 3.4.0 and 3.5.0.
+
+### Added
+
+- `PerformanceResult` — a comprehensive performance model replacing
+  `PerformanceMetrics`, with supporting types `PerformanceScopeDescriptor`,
+  `PerformancePeriod`, `ReturnMethod`, `PerformanceReturns`,
+  `PerformanceAttribution`, `PerformanceRisk`, `PerformanceDataQuality`.
+- Goal enrichment: `GoalType`, `GoalLifecycle`, `GoalHealth` types; `Goal` gains
+  `goalType`, `statusHealth`, `priority`, `coverImageKey`, `currency`, dates,
+  valuation summaries, and timestamps. `GoalProgress` gains `goalId`,
+  `statusHealth`, `targetDate`.
+- Asset resolution: `AssetResolutionInput` (`quoteCcy`, `instrumentType`,
+  `providerId`, `providerSymbol`); an `asset` field on `ActivityCreate` /
+  `ActivityUpdate`; `assetId` on `ActivityImport`.
+- Provider-aware market data: `providerId` / `providerSymbol` plus canonical
+  `canonicalSymbol` / `canonicalExchangeMic` on `SymbolSearchResult`;
+  `DividendEvent` type and `FetchDividendsOptions`.
+- `AccountType` gains `CREDIT_CARD`; `Settings.defaultReturnMetric`
+  (`'twr' | 'irr' | 'valueReturn'`).
+- Base-currency fields on `AccountValuation` (`totalValueBase`, `costBasisBase`,
+  `netContributionBase`, …) and provider/quote fields on `SnapshotHoldingInput`
+  / `SnapshotPositionInput`.
+
+### Changed
+
+- Performance API now returns the new `Result` types: `calculateHistory()` (with
+  `startDate` / `endDate` now optional) and `calculateSummary()` return
+  `PerformanceResult`; `calculateAccountsSimple()`, `AccountSummaryView`, and
+  `AccountGroup` use `SimplePerformanceResult`.
+- `fetchDividends()` accepts an optional `FetchDividendsOptions` and returns
+  `DividendEvent[]` (was `YahooDividend[]`).
+- `backupDatabase()` returns `{ filename: string }` (dropped the
+  `data: Uint8Array` payload).
+
+### Deprecated
+
+- `PerformanceMetrics` / `SimplePerformanceMetrics` (aliases for their `Result`
+  counterparts), `SymbolInput` (use `AssetResolutionInput`), and the `symbol`
+  field on `ActivityCreate` / `ActivityUpdate` (use `asset`).
+
+### Removed
+
+- `YahooDividend` (replaced by `DividendEvent`); `dayGainLossAmount` and
+  `dayReturnPercentModDietz` from `SimplePerformanceResult`.
+
+## [3.3.0] - 2026-05-01
+
+### Added
+
+- `GoalsAPI.getFunding(goalId)` and `saveFunding(goalId, rules)`, with matching
+  `getFunding` / `saveFunding` functions under the renamed `financial-planning`
+  permission.
+- `GoalAllocation.taxBucket`.
+
+### Changed
+
+- `Goal.isAchieved` replaced by `Goal.statusLifecycle`
+  (`'active' | 'achieved' | 'archived'`).
+- `GoalAllocation.percentAllocation` renamed to `sharePercent`.
+- `goals` permission category renamed to `financial-planning`.
+
+### Deprecated
+
+- `GoalsAPI.updateAllocations()` (use `saveFunding`) and `getAllocations()` (use
+  `getAll()` + `getFunding(goalId)`).
+
+## [3.2.0] - 2026-04-02
+
+### Changed
+
+- `ActivitiesAPI.checkImport()` dropped its `accountId` parameter — now
+  `checkImport(activities)`, a read-only preview.
+- `ActivitiesAPI.getImportMapping()` accepts an optional `contextKind` (default
+  `'ACTIVITY'`).
+- `ImportMappingData.fieldMappings` widened to
+  `Record<string, string | string[]>`.
+- `PerformanceMetrics.periodReturn` is now nullable (`number | null`).
+
+## [3.1.1] - 2026-03-14
+
+A large release that overhauls the asset and activity data models (also includes
+the unpublished 3.0.1–3.1.0). **Breaking** for addons that read or write assets,
+activities, or quotes.
+
+### Breaking
+
+- **Asset model** is now keyed by an opaque UUID instead of a symbol. `Asset` is
+  redesigned with `kind` (`AssetKind`), `displayCode`, `quoteMode`, `quoteCcy`,
+  `instrumentType`, `instrumentSymbol`, `instrumentKey`, `providerConfig`, …;
+  removed `symbol`, `isin`, `assetClass`, `countries`, `sectors`, `dataSource`,
+  and more.
+- **Activity model** redesigned: `type` → `activityType`, `date` →
+  `activityDate`, `assetId` now optional, monetary/quantity fields are decimal
+  strings; new lifecycle fields (`subtype`, `status`, `settlementDate`,
+  `idempotencyKey`, `importRunId`, `metadata`, …). `ActivityType` is now a
+  closed set of 14 (removed `ADD_HOLDING` / `REMOVE_HOLDING`; added `SPLIT`,
+  `CREDIT`, `ADJUSTMENT`, `UNKNOWN`).
+- **Quotes / assets APIs** now take `assetId` instead of `symbol`:
+  `QuotesAPI.update()` / `getHistory()`, `Quote` / `QuoteUpdate`,
+  `MarketDataAPI.sync(assetIds)`. `AssetsAPI.updateDataSource()` →
+  `updateQuoteMode(assetId, quoteMode)`. `searchTicker()` returns
+  `SymbolSearchResult` (renamed from `QuoteSummary`).
+- `ActivitiesAPI.import()` returns `ImportActivitiesResult` (was
+  `ActivityImport[]`); `SettingsAPI.update()` takes `Partial<Settings>`;
+  `IncomeSummary.bySymbol` → `byAsset`.
+
+### Added
+
+- New APIs: `SnapshotsAPI` (holdings snapshots) and `ToastAPI` (`success` /
+  `error` / `warning` / `info`), each with a matching permission category;
+  `MarketDataAPI.fetchDividends(symbol)`.
+- Activity taxonomy: `ActivityStatus`, `ACTIVITY_SUBTYPES` / `ActivitySubtype`,
+  `AssetKind`, `QuoteMode` constants; helpers `getEffectiveType()` and
+  `hasUserOverride()`.
+- `calculateGoalProgress()` helper (new `goal-progress` module).
+- Import/sync types (`ImportRun*`, `BrokerSyncState`, `SyncStatus`), snapshot
+  types (`Snapshot*`), classification types (`AssetClassifications`,
+  `TaxonomyCategory`, `CategoryWithWeight`), and `QueryKeys.SNAPSHOTS`.
+- React peer dependency bumped to `^19.2.4`.
+
+### Removed
+
+- `AssetProfile`, `MarketData`, `Sector`, `Country`, `SettingsContextType`;
+  `ActivityType` values `ADD_HOLDING` / `REMOVE_HOLDING`.
+
+## [3.0.0] - 2026-02-24
+
+### Breaking
+
+- React peer dependency updated to 19 (`ReactVersion` `18.3.1` → `19.1.1`).
+- `ActivitiesAPI.search()` now takes typed `ActivitySearchFilters` and
+  `ActivitySort` (was `unknown`).
+- `ActivitiesAPI.saveMany()` takes `ActivityBulkMutationRequest` and returns
+  `ActivityBulkMutationResult` (was `ActivityUpdate[]` → `Activity[]`).
+
+### Added
+
+- Bulk-mutation types: `ActivityBulkMutationRequest`,
+  `ActivityBulkMutationResult`, `ActivityBulkMutationError`,
+  `ActivityBulkIdentifierMapping`; exported `ActivitySearchFilters` and
+  `ActivitySort`.
+- `Activity.assetDataSource`, `ActivityCreate.id` / `assetDataSource`,
+  `UpdateAssetProfile.symbolMapping`.
+
+### Changed
+
+- Build now emits `.js` / `.d.ts` (was `.mjs` / `.d.mts`); the types entry moved
+  to `dist/src/index.d.ts`.
+
+## [2.0.0] - 2025-11-22
+
+### Breaking
+
+- Package now ships as an ES module (`"type": "module"`).
+
+### Changed
+
+- Tightened types: loose `any` parameters/returns replaced with `unknown` across
+  `AccountsAPI.create()`, `ActivitiesAPI.search()`, `GoalsAPI.create()`,
+  `FilesAPI.openSaveDialog()`, `QueryAPI.getClient()`, `isAddonManifest()`, and
+  `RouteConfig.component`.
+- `DateRange` and `TrackedItem` changed from type aliases to interfaces.
 
 ## [1.0.0] - 2024-12-19
 

--- a/packages/addon-sdk/src/icons.ts
+++ b/packages/addon-sdk/src/icons.ts
@@ -21,6 +21,7 @@ export const ADDON_ICON_NAMES = [
   'receipt',
   'invoice',
   'hand-coins',
+  'hand-deposit',
   'vault',
   'chart-line-up',
   'chart-line',

--- a/packages/ui/src/components/ui/addon-icons.tsx
+++ b/packages/ui/src/components/ui/addon-icons.tsx
@@ -13,6 +13,7 @@ import { PiggyBankIcon } from "@phosphor-icons/react/dist/csr/PiggyBank";
 import { ReceiptIcon } from "@phosphor-icons/react/dist/csr/Receipt";
 import { InvoiceIcon } from "@phosphor-icons/react/dist/csr/Invoice";
 import { HandCoinsIcon } from "@phosphor-icons/react/dist/csr/HandCoins";
+import { HandDepositIcon } from "@phosphor-icons/react/dist/csr/HandDeposit";
 import { VaultIcon } from "@phosphor-icons/react/dist/csr/Vault";
 import { ChartLineUpIcon } from "@phosphor-icons/react/dist/csr/ChartLineUp";
 import { ChartLineIcon } from "@phosphor-icons/react/dist/csr/ChartLine";
@@ -107,6 +108,7 @@ export const addonIcons: Record<string, AddonIconComponent> = {
   receipt: duotone(ReceiptIcon),
   invoice: duotone(InvoiceIcon),
   "hand-coins": duotone(HandCoinsIcon),
+  "hand-deposit": duotone(HandDepositIcon),
   vault: duotone(VaultIcon),
   "chart-line-up": duotone(ChartLineUpIcon),
   "chart-line": duotone(ChartLineIcon),


### PR DESCRIPTION
## Summary

Follow-up work for the unreleased addon SDK **3.6.1** (repo is at 3.6.1; npm `latest` is still 3.6.0). Three independent changes:

- **docs(addon-sdk): changelog** — add the `[3.6.1]` entry (typed `AddonIconName` sidebar icons) and move the icon items out of `[3.6.0]`, since they landed _after_ the 3.6.0 npm publish. Also **backfill every published version that was missing** from the changelog (`2.0.0`, `3.0.0`, `3.1.1`, `3.2.0`, `3.3.0`, `3.5.1`), reconstructed from the addon-sdk source diffs between each published release. The file previously jumped `3.6.0 → 1.0.0`.
- **feat(addons): `hand-deposit` sidebar icon** — added to the curated `ADDON_ICON_NAMES` set and registered as a duotone Phosphor wrapper in the UI icon registry (list ↔ registry kept in sync).
- **fix(addons): sandbox background theme** — prefer the live `--background`/`--foreground` tokens (re-copied on every `applyHostTheme`) over the one-time `--addon-initial-*` snapshot, and refresh the snapshot fallbacks on theme apply, so the sandbox no longer stays on a stale dark background after the app resolves its real theme.

## Verification

- `prettier --check` — clean on all changed files
- `eslint` — clean on `icons.ts`, `addon-icons.tsx`, `addon-sandbox-theme.ts`
- icon-sync test (`addon-icons.test.ts`) — passes, confirming SDK list ↔ UI registry parity with the new icon

## Note

The changelog is reconstructed from source diffs, not original release notes — faithful to the public API surface but worth a skim, especially the large `3.1.1` (asset-model-v2 overhaul) and `3.5.1` (performance model rewrite) entries.
