### PR TITLE
Fix custom provider paths and price precision

### DIFF
--- a/apps/frontend/src/components/history-chart-symbol.tsx
+++ b/apps/frontend/src/components/history-chart-symbol.tsx
@@ -1,6 +1,6 @@
 import { TimePeriod } from "@/lib/types";
 import { formatDate } from "@/lib/utils";
-import { formatAmount } from "@wealthfolio/ui";
+import { formatPrice } from "@wealthfolio/ui";
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
@@ -177,7 +177,7 @@ function SymbolToolTip({ active, payload }: SymbolTooltipProps) {
     <div className="bg-popover pointer-events-none grid grid-cols-1 gap-1.5 rounded-md border p-2 shadow-md">
       <p className="text-muted-foreground text-xs">{formatDate(data.timestamp)}</p>
 
-      <p className="text-base font-bold">{formatAmount(payload[0].value, data.currency, false)}</p>
+      <p className="text-base font-bold">{formatPrice(payload[0].value, data.currency, false)}</p>
 
       {data.activities && data.activities.length > 0 && (
         <>
@@ -202,7 +202,7 @@ function SymbolToolTip({ active, payload }: SymbolTooltipProps) {
                 {hasPriceDetails && (
                   <span className="text-muted-foreground text-sm tabular-nums">
                     {parseFloat(act.quantity || "0")} at{" "}
-                    {formatAmount(parseFloat(act.unitPrice || "0"), data.currency, false)}
+                    {formatPrice(parseFloat(act.unitPrice || "0"), data.currency, false)}
                   </span>
                 )}
               </div>

--- a/apps/frontend/src/components/ticker-search.tsx
+++ b/apps/frontend/src/components/ticker-search.tsx
@@ -4,6 +4,7 @@ import { debounce } from "@/lib/debounce";
 import { SymbolSearchResult } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { useQuery } from "@tanstack/react-query";
+import { formatPrice } from "@wealthfolio/ui";
 import { Button } from "@wealthfolio/ui/components/ui/button";
 import {
   Command,
@@ -517,10 +518,7 @@ const TickerSearchInput = forwardRef<HTMLButtonElement, SearchProps>(
                         ) : (
                           quoteInfo?.price != null && (
                             <span className="tabular-nums">
-                              {quoteInfo.price.toLocaleString(undefined, {
-                                minimumFractionDigits: 2,
-                                maximumFractionDigits: 4,
-                              })}
+                              {formatPrice(quoteInfo.price, quoteInfo.currency ?? "USD", false)}
                             </span>
                           )
                         )}

--- a/apps/frontend/src/features/ai-assistant/components/tool-uis/record-activity-tool-ui.tsx
+++ b/apps/frontend/src/features/ai-assistant/components/tool-uis/record-activity-tool-ui.tsx
@@ -1,6 +1,15 @@
 import type { ToolCallMessagePartProps } from "@assistant-ui/react";
 import { makeAssistantToolUI } from "@assistant-ui/react";
-import { Badge, Button, Card, CardContent, CardHeader, CardTitle, Skeleton } from "@wealthfolio/ui";
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  formatPrice,
+  Skeleton,
+} from "@wealthfolio/ui";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
 import { memo, useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -670,7 +679,11 @@ function DraftReview({
         {draft.unitPrice !== undefined && (
           <ReviewField
             label={t("ai:recordActivity.unitPrice")}
-            value={formatAmount(draft.unitPrice)}
+            value={
+              isBalanceHidden
+                ? "\u2022\u2022\u2022\u2022\u2022"
+                : formatPrice(draft.unitPrice, draft.currency)
+            }
           />
         )}
         {draft.amount !== undefined && (

--- a/apps/frontend/src/lib/utils.currency.test.ts
+++ b/apps/frontend/src/lib/utils.currency.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { formatPrice } from "@wealthfolio/ui";
 
 import { formatAmount, normalizeCurrency } from "./utils";
 
@@ -18,5 +19,13 @@ describe("currency utilities", () => {
 
     expect(formatAmount(12.34, "GBp")).toBe("12.34p");
     expect(formatAmount(12.34, "ILA")).toBe("12.34ag");
+  });
+
+  it("preserves meaningful precision for per-unit prices", () => {
+    expect(formatPrice(1.4018, "CNY")).toBe("CN¥1.4018");
+    expect(formatPrice(12, "USD")).toBe("$12.00");
+    expect(formatPrice(0.00012345, "USD", false)).toBe("0.00012345");
+    expect(formatPrice(-0.000000001, "USD", false)).toBe("0.00");
+    expect(formatPrice(1.4018, "GBp")).toBe("1.4018p");
   });
 });

--- a/apps/frontend/src/pages/activity/components/activity-detail-sheet.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-detail-sheet.tsx
@@ -6,6 +6,7 @@ import {
   Badge,
   Button,
   Icons,
+  PriceDisplay,
   Separator,
   Sheet,
   SheetContent,
@@ -210,7 +211,7 @@ export function ActivityDetailSheet({ activity, open, onOpenChange }: ActivityDe
               <DetailRow
                 label={t("activity:detail.strike_price")}
                 value={
-                  <AmountDisplay value={parsedOption.strikePrice} currency={activity.currency} />
+                  <PriceDisplay value={parsedOption.strikePrice} currency={activity.currency} />
                 }
               />
               <DetailRow label={t("activity:detail.expiration")} value={optionExpirationDisplay} />
@@ -237,7 +238,7 @@ export function ActivityDetailSheet({ activity, open, onOpenChange }: ActivityDe
                   isOption ? t("activity:detail.premium_share") : t("activity:activity_unit_price")
                 }
                 value={
-                  <AmountDisplay value={Number(activity.unitPrice)} currency={activity.currency} />
+                  <PriceDisplay value={Number(activity.unitPrice)} currency={activity.currency} />
                 }
               />
             )}

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table-mobile.tsx
@@ -17,7 +17,14 @@ import { parseOccSymbol } from "@/lib/occ-symbol";
 import { useSettingsContext } from "@/lib/settings-provider";
 import { ActivityDetails } from "@/lib/types";
 import { formatDateTime } from "@/lib/utils";
-import { Button, EmptyPlaceholder, formatAmount, Icons, Separator } from "@wealthfolio/ui";
+import {
+  Button,
+  EmptyPlaceholder,
+  formatAmount,
+  formatPrice,
+  Icons,
+  Separator,
+} from "@wealthfolio/ui";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { ActivityOperations } from "../activity-operations";
@@ -298,7 +305,7 @@ export const ActivityTableMobile = ({
                             isCashTransfer(activity.activityType, symbol, activity.assetId) ||
                             (isIncomeActivity(activity.activityType) && !isAssetBackedIncome)
                           ? formatAmount(Number(activity.amount), activity.currency)
-                          : formatAmount(Number(activity.unitPrice), activity.currency)}
+                          : formatPrice(Number(activity.unitPrice), activity.currency)}
                   </span>
                 </div>
 

--- a/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-table/activity-table.tsx
@@ -44,7 +44,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import { Button, EmptyPlaceholder, formatAmount } from "@wealthfolio/ui";
+import { Button, EmptyPlaceholder, formatAmount, formatPrice } from "@wealthfolio/ui";
 import { Link } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import { useActivityMutations } from "../../hooks/use-activity-mutations";
@@ -359,7 +359,7 @@ export const ActivityTable = ({
             return <div className="text-right">{formatAmount(Number(amount), currency)}</div>;
           }
 
-          return <div className="text-right">{formatAmount(unitPrice, currency)}</div>;
+          return <div className="text-right">{formatPrice(unitPrice, currency)}</div>;
         },
       },
       {

--- a/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/rebalance-tab.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type CSSProperties, type ReactNode } from "react";
-import { Button, Card, CardContent, Icons, Skeleton } from "@wealthfolio/ui";
+import { Button, Card, CardContent, formatPrice, Icons, Skeleton } from "@wealthfolio/ui";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@wealthfolio/ui/components/ui/tooltip";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
@@ -312,7 +312,7 @@ function exportCsv(plan: RebalancePlan, currency: string, profileName: string, t
       t.holdingId ?? "",
       t.estimatedAmount.toFixed(fractionDigits),
       t.quantity != null ? t.quantity.toFixed(t.quantity % 1 === 0 ? 0 : 4) : "",
-      t.estimatedPrice != null ? t.estimatedPrice.toFixed(fractionDigits) : "",
+      t.estimatedPrice != null ? String(t.estimatedPrice) : "",
       t.reason,
     ]
       .map(csvCell)
@@ -359,7 +359,7 @@ function copyToText(plan: RebalancePlan, currency: string, t: TFunction) {
         (trade.quantity != null
           ? `  ${t("allocation:copyText.shares", { qty: trade.quantity.toFixed(trade.quantity % 1 === 0 ? 0 : 4) })}`
           : "") +
-        (trade.estimatedPrice != null ? ` @ ${formatAmount(trade.estimatedPrice, currency)}` : ""),
+        (trade.estimatedPrice != null ? ` @ ${formatPrice(trade.estimatedPrice, currency)}` : ""),
     ),
   ];
   if (plan.warnings.length) {
@@ -1178,9 +1178,7 @@ function TradesTable({ trades, currency }: { trades: SuggestedManualTrade[]; cur
                   {t("allocation:trades.price")}
                 </div>
                 <div className="text-foreground mt-1 tabular-nums">
-                  {trade.estimatedPrice != null
-                    ? formatAmount(trade.estimatedPrice, currency)
-                    : "—"}
+                  {trade.estimatedPrice != null ? formatPrice(trade.estimatedPrice, currency) : "—"}
                 </div>
               </div>
               <div className="min-w-0">
@@ -1273,9 +1271,7 @@ function TradesTable({ trades, currency }: { trades: SuggestedManualTrade[]; cur
                   {tradeQuantityLabel(trade.quantity)}
                 </td>
                 <td className="text-muted-foreground pr-7 text-right tabular-nums">
-                  {trade.estimatedPrice != null
-                    ? formatAmount(trade.estimatedPrice, currency)
-                    : "—"}
+                  {trade.estimatedPrice != null ? formatPrice(trade.estimatedPrice, currency) : "—"}
                 </td>
                 <td
                   className="text-muted-foreground max-w-0 truncate pl-10 pr-5 text-xs"

--- a/apps/frontend/src/pages/asset/asset-detail-card.tsx
+++ b/apps/frontend/src/pages/asset/asset-detail-card.tsx
@@ -6,6 +6,7 @@ import { Separator } from "@wealthfolio/ui/components/ui/separator";
 import { formatPercent } from "@wealthfolio/ui";
 import { GainPercent } from "@wealthfolio/ui";
 import { AmountDisplay } from "@wealthfolio/ui";
+import { PriceDisplay } from "@wealthfolio/ui";
 import { QuantityDisplay } from "@wealthfolio/ui";
 import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
 
@@ -112,7 +113,7 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
     },
     {
       label: averageCostLabel,
-      value: <AmountDisplay value={averagePrice} currency={currency} isHidden={isBalanceHidden} />,
+      value: <PriceDisplay value={averagePrice} currency={currency} isHidden={isBalanceHidden} />,
     },
     { label: t("asset:detailCard.percent_of_portfolio"), value: formatPercent(portfolioPercent) },
   ];
@@ -264,7 +265,7 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
                     {t("asset:detailCard.open")}
                   </span>
                   <div className="text-sm font-medium">
-                    <AmountDisplay
+                    <PriceDisplay
                       value={quote.open}
                       currency={quoteCurrency ?? currency}
                       isHidden={isBalanceHidden}
@@ -276,7 +277,7 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
                     {t("asset:detailCard.close")}
                   </span>
                   <div className="text-sm font-medium">
-                    <AmountDisplay
+                    <PriceDisplay
                       value={quote.close}
                       currency={quoteCurrency ?? currency}
                       isHidden={isBalanceHidden}
@@ -288,7 +289,7 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
                     {t("asset:detailCard.high")}
                   </span>
                   <div className="text-success text-sm font-medium">
-                    <AmountDisplay
+                    <PriceDisplay
                       value={quote.high}
                       currency={quoteCurrency ?? currency}
                       isHidden={isBalanceHidden}
@@ -298,7 +299,7 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
                 <div className="flex flex-col items-end">
                   <span className="text-muted-foreground text-xs">{t("asset:detailCard.low")}</span>
                   <div className="text-destructive text-sm font-medium">
-                    <AmountDisplay
+                    <PriceDisplay
                       value={quote.low}
                       currency={quoteCurrency ?? currency}
                       isHidden={isBalanceHidden}
@@ -310,7 +311,7 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
                     {t("asset:detailCard.adj_close")}
                   </span>
                   <div className="text-sm font-medium">
-                    <AmountDisplay
+                    <PriceDisplay
                       value={quote.adjclose}
                       currency={quoteCurrency ?? currency}
                       isHidden={isBalanceHidden}
@@ -385,7 +386,7 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
                     {t("asset:detailCard.strike")}
                   </span>
                   <div className="text-sm font-medium">
-                    <AmountDisplay
+                    <PriceDisplay
                       value={optionSpec.strike}
                       currency={quoteCurrency ?? currency}
                       isHidden={isBalanceHidden}

--- a/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
+++ b/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
@@ -6,7 +6,7 @@ import { useCustomProviders } from "@/hooks/use-custom-providers";
 import { useMarketDataProviders } from "@/hooks/use-market-data-providers";
 import { useTaxonomies } from "@/hooks/use-taxonomies";
 import type { Asset, Quote } from "@/lib/types";
-import { formatAmount } from "@/lib/utils";
+import { formatPrice } from "@wealthfolio/ui";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -996,7 +996,7 @@ export function AssetEditSheet({
                         <div className="grid grid-cols-3 gap-4 text-center">
                           <div>
                             <p className="text-xl font-semibold">
-                              {formatAmount(latestQuote.close, latestQuote.currency)}
+                              {formatPrice(latestQuote.close, latestQuote.currency)}
                             </p>
                             <p className="text-muted-foreground text-xs">
                               {t("asset:editSheet.latest_price")}

--- a/apps/frontend/src/pages/asset/asset-history-card.tsx
+++ b/apps/frontend/src/pages/asset/asset-history-card.tsx
@@ -25,6 +25,7 @@ import {
   HoverCardTrigger,
   Icons,
   IntervalSelector,
+  PriceDisplay,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -187,7 +188,7 @@ const AssetHistoryCard: React.FC<AssetHistoryProps> = ({
               <HoverCardTrigger asChild className="cursor-pointer">
                 <div>
                   <p className="pt-3 text-xl font-bold">
-                    <AmountDisplay
+                    <PriceDisplay
                       value={marketPrice}
                       currency={currency}
                       isHidden={isBalanceHidden}

--- a/apps/frontend/src/pages/asset/asset-lots-table.tsx
+++ b/apps/frontend/src/pages/asset/asset-lots-table.tsx
@@ -15,7 +15,7 @@ import {
   GainAmount,
   GainPercent,
   PrivacyAmount,
-  formatAmount,
+  formatPrice,
   formatPercent,
 } from "@wealthfolio/ui";
 import { cn, formatDate, formatQuantity, normalizeCurrency } from "@/lib/utils";
@@ -330,7 +330,7 @@ function KpiStrip({
         />
         <span className="text-muted-foreground text-[11px]">
           {formatQuantity(totals.shares)} {t("asset:lots.shares_suffix")}
-          {marketPrice ? ` @ ${formatAmount(marketPrice, currency)}` : null}
+          {marketPrice ? ` @ ${formatPrice(marketPrice, currency)}` : null}
         </span>
       </KpiCell>
 
@@ -341,7 +341,7 @@ function KpiStrip({
           className={cn("text-foreground", bigAmountClass)}
         />
         <span className="text-muted-foreground text-[11px]">
-          {t("asset:lots.avg", { amount: formatAmount(totals.averageUnitCost, currency) })}
+          {t("asset:lots.avg", { amount: formatPrice(totals.averageUnitCost, currency) })}
         </span>
       </KpiCell>
 

--- a/apps/frontend/src/pages/asset/asset-profile-page.tsx
+++ b/apps/frontend/src/pages/asset/asset-profile-page.tsx
@@ -948,7 +948,6 @@ export const AssetProfilePage = () => {
         data={quoteHistory ?? []}
         assetId={assetId}
         currency={quote?.currency ?? profile?.currency ?? baseCurrency}
-        assetKind={assetProfile?.kind}
         isManualDataSource={isManualPricingMode}
         onSaveQuote={(q: Quote) => saveQuoteMutation.mutate(q)}
         onDeleteQuote={(id: string) => deleteQuoteMutation.mutate(id)}
@@ -1175,7 +1174,6 @@ export const AssetProfilePage = () => {
               data={quoteHistory ?? []}
               assetId={assetId}
               currency={profile?.currency ?? baseCurrency}
-              assetKind={assetProfile?.kind}
               isManualDataSource={isManualPricingMode}
               onSaveQuote={(quote: Quote) => saveQuoteMutation.mutate(quote)}
               onDeleteQuote={(id: string) => deleteQuoteMutation.mutate(id)}

--- a/apps/frontend/src/pages/asset/assets-table-mobile.tsx
+++ b/apps/frontend/src/pages/asset/assets-table-mobile.tsx
@@ -2,13 +2,13 @@ import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 
-import { Badge, Card, Input } from "@wealthfolio/ui";
+import { Badge, Card, formatPrice, Input } from "@wealthfolio/ui";
 
 import { TickerAvatar } from "@/components/ticker-avatar";
 import { useSettingsContext } from "@/lib/settings-provider";
 import { ASSET_KIND_DISPLAY_NAMES, LatestQuoteSnapshot } from "@/lib/types";
 import { parseOccSymbol } from "@/lib/occ-symbol";
-import { cn, formatAmount, formatDate } from "@/lib/utils";
+import { cn, formatDate } from "@/lib/utils";
 import { ScrollArea, Separator } from "@wealthfolio/ui";
 import { Button } from "@wealthfolio/ui/components/ui/button";
 import {
@@ -256,7 +256,7 @@ export function AssetsTableMobile({
                       return (
                         <>
                           <div className="flex items-center justify-end gap-1 font-semibold">
-                            {formatAmount(
+                            {formatPrice(
                               quote.close,
                               quote.currency ?? asset.quoteCcy ?? baseCurrency,
                             )}

--- a/apps/frontend/src/pages/asset/assets-table.tsx
+++ b/apps/frontend/src/pages/asset/assets-table.tsx
@@ -29,7 +29,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@wealthfolio/ui/compone
 
 import { ASSET_KIND_DISPLAY_NAMES, LatestQuoteSnapshot } from "@/lib/types";
 import { parseOccSymbol } from "@/lib/occ-symbol";
-import { formatAmount, formatDate } from "@/lib/utils";
+import { formatDate } from "@/lib/utils";
+import { formatPrice } from "@wealthfolio/ui";
 import { useSettingsContext } from "@/lib/settings-provider";
 import { getNoQuoteReasonText, isStaleQuote, ParsedAsset } from "./asset-utils";
 
@@ -259,7 +260,7 @@ export function AssetsTable({
                   </Tooltip>
                 ) : null}
                 <span className="font-semibold tabular-nums">
-                  {formatAmount(quote.close, quote.currency ?? asset.quoteCcy ?? baseCurrency)}
+                  {formatPrice(quote.close, quote.currency ?? asset.quoteCcy ?? baseCurrency)}
                 </span>
               </div>
               <div className="text-muted-foreground text-[11px]">{formatDate(quote.timestamp)}</div>

--- a/apps/frontend/src/pages/asset/quote-history-data-grid.test.ts
+++ b/apps/frontend/src/pages/asset/quote-history-data-grid.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+
+import type { Quote } from "@/lib/types";
+import { toQuoteEntry } from "./quote-history-utils";
+
+describe("quote history edit state", () => {
+  it("preserves OHLC precision", () => {
+    const quote: Quote = {
+      id: "20260711_asset",
+      createdAt: "2026-07-11T00:00:00.000Z",
+      dataSource: "CUSTOM_SCRAPER",
+      timestamp: "2026-07-11T00:00:00.000Z",
+      assetId: "asset",
+      open: 1.4018,
+      high: 1.40267,
+      low: 1.39995,
+      close: 1.4026,
+      adjclose: 1.4026,
+      volume: 0,
+      currency: "CNY",
+    };
+
+    expect(toQuoteEntry(quote)).toMatchObject({
+      open: 1.4018,
+      high: 1.40267,
+      low: 1.39995,
+      close: 1.4026,
+    });
+  });
+});

--- a/apps/frontend/src/pages/asset/quote-history-data-grid.tsx
+++ b/apps/frontend/src/pages/asset/quote-history-data-grid.tsx
@@ -5,13 +5,14 @@ import {
   Icons,
   Input,
   useDataGrid,
-  formatAmount,
+  formatPrice,
 } from "@wealthfolio/ui";
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { createColumnHelper } from "@tanstack/react-table";
-import type { AssetKind, Quote } from "@/lib/types";
+import type { Quote } from "@/lib/types";
 import { QuoteHistoryToolbar } from "./quote-history-toolbar";
+import { toQuoteEntry, type QuoteEntry } from "./quote-history-utils";
 import { format } from "date-fns";
 import { useIsMobileViewport } from "@/hooks/use-platform";
 
@@ -21,36 +22,7 @@ const normalizeDate = (value: Date | string): Date => {
   return new Date(value);
 };
 
-// Get decimal precision based on asset kind
-const getDecimalPrecision = (assetKind?: AssetKind | null): number => {
-  switch (assetKind) {
-    case "FX":
-      return 6; // FX rates need high precision
-    default:
-      return 2; // Standard precision for stocks, ETFs, etc.
-  }
-};
-
-// Round number to specified decimal places
-const roundToDecimals = (value: number, decimals: number): number => {
-  const factor = Math.pow(10, decimals);
-  return Math.round(value * factor) / factor;
-};
-
-/**
- * Local representation of a quote entry for the data grid.
- */
-export interface QuoteEntry {
-  id: string;
-  date: Date;
-  open: number;
-  high: number;
-  low: number;
-  close: number;
-  volume: number;
-  currency: string;
-  isNew?: boolean;
-}
+const QUOTE_DECIMAL_PRECISION = 8;
 
 interface QuoteHistoryDataGridProps {
   /** Quote data from the backend */
@@ -59,8 +31,6 @@ interface QuoteHistoryDataGridProps {
   assetId: string;
   /** Currency for the asset */
   currency: string;
-  /** Asset kind for decimal precision */
-  assetKind?: AssetKind | null;
   /** Whether manual tracking is enabled */
   isManualDataSource?: boolean;
   /** Callback to save a quote */
@@ -73,19 +43,6 @@ interface QuoteHistoryDataGridProps {
 
 // Generate a temporary ID for new entries
 const generateTempId = () => `temp-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
-
-// Convert Quote to QuoteEntry with optional rounding
-const toQuoteEntry = (quote: Quote, decimals?: number): QuoteEntry => ({
-  id: quote.id,
-  date: new Date(quote.timestamp),
-  open: decimals !== undefined ? roundToDecimals(quote.open, decimals) : quote.open,
-  high: decimals !== undefined ? roundToDecimals(quote.high, decimals) : quote.high,
-  low: decimals !== undefined ? roundToDecimals(quote.low, decimals) : quote.low,
-  close: decimals !== undefined ? roundToDecimals(quote.close, decimals) : quote.close,
-  volume: Math.round(quote.volume), // Volume is always integer
-  currency: quote.currency,
-  isNew: false,
-});
 
 // Convert QuoteEntry back to Quote for saving
 const toQuote = (entry: QuoteEntry, assetId: string): Quote => {
@@ -126,7 +83,6 @@ export function QuoteHistoryDataGrid({
   data,
   assetId,
   currency,
-  assetKind,
   isManualDataSource = false,
   onSaveQuote,
   onDeleteQuote,
@@ -134,16 +90,10 @@ export function QuoteHistoryDataGrid({
 }: QuoteHistoryDataGridProps) {
   const { t } = useTranslation();
   const isMobile = useIsMobileViewport();
-  // Get decimal precision based on asset kind
-  const decimalPrecision = getDecimalPrecision(assetKind);
-
-  // Convert quotes to local entries with rounding
+  // Convert quotes to local entries without changing their stored precision.
   const initialEntries = useMemo(
-    () =>
-      data
-        .map((quote) => toQuoteEntry(quote, decimalPrecision))
-        .sort((a, b) => b.date.getTime() - a.date.getTime()),
-    [data, decimalPrecision],
+    () => data.map(toQuoteEntry).sort((a, b) => b.date.getTime() - a.date.getTime()),
+    [data],
   );
 
   const [localEntries, setLocalEntries] = useState<QuoteEntry[]>(initialEntries);
@@ -164,7 +114,7 @@ export function QuoteHistoryDataGrid({
   const columnHelper = createColumnHelper<QuoteEntry>();
 
   // Calculate step value for number inputs based on precision
-  const stepValue = Math.pow(10, -decimalPrecision);
+  const stepValue = Math.pow(10, -QUOTE_DECIMAL_PRECISION);
 
   // Delete a single row
   const handleDeleteRow = useCallback((entry: QuoteEntry) => {
@@ -602,7 +552,7 @@ export function QuoteHistoryDataGrid({
                     <span className="text-sm font-medium">{format(entry.date, "yyyy-MM-dd")}</span>
                     <div className="flex items-center gap-2">
                       <span className="text-sm font-semibold">
-                        {formatAmount(entry.close, entry.currency, false)}
+                        {formatPrice(entry.close, entry.currency, false)}
                       </span>
                       {isManualDataSource && (
                         <Button
@@ -623,19 +573,19 @@ export function QuoteHistoryDataGrid({
                     <div>
                       <span className="block">{t("asset:quoteGrid.open")}</span>
                       <span className="text-foreground">
-                        {formatAmount(entry.open, entry.currency, false)}
+                        {formatPrice(entry.open, entry.currency, false)}
                       </span>
                     </div>
                     <div>
                       <span className="block">{t("asset:quoteGrid.high")}</span>
                       <span className="text-foreground">
-                        {formatAmount(entry.high, entry.currency, false)}
+                        {formatPrice(entry.high, entry.currency, false)}
                       </span>
                     </div>
                     <div>
                       <span className="block">{t("asset:quoteGrid.low")}</span>
                       <span className="text-foreground">
-                        {formatAmount(entry.low, entry.currency, false)}
+                        {formatPrice(entry.low, entry.currency, false)}
                       </span>
                     </div>
                     <div>

--- a/apps/frontend/src/pages/asset/quote-history-table.tsx
+++ b/apps/frontend/src/pages/asset/quote-history-table.tsx
@@ -31,7 +31,7 @@ declare module "@tanstack/react-table" {
 import {
   Button,
   DatePickerInput,
-  formatAmount,
+  formatPrice,
   Icons,
   Input,
   Label,
@@ -199,7 +199,7 @@ export const QuoteHistoryTable: React.FC<QuoteHistoryTableProps> = ({
               onChange={(e) => handleInputChange("open", e.target.value)}
             />
           ) : (
-            formatAmount(value, info.row.original.currency, false)
+            formatPrice(value, info.row.original.currency, false)
           );
         },
         enableSorting: false,
@@ -217,7 +217,7 @@ export const QuoteHistoryTable: React.FC<QuoteHistoryTableProps> = ({
               autoFocus={true}
             />
           ) : (
-            formatAmount(value, info.row.original.currency, false)
+            formatPrice(value, info.row.original.currency, false)
           );
         },
         enableSorting: false,
@@ -234,7 +234,7 @@ export const QuoteHistoryTable: React.FC<QuoteHistoryTableProps> = ({
               onChange={(e) => handleInputChange("low", e.target.value)}
             />
           ) : (
-            formatAmount(value, info.row.original.currency, false)
+            formatPrice(value, info.row.original.currency, false)
           );
         },
         enableSorting: false,
@@ -251,7 +251,7 @@ export const QuoteHistoryTable: React.FC<QuoteHistoryTableProps> = ({
               onChange={(e) => handleInputChange("close", e.target.value)}
             />
           ) : (
-            formatAmount(value, info.row.original.currency, false)
+            formatPrice(value, info.row.original.currency, false)
           );
         },
         enableSorting: false,

--- a/apps/frontend/src/pages/asset/quote-history-utils.ts
+++ b/apps/frontend/src/pages/asset/quote-history-utils.ts
@@ -1,0 +1,28 @@
+import type { Quote } from "@/lib/types";
+
+export interface QuoteEntry {
+  id: string;
+  date: Date;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+  volume: number;
+  currency: string;
+  isNew?: boolean;
+}
+
+/** Preserve source precision in edit state; formatting belongs at render time. */
+export function toQuoteEntry(quote: Quote): QuoteEntry {
+  return {
+    id: quote.id,
+    date: new Date(quote.timestamp),
+    open: quote.open,
+    high: quote.high,
+    low: quote.low,
+    close: quote.close,
+    volume: Math.round(quote.volume),
+    currency: quote.currency,
+    isNew: false,
+  };
+}

--- a/apps/frontend/src/pages/holdings/components/holdings-edit-mode.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-edit-mode.tsx
@@ -120,7 +120,7 @@ export const HoldingsEditMode = ({
         let averageCost = "";
         if (h.costBasis?.local && h.quantity > 0) {
           const avgCostValue = h.costBasis.local / h.quantity;
-          averageCost = avgCostValue.toFixed(4).replace(/\.?0+$/, "");
+          averageCost = avgCostValue.toFixed(8).replace(/\.?0+$/, "");
         }
         return {
           assetId: h.instrument?.id ?? h.id,

--- a/apps/frontend/src/pages/holdings/components/holdings-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table.tsx
@@ -18,7 +18,7 @@ import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
 import { HoldingType } from "@/lib/constants";
 import { useSettingsContext } from "@/lib/settings-provider";
 import { Holding } from "@/lib/types";
-import { AmountDisplay, QuantityDisplay, formatPercent } from "@wealthfolio/ui";
+import { AmountDisplay, PriceDisplay, QuantityDisplay, formatPercent } from "@wealthfolio/ui";
 import { Skeleton } from "@wealthfolio/ui/components/ui/skeleton";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@wealthfolio/ui/components/ui/tooltip";
 import { useState } from "react";
@@ -335,7 +335,7 @@ const getColumns = (
       const currency = holding.localCurrency;
       return (
         <div className="flex min-h-[40px] flex-col items-end justify-center px-4">
-          <AmountDisplay value={price} currency={currency} />
+          <PriceDisplay value={price} currency={currency} />
           <GainPercent className="text-xs" value={holding.dayChangePct || 0} />
         </div>
       );
@@ -364,7 +364,7 @@ const getColumns = (
           {averagePrice == null ? (
             <span className="text-muted-foreground">-</span>
           ) : (
-            <AmountDisplay
+            <PriceDisplay
               value={averagePrice}
               currency={row.original.localCurrency}
               isHidden={isHidden}

--- a/apps/frontend/src/pages/settings/market-data/json-path-suggestions.test.ts
+++ b/apps/frontend/src/pages/settings/market-data/json-path-suggestions.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { appendJsonPathKey, walkJson } from "./json-path-suggestions";
+
+describe("JSONPath generation", () => {
+  it("keeps parser-safe keys in dot notation", () => {
+    expect(appendJsonPathKey("$.data", "unit_price")).toBe("$.data.unit_price");
+  });
+
+  it("quotes Unicode and special-character keys", () => {
+    expect(appendJsonPathKey("$[*]", "单位净值")).toBe('$[*]["单位净值"]');
+    expect(appendJsonPathKey("$", "price.usd")).toBe('$["price.usd"]');
+    expect(appendJsonPathKey("$", 'price"usd')).toBe('$["price\\"usd"]');
+  });
+
+  it("generates valid paths for numeric values under Chinese keys", () => {
+    const entries = walkJson([{ 净值日期: "2026-07-11", 单位净值: 1.4018 }]);
+
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        { path: '$[*]["单位净值"]', value: 1.4018 },
+        { path: '$[0]["单位净值"]', value: 1.4018 },
+      ]),
+    );
+  });
+});

--- a/apps/frontend/src/pages/settings/market-data/json-path-suggestions.tsx
+++ b/apps/frontend/src/pages/settings/market-data/json-path-suggestions.tsx
@@ -12,6 +12,13 @@ export interface PathEntry {
   raw?: string;
 }
 
+const DOT_NOTATION_KEY = /^(?!length\(\)$)[A-Za-z0-9_#/\\-]+$/;
+
+/** Append an object key using syntax accepted by the backend JSONPath parser. */
+export function appendJsonPathKey(path: string, key: string): string {
+  return DOT_NOTATION_KEY.test(key) ? `${path}.${key}` : `${path}[${JSON.stringify(key)}]`;
+}
+
 /** Recursively collect all numeric leaf paths from a parsed JSON value.
  *  For arrays, generates both `[0]` (specific) and `[*]` (all elements) paths.
  *  The `[*]` variant is shown first for arrays with homogeneous structure. */
@@ -34,7 +41,7 @@ export function walkJson(value: unknown, path = "$"): PathEntry[] {
     return [...wildcardEntries, ...specificEntries];
   }
   if (typeof value === "object" && value !== null) {
-    return Object.entries(value).flatMap(([k, v]) => walkJson(v, `${path}.${k}`));
+    return Object.entries(value).flatMap(([k, v]) => walkJson(v, appendJsonPathKey(path, k)));
   }
   return [];
 }

--- a/apps/frontend/src/pages/settings/market-data/response-preview.test.tsx
+++ b/apps/frontend/src/pages/settings/market-data/response-preview.test.tsx
@@ -1,0 +1,22 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { RawResponseViewer } from "./response-preview";
+
+describe("RawResponseViewer", () => {
+  it("selects Unicode JSON keys using quoted bracket notation", () => {
+    const onPathClick = vi.fn();
+
+    render(
+      <RawResponseViewer
+        rawResponse='[{"净值日期":"2026-07-11","单位净值":1.4018}]'
+        format="json"
+        onPathClick={onPathClick}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('"单位净值"').closest('[role="button"]')!);
+
+    expect(onPathClick).toHaveBeenCalledWith('$[*]["单位净值"]');
+  });
+});

--- a/apps/frontend/src/pages/settings/market-data/response-preview.tsx
+++ b/apps/frontend/src/pages/settings/market-data/response-preview.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useMemo } from "react";
 
 import { cn } from "@/lib/utils";
+import { appendJsonPathKey } from "./json-path-suggestions";
 
 interface RawResponseViewerProps {
   rawResponse: string;
@@ -158,7 +159,7 @@ function ObjectBlock({
       {"{"}
       {"\n"}
       {entries.map(([key, val], i) => {
-        const childPath = `${path}.${key}`;
+        const childPath = appendJsonPathKey(path, key);
         const last = i === entries.length - 1;
         return (
           <Fragment key={key}>

--- a/crates/core/src/custom_provider/service.rs
+++ b/crates/core/src/custom_provider/service.rs
@@ -1270,6 +1270,20 @@ pub fn detect_html_locale(body: &str) -> Option<String> {
 mod tests {
     use super::*;
 
+    #[test]
+    fn extracts_json_values_from_unicode_keys() {
+        let body = r#"[{"净值日期":"2026-07-11","单位净值":1.4018}]"#;
+
+        assert_eq!(
+            extract_json_value(body, r#"$[*]["单位净值"]"#),
+            Some(1.4018)
+        );
+        assert_eq!(
+            extract_json_string(body, r#"$[*]["净值日期"]"#),
+            Some("2026-07-11".to_string())
+        );
+    }
+
     // Header row uses <td> (no <thead>/<th>) — like ariva.de's historical
     // prices table. The first <td> row is the headers, not data.
     const TD_HEADER_TABLE: &str = r#"<html><body><table>

--- a/crates/core/src/quotes/custom_scraper_provider.rs
+++ b/crates/core/src/quotes/custom_scraper_provider.rs
@@ -1500,6 +1500,24 @@ mod tests {
     }
 
     #[test]
+    fn extract_json_rows_supports_unicode_keys() {
+        let body = r#"[
+            { "净值日期": "2026-07-10T00:00:00.000", "单位净值": 1.4018 },
+            { "净值日期": "2026-07-11T00:00:00.000", "单位净值": 1.4026 }
+        ]"#;
+        let mut source = json_source(r#"$[*]["单位净值"]"#);
+        source.date_path = Some(r#"$[*]["净值日期"]"#.to_string());
+
+        let rows = extract_json_rows(body, &source, "001097", Some("CNY"), None, None, None);
+
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].date, Some(ymd(2026, 7, 10)));
+        assert_eq!(rows[0].close, 1.4018);
+        assert_eq!(rows[1].date, Some(ymd(2026, 7, 11)));
+        assert_eq!(rows[1].close, 1.4026);
+    }
+
+    #[test]
     fn parse_date_iso_date_only() {
         assert_eq!(parse_date("2026-03-30", None), Some(ymd(2026, 3, 30)));
     }

--- a/packages/ui/src/components/financial/index.ts
+++ b/packages/ui/src/components/financial/index.ts
@@ -1,5 +1,6 @@
 // Export all financial components
 export { AmountDisplay } from "./amount-display";
+export { PriceDisplay } from "./price-display";
 export { GainAmount } from "./gain-amount";
 export { GainPercent } from "./gain-percent";
 export { PrivacyAmount } from "./privacy-amount";

--- a/packages/ui/src/components/financial/price-display.tsx
+++ b/packages/ui/src/components/financial/price-display.tsx
@@ -1,0 +1,19 @@
+import { cn, formatPrice } from "../../lib/utils";
+
+interface PriceDisplayProps {
+  value: number;
+  currency: string;
+  isHidden?: boolean;
+  displayCurrency?: boolean;
+  className?: string;
+}
+
+export function PriceDisplay({
+  value,
+  currency = "USD",
+  isHidden,
+  displayCurrency = true,
+  className,
+}: PriceDisplayProps) {
+  return <span className={cn(className)}>{isHidden ? "••••" : formatPrice(value, currency, displayCurrency)}</span>;
+}

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -12,9 +12,15 @@ const DECIMAL_FORMAT_OPTIONS: Intl.NumberFormatOptions = {
   minimumFractionDigits: DISPLAY_DECIMAL_PRECISION,
   maximumFractionDigits: DISPLAY_DECIMAL_PRECISION,
 };
+const PRICE_FORMAT_OPTIONS: Intl.NumberFormatOptions = {
+  minimumFractionDigits: DISPLAY_DECIMAL_PRECISION,
+  maximumFractionDigits: DECIMAL_PRECISION,
+};
 
 const decimalFormatter = new Intl.NumberFormat("en-US", DECIMAL_FORMAT_OPTIONS);
+const priceDecimalFormatter = new Intl.NumberFormat("en-US", PRICE_FORMAT_OPTIONS);
 const currencyFormatterCache = new Map<string, Intl.NumberFormat>();
+const priceCurrencyFormatterCache = new Map<string, Intl.NumberFormat>();
 const compactCurrencyFormatterCache = new Map<string, Intl.NumberFormat>();
 const currencySymbolFormatterCache = new Map<string, Intl.NumberFormat>();
 
@@ -38,6 +44,28 @@ const getCurrencyFormatter = (currency: string) => {
   }
 
   currencyFormatterCache.set(cacheKey, formatter);
+  return formatter;
+};
+
+const getPriceCurrencyFormatter = (currency: string) => {
+  const normalizedCurrency = currency?.toUpperCase?.() ?? "USD";
+
+  if (priceCurrencyFormatterCache.has(normalizedCurrency)) {
+    return priceCurrencyFormatterCache.get(normalizedCurrency)!;
+  }
+
+  let formatter: Intl.NumberFormat;
+  try {
+    formatter = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: normalizedCurrency,
+      ...PRICE_FORMAT_OPTIONS,
+    });
+  } catch {
+    formatter = priceDecimalFormatter;
+  }
+
+  priceCurrencyFormatterCache.set(normalizedCurrency, formatter);
   return formatter;
 };
 
@@ -121,6 +149,31 @@ export function formatAmount(
   }
 
   return getCurrencyFormatter(rawCurrency).format(displayAmount);
+}
+
+/** Format a per-unit price without discarding meaningful precision. */
+export function formatPrice(
+  amount: number | string | null | undefined,
+  currency: string,
+  displayCurrency = true,
+) {
+  if (amount == null) return "-";
+  const numericAmount = typeof amount === "string" ? Number(amount) : amount;
+  if (!Number.isFinite(numericAmount)) return "-";
+  const displayPrice = Math.abs(numericAmount) < 0.000000005 ? 0 : numericAmount;
+  const rawCurrency = currency ?? "USD";
+  const quoteUnit = getQuoteUnitCurrency(rawCurrency);
+
+  if (quoteUnit) {
+    const formattedNumber = priceDecimalFormatter.format(displayPrice);
+    return displayCurrency ? `${formattedNumber}${quoteUnit.symbol}` : formattedNumber;
+  }
+
+  if (!displayCurrency) {
+    return priceDecimalFormatter.format(displayPrice);
+  }
+
+  return getPriceCurrencyFormatter(rawCurrency).format(displayPrice);
 }
 
 export function formatCompactAmount(


### PR DESCRIPTION
## Summary
- generate parser-safe JSONPath expressions for Unicode and special-character response keys
- preserve and display per-unit quote precision up to eight decimal places
- prevent quote, holding, activity, and rebalance edit/export paths from truncating prices

## Root cause
The custom-provider preview emitted dot notation for every JSON key, while the Rust JSONPath parser requires non-ASCII keys such as `单位净值` and `净值日期` to use quoted bracket notation. Separately, shared amount formatting and quote editor initialization forced price values into two- or four-decimal representations.

## Precision review
Price-like values now use a dedicated formatter/component with 2–8 decimals while ordinary monetary totals remain at two decimals. Quote editor state retains the backend value instead of rounding it, and rebalance CSV output uses the same price semantics as the UI.

## Testing
- `pnpm format:check`
- `pnpm lint`
- `pnpm type-check`
- `pnpm test` (1,061 tests)
- `pnpm build`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `CONNECT_API_URL=http://test.local cargo test --workspace`
- `cargo check -p wealthfolio-server --release`

Closes #1287