### PR TITLE
fix(activities): align FEE/TAX display value with backend charge precedence

### DIFF
--- a/apps/frontend/src/lib/activity-utils.test.ts
+++ b/apps/frontend/src/lib/activity-utils.test.ts
@@ -305,6 +305,69 @@ describe("Activity Utilities", () => {
       expect(calculateActivityValue(activity)).toBe(10);
     });
 
+    it("should prefer fee over amount for FEE activities", () => {
+      const activity = createActivity({
+        activityType: ActivityType.FEE,
+        fee: "10",
+        amount: "25",
+      });
+
+      expect(calculateActivityValue(activity)).toBe(10);
+    });
+
+    it("should fall back to amount for FEE activities when fee is zero", () => {
+      const activity = createActivity({
+        activityType: ActivityType.FEE,
+        fee: "0",
+        amount: "25",
+      });
+
+      expect(calculateActivityValue(activity)).toBe(25);
+    });
+
+    it("should use tax for TAX activities when only tax is set", () => {
+      const activity = createActivity({
+        activityType: ActivityType.TAX,
+        tax: "15",
+        fee: "0",
+        amount: "0",
+      });
+
+      expect(calculateActivityValue(activity)).toBe(15);
+      expect(calculateActivityCashImpact(activity)).toBe(-15);
+    });
+
+    it("should prefer tax over fee and amount for TAX activities", () => {
+      const activity = createActivity({
+        activityType: ActivityType.TAX,
+        tax: "15",
+        fee: "10",
+        amount: "25",
+      });
+
+      expect(calculateActivityValue(activity)).toBe(15);
+    });
+
+    it("should fall back to fee, then amount for TAX activities", () => {
+      const withFee = createActivity({
+        activityType: ActivityType.TAX,
+        tax: "0",
+        fee: "10",
+        amount: "25",
+      });
+
+      expect(calculateActivityValue(withFee)).toBe(10);
+
+      const withAmount = createActivity({
+        activityType: ActivityType.TAX,
+        tax: "0",
+        fee: "0",
+        amount: "25",
+      });
+
+      expect(calculateActivityValue(withAmount)).toBe(25);
+    });
+
     it("should calculate SPLIT activity value correctly", () => {
       const activity = createActivity({
         activityType: ActivityType.SPLIT,

--- a/apps/frontend/src/lib/activity-utils.ts
+++ b/apps/frontend/src/lib/activity-utils.ts
@@ -363,12 +363,20 @@ export const calculateActivityValue = (activity: ActivityDetails): number => {
     return 0; // Split activities don't have a monetary value
   }
 
+  // Standalone charges mirror the backend's charge_amt_for precedence:
+  // TAX prefers tax, then fee, then amount; FEE prefers fee, then amount.
   if (activityType === ActivityType.FEE || activityType === ActivityType.TAX) {
-    const amount = getAmount(activity);
-    if (amount !== 0) {
-      return roundCurrency(amount);
+    if (activityType === ActivityType.TAX) {
+      const tax = getTax(activity);
+      if (tax !== 0) {
+        return roundCurrency(tax);
+      }
     }
-    return roundCurrency(getFee(activity));
+    const fee = getFee(activity);
+    if (fee !== 0) {
+      return roundCurrency(fee);
+    }
+    return roundCurrency(getAmount(activity));
   }
 
   const isSecTransfer = isSecuritiesTransfer(activityType, assetSymbol, assetId);

--- a/apps/frontend/src/pages/activity/components/forms/__tests__/form-schemas.test.ts
+++ b/apps/frontend/src/pages/activity/components/forms/__tests__/form-schemas.test.ts
@@ -1112,6 +1112,113 @@ describe("Form Schemas Validation", () => {
     });
   });
 
+  describe("standalone charge (FEE/TAX) defaults and payload", () => {
+    it("FEE getDefaults surfaces the fee field as the editable amount (fee → amount)", () => {
+      const defaults = ACTIVITY_FORM_CONFIG.FEE.getDefaults(
+        {
+          activityType: ActivityType.FEE,
+          accountId: "acc-123",
+          date: new Date(),
+          fee: "10",
+          amount: "0",
+          currency: "USD",
+        },
+        [],
+      ) as any;
+
+      expect(defaults.amount).toBe(10);
+    });
+
+    it("FEE getDefaults falls back to amount when fee is absent", () => {
+      const defaults = ACTIVITY_FORM_CONFIG.FEE.getDefaults(
+        {
+          activityType: ActivityType.FEE,
+          accountId: "acc-123",
+          date: new Date(),
+          fee: "0",
+          amount: "25",
+          currency: "USD",
+        },
+        [],
+      ) as any;
+
+      expect(defaults.amount).toBe(25);
+    });
+
+    it("FEE toPayload resets legacy fee to zero so amount is booked", () => {
+      const payload = ACTIVITY_FORM_CONFIG.FEE.toPayload({
+        accountId: "acc-123",
+        activityDate: new Date(),
+        amount: 20,
+        comment: null,
+        subtype: null,
+        currency: "USD",
+      } as any) as any;
+
+      expect(payload).toMatchObject({ amount: 20, fee: 0 });
+    });
+
+    it("TAX getDefaults surfaces the tax field as the editable amount (tax → fee → amount)", () => {
+      const defaults = ACTIVITY_FORM_CONFIG.TAX.getDefaults(
+        {
+          activityType: ActivityType.TAX,
+          accountId: "acc-123",
+          date: new Date(),
+          tax: "15",
+          fee: "0",
+          amount: "0",
+          currency: "USD",
+        },
+        [],
+      ) as any;
+
+      expect(defaults.amount).toBe(15);
+    });
+
+    it("TAX getDefaults falls back to fee, then amount", () => {
+      const withFee = ACTIVITY_FORM_CONFIG.TAX.getDefaults(
+        {
+          activityType: ActivityType.TAX,
+          accountId: "acc-123",
+          date: new Date(),
+          tax: "0",
+          fee: "10",
+          amount: "25",
+          currency: "USD",
+        },
+        [],
+      ) as any;
+      expect(withFee.amount).toBe(10);
+
+      const withAmount = ACTIVITY_FORM_CONFIG.TAX.getDefaults(
+        {
+          activityType: ActivityType.TAX,
+          accountId: "acc-123",
+          date: new Date(),
+          tax: "0",
+          fee: "0",
+          amount: "25",
+          currency: "USD",
+        },
+        [],
+      ) as any;
+      expect(withAmount.amount).toBe(25);
+    });
+
+    it("TAX toPayload resets legacy tax and fee to zero so amount is booked", () => {
+      const payload = ACTIVITY_FORM_CONFIG.TAX.toPayload({
+        accountId: "acc-123",
+        activityDate: new Date(),
+        amount: 20,
+        comment: null,
+        subtype: null,
+        currency: "USD",
+      } as any) as any;
+
+      expect(payload).toMatchObject({ amount: 20, fee: 0, tax: 0 });
+    });
+  });
+
   describe("asset identity payloads", () => {
     it("omits stale selected asset id for option payloads", () => {
       const payload = ACTIVITY_FORM_CONFIG.BUY.toPayload({

--- a/apps/frontend/src/pages/activity/config/activity-form-config.ts
+++ b/apps/frontend/src/pages/activity/config/activity-form-config.ts
@@ -507,7 +507,10 @@ export const ACTIVITY_FORM_CONFIG: Record<
     activityType: ActivityType.FEE,
     getDefaults: (activity, accounts) => ({
       ...getBaseDefaults(activity, accounts),
-      amount: absNum(activity?.amount),
+      // The charge may be stored in `fee` (imported rows) or `amount`. Surface it
+      // with the backend's charge precedence (fee → amount) so editing shows the
+      // value that is actually displayed and booked.
+      amount: absNum(activity?.fee) || absNum(activity?.amount),
       // Advanced options
       currency: activity?.currency,
       subtype: activity?.subtype ?? null,
@@ -518,6 +521,9 @@ export const ACTIVITY_FORM_CONFIG: Record<
         accountId: d.accountId,
         activityDate: d.activityDate,
         amount: d.amount,
+        // Normalize the charge into `amount` and reset any legacy `fee` to zero so
+        // the backend's charge precedence (fee → amount) books the edited amount.
+        fee: 0,
         comment: d.comment,
         subtype: d.subtype,
         currency: d.currency,
@@ -569,7 +575,10 @@ export const ACTIVITY_FORM_CONFIG: Record<
     activityType: ActivityType.TAX,
     getDefaults: (activity, accounts) => ({
       ...getBaseDefaults(activity, accounts),
-      amount: absNum(activity?.amount),
+      // The charge may be stored in `tax`/`fee` (imported rows) or `amount`. Surface
+      // it with the backend's charge precedence (tax → fee → amount) so editing shows
+      // the value that is actually displayed and booked.
+      amount: absNum(activity?.tax) || absNum(activity?.fee) || absNum(activity?.amount),
       // Advanced options
       currency: activity?.currency,
       subtype: activity?.subtype ?? null,
@@ -580,6 +589,10 @@ export const ACTIVITY_FORM_CONFIG: Record<
         accountId: d.accountId,
         activityDate: d.activityDate,
         amount: d.amount,
+        // Normalize the charge into `amount` and reset any legacy `tax`/`fee` to zero
+        // so the backend's charge precedence (tax → fee → amount) books the edited amount.
+        fee: 0,
+        tax: 0,
         comment: d.comment,
         subtype: d.subtype,
         currency: d.currency,


### PR DESCRIPTION
## Problem

A standalone TAX activity with only the `tax` field populated books a cash outflow in the backend but displays a value of **0** in the frontend.

The backend's `charge_amt_for` (`crates/core/src/activities/activities_model.rs`) resolves standalone charges as: **tax → fee → amount** for Tax activities, and **fee → amount** for Fee activities. The frontend's `calculateActivityValue` never read the `tax` field at all, and checked `amount` before `fee` — both diverging from what the backend actually books.

## Fix

Mirror the backend precedence in the FEE/TAX branch of `calculateActivityValue`:
- **TAX**: `tax` if non-zero, then `fee`, then `amount`
- **FEE**: `fee` if non-zero, then `amount`

`calculateActivityCashImpact` needs no change — it negates the value, so tax-only TAX activities now correctly show as outflows.

Note: for rows where both `amount` and `fee`/`tax` are populated with different values (possible via CSV import), the displayed value switches from `amount` to the charge field — this now matches the amount the backend books, which is the point of the change.

## Tests

Added cases covering tax-only TAX (value + cash impact), full TAX precedence (tax > fee > amount) with fallbacks, and FEE precedence (fee > amount) with fallback.

- `pnpm test`: 1060 passed (124 files)
- `pnpm type-check`: clean
- `pnpm lint`: no issues in changed files