### PR TITLE
fix(holdings): deduct tax from cash balance for all cash activity types

### DIFF
--- a/apps/frontend/src/lib/activity-utils.test.ts
+++ b/apps/frontend/src/lib/activity-utils.test.ts
@@ -296,6 +296,30 @@ describe("Activity Utilities", () => {
       expect(calculateActivityValue(activity)).toBe(1010);
     });
 
+    it("should include tax in WITHDRAWAL activity value", () => {
+      const activity = createActivity({
+        activityType: ActivityType.WITHDRAWAL,
+        amount: "1000",
+        fee: "10",
+        tax: "5",
+      });
+
+      // 1000 + 10 + 5 = 1015
+      expect(calculateActivityValue(activity)).toBe(1015);
+    });
+
+    it("should deduct tax from CREDIT activity value", () => {
+      const activity = createActivity({
+        activityType: ActivityType.CREDIT,
+        amount: "100",
+        fee: "2",
+        tax: "10",
+      });
+
+      // 100 - 2 - 10 = 88
+      expect(calculateActivityValue(activity)).toBe(88);
+    });
+
     it("should calculate FEE activity value correctly", () => {
       const activity = createActivity({
         activityType: ActivityType.FEE,
@@ -332,6 +356,30 @@ describe("Activity Utilities", () => {
       });
 
       expect(calculateActivityValue(transferOut)).toBe(1010);
+    });
+
+    it("should include tax in cash transfer activity values", () => {
+      const transferIn = createActivity({
+        activityType: ActivityType.TRANSFER_IN,
+        assetSymbol: "CASH:USD",
+        amount: "1000",
+        fee: "10",
+        tax: "5",
+      });
+
+      // 1000 - 10 - 5 = 985
+      expect(calculateActivityValue(transferIn)).toBe(985);
+
+      const transferOut = createActivity({
+        activityType: ActivityType.TRANSFER_OUT,
+        assetSymbol: "CASH:USD",
+        amount: "1000",
+        fee: "10",
+        tax: "5",
+      });
+
+      // 1000 + 10 + 5 = 1015
+      expect(calculateActivityValue(transferOut)).toBe(1015);
     });
 
     it("treats blank-asset transfers as cash and uses amount", () => {
@@ -447,9 +495,21 @@ describe("Activity Utilities", () => {
             activityType: ActivityType.WITHDRAWAL,
             amount: "100",
             fee: "5",
+            tax: "3",
           }),
         ),
-      ).toBe(-105);
+      ).toBe(-108);
+
+      expect(
+        calculateActivityCashImpact(
+          createActivity({
+            activityType: ActivityType.CREDIT,
+            amount: "100",
+            fee: "2",
+            tax: "10",
+          }),
+        ),
+      ).toBe(88);
 
       expect(
         calculateActivityCashImpact(

--- a/apps/frontend/src/lib/activity-utils.ts
+++ b/apps/frontend/src/lib/activity-utils.ts
@@ -390,9 +390,9 @@ export const calculateActivityValue = (activity: ActivityDetails): number => {
       }
     }
 
-    // For outgoing cash activities, subtract fee from amount
+    // For outgoing cash activities, add fee and tax to amount (total cash out)
     if (activityType === ActivityType.WITHDRAWAL || activityType === ActivityType.TRANSFER_OUT) {
-      return roundCurrency(Number(amount) + Number(fee));
+      return roundCurrency(Number(amount) + Number(fee) + Number(tax));
     }
 
     // For incoming cash activities, subtract fee and withholding tax from amount

--- a/crates/core/src/portfolio/performance/performance_service.rs
+++ b/crates/core/src/portfolio/performance/performance_service.rs
@@ -2177,6 +2177,11 @@ impl PerformanceService {
                 Decimal::ZERO,
                 activity.charge_amt_for(activity_type),
             ),
+            ActivityType::Credit
+            | ActivityType::Deposit
+            | ActivityType::Withdrawal
+            | ActivityType::TransferIn
+            | ActivityType::TransferOut => (Decimal::ZERO, Decimal::ZERO, activity.tax_amt()),
             _ => (Decimal::ZERO, Decimal::ZERO, Decimal::ZERO),
         }
     }

