### PR TITLE
feat(rebalance): add transfer-only rebalance mode

### DIFF
--- a/apps/frontend/src/i18n/locales/de/allocation.json
+++ b/apps/frontend/src/i18n/locales/de/allocation.json
@@ -87,6 +87,9 @@
     "hybrid": "Hybrid",
     "hybridShort": "Hybrid",
     "hybridHint": "Bargeld + Verkäufe",
+    "transferOnly": "Nur Umschichtung",
+    "transferShort": "Umschichtung",
+    "transferHint": "Wert verschieben, keine Käufe/Verkäufe",
     "enableSellsTip": "Aktivieren Sie „Verkäufe zulassen“ für dieses Ziel, um diesen Modus zu verwenden"
   },
   "planner": {
@@ -102,7 +105,8 @@
     "driverSentenceUnder": "{{name}} liegt {{current}} % unter einem Ziel von {{target}} %.",
     "modeVerbSells": "Verkäufe und Käufe",
     "modeVerbHybrid": "Bargeld und Verkäufe",
-    "modeVerbCashFlow": "Cashflow-Käufe"
+    "modeVerbCashFlow": "Cashflow-Käufe",
+    "modeVerbTransfer": "Umschichtungen"
   },
   "narrative": {
     "liftAndShrink": "{{verb}} führen {{lifted}} näher an das Ziel und verringern die Übergewichtung von {{shrank}} von {{before}} auf {{after}}.",
@@ -192,6 +196,12 @@
     "tradesSummarySells": "{{buys}} · {{sells}} · {{cash}} neues Bargeld",
     "tradesSummaryDeployed": "{{buys}} · {{cash}} eingesetzt",
     "noTrades": "Keine Transaktionen — alle Positionen sind bereits im Band oder es wurden keine Bestände gefunden.",
+    "transferSummary_one": "{{count}} Umschichtung · {{amount}} bewegt",
+    "transferSummary_other": "{{count}} Umschichtungen · {{amount}} bewegt",
+    "proposedTransfers": "Vorgeschlagene Umschichtungen",
+    "noTransfers": "Keine Umschichtungen — alle Positionen sind bereits im Band.",
+    "residualGapTitle": "Angenäherter Plan — {{gap}} Lücke verbleibend",
+    "descriptionTransfer": "Rebalancing durch Verschiebung von Werten zwischen Positionen — keine Käufe oder Verkäufe erforderlich.",
     "calculatedFooter": "{{name}} · Berechnet am {{date}}",
     "copyAsText": "Als Text kopieren",
     "exportCsv": "CSV exportieren"
@@ -217,7 +227,11 @@
     "amount": "Betrag ({{currency}})",
     "shares": "Anteile",
     "lastPrice": "Letzter Preis ({{currency}})",
-    "reason": "Grund"
+    "reason": "Grund",
+    "from": "Von",
+    "fromName": "Name Quelle",
+    "to": "Nach",
+    "toName": "Name Ziel"
   },
   "copyText": {
     "header": "Rebalancing-Plan · {{date}}",
@@ -225,6 +239,8 @@
     "cashDeployed": "Eingesetztes Bargeld: {{used}} von {{available}}",
     "maxDrift": "Max. Abweichung: {{before}} → {{after}}",
     "proposedTrades": "VORGESCHLAGENE TRANSAKTIONEN",
+    "proposedTransfers": "VORGESCHLAGENE UMSCHICHTUNGEN",
+    "transfer": "UMSCHICHTUNG  {{from}} → {{to}}  {{amount}}",
     "account": "Konto {{account}}",
     "shares": "{{qty}} Anteile",
     "warnings_one": "{{count}} Warnung:",

--- a/apps/frontend/src/i18n/locales/en/allocation.json
+++ b/apps/frontend/src/i18n/locales/en/allocation.json
@@ -87,6 +87,9 @@
     "hybrid": "Hybrid",
     "hybridShort": "Hybrid",
     "hybridHint": "cash + sells",
+    "transferOnly": "Transfer only",
+    "transferShort": "Transfer",
+    "transferHint": "move value, no buys/sells",
     "enableSellsTip": "Enable 'Allow sells' on this target to use this mode"
   },
   "planner": {
@@ -102,7 +105,8 @@
     "driverSentenceUnder": "{{name}} sits {{current}}% under a {{target}}% target.",
     "modeVerbSells": "Sells and buys",
     "modeVerbHybrid": "Cash and sells",
-    "modeVerbCashFlow": "Cash-flow buys"
+    "modeVerbCashFlow": "Cash-flow buys",
+    "modeVerbTransfer": "Transfers"
   },
   "narrative": {
     "liftAndShrink": "{{verb}} lift {{lifted}} toward target and shrink the {{shrank}} overweight from {{before}} to {{after}}.",
@@ -187,11 +191,17 @@
     "descriptionSell": "Sell what you're overweight to buy what you're underweight. Your cash stays put. Tax impact is not estimated.",
     "descriptionHybrid": "Invest your cash first, then sell overweight sleeves only if cash alone can't close the gap. Cash can add to a holding but can't shrink one you already own too much of. Tax impact is not estimated.",
     "descriptionCashFlow": "Put your new cash to work in the sleeves you're light on. Buys only — nothing is sold.",
+    "descriptionTransfer": "Rebalance by moving value between holdings — no buys or sells required.",
     "stalePlan": "Portfolio data changed. Recalculate to refresh this plan.",
     "proposedTrades": "Proposed trades",
     "tradesSummarySells": "{{buys}} · {{sells}} · {{cash}} new cash",
     "tradesSummaryDeployed": "{{buys}} · {{cash}} deployed",
     "noTrades": "No trades — all sleeves are already within band or no holdings found.",
+    "transferSummary_one": "{{count}} transfer · {{amount}} moved",
+    "transferSummary_other": "{{count}} transfers · {{amount}} moved",
+    "proposedTransfers": "Proposed transfers",
+    "noTransfers": "No transfers — all sleeves are already within band.",
+    "residualGapTitle": "Approximate plan — {{gap}} gap remaining",
     "calculatedFooter": "{{name}} · Calculated {{date}}",
     "copyAsText": "Copy as text",
     "exportCsv": "Export CSV"
@@ -217,7 +227,11 @@
     "amount": "Amount ({{currency}})",
     "shares": "Shares",
     "lastPrice": "Last Price ({{currency}})",
-    "reason": "Reason"
+    "reason": "Reason",
+    "from": "From",
+    "fromName": "From Name",
+    "to": "To",
+    "toName": "To Name"
   },
   "copyText": {
     "header": "Rebalance plan · {{date}}",
@@ -225,6 +239,8 @@
     "cashDeployed": "Cash deployed: {{used}} of {{available}}",
     "maxDrift": "Max drift: {{before}} → {{after}}",
     "proposedTrades": "PROPOSED TRADES",
+    "proposedTransfers": "PROPOSED TRANSFERS",
+    "transfer": "TRANSFER  {{from}} → {{to}}  {{amount}}",
     "account": "account {{account}}",
     "shares": "{{qty}} sh",
     "warnings_one": "{{count}} warning:",

--- a/apps/frontend/src/i18n/locales/es/allocation.json
+++ b/apps/frontend/src/i18n/locales/es/allocation.json
@@ -87,6 +87,9 @@
     "hybrid": "Híbrido",
     "hybridShort": "Híbrido",
     "hybridHint": "efectivo + ventas",
+    "transferOnly": "Solo traspasos",
+    "transferShort": "Traspasos",
+    "transferHint": "mover valor, sin compras/ventas",
     "enableSellsTip": "Activa 'Permitir ventas' en este objetivo para usar este modo"
   },
   "planner": {
@@ -102,7 +105,8 @@
     "driverSentenceUnder": "{{name}} está {{current}}% por debajo de un objetivo del {{target}}%.",
     "modeVerbSells": "Ventas y compras",
     "modeVerbHybrid": "Efectivo y ventas",
-    "modeVerbCashFlow": "Compras con flujo de efectivo"
+    "modeVerbCashFlow": "Compras con flujo de efectivo",
+    "modeVerbTransfer": "Traspasos"
   },
   "narrative": {
     "liftAndShrink": "{{verb}} elevar {{lifted}} hacia el objetivo y reducir el sobrepeso de {{shrank}} de {{before}} a {{after}}.",
@@ -187,11 +191,17 @@
     "descriptionSell": "Vende lo que tienes sobreponderado para comprar lo que tienes infraponderado. Tu efectivo se mantiene. No se estima el impacto fiscal.",
     "descriptionHybrid": "Invierte primero tu efectivo y luego vende los tramos sobreponderados solo si el efectivo por sí solo no puede cerrar la brecha. El efectivo puede aumentar una posición, pero no puede reducir una que ya tienes en exceso. No se estima el impacto fiscal.",
     "descriptionCashFlow": "Pon a trabajar tu nuevo efectivo en los tramos donde estás corto. Solo compras; no se vende nada.",
+    "descriptionTransfer": "Reequilibra moviendo valor entre posiciones — sin compras ni ventas.",
     "stalePlan": "Los datos de la cartera cambiaron. Recalcula para actualizar este plan.",
     "proposedTrades": "Operaciones propuestas",
     "tradesSummarySells": "{{buys}} · {{sells}} · {{cash}} de efectivo nuevo",
     "tradesSummaryDeployed": "{{buys}} · {{cash}} desplegado",
     "noTrades": "Sin operaciones: todos los tramos ya están dentro de la banda o no se encontraron posiciones.",
+    "transferSummary_one": "{{count}} traspaso · {{amount}} movido",
+    "transferSummary_other": "{{count}} traspasos · {{amount}} movidos",
+    "proposedTransfers": "Traspasos propuestos",
+    "noTransfers": "Sin traspasos — todos los tramos ya están dentro de la banda.",
+    "residualGapTitle": "Plan aproximado — {{gap}} de diferencia restante",
     "calculatedFooter": "{{name}} · Calculado {{date}}",
     "copyAsText": "Copiar como texto",
     "exportCsv": "Exportar CSV"
@@ -217,7 +227,11 @@
     "amount": "Importe ({{currency}})",
     "shares": "Acciones",
     "lastPrice": "Último precio ({{currency}})",
-    "reason": "Motivo"
+    "reason": "Motivo",
+    "from": "Desde",
+    "fromName": "Nombre origen",
+    "to": "Hacia",
+    "toName": "Nombre destino"
   },
   "copyText": {
     "header": "Plan de reequilibrio · {{date}}",
@@ -225,6 +239,8 @@
     "cashDeployed": "Efectivo desplegado: {{used}} de {{available}}",
     "maxDrift": "Desviación máxima: {{before}} → {{after}}",
     "proposedTrades": "OPERACIONES PROPUESTAS",
+    "proposedTransfers": "TRASPASOS PROPUESTOS",
+    "transfer": "TRASPASO  {{from}} → {{to}}  {{amount}}",
     "account": "cuenta {{account}}",
     "shares": "{{qty}} acc",
     "warnings_one": "{{count}} advertencia:",

--- a/apps/frontend/src/i18n/locales/fr/allocation.json
+++ b/apps/frontend/src/i18n/locales/fr/allocation.json
@@ -87,6 +87,9 @@
     "hybrid": "Hybride",
     "hybridShort": "Hybride",
     "hybridHint": "trésorerie + ventes",
+    "transferOnly": "Transfert uniquement",
+    "transferShort": "Transfert",
+    "transferHint": "déplacer la valeur, sans achats/ventes",
     "enableSellsTip": "Activez « Autoriser les ventes » sur cette cible pour utiliser ce mode"
   },
   "planner": {
@@ -102,7 +105,8 @@
     "driverSentenceUnder": "{{name}} est à {{current}} % en dessous d'une cible de {{target}} %.",
     "modeVerbSells": "Les ventes et achats",
     "modeVerbHybrid": "La trésorerie et les ventes",
-    "modeVerbCashFlow": "Les achats par flux de trésorerie"
+    "modeVerbCashFlow": "Les achats par flux de trésorerie",
+    "modeVerbTransfer": "Les transferts"
   },
   "narrative": {
     "liftAndShrink": "{{verb}} rapprochent {{lifted}} de la cible et réduisent la surpondération de {{shrank}} de {{before}} à {{after}}.",
@@ -192,6 +196,12 @@
     "tradesSummarySells": "{{buys}} · {{sells}} · {{cash}} de nouvelle trésorerie",
     "tradesSummaryDeployed": "{{buys}} · {{cash}} déployé",
     "noTrades": "Aucune transaction — toutes les poches sont déjà dans la bande ou aucune position trouvée.",
+    "transferSummary_one": "{{count}} transfert · {{amount}} déplacé",
+    "transferSummary_other": "{{count}} transferts · {{amount}} déplacés",
+    "proposedTransfers": "Transferts proposés",
+    "noTransfers": "Aucun transfert — toutes les poches sont déjà dans la bande.",
+    "residualGapTitle": "Plan approximatif — {{gap}} d'écart restant",
+    "descriptionTransfer": "Rééquilibrer en déplaçant la valeur entre les positions — aucun achat ni vente requis.",
     "calculatedFooter": "{{name}} · Calculé le {{date}}",
     "copyAsText": "Copier comme texte",
     "exportCsv": "Exporter en CSV"
@@ -217,7 +227,11 @@
     "amount": "Montant ({{currency}})",
     "shares": "Parts",
     "lastPrice": "Dernier prix ({{currency}})",
-    "reason": "Motif"
+    "reason": "Motif",
+    "from": "De",
+    "fromName": "Nom source",
+    "to": "Vers",
+    "toName": "Nom destination"
   },
   "copyText": {
     "header": "Plan de rééquilibrage · {{date}}",
@@ -225,6 +239,8 @@
     "cashDeployed": "Trésorerie déployée : {{used}} sur {{available}}",
     "maxDrift": "Écart max : {{before}} → {{after}}",
     "proposedTrades": "TRANSACTIONS PROPOSÉES",
+    "proposedTransfers": "TRANSFERTS PROPOSÉS",
+    "transfer": "TRANSFERT  {{from}} → {{to}}  {{amount}}",
     "account": "compte {{account}}",
     "shares": "{{qty}} parts",
     "warnings_one": "{{count}} avertissement :",

--- a/apps/frontend/src/i18n/locales/zh/allocation.json
+++ b/apps/frontend/src/i18n/locales/zh/allocation.json
@@ -87,6 +87,9 @@
     "hybrid": "混合",
     "hybridShort": "混合",
     "hybridHint": "现金 + 卖出",
+    "transferOnly": "仅转移",
+    "transferShort": "转移",
+    "transferHint": "移动价值，无买卖",
     "enableSellsTip": "在此目标上启用“允许卖出”以使用此模式"
   },
   "planner": {
@@ -102,7 +105,8 @@
     "driverSentenceUnder": "{{name}} 位于 {{current}}%，低于 {{target}}% 的目标。",
     "modeVerbSells": "卖出并买入",
     "modeVerbHybrid": "现金与卖出",
-    "modeVerbCashFlow": "现金流买入"
+    "modeVerbCashFlow": "现金流买入",
+    "modeVerbTransfer": "转移"
   },
   "narrative": {
     "liftAndShrink": "{{verb}}将 {{lifted}} 提升至目标，并将 {{shrank}} 的超配从 {{before}} 缩减至 {{after}}。",
@@ -192,6 +196,12 @@
     "tradesSummarySells": "{{buys}} · {{sells}} · {{cash}} 新现金",
     "tradesSummaryDeployed": "{{buys}} · 已投入 {{cash}}",
     "noTrades": "无交易——所有类别均已在容差带内，或未找到持仓。",
+    "transferSummary_one": "{{count}} 笔转移 · 已移动 {{amount}}",
+    "transferSummary_other": "{{count}} 笔转移 · 已移动 {{amount}}",
+    "proposedTransfers": "建议转移",
+    "noTransfers": "无转移——所有类别均已在容差带内。",
+    "residualGapTitle": "近似方案——剩余 {{gap}} 差距",
+    "descriptionTransfer": "通过在持仓之间移动价值进行再平衡——无需买入或卖出。",
     "calculatedFooter": "{{name}} · 计算于 {{date}}",
     "copyAsText": "复制为文本",
     "exportCsv": "导出 CSV"
@@ -217,7 +227,11 @@
     "amount": "金额（{{currency}}）",
     "shares": "股数",
     "lastPrice": "最新价格（{{currency}}）",
-    "reason": "原因"
+    "reason": "原因",
+    "from": "从",
+    "fromName": "来源名称",
+    "to": "至",
+    "toName": "目标名称"
   },
   "copyText": {
     "header": "再平衡方案 · {{date}}",
@@ -225,6 +239,8 @@
     "cashDeployed": "已投入现金：{{available}} 中的 {{used}}",
     "maxDrift": "最大偏离：{{before}} → {{after}}",
     "proposedTrades": "建议交易",
+    "proposedTransfers": "建议转移",
+    "transfer": "转移  {{from}} → {{to}}  {{amount}}",
     "account": "账户 {{account}}",
     "shares": "{{qty}} 股",
     "warnings_one": "{{count}} 条警告：",

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -2527,7 +2527,7 @@ export interface SaveUpProjectionPointDTO extends SaveUpTrajectoryPointDTO {
 export type TargetScopeType = "all" | "portfolio" | "account";
 export type TriggerType = "manual" | "threshold";
 export type RebalanceGoal = "nearest_band" | "exact_target";
-export type ScenarioMode = "cash_flow_only" | "sell_to_rebalance" | "hybrid";
+export type ScenarioMode = "cash_flow_only" | "sell_to_rebalance" | "hybrid" | "transfer_only";
 export type DriftStatus = "in_band" | "underweight" | "overweight" | "not_targeted";
 export type RebalanceTo = "nearest_band" | "exact_target";
 
@@ -2696,6 +2696,29 @@ export interface SuggestedManualTrade {
   reason: string;
 }
 
+export interface SuggestedTransfer {
+  fromAssetId: string;
+  fromSymbol: string;
+  fromName?: string | null;
+  fromAccountId?: string | null;
+  fromHoldingId?: string | null;
+  toAssetId: string;
+  toSymbol: string;
+  toName?: string | null;
+  toAccountId?: string | null;
+  toHoldingId?: string | null;
+  amount: number;
+  reason: string;
+  driftImprovementBps: number;
+}
+
+export interface ResidualGap {
+  categoryId: string;
+  categoryName: string;
+  gapBps: number;
+  cause: string;
+}
+
 export interface RebalancePlan {
   targetId: string;
   availableCash: number;
@@ -2706,4 +2729,6 @@ export interface RebalancePlan {
   trades: SuggestedManualTrade[];
   warnings: RebalanceWarning[];
   afterBpsByCategory: Record<string, number>;
+  transferPairs?: SuggestedTransfer[];
+  residualGaps?: ResidualGap[];
 }

--- a/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
@@ -1,25 +1,27 @@
-import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
-import { Button, Card, CardContent, Icons, Skeleton } from "@wealthfolio/ui";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@wealthfolio/ui/components/ui/tooltip";
-import { useTranslation } from "react-i18next";
-import type { TFunction } from "i18next";
-import { cn, formatAmount } from "@/lib/utils";
-import { toast } from "sonner";
 import type {
   AccountScope,
+  AllocationTarget,
   DriftReport,
   RebalancePlan,
   RebalanceWarning,
+  ResidualGap,
   ScenarioMode,
   SuggestedManualTrade,
-  AllocationTarget,
+  SuggestedTransfer,
 } from "@/lib/types";
+import { cn, formatAmount } from "@/lib/utils";
+import { Button, Card, CardContent, Icons, Skeleton } from "@wealthfolio/ui";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@wealthfolio/ui/components/ui/tooltip";
+import type { TFunction } from "i18next";
+import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { useRebalancePlan } from "../hooks/use-rebalance";
 import {
   allocationTargetColorForRow,
   buildAllocationTargetColorMap,
 } from "./allocation-target-colors";
 import { accountScopeKey } from "./target-scope";
-import { useRebalancePlan } from "../hooks/use-rebalance";
 
 // Drift direction colors — clay for overweight (+), slate-blue for underweight (−).
 const DRIFT_OVER = "#b4664a";
@@ -184,7 +186,7 @@ function driftDriverSentence(driftReport: DriftReport, t: TFunction): string | n
       : "allocation:planner.driverSentenceUnder",
     {
       name: top.name,
-      current: (top.cur / 100).toFixed(0),
+      current: (Math.abs(top.drift) / 100).toFixed(0),
       target: (top.tgt / 100).toFixed(0),
     },
   );
@@ -193,6 +195,7 @@ function driftDriverSentence(driftReport: DriftReport, t: TFunction): string | n
 function modeVerb(mode: ScenarioMode, t: TFunction): string {
   if (mode === "sell_to_rebalance") return t("allocation:planner.modeVerbSells");
   if (mode === "hybrid") return t("allocation:planner.modeVerbHybrid");
+  if (mode === "transfer_only") return t("allocation:planner.modeVerbTransfer");
   return t("allocation:planner.modeVerbCashFlow");
 }
 
@@ -287,6 +290,41 @@ function exportCsv(plan: RebalancePlan, currency: string, profileName: string, t
     .map((row) => row.map(csvCell).join(","))
     .join("\n");
 
+  // Transfer-only mode: export transfer pairs instead of trades.
+  if (plan.transferPairs && plan.transferPairs.length > 0) {
+    const header = [
+      t("allocation:csv.from"),
+      t("allocation:csv.fromName"),
+      t("allocation:csv.to"),
+      t("allocation:csv.toName"),
+      t("allocation:csv.amount", { currency }),
+      t("allocation:csv.reason"),
+    ]
+      .map(csvCell)
+      .join(",");
+    const rows = plan.transferPairs.map((p) =>
+      [
+        p.fromSymbol,
+        p.fromName ?? "",
+        p.toSymbol,
+        p.toName ?? "",
+        p.amount.toFixed(fractionDigits),
+        p.reason,
+      ]
+        .map(csvCell)
+        .join(","),
+    );
+    const csv = [meta, "", header, ...rows].join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `rebalance-plan-${profileName.replace(/[^a-z0-9]/gi, "-").toLowerCase()}-${generated}.csv`;
+    a.click();
+    URL.revokeObjectURL(url);
+    return;
+  }
+
   const header = [
     t("allocation:csv.action"),
     t("allocation:csv.symbol"),
@@ -330,38 +368,61 @@ function exportCsv(plan: RebalancePlan, currency: string, profileName: string, t
 }
 
 function copyToText(plan: RebalancePlan, currency: string, t: TFunction) {
-  const cashTotals = planCashTotals(plan);
-  const lines = [
-    t("allocation:copyText.header", { date: new Date().toLocaleDateString() }),
-    cashTotals.hasSells
-      ? t("allocation:copyText.newCashUsed", {
-          used: formatAmount(cashTotals.newCashUsed, currency),
-          buyTotal: formatAmount(cashTotals.buyTotal, currency),
-          sellProceeds: formatAmount(cashTotals.sellProceeds, currency),
-          cashRemaining: formatAmount(plan.cashRemaining, currency),
-        })
-      : t("allocation:copyText.cashDeployed", {
-          used: formatAmount(plan.cashUsed, currency),
-          available: formatAmount(plan.availableCash, currency),
+  const lines = [t("allocation:copyText.header", { date: new Date().toLocaleDateString() })];
+
+  // Transfer-only mode.
+  if (plan.transferPairs && plan.transferPairs.length > 0) {
+    lines.push(
+      t("allocation:copyText.maxDrift", {
+        before: fmtBps(plan.maxDriftBpsBefore),
+        after: fmtBps(plan.maxDriftBpsAfter),
+      }),
+      "",
+      t("allocation:copyText.proposedTransfers"),
+      ...plan.transferPairs.map((p) =>
+        t("allocation:copyText.transfer", {
+          from: p.fromSymbol,
+          to: p.toSymbol,
+          amount: formatAmount(p.amount, currency),
         }),
-    t("allocation:copyText.maxDrift", {
-      before: fmtBps(plan.maxDriftBpsBefore),
-      after: fmtBps(plan.maxDriftBpsAfter),
-    }),
-    "",
-    t("allocation:copyText.proposedTrades"),
-    ...plan.trades.map(
-      (trade) =>
-        `${trade.action.toUpperCase()}  ${trade.symbol ?? trade.categoryName}  ${formatAmount(trade.estimatedAmount, currency)}` +
-        (trade.accountId
-          ? `  ${t("allocation:copyText.account", { account: trade.accountId })}`
-          : "") +
-        (trade.quantity != null
-          ? `  ${t("allocation:copyText.shares", { qty: trade.quantity.toFixed(trade.quantity % 1 === 0 ? 0 : 4) })}`
-          : "") +
-        (trade.estimatedPrice != null ? ` @ ${formatAmount(trade.estimatedPrice, currency)}` : ""),
-    ),
-  ];
+      ),
+    );
+  } else {
+    const cashTotals = planCashTotals(plan);
+    lines.push(
+      cashTotals.hasSells
+        ? t("allocation:copyText.newCashUsed", {
+            used: formatAmount(cashTotals.newCashUsed, currency),
+            buyTotal: formatAmount(cashTotals.buyTotal, currency),
+            sellProceeds: formatAmount(cashTotals.sellProceeds, currency),
+            cashRemaining: formatAmount(plan.cashRemaining, currency),
+          })
+        : t("allocation:copyText.cashDeployed", {
+            used: formatAmount(plan.cashUsed, currency),
+            available: formatAmount(plan.availableCash, currency),
+          }),
+      t("allocation:copyText.maxDrift", {
+        before: fmtBps(plan.maxDriftBpsBefore),
+        after: fmtBps(plan.maxDriftBpsAfter),
+      }),
+      "",
+      t("allocation:copyText.proposedTrades"),
+      ...plan.trades.map(
+        (trade) =>
+          `${trade.action.toUpperCase()}  ${trade.symbol ?? trade.categoryName}  ${formatAmount(trade.estimatedAmount, currency)}` +
+          (trade.accountId
+            ? `  ${t("allocation:copyText.account", { account: trade.accountId })}`
+            : "") +
+          (trade.quantity != null
+            ? `  ${t("allocation:copyText.shares", { qty: trade.quantity.toFixed(trade.quantity % 1 === 0 ? 0 : 4) })}`
+            : "") +
+          (trade.estimatedPrice != null
+            ? ` @ ${formatAmount(trade.estimatedPrice, currency)}`
+            : ""),
+      ),
+    );
+  }
+
   if (plan.warnings.length) {
     lines.push("", t("allocation:copyText.warnings", { count: plan.warnings.length }));
     plan.warnings.forEach((w) => lines.push(`  · ${w.message}`));
@@ -417,12 +478,18 @@ function ModeSwitch({
       shortLabel: t("allocation:mode.hybridShort"),
       hint: t("allocation:mode.hybridHint"),
     },
+    {
+      id: "transfer_only",
+      label: t("allocation:mode.transferOnly"),
+      shortLabel: t("allocation:mode.transferShort"),
+      hint: t("allocation:mode.transferHint"),
+    },
   ];
 
   return (
-    <div className="border-border/60 bg-card/40 grid w-full max-w-full grid-cols-3 gap-1 rounded-2xl border p-1 backdrop-blur-xl sm:inline-flex sm:w-auto sm:grid-cols-none">
+    <div className="border-border/60 bg-card/40 grid w-full max-w-full grid-cols-2 gap-1 rounded-2xl border p-1 backdrop-blur-xl sm:inline-flex sm:w-auto sm:grid-cols-none">
       {modes.map((m) => {
-        const disabled = !allowSells && m.id !== "cash_flow_only";
+        const disabled = !allowSells && m.id !== "cash_flow_only" && m.id !== "transfer_only";
         const active = value === m.id;
         const button = (
           <button
@@ -1303,6 +1370,54 @@ function TradesTable({ trades, currency }: { trades: SuggestedManualTrade[]; cur
   );
 }
 
+// ── Transfer pair row ─────────────────────────────────────────────────────────
+
+function TransferPairRow({ pair, currency }: { pair: SuggestedTransfer; currency: string }) {
+  return (
+    <div className="bg-muted/30 flex items-center gap-3 rounded-lg border p-3">
+      <div className="min-w-0 flex-1">
+        <div className="text-foreground truncate text-sm font-semibold">{pair.fromSymbol}</div>
+        <div className="text-muted-foreground truncate text-xs">{pair.fromName}</div>
+      </div>
+      <div className="flex flex-col items-center gap-0.5">
+        <span className="text-lg text-emerald-500">→</span>
+        <span className="font-mono text-xs font-bold text-emerald-500">
+          {formatAmount(pair.amount, currency)}
+        </span>
+      </div>
+      <div className="min-w-0 flex-1 text-right">
+        <div className="text-foreground truncate text-sm font-semibold">{pair.toSymbol}</div>
+        <div className="text-muted-foreground truncate text-xs">{pair.toName}</div>
+      </div>
+    </div>
+  );
+}
+
+// ── Residual gap banner ───────────────────────────────────────────────────────
+
+function ResidualGapBanner({ gaps }: { gaps: ResidualGap[] }) {
+  const { t } = useTranslation();
+  const maxGap = Math.max(...gaps.map((g) => g.gapBps));
+
+  return (
+    <div className="flex items-start gap-2.5 rounded-lg border border-amber-500/30 bg-amber-500/5 px-4 py-3">
+      <Icons.AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+      <div>
+        <div className="text-sm font-semibold text-amber-200">
+          {t("allocation:rebalance.residualGapTitle", { gap: fmtBps(maxGap) })}
+        </div>
+        <div className="mt-1 space-y-0.5 text-xs text-amber-200/70">
+          {gaps.map((g) => (
+            <div key={g.categoryId}>
+              {g.categoryName}: {fmtBps(g.gapBps)} gap — {g.cause}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ── Main component ────────────────────────────────────────────────────────────
 
 interface RebalanceTabProps {
@@ -1347,7 +1462,8 @@ export function RebalanceTab({
   const cachedPlan = planQuery.data ?? null;
   const hasStalePlan = !!cachedPlan && cachedPlan.sourceKey !== sourceKey;
   const plan = hasStalePlan ? null : (cachedPlan?.plan ?? null);
-  const isSellMode = scenarioMode !== "cash_flow_only";
+  const isTransferMode = scenarioMode === "transfer_only";
+  const isSellMode = scenarioMode !== "cash_flow_only" && !isTransferMode;
 
   useEffect(() => {
     if (!profile?.allowSells && isSellMode) {
@@ -1365,17 +1481,19 @@ export function RebalanceTab({
       toast.error(t("allocation:toast.dataLoading"));
       return;
     }
-    if (availableCashLimit <= 0 && !isSellMode) {
-      toast.error(t("allocation:toast.noCashAvailable"));
-      return;
-    }
-    if (cash <= 0 && !isSellMode) {
-      toast.error(t("allocation:toast.enterValidCash"));
-      return;
-    }
-    if (cash > availableCashLimit) {
-      toast.error(t("allocation:toast.cashExceeds"));
-      return;
+    if (!isTransferMode) {
+      if (availableCashLimit <= 0 && !isSellMode) {
+        toast.error(t("allocation:toast.noCashAvailable"));
+        return;
+      }
+      if (cash <= 0 && !isSellMode) {
+        toast.error(t("allocation:toast.enterValidCash"));
+        return;
+      }
+      if (cash > availableCashLimit) {
+        toast.error(t("allocation:toast.cashExceeds"));
+        return;
+      }
     }
     void planQuery.refetch().then((res) => {
       if (res.error)
@@ -1397,8 +1515,9 @@ export function RebalanceTab({
     );
   }
 
-  const description =
-    scenarioMode === "sell_to_rebalance"
+  const description = isTransferMode
+    ? t("allocation:rebalance.descriptionTransfer")
+    : scenarioMode === "sell_to_rebalance"
       ? t("allocation:rebalance.descriptionSell")
       : scenarioMode === "hybrid"
         ? t("allocation:rebalance.descriptionHybrid")
@@ -1429,17 +1548,36 @@ export function RebalanceTab({
         <CardContent className="p-0">
           <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,0.85fr)_minmax(0,1.15fr)]">
             <div className="border-border/60 border-b px-4 py-4 sm:px-5 sm:py-5 lg:border-b-0 lg:border-r">
-              <PlannerInput
-                description={description}
-                cashValue={cashValue}
-                availableCash={availableCash}
-                currency={currency}
-                onCashChange={handleCashChange}
-                onCalculate={handleCalculate}
-                hasPlan={!!plan || hasStalePlan}
-                isCalculating={isCalculating}
-                isSourceLoading={!sourceReady}
-              />
+              {isTransferMode ? (
+                <div className="flex h-full flex-col">
+                  <Eyebrow>{t("allocation:rebalance.descriptionTransfer")}</Eyebrow>
+                  <div className="mt-auto flex pt-4">
+                    <Button
+                      className="flex-1"
+                      onClick={handleCalculate}
+                      disabled={isCalculating || !sourceReady}
+                    >
+                      {isCalculating
+                        ? t("allocation:planner.calculating")
+                        : plan || hasStalePlan
+                          ? t("allocation:planner.recalculate")
+                          : t("allocation:planner.calculatePlan")}
+                    </Button>
+                  </div>
+                </div>
+              ) : (
+                <PlannerInput
+                  description={description}
+                  cashValue={cashValue}
+                  availableCash={availableCash}
+                  currency={currency}
+                  onCashChange={handleCashChange}
+                  onCalculate={handleCalculate}
+                  hasPlan={!!plan || hasStalePlan}
+                  isCalculating={isCalculating}
+                  isSourceLoading={!sourceReady}
+                />
+              )}
             </div>
             <div className="px-4 py-4 sm:px-5 sm:py-5">
               {!driftReport ? (
@@ -1482,46 +1620,84 @@ export function RebalanceTab({
         <>
           <Warnings items={plan.warnings} />
 
+          {plan.residualGaps && plan.residualGaps.length > 0 && (
+            <ResidualGapBanner gaps={plan.residualGaps} />
+          )}
+
           {sleeveSummary.length > 0 && (
             <SleeveReshapeCard sleeves={sleeveSummary} mode={scenarioMode} />
           )}
 
-          <Card ref={tradesRef}>
-            <CardContent className="p-0">
-              <div className="px-5 pb-2 pt-4">
-                <h3 className="text-foreground font-mono text-sm font-semibold">
-                  {t("allocation:rebalance.proposedTrades")}
-                </h3>
-                <p className="text-muted-foreground mt-1 font-mono text-xs">
-                  {(() => {
-                    const buys = plan.trades.filter((trade) => trade.action === "buy").length;
-                    const sells = plan.trades.filter((trade) => trade.action === "sell").length;
-                    const cashTotals = planCashTotals(plan);
-                    const buysWord = t("allocation:result.buysCount", { count: buys });
-                    return sells > 0
-                      ? t("allocation:rebalance.tradesSummarySells", {
-                          buys: buysWord,
-                          sells: t("allocation:result.sellsCount", { count: sells }),
-                          cash: formatAmount(cashTotals.newCashUsed, currency),
-                        })
-                      : t("allocation:rebalance.tradesSummaryDeployed", {
-                          buys: buysWord,
-                          cash: formatAmount(plan.cashUsed, currency),
-                        });
-                  })()}
-                </p>
-              </div>
-              {plan.trades.length > 0 ? (
-                <div className="pb-1 pt-2">
-                  <TradesTable trades={plan.trades} currency={currency} />
+          {isTransferMode && plan.transferPairs ? (
+            <Card ref={tradesRef}>
+              <CardContent className="p-0">
+                <div className="px-5 pb-2 pt-4">
+                  <h3 className="text-foreground font-mono text-sm font-semibold">
+                    {t("allocation:rebalance.proposedTransfers")}
+                  </h3>
+                  {plan.transferPairs.length > 0 && (
+                    <p className="text-muted-foreground mt-1 font-mono text-xs">
+                      {t("allocation:rebalance.transferSummary", {
+                        count: plan.transferPairs.length,
+                        amount: formatAmount(
+                          plan.transferPairs.reduce((sum, p) => sum + p.amount, 0),
+                          currency,
+                        ),
+                      })}
+                    </p>
+                  )}
                 </div>
-              ) : (
-                <p className="text-muted-foreground px-6 py-4 font-mono text-xs">
-                  {t("allocation:rebalance.noTrades")}
-                </p>
-              )}
-            </CardContent>
-          </Card>
+                {plan.transferPairs.length > 0 ? (
+                  <div className="space-y-2 px-5 pb-4">
+                    {plan.transferPairs.map((pair, i) => (
+                      <TransferPairRow key={i} pair={pair} currency={currency} />
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-muted-foreground px-6 py-4 font-mono text-xs">
+                    {t("allocation:rebalance.noTransfers")}
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          ) : (
+            <Card ref={tradesRef}>
+              <CardContent className="p-0">
+                <div className="px-5 pb-2 pt-4">
+                  <h3 className="text-foreground font-mono text-sm font-semibold">
+                    {t("allocation:rebalance.proposedTrades")}
+                  </h3>
+                  <p className="text-muted-foreground mt-1 font-mono text-xs">
+                    {(() => {
+                      const buys = plan.trades.filter((trade) => trade.action === "buy").length;
+                      const sells = plan.trades.filter((trade) => trade.action === "sell").length;
+                      const cashTotals = planCashTotals(plan);
+                      const buysWord = t("allocation:result.buysCount", { count: buys });
+                      return sells > 0
+                        ? t("allocation:rebalance.tradesSummarySells", {
+                            buys: buysWord,
+                            sells: t("allocation:result.sellsCount", { count: sells }),
+                            cash: formatAmount(cashTotals.newCashUsed, currency),
+                          })
+                        : t("allocation:rebalance.tradesSummaryDeployed", {
+                            buys: buysWord,
+                            cash: formatAmount(plan.cashUsed, currency),
+                          });
+                    })()}
+                  </p>
+                </div>
+                {plan.trades.length > 0 ? (
+                  <div className="pb-1 pt-2">
+                    <TradesTable trades={plan.trades} currency={currency} />
+                  </div>
+                ) : (
+                  <p className="text-muted-foreground px-6 py-4 font-mono text-xs">
+                    {t("allocation:rebalance.noTrades")}
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          )}
 
           {/* Footer */}
           <div className="border-border flex flex-col gap-3 border-t pt-4 sm:flex-row sm:items-center sm:justify-between">

--- a/crates/core/src/custom_provider/service.rs
+++ b/crates/core/src/custom_provider/service.rs
@@ -863,7 +863,13 @@ fn truncate_str(s: &str, max_bytes: usize) -> String {
         return s.to_string();
     }
     // Walk backward from max_bytes to find a char boundary
-    let end = s.floor_char_boundary(max_bytes);
+    let end = {
+        let mut e = max_bytes.min(s.len());
+        while e > 0 && !s.is_char_boundary(e) {
+            e -= 1;
+        }
+        e
+    };
     format!("{}...", &s[..end])
 }
 

--- a/crates/core/src/portfolio/allocation_targets/mod.rs
+++ b/crates/core/src/portfolio/allocation_targets/mod.rs
@@ -4,6 +4,7 @@ mod model;
 mod optimizer;
 mod rebalance_service;
 mod target_service;
+mod transfer_optimizer;
 mod validation;
 
 pub use drift_service::*;
@@ -11,4 +12,5 @@ pub use model::*;
 pub use optimizer::*;
 pub use rebalance_service::*;
 pub use target_service::*;
+pub use transfer_optimizer::*;
 pub use validation::*;

--- a/crates/core/src/portfolio/allocation_targets/model.rs
+++ b/crates/core/src/portfolio/allocation_targets/model.rs
@@ -67,6 +67,7 @@ pub enum ScenarioMode {
     CashFlowOnly,
     SellToRebalance,
     Hybrid,
+    TransferOnly,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -453,6 +454,33 @@ pub struct SuggestedManualTrade {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct SuggestedTransfer {
+    pub from_asset_id: String,
+    pub from_symbol: String,
+    pub from_name: Option<String>,
+    pub from_account_id: Option<String>,
+    pub from_holding_id: Option<String>,
+    pub to_asset_id: String,
+    pub to_symbol: String,
+    pub to_name: Option<String>,
+    pub to_account_id: Option<String>,
+    pub to_holding_id: Option<String>,
+    pub amount: Decimal,
+    pub reason: String,
+    pub drift_improvement_bps: i32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResidualGap {
+    pub category_id: String,
+    pub category_name: String,
+    pub gap_bps: i32,
+    pub cause: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RebalancePlan {
     pub target_id: String,
     pub available_cash: Decimal,
@@ -467,6 +495,10 @@ pub struct RebalancePlan {
     /// instead of re-deriving from trades (which only carry the primary category).
     #[serde(default)]
     pub after_bps_by_category: std::collections::HashMap<String, i32>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub transfer_pairs: Vec<SuggestedTransfer>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub residual_gaps: Vec<ResidualGap>,
 }
 
 #[cfg(test)]

--- a/crates/core/src/portfolio/allocation_targets/optimizer.rs
+++ b/crates/core/src/portfolio/allocation_targets/optimizer.rs
@@ -849,6 +849,8 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
                 trades: vec![],
                 warnings,
                 after_bps_by_category: HashMap::new(),
+                transfer_pairs: vec![],
+                residual_gaps: vec![],
             });
         }
 
@@ -1258,6 +1260,8 @@ impl RebalanceOptimizer for DriftPriorityOptimizer {
             trades,
             warnings,
             after_bps_by_category,
+            transfer_pairs: vec![],
+            residual_gaps: vec![],
         })
     }
 }

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -16,12 +16,14 @@ use super::cash::{
 use super::drift_service::DriftServiceTrait;
 use super::model::{
     CalculateRebalancePlanInput, RebalancePlan, RebalanceWarning, RebalanceWarningKind,
+    ScenarioMode,
 };
 use super::optimizer::{
     AssetCandidate, CategoryState, DriftPriorityOptimizer, RebalanceInput, RebalanceOptimizer,
     RebalanceProfile, SellCandidate,
 };
 use super::target_service::AllocationTargetServiceTrait;
+use super::transfer_optimizer::TransferOptimizer;
 
 // ── Service trait ─────────────────────────────────────────────────────────────
 
@@ -491,6 +493,8 @@ impl RebalanceServiceTrait for RebalanceService {
                 trades: vec![],
                 warnings: vec![],
                 after_bps_by_category: std::collections::HashMap::new(),
+                transfer_pairs: vec![],
+                residual_gaps: vec![],
             });
         }
 
@@ -610,6 +614,10 @@ impl RebalanceServiceTrait for RebalanceService {
             warnings: classification_warnings,
             max_turnover_bps,
         };
+
+        if matches!(optimizer_input.scenario_mode, ScenarioMode::TransferOnly) {
+            return TransferOptimizer.plan(optimizer_input);
+        }
 
         DriftPriorityOptimizer.plan(optimizer_input)
     }
@@ -2154,6 +2162,36 @@ mod tests {
             plan.max_drift_bps_after <= plan.max_drift_bps_before,
             "drift must not increase after buying"
         );
+    }
+
+    // ── TransferOnly tests ──────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn transfer_only_never_generates_buy_or_sell_trades() {
+        let total = dec!(10000);
+        let h_vti = make_holding("h1", "VTI", dec!(10), dec!(6000));
+        let h_bnd = make_holding("h2", "BND", dec!(40), dec!(4000));
+        let c_vti = make_contribution(&h_vti, "equity", dec!(6000));
+        let c_bnd = make_contribution(&h_bnd, "bond", dec!(4000));
+        let rows = vec![
+            make_drift_row("equity", 6000, 7000, total),
+            make_drift_row("bond", 4000, 3000, total),
+        ];
+        let svc = make_service(
+            make_profile(RebalanceGoal::ExactTarget, false),
+            make_report(rows, total),
+            make_contributions(vec![c_vti, c_bnd]),
+            vec![make_cash_holding(dec!(0), "USD"), h_vti, h_bnd],
+        );
+        let plan = svc
+            .calculate_plan(make_input_with_mode(dec!(0), ScenarioMode::TransferOnly))
+            .await
+            .unwrap();
+        assert!(
+            plan.trades.is_empty(),
+            "transfer_only must not produce trades"
+        );
+        assert_eq!(plan.cash_used, dec!(0));
     }
 
     // ── Sell-to-rebalance tests ────────────────────────────────────────────────

--- a/crates/core/src/portfolio/allocation_targets/transfer_optimizer.rs
+++ b/crates/core/src/portfolio/allocation_targets/transfer_optimizer.rs
@@ -1,0 +1,796 @@
+use std::collections::HashMap;
+
+use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+
+use crate::errors::Result as CoreResult;
+
+use super::model::{RebalancePlan, ResidualGap, SuggestedTransfer};
+use super::optimizer::RebalanceInput;
+
+pub struct TransferOptimizer;
+
+fn decimal_to_bps(value: Decimal, total_value: Decimal) -> i32 {
+    if total_value <= Decimal::ZERO {
+        return 0;
+    }
+    ((value / total_value) * dec!(10000))
+        .round()
+        .to_i32()
+        .unwrap_or(0)
+}
+
+impl TransferOptimizer {
+    pub fn plan(&self, input: RebalanceInput) -> CoreResult<RebalancePlan> {
+        let total_value = input.total_value;
+        let target_id = input.profile.target_id.clone();
+        let min_trade = input.profile.min_trade_amount;
+
+        // Build category lookup: category_id -> (name, target_bps, current_value)
+        let mut category_map: HashMap<String, (String, i32, Decimal)> = HashMap::new();
+        for cat in &input.categories {
+            category_map.insert(
+                cat.category_id.clone(),
+                (cat.category_name.clone(), cat.target_bps, cat.current_value),
+            );
+        }
+
+        // Compute max_drift_bps_before
+        let max_drift_bps_before = input
+            .categories
+            .iter()
+            .filter(|c| c.is_required && !c.is_cash)
+            .map(|c| {
+                let current_bps = decimal_to_bps(c.current_value, total_value);
+                (current_bps - c.target_bps).abs()
+            })
+            .max()
+            .unwrap_or(0);
+
+        // Two-tier supply strategy for minimum transfers:
+        //
+        // Tier 1 (primary): excess above TARGET — take from overweight categories first.
+        //   These funds are above their objective, so reducing them improves the portfolio.
+        //
+        // Tier 2 (secondary): headroom between lower band edge and target — only used
+        //   when Tier 1 doesn't cover all demand. This avoids worsening funds that are
+        //   already at or below target unless absolutely necessary.
+        //
+        // Demand: deficit below the category's LOWER band edge.
+        //
+        // The transportation algorithm runs with supply sorted by amount DESC,
+        // so the biggest overweight funds donate first → minimum number of pairs.
+
+        // Per-asset supply tiers and demand.
+        let mut primary_supply: Vec<(usize, Decimal)> = Vec::new();
+        let mut secondary_supply: Vec<(usize, Decimal)> = Vec::new();
+        let mut deficit_assets: Vec<(usize, Decimal)> = Vec::new();
+
+        for (idx, candidate) in input.candidates.iter().enumerate() {
+            let mut asset_primary = Decimal::ZERO;
+            let mut asset_secondary = Decimal::ZERO;
+            let mut asset_demand = Decimal::ZERO;
+
+            for (cat_id, exposure) in &candidate.exposure_per_share {
+                if let Some((_, target_bps, current_value)) = category_map.get(cat_id) {
+                    let target_value = total_value * Decimal::from(*target_bps) / dec!(10000);
+                    let band_bps = input.profile.effective_band_bps(*target_bps);
+                    let band_value = total_value * Decimal::from(band_bps) / dec!(10000);
+                    let lower_edge = (target_value - band_value).max(Decimal::ZERO);
+
+                    let category_total_exposure: Decimal = input
+                        .candidates
+                        .iter()
+                        .filter_map(|c| c.exposure_per_share.get(cat_id))
+                        .sum();
+
+                    if category_total_exposure <= Decimal::ZERO {
+                        continue;
+                    }
+
+                    let share = *exposure / category_total_exposure;
+
+                    if *current_value < lower_edge {
+                        // Below lower band edge — needs inflow.
+                        asset_demand += (lower_edge - *current_value) * share;
+                    } else if *current_value > target_value {
+                        // Above target — primary supply (excess over target).
+                        asset_primary += (*current_value - target_value) * share;
+                        // Also has secondary headroom (target down to lower edge).
+                        asset_secondary += (target_value - lower_edge) * share;
+                    } else {
+                        // Between lower edge and target — secondary supply only.
+                        asset_secondary += (*current_value - lower_edge) * share;
+                    }
+                }
+            }
+
+            if asset_primary > Decimal::ZERO {
+                primary_supply.push((idx, asset_primary));
+            }
+            if asset_secondary > Decimal::ZERO {
+                secondary_supply.push((idx, asset_secondary));
+            }
+            if asset_demand > Decimal::ZERO {
+                deficit_assets.push((idx, asset_demand));
+            }
+        }
+
+        // Decide which supply tiers to use.
+        let total_demand: Decimal = deficit_assets.iter().map(|(_, d)| *d).sum();
+        let total_primary: Decimal = primary_supply.iter().map(|(_, s)| *s).sum();
+
+        let mut excess_assets: Vec<(usize, Decimal)> = Vec::new();
+
+        if total_demand <= Decimal::ZERO {
+            // Nothing to do — all categories are within band.
+        } else if total_primary >= total_demand {
+            // Tier 1 alone covers demand — only take from overweight funds.
+            excess_assets = primary_supply;
+        } else {
+            // Tier 1 doesn't cover — combine with Tier 2.
+            // Merge primary + secondary per asset.
+            let mut combined: HashMap<usize, Decimal> = HashMap::new();
+            for (idx, amount) in &primary_supply {
+                *combined.entry(*idx).or_default() += *amount;
+            }
+            for (idx, amount) in &secondary_supply {
+                *combined.entry(*idx).or_default() += *amount;
+            }
+            excess_assets = combined.into_iter().collect();
+        }
+
+        // Sort supply by amount DESC (biggest donors first → fewer pairs),
+        // then asset_id ASC for deterministic tie-break.
+        excess_assets.sort_by(|a, b| {
+            b.1.cmp(&a.1).then_with(|| {
+                input.candidates[a.0]
+                    .asset_id
+                    .cmp(&input.candidates[b.0].asset_id)
+            })
+        });
+        deficit_assets.sort_by(|a, b| {
+            b.1.cmp(&a.1).then_with(|| {
+                input.candidates[a.0]
+                    .asset_id
+                    .cmp(&input.candidates[b.0].asset_id)
+            })
+        });
+
+        // Northwest-corner transportation algorithm: greedily match supply to demand
+        let mut transfer_pairs: Vec<SuggestedTransfer> = Vec::new();
+        let mut supply: Vec<Decimal> = excess_assets.iter().map(|(_, v)| *v).collect();
+        let mut demand: Vec<Decimal> = deficit_assets.iter().map(|(_, v)| *v).collect();
+
+        let mut i = 0usize;
+        let mut j = 0usize;
+        while i < supply.len() && j < demand.len() {
+            let flow = supply[i].min(demand[j]);
+            if flow > Decimal::ZERO {
+                let from = &input.candidates[excess_assets[i].0];
+                let to = &input.candidates[deficit_assets[j].0];
+                transfer_pairs.push(SuggestedTransfer {
+                    from_asset_id: from.asset_id.clone(),
+                    from_symbol: from.symbol.clone(),
+                    from_name: from.name.clone(),
+                    from_account_id: None,
+                    from_holding_id: Some(from.holding_id.clone()),
+                    to_asset_id: to.asset_id.clone(),
+                    to_symbol: to.symbol.clone(),
+                    to_name: to.name.clone(),
+                    to_account_id: None,
+                    to_holding_id: Some(to.holding_id.clone()),
+                    amount: flow,
+                    reason: String::new(),
+                    drift_improvement_bps: 0,
+                });
+                supply[i] -= flow;
+                demand[j] -= flow;
+            }
+            if supply[i] == Decimal::ZERO {
+                i += 1;
+            }
+            if j < demand.len() && demand[j] == Decimal::ZERO {
+                j += 1;
+            }
+        }
+
+        // Prune pairs below min_trade_amount; track pruned amounts for residual gap cause
+        let mut pruned_amount_by_dest: HashMap<String, Decimal> = HashMap::new();
+        if min_trade > Decimal::ZERO {
+            transfer_pairs.retain(|p| {
+                if p.amount < min_trade {
+                    *pruned_amount_by_dest
+                        .entry(p.to_asset_id.clone())
+                        .or_default() += p.amount;
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+
+        // Compute after-values per category by applying the remaining transfers
+        let mut after_values: HashMap<String, Decimal> = input
+            .categories
+            .iter()
+            .map(|c| (c.category_id.clone(), c.current_value))
+            .collect();
+
+        for pair in &transfer_pairs {
+            let from = input
+                .candidates
+                .iter()
+                .find(|c| c.asset_id == pair.from_asset_id);
+            let to = input
+                .candidates
+                .iter()
+                .find(|c| c.asset_id == pair.to_asset_id);
+
+            if let Some(from) = from {
+                let total_exposure: Decimal = from.exposure_per_share.values().sum();
+                if total_exposure > Decimal::ZERO {
+                    for (cat_id, exp) in &from.exposure_per_share {
+                        let proportion = *exp / total_exposure;
+                        if let Some(val) = after_values.get_mut(cat_id) {
+                            *val -= pair.amount * proportion;
+                        }
+                    }
+                }
+            }
+            if let Some(to) = to {
+                let total_exposure: Decimal = to.exposure_per_share.values().sum();
+                if total_exposure > Decimal::ZERO {
+                    for (cat_id, exp) in &to.exposure_per_share {
+                        let proportion = *exp / total_exposure;
+                        if let Some(val) = after_values.get_mut(cat_id) {
+                            *val += pair.amount * proportion;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Compute after bps by category
+        let mut after_bps_by_category: HashMap<String, i32> = HashMap::new();
+        for (cat_id, value) in &after_values {
+            after_bps_by_category.insert(cat_id.clone(), decimal_to_bps(*value, total_value));
+        }
+
+        let max_drift_bps_after = input
+            .categories
+            .iter()
+            .filter(|c| c.is_required && !c.is_cash)
+            .map(|c| {
+                let after = after_bps_by_category
+                    .get(&c.category_id)
+                    .copied()
+                    .unwrap_or(0);
+                (after - c.target_bps).abs()
+            })
+            .max()
+            .unwrap_or(0);
+
+        // Fill in reasons and drift_improvement_bps for each pair
+        for pair in &mut transfer_pairs {
+            let from_cats: Vec<String> = input
+                .candidates
+                .iter()
+                .find(|c| c.asset_id == pair.from_asset_id)
+                .map(|c| c.exposure_per_share.keys().cloned().collect())
+                .unwrap_or_default();
+            let cat_name = from_cats
+                .first()
+                .and_then(|id| category_map.get(id))
+                .map(|(name, _, _)| name.clone())
+                .unwrap_or_default();
+            pair.reason = format!(
+                "Transfer {} from {} to {} to reduce {} drift",
+                pair.amount, pair.from_symbol, pair.to_symbol, cat_name
+            );
+            pair.drift_improvement_bps = max_drift_bps_before - max_drift_bps_after;
+        }
+
+        // Build residual gaps for categories that still have drift after transfers
+        let has_pruned = pruned_amount_by_dest.values().any(|v| *v > Decimal::ZERO);
+        let mut residual_gaps: Vec<ResidualGap> = Vec::new();
+        for cat in &input.categories {
+            if !cat.is_required || cat.is_cash {
+                continue;
+            }
+            let after = after_bps_by_category
+                .get(&cat.category_id)
+                .copied()
+                .unwrap_or(0);
+            let gap = (after - cat.target_bps).abs();
+            if gap > 0 {
+                let cause = if has_pruned {
+                    "below_minimum".to_string()
+                } else {
+                    "rounding".to_string()
+                };
+                residual_gaps.push(ResidualGap {
+                    category_id: cat.category_id.clone(),
+                    category_name: cat.category_name.clone(),
+                    gap_bps: gap,
+                    cause,
+                });
+            }
+        }
+
+        Ok(RebalancePlan {
+            target_id,
+            available_cash: input.available_cash,
+            cash_used: Decimal::ZERO,
+            cash_remaining: input.available_cash,
+            max_drift_bps_before,
+            max_drift_bps_after,
+            trades: vec![],
+            warnings: input.warnings,
+            after_bps_by_category,
+            transfer_pairs,
+            residual_gaps,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::model::{BandType, RebalanceGoal, ScenarioMode};
+    use super::super::optimizer::{AssetCandidate, CategoryState, RebalanceProfile};
+    use super::*;
+
+    fn make_profile(min_trade: Decimal) -> RebalanceProfile {
+        RebalanceProfile {
+            target_id: "t1".to_string(),
+            drift_band_bps: 500,
+            band_type: BandType::Absolute,
+            relative_factor_bps: 0,
+            rebalance_goal: RebalanceGoal::ExactTarget,
+            min_trade_amount: min_trade,
+            whole_shares_only: false,
+        }
+    }
+
+    fn make_input(
+        categories: Vec<CategoryState>,
+        candidates: Vec<AssetCandidate>,
+        total_value: Decimal,
+    ) -> RebalanceInput {
+        RebalanceInput {
+            profile: make_profile(dec!(0)),
+            scenario_mode: ScenarioMode::TransferOnly,
+            available_cash: dec!(0),
+            total_value,
+            categories,
+            candidates,
+            sell_candidates: vec![],
+            warnings: vec![],
+            max_turnover_bps: None,
+        }
+    }
+
+    #[test]
+    fn two_assets_one_overweight_one_underweight() {
+        // Portfolio: $10,000 total. EQUITY at 70% (target 60%), BONDS at 30% (target 40%).
+        // Band = 500 bps (5%).
+        // EQ: upper=65%, lower=55%. Current 70% → supply headroom = 70%-55% = $1,500.
+        // BD: upper=45%, lower=35%. Current 30% → demand = 35%-30% = $500.
+        // Supply ($1,500) > demand ($500) → cap supply to $500.
+        // Transfer $500 from VTI to BND → BD reaches exactly 35% (lower edge).
+        let categories = vec![
+            CategoryState {
+                category_id: "EQ".to_string(),
+                category_name: "Equity".to_string(),
+                target_bps: 6000,
+                current_value: dec!(7000),
+                is_cash: false,
+                is_required: true,
+            },
+            CategoryState {
+                category_id: "BD".to_string(),
+                category_name: "Bonds".to_string(),
+                target_bps: 4000,
+                current_value: dec!(3000),
+                is_cash: false,
+                is_required: true,
+            },
+        ];
+
+        let candidates = vec![
+            AssetCandidate {
+                holding_id: "h-vti".to_string(),
+                asset_id: "vti".to_string(),
+                symbol: "VTI".to_string(),
+                name: Some("Vanguard Total Stock".to_string()),
+                price: dec!(100),
+                exposure_per_share: HashMap::from([("EQ".to_string(), dec!(100))]),
+            },
+            AssetCandidate {
+                holding_id: "h-bnd".to_string(),
+                asset_id: "bnd".to_string(),
+                symbol: "BND".to_string(),
+                name: Some("Vanguard Total Bond".to_string()),
+                price: dec!(80),
+                exposure_per_share: HashMap::from([("BD".to_string(), dec!(80))]),
+            },
+        ];
+
+        let plan = TransferOptimizer
+            .plan(make_input(categories, candidates, dec!(10000)))
+            .unwrap();
+
+        assert!(
+            plan.trades.is_empty(),
+            "transfer_only must not produce trades"
+        );
+        assert_eq!(plan.cash_used, dec!(0));
+        assert_eq!(plan.transfer_pairs.len(), 1);
+
+        let pair = &plan.transfer_pairs[0];
+        assert_eq!(pair.from_asset_id, "vti");
+        assert_eq!(pair.to_asset_id, "bnd");
+        // Transfer exactly enough to bring BD to its lower band edge (35%)
+        assert!(
+            (pair.amount - dec!(500)).abs() < dec!(1),
+            "expected ~500, got {}",
+            pair.amount
+        );
+        assert!(plan.max_drift_bps_after < plan.max_drift_bps_before);
+    }
+
+    #[test]
+    fn already_balanced_produces_empty_plan() {
+        let categories = vec![
+            CategoryState {
+                category_id: "EQ".to_string(),
+                category_name: "Equity".to_string(),
+                target_bps: 6000,
+                current_value: dec!(6000),
+                is_cash: false,
+                is_required: true,
+            },
+            CategoryState {
+                category_id: "BD".to_string(),
+                category_name: "Bonds".to_string(),
+                target_bps: 4000,
+                current_value: dec!(4000),
+                is_cash: false,
+                is_required: true,
+            },
+        ];
+        let candidates = vec![
+            AssetCandidate {
+                holding_id: "h-vti".to_string(),
+                asset_id: "vti".to_string(),
+                symbol: "VTI".to_string(),
+                name: None,
+                price: dec!(100),
+                exposure_per_share: HashMap::from([("EQ".to_string(), dec!(100))]),
+            },
+            AssetCandidate {
+                holding_id: "h-bnd".to_string(),
+                asset_id: "bnd".to_string(),
+                symbol: "BND".to_string(),
+                name: None,
+                price: dec!(80),
+                exposure_per_share: HashMap::from([("BD".to_string(), dec!(80))]),
+            },
+        ];
+
+        let plan = TransferOptimizer
+            .plan(make_input(categories, candidates, dec!(10000)))
+            .unwrap();
+        assert!(plan.transfer_pairs.is_empty());
+        assert!(plan.residual_gaps.is_empty());
+    }
+
+    #[test]
+    fn three_assets_multi_pair() {
+        // EQ at 50% (target 33%), BD at 25% (target 33%), RE at 25% (target 34%).
+        let categories = vec![
+            CategoryState {
+                category_id: "EQ".to_string(),
+                category_name: "Equity".to_string(),
+                target_bps: 3300,
+                current_value: dec!(5000),
+                is_cash: false,
+                is_required: true,
+            },
+            CategoryState {
+                category_id: "BD".to_string(),
+                category_name: "Bonds".to_string(),
+                target_bps: 3300,
+                current_value: dec!(2500),
+                is_cash: false,
+                is_required: true,
+            },
+            CategoryState {
+                category_id: "RE".to_string(),
+                category_name: "Real Estate".to_string(),
+                target_bps: 3400,
+                current_value: dec!(2500),
+                is_cash: false,
+                is_required: true,
+            },
+        ];
+        let candidates = vec![
+            AssetCandidate {
+                holding_id: "h-vti".to_string(),
+                asset_id: "vti".to_string(),
+                symbol: "VTI".to_string(),
+                name: None,
+                price: dec!(100),
+                exposure_per_share: HashMap::from([("EQ".to_string(), dec!(100))]),
+            },
+            AssetCandidate {
+                holding_id: "h-bnd".to_string(),
+                asset_id: "bnd".to_string(),
+                symbol: "BND".to_string(),
+                name: None,
+                price: dec!(80),
+                exposure_per_share: HashMap::from([("BD".to_string(), dec!(80))]),
+            },
+            AssetCandidate {
+                holding_id: "h-vnq".to_string(),
+                asset_id: "vnq".to_string(),
+                symbol: "VNQ".to_string(),
+                name: None,
+                price: dec!(90),
+                exposure_per_share: HashMap::from([("RE".to_string(), dec!(90))]),
+            },
+        ];
+
+        let plan = TransferOptimizer
+            .plan(make_input(categories, candidates, dec!(10000)))
+            .unwrap();
+        assert!(plan.trades.is_empty());
+        assert!(
+            plan.transfer_pairs.len() >= 2,
+            "should produce at least 2 pairs"
+        );
+        assert!(plan.max_drift_bps_after < plan.max_drift_bps_before);
+    }
+
+    #[test]
+    fn determinism_same_input_same_output() {
+        let make = || {
+            let categories = vec![
+                CategoryState {
+                    category_id: "EQ".to_string(),
+                    category_name: "Equity".to_string(),
+                    target_bps: 6000,
+                    current_value: dec!(7000),
+                    is_cash: false,
+                    is_required: true,
+                },
+                CategoryState {
+                    category_id: "BD".to_string(),
+                    category_name: "Bonds".to_string(),
+                    target_bps: 4000,
+                    current_value: dec!(3000),
+                    is_cash: false,
+                    is_required: true,
+                },
+            ];
+            let candidates = vec![
+                AssetCandidate {
+                    holding_id: "h-vti".to_string(),
+                    asset_id: "vti".to_string(),
+                    symbol: "VTI".to_string(),
+                    name: None,
+                    price: dec!(100),
+                    exposure_per_share: HashMap::from([("EQ".to_string(), dec!(100))]),
+                },
+                AssetCandidate {
+                    holding_id: "h-bnd".to_string(),
+                    asset_id: "bnd".to_string(),
+                    symbol: "BND".to_string(),
+                    name: None,
+                    price: dec!(80),
+                    exposure_per_share: HashMap::from([("BD".to_string(), dec!(80))]),
+                },
+            ];
+            make_input(categories, candidates, dec!(10000))
+        };
+
+        let plan1 = TransferOptimizer.plan(make()).unwrap();
+        let plan2 = TransferOptimizer.plan(make()).unwrap();
+
+        assert_eq!(plan1.transfer_pairs.len(), plan2.transfer_pairs.len());
+        for (a, b) in plan1.transfer_pairs.iter().zip(plan2.transfer_pairs.iter()) {
+            assert_eq!(a.from_asset_id, b.from_asset_id);
+            assert_eq!(a.to_asset_id, b.to_asset_id);
+            assert_eq!(a.amount, b.amount);
+        }
+    }
+
+    #[test]
+    fn min_trade_filter_prunes_small_pairs() {
+        // Portfolio: $10,000. EQ at 62% (target 50%), BD at 38% (target 50%).
+        // Band = 500 bps (5%). EQ excess beyond band = 62% - 55% = 7% → $700.
+        // But with min_trade = $800, the $700 pair is pruned.
+        let categories = vec![
+            CategoryState {
+                category_id: "EQ".to_string(),
+                category_name: "Equity".to_string(),
+                target_bps: 5000,
+                current_value: dec!(6200),
+                is_cash: false,
+                is_required: true,
+            },
+            CategoryState {
+                category_id: "BD".to_string(),
+                category_name: "Bonds".to_string(),
+                target_bps: 5000,
+                current_value: dec!(3800),
+                is_cash: false,
+                is_required: true,
+            },
+        ];
+        let candidates = vec![
+            AssetCandidate {
+                holding_id: "h-vti".to_string(),
+                asset_id: "vti".to_string(),
+                symbol: "VTI".to_string(),
+                name: None,
+                price: dec!(100),
+                exposure_per_share: HashMap::from([("EQ".to_string(), dec!(100))]),
+            },
+            AssetCandidate {
+                holding_id: "h-bnd".to_string(),
+                asset_id: "bnd".to_string(),
+                symbol: "BND".to_string(),
+                name: None,
+                price: dec!(80),
+                exposure_per_share: HashMap::from([("BD".to_string(), dec!(80))]),
+            },
+        ];
+
+        let mut input = make_input(categories, candidates, dec!(10000));
+        input.profile = make_profile(dec!(800)); // min trade $800
+
+        let plan = TransferOptimizer.plan(input).unwrap();
+        assert!(
+            plan.transfer_pairs.is_empty(),
+            "pair below min_trade should be pruned"
+        );
+        assert!(!plan.residual_gaps.is_empty(), "should report gap");
+    }
+
+    #[test]
+    fn single_asset_no_transfer_possible() {
+        let categories = vec![CategoryState {
+            category_id: "EQ".to_string(),
+            category_name: "Equity".to_string(),
+            target_bps: 6000,
+            current_value: dec!(10000),
+            is_cash: false,
+            is_required: true,
+        }];
+        let candidates = vec![AssetCandidate {
+            holding_id: "h-vti".to_string(),
+            asset_id: "vti".to_string(),
+            symbol: "VTI".to_string(),
+            name: None,
+            price: dec!(100),
+            exposure_per_share: HashMap::from([("EQ".to_string(), dec!(100))]),
+        }];
+
+        let plan = TransferOptimizer
+            .plan(make_input(categories, candidates, dec!(10000)))
+            .unwrap();
+        assert!(plan.transfer_pairs.is_empty());
+    }
+
+    #[test]
+    fn within_band_drift_produces_no_transfers() {
+        // Portfolio: $10,000. EQ at 63% (target 60%), BD at 37% (target 40%).
+        // Drift is 3% (300 bps), band is 5% (500 bps) → within band → no transfers.
+        let categories = vec![
+            CategoryState {
+                category_id: "EQ".to_string(),
+                category_name: "Equity".to_string(),
+                target_bps: 6000,
+                current_value: dec!(6300),
+                is_cash: false,
+                is_required: true,
+            },
+            CategoryState {
+                category_id: "BD".to_string(),
+                category_name: "Bonds".to_string(),
+                target_bps: 4000,
+                current_value: dec!(3700),
+                is_cash: false,
+                is_required: true,
+            },
+        ];
+        let candidates = vec![
+            AssetCandidate {
+                holding_id: "h-vti".to_string(),
+                asset_id: "vti".to_string(),
+                symbol: "VTI".to_string(),
+                name: None,
+                price: dec!(100),
+                exposure_per_share: HashMap::from([("EQ".to_string(), dec!(100))]),
+            },
+            AssetCandidate {
+                holding_id: "h-bnd".to_string(),
+                asset_id: "bnd".to_string(),
+                symbol: "BND".to_string(),
+                name: None,
+                price: dec!(80),
+                exposure_per_share: HashMap::from([("BD".to_string(), dec!(80))]),
+            },
+        ];
+
+        let plan = TransferOptimizer
+            .plan(make_input(categories, candidates, dec!(10000)))
+            .unwrap();
+        assert!(
+            plan.transfer_pairs.is_empty(),
+            "drift within band should produce no transfers"
+        );
+    }
+
+    #[test]
+    fn transfers_bring_underweight_into_band_using_in_band_headroom() {
+        // Portfolio: $10,000. EQ at 68% (target 60%), BD at 32% (target 40%).
+        // Band = 500 bps (5%).
+        // EQ: upper=65%, lower=55%. Current 68% → supply headroom = 68%-55% = $1,300.
+        // BD: upper=45%, lower=35%. Current 32% → demand = 35%-32% = $300.
+        // Supply ($1,300) > demand ($300) → cap supply to $300.
+        // Transfer $300 → BD reaches 35% (lower edge, in band).
+        let categories = vec![
+            CategoryState {
+                category_id: "EQ".to_string(),
+                category_name: "Equity".to_string(),
+                target_bps: 6000,
+                current_value: dec!(6800),
+                is_cash: false,
+                is_required: true,
+            },
+            CategoryState {
+                category_id: "BD".to_string(),
+                category_name: "Bonds".to_string(),
+                target_bps: 4000,
+                current_value: dec!(3200),
+                is_cash: false,
+                is_required: true,
+            },
+        ];
+        let candidates = vec![
+            AssetCandidate {
+                holding_id: "h-vti".to_string(),
+                asset_id: "vti".to_string(),
+                symbol: "VTI".to_string(),
+                name: None,
+                price: dec!(100),
+                exposure_per_share: HashMap::from([("EQ".to_string(), dec!(100))]),
+            },
+            AssetCandidate {
+                holding_id: "h-bnd".to_string(),
+                asset_id: "bnd".to_string(),
+                symbol: "BND".to_string(),
+                name: None,
+                price: dec!(80),
+                exposure_per_share: HashMap::from([("BD".to_string(), dec!(80))]),
+            },
+        ];
+
+        let plan = TransferOptimizer
+            .plan(make_input(categories, candidates, dec!(10000)))
+            .unwrap();
+
+        assert_eq!(plan.transfer_pairs.len(), 1);
+        let pair = &plan.transfer_pairs[0];
+        assert_eq!(pair.from_asset_id, "vti");
+        assert_eq!(pair.to_asset_id, "bnd");
+        assert!(
+            (pair.amount - dec!(300)).abs() < dec!(1),
+            "expected ~300, got {}",
+            pair.amount
+        );
+    }
+}


### PR DESCRIPTION
## Description

Adds a **Transfer Only** rebalance mode — paired origin→destination fund movements without buy/sell operations. Designed for jurisdictions where fund transfers between same-category vehicles are tax-exempt (e.g. Spain's *traspasos*).

### Why

In Spain (and other EU countries), transferring between funds doesn't trigger capital gains tax. Users can rebalance by moving money between funds rather than selling and rebuying — preserving their tax-deferred status.

### Algorithm

- **Two-tier supply**: draws from overweight categories first, then taps in-band headroom only if needed. Never worsens at-target funds.
- **Tolerance-aware**: minimizes transfers to bring categories within the configured drift band — not to exact target.
- **Northwest-corner transport**: supply sorted DESC for minimum transfer pairs. Deterministic output.

### Changes

**Backend (Rust)**
- `ScenarioMode::TransferOnly` variant + `SuggestedTransfer`, `ResidualGap` types
- `TransferOptimizer` (new module) with 8 unit tests
- `RebalanceService` routing + integration test

**Frontend (React)**
- 4th mode button in `ModeSwitch` (responsive 2×2 grid on mobile)
- `TransferPairRow` cards showing origin → amount → destination
- `ResidualGapBanner` when plan is approximate (insufficient supply)
- CSV export and copy-to-clipboard adapted for transfer pairs (fully i18n)
- i18n keys for all 5 locales (EN, ES, DE, FR, ZH)

### Bug fix (included)

Fixed drift-driver sentence displaying actual allocation instead of deviation amount (e.g. "1% below" → "2% below").

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).