### PR TITLE
Add MCP asset classification commit flow

### DIFF
--- a/apps/frontend/src/adapters/tauri/events.ts
+++ b/apps/frontend/src/adapters/tauri/events.ts
@@ -85,6 +85,13 @@ export async function listenMarketSyncError<T>(handler: EventCallback<T>): Promi
   return adaptUnlisten(unlisten);
 }
 
+export async function listenAssetClassificationsChanged<T>(
+  handler: EventCallback<T>,
+): Promise<UnlistenFn> {
+  const unlisten = await listen<T>("asset:classifications-changed", adaptCallback(handler));
+  return adaptUnlisten(unlisten);
+}
+
 export async function listenBrokerSyncStart<T>(handler: EventCallback<T>): Promise<UnlistenFn> {
   const unlisten = await listen<T>("broker:sync-start", adaptCallback(handler));
   return adaptUnlisten(unlisten);

--- a/apps/frontend/src/adapters/tauri/index.ts
+++ b/apps/frontend/src/adapters/tauri/index.ts
@@ -217,6 +217,7 @@ export {
   listenPortfolioUpdateComplete,
   listenDatabaseRestored,
   listenPortfolioUpdateError,
+  listenAssetClassificationsChanged,
   listenMarketSyncComplete,
   listenMarketSyncStart,
   listenMarketSyncError,

--- a/apps/frontend/src/adapters/web/events.ts
+++ b/apps/frontend/src/adapters/web/events.ts
@@ -144,6 +144,12 @@ export const listenMarketSyncError = <T>(handler: EventCallback<T>): Promise<Unl
   return portfolioEventBridge.listen("market:sync-error", handler);
 };
 
+export const listenAssetClassificationsChanged = <T>(
+  handler: EventCallback<T>,
+): Promise<UnlistenFn> => {
+  return portfolioEventBridge.listen("asset:classifications-changed", handler);
+};
+
 // Desktop-only features - no-op in web
 const noopUnlisten: UnlistenFn = () => Promise.resolve();
 

--- a/apps/frontend/src/adapters/web/index.ts
+++ b/apps/frontend/src/adapters/web/index.ts
@@ -395,6 +395,7 @@ export { streamAiChat } from "./ai-streaming";
 
 // Event Listeners (web-specific SSE implementation)
 export {
+  listenAssetClassificationsChanged,
   listenBrokerSyncComplete,
   listenBrokerSyncError,
   listenBrokerSyncStart,

--- a/apps/frontend/src/components/classification/multi-select-taxonomy.tsx
+++ b/apps/frontend/src/components/classification/multi-select-taxonomy.tsx
@@ -212,10 +212,18 @@ export function MultiSelectTaxonomy({
         const category = categoryMap.get(assignment.categoryId);
         return category ? { assignment, category } : null;
       })
-      .filter(Boolean) as {
-      assignment: AssetTaxonomyAssignment;
-      category: TaxonomyCategory;
-    }[];
+      .filter((item): item is { assignment: AssetTaxonomyAssignment; category: TaxonomyCategory } =>
+        Boolean(item),
+      )
+      .sort((a, b) => {
+        const weightComparison = b.assignment.weight - a.assignment.weight;
+        if (weightComparison !== 0) return weightComparison;
+
+        const sortOrderComparison = a.category.sortOrder - b.category.sortOrder;
+        if (sortOrderComparison !== 0) return sortOrderComparison;
+
+        return a.category.name.localeCompare(b.category.name);
+      });
   }, [assignments, categoryMap]);
 
   if (isLoading) {

--- a/apps/frontend/src/i18n/locales/de/settings.json
+++ b/apps/frontend/src/i18n/locales/de/settings.json
@@ -1369,13 +1369,17 @@
       "classification_suggest": {
         "label": "Klassifizierung — vorschlagen",
         "description": "Instrumentenklassifizierungen zur Prüfung vorschlagen."
+      },
+      "classification_write": {
+        "label": "Klassifizierung — anwenden/schreiben",
+        "description": "Geprüfte Klassifizierungsentwürfe anwenden. Erfordert die Vorschlags-Berechtigung."
       }
     },
     "preset": {
       "read_only": "Nur Lesen",
       "read_activity_draft": "Lesen + Entwurf",
       "read_activity_write": "Lesen + Schreiben",
-      "read_activity_write_classification_suggest": "Lesen + Schreiben + Vorschlag"
+      "read_activity_write_classification_suggest": "Lesen + Schreiben + Klassifizieren"
     },
     "copied_generic": "{{label}} in die Zwischenablage kopiert.",
     "hero_aria": "Status des KI-Agenten-Zugriffs",

--- a/apps/frontend/src/i18n/locales/en/settings.json
+++ b/apps/frontend/src/i18n/locales/en/settings.json
@@ -1369,13 +1369,17 @@
       "classification_suggest": {
         "label": "Classification — suggest",
         "description": "Suggest instrument classifications for review."
+      },
+      "classification_write": {
+        "label": "Classification — apply/write",
+        "description": "Apply reviewed classification drafts. Requires the suggest scope."
       }
     },
     "preset": {
       "read_only": "Read-only",
       "read_activity_draft": "Read + draft",
       "read_activity_write": "Read + write",
-      "read_activity_write_classification_suggest": "Read + write + suggest"
+      "read_activity_write_classification_suggest": "Read + write + classify"
     },
     "copied_generic": "{{label}} copied to clipboard.",
     "hero_aria": "AI Agent Access status",

--- a/apps/frontend/src/i18n/locales/es/settings.json
+++ b/apps/frontend/src/i18n/locales/es/settings.json
@@ -1369,13 +1369,17 @@
       "classification_suggest": {
         "label": "Clasificación: sugerir",
         "description": "Sugerir clasificaciones de instrumentos para su revisión."
+      },
+      "classification_write": {
+        "label": "Clasificación: aplicar/escribir",
+        "description": "Aplicar borradores de clasificación revisados. Requiere el ámbito de sugerencia."
       }
     },
     "preset": {
       "read_only": "Solo lectura",
       "read_activity_draft": "Lectura + borrador",
       "read_activity_write": "Lectura + escritura",
-      "read_activity_write_classification_suggest": "Lectura + escritura + sugerir"
+      "read_activity_write_classification_suggest": "Lectura + escritura + clasificar"
     },
     "copied_generic": "{{label}} copiado al portapapeles.",
     "hero_aria": "Estado del acceso de agentes de IA",

--- a/apps/frontend/src/i18n/locales/fr/settings.json
+++ b/apps/frontend/src/i18n/locales/fr/settings.json
@@ -1369,13 +1369,17 @@
       "classification_suggest": {
         "label": "Classification — suggérer",
         "description": "Suggérer des classifications d'instruments pour révision."
+      },
+      "classification_write": {
+        "label": "Classification — appliquer/écrire",
+        "description": "Appliquer des brouillons de classification révisés. Nécessite la portée suggestion."
       }
     },
     "preset": {
       "read_only": "Lecture seule",
       "read_activity_draft": "Lecture + brouillon",
       "read_activity_write": "Lecture + écriture",
-      "read_activity_write_classification_suggest": "Lecture + écriture + suggestion"
+      "read_activity_write_classification_suggest": "Lecture + écriture + classification"
     },
     "copied_generic": "{{label}} copié dans le presse-papiers.",
     "hero_aria": "État de l'accès des agents IA",

--- a/apps/frontend/src/i18n/locales/zh/settings.json
+++ b/apps/frontend/src/i18n/locales/zh/settings.json
@@ -1369,13 +1369,17 @@
       "classification_suggest": {
         "label": "分类——建议",
         "description": "为审核建议金融工具分类。"
+      },
+      "classification_write": {
+        "label": "分类——应用/写入",
+        "description": "应用已审核的分类草稿。需要建议作用域。"
       }
     },
     "preset": {
       "read_only": "仅读取",
       "read_activity_draft": "读取 + 草稿",
       "read_activity_write": "读取 + 写入",
-      "read_activity_write_classification_suggest": "读取 + 写入 + 建议"
+      "read_activity_write_classification_suggest": "读取 + 写入 + 分类"
     },
     "copied_generic": "{{label}} 已复制到剪贴板。",
     "hero_aria": "AI 代理访问状态",

