### PR TITLE
Fix shared split-adjusted valuations

### DIFF
--- a/apps/server/src/domain_events/planner.rs
+++ b/apps/server/src/domain_events/planner.rs
@@ -78,6 +78,7 @@ pub fn plan_portfolio_job(events: &[DomainEvent], timezone: &str) -> Option<Port
     let mut account_ids: HashSet<String> = HashSet::new();
     let mut asset_ids: HashSet<String> = HashSet::new();
     let mut has_recalc_event = false;
+    let mut recalculate_all_accounts = false;
     let mut min_activity_at_utc: Option<DateTime<Utc>> = None;
 
     for event in events {
@@ -95,6 +96,23 @@ pub fn plan_portfolio_job(events: &[DomainEvent], timezone: &str) -> Option<Port
                     }
                 }
                 for id in ast_ids {
+                    if !id.is_empty() {
+                        asset_ids.insert(id.clone());
+                    }
+                }
+                min_activity_at_utc = match (min_activity_at_utc, earliest_activity_at_utc) {
+                    (Some(current), Some(new)) => Some(current.min(*new)),
+                    (None, Some(new)) => Some(*new),
+                    (current, None) => current,
+                };
+            }
+            DomainEvent::AssetSplitActivitiesChanged {
+                asset_ids: ids,
+                earliest_activity_at_utc,
+            } => {
+                has_recalc_event = true;
+                recalculate_all_accounts = true;
+                for id in ids {
                     if !id.is_empty() {
                         asset_ids.insert(id.clone());
                     }
@@ -140,6 +158,7 @@ pub fn plan_portfolio_job(events: &[DomainEvent], timezone: &str) -> Option<Port
             }
             DomainEvent::DeviceSyncPullComplete => {
                 has_recalc_event = true;
+                recalculate_all_accounts = true;
             }
             DomainEvent::AssetsUpdated { asset_ids: ids } => {
                 has_recalc_event = true;
@@ -180,7 +199,7 @@ pub fn plan_portfolio_job(events: &[DomainEvent], timezone: &str) -> Option<Port
     }
 
     Some(PortfolioJobConfig {
-        account_ids: if account_ids.is_empty() {
+        account_ids: if recalculate_all_accounts || account_ids.is_empty() {
             None
         } else {
             Some(account_ids.into_iter().collect())
@@ -194,8 +213,11 @@ pub fn plan_portfolio_job(events: &[DomainEvent], timezone: &str) -> Option<Port
         },
         snapshot_mode: SnapshotRecalcMode::Full,
         valuation_mode: ValuationRecalcMode::Full,
-        since_date: min_activity_at_utc
-            .map(|instant| activity_date_in_user_timezone(instant, timezone)),
+        since_date: if recalculate_all_accounts {
+            None
+        } else {
+            min_activity_at_utc.map(|instant| activity_date_in_user_timezone(instant, timezone))
+        },
     })
 }
 
@@ -320,6 +342,24 @@ mod tests {
         } else {
             panic!("Expected Incremental mode");
         }
+    }
+
+    #[test]
+    fn test_split_activity_change_recalculates_all_accounts() {
+        let events = vec![
+            DomainEvent::ActivitiesChanged {
+                account_ids: vec!["edited-account".to_string()],
+                asset_ids: vec!["VGT".to_string()],
+                currencies: vec!["USD".to_string()],
+                earliest_activity_at_utc: None,
+            },
+            DomainEvent::asset_split_activities_changed(vec!["VGT".to_string()], None),
+        ];
+
+        let config = plan_portfolio_job(&events, "UTC").unwrap();
+
+        assert!(config.account_ids.is_none());
+        assert!(config.since_date.is_none());
     }
 
     #[test]