--- a/crates/core/src/portfolio/performance/performance_service.rs
+++ b/crates/core/src/portfolio/performance/performance_service.rs
@@ -2177,6 +2177,9 @@ impl PerformanceService {
                 Decimal::ZERO,
                 activity.charge_amt_for(activity_type),
             ),
+            // Note: fees on these cash flows (and cash transfers below) are booked
+            // to cash but knowingly not attributed — only trade and income fees are
+            // treated as performance costs today.
             ActivityType::Credit | ActivityType::Deposit | ActivityType::Withdrawal => {
                 (Decimal::ZERO, Decimal::ZERO, activity.tax_amt())
             }

--- a/crates/core/src/portfolio/performance/performance_service.rs
+++ b/crates/core/src/portfolio/performance/performance_service.rs
@@ -2177,11 +2177,17 @@ impl PerformanceService {
                 Decimal::ZERO,
                 activity.charge_amt_for(activity_type),
             ),
-            ActivityType::Credit
-            | ActivityType::Deposit
-            | ActivityType::Withdrawal
-            | ActivityType::TransferIn
-            | ActivityType::TransferOut => (Decimal::ZERO, Decimal::ZERO, activity.tax_amt()),
+            ActivityType::Credit | ActivityType::Deposit | ActivityType::Withdrawal => {
+                (Decimal::ZERO, Decimal::ZERO, activity.tax_amt())
+            }
+            // Cash transfers book tax to cash; asset transfers book only the fee.
+            // Attribute tax only when it was actually booked (empty asset_id = cash),
+            // so "attributed ⇔ booked" stays in sync and no phantom residual appears.
+            ActivityType::TransferIn | ActivityType::TransferOut
+                if activity.asset_id.as_deref().unwrap_or("").is_empty() =>
+            {
+                (Decimal::ZERO, Decimal::ZERO, activity.tax_amt())
+            }
             _ => (Decimal::ZERO, Decimal::ZERO, Decimal::ZERO),
         }
     }
@@ -7854,6 +7860,53 @@ mod tests {
             PerformanceService::activity_attribution_components(&taxable_buy, &ActivityType::Buy),
             (Decimal::ZERO, dec!(1), dec!(3))
         );
+
+        // Cash activity types book tax to cash, so their tax is attributed.
+        for cash_type in [
+            ActivityType::Credit,
+            ActivityType::Deposit,
+            ActivityType::Withdrawal,
+        ] {
+            let mut cash = activity_fixture(cash_type.clone(), dec!(100), dec!(2));
+            cash.tax = Some(dec!(10));
+            assert_eq!(
+                PerformanceService::activity_attribution_components(&cash, &cash_type),
+                (Decimal::ZERO, Decimal::ZERO, dec!(10)),
+                "{} tax should be attributed",
+                cash_type.as_str()
+            );
+        }
+
+        // Cash transfers (no asset_id) book tax to cash, so tax is attributed.
+        for transfer_type in [ActivityType::TransferIn, ActivityType::TransferOut] {
+            let mut cash_transfer = activity_fixture(transfer_type.clone(), dec!(100), dec!(2));
+            cash_transfer.tax = Some(dec!(10));
+            assert_eq!(
+                cash_transfer.asset_id, None,
+                "fixture should default to a cash transfer"
+            );
+            assert_eq!(
+                PerformanceService::activity_attribution_components(&cash_transfer, &transfer_type),
+                (Decimal::ZERO, Decimal::ZERO, dec!(10)),
+                "cash {} tax should be attributed",
+                transfer_type.as_str()
+            );
+
+            // Asset transfers book only the fee to cash — tax must NOT be attributed,
+            // otherwise attribution reports a tax that never hit cash (phantom residual).
+            let mut asset_transfer = activity_fixture(transfer_type.clone(), dec!(100), dec!(2));
+            asset_transfer.asset_id = Some("AAPL".to_string());
+            asset_transfer.tax = Some(dec!(10));
+            assert_eq!(
+                PerformanceService::activity_attribution_components(
+                    &asset_transfer,
+                    &transfer_type
+                ),
+                (Decimal::ZERO, Decimal::ZERO, Decimal::ZERO),
+                "asset {} tax must not be attributed",
+                transfer_type.as_str()
+            );
+        }
     }
 
     #[test]