--- a/apps/frontend/src/lib/query-invalidation.ts
+++ b/apps/frontend/src/lib/query-invalidation.ts
@@ -1,4 +1,5 @@
 import { QueryKeys } from "@/lib/query-keys";
+import type { QueryClient } from "@tanstack/react-query";
 
 // Cloud/network-backed queries that should NOT be refetched on a portfolio change.
 const CLOUD_SYNC_INVALIDATION_EXCLUSIONS = new Set<string>([
@@ -30,4 +31,33 @@ export function shouldInvalidateAfterPortfolioUpdate(queryKey: readonly unknown[
   }
 
   return true;
+}
+
+export interface AssetClassificationsChangedPayload {
+  assetIds?: string[];
+  taxonomyIds?: string[];
+}
+
+export function invalidateAfterAssetClassificationsChanged(
+  queryClient: QueryClient,
+  payload?: AssetClassificationsChangedPayload | null,
+) {
+  const assetIds = Array.isArray(payload?.assetIds) ? payload.assetIds : [];
+
+  if (assetIds.length > 0) {
+    for (const assetId of assetIds) {
+      queryClient.invalidateQueries({
+        queryKey: QueryKeys.assetTaxonomyAssignments(assetId),
+      });
+    }
+  } else {
+    queryClient.invalidateQueries({
+      queryKey: [QueryKeys.ASSET_TAXONOMY_ASSIGNMENTS],
+    });
+  }
+
+  queryClient.invalidateQueries({ queryKey: [QueryKeys.PORTFOLIO_ALLOCATIONS] });
+  queryClient.invalidateQueries({ queryKey: [QueryKeys.HOLDINGS] });
+  queryClient.invalidateQueries({ queryKey: [QueryKeys.ALLOCATION_TARGET_DRIFT] });
+  queryClient.invalidateQueries({ queryKey: [QueryKeys.HEALTH_STATUS] });
 }

--- a/apps/frontend/src/lib/query-invalidation.ts
+++ b/apps/frontend/src/lib/query-invalidation.ts
@@ -58,6 +58,7 @@ export function invalidateAfterAssetClassificationsChanged(
 
   queryClient.invalidateQueries({ queryKey: [QueryKeys.PORTFOLIO_ALLOCATIONS] });
   queryClient.invalidateQueries({ queryKey: [QueryKeys.HOLDINGS] });
+  queryClient.invalidateQueries({ queryKey: [QueryKeys.HOLDINGS_BY_ALLOCATION] });
   queryClient.invalidateQueries({ queryKey: [QueryKeys.ALLOCATION_TARGET_DRIFT] });
   queryClient.invalidateQueries({ queryKey: [QueryKeys.HEALTH_STATUS] });
 }

--- a/apps/frontend/src/pages/settings/agent-access/components/pat-create-dialog.test.tsx
+++ b/apps/frontend/src/pages/settings/agent-access/components/pat-create-dialog.test.tsx
@@ -64,4 +64,30 @@ describe("PatCreateDialog scope dependencies", () => {
     expect(write).toHaveAttribute("aria-checked", "false");
     expect(draft).toHaveAttribute("aria-checked", "true");
   });
+
+  it("derives classification suggest from classification write", () => {
+    render(
+      <PatCreateDialog
+        open
+        onOpenChange={vi.fn()}
+        onCreate={vi.fn().mockResolvedValue("wfp_secret")}
+        isCreating={false}
+      />,
+    );
+
+    const write = scopeCheckbox("Classification — apply/write");
+    const suggest = scopeCheckbox("Classification — suggest");
+
+    expect(suggest).toHaveAttribute("aria-checked", "false");
+
+    fireEvent.click(write);
+    expect(write).toHaveAttribute("aria-checked", "true");
+    expect(suggest).toHaveAttribute("aria-checked", "true");
+    expect(suggest).toBeDisabled();
+
+    fireEvent.click(write);
+    expect(write).toHaveAttribute("aria-checked", "false");
+    expect(suggest).toHaveAttribute("aria-checked", "false");
+    expect(suggest).not.toBeDisabled();
+  });
 });