--- a/apps/tauri/src/domain_events/planner.rs
+++ b/apps/tauri/src/domain_events/planner.rs
@@ -82,6 +82,7 @@ pub fn plan_portfolio_job(
     let mut account_ids: HashSet<String> = HashSet::new();
     let mut asset_ids: HashSet<String> = HashSet::new();
     let mut has_recalc_events = false;
+    let mut recalculate_all_accounts = false;
     let mut min_activity_at_utc: Option<DateTime<Utc>> = None;
 
     for event in events {
@@ -95,6 +96,19 @@ pub fn plan_portfolio_job(
                 has_recalc_events = true;
                 account_ids.extend(acc_ids.iter().cloned());
                 asset_ids.extend(a_ids.iter().cloned());
+                min_activity_at_utc = match (min_activity_at_utc, earliest_activity_at_utc) {
+                    (Some(current), Some(new)) => Some(current.min(*new)),
+                    (None, Some(new)) => Some(*new),
+                    (current, None) => current,
+                };
+            }
+            DomainEvent::AssetSplitActivitiesChanged {
+                asset_ids: ids,
+                earliest_activity_at_utc,
+            } => {
+                has_recalc_events = true;
+                recalculate_all_accounts = true;
+                asset_ids.extend(ids.iter().filter(|id| !id.is_empty()).cloned());
                 min_activity_at_utc = match (min_activity_at_utc, earliest_activity_at_utc) {
                     (Some(current), Some(new)) => Some(current.min(*new)),
                     (None, Some(new)) => Some(*new),
@@ -122,6 +136,7 @@ pub fn plan_portfolio_job(
             }
             DomainEvent::DeviceSyncPullComplete => {
                 has_recalc_events = true;
+                recalculate_all_accounts = true;
             }
             DomainEvent::AssetsUpdated { asset_ids: ids } => {
                 has_recalc_events = true;
@@ -163,7 +178,7 @@ pub fn plan_portfolio_job(
     let mut builder = PortfolioRequestPayload::builder();
 
     // Set account IDs if we have specific ones, otherwise None means all
-    if !account_ids.is_empty() {
+    if !recalculate_all_accounts && !account_ids.is_empty() {
         builder = builder.account_ids(Some(account_ids.into_iter().collect()));
     }
 
@@ -176,9 +191,11 @@ pub fn plan_portfolio_job(
         }
     };
     builder = builder.market_sync_mode(sync_mode);
-    builder = builder.since_date(
-        min_activity_at_utc.map(|instant| activity_date_in_user_timezone(instant, timezone)),
-    );
+    builder = builder.since_date(if recalculate_all_accounts {
+        None
+    } else {
+        min_activity_at_utc.map(|instant| activity_date_in_user_timezone(instant, timezone))
+    });
 
     Some(builder.build())
 }
@@ -300,6 +317,24 @@ mod tests {
         assert!(payload.account_ids.is_some());
         let account_ids = payload.account_ids.unwrap();
         assert!(account_ids.contains(&"acc1".to_string()));
+    }
+
+    #[test]
+    fn test_split_activity_change_recalculates_all_accounts() {
+        let events = vec![
+            DomainEvent::ActivitiesChanged {
+                account_ids: vec!["edited-account".to_string()],
+                asset_ids: vec!["VGT".to_string()],
+                currencies: vec!["USD".to_string()],
+                earliest_activity_at_utc: None,
+            },
+            DomainEvent::asset_split_activities_changed(vec!["VGT".to_string()], None),
+        ];
+
+        let payload = plan_portfolio_job(&events, "UTC").unwrap();
+
+        assert!(payload.account_ids.is_none());
+        assert!(payload.since_date.is_none());
     }
 
     #[test]

--- a/crates/core/src/activities/activities_model.rs
+++ b/crates/core/src/activities/activities_model.rs
@@ -1794,6 +1794,10 @@ pub struct BulkUpsertResult {
     pub updated: usize,
     /// Number of activities skipped (e.g., user-modified)
     pub skipped: usize,
+    /// Asset ids of pre-existing SPLIT rows that were overwritten, so callers can
+    /// emit asset-level split events even when the incoming row is no longer a SPLIT
+    #[serde(skip)]
+    pub updated_split_asset_ids: Vec<String>,
 }
 
 /// Activity ready for persistence

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -5479,6 +5479,14 @@ impl ActivityServiceTrait for ActivityService {
                 currencies,
                 earliest_activity_at_utc,
             );
+            // Include pre-existing SPLIT rows that this upsert overwrote (possibly
+            // reclassified or moved to another asset), not just incoming SPLIT rows.
+            let split_asset_ids: Vec<String> = split_asset_ids
+                .into_iter()
+                .chain(result.updated_split_asset_ids.iter().cloned())
+                .collect::<HashSet<_>>()
+                .into_iter()
+                .collect();
             self.emit_asset_split_change(split_asset_ids, earliest_activity_at_utc);
         }
 

--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -629,6 +629,43 @@ impl ActivityService {
         ));
     }
 
+    fn emit_asset_split_activities_changed<'a>(
+        &self,
+        activities: impl IntoIterator<Item = &'a Activity>,
+    ) {
+        let split_activities: Vec<&Activity> = activities
+            .into_iter()
+            .filter(|activity| activity.effective_type() == ACTIVITY_TYPE_SPLIT)
+            .collect();
+        let asset_ids: HashSet<String> = split_activities
+            .iter()
+            .filter_map(|activity| activity.asset_id.clone())
+            .collect();
+        if asset_ids.is_empty() {
+            return;
+        }
+
+        self.event_sink
+            .emit(DomainEvent::asset_split_activities_changed(
+                asset_ids.into_iter().collect(),
+                Self::earliest_activity_at_utc(split_activities),
+            ));
+    }
+
+    fn emit_asset_split_change(
+        &self,
+        asset_ids: Vec<String>,
+        earliest_activity_at_utc: Option<DateTime<Utc>>,
+    ) {
+        if !asset_ids.is_empty() {
+            self.event_sink
+                .emit(DomainEvent::asset_split_activities_changed(
+                    asset_ids,
+                    earliest_activity_at_utc,
+                ));
+        }
+    }
+
     /// Sets the domain event sink for this service.
     ///
     /// Events are emitted after successful mutations (create, update, delete).
@@ -3745,6 +3782,7 @@ impl ActivityServiceTrait for ActivityService {
             currencies,
             Some(created.activity_date),
         );
+        self.emit_asset_split_activities_changed(std::iter::once(&created));
 
         Ok(created)
     }
@@ -3893,6 +3931,7 @@ impl ActivityServiceTrait for ActivityService {
             currencies,
             Some(earliest_activity_at_utc),
         );
+        self.emit_asset_split_activities_changed([&existing, &updated]);
 
         Ok(updated)
     }
@@ -3951,6 +3990,7 @@ impl ActivityServiceTrait for ActivityService {
             currencies,
             Some(deleted.activity_date),
         );
+        self.emit_asset_split_activities_changed(std::iter::once(&deleted));
 
         Ok(deleted)
     }
