### PR TITLE
fix(addons): safely rewrite module imports

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -65,6 +65,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
+    "es-module-lexer": "^2.1.0",
     "lucide-react": "^0.561.0",
     "motion": "^12.34.0",
     "nanoid": "^5.1.6",

--- a/apps/frontend/src/addons/iframe/addon-module-rewriter.test.ts
+++ b/apps/frontend/src/addons/iframe/addon-module-rewriter.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment node
+
+import { describe, expect, it } from "vitest";
+import { rewriteModuleSpecifiers } from "./addon-module-rewriter";
+
+const replacements: Record<string, string> = {
+  "./feature.js": "blob:feature",
+  "./side-effect.js": "blob:side-effect",
+  "chunk.js": "blob:chunk",
+  react: "blob:react",
+};
+
+function shouldRewriteStaticSpecifier(specifier: string) {
+  return specifier.startsWith(".") || specifier === "react";
+}
+
+function rewrite(code: string, importerPath = "dist/addon.js") {
+  return rewriteModuleSpecifiers(
+    importerPath,
+    code,
+    (_importerPath, specifier) => replacements[specifier] ?? specifier,
+    shouldRewriteStaticSpecifier,
+  );
+}
+
+describe("addon module rewriter", () => {
+  it("rewrites static imports, re-exports, and side-effect imports", () => {
+    const source = [
+      `import React from "react";`,
+      `import { feature } from "./feature.js";`,
+      `export { value } from "./feature.js";`,
+      `export * from "./feature.js";`,
+      `export * as featureModule from "./feature.js";`,
+      `import "./side-effect.js";`,
+      `import untouched from "other-package";`,
+      `import localCollision from "chunk.js";`,
+    ].join("\n");
+
+    expect(rewrite(source)).toBe(
+      [
+        `import React from "blob:react";`,
+        `import { feature } from "blob:feature";`,
+        `export { value } from "blob:feature";`,
+        `export * from "blob:feature";`,
+        `export * as featureModule from "blob:feature";`,
+        `import "blob:side-effect";`,
+        `import untouched from "other-package";`,
+        `import localCollision from "chunk.js";`,
+      ].join("\n"),
+    );
+  });
+
+  it("rewrites normal dynamic import expressions", () => {
+    expect(
+      rewrite(
+        [
+          `const literal = import("./feature.js");`,
+          `const expression = import(moduleName);`,
+          `const commented = import /* webpackIgnore: true */ (moduleName);`,
+        ].join("\n"),
+      ),
+    ).toBe(
+      [
+        `const literal = globalThis.__wealthfolioImport("dist/addon.js", "./feature.js");`,
+        `const expression = globalThis.__wealthfolioImport("dist/addon.js", moduleName);`,
+        `const commented = globalThis.__wealthfolioImport("dist/addon.js", moduleName);`,
+      ].join("\n"),
+    );
+  });
+
+  it("leaves import method calls unchanged", () => {
+    const source = [
+      `await ctx.api.activities.import(activities);`,
+      `await ctx.api.activities?.import(activities);`,
+      `await ctx.api.activities["import"](activities);`,
+      `const { import: importActivities } = ctx.api.activities;`,
+    ].join("\n");
+
+    expect(rewrite(source)).toBe(source);
+  });
+
+  it("leaves import-like text in strings, templates, and comments unchanged", () => {
+    const source = [
+      `const doubleQuoted = "import('./feature.js')";`,
+      `const singleQuoted = 'import("./feature.js")';`,
+      "const template = `import('./feature.js')`;",
+      `const pattern = /import\\(.*\\)/;`,
+      `// import("./feature.js")`,
+      `/* import("./feature.js") */`,
+    ].join("\n");
+
+    expect(rewrite(source)).toBe(source);
+  });
+
+  it("rewrites dynamic imports inside template expressions only", () => {
+    const source = "const template = `import('./fake.js') ${import('./feature.js')}`;";
+
+    expect(rewrite(source)).toBe(
+      "const template = `import('./fake.js') ${globalThis.__wealthfolioImport(\"dist/addon.js\", './feature.js')}`;",
+    );
+  });
+
+  it("leaves identifiers and import.meta unchanged", () => {
+    const source = [
+      `someimport("./feature.js");`,
+      `$import("./feature.js");`,
+      `const url = import.meta.url;`,
+    ].join("\n");
+
+    expect(rewrite(source)).toBe(source);
+  });
+
+  it("escapes resolved static specifiers for their original quote style", () => {
+    const source = `import first from "./first.js";\nimport second from './second.js';`;
+    const result = rewriteModuleSpecifiers(
+      "addon.js",
+      source,
+      (_importerPath, specifier) =>
+        specifier === "./first.js" ? 'blob:value"one' : "blob:value'two",
+      () => true,
+    );
+
+    expect(result).toBe(
+      `import first from "blob:value\\"one";\nimport second from 'blob:value\\'two';`,
+    );
+  });
+
+  it("reports malformed addon modules with their path and lexer offset", () => {
+    expect(() => rewrite(`import(`, "chunks/broken.js")).toThrowError(
+      /Failed to parse addon module 'chunks\/broken\.js': Parse error.*offset 0/,
+    );
+  });
+
+  it.each([
+    ["import.source", `import.source("./feature.js")`],
+    ["import.defer", `import.defer("./feature.js")`],
+  ])("rejects unsupported %s expressions clearly", (syntax, source) => {
+    expect(() => rewrite(source)).toThrowError(
+      `Unsupported ${syntax}() in addon module 'dist/addon.js' at offset 0`,
+    );
+  });
+});

