### PR TITLE
fix: handle non-ASCII Yahoo suffix parsing

### DIFF
--- a/crates/core/src/assets/asset_id.rs
+++ b/crates/core/src/assets/asset_id.rs
@@ -40,13 +40,10 @@ pub fn parse_symbol_with_exchange_suffix(symbol: &str) -> (&str, Option<&'static
     let trimmed = symbol.trim();
     let base_symbol = strip_yahoo_suffix(trimmed);
 
-    let mic = yahoo_exchange_suffixes()
-        .iter()
-        .find(|suffix| {
-            trimmed.len() >= suffix.len()
-                && trimmed[trimmed.len() - suffix.len()..].eq_ignore_ascii_case(suffix)
-        })
-        .and_then(|suffix| yahoo_suffix_to_mic(&suffix[1..]));
+    let mic = trimmed
+        .get(base_symbol.len()..)
+        .and_then(|suffix| suffix.strip_prefix('.'))
+        .and_then(yahoo_suffix_to_mic);
 
     (base_symbol, mic)
 }
@@ -164,6 +161,19 @@ mod tests {
         let (symbol, mic) = parse_symbol_with_exchange_suffix("BRK.B");
         assert_eq!(symbol, "BRK.B");
         assert_eq!(mic, None);
+    }
+
+    #[test]
+    fn test_parse_symbol_with_exchange_suffix_handles_non_ascii_symbols() {
+        for symbol in ["ÅÄÖ", "سهم", "東京", "😀"] {
+            assert_eq!(parse_symbol_with_exchange_suffix(symbol), (symbol, None));
+
+            let suffixed = format!("{symbol}.TO");
+            assert_eq!(
+                parse_symbol_with_exchange_suffix(&suffixed),
+                (symbol, Some("XTSE"))
+            );
+        }
     }
 
     #[test]

--- a/crates/market-data/src/resolver/exchange_suffixes.rs
+++ b/crates/market-data/src/resolver/exchange_suffixes.rs
@@ -141,18 +141,22 @@ pub fn yahoo_suffix_to_mic(suffix: &str) -> Option<&'static str> {
         .copied()
 }
 