@@ -4212,6 +4252,7 @@ impl ActivityServiceTrait for ActivityService {
         let mut old_asset_ids: HashSet<String> = HashSet::new();
         let mut old_currencies: HashSet<String> = HashSet::new();
         let mut old_activity_dates: Vec<DateTime<Utc>> = Vec::new();
+        let mut old_activities: Vec<Activity> = Vec::new();
 
         let explicit_update_ids: HashSet<String> = request
             .updates
@@ -4324,6 +4365,7 @@ impl ActivityServiceTrait for ActivityService {
                     }
                     old_currencies.insert(existing.currency.clone());
                     old_activity_dates.push(existing.activity_date);
+                    old_activities.push(existing.clone());
                     if let Err(err) = self.hydrate_and_validate_update_against_existing(
                         &mut update_request,
                         &existing,
@@ -4363,6 +4405,7 @@ impl ActivityServiceTrait for ActivityService {
                     }
                     old_currencies.insert(existing.currency.clone());
                     old_activity_dates.push(existing.activity_date);
+                    old_activities.push(existing.clone());
                     valid_delete_ids.push(delete_id.clone());
                 }
                 Err(err) => {
@@ -4442,6 +4485,13 @@ impl ActivityServiceTrait for ActivityService {
                 earliest_activity_at_utc,
             );
         }
+        self.emit_asset_split_activities_changed(
+            old_activities
+                .iter()
+                .chain(persisted.created.iter())
+                .chain(persisted.updated.iter())
+                .chain(persisted.deleted.iter()),
+        );
 
         Ok(persisted)
     }
