### PR TITLE
fix(addons): update mobile navbar to fix addon page height

### DIFF
--- a/apps/frontend/src/pages/layouts/navigation/mobile-navbar.tsx
+++ b/apps/frontend/src/pages/layouts/navigation/mobile-navbar.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from "react-i18next";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { type NavLink, type NavigationProps, isPathActive } from "./app-navigation";
 import { resolveNavigationIcon } from "./navigation-icons";
-
+import { createPortal } from "react-dom";
 interface MobileNavBarProps {
   navigation: NavigationProps;
 }
@@ -71,7 +71,7 @@ export function MobileNavBar({ navigation }: MobileNavBarProps) {
   const hasMenu = moreItems.length > 0;
   const columnCount = visibleItems.length + (hasMenu ? 1 : 0);
 
-  return (
+  return createPortal(
     <div className={containerClassName}>
       {/* Lift off bottom by the design gap while respecting safe area */}
       <div className="flex justify-center px-4 pb-[var(--mobile-nav-bottom-offset)]">
@@ -260,6 +260,7 @@ export function MobileNavBar({ navigation }: MobileNavBarProps) {
           </div>
         </SheetContent>
       </Sheet>
-    </div>
+    </div>,
+    document.body,
   );
 }


### PR DESCRIPTION
## Description

### Issue
On desktop, an empty space is left at the bottom of all addon pages for the mobile navbar. On mobile, the nav bar is not translucent over the content like on other pages.

Before:
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/b8b89889-e710-489a-af4c-ce16aba6d4f3" />

<img width="454" height="952" alt="image" src="https://github.com/user-attachments/assets/4595fa25-288d-4d63-8dfe-5ee15a62d726" />


## Fix
- Changed mobile nav bar to render using createPortal 
- Made addon pages full height

After:
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/1bb68059-42ec-4674-b420-f88d5264c5dd" />

<img width="539" height="952" alt="image" src="https://github.com/user-attachments/assets/b40fd941-980a-497f-a1a6-099c874629d4" />

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