--- a/apps/frontend/src/pages/settings/agent-access/components/pat-create-dialog.tsx
+++ b/apps/frontend/src/pages/settings/agent-access/components/pat-create-dialog.tsx
@@ -96,9 +96,9 @@ export function PatCreateDialog({
   };
 
   const toggleScope = (key: ScopeKey) => {
-    // Store only the user's raw selection; dependencies (e.g. write ⇒ draft)
-    // are derived in `selectedScopes`. Baking them into state here would leave
-    // `activities:draft` stuck on after `activities:write` is unchecked.
+    // Store only the user's raw selection; dependencies are derived in
+    // `selectedScopes`. Baking them into state here would leave implied scopes
+    // stuck on after their dependent write scopes are unchecked.
     setSelected((prev) => {
       const next = new Set(prev);
       if (next.has(key)) {
@@ -147,8 +147,9 @@ export function PatCreateDialog({
     const checked = selectedScopes.includes(scope.key);
     const label = scopeLabel(t, scope.key);
     const description = scopeDescription(t, scope.key);
-    // `activities:draft` is implied by (and locked on while) `activities:write`.
-    const locked = scope.key === "activities:draft" && selectedScopes.includes("activities:write");
+    const locked =
+      (scope.key === "activities:draft" && selectedScopes.includes("activities:write")) ||
+      (scope.key === "classification:suggest" && selectedScopes.includes("classification:write"));
     return (
       <button
         key={scope.key}

--- a/apps/frontend/src/pages/settings/agent-access/scopes.ts
+++ b/apps/frontend/src/pages/settings/agent-access/scopes.ts
@@ -1,7 +1,7 @@
 // Canonical agent-access token scopes shared by the web (server PAT) and
 // desktop (Tauri) surfaces. The backend rejects unknown scopes, empty scope
-// sets, and `activities:write` without `activities:draft`; this module keeps
-// the UI in sync with that contract.
+// sets, and write scopes without their draft/suggest prerequisites; this
+// module keeps the UI in sync with that contract.
 
 import type { TFunction } from "i18next";
 
@@ -15,7 +15,8 @@ export type ScopeKey =
   | "classification:read"
   | "activities:draft"
   | "activities:write"
-  | "classification:suggest";
+  | "classification:suggest"
+  | "classification:write";
 
 export type ScopeGroup = "read" | "write";
 
@@ -26,7 +27,7 @@ export interface ScopeMeta {
   group: ScopeGroup;
 }
 
-/** Ordered list of all 10 scopes, grouped reads first then write/suggest. */
+/** Ordered list of all 11 scopes, grouped reads first then write/suggest. */
 export const SCOPES: ScopeMeta[] = [
   { key: "accounts:read", i18n: "accounts_read", group: "read" },
   { key: "holdings:read", i18n: "holdings_read", group: "read" },
@@ -38,6 +39,7 @@ export const SCOPES: ScopeMeta[] = [
   { key: "activities:draft", i18n: "activities_draft", group: "write" },
   { key: "activities:write", i18n: "activities_write", group: "write" },
   { key: "classification:suggest", i18n: "classification_suggest", group: "write" },
+  { key: "classification:write", i18n: "classification_write", group: "write" },
 ];
 
 /** The 7 read scopes, in canonical order. */
@@ -72,7 +74,13 @@ export const SCOPE_PRESETS: ScopePreset[] = [
   {
     key: "read-activity-write-classification-suggest",
     i18n: "read_activity_write_classification_suggest",
-    scopes: [...READ_SCOPES, "activities:draft", "activities:write", "classification:suggest"],
+    scopes: [
+      ...READ_SCOPES,
+      "activities:draft",
+      "activities:write",
+      "classification:suggest",
+      "classification:write",
+    ],
   },
 ];
 
@@ -96,13 +104,15 @@ export function presetLabel(t: TFunction, preset: ScopePreset): string {
 }
 
 /**
- * Apply the dependency rule: selecting `activities:write` also selects
- * `activities:draft`. Returns scopes in canonical order with duplicates removed.
+ * Apply dependency rules. Returns scopes in canonical order with duplicates removed.
  */
 export function applyScopeDependencies(scopes: Iterable<string>): ScopeKey[] {
   const set = new Set<string>(scopes);
   if (set.has("activities:write")) {
     set.add("activities:draft");
+  }
+  if (set.has("classification:write")) {
+    set.add("classification:suggest");
   }
   return SCOPES.filter((scope) => set.has(scope.key)).map((scope) => scope.key);
 }

--- a/apps/frontend/src/use-global-event-listener.ts
+++ b/apps/frontend/src/use-global-event-listener.ts
@@ -1,6 +1,7 @@
 // useGlobalEventListener.ts
 import {
   isDesktop,
+  listenAssetClassificationsChanged,
   listenBrokerSyncComplete,
   listenBrokerSyncError,
   listenDatabaseRestored,
@@ -15,7 +16,11 @@ import {
 } from "@/adapters";
 import { usePortfolioSyncOptional } from "@/context/portfolio-sync-context";
 import { useIsMobileViewport } from "@/hooks/use-platform";
-import { shouldInvalidateAfterPortfolioUpdate } from "@/lib/query-invalidation";
+import {
+  invalidateAfterAssetClassificationsChanged,
+  shouldInvalidateAfterPortfolioUpdate,
+  type AssetClassificationsChangedPayload,
+} from "@/lib/query-invalidation";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -163,6 +168,12 @@ const useGlobalEventListener = () => {
       });
     };
 
+    const handleAssetClassificationsChanged = (event: {
+      payload: AssetClassificationsChangedPayload | null;
+    }) => {
+      invalidateAfterAssetClassificationsChanged(queryClientRef.current, event.payload);
+    };
+
     const handleBrokerSyncComplete = (event: {
       payload: {
         success: boolean;
@@ -279,6 +290,10 @@ const useGlobalEventListener = () => {
         ["market-sync-start", listenMarketSyncStart(handleMarketSyncStart)],
         ["market-sync-complete", listenMarketSyncComplete(handleMarketSyncComplete)],
         ["market-sync-error", listenMarketSyncError(handleMarketSyncError)],
+        [
+          "asset-classifications-changed",
+          listenAssetClassificationsChanged(handleAssetClassificationsChanged),
+        ],
         ["database-restored", listenDatabaseRestored(handleDatabaseRestored)],
         ["broker-sync-complete", listenBrokerSyncComplete(handleBrokerSyncComplete)],
         ["broker-sync-error", listenBrokerSyncError(handleBrokerSyncError)],

--- a/apps/server/src/domain_events/planner.rs
+++ b/apps/server/src/domain_events/planner.rs
@@ -16,6 +16,57 @@ use wealthfolio_core::{
 
 use crate::api::shared::PortfolioJobConfig;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AssetClassificationChangePlan {
+    pub asset_ids: Vec<String>,
+    pub taxonomy_ids: Vec<String>,
+}
+
+/// Plans a UI cache refresh for asset classification changes.
+pub fn plan_asset_classification_change(
+    events: &[DomainEvent],
+) -> Option<AssetClassificationChangePlan> {
+    let mut asset_ids: HashSet<String> = HashSet::new();
+    let mut taxonomy_ids: HashSet<String> = HashSet::new();
+    let mut has_event = false;
+
+    for event in events {
+        if let DomainEvent::AssetClassificationsChanged {
+            asset_ids: changed_asset_ids,
+            taxonomy_ids: changed_taxonomy_ids,
+        } = event
+        {
+            has_event = true;
+            asset_ids.extend(
+                changed_asset_ids
+                    .iter()
+                    .filter(|id| !id.is_empty())
+                    .cloned(),
+            );
+            taxonomy_ids.extend(
+                changed_taxonomy_ids
+                    .iter()
+                    .filter(|id| !id.is_empty())
+                    .cloned(),
+            );
+        }
+    }
+
+    if !has_event {
+        return None;
+    }
+
+    let mut asset_ids = asset_ids.into_iter().collect::<Vec<_>>();
+    asset_ids.sort();
+    let mut taxonomy_ids = taxonomy_ids.into_iter().collect::<Vec<_>>();
+    taxonomy_ids.sort();
+
+    Some(AssetClassificationChangePlan {
+        asset_ids,
+        taxonomy_ids,
+    })
+}
+
 /// Plans a portfolio job from a batch of domain events.
 ///
 /// Merges account_ids and asset_ids from ActivitiesChanged, HoldingsChanged,
@@ -106,6 +157,7 @@ pub fn plan_portfolio_job(events: &[DomainEvent], timezone: &str) -> Option<Port
                     }
                 }
             }
+            DomainEvent::AssetClassificationsChanged { .. } => {}
             DomainEvent::TrackingModeChanged {
                 account_id,
                 old_mode,
@@ -359,6 +411,40 @@ mod tests {
         } else {
             panic!("Expected Incremental mode");
         }
+    }
+
+    #[test]
+    fn test_plan_portfolio_job_asset_classifications_changed_does_not_trigger_recalc() {
+        let events = vec![DomainEvent::asset_classifications_changed(
+            vec!["asset-1".to_string()],
+            vec!["asset_classes".to_string()],
+        )];
+
+        assert!(plan_portfolio_job(&events, "UTC").is_none());
+    }
+
+    #[test]
+    fn test_plan_asset_classification_change_deduplicates_ids() {
+        let events = vec![
+            DomainEvent::asset_classifications_changed(
+                vec!["asset-2".to_string(), "asset-1".to_string()],
+                vec!["regions".to_string()],
+            ),
+            DomainEvent::asset_classifications_changed(
+                vec!["asset-1".to_string(), "".to_string()],
+                vec!["regions".to_string(), "asset_classes".to_string()],
+            ),
+        ];
+
+        let plan = plan_asset_classification_change(&events).unwrap();
+        assert_eq!(
+            plan.asset_ids,
+            vec!["asset-1".to_string(), "asset-2".to_string()]
+        );
+        assert_eq!(
+            plan.taxonomy_ids,
+            vec!["asset_classes".to_string(), "regions".to_string()]
+        );
     }
 
     #[test]

--- a/apps/server/src/domain_events/queue_worker.rs
+++ b/apps/server/src/domain_events/queue_worker.rs
@@ -23,7 +23,8 @@ use wealthfolio_core::{
 };
 
 use super::planner::{
-    plan_asset_enrichment, plan_broker_sync, plan_categorization_job, plan_portfolio_job,
+    plan_asset_classification_change, plan_asset_enrichment, plan_broker_sync,
+    plan_categorization_job, plan_portfolio_job,
 };
 use crate::events::EventBus;
 
@@ -143,6 +144,17 @@ pub async fn event_queue_worker(
 /// Processes a batch of domain events.
 async fn process_event_batch(events: &[DomainEvent], deps: Arc<QueueWorkerDeps>) {
     tracing::info!("Processing batch of {} domain event(s)", events.len());
+
+    if let Some(plan) = plan_asset_classification_change(events) {
+        deps.event_bus
+            .publish(crate::events::ServerEvent::with_payload(
+                crate::events::ASSET_CLASSIFICATIONS_CHANGED,
+                serde_json::json!({
+                    "assetIds": plan.asset_ids,
+                    "taxonomyIds": plan.taxonomy_ids,
+                }),
+            ));
+    }
 
     // 1. Plan and run asset enrichment FIRST so that bond metadata (coupon rate,
     //    maturity date, etc.) is available before the portfolio job tries to

--- a/apps/server/src/events.rs
+++ b/apps/server/src/events.rs
@@ -10,6 +10,7 @@ pub const PORTFOLIO_UPDATE_COMPLETE: &str = "portfolio:update-complete";
 pub const PORTFOLIO_UPDATE_ERROR: &str = "portfolio:update-error";
 pub const ASSET_ENRICHMENT_START: &str = "asset:enrichment-start";
 pub const ASSET_ENRICHMENT_COMPLETE: &str = "asset:enrichment-complete";
+pub const ASSET_CLASSIFICATIONS_CHANGED: &str = "asset:classifications-changed";
 
 pub const ASSET_ENRICHMENT_PROGRESS: &str = "asset:enrichment-progress";
 pub const BROKER_SYNC_START: &str = "broker:sync-start";

--- a/apps/server/src/main_lib.rs
+++ b/apps/server/src/main_lib.rs
@@ -391,7 +391,9 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
 
     // Create taxonomy service for auto-classification
     let taxonomy_repository = Arc::new(TaxonomyRepository::new(pool.clone(), writer.clone()));
-    let taxonomy_service = Arc::new(TaxonomyService::new(taxonomy_repository));
+    let taxonomy_service = Arc::new(
+        TaxonomyService::new(taxonomy_repository).with_event_sink(domain_event_sink.clone()),
+    );
 
     let asset_service = Arc::new(
         AssetService::with_taxonomy_service(

--- a/apps/server/src/mcp/mod.rs
+++ b/apps/server/src/mcp/mod.rs
@@ -17,7 +17,7 @@ use crate::{config::Config, main_lib::AppState};
 
 const INSTRUCTIONS: &str = "Read and write access to the user's Wealthfolio portfolio: accounts, \
 holdings, valuations, performance, activities, income, goals, health, and classifications. \
-Write capabilities (drafting and committing activities, classification suggestions) depend on the \
+Write capabilities (drafting and committing activities, classification suggestions and commits) depend on the \
 scopes granted to the access token in use.";
 
 /// Builds the `/mcp` router: the Streamable HTTP MCP service behind PAT

--- a/apps/server/tests/agent_access.rs
+++ b/apps/server/tests/agent_access.rs
@@ -275,6 +275,15 @@ async fn mcp_pat_lifecycle() {
     .await;
     assert_eq!(status, 400);
 
+    // classification:write without classification:suggest is rejected (dependency).
+    let (status, _) = create_pat(
+        &server,
+        &cookie,
+        serde_json::json!({ "name": "classification write only", "scopes": ["classification:write"] }),
+    )
+    .await;
+    assert_eq!(status, 400);
+
     let session = mcp_initialize(&server, &pat).await;
 
     // tools/list -> the read-only catalog: 16 read tools + get_import_mapping
@@ -440,7 +449,7 @@ async fn mcp_pat_lifecycle() {
 /// A write/suggest-scoped token sees the draft, suggest, commit, AND import
 /// tools via `tools/list` — proving scope-gated visibility extends past the
 /// read-only catalog. (Read-only tokens see 17; the full MCP catalog is
-/// 16 read + get_import_mapping + 5 draft/suggest + 2 commit + 2 import = 26.)
+/// 16 read + get_import_mapping + 5 draft/suggest + 3 commit + 2 import = 27.)
 #[tokio::test]
 async fn mcp_write_scoped_token_sees_write_tools() {
     let server = spawn_server(true, false).await;
@@ -453,6 +462,7 @@ async fn mcp_write_scoped_token_sees_write_tools() {
             "activities:draft",
             "activities:write",
             "classification:suggest",
+            "classification:write",
         ])
         .collect();
     let (status, created) = create_pat(
@@ -462,7 +472,7 @@ async fn mcp_write_scoped_token_sees_write_tools() {
     )
     .await;
     assert_eq!(status, 201);
-    assert_eq!(created["scopes"].as_array().unwrap().len(), 10);
+    assert_eq!(created["scopes"].as_array().unwrap().len(), 11);
     let pat = created["token"].as_str().unwrap().to_string();
 
     let session = mcp_initialize(&server, &pat).await;
@@ -479,8 +489,8 @@ async fn mcp_write_scoped_token_sees_write_tools() {
     let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
     assert_eq!(
         tools.len(),
-        26,
-        "full-scope token must see all 26 tools: {names:?}"
+        27,
+        "full-scope token must see all 27 tools: {names:?}"
     );
     assert!(
         names.contains(&"commit_activity_import"),
@@ -498,6 +508,10 @@ async fn mcp_write_scoped_token_sees_write_tools() {
     assert!(
         names.contains(&"commit_activity_drafts"),
         "batch commit tool visible"
+    );
+    assert!(
+        names.contains(&"commit_asset_classification_draft"),
+        "classification commit tool visible"
     );
 }
 

--- a/apps/tauri/src/context/providers.rs
+++ b/apps/tauri/src/context/providers.rs
@@ -219,7 +219,9 @@ pub async fn initialize_context(
 
     // Create taxonomy service before asset service (needed for auto-classification)
     let taxonomy_repository = Arc::new(TaxonomyRepository::new(pool.clone(), writer.clone()));
-    let taxonomy_service = Arc::new(TaxonomyService::new(taxonomy_repository));
+    let taxonomy_service = Arc::new(
+        TaxonomyService::new(taxonomy_repository).with_event_sink(domain_event_sink.clone()),
+    );
 
     let asset_service = Arc::new(
         AssetService::with_taxonomy_service(

--- a/apps/tauri/src/domain_events/planner.rs
+++ b/apps/tauri/src/domain_events/planner.rs
@@ -12,6 +12,57 @@ use wealthfolio_core::utils::time_utils::activity_date_in_user_timezone;
 
 use crate::events::PortfolioRequestPayload;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AssetClassificationChangePlan {
+    pub asset_ids: Vec<String>,
+    pub taxonomy_ids: Vec<String>,
+}
+
+/// Plans a UI cache refresh for asset classification changes.
+pub fn plan_asset_classification_change(
+    events: &[DomainEvent],
+) -> Option<AssetClassificationChangePlan> {
+    let mut asset_ids: HashSet<String> = HashSet::new();
+    let mut taxonomy_ids: HashSet<String> = HashSet::new();
+    let mut has_event = false;
+
+    for event in events {
+        if let DomainEvent::AssetClassificationsChanged {
+            asset_ids: changed_asset_ids,
+            taxonomy_ids: changed_taxonomy_ids,
+        } = event
+        {
+            has_event = true;
+            asset_ids.extend(
+                changed_asset_ids
+                    .iter()
+                    .filter(|id| !id.is_empty())
+                    .cloned(),
+            );
+            taxonomy_ids.extend(
+                changed_taxonomy_ids
+                    .iter()
+                    .filter(|id| !id.is_empty())
+                    .cloned(),
+            );
+        }
+    }
+
+    if !has_event {
+        return None;
+    }
+
+    let mut asset_ids = asset_ids.into_iter().collect::<Vec<_>>();
+    asset_ids.sort();
+    let mut taxonomy_ids = taxonomy_ids.into_iter().collect::<Vec<_>>();
+    taxonomy_ids.sort();
+
+    Some(AssetClassificationChangePlan {
+        asset_ids,
+        taxonomy_ids,
+    })
+}
+
 /// Plans a portfolio recalculation job from a batch of domain events.
 ///
 /// Merges account_ids and asset_ids from:
@@ -88,6 +139,7 @@ pub fn plan_portfolio_job(
                     }
                 }
             }
+            DomainEvent::AssetClassificationsChanged { .. } => {}
             DomainEvent::AssetsMerged { .. } => {}
             DomainEvent::TrackingModeChanged {
                 account_id,
@@ -370,6 +422,40 @@ mod tests {
         } else {
             panic!("Expected Incremental sync mode");
         }
+    }
+
+    #[test]
+    fn test_plan_portfolio_job_asset_classifications_changed_does_not_trigger_recalc() {
+        let events = vec![DomainEvent::asset_classifications_changed(
+            vec!["asset-1".to_string()],
+            vec!["asset_classes".to_string()],
+        )];
+
+        assert!(plan_portfolio_job(&events, "UTC").is_none());
+    }
+
+    #[test]
+    fn test_plan_asset_classification_change_deduplicates_ids() {
+        let events = vec![
+            DomainEvent::asset_classifications_changed(
+                vec!["asset-2".to_string(), "asset-1".to_string()],
+                vec!["regions".to_string()],
+            ),
+            DomainEvent::asset_classifications_changed(
+                vec!["asset-1".to_string(), "".to_string()],
+                vec!["regions".to_string(), "asset_classes".to_string()],
+            ),
+        ];
+
+        let plan = plan_asset_classification_change(&events).unwrap();
+        assert_eq!(
+            plan.asset_ids,
+            vec!["asset-1".to_string(), "asset-2".to_string()]
+        );
+        assert_eq!(
+            plan.taxonomy_ids,
+            vec!["asset_classes".to_string(), "regions".to_string()]
+        );
     }
 
     #[test]

--- a/apps/tauri/src/domain_events/queue_worker.rs
+++ b/apps/tauri/src/domain_events/queue_worker.rs
@@ -21,14 +21,18 @@ use wealthfolio_core::utils::time_utils::{parse_user_timezone_or_default, user_t
 
 #[cfg(feature = "connect-sync")]
 use super::planner::plan_broker_sync;
-use super::planner::{plan_asset_enrichment, plan_categorization_job, plan_portfolio_job};
+use super::planner::{
+    plan_asset_classification_change, plan_asset_enrichment, plan_categorization_job,
+    plan_portfolio_job,
+};
 #[cfg(feature = "connect-sync")]
 use crate::commands::brokers_sync::perform_broker_sync;
 use crate::context::ServiceContext;
 use crate::events::{
-    MarketSyncResult, PortfolioRequestPayload, ASSET_ENRICHMENT_COMPLETE,
-    ASSET_ENRICHMENT_PROGRESS, ASSET_ENRICHMENT_START, MARKET_SYNC_COMPLETE, MARKET_SYNC_ERROR,
-    MARKET_SYNC_START, PORTFOLIO_UPDATE_COMPLETE, PORTFOLIO_UPDATE_ERROR, PORTFOLIO_UPDATE_START,
+    MarketSyncResult, PortfolioRequestPayload, ASSET_CLASSIFICATIONS_CHANGED,
+    ASSET_ENRICHMENT_COMPLETE, ASSET_ENRICHMENT_PROGRESS, ASSET_ENRICHMENT_START,
+    MARKET_SYNC_COMPLETE, MARKET_SYNC_ERROR, MARKET_SYNC_START, PORTFOLIO_UPDATE_COMPLETE,
+    PORTFOLIO_UPDATE_ERROR, PORTFOLIO_UPDATE_START,
 };
 
 /// Debounce window duration in milliseconds.
@@ -115,6 +119,16 @@ async fn process_event_batch(
     }
 
     info!("Processing batch of {} domain events", events.len());
+
+    if let Some(plan) = plan_asset_classification_change(events) {
+        let _ = app_handle.emit(
+            ASSET_CLASSIFICATIONS_CHANGED,
+            serde_json::json!({
+                "assetIds": plan.asset_ids,
+                "taxonomyIds": plan.taxonomy_ids,
+            }),
+        );
+    }
 
     // 1. Plan and run asset enrichment FIRST so that bond metadata (coupon rate,
     //    maturity date, etc.) is available before the portfolio job tries to

--- a/apps/tauri/src/events.rs
+++ b/apps/tauri/src/events.rs
@@ -39,6 +39,9 @@ pub struct MarketSyncResult {
 /// Event emitted when the market data sync process encounters an error.
 pub const MARKET_SYNC_ERROR: &str = "market:sync-error";
 
+/// Event emitted when asset taxonomy assignments change.
+pub const ASSET_CLASSIFICATIONS_CHANGED: &str = "asset:classifications-changed";
+
 /// Event emitted when the broker sync process starts.
 pub const BROKER_SYNC_START: &str = "broker:sync-start";
 

--- a/apps/tauri/src/mcp/server.rs
+++ b/apps/tauri/src/mcp/server.rs
@@ -24,7 +24,7 @@ pub const DEFAULT_PORT: u16 = 8639;
 
 const INSTRUCTIONS: &str = "Read and write access to the user's Wealthfolio portfolio: accounts, \
 holdings, valuations, performance, activities, income, goals, health, and classifications. \
-Write capabilities (drafting and committing activities, classification suggestions) depend on the \
+Write capabilities (drafting and committing activities, classification suggestions and commits) depend on the \
 scopes granted to the access token in use.";
 
 async fn health() -> Json<serde_json::Value> {

--- a/crates/agent-tools/src/catalog.rs
+++ b/crates/agent-tools/src/catalog.rs
@@ -205,6 +205,7 @@ mod tests {
         // Commit and CSV-import tools are NOT exposed to the assistant.
         assert!(!names.contains(&"commit_activity_draft"));
         assert!(!names.contains(&"commit_activity_drafts"));
+        assert!(!names.contains(&"commit_asset_classification_draft"));
         assert!(!names.contains(&"prepare_activity_import"));
         assert!(!names.contains(&"commit_activity_import"));
         assert!(!names.contains(&"get_import_mapping"));
@@ -216,6 +217,7 @@ mod tests {
         let names: Vec<&str> = catalog.iter().map(|tool| tool.name()).collect();
         assert!(names.contains(&"commit_activity_draft"));
         assert!(names.contains(&"commit_activity_drafts"));
+        assert!(names.contains(&"commit_asset_classification_draft"));
         assert!(names.contains(&"get_import_mapping"));
         assert!(names.contains(&"prepare_activity_import"));
         assert!(names.contains(&"commit_activity_import"));
@@ -227,7 +229,11 @@ mod tests {
     async fn execute_denies_commit_tools_with_empty_scopes() {
         let catalog = AgentToolCatalog::mcp_catalog();
         let granted = AgentScopeSet::new();
-        for name in ["commit_activity_draft", "commit_activity_drafts"] {
+        for name in [
+            "commit_activity_draft",
+            "commit_activity_drafts",
+            "commit_asset_classification_draft",
+        ] {
             let err = catalog
                 .execute(Arc::new(PanicEnv), &granted, name, serde_json::json!({}))
                 .await

--- a/crates/agent-tools/src/scope.rs
+++ b/crates/agent-tools/src/scope.rs
@@ -22,6 +22,7 @@ pub enum AgentScope {
     ActivitiesDraft,
     ActivitiesWrite,
     ClassificationSuggest,
+    ClassificationWrite,
 }
 
 impl AgentScope {
@@ -38,6 +39,7 @@ impl AgentScope {
         AgentScope::ActivitiesDraft,
         AgentScope::ActivitiesWrite,
         AgentScope::ClassificationSuggest,
+        AgentScope::ClassificationWrite,
     ];
 
     /// The read-only scopes — what the `read-only` preset grants. Kept
@@ -66,6 +68,7 @@ impl AgentScope {
             AgentScope::ActivitiesDraft => "activities:draft",
             AgentScope::ActivitiesWrite => "activities:write",
             AgentScope::ClassificationSuggest => "classification:suggest",
+            AgentScope::ClassificationWrite => "classification:write",
         }
     }
 
@@ -126,10 +129,11 @@ impl AgentScopeSet {
         set
     }
 
-    /// Read-only + activity writes + classification suggestions.
+    /// Read-only + activity writes + classification suggestions/writes.
     pub fn read_activity_write_classification_suggest() -> Self {
         let mut set = Self::read_activity_write();
         set.insert(AgentScope::ClassificationSuggest);
+        set.insert(AgentScope::ClassificationWrite);
         set
     }
 
@@ -162,14 +166,21 @@ impl AgentScopeSet {
     }
 
     /// Validate scope dependencies. Returns a human-readable error when a
-    /// granted scope is missing a prerequisite: committing activities
-    /// (`activities:write`) requires the ability to draft them
-    /// (`activities:draft`).
+    /// granted scope is missing a prerequisite: committing requires the
+    /// matching draft/suggest scope.
     pub fn dependency_error(&self) -> Option<String> {
         if self.contains(AgentScope::ActivitiesWrite) && !self.contains(AgentScope::ActivitiesDraft)
         {
             return Some(
                 "activities:write requires activities:draft (commit needs a draft)".to_string(),
+            );
+        }
+        if self.contains(AgentScope::ClassificationWrite)
+            && !self.contains(AgentScope::ClassificationSuggest)
+        {
+            return Some(
+                "classification:write requires classification:suggest (commit needs a draft)"
+                    .to_string(),
             );
         }
         None
@@ -214,6 +225,7 @@ mod tests {
         assert!(!set.contains(AgentScope::ActivitiesDraft));
         assert!(!set.contains(AgentScope::ActivitiesWrite));
         assert!(!set.contains(AgentScope::ClassificationSuggest));
+        assert!(!set.contains(AgentScope::ClassificationWrite));
     }
 
     #[test]
@@ -225,9 +237,11 @@ mod tests {
         assert!(write.contains(AgentScope::ActivitiesDraft));
         assert!(write.contains(AgentScope::ActivitiesWrite));
         assert!(!write.contains(AgentScope::ClassificationSuggest));
+        assert!(!write.contains(AgentScope::ClassificationWrite));
 
         let full = AgentScopeSet::read_activity_write_classification_suggest();
         assert!(full.contains(AgentScope::ClassificationSuggest));
+        assert!(full.contains(AgentScope::ClassificationWrite));
     }
 
     #[test]
@@ -239,12 +253,18 @@ mod tests {
     }
 
     #[test]
-    fn dependency_error_flags_write_without_draft() {
+    fn dependency_error_flags_write_without_matching_draft_scope() {
         let mut set = AgentScopeSet::read_only();
         set.insert(AgentScope::ActivitiesWrite);
         assert!(set.dependency_error().is_some());
 
         set.insert(AgentScope::ActivitiesDraft);
+        assert!(set.dependency_error().is_none());
+
+        set.insert(AgentScope::ClassificationWrite);
+        assert!(set.dependency_error().is_some());
+
+        set.insert(AgentScope::ClassificationSuggest);
         assert!(set.dependency_error().is_none());
     }
 }

--- a/crates/agent-tools/src/tools/commit_asset_classification.rs
+++ b/crates/agent-tools/src/tools/commit_asset_classification.rs
@@ -1,0 +1,265 @@
+//! Commit Asset Classification tool (MCP-only).
+//!
+//! `commit_asset_classification_draft` takes the reviewed assignment shape
+//! produced by `prepare_asset_classification` and persists it through the same
+//! taxonomy replacement service the in-app confirmation widget uses.
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use wealthfolio_core::taxonomies::{AssetTaxonomyAssignment, NewAssetTaxonomyAssignment};
+
+use crate::env::AgentEnvironment;
+use crate::scope::AgentScope;
+use crate::tool::{AgentTool, AgentToolAccess, AgentToolError, AgentToolResult};
+
+const AI_ASSIGNMENT_SOURCE: &str = "ai";
+
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitAssetClassificationAssignmentInput {
+    pub category_id: String,
+    pub weight_basis_points: i32,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitAssetClassificationDraftArgs {
+    pub asset_id: String,
+    pub taxonomy_id: String,
+    pub assignments: Vec<CommitAssetClassificationAssignmentInput>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommittedAssetClassificationAssignment {
+    pub assignment_id: String,
+    pub asset_id: String,
+    pub taxonomy_id: String,
+    pub category_id: String,
+    pub weight_basis_points: i32,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CommitAssetClassificationDraftOutput {
+    pub draft_status: String,
+    pub asset_id: String,
+    pub taxonomy_id: String,
+    pub assignment_count: usize,
+    pub assignments: Vec<CommittedAssetClassificationAssignment>,
+    pub applied_at: String,
+}
+
+fn build_new_assignments(
+    asset_id: &str,
+    taxonomy_id: &str,
+    assignments: Vec<CommitAssetClassificationAssignmentInput>,
+) -> Result<Vec<NewAssetTaxonomyAssignment>, AgentToolError> {
+    let asset_id = asset_id.trim();
+    if asset_id.is_empty() {
+        return Err(AgentToolError::InvalidInput(
+            "assetId is required".to_string(),
+        ));
+    }
+
+    let taxonomy_id = taxonomy_id.trim();
+    if taxonomy_id.is_empty() {
+        return Err(AgentToolError::InvalidInput(
+            "taxonomyId is required".to_string(),
+        ));
+    }
+
+    assignments
+        .into_iter()
+        .map(|assignment| {
+            let category_id = assignment.category_id.trim();
+            if category_id.is_empty() {
+                return Err(AgentToolError::InvalidInput(
+                    "categoryId is required".to_string(),
+                ));
+            }
+
+            Ok(NewAssetTaxonomyAssignment {
+                id: None,
+                asset_id: asset_id.to_string(),
+                taxonomy_id: taxonomy_id.to_string(),
+                category_id: category_id.to_string(),
+                weight: assignment.weight_basis_points,
+                source: AI_ASSIGNMENT_SOURCE.to_string(),
+            })
+        })
+        .collect()
+}
+
+fn committed_assignment_dto(
+    assignment: AssetTaxonomyAssignment,
+) -> CommittedAssetClassificationAssignment {
+    CommittedAssetClassificationAssignment {
+        assignment_id: assignment.id,
+        asset_id: assignment.asset_id,
+        taxonomy_id: assignment.taxonomy_id,
+        category_id: assignment.category_id,
+        weight_basis_points: assignment.weight,
+        source: assignment.source,
+    }
+}
+
+/// Commit a reviewed asset classification draft.
+pub struct CommitAssetClassificationDraft;
+
+#[async_trait::async_trait]
+impl AgentTool for CommitAssetClassificationDraft {
+    fn name(&self) -> &'static str {
+        "commit_asset_classification_draft"
+    }
+
+    fn description(&self) -> &'static str {
+        "Persist a reviewed asset classification draft produced by \
+         prepare_asset_classification. This MUTATES data — only call it after \
+         the user has reviewed and confirmed the draft. Use assetId from \
+         resolvedAsset.assetId, or from the chosen asset candidate when the \
+         draft required asset selection. The assignments replace all current \
+         assignments for the selected asset and taxonomy; pass an empty array \
+         only when the user confirmed clearing that taxonomy."
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "assetId": {
+                    "type": "string",
+                    "description": "Asset ID from prepare_asset_classification.resolvedAsset.assetId, or the chosen asset candidate ID."
+                },
+                "taxonomyId": {
+                    "type": "string",
+                    "description": "Taxonomy ID from prepare_asset_classification.taxonomy.taxonomyId."
+                },
+                "assignments": {
+                    "type": "array",
+                    "description": "Reviewed proposed assignments from prepare_asset_classification.proposedAssignments. This array replaces every current assignment for the asset and taxonomy; [] clears the taxonomy.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "categoryId": { "type": "string" },
+                            "weightBasisPoints": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 10000
+                            }
+                        },
+                        "required": ["categoryId", "weightBasisPoints"]
+                    }
+                }
+            },
+            "required": ["assetId", "taxonomyId", "assignments"]
+        })
+    }
+
+    fn required_scopes(&self) -> &'static [AgentScope] {
+        &[
+            AgentScope::ClassificationSuggest,
+            AgentScope::ClassificationWrite,
+        ]
+    }
+
+    fn access_level(&self) -> AgentToolAccess {
+        AgentToolAccess::Write
+    }
+
+    async fn call(
+        &self,
+        env: Arc<dyn AgentEnvironment>,
+        args: serde_json::Value,
+    ) -> Result<AgentToolResult, AgentToolError> {
+        let args: CommitAssetClassificationDraftArgs = serde_json::from_value(args)?;
+        let asset_id = args.asset_id.trim().to_string();
+        let taxonomy_id = args.taxonomy_id.trim().to_string();
+        let assignments = build_new_assignments(&asset_id, &taxonomy_id, args.assignments)?;
+
+        let replaced = env
+            .taxonomy_service()
+            .replace_asset_taxonomy_assignments(&asset_id, &taxonomy_id, assignments)
+            .await
+            .map_err(|e| AgentToolError::ExecutionFailed(e.to_string()))?;
+        env.health_service().clear_cache().await;
+
+        let assignments = replaced
+            .into_iter()
+            .map(committed_assignment_dto)
+            .collect::<Vec<_>>();
+        let output = CommitAssetClassificationDraftOutput {
+            draft_status: "applied".to_string(),
+            asset_id,
+            taxonomy_id,
+            assignment_count: assignments.len(),
+            assignments,
+            applied_at: Utc::now().to_rfc3339(),
+        };
+        Ok(AgentToolResult {
+            content: serde_json::to_value(output)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_reviewed_assignments_to_replacement_payload() {
+        let assignments = build_new_assignments(
+            " asset-1 ",
+            " sector ",
+            vec![CommitAssetClassificationAssignmentInput {
+                category_id: "technology".to_string(),
+                weight_basis_points: 7500,
+            }],
+        )
+        .unwrap();
+
+        assert_eq!(assignments.len(), 1);
+        assert_eq!(assignments[0].asset_id, "asset-1");
+        assert_eq!(assignments[0].taxonomy_id, "sector");
+        assert_eq!(assignments[0].category_id, "technology");
+        assert_eq!(assignments[0].weight, 7500);
+        assert_eq!(assignments[0].source, AI_ASSIGNMENT_SOURCE);
+        assert!(assignments[0].id.is_none());
+    }
+
+    #[test]
+    fn empty_assignments_are_allowed_for_confirmed_clears() {
+        let assignments = build_new_assignments("asset-1", "sector", Vec::new()).unwrap();
+        assert!(assignments.is_empty());
+    }
+
+    #[test]
+    fn blank_asset_or_taxonomy_is_rejected() {
+        assert!(matches!(
+            build_new_assignments(" ", "sector", Vec::new()),
+            Err(AgentToolError::InvalidInput(_))
+        ));
+        assert!(matches!(
+            build_new_assignments("asset-1", " ", Vec::new()),
+            Err(AgentToolError::InvalidInput(_))
+        ));
+    }
+
+    #[test]
+    fn blank_category_is_rejected() {
+        assert!(matches!(
+            build_new_assignments(
+                "asset-1",
+                "sector",
+                vec![CommitAssetClassificationAssignmentInput {
+                    category_id: " ".to_string(),
+                    weight_basis_points: 10000,
+                }],
+            ),
+            Err(AgentToolError::InvalidInput(_))
+        ));
+    }
+}

--- a/crates/agent-tools/src/tools/commit_asset_classification.rs
+++ b/crates/agent-tools/src/tools/commit_asset_classification.rs
@@ -16,6 +16,27 @@ use crate::tool::{AgentTool, AgentToolAccess, AgentToolError, AgentToolResult};
 
 const AI_ASSIGNMENT_SOURCE: &str = "ai";
 
+/// Drop classification commit details from audit args. This is an allowlist so
+/// extra top-level fields cannot smuggle raw payloads into `mcp_audit_log`.
+fn redact_classification_commit(args: &serde_json::Value) -> serde_json::Value {
+    let mut redacted = serde_json::Map::new();
+    if let Some(obj) = args.as_object() {
+        if obj.contains_key("assetId") {
+            redacted.insert("assetId".to_string(), serde_json::json!("[redacted]"));
+        }
+        if obj.contains_key("taxonomyId") {
+            redacted.insert("taxonomyId".to_string(), serde_json::json!("[redacted]"));
+        }
+        if let Some(assignments) = obj.get("assignments").and_then(|a| a.as_array()) {
+            redacted.insert(
+                "assignments".to_string(),
+                serde_json::json!(format!("[{} assignments]", assignments.len())),
+            );
+        }
+    }
+    serde_json::Value::Object(redacted)
+}
+
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CommitAssetClassificationAssignmentInput {
@@ -170,6 +191,10 @@ impl AgentTool for CommitAssetClassificationDraft {
         AgentToolAccess::Write
     }
 
+    fn sanitize_args_for_audit(&self, args: &serde_json::Value) -> serde_json::Value {
+        redact_classification_commit(args)
+    }
+
     async fn call(
         &self,
         env: Arc<dyn AgentEnvironment>,
@@ -261,5 +286,46 @@ mod tests {
             ),
             Err(AgentToolError::InvalidInput(_))
         ));
+    }
+
+    #[test]
+    fn audit_redaction_summarizes_classification_commit() {
+        let args = serde_json::json!({
+            "assetId": "asset-secret",
+            "taxonomyId": "regions",
+            "assignments": [
+                { "categoryId": "us", "weightBasisPoints": 9740 },
+                { "categoryId": "ca", "weightBasisPoints": 260 }
+            ],
+        });
+
+        assert_eq!(
+            CommitAssetClassificationDraft.sanitize_args_for_audit(&args),
+            serde_json::json!({
+                "assetId": "[redacted]",
+                "taxonomyId": "[redacted]",
+                "assignments": "[2 assignments]",
+            })
+        );
+    }
+
+    #[test]
+    fn audit_redaction_drops_unknown_keys() {
+        let args = serde_json::json!({
+            "assetId": "asset-secret",
+            "taxonomyId": "regions",
+            "assignments": [],
+            "note": "do not store me",
+            "payload": { "categoryId": "private" },
+        });
+
+        let redacted = CommitAssetClassificationDraft.sanitize_args_for_audit(&args);
+        assert!(redacted.get("note").is_none());
+        assert!(redacted.get("payload").is_none());
+        assert_eq!(redacted.as_object().unwrap().len(), 3);
+        assert_eq!(
+            redacted["assignments"],
+            serde_json::json!("[0 assignments]")
+        );
     }
 }

--- a/crates/agent-tools/src/tools/mod.rs
+++ b/crates/agent-tools/src/tools/mod.rs
@@ -13,6 +13,7 @@ pub mod asset_taxonomies;
 pub mod cash_balances;
 pub mod categorization_context;
 pub mod commit_activity;
+pub mod commit_asset_classification;
 pub mod contribution_limits;
 pub mod create_categorization_rule;
 pub mod goals;
@@ -95,6 +96,11 @@ pub use commit_activity::{
     CommitActivityDraft, CommitActivityDraftOutput, CommitActivityDrafts, CommitActivityDraftsArgs,
     CommitActivityDraftsOutput, CommitError, CommittedActivity,
 };
+pub use commit_asset_classification::{
+    CommitAssetClassificationAssignmentInput, CommitAssetClassificationDraft,
+    CommitAssetClassificationDraftArgs, CommitAssetClassificationDraftOutput,
+    CommittedAssetClassificationAssignment,
+};
 
 // MCP-only CSV import tools (validate + dedup-safe import pipeline).
 pub use activity_import::{
@@ -150,6 +156,7 @@ pub fn commit_tools() -> Vec<Arc<dyn AgentTool>> {
     vec![
         Arc::new(CommitActivityDraft),
         Arc::new(CommitActivityDrafts),
+        Arc::new(CommitAssetClassificationDraft),
     ]
 }
 

--- a/crates/core/src/events/domain_event.rs
+++ b/crates/core/src/events/domain_event.rs
@@ -43,6 +43,12 @@ pub enum DomainEvent {
     /// Existing assets were updated and require quote sync/recalculation.
     AssetsUpdated { asset_ids: Vec<String> },
 
+    /// Asset taxonomy assignments changed.
+    AssetClassificationsChanged {
+        asset_ids: Vec<String>,
+        taxonomy_ids: Vec<String>,
+    },
+
     /// UNKNOWN asset was merged into a resolved asset.
     AssetsMerged {
         /// The UNKNOWN asset ID being merged (source)
@@ -122,6 +128,17 @@ impl DomainEvent {
     /// Creates an AssetsUpdated event.
     pub fn assets_updated(asset_ids: Vec<String>) -> Self {
         Self::AssetsUpdated { asset_ids }
+    }
+
+    /// Creates an AssetClassificationsChanged event.
+    pub fn asset_classifications_changed(
+        asset_ids: Vec<String>,
+        taxonomy_ids: Vec<String>,
+    ) -> Self {
+        Self::AssetClassificationsChanged {
+            asset_ids,
+            taxonomy_ids,
+        }
     }
 
     /// Creates an AssetsMerged event.
@@ -235,6 +252,28 @@ mod tests {
                 assert_eq!(asset_ids, vec!["asset-1".to_string()]);
             }
             _ => panic!("Expected AssetsUpdated"),
+        }
+    }
+
+    #[test]
+    fn test_asset_classifications_changed_serialization() {
+        let event = DomainEvent::asset_classifications_changed(
+            vec!["asset-1".to_string()],
+            vec!["asset_classes".to_string()],
+        );
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("asset_classifications_changed"));
+
+        let deserialized: DomainEvent = serde_json::from_str(&json).unwrap();
+        match deserialized {
+            DomainEvent::AssetClassificationsChanged {
+                asset_ids,
+                taxonomy_ids,
+            } => {
+                assert_eq!(asset_ids, vec!["asset-1".to_string()]);
+                assert_eq!(taxonomy_ids, vec!["asset_classes".to_string()]);
+            }
+            _ => panic!("Expected AssetClassificationsChanged"),
         }
     }
 

--- a/crates/core/src/taxonomies/taxonomy_service.rs
+++ b/crates/core/src/taxonomies/taxonomy_service.rs
@@ -5,6 +5,7 @@ use std::{collections::HashSet, sync::Arc};
 use uuid::Uuid;
 
 use crate::errors::{DatabaseError, ValidationError};
+use crate::events::{DomainEvent, DomainEventSink, NoOpDomainEventSink};
 use crate::Result;
 
 use super::{
@@ -15,11 +16,32 @@ use super::{
 
 pub struct TaxonomyService {
     repository: Arc<dyn TaxonomyRepositoryTrait>,
+    event_sink: Arc<dyn DomainEventSink>,
 }
 
 impl TaxonomyService {
     pub fn new(repository: Arc<dyn TaxonomyRepositoryTrait>) -> Self {
-        Self { repository }
+        Self {
+            repository,
+            event_sink: Arc::new(NoOpDomainEventSink),
+        }
+    }
+
+    pub fn with_event_sink(mut self, event_sink: Arc<dyn DomainEventSink>) -> Self {
+        self.event_sink = event_sink;
+        self
+    }
+
+    fn emit_asset_classifications_changed(
+        &self,
+        asset_ids: Vec<String>,
+        taxonomy_ids: Vec<String>,
+    ) {
+        self.event_sink
+            .emit(DomainEvent::asset_classifications_changed(
+                asset_ids,
+                taxonomy_ids,
+            ));
     }
 
     /// Recursively flatten category JSON into NewCategory records
@@ -377,6 +399,9 @@ impl TaxonomyServiceTrait for TaxonomyService {
         &self,
         assignment: NewAssetTaxonomyAssignment,
     ) -> Result<AssetTaxonomyAssignment> {
+        let asset_id = assignment.asset_id.clone();
+        let taxonomy_id = assignment.taxonomy_id.clone();
+
         // Check if taxonomy is single-select
         if let Some(taxonomy) = self.repository.get_taxonomy(&assignment.taxonomy_id)? {
             if taxonomy.is_single_select {
@@ -387,7 +412,9 @@ impl TaxonomyServiceTrait for TaxonomyService {
             }
         }
 
-        self.repository.upsert_assignment(assignment).await
+        let created = self.repository.upsert_assignment(assignment).await?;
+        self.emit_asset_classifications_changed(vec![asset_id], vec![taxonomy_id]);
+        Ok(created)
     }
 
     async fn replace_asset_taxonomy_assignments(
@@ -397,12 +424,22 @@ impl TaxonomyServiceTrait for TaxonomyService {
         assignments: Vec<NewAssetTaxonomyAssignment>,
     ) -> Result<Vec<AssetTaxonomyAssignment>> {
         self.validate_asset_assignment_replacement(asset_id, taxonomy_id, &assignments)?;
-        self.repository
+        let replaced = self
+            .repository
             .replace_asset_assignments(asset_id, taxonomy_id, assignments)
-            .await
+            .await?;
+        self.emit_asset_classifications_changed(
+            vec![asset_id.to_string()],
+            vec![taxonomy_id.to_string()],
+        );
+        Ok(replaced)
     }
 
     async fn remove_asset_assignment(&self, id: &str) -> Result<usize> {
-        self.repository.delete_assignment(id).await
+        let deleted = self.repository.delete_assignment(id).await?;
+        if deleted > 0 {
+            self.emit_asset_classifications_changed(Vec::new(), Vec::new());
+        }
+        Ok(deleted)
     }
 }

--- a/docs/architecture/cli-mcp-agent-access.md
+++ b/docs/architecture/cli-mcp-agent-access.md
@@ -61,7 +61,7 @@ audit logging it currently lacks.
 - No raw SQL tools.
 - No tools for secrets, addon installation, backups, updater, device pairing, or
   arbitrary file access.
-- No automatic classification writes.
+- No unreviewed automatic classification writes.
 - No separate user-facing MCP binary.
 
 ## Current Repository Context
@@ -448,6 +448,7 @@ prepare_asset_classification
 ```text
 commit_activity_draft              -- persist one reviewed draft
 commit_activity_drafts             -- persist a batch
+commit_asset_classification_draft  -- persist one reviewed classification draft
 ```
 
 ### MCP-only CSV Import Tools
@@ -463,8 +464,10 @@ agent-facing CSV path is the three import tools above.
 
 Rules:
 
-- Draft and import-preview tools never mutate data; committing requires the
-  `activities:write` scope (which itself requires `activities:draft`).
+- Draft and import-preview tools never mutate data; activity commits require
+  `activities:write` (which itself requires `activities:draft`), and
+  classification commits require `classification:write` (which itself requires
+  `classification:suggest`).
 - CSV / activity-row content must not be persisted in raw audit logs: the
   write/import tools redact their `activities`/row arguments to a count
   (`"[N rows]"`) via per-tool audit sanitization.
@@ -518,10 +521,13 @@ activities:write         commit_activity_draft / commit_activity_drafts,
 classification:suggest   propose_transaction_categories,
                          create_categorization_rule,
                          prepare_asset_classification
+classification:write     commit_asset_classification_draft
+                         (also requires classification:suggest)
 ```
 
-Dependency rule: `activities:write` requires `activities:draft` (you cannot
-commit without the ability to draft). Token creation validates this.
+Dependency rules: `activities:write` requires `activities:draft`, and
+`classification:write` requires `classification:suggest` (you cannot commit
+without the matching draft/suggest capability). Token creation validates this.
 
 Presets (`AgentScopeSet` constructors):
 
@@ -529,7 +535,7 @@ Presets (`AgentScopeSet` constructors):
 - `read-activity-draft` — read + `activities:draft`.
 - `read-activity-write` — read + `activities:draft` + `activities:write`.
 - `read-activity-write-classification-suggest` — the above plus
-  `classification:suggest`.
+  `classification:suggest` and `classification:write`.
 
 Scope strings are parsed with `AgentScope::parse`, which rejects unknown scopes
 (including the removed `portfolio:read`). Token creation rejects unknown scopes;
@@ -719,7 +725,8 @@ calls unchanged; no direct SQLite access introduced by MCP.
 - PAT creation UX: name + fixed expiry options (30/90 days, 1 year, none) +
   **selectable scopes** (presets: read-only, read-activity-draft,
   read-activity-write, read-activity-write-classification-suggest); token shown
-  once. Dependency rule enforced (`activities:write` ⇒ `activities:draft`).
+  once. Dependency rules enforced (`activities:write` ⇒ `activities:draft`,
+  `classification:write` ⇒ `classification:suggest`).
 - Server MCP fail-closed: `WF_MCP_ENABLED=true` on a non-loopback address
   requires auth configured, with no `WF_AUTH_REQUIRED=false` escape hatch
   (otherwise anyone could mint PATs).
@@ -743,5 +750,4 @@ calls unchanged; no direct SQLite access introduced by MCP.
 - Auth is PAT-only on both hosts; lock file never contains secrets.
 - Audit log stored in SQLite with `session_id`.
 - Selectable scopes from the start: read, activity draft/commit, and
-  classification suggest all ship behind explicit scopes; classification stays
-  read/suggest-only (no classification writes).
+  classification suggest/write all ship behind explicit scopes.


### PR DESCRIPTION
## Summary

- add `classification:write` and the MCP-only `commit_asset_classification_draft` tool
- emit a first-class asset-classification domain event after taxonomy assignment writes
- bridge that event through desktop/web runtimes and invalidate the relevant frontend caches
- align token scope dependency UX so `classification:suggest` is visibly implied by `classification:write`

## Why

MCP classification commits were able to persist data without a targeted UI refresh path. Reusing `AssetsUpdated` would refresh the UI, but it would also imply quote sync and portfolio recalculation. This PR adds a classification-specific event so MCP, Tauri, and web API writes share the same refresh behavior without triggering unrelated portfolio work.

## Validation

- `pnpm format:check`
- `pnpm lint` (existing warnings only, no errors)
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