@@ -5069,6 +5119,13 @@ impl ActivityServiceTrait for ActivityService {
             .into_iter()
             .collect();
         let earliest_at = Self::earliest_new_activity_at_utc(insertable_new_activities.iter());
+        let split_asset_ids: Vec<String> = insertable_new_activities
+            .iter()
+            .filter(|activity| activity.activity_type == ACTIVITY_TYPE_SPLIT)
+            .filter_map(|activity| activity.get_symbol_id().map(str::to_string))
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
 
         // ── 9. Insert all non-duplicate activities in one transaction ────────
         let inserted_count = if insertable_new_activities.is_empty() {
@@ -5115,6 +5172,7 @@ impl ActivityServiceTrait for ActivityService {
         // ── 11. Emit events + build ordered result ────────────────────────────
         if inserted_count > 0 {
             self.emit_activities_changed(account_ids, asset_ids, currencies, earliest_at);
+            self.emit_asset_split_change(split_asset_ids, earliest_at);
         }
 
         for (idx, activity) in import_activities_indexed {
@@ -5381,6 +5439,13 @@ impl ActivityServiceTrait for ActivityService {
         }
 
         let earliest_activity_at_utc = Self::earliest_upsert_activity_at_utc(&activities);
+        let split_asset_ids: Vec<String> = activities
+            .iter()
+            .filter(|activity| activity.activity_type == ACTIVITY_TYPE_SPLIT)
+            .filter_map(|activity| activity.asset_id.clone())
+            .collect::<HashSet<_>>()
+            .into_iter()
+            .collect();
 
         // Collect unique account_ids, asset_ids, and currencies for the event before the upsert
         let account_ids: Vec<String> = activities
@@ -5414,6 +5479,7 @@ impl ActivityServiceTrait for ActivityService {
                 currencies,
                 earliest_activity_at_utc,
             );
+            self.emit_asset_split_change(split_asset_ids, earliest_activity_at_utc);
         }
 
         Ok(result)

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -2392,6 +2392,7 @@ mod tests {
         let asset_service = Arc::new(MockAssetService::new());
         let fx_service = Arc::new(MockFxService::new());
         let activity_repository = Arc::new(MockActivityRepository::new());
+        let event_sink = Arc::new(MockDomainEventSink::new());
 
         account_service.add_account(create_test_account("acc-1", "USD"));
         asset_service.add_asset(create_test_asset("AAPL", "USD"));
@@ -2402,7 +2403,8 @@ mod tests {
             asset_service,
             fx_service,
             Arc::new(MockQuoteService),
-        );
+        )
+        .with_event_sink(event_sink.clone());
 
         let new_activity = NewActivity {
             id: Some("split-1".to_string()),
@@ -2436,6 +2438,11 @@ mod tests {
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap().amount, Some(dec!(2)));
+        assert!(event_sink.events().iter().any(|event| matches!(
+            event,
+            DomainEvent::AssetSplitActivitiesChanged { asset_ids, .. }
+                if asset_ids == &["AAPL".to_string()]
+        )));
     }
 
     #[tokio::test]

--- a/crates/core/src/activities/activities_traits.rs
+++ b/crates/core/src/activities/activities_traits.rs
@@ -55,6 +55,31 @@ pub trait ActivityRepositoryTrait: Send + Sync {
         });
         Ok(activities)
     }
+    fn get_split_activities_by_asset_ids_in_date_range(
+        &self,
+        asset_ids: &[String],
+        start_utc: DateTime<Utc>,
+        end_exclusive_utc: DateTime<Utc>,
+    ) -> Result<Vec<Activity>> {
+        if asset_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let requested_assets: HashSet<&str> = asset_ids.iter().map(String::as_str).collect();
+        let mut activities = self.get_activities()?;
+        activities.retain(|activity| {
+            activity
+                .asset_id
+                .as_deref()
+                .is_some_and(|asset_id| requested_assets.contains(asset_id))
+                && activity.is_posted()
+                && activity.effective_type() == super::ACTIVITY_TYPE_SPLIT
+                && activity.activity_date >= start_utc
+                && activity.activity_date < end_exclusive_utc
+        });
+        activities.sort_by_key(|activity| activity.activity_date);
+        Ok(activities)
+    }
     fn get_transfer_activities_touching_account_ids_in_date_range(
         &self,
         account_ids: &[String],

--- a/crates/core/src/events/domain_event.rs
+++ b/crates/core/src/events/domain_event.rs
@@ -24,6 +24,13 @@ pub enum DomainEvent {
         earliest_activity_at_utc: Option<DateTime<Utc>>,
     },
 
+    /// Account-level split activities changed. Since split price adjustments are shared by
+    /// asset, every account valuation may need to be rebuilt.
+    AssetSplitActivitiesChanged {
+        asset_ids: Vec<String>,
+        earliest_activity_at_utc: Option<DateTime<Utc>>,
+    },
+
     /// Holdings snapshots were created or updated.
     HoldingsChanged {
         account_ids: Vec<String>,
@@ -97,6 +104,16 @@ impl DomainEvent {
             account_ids,
             asset_ids,
             currencies,
+            earliest_activity_at_utc,
+        }
+    }
+
+    pub fn asset_split_activities_changed(
+        asset_ids: Vec<String>,
+        earliest_activity_at_utc: Option<DateTime<Utc>>,
+    ) -> Self {
+        Self::AssetSplitActivitiesChanged {
+            asset_ids,
             earliest_activity_at_utc,
         }
     }

--- a/crates/core/src/portfolio/valuation/valuation_service.rs
+++ b/crates/core/src/portfolio/valuation/valuation_service.rs
@@ -1,6 +1,6 @@
 use crate::activities::{
-    Activity, ActivityRepositoryTrait, TransferPairResolution, ACTIVITY_TYPE_SPLIT,
-    ACTIVITY_TYPE_TRANSFER_IN, ACTIVITY_TYPE_TRANSFER_OUT, ACTIVITY_TYPE_WITHDRAWAL,
+    Activity, ActivityRepositoryTrait, TransferPairResolution, ACTIVITY_TYPE_TRANSFER_IN,
+    ACTIVITY_TYPE_TRANSFER_OUT, ACTIVITY_TYPE_WITHDRAWAL,
 };
 use crate::errors::{CalculatorError, Error as CoreError, Result as CoreResult};
 use crate::fx::currency::normalize_currency_code;
@@ -991,9 +991,85 @@ impl ValuationService {
         adjusted_distance < raw_distance
     }
 
-    fn quote_adjusted_split_events_for_account(
+    fn split_activity_source_rank(activity: &Activity) -> u8 {
+        if activity.is_user_modified {
+            return 3;
+        }
+
+        match activity
+            .source_system
+            .as_deref()
+            .map(str::trim)
+            .filter(|source| !source.is_empty())
+        {
+            None => 3,
+            Some(source)
+                if source.eq_ignore_ascii_case("MANUAL") || source.eq_ignore_ascii_case("CSV") =>
+            {
+                3
+            }
+            Some(source) if source.eq_ignore_ascii_case("GENERATED") => 1,
+            Some(_) => 2,
+        }
+    }
+
+    fn select_shared_split_activities(
+        activities: Vec<Activity>,
+        timezone: chrono_tz::Tz,
+    ) -> Vec<(Activity, NaiveDate, Decimal)> {
+        let mut candidates_by_event: BTreeMap<(String, NaiveDate), Vec<(Activity, Decimal)>> =
+            BTreeMap::new();
+
+        for activity in activities {
+            let Some(asset_id) = activity
+                .asset_id
+                .as_ref()
+                .filter(|asset_id| !asset_id.is_empty())
+                .cloned()
+            else {
+                continue;
+            };
+            let Some(ratio) = Self::split_ratio_from_activity(&activity) else {
+                continue;
+            };
+            let split_date = time_utils::activity_date_in_tz(activity.activity_date, timezone);
+            candidates_by_event
+                .entry((asset_id, split_date))
+                .or_default()
+                .push((activity, ratio));
+        }
+
+        candidates_by_event
+            .into_iter()
+            .filter_map(|((asset_id, split_date), mut candidates)| {
+                candidates.sort_by(|(left, _), (right, _)| {
+                    Self::split_activity_source_rank(right)
+                        .cmp(&Self::split_activity_source_rank(left))
+                        .then_with(|| right.updated_at.cmp(&left.updated_at))
+                        .then_with(|| left.id.cmp(&right.id))
+                });
+
+                let distinct_ratios: HashSet<Decimal> =
+                    candidates.iter().map(|(_, ratio)| *ratio).collect();
+                let (selected, selected_ratio) = candidates.into_iter().next()?;
+                if distinct_ratios.len() > 1 {
+                    let mut ratios: Vec<String> =
+                        distinct_ratios.into_iter().map(|ratio| ratio.to_string()).collect();
+                    ratios.sort();
+                    warn!(
+                        "Conflicting split ratios for asset '{}' on {}: {:?}. Using ratio {} from activity '{}'.",
+                        asset_id, split_date, ratios, selected_ratio, selected.id
+                    );
+                }
+
+                Some((selected, split_date, selected_ratio))
+            })
+            .collect()
+    }
+
+    fn quote_adjusted_split_events_for_assets(
         &self,
-        account_id: &str,
+        asset_ids: &HashSet<String>,
         start_date: NaiveDate,
         end_date: NaiveDate,
         quote_closes_by_asset_date: &HashMap<String, BTreeMap<NaiveDate, Decimal>>,
@@ -1006,23 +1082,19 @@ impl ValuationService {
             let timezone_guard = self.timezone.read().unwrap();
             time_utils::parse_user_timezone_or_default(&timezone_guard)
         };
-        let account_ids = vec![account_id.to_string()];
         let (start_utc, end_exclusive_utc) =
             Self::activity_query_utc_bounds(Some(start_date), Some(end_date));
-        let activities = activity_repository.get_activities_by_account_ids_in_date_range(
-            &account_ids,
+        let asset_ids: Vec<String> = asset_ids.iter().cloned().collect();
+        let activities = activity_repository.get_split_activities_by_asset_ids_in_date_range(
+            &asset_ids,
             start_utc.expect("start bound is provided"),
             end_exclusive_utc.expect("end bound is provided"),
         )?;
 
         let mut events = Vec::new();
-        let mut seen_events: HashSet<(String, NaiveDate)> = HashSet::new();
-        for activity in activities {
-            if !activity.is_posted() || activity.effective_type() != ACTIVITY_TYPE_SPLIT {
-                continue;
-            }
-
-            let split_date = time_utils::activity_date_in_tz(activity.activity_date, timezone);
+        for (activity, split_date, ratio) in
+            Self::select_shared_split_activities(activities, timezone)
+        {
             if !Self::activity_date_in_range(split_date, Some(start_date), Some(end_date)) {
                 continue;
             }
@@ -1034,17 +1106,12 @@ impl ValuationService {
             else {
                 continue;
             };
-            let Some(ratio) = Self::split_ratio_from_activity(&activity) else {
-                continue;
-            };
-
             if Self::quotes_appear_split_adjusted(
                 quote_closes_by_asset_date,
                 asset_id,
                 split_date,
                 ratio,
-            ) && seen_events.insert((asset_id.clone(), split_date))
-            {
+            ) {
                 events.push(QuoteAdjustedSplitEvent {
                     asset_id: asset_id.clone(),
                     split_date,
@@ -1688,8 +1755,8 @@ impl ValuationServiceTrait for ValuationService {
             calculation_end_date,
         )?;
         let quote_closes_by_asset_date = Self::quote_close_by_asset_date(&quotes_vec);
-        let quote_adjusted_split_events = self.quote_adjusted_split_events_for_account(
-            account_id,
+        let quote_adjusted_split_events = self.quote_adjusted_split_events_for_assets(
+            &required_asset_ids,
             actual_calculation_start_date,
             calculation_end_date,
             &quote_closes_by_asset_date,
@@ -2588,6 +2655,23 @@ mod tests {
         }
     }
 
+    fn split_activity_on_date(
+        id: &str,
+        account_id: &str,
+        asset_id: &str,
+        activity_date: &str,
+        ratio: Decimal,
+        source_system: Option<&str>,
+    ) -> Activity {
+        let mut activity = transfer_activity_on_date(id, "SPLIT", activity_date, account_id);
+        activity.asset_id = Some(asset_id.to_string());
+        activity.quantity = None;
+        activity.unit_price = None;
+        activity.amount = Some(ratio);
+        activity.source_system = source_system.map(str::to_string);
+        activity
+    }
+
     fn transfer_activity(
         activity_type: &str,
         asset_id: Option<&str>,
@@ -2714,6 +2798,122 @@ mod tests {
             date("2025-11-17"),
             dec!(10),
         ));
+    }
+
+    #[test]
+    fn shared_split_selection_deduplicates_matching_account_rows() {
+        let activities = vec![
+            split_activity_on_date(
+                "account-1-split",
+                "account-1",
+                "VGT",
+                "2025-12-01",
+                dec!(4),
+                Some("MANUAL"),
+            ),
+            split_activity_on_date(
+                "account-2-split",
+                "account-2",
+                "VGT",
+                "2025-12-01",
+                dec!(4),
+                Some("SNAPTRADE"),
+            ),
+        ];
+
+        let selected = ValuationService::select_shared_split_activities(activities, chrono_tz::UTC);
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].0.id, "account-1-split");
+        assert_eq!(selected[0].2, dec!(4));
+    }
+
+    #[test]
+    fn shared_split_selection_uses_same_conflict_winner_for_every_account() {
+        let activities = vec![
+            split_activity_on_date(
+                "losing-valued-account-row",
+                "account-being-valued",
+                "VGT",
+                "2025-12-01",
+                dec!(4.5),
+                Some("SNAPTRADE"),
+            ),
+            split_activity_on_date(
+                "manual-winner",
+                "other-account",
+                "VGT",
+                "2025-12-01",
+                dec!(4),
+                Some("MANUAL"),
+            ),
+        ];
+
+        let selected = ValuationService::select_shared_split_activities(activities, chrono_tz::UTC);
+
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].0.id, "manual-winner");
+        assert_eq!(selected[0].2, dec!(4));
+        let factors = ValuationService::split_price_factors_for_date(
+            date("2025-11-30"),
+            &[QuoteAdjustedSplitEvent {
+                asset_id: "VGT".to_string(),
+                split_date: selected[0].1,
+                ratio: selected[0].2,
+            }],
+        );
+        assert_eq!(factors.get("VGT"), Some(&dec!(4)));
+    }
+
+    #[test]
+    fn split_recorded_in_other_account_corrects_pre_sale_valuation() {
+        let selected = ValuationService::select_shared_split_activities(
+            vec![split_activity_on_date(
+                "other-account-split",
+                "other-account",
+                "VGT",
+                "2025-12-01",
+                dec!(4),
+                Some("MANUAL"),
+            )],
+            chrono_tz::UTC,
+        );
+        let quote_closes = ValuationService::quote_close_by_asset_date(&[
+            quote_on_date("VGT", dec!(25), "USD", "2025-11-28"),
+            quote_on_date("VGT", dec!(26), "USD", "2025-12-01"),
+        ]);
+        let (_, split_date, ratio) = &selected[0];
+        assert!(ValuationService::quotes_appear_split_adjusted(
+            &quote_closes,
+            "VGT",
+            *split_date,
+            *ratio,
+        ));
+
+        let factors = ValuationService::split_price_factors_for_date(
+            date("2025-11-28"),
+            &[QuoteAdjustedSplitEvent {
+                asset_id: "VGT".to_string(),
+                split_date: *split_date,
+                ratio: *ratio,
+            }],
+        );
+        let snapshot = snapshot_with_position("2025-11-28", "VGT", dec!(10));
+        let valuation = calculate_valuation_with_price_factors(
+            &snapshot,
+            &HashMap::from([(
+                "VGT".to_string(),
+                quote_on_date("VGT", dec!(25), "USD", "2025-11-28"),
+            )]),
+            &HashMap::new(),
+            &HashMap::new(),
+            date("2025-11-28"),
+            "USD",
+            &factors,
+        )
+        .unwrap();
+
+        assert_eq!(valuation.investment_market_value, dec!(1000));
     }
 
     #[test]

--- a/crates/core/src/portfolio/valuation/valuation_service.rs
+++ b/crates/core/src/portfolio/valuation/valuation_service.rs
@@ -1017,7 +1017,12 @@ impl ValuationService {
         activities: Vec<Activity>,
         timezone: chrono_tz::Tz,
     ) -> Vec<(Activity, NaiveDate, Decimal)> {
-        let mut candidates_by_event: BTreeMap<(String, NaiveDate), Vec<(Activity, Decimal)>> =
+        // Rows for the same real-world split can resolve to adjacent local dates when
+        // sources stamp different times of day, so cluster per asset by date gap
+        // instead of keying on the exact date; two events would apply the factor twice.
+        const MERGE_GAP_DAYS: i64 = 1;
+
+        let mut candidates_by_asset: BTreeMap<String, Vec<(Activity, NaiveDate, Decimal)>> =
             BTreeMap::new();
 
         for activity in activities {
@@ -1033,16 +1038,32 @@ impl ValuationService {
                 continue;
             };
             let split_date = time_utils::activity_date_in_tz(activity.activity_date, timezone);
-            candidates_by_event
-                .entry((asset_id, split_date))
+            candidates_by_asset
+                .entry(asset_id)
                 .or_default()
-                .push((activity, ratio));
+                .push((activity, split_date, ratio));
         }
 
-        candidates_by_event
-            .into_iter()
-            .filter_map(|((asset_id, split_date), mut candidates)| {
-                candidates.sort_by(|(left, _), (right, _)| {
+        let mut selected_events = Vec::new();
+        for (asset_id, mut candidates) in candidates_by_asset {
+            candidates.sort_by_key(|(_, split_date, _)| *split_date);
+
+            let mut clusters: Vec<Vec<(Activity, NaiveDate, Decimal)>> = Vec::new();
+            for candidate in candidates {
+                match clusters.last_mut() {
+                    Some(cluster)
+                        if cluster.last().is_some_and(|(_, last_date, _)| {
+                            (candidate.1 - *last_date).num_days() <= MERGE_GAP_DAYS
+                        }) =>
+                    {
+                        cluster.push(candidate);
+                    }
+                    _ => clusters.push(vec![candidate]),
+                }
+            }
+
+            for mut cluster in clusters {
+                cluster.sort_by(|(left, _, _), (right, _, _)| {
                     Self::split_activity_source_rank(right)
                         .cmp(&Self::split_activity_source_rank(left))
                         .then_with(|| right.updated_at.cmp(&left.updated_at))
@@ -1050,11 +1071,16 @@ impl ValuationService {
                 });
 
                 let distinct_ratios: HashSet<Decimal> =
-                    candidates.iter().map(|(_, ratio)| *ratio).collect();
-                let (selected, selected_ratio) = candidates.into_iter().next()?;
+                    cluster.iter().map(|(_, _, ratio)| *ratio).collect();
+                let Some((selected, split_date, selected_ratio)) = cluster.into_iter().next()
+                else {
+                    continue;
+                };
                 if distinct_ratios.len() > 1 {
-                    let mut ratios: Vec<String> =
-                        distinct_ratios.into_iter().map(|ratio| ratio.to_string()).collect();
+                    let mut ratios: Vec<String> = distinct_ratios
+                        .into_iter()
+                        .map(|ratio| ratio.to_string())
+                        .collect();
                     ratios.sort();
                     warn!(
                         "Conflicting split ratios for asset '{}' on {}: {:?}. Using ratio {} from activity '{}'.",
@@ -1062,9 +1088,11 @@ impl ValuationService {
                     );
                 }
 
-                Some((selected, split_date, selected_ratio))
-            })
-            .collect()
+                selected_events.push((selected, split_date, selected_ratio));
+            }
+        }
+
+        selected_events
     }
 
     fn quote_adjusted_split_events_for_assets(
@@ -2863,6 +2891,45 @@ mod tests {
             }],
         );
         assert_eq!(factors.get("VGT"), Some(&dec!(4)));
+    }
+
+    #[test]
+    fn shared_split_selection_merges_adjacent_dates_for_same_event() {
+        let activities = vec![
+            split_activity_on_date(
+                "broker-day-before",
+                "account-1",
+                "VGT",
+                "2025-11-30",
+                dec!(4),
+                Some("SNAPTRADE"),
+            ),
+            split_activity_on_date(
+                "manual-winner",
+                "account-2",
+                "VGT",
+                "2025-12-01",
+                dec!(4),
+                Some("MANUAL"),
+            ),
+            split_activity_on_date(
+                "earlier-distinct-split",
+                "account-1",
+                "VGT",
+                "2025-06-15",
+                dec!(2),
+                Some("SNAPTRADE"),
+            ),
+        ];
+
+        let selected = ValuationService::select_shared_split_activities(activities, chrono_tz::UTC);
+
+        assert_eq!(selected.len(), 2);
+        assert_eq!(selected[0].0.id, "earlier-distinct-split");
+        assert_eq!(selected[0].1, date("2025-06-15"));
+        assert_eq!(selected[1].0.id, "manual-winner");
+        assert_eq!(selected[1].1, date("2025-12-01"));
+        assert_eq!(selected[1].2, dec!(4));
     }
 
     #[test]

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -1388,6 +1388,42 @@ impl ActivityRepositoryTrait for ActivityRepository {
         Ok(activities_db.into_iter().map(Activity::from).collect())
     }
 
+    fn get_split_activities_by_asset_ids_in_date_range(
+        &self,
+        asset_ids: &[String],
+        start_utc: DateTime<Utc>,
+        end_exclusive_utc: DateTime<Utc>,
+    ) -> Result<Vec<Activity>> {
+        if asset_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let mut conn = get_connection(&self.pool)?;
+        let mut results = Vec::new();
+        let start = start_utc.to_rfc3339();
+        let end_exclusive = end_exclusive_utc.to_rfc3339();
+
+        for chunk in chunk_for_sqlite(asset_ids) {
+            let activities_db = activities::table
+                .filter(activities::asset_id.eq_any(chunk))
+                .filter(activities::status.eq("POSTED"))
+                .filter(diesel::dsl::sql::<Bool>(
+                    "COALESCE(activity_type_override, activity_type) = 'SPLIT'",
+                ))
+                .filter(activities::activity_date.ge(&start))
+                .filter(activities::activity_date.lt(&end_exclusive))
+                .select(ActivityDB::as_select())
+                .order(activities::activity_date.asc())
+                .load::<ActivityDB>(&mut conn)
+                .map_err(StorageError::from)?;
+
+            results.extend(activities_db.into_iter().map(Activity::from));
+        }
+
+        results.sort_by_key(|activity| activity.activity_date);
+        Ok(results)
+    }
+
     fn get_transfer_activities_touching_account_ids_in_date_range(
         &self,
         account_ids: &[String],
@@ -2826,6 +2862,62 @@ mod tests {
             .count()
             .get_result::<i64>(conn)
             .expect("count outbox")
+    }
+
+    #[tokio::test]
+    async fn split_activity_query_loads_posted_rows_across_accounts() {
+        let (pool, writer) = setup_db();
+        let repo = ActivityRepository::new(pool.clone(), writer);
+
+        {
+            let mut conn = get_connection(&pool).expect("conn");
+            insert_account(&mut conn, "account-1");
+            insert_account(&mut conn, "account-2");
+            insert_account_with_archived(&mut conn, "archived-account", true);
+            diesel::sql_query(
+                "INSERT INTO assets
+                 (id, kind, name, display_code, is_active, quote_mode, quote_ccy,
+                  instrument_type, instrument_symbol, created_at, updated_at)
+                 VALUES ('asset-vgt', 'INVESTMENT', 'VGT', 'VGT', 1, 'MARKET', 'USD',
+                         'EQUITY', 'VGT', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+            )
+            .execute(&mut conn)
+            .expect("insert asset");
+            diesel::sql_query(
+                "INSERT INTO activities
+                 (id, account_id, asset_id, activity_type, status, activity_date, amount,
+                  currency, is_user_modified, needs_review, created_at, updated_at)
+                 VALUES
+                 ('split-1', 'account-1', 'asset-vgt', 'SPLIT', 'POSTED',
+                  '2025-12-01T12:00:00Z', '4', 'USD', 0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                 ('split-2', 'account-2', 'asset-vgt', 'SPLIT', 'POSTED',
+                  '2025-12-01T12:00:00Z', '4', 'USD', 0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                 ('draft-split', 'account-1', 'asset-vgt', 'SPLIT', 'DRAFT',
+                  '2025-12-01T12:00:00Z', '4', 'USD', 0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                 ('archived-split', 'archived-account', 'asset-vgt', 'SPLIT', 'POSTED',
+                  '2025-12-01T12:00:00Z', '4', 'USD', 0, 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+            )
+            .execute(&mut conn)
+            .expect("insert activities");
+        }
+
+        let activities = repo
+            .get_split_activities_by_asset_ids_in_date_range(
+                &["asset-vgt".to_string()],
+                DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+                DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+            )
+            .unwrap();
+
+        let ids: HashSet<&str> = activities
+            .iter()
+            .map(|activity| activity.id.as_str())
+            .collect();
+        assert_eq!(ids, HashSet::from(["split-1", "split-2", "archived-split"]));
     }
 
     fn insert_holdings_snapshot(

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -2485,6 +2485,34 @@ impl ActivityRepositoryTrait for ActivityRepository {
                     }
                 }
 
+                // Capture pre-images of candidate rows that are effectively SPLIT, so the
+                // service can emit asset-level split events even when the incoming row
+                // reclassifies the activity or moves it to another asset.
+                let candidate_ids: Vec<String> = existing_by_id
+                    .keys()
+                    .cloned()
+                    .chain(existing_by_idemp.values().map(|(id, _)| id.clone()))
+                    .chain(existing_by_source.values().map(|(id, _)| id.clone()))
+                    .collect::<HashSet<_>>()
+                    .into_iter()
+                    .collect();
+                let existing_split_assets: HashMap<String, String> = if candidate_ids.is_empty() {
+                    HashMap::new()
+                } else {
+                    activities::table
+                        .filter(activities::id.eq_any(&candidate_ids))
+                        .filter(diesel::dsl::sql::<Bool>(
+                            "COALESCE(activity_type_override, activity_type) = 'SPLIT'",
+                        ))
+                        .select((activities::id, activities::asset_id))
+                        .load::<(String, Option<String>)>(tx.conn())
+                        .map_err(StorageError::from)?
+                        .into_iter()
+                        .filter_map(|(id, asset_id)| asset_id.map(|asset_id| (id, asset_id)))
+                        .collect()
+                };
+                let mut updated_split_asset_ids: HashSet<String> = HashSet::new();
+
                 let mut result = BulkUpsertResult::default();
 
                 for mut activity_db in activity_rows {
@@ -2627,6 +2655,11 @@ impl ActivityRepositoryTrait for ActivityRepository {
                                 result.upserted += count;
                                 if will_update {
                                     result.updated += count;
+                                    if let Some(asset_id) =
+                                        existing_split_assets.get(&activity_db.id)
+                                    {
+                                        updated_split_asset_ids.insert(asset_id.clone());
+                                    }
                                 } else {
                                     result.created += count;
                                 }
@@ -2668,6 +2701,7 @@ impl ActivityRepositoryTrait for ActivityRepository {
                     result.skipped
                 );
 
+                result.updated_split_asset_ids = updated_split_asset_ids.into_iter().collect();
                 Ok(result)
             })
             .await
@@ -4599,6 +4633,76 @@ mod tests {
         assert_eq!(rows[0].2.as_deref(), Some("SNAPTRADE"));
         assert_eq!(rows[0].3.as_deref(), Some("txn-1"));
         assert_eq!(rows[0].4.as_deref(), Some("idemp-2"));
+    }
+
+    #[tokio::test]
+    async fn bulk_upsert_reports_overwritten_split_asset_ids() {
+        let (pool, writer) = setup_db();
+        let repo = ActivityRepository::new(pool.clone(), writer);
+
+        {
+            let mut conn = get_connection(&pool).expect("conn");
+            insert_account(&mut conn, "acc-sync");
+            diesel::sql_query(
+                "INSERT INTO assets
+                 (id, kind, name, display_code, is_active, quote_mode, quote_ccy,
+                  instrument_type, instrument_symbol, created_at, updated_at)
+                 VALUES ('asset-vgt', 'INVESTMENT', 'VGT', 'VGT', 1, 'MARKET', 'USD',
+                         'EQUITY', 'VGT', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+            )
+            .execute(&mut conn)
+            .expect("insert asset");
+        }
+
+        let split = ActivityUpsert {
+            id: "provider-id-1".to_string(),
+            account_id: "acc-sync".to_string(),
+            asset_id: Some("asset-vgt".to_string()),
+            activity_type: "SPLIT".to_string(),
+            subtype: None,
+            activity_date: "2024-01-15".to_string(),
+            quantity: None,
+            unit_price: None,
+            currency: "USD".to_string(),
+            fee: None,
+            tax: None,
+            amount: Some(Decimal::from(4)),
+            status: None,
+            notes: None,
+            fx_rate: None,
+            metadata: None,
+            needs_review: None,
+            source_system: Some("SNAPTRADE".to_string()),
+            source_record_id: Some("txn-split".to_string()),
+            source_group_id: None,
+            idempotency_key: Some("idemp-1".to_string()),
+            import_run_id: None,
+        };
+        let mut reclassified_to_buy = split.clone();
+        reclassified_to_buy.id = "provider-id-2".to_string();
+        reclassified_to_buy.activity_type = "BUY".to_string();
+        reclassified_to_buy.quantity = Some(Decimal::ONE);
+        reclassified_to_buy.unit_price = Some(Decimal::from(100));
+        reclassified_to_buy.amount = Some(Decimal::from(100));
+        reclassified_to_buy.idempotency_key = Some("idemp-2".to_string());
+
+        let first_result = repo
+            .bulk_upsert(vec![split])
+            .await
+            .expect("split upsert succeeds");
+        assert_eq!(first_result.created, 1);
+        assert!(first_result.updated_split_asset_ids.is_empty());
+
+        let second_result = repo
+            .bulk_upsert(vec![reclassified_to_buy])
+            .await
+            .expect("reclassifying upsert succeeds");
+        assert_eq!(second_result.updated, 1);
+        assert_eq!(
+            second_result.updated_split_asset_ids,
+            vec!["asset-vgt".to_string()],
+            "overwriting an existing SPLIT row must surface its asset id"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- load posted split activities by asset across all accounts when calculating historical valuations
- deduplicate split records by asset and local split date, with deterministic conflict resolution and warnings
- preserve the existing raw-vs-split-adjusted quote detection guard
- trigger full-history recalculation for all accounts whenever split activities change

## Root cause

Historical price adjustment was derived only from `SPLIT` activities in the account being valued. Accounts that sold an asset before a later split therefore had no local split row, even when another account recorded the same asset-level event, so split-adjusted historical closes were combined with pre-split quantities.

## Impact

A split entered in any account now corrects historical valuation for every account that held the same asset, including accounts that sold before the split. Quantity changes remain account-specific. Assets with no split activity anywhere still require one manual entry until the planned asset-level split feed is implemented.

Conflicting ratios for the same asset/date resolve consistently using user/manual entries before broker entries and generated entries, then latest update and stable activity ID. A warning records the conflict instead of failing background rebuilds.

## Validation

- `pnpm check`
- `pnpm test` — 1,055 frontend tests
- `pnpm build`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace`
- `cargo check -p wealthfolio-server --release`

Addresses #1286.