### PR TITLE
fix(taxonomies): category creation silently fails for non-Latin names

### DIFF
--- a/apps/frontend/src/pages/settings/taxonomies/components/category-form.tsx
+++ b/apps/frontend/src/pages/settings/taxonomies/components/category-form.tsx
@@ -46,10 +46,14 @@ interface CategoryFormProps {
 }
 
 function generateKey(name: string): string {
-  return name
+  const key = name
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "_")
     .replace(/^_|_$/g, "");
+  // Names without any Latin letters or digits (e.g. Chinese, Japanese, Arabic)
+  // slugify to an empty string; fall back so the hidden key field doesn't fail
+  // validation and silently block category creation.
+  return key || `cat_${Date.now()}`;
 }
 
 export function CategoryForm({


### PR DESCRIPTION
## Bug

In Settings → Classifications, creating a category whose name contains no Latin letters or digits (e.g. `贵金属`, `債券`, `عقارات`) does nothing when you click "Create category" — no error, no toast, the form just sits there.

## Root cause

`generateKey` (`category-form.tsx`) slugifies the name with `replace(/[^a-z0-9]+/g, "_")`, so a fully non-Latin name produces an **empty string**. The auto-generated `key` is a hidden form field — it isn't rendered, so its `min(1)` zod error has nowhere to display, and `handleSubmit` silently refuses to submit.

A name like `A股宽基` happens to work only because the single Latin letter survives as the key (`"a"`), which makes the failure look random to affected users.

## Fix

Fall back to a timestamp-based key when the slug comes out empty — the same convention the spending categories page already uses (`slugify(values.name) || `cat_${Date.now()}``). One function, five lines.

## Testing

- `pnpm check` and `pnpm test` (1018 tests) pass.
- Verification on a local zh build in progress (creating 贵金属/纳斯达克/债券/红利 under Custom Groups); will confirm in a follow-up comment.