--- a/apps/frontend/src/addons/iframe/addon-module-rewriter.ts
+++ b/apps/frontend/src/addons/iframe/addon-module-rewriter.ts
@@ -1,0 +1,116 @@
+import { parse } from "es-module-lexer/js";
+
+export type ModuleSpecifierResolver = (importerPath: string, specifier: string) => string;
+export type StaticSpecifierEligibility = (specifier: string) => boolean;
+
+interface SourceEdit {
+  end: number;
+  replacement: string;
+  start: number;
+}
+
+// es-module-lexer declares ImportType in its types but does not export it from
+// the CSP-safe `/js` runtime build. Keep these values aligned with its public
+// ImportType enum and handle only syntax whose semantics this loader supports.
+const IMPORT_TYPE = {
+  STATIC: 1,
+  DYNAMIC: 2,
+  STATIC_SOURCE_PHASE: 4,
+  DYNAMIC_SOURCE_PHASE: 5,
+  STATIC_DEFER_PHASE: 6,
+  DYNAMIC_DEFER_PHASE: 7,
+} as const;
+const STATIC_IMPORT_TYPES = new Set<number>([
+  IMPORT_TYPE.STATIC,
+  IMPORT_TYPE.STATIC_SOURCE_PHASE,
+  IMPORT_TYPE.STATIC_DEFER_PHASE,
+]);
+
+function formatParseError(error: unknown) {
+  if (!(error instanceof Error)) {
+    return String(error);
+  }
+
+  const index = "idx" in error && typeof error.idx === "number" ? ` at offset ${error.idx}` : "";
+  return `${error.message}${index}`;
+}
+
+function escapeSpecifier(specifier: string, quote: string) {
+  const escaped = specifier
+    .replace(/\\/g, "\\\\")
+    .replace(/\r/g, "\\r")
+    .replace(/\n/g, "\\n")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+  return quote === '"' ? escaped.replace(/"/g, '\\"') : escaped.replace(/'/g, "\\'");
+}
+
+function applySourceEdits(code: string, edits: SourceEdit[]) {
+  return edits
+    .sort((left, right) => right.start - left.start)
+    .reduce(
+      (rewritten, edit) =>
+        `${rewritten.slice(0, edit.start)}${edit.replacement}${rewritten.slice(edit.end)}`,
+      code,
+    );
+}
+
+export function rewriteModuleSpecifiers(
+  importerPath: string,
+  code: string,
+  resolveSpecifier: ModuleSpecifierResolver,
+  shouldRewriteStaticSpecifier: StaticSpecifierEligibility,
+) {
+  let imports: ReturnType<typeof parse>[0];
+  try {
+    [imports] = parse(code, importerPath);
+  } catch (error) {
+    throw new Error(`Failed to parse addon module '${importerPath}': ${formatParseError(error)}`, {
+      cause: error,
+    });
+  }
+
+  const edits: SourceEdit[] = [];
+  for (const moduleImport of imports) {
+    const importType = Number(moduleImport.t);
+    if (STATIC_IMPORT_TYPES.has(importType) && moduleImport.n !== undefined) {
+      if (!shouldRewriteStaticSpecifier(moduleImport.n)) {
+        continue;
+      }
+
+      const resolvedSpecifier = resolveSpecifier(importerPath, moduleImport.n);
+      if (resolvedSpecifier === moduleImport.n) {
+        continue;
+      }
+
+      edits.push({
+        start: moduleImport.s,
+        end: moduleImport.e,
+        replacement: escapeSpecifier(resolvedSpecifier, code[moduleImport.s - 1] ?? '"'),
+      });
+      continue;
+    }
+
+    if (importType === IMPORT_TYPE.DYNAMIC) {
+      edits.push({
+        start: moduleImport.ss,
+        end: moduleImport.d + 1,
+        replacement: `globalThis.__wealthfolioImport(${JSON.stringify(importerPath)}, `,
+      });
+      continue;
+    }
+
+    if (
+      importType === IMPORT_TYPE.DYNAMIC_SOURCE_PHASE ||
+      importType === IMPORT_TYPE.DYNAMIC_DEFER_PHASE
+    ) {
+      const syntax =
+        importType === IMPORT_TYPE.DYNAMIC_SOURCE_PHASE ? "import.source()" : "import.defer()";
+      throw new Error(
+        `Unsupported ${syntax} in addon module '${importerPath}' at offset ${moduleImport.ss}`,
+      );
+    }
+  }
+
+  return applySourceEdits(code, edits);
+}

