### PR TITLE
feat(addons): support Basic auth type in addon network requests

### DIFF
--- a/apps/frontend/src/adapters/types.ts
+++ b/apps/frontend/src/adapters/types.ts
@@ -116,7 +116,7 @@ export interface AddonNetworkResponse {
 }
 
 export interface AddonNetworkAuth {
-  type: "bearer";
+  type: "bearer" | "basic";
   secretKey: string;
 }
 

--- a/crates/core/src/addons/network.rs
+++ b/crates/core/src/addons/network.rs
@@ -139,9 +139,11 @@ pub fn resolve_addon_network_auth_header(
     let Some(auth) = auth else {
         return Ok(None);
     };
-    if auth.auth_type != "bearer" {
-        return Err("Addon network auth type is not supported".to_string());
-    }
+    let scheme = match auth.auth_type.as_str() {
+        "bearer" => "Bearer",
+        "basic" => "Basic",
+        _ => return Err("Addon network auth type is not supported".to_string()),
+    };
     let service_id = addon_secret_service_id(addon_id, &auth.secret_key)?;
     let legacy_service_id = legacy_addon_secret_service_id(addon_id, &auth.secret_key)?;
     let secret = match secret_store
@@ -157,7 +159,7 @@ pub fn resolve_addon_network_auth_header(
     if secret.trim().is_empty() {
         return Err("Addon network auth secret is empty".to_string());
     }
-    Ok(Some(format!("Bearer {}", secret)))
+    Ok(Some(format!("{} {}", scheme, secret)))
 }
 
 fn validate_url(url: &str, allowed_hosts: &[String]) -> Result<Url, String> {
@@ -401,6 +403,27 @@ mod tests {
     }
 
     #[test]
+    fn resolves_basic_auth_from_addon_scoped_secret() {
+        let store = TestSecretStore {
+            secrets: BTreeMap::from([(
+                "addon:example-addon:simplefin-access".to_string(),
+                "dXNlcjpwYXNz".to_string(),
+            )]),
+        };
+        let header = resolve_addon_network_auth_header(
+            "example-addon",
+            Some(&AddonNetworkAuth {
+                auth_type: "basic".to_string(),
+                secret_key: "simplefin-access".to_string(),
+            }),
+            &store,
+        )
+        .unwrap();
+
+        assert_eq!(header, Some("Basic dXNlcjpwYXNz".to_string()));
+    }
+
+    #[test]
     fn rejects_invalid_network_auth_requests() {
         let store = TestSecretStore {
             secrets: BTreeMap::new(),
@@ -409,7 +432,7 @@ mod tests {
         assert!(resolve_addon_network_auth_header(
             "example-addon",
             Some(&AddonNetworkAuth {
-                auth_type: "basic".to_string(),
+                auth_type: "digest".to_string(),
                 secret_key: "api-token".to_string(),
             }),
             &store,

--- a/docs/addons/addon-migration-guide-v3.5-to-v3.6.md
+++ b/docs/addons/addon-migration-guide-v3.5-to-v3.6.md
@@ -354,6 +354,11 @@ const res = await ctx.api.network.request({
 Store the token once with `ctx.api.secrets.set('example-api-key', token)`; the
 broker reads it by `secretKey` so the raw token never enters addon code paths.
 
+`auth.type` accepts `"bearer"` (injects `Authorization: Bearer <secret>`) or
+`"basic"` (injects `Authorization: Basic <secret>`). For `"basic"`, store the
+already base64-encoded `user:pass` string as the secret — the broker only
+prefixes the scheme.
+
 ---
 
 ## 7. New capability: durable storage (replaces `localStorage`)

--- a/packages/addon-sdk/src/host-api.ts
+++ b/packages/addon-sdk/src/host-api.ts
@@ -775,7 +775,11 @@ export interface NetworkResponse {
 }
 
 export interface NetworkAuth {
-  type: 'bearer';
+  /**
+   * Authorization scheme. For `basic`, the stored secret must be the
+   * base64-encoded `user:pass` value.
+   */
+  type: 'bearer' | 'basic';
   secretKey: string;
 }
 


### PR DESCRIPTION
## Summary

Implements #1274: allows addons to declare `auth: { type: 'basic', secretKey }` in brokered network requests, alongside the existing `bearer` type. The backend injects `Authorization: Basic <secret>`, where the stored secret is the base64-encoded `user:pass` value.

This enables addons for APIs that require HTTP Basic auth — notably SimpleFin Bridge, whose access URLs embed credentials that the proxy (correctly) refuses to pass through.

## Changes

- `crates/core/src/addons/network.rs` — `resolve_addon_network_auth_header` now maps `bearer` → `Bearer` and `basic` → `Basic`, rejecting any other type. Secret lookup is unchanged.
- `packages/addon-sdk/src/host-api.ts` — `NetworkAuth.type` widened to `'bearer' | 'basic'`, with a doc comment noting the secret must be pre-encoded base64 for basic.
- `apps/frontend/src/adapters/types.ts` — duplicate `AddonNetworkAuth` type updated in lockstep.
- Tests: added `resolves_basic_auth_from_addon_scoped_secret`; the negative test's unsupported-type case changed from `basic` to `digest`.

## Security model (unchanged)

- Secret is resolved server-side from the secrets store; the credential never enters addon JS.
- URL-embedded credentials and raw `Authorization` headers remain blocked.
- The `secrets.use` permission gate still applies to any authenticated request, as do the host allowlist and private-IP blocking.

## Verification

- `cargo test -p wealthfolio-core addons::network` — 7/7 pass (incl. new basic-auth test)
- Service-level `network_auth` permission tests — 3/3 pass
- `cargo fmt --check`, `cargo clippy -p wealthfolio-core --all-targets` — clean
- `pnpm type-check`, `pnpm lint` — clean (0 errors)
- Frontend vitest suite — 1051 tests pass

Closes #1274