--- a/crates/core/src/portfolio/snapshot/holdings_calculator/handlers/cash_flows.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator/handlers/cash_flows.rs
@@ -22,8 +22,8 @@ impl HoldingsCalculator {
         let activity_date = self.activity_local_date(activity);
         let activity_amount = activity.amt();
 
-        // Book cash in ACTIVITY currency (amount - fee)
-        let net_amount = activity_amount - activity.fee_amt();
+        // Book cash in ACTIVITY currency (amount - fee - tax)
+        let net_amount = activity_amount - activity.fee_amt() - activity.tax_amt();
         add_cash(state, activity_currency, net_amount);
 
         // Convert for net_contribution (pre-fee amount in account currency)
@@ -71,8 +71,8 @@ impl HoldingsCalculator {
         // Use absolute value - activity type dictates direction
         let activity_amount = -activity.amt().abs();
 
-        // Book cash outflow in ACTIVITY currency (amount + fee)
-        let net_amount = activity_amount - activity.fee_amt();
+        // Book cash outflow in ACTIVITY currency (amount + fee + tax)
+        let net_amount = activity_amount - activity.fee_amt() - activity.tax_amt();
         add_cash(state, activity_currency, net_amount);
 
         // Convert for net_contribution (pre-fee amount in account currency)
@@ -124,7 +124,9 @@ impl HoldingsCalculator {
         let activity_currency = &activity.currency;
         let activity_amount = activity.amt();
         let withholding_tax = match ActivityType::from_str(activity.effective_type()) {
-            Ok(ActivityType::Dividend | ActivityType::Interest) => activity.tax_amt(),
+            Ok(ActivityType::Dividend | ActivityType::Interest | ActivityType::Credit) => {
+                activity.tax_amt()
+            }
             _ => Decimal::ZERO,
         };
 

--- a/crates/core/src/portfolio/snapshot/holdings_calculator/handlers/cash_flows.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator/handlers/cash_flows.rs
@@ -6,7 +6,6 @@ use crate::errors::Result;
 use crate::portfolio::snapshot::AccountStateSnapshot;
 use log::warn;
 use rust_decimal::Decimal;
-use std::str::FromStr;
 
 impl HoldingsCalculator {
     /// Handle DEPOSIT activity.
@@ -123,15 +122,10 @@ impl HoldingsCalculator {
 
         let activity_currency = &activity.currency;
         let activity_amount = activity.amt();
-        let withholding_tax = match ActivityType::from_str(activity.effective_type()) {
-            Ok(ActivityType::Dividend | ActivityType::Interest | ActivityType::Credit) => {
-                activity.tax_amt()
-            }
-            _ => Decimal::ZERO,
-        };
 
-        // Book cash in ACTIVITY currency (gross income - fees - withholding tax)
-        let net_amount = activity_amount - activity.fee_amt() - withholding_tax;
+        // Book cash in ACTIVITY currency (gross income - fees - withholding tax).
+        // All types dispatched here (DIVIDEND/INTEREST/CREDIT) apply withholding tax.
+        let net_amount = activity_amount - activity.fee_amt() - activity.tax_amt();
         add_cash(state, activity_currency, net_amount);
 
         // CREDIT/BONUS is external contribution (new capital entering portfolio)

--- a/crates/core/src/portfolio/snapshot/holdings_calculator/handlers/transfers.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator/handlers/transfers.rs
@@ -92,8 +92,8 @@ impl HoldingsCalculator {
         let asset_id = activity.asset_id.as_deref().unwrap_or("");
 
         if asset_id.is_empty() {
-            // Cash transfer: book in ACTIVITY currency
-            let net_amount = activity_amount - activity.fee_amt();
+            // Cash transfer: book in ACTIVITY currency (amount - fee - tax)
+            let net_amount = activity_amount - activity.fee_amt() - activity.tax_amt();
             add_cash(state, activity_currency, net_amount);
 
             let activity_date = self.activity_local_date(activity);
@@ -413,8 +413,8 @@ impl HoldingsCalculator {
         let asset_id = activity.asset_id.as_deref().unwrap_or("");
 
         if asset_id.is_empty() {
-            // Cash transfer: book outflow in ACTIVITY currency (amount + fee)
-            let net_amount = activity_amount - activity.fee_amt();
+            // Cash transfer: book outflow in ACTIVITY currency (amount + fee + tax)
+            let net_amount = activity_amount - activity.fee_amt() - activity.tax_amt();
             add_cash(state, activity_currency, net_amount);
 
             let amount_acct = self.convert_to_account_currency(

--- a/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
@@ -1742,6 +1742,260 @@ mod tests {
     }
 
     #[test]
+    fn test_credit_activity_with_tax_deducts_cash() {
+        let mock_fx_service = MockFxService::new();
+        let target_date_str = "2023-01-06";
+        let target_date = NaiveDate::from_str(target_date_str).unwrap();
+        let account_currency = "USD";
+
+        let base_currency = Arc::new(RwLock::new(account_currency.to_string()));
+        let mut calculator = create_calculator(Arc::new(mock_fx_service), base_currency);
+
+        let mut previous_snapshot =
+            create_initial_snapshot("acc_credit", account_currency, "2023-01-05");
+        previous_snapshot
+            .cash_balances
+            .insert(account_currency.to_string(), dec!(1000));
+        previous_snapshot.net_contribution = dec!(500);
+        previous_snapshot.net_contribution_base = dec!(500);
+
+        let mut credit_activity = create_cash_activity(
+            "act_credit_1",
+            ActivityType::Credit,
+            dec!(100),
+            dec!(2),
+            account_currency,
+            target_date_str,
+        );
+        credit_activity.tax = Some(dec!(10));
+
+        let result =
+            calculator.calculate_next_holdings(&previous_snapshot, &[credit_activity], target_date);
+        assert!(result.is_ok(), "Calculation failed: {:?}", result.err());
+        let next_state = result.unwrap().snapshot;
+
+        // Cash: 1000 + (100 - 2 fee - 10 tax) = 1088
+        assert_eq!(
+            next_state.cash_balances.get(account_currency),
+            Some(&dec!(1088))
+        );
+        // Non-BONUS credit does not affect net_contribution
+        assert_eq!(
+            next_state.net_contribution,
+            previous_snapshot.net_contribution
+        );
+    }
+
+    #[test]
+    fn test_credit_bonus_with_tax_deducts_cash_and_adds_gross_contribution() {
+        use crate::activities::ACTIVITY_SUBTYPE_BONUS;
+
+        let mock_fx_service = MockFxService::new();
+        let target_date_str = "2023-01-06";
+        let target_date = NaiveDate::from_str(target_date_str).unwrap();
+        let account_currency = "USD";
+
+        let base_currency = Arc::new(RwLock::new(account_currency.to_string()));
+        let mut calculator = create_calculator(Arc::new(mock_fx_service), base_currency);
+
+        let mut previous_snapshot =
+            create_initial_snapshot("acc_credit_bonus", account_currency, "2023-01-05");
+        previous_snapshot
+            .cash_balances
+            .insert(account_currency.to_string(), dec!(1000));
+        previous_snapshot.net_contribution = dec!(500);
+        previous_snapshot.net_contribution_base = dec!(500);
+
+        let mut bonus_activity = create_cash_activity(
+            "act_credit_bonus_1",
+            ActivityType::Credit,
+            dec!(100),
+            dec!(2),
+            account_currency,
+            target_date_str,
+        );
+        bonus_activity.tax = Some(dec!(10));
+        bonus_activity.subtype = Some(ACTIVITY_SUBTYPE_BONUS.to_string());
+
+        let result =
+            calculator.calculate_next_holdings(&previous_snapshot, &[bonus_activity], target_date);
+        assert!(result.is_ok(), "Calculation failed: {:?}", result.err());
+        let next_state = result.unwrap().snapshot;
+
+        // Cash: 1000 + (100 - 2 fee - 10 tax) = 1088
+        assert_eq!(
+            next_state.cash_balances.get(account_currency),
+            Some(&dec!(1088))
+        );
+        // BONUS credit adds GROSS amount to net_contribution: 500 + 100 = 600
+        assert_eq!(next_state.net_contribution, dec!(600));
+        assert_eq!(next_state.net_contribution_base, dec!(600));
+    }
+
+    #[test]
+    fn test_deposit_activity_with_tax_deducts_cash() {
+        let mock_fx_service = MockFxService::new();
+        let target_date_str = "2023-01-06";
+        let target_date = NaiveDate::from_str(target_date_str).unwrap();
+        let account_currency = "USD";
+
+        let base_currency = Arc::new(RwLock::new(account_currency.to_string()));
+        let mut calculator = create_calculator(Arc::new(mock_fx_service), base_currency);
+
+        let mut previous_snapshot =
+            create_initial_snapshot("acc_dep_tax", account_currency, "2023-01-05");
+        previous_snapshot
+            .cash_balances
+            .insert(account_currency.to_string(), dec!(1000));
+        previous_snapshot.net_contribution = dec!(500);
+        previous_snapshot.net_contribution_base = dec!(500);
+
+        let mut deposit_activity = create_cash_activity(
+            "act_dep_tax_1",
+            ActivityType::Deposit,
+            dec!(100),
+            dec!(2),
+            account_currency,
+            target_date_str,
+        );
+        deposit_activity.tax = Some(dec!(10));
+
+        let result = calculator.calculate_next_holdings(
+            &previous_snapshot,
+            &[deposit_activity],
+            target_date,
+        );
+        assert!(result.is_ok(), "Calculation failed: {:?}", result.err());
+        let next_state = result.unwrap().snapshot;
+
+        // Cash: 1000 + (100 - 2 fee - 10 tax) = 1088
+        assert_eq!(
+            next_state.cash_balances.get(account_currency),
+            Some(&dec!(1088))
+        );
+        // net_contribution uses GROSS amount: 500 + 100 = 600
+        assert_eq!(next_state.net_contribution, dec!(600));
+    }
+
+    #[test]
+    fn test_withdrawal_activity_with_tax_deducts_cash() {
+        let mock_fx_service = MockFxService::new();
+        let target_date_str = "2023-01-06";
+        let target_date = NaiveDate::from_str(target_date_str).unwrap();
+        let account_currency = "USD";
+
+        let base_currency = Arc::new(RwLock::new(account_currency.to_string()));
+        let mut calculator = create_calculator(Arc::new(mock_fx_service), base_currency);
+
+        let mut previous_snapshot =
+            create_initial_snapshot("acc_wd_tax", account_currency, "2023-01-05");
+        previous_snapshot
+            .cash_balances
+            .insert(account_currency.to_string(), dec!(1000));
+        previous_snapshot.net_contribution = dec!(500);
+        previous_snapshot.net_contribution_base = dec!(500);
+
+        let mut withdrawal_activity = create_cash_activity(
+            "act_wd_tax_1",
+            ActivityType::Withdrawal,
+            dec!(100),
+            dec!(2),
+            account_currency,
+            target_date_str,
+        );
+        withdrawal_activity.tax = Some(dec!(10));
+
+        let result = calculator.calculate_next_holdings(
+            &previous_snapshot,
+            &[withdrawal_activity],
+            target_date,
+        );
+        assert!(result.is_ok(), "Calculation failed: {:?}", result.err());
+        let next_state = result.unwrap().snapshot;
+
+        // Cash: 1000 - (100 + 2 fee + 10 tax) = 888
+        assert_eq!(
+            next_state.cash_balances.get(account_currency),
+            Some(&dec!(888))
+        );
+        // net_contribution uses GROSS amount: 500 - 100 = 400
+        assert_eq!(next_state.net_contribution, dec!(400));
+    }
+
+    #[test]
+    fn test_cash_transfers_with_tax_deduct_cash() {
+        let mock_fx_service = MockFxService::new();
+        let target_date_str = "2023-01-06";
+        let target_date = NaiveDate::from_str(target_date_str).unwrap();
+        let account_currency = "USD";
+
+        let base_currency = Arc::new(RwLock::new(account_currency.to_string()));
+        let mut calculator = create_calculator(Arc::new(mock_fx_service), base_currency);
+
+        let mut previous_snapshot =
+            create_initial_snapshot("acc_tx_tax", account_currency, "2023-01-05");
+        previous_snapshot
+            .cash_balances
+            .insert(account_currency.to_string(), dec!(1000));
+        previous_snapshot.net_contribution = dec!(500);
+        previous_snapshot.net_contribution_base = dec!(500);
+
+        // Cash TransferIn with tax (asset_id is None -> cash branch)
+        let mut transfer_in_activity = create_cash_activity(
+            "act_tx_in_tax_1",
+            ActivityType::TransferIn,
+            dec!(100),
+            dec!(2),
+            account_currency,
+            target_date_str,
+        );
+        transfer_in_activity.tax = Some(dec!(10));
+
+        let result = calculator.calculate_next_holdings(
+            &previous_snapshot,
+            &[transfer_in_activity],
+            target_date,
+        );
+        assert!(result.is_ok(), "TransferIn failed: {:?}", result.err());
+        let state_after_in = result.unwrap().snapshot;
+
+        // Cash: 1000 + (100 - 2 fee - 10 tax) = 1088
+        assert_eq!(
+            state_after_in.cash_balances.get(account_currency),
+            Some(&dec!(1088))
+        );
+        // net_contribution uses GROSS amount: 500 + 100 = 600
+        assert_eq!(state_after_in.net_contribution, dec!(600));
+
+        // Cash TransferOut with tax
+        let mut transfer_out_activity = create_cash_activity(
+            "act_tx_out_tax_1",
+            ActivityType::TransferOut,
+            dec!(50),
+            dec!(2),
+            account_currency,
+            "2023-01-07",
+        );
+        transfer_out_activity.tax = Some(dec!(5));
+
+        let result = calculator.calculate_next_holdings(
+            &state_after_in,
+            &[transfer_out_activity],
+            NaiveDate::from_str("2023-01-07").unwrap(),
+        );
+        assert!(result.is_ok(), "TransferOut failed: {:?}", result.err());
+        let state_after_out = result.unwrap().snapshot;
+
+        // Cash: 1088 - (50 + 2 fee + 5 tax) = 1031
+        assert_eq!(
+            state_after_out.cash_balances.get(account_currency),
+            Some(&dec!(1031))
+        );
+        // net_contribution uses GROSS amount: 600 - 50 = 550
+        assert_eq!(state_after_out.net_contribution, dec!(550));
+    }
+
+    #[test]
     fn test_credit_card_interest_books_as_liability_charge() {
         let mock_fx_service = MockFxService::new();
         let target_date_str = "2023-01-06";


### PR DESCRIPTION
## Problem

Fixes #1268. A **Credit** activity with a built-in tax amount did not deduct the tax from the account cash balance. The transaction total displayed correctly in the activity view (the frontend already subtracts tax), but the dashboard and account cash balances were wrong.

**Root cause:** in the holdings calculator, only `Dividend`/`Interest` (and `Buy`/`Sell`) applied the `tax` field to cash. `handle_income`'s match fell into `_ => Decimal::ZERO` for `Credit`, and `handle_deposit`/`handle_withdrawal`/cash `TransferIn`/`TransferOut` never referenced `tax_amt()` at all. This produced a frontend/backend mismatch: the activity total showed `amount − fee − tax` while cash was booked as `amount − fee`.

## Changes

**Backend — cash booking** (`crates/core/.../handlers/`)
- `handle_income`: include `Credit` in the withholding-tax deduction.
- `handle_deposit` / `handle_withdrawal`: subtract `tax_amt()` from booked cash.
- cash `handle_transfer_in` / `handle_transfer_out`: subtract `tax_amt()` from booked cash.
- `net_contribution` stays gross (pre-fee, pre-tax) — unchanged by design.

**Backend — performance attribution** (`performance_service.rs`)
- `activity_attribution_components`: attribute `tax` for Credit/Deposit/Withdrawal/TransferIn/TransferOut, for parity with the cash fix.

**Frontend — display parity** (`activity-utils.ts`)
- Withdrawal/TransferOut value now includes tax (`amount + fee + tax`), matching the backend outflow. The incoming-cash branch already subtracted tax.

**Tests**
- Rust: new cases for Credit (incl. `BONUS` subtype), Deposit, Withdrawal, and cash TransferIn/TransferOut with tax.
- Frontend: new cases for Withdrawal/TransferOut/Credit value and cash-impact with tax.

## Verification

- `cargo test --workspace` — all pass (incl. 5 new holdings tests).
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.
- `pnpm test` (1054), `pnpm type-check`, `pnpm lint` (0 errors), `pnpm format:check`, `pnpm build` — all pass.
- **End-to-end (web dev mode):** created an account, a \$1,000 deposit, then a \$100 Credit with \$2 fee + \$10 tax. Dashboard and account page now show **\$1,088.00** cash (was \$1,098 before the fix); net contribution correctly shows \$1,000 (gross deposit only).

## Notes

Existing users' balances self-correct on the next portfolio recalculation (triggered by any activity change or manual portfolio update) — no migration required.