--- a/apps/frontend/src/addons/iframe/addon-sandbox-entry.tsx
+++ b/apps/frontend/src/addons/iframe/addon-sandbox-entry.tsx
@@ -13,6 +13,7 @@ import {
   type SandboxAddonFile,
 } from "./addon-sandbox-styles";
 import { applyHostTheme, type AddonThemeSnapshot } from "./addon-sandbox-theme";
+import { rewriteModuleSpecifiers } from "./addon-module-rewriter";
 
 const CHANNEL = "wealthfolio:addon-sandbox:v1";
 
@@ -61,7 +62,6 @@ interface SandboxMessage {
 }
 
 type RouteRenderer = (context: RouteRenderContext) => Promise<void> | void;
-type ModuleSpecifierResolver = (importerPath: string, specifier: string) => string;
 
 const init = new URLSearchParams(window.location.hash.slice(1));
 const ADDON_ID = init.get("addonId") ?? "";
@@ -249,7 +249,14 @@ function createAddonModuleRegistry(code: string, files: SandboxAddonFile[] = [])
     if (!moduleUrl) {
       moduleUrl = URL.createObjectURL(
         new Blob(
-          [rewriteModuleSpecifiers(moduleEntry.path, moduleEntry.source, resolveModuleSpecifier)],
+          [
+            rewriteModuleSpecifiers(
+              moduleEntry.path,
+              moduleEntry.source,
+              resolveModuleSpecifier,
+              (specifier) => isHostDependencySpecifier(specifier) || specifier.startsWith("."),
+            ),
+          ],
           {
             type: "text/javascript",
           },
@@ -274,46 +281,6 @@ function createAddonModuleRegistry(code: string, files: SandboxAddonFile[] = [])
     mainUrl: resolveModuleSpecifier(mainPath, mainPath),
     objectUrls,
   };
-}
-
-function rewriteStaticImportSpecifiers(
-  importerPath: string,
-  code: string,
-  resolveSpecifier: ModuleSpecifierResolver,
-) {
-  const rewrite = (match: string, prefix: string, quote: string, specifier: string) => {
-    if (!isHostDependencySpecifier(specifier) && !specifier.startsWith(".")) {
-      return match;
-    }
-    return `${prefix}${quote}${resolveSpecifier(importerPath, specifier)}${quote}`;
-  };
-
-  const withFromImports = code.replace(
-    /(\b(?:import|export)\s*[^'"]*?\bfrom\s*)(["'])([^"']+)\2/g,
-    (match, prefix: string, quote: string, specifier: string) => {
-      return rewrite(match, prefix, quote, specifier);
-    },
-  );
-
-  return withFromImports.replace(
-    /(\bimport\s*)(["'])([^"']+)\2/g,
-    (match, prefix: string, quote: string, specifier: string) => {
-      return rewrite(match, prefix, quote, specifier);
-    },
-  );
-}
-
-function rewriteModuleSpecifiers(
-  importerPath: string,
-  code: string,
-  resolveSpecifier: ModuleSpecifierResolver,
-) {
-  const withStaticImports = rewriteStaticImportSpecifiers(importerPath, code, resolveSpecifier);
-
-  return withStaticImports.replace(
-    /\bimport\s*\(/g,
-    `globalThis.__wealthfolioImport(${JSON.stringify(importerPath)}, `,
-  );
 }
 
 function findAnchor(target: EventTarget | null) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      es-module-lexer:
+        specifier: ^2.1.0
+        version: 2.1.0
       i18next:
         specifier: ^25.6.0
         version: 25.10.10(typescript@5.9.3)


### PR DESCRIPTION
## Summary

- replace regex-based addon import rewriting with the CSP-safe `es-module-lexer/js` parser
- preserve the existing V1 policy: only relative and approved host static imports are rewritten
- keep legitimate methods such as `ctx.api.activities.import(...)` unchanged
- reject unsupported `import.source()` and `import.defer()` syntax with actionable errors
- add regression coverage for static imports, dynamic imports, re-exports, lexical edge cases, and malformed modules

## Root cause

The sandbox used `/\bimport\s*\(/g` to identify dynamic imports. A word boundary exists between `.` and `import`, so the documented `activities.import(...)` host API method was rewritten into an invalid method path.

Fixes #1275.

## Compatibility

No previously-loading addon changes behavior. Non-relative, non-host static imports continue to fail instead of resolving accidentally. Unsupported dynamic source/defer imports now fail earlier with explicit diagnostics.

## Validation

- 10 focused module-rewriter tests
- 28 addon iframe tests
- 1,065 frontend tests across 125 files
- package-scoped ESLint
- frontend TypeScript check
- web production build
- Tauri-mode frontend production build
- `git diff --check`