+fn strip_ascii_suffix_ignore_case<'a>(value: &'a str, suffix: &str) -> Option<&'a str> {
+    let start = value.len().checked_sub(suffix.len())?;
+    let candidate = value.get(start..)?;
+    if candidate.eq_ignore_ascii_case(suffix) {
+        value.get(..start)
+    } else {
+        None
+    }
+}
+
 fn split_known_yahoo_suffix(symbol: &str) -> (&str, Option<&'static str>, Option<&'static str>) {
     let trimmed = symbol.trim();
     for suffix in yahoo_exchange_suffixes() {
-        if trimmed.len() >= suffix.len()
-            && trimmed[trimmed.len() - suffix.len()..].eq_ignore_ascii_case(suffix)
-        {
+        if let Some(base) = strip_ascii_suffix_ignore_case(trimmed, suffix) {
             let suffix_code = suffix.strip_prefix('.').unwrap_or(suffix);
-            return (
-                &trimmed[..trimmed.len() - suffix.len()],
-                yahoo_suffix_to_mic(suffix_code),
-                Some(*suffix),
-            );
+            return (base, yahoo_suffix_to_mic(suffix_code), Some(*suffix));
         }
     }
     (trimmed, None, None)
@@ -176,7 +180,7 @@ pub fn yahoo_equity_provider_symbol_to_canonical(symbol: &str) -> String {
     let trimmed = symbol.trim();
     let (base, _suffix_mic, known_suffix) = split_known_yahoo_suffix(trimmed);
     if known_suffix.is_some() {
-        let suffix = &trimmed[base.len()..];
+        let suffix = trimmed.get(base.len()..).unwrap_or_default();
         return format!(
             "{}{}",
             yahoo_equity_provider_base_to_canonical(base),
@@ -212,7 +216,7 @@ pub fn yahoo_equity_search_queries(query: &str) -> Vec<String> {
     let (base, _suffix_mic, known_suffix) = split_known_yahoo_suffix(trimmed);
     let provider_base = yahoo_equity_base_to_provider(base);
     let provider_query = if known_suffix.is_some() {
-        let suffix = &trimmed[base.len()..];
+        let suffix = trimmed.get(base.len()..).unwrap_or_default();
         format!("{provider_base}{suffix}")
     } else {
         provider_base
@@ -231,21 +235,19 @@ pub fn yahoo_equity_search_queries(query: &str) -> Vec<String> {
 /// share classes like BRK.B or RDS.A (since .B and .A are not in the whitelist).
 pub fn strip_yahoo_suffix(symbol: &str) -> &str {
     // Handle special suffixes first
-    if symbol.len() >= 2 && symbol[symbol.len() - 2..].eq_ignore_ascii_case("=X") {
+    if let Some(base) = strip_ascii_suffix_ignore_case(symbol, "=X") {
         // FX pairs like EURUSD=X
-        return &symbol[..symbol.len() - 2];
+        return base;
     }
-    if symbol.len() >= 2 && symbol[symbol.len() - 2..].eq_ignore_ascii_case("=F") {
+    if let Some(base) = strip_ascii_suffix_ignore_case(symbol, "=F") {
         // Futures like GC=F
-        return &symbol[..symbol.len() - 2];
+        return base;
     }
 
     // Only strip if suffix is in our known exchange whitelist
     for suffix in yahoo_exchange_suffixes() {
-        if symbol.len() >= suffix.len()
-            && symbol[symbol.len() - suffix.len()..].eq_ignore_ascii_case(suffix)
-        {
-            return &symbol[..symbol.len() - suffix.len()];
+        if let Some(base) = strip_ascii_suffix_ignore_case(symbol, suffix) {
+            return base;
         }
     }
 
@@ -398,6 +400,26 @@ mod tests {
         assert_eq!(strip_yahoo_suffix("eurusd=x"), "eurusd");
         assert_eq!(strip_yahoo_suffix("GC=F"), "GC");
         assert_eq!(strip_yahoo_suffix("gc=f"), "gc");
+    }
+
+    #[test]
+    fn test_yahoo_suffix_helpers_handle_non_ascii_symbols() {
+        for symbol in ["ÅÄÖ", "سهم", "東京", "😀"] {
+            assert_eq!(strip_yahoo_suffix(symbol), symbol);
+            assert_eq!(yahoo_equity_search_queries(symbol), vec![symbol]);
+            assert_eq!(yahoo_equity_provider_symbol_to_canonical(symbol), symbol);
+
+            let suffixed = format!("{symbol}.TO");
+            assert_eq!(strip_yahoo_suffix(&suffixed), symbol);
+            assert_eq!(
+                yahoo_equity_search_queries(&suffixed),
+                vec![suffixed.clone()]
+            );
+            assert_eq!(
+                yahoo_equity_provider_symbol_to_canonical(&suffixed),
+                suffixed
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1234.

This makes Yahoo suffix parsing char-boundary-safe so symbol search no longer panics when a manually entered asset or query contains non-ASCII characters such as Nordic accented letters, Arabic, CJK text, or emoji.

## Root cause

`strip_yahoo_suffix` and related Yahoo suffix helpers computed suffix starts with byte offsets like `symbol.len() - suffix.len()` and then sliced the string directly. For UTF-8 symbols, that offset can land inside a multi-byte character before suffix matching can determine that no suffix is present.

## Changes

- Added a safe suffix matcher that uses `str::get(...)` and returns no match when the computed offset is not a char boundary.
- Reused that matcher for Yahoo exchange suffixes and special `=X` / `=F` suffixes.
- Updated core asset suffix parsing to derive MICs from the safely stripped base instead of repeating byte slicing.
- Added regression coverage for Nordic, Arabic, CJK, and emoji symbols with and without known Yahoo suffixes.

## Impact

Existing ASCII behavior is preserved for symbols like `SHOP.TO`, `BRK.B`, `EURUSD=X`, and `GC=F`. The functional change is that valid UTF-8 input now returns "no suffix" instead of panicking when a byte offset would fall inside a character.

## Similar scan

I also scanned for similar direct string slicing patterns. No remaining unsafe Yahoo suffix slicing remains in the touched parser files. A few broader diagnostic truncation sites still slice arbitrary response/error strings by byte count; those are outside this search-path fix and should be handled separately if we want repo-wide UTF-8 truncation hardening.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p wealthfolio-market-data resolver::exchange_suffixes`
- `cargo test -p wealthfolio-core assets::asset_id`