### PR TITLE
(feat) add manual expense ratio tracking

### DIFF
--- a/apps/frontend/src/i18n/locales/de/asset.json
+++ b/apps/frontend/src/i18n/locales/de/asset.json
@@ -231,6 +231,8 @@
     "name_placeholder": "Anzeigename der Anlage",
     "isin": "ISIN",
     "isin_placeholder": "z. B. FR0010959676",
+    "expense_ratio": "Kostenquote (%)",
+    "expense_ratio_placeholder": "z. B. 0.03",
     "notes": "Notizen",
     "notes_placeholder": "Kontext oder Links hinzufügen",
     "symbol": "Symbol",

--- a/apps/frontend/src/i18n/locales/de/holdings.json
+++ b/apps/frontend/src/i18n/locales/de/holdings.json
@@ -13,6 +13,7 @@
   "gain_loss_percent": "Gewinn/Verlust %",
   "today_gain": "Heutiger Gewinn",
   "weight": "Gewichtung",
+  "expense_ratio": "Kostenquote",
   "sector": "Sektor",
   "asset_class": "Anlageklasse",
   "sort_by": "Sortieren nach",

--- a/apps/frontend/src/i18n/locales/en/asset.json
+++ b/apps/frontend/src/i18n/locales/en/asset.json
@@ -231,6 +231,8 @@
     "name_placeholder": "Asset display name",
     "isin": "ISIN",
     "isin_placeholder": "e.g. FR0010959676",
+    "expense_ratio": "Expense Ratio (%)",
+    "expense_ratio_placeholder": "e.g. 0.03",
     "notes": "Notes",
     "notes_placeholder": "Add any context or links",
     "symbol": "Symbol",

--- a/apps/frontend/src/i18n/locales/en/holdings.json
+++ b/apps/frontend/src/i18n/locales/en/holdings.json
@@ -13,6 +13,7 @@
   "gain_loss_percent": "Gain/Loss %",
   "today_gain": "Today's Gain",
   "weight": "Weight",
+  "expense_ratio": "Expense Ratio",
   "sector": "Sector",
   "asset_class": "Asset Class",
   "sort_by": "Sort by",

--- a/apps/frontend/src/i18n/locales/es/asset.json
+++ b/apps/frontend/src/i18n/locales/es/asset.json
@@ -231,6 +231,8 @@
     "name_placeholder": "Nombre para mostrar del activo",
     "isin": "ISIN",
     "isin_placeholder": "p. ej. FR0010959676",
+    "expense_ratio": "Ratio de gastos (%)",
+    "expense_ratio_placeholder": "p. ej. 0.03",
     "notes": "Notas",
     "notes_placeholder": "Añade cualquier contexto o enlace",
     "symbol": "Símbolo",

--- a/apps/frontend/src/i18n/locales/es/holdings.json
+++ b/apps/frontend/src/i18n/locales/es/holdings.json
@@ -13,6 +13,7 @@
   "gain_loss_percent": "Ganancia/Pérdida %",
   "today_gain": "Ganancia de hoy",
   "weight": "Peso",
+  "expense_ratio": "Ratio de gastos",
   "sector": "Sector",
   "asset_class": "Clase de activo",
   "sort_by": "Ordenar por",

--- a/apps/frontend/src/i18n/locales/fr/asset.json
+++ b/apps/frontend/src/i18n/locales/fr/asset.json
@@ -231,6 +231,8 @@
     "name_placeholder": "Nom d'affichage de l'actif",
     "isin": "ISIN",
     "isin_placeholder": "p. ex. FR0010959676",
+    "expense_ratio": "Ratio de frais (%)",
+    "expense_ratio_placeholder": "p. ex. 0.03",
     "notes": "Notes",
     "notes_placeholder": "Ajoutez du contexte ou des liens",
     "symbol": "Symbole",

--- a/apps/frontend/src/i18n/locales/fr/holdings.json
+++ b/apps/frontend/src/i18n/locales/fr/holdings.json
@@ -13,6 +13,7 @@
   "gain_loss_percent": "Gain/Perte %",
   "today_gain": "Gain du jour",
   "weight": "Poids",
+  "expense_ratio": "Ratio de frais",
   "sector": "Secteur",
   "asset_class": "Classe d'actifs",
   "sort_by": "Trier par",

--- a/apps/frontend/src/i18n/locales/zh/asset.json
+++ b/apps/frontend/src/i18n/locales/zh/asset.json
@@ -231,6 +231,8 @@
     "name_placeholder": "资产显示名称",
     "isin": "ISIN",
     "isin_placeholder": "例如 FR0010959676",
+    "expense_ratio": "费用比率 (%)",
+    "expense_ratio_placeholder": "例如 0.03",
     "notes": "备注",
     "notes_placeholder": "添加任何背景信息或链接",
     "symbol": "代码",

--- a/apps/frontend/src/i18n/locales/zh/holdings.json
+++ b/apps/frontend/src/i18n/locales/zh/holdings.json
@@ -13,6 +13,7 @@
   "gain_loss_percent": "盈亏 %",
   "today_gain": "今日盈亏",
   "weight": "权重",
+  "expense_ratio": "费用比率",
   "sector": "行业",
   "asset_class": "资产类别",
   "sort_by": "排序方式",

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -622,6 +622,8 @@ export interface Instrument {
   preferredProvider?: string | null;
   isin?: string | null;
   exchangeMic?: string | null;
+  /** Fraction (e.g. 0.0003 = 0.03%), read from asset metadata. */
+  expenseRatio?: number | null;
 
   // Taxonomy-based classifications
   classifications?: AssetClassifications | null;

--- a/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
+++ b/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
@@ -79,6 +79,7 @@ const assetFormSchema = (t: TFunction) =>
     name: z.string().optional(),
     notes: z.string().optional(),
     isin: z.string().optional(),
+    expenseRatio: z.string().optional(),
     instrumentType: z.string().optional(),
     quoteCcy: z.string().min(1, t("asset:editSheet.currency_required")),
     instrumentExchangeMic: z.string().optional(),
@@ -123,6 +124,15 @@ function extractIsin(metadata: unknown): string {
   const identifiers = (metadata as Record<string, unknown>).identifiers;
   if (!identifiers || typeof identifiers !== "object") return "";
   return ((identifiers as Record<string, unknown>).isin as string) ?? "";
+}
+
+// expenseRatio is stored in metadata as a fraction (e.g. 0.0003 = 0.03%).
+// The form displays/edits it as a percent string (e.g. "0.03").
+function extractExpenseRatio(metadata: unknown): string {
+  if (!metadata || typeof metadata !== "object") return "";
+  const value = (metadata as Record<string, unknown>).expenseRatio;
+  if (typeof value !== "number" || Number.isNaN(value)) return "";
+  return (value * 100).toString();
 }
 
 // Parse provider overrides from config JSON (supports nested and flat formats)
@@ -533,6 +543,7 @@ export function AssetEditSheet({
       name: asset?.name ?? "",
       notes: asset?.notes ?? "",
       isin: extractIsin(asset?.metadata),
+      expenseRatio: extractExpenseRatio(asset?.metadata),
       instrumentType: asset?.instrumentType ?? "",
       quoteCcy: asset?.quoteCcy ?? "",
       instrumentExchangeMic: normalizeMic(asset?.instrumentExchangeMic),
@@ -562,6 +573,7 @@ export function AssetEditSheet({
         name: asset.name ?? "",
         notes: asset.notes ?? "",
         isin: extractIsin(asset.metadata),
+        expenseRatio: extractExpenseRatio(asset.metadata),
         instrumentType: asset.instrumentType ?? "",
         quoteCcy: asset.quoteCcy ?? "",
         instrumentExchangeMic: normalizeMic(asset.instrumentExchangeMic),
@@ -612,11 +624,14 @@ export function AssetEditSheet({
         const newIdentifiers = isinTrimmed
           ? { ...existingIdentifiers, isin: isinTrimmed }
           : Object.fromEntries(Object.entries(existingIdentifiers).filter(([k]) => k !== "isin"));
+        const expenseRatioTrimmed = values.expenseRatio?.trim() ?? "";
+        const expenseRatioParsed = expenseRatioTrimmed ? Number(expenseRatioTrimmed) : NaN;
         const newMetadata = {
           ...existingMeta,
           ...(Object.keys(newIdentifiers).length > 0
             ? { identifiers: newIdentifiers }
             : { identifiers: undefined }),
+          expenseRatio: Number.isFinite(expenseRatioParsed) ? expenseRatioParsed / 100 : undefined,
         };
 
         // Update profile with all fields including quote mode
@@ -844,6 +859,26 @@ export function AssetEditSheet({
                                 className="font-mono uppercase"
                                 {...field}
                                 onChange={(e) => field.onChange(e.target.value.toUpperCase())}
+                              />
+                            </FormControl>
+                            <FormMessage />
+                          </FormItem>
+                        )}
+                      />
+
+                      <FormField
+                        control={form.control}
+                        name="expenseRatio"
+                        render={({ field }) => (
+                          <FormItem>
+                            <FormLabel>{t("asset:editSheet.expense_ratio")}</FormLabel>
+                            <FormControl>
+                              <Input
+                                type="number"
+                                step="0.01"
+                                min="0"
+                                placeholder={t("asset:editSheet.expense_ratio_placeholder")}
+                                {...field}
                               />
                             </FormControl>
                             <FormMessage />

--- a/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
+++ b/apps/frontend/src/pages/asset/asset-edit-sheet.tsx
@@ -51,12 +51,12 @@ import {
 import { Skeleton } from "@wealthfolio/ui/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@wealthfolio/ui/components/ui/tabs";
 import { Textarea } from "@wealthfolio/ui/components/ui/textarea";
+import { toast } from "@wealthfolio/ui/components/ui/use-toast";
+import type { TFunction } from "i18next";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { type Path, useFieldArray, useForm, useWatch } from "react-hook-form";
 import { useTranslation } from "react-i18next";
-import type { TFunction } from "i18next";
 import * as z from "zod";
-import { toast } from "@wealthfolio/ui/components/ui/use-toast";
 import { serializeProviderConfig } from "./asset-provider-config";
 import { useAssetProfileMutations } from "./hooks/use-asset-profile-mutations";
 
@@ -133,6 +133,20 @@ function extractExpenseRatio(metadata: unknown): string {
   const value = (metadata as Record<string, unknown>).expenseRatio;
   if (typeof value !== "number" || Number.isNaN(value)) return "";
   return (value * 100).toString();
+}
+
+const EXPENSE_RATIO_ELIGIBLE_QUOTE_TYPES = new Set(["ETF", "MUTUALFUND"]);
+
+// Expense ratio only applies to funds; quoteType comes from the provider profile
+// synced into metadata.profile.quoteType (e.g. EQUITY, ETF, MUTUALFUND, INDEX).
+function canEditExpenseRatio(metadata: unknown): boolean {
+  if (!metadata || typeof metadata !== "object") return false;
+  const profile = (metadata as Record<string, unknown>).profile;
+  if (!profile || typeof profile !== "object") return false;
+  const quoteType = (profile as Record<string, unknown>).quoteType;
+  return (
+    typeof quoteType === "string" && EXPENSE_RATIO_ELIGIBLE_QUOTE_TYPES.has(quoteType.toUpperCase())
+  );
 }
 
 // Parse provider overrides from config JSON (supports nested and flat formats)
@@ -662,6 +676,7 @@ export function AssetEditSheet({
 
   // Check if current asset kind is system-managed (shouldn't allow editing)
   const isSystemManagedKind = asset?.kind === "FX";
+  const expenseRatioEditable = canEditExpenseRatio(asset?.metadata);
 
   if (!asset) return null;
 
@@ -866,25 +881,27 @@ export function AssetEditSheet({
                         )}
                       />
 
-                      <FormField
-                        control={form.control}
-                        name="expenseRatio"
-                        render={({ field }) => (
-                          <FormItem>
-                            <FormLabel>{t("asset:editSheet.expense_ratio")}</FormLabel>
-                            <FormControl>
-                              <Input
-                                type="number"
-                                step="0.01"
-                                min="0"
-                                placeholder={t("asset:editSheet.expense_ratio_placeholder")}
-                                {...field}
-                              />
-                            </FormControl>
-                            <FormMessage />
-                          </FormItem>
-                        )}
-                      />
+                      {expenseRatioEditable && (
+                        <FormField
+                          control={form.control}
+                          name="expenseRatio"
+                          render={({ field }) => (
+                            <FormItem>
+                              <FormLabel>{t("asset:editSheet.expense_ratio")}</FormLabel>
+                              <FormControl>
+                                <Input
+                                  type="number"
+                                  step="0.01"
+                                  min="0"
+                                  placeholder={t("asset:editSheet.expense_ratio_placeholder")}
+                                  {...field}
+                                />
+                              </FormControl>
+                              <FormMessage />
+                            </FormItem>
+                          )}
+                        />
+                      )}
 
                       <FormField
                         control={form.control}

--- a/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
@@ -4,7 +4,7 @@ import { HoldingType } from "@/lib/constants";
 import { parseOccSymbol } from "@/lib/occ-symbol";
 import { Account, AccountScope, Holding } from "@/lib/types";
 import { cn } from "@/lib/utils";
-import { AmountDisplay, GainPercent, Input, Separator } from "@wealthfolio/ui";
+import { AmountDisplay, formatPercent, GainPercent, Input, Separator } from "@wealthfolio/ui";
 import { Button } from "@wealthfolio/ui/components/ui/button";
 import { Card } from "@wealthfolio/ui/components/ui/card";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
@@ -201,6 +201,12 @@ export const HoldingsTableMobile = ({
                       </div>
                       {subtitle && (
                         <p className="text-muted-foreground truncate text-sm">{subtitle}</p>
+                      )}
+                      {holding.instrument?.expenseRatio != null && (
+                        <p className="text-muted-foreground truncate text-xs">
+                          {t("holdings:expense_ratio")}:{" "}
+                          {formatPercent(holding.instrument.expenseRatio)}
+                        </p>
                       )}
                     </div>
                   </div>

--- a/apps/frontend/src/pages/holdings/components/holdings-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table.tsx
@@ -136,6 +136,7 @@ export const HoldingsTable = ({
           holdingType: false,
           avgPrice: false,
           weight: false,
+          expenseRatio: false,
           bookValue: false,
           totalPnl: false,
           unrealizedPnl: false,
@@ -694,6 +695,39 @@ const getColumns = (
       <DataTableColumnHeader column={column} title={t("holdings:asset_type")} />
     ),
     filterFn: "arrIncludesSome",
+  },
+  {
+    id: "expenseRatio",
+    accessorFn: (row) => row.instrument?.expenseRatio ?? null,
+    enableHiding: true,
+    enableSorting: true,
+    header: ({ column }) => (
+      <DataTableColumnHeader
+        className="justify-end text-right"
+        column={column}
+        title={t("holdings:expense_ratio")}
+      />
+    ),
+    meta: {
+      label: t("holdings:expense_ratio"),
+    },
+    cell: ({ row }) => {
+      const expenseRatio = row.original.instrument?.expenseRatio;
+      return (
+        <div className="flex min-h-[40px] flex-col items-end justify-center px-4">
+          {expenseRatio == null ? (
+            <span className="text-muted-foreground">-</span>
+          ) : (
+            <span className="tabular-nums">{formatPercent(expenseRatio)}</span>
+          )}
+        </div>
+      );
+    },
+    sortingFn: (rowA, rowB) => {
+      const valueA = rowA.original.instrument?.expenseRatio ?? -1;
+      const valueB = rowB.original.instrument?.expenseRatio ?? -1;
+      return valueA - valueB;
+    },
   },
   {
     id: "currency",

--- a/crates/core/src/exports.rs
+++ b/crates/core/src/exports.rs
@@ -459,6 +459,7 @@ mod tests {
                 isin: Some("US0378331005".to_string()),
                 exchange_mic: Some("XNAS".to_string()),
                 classifications: None,
+                expense_ratio: None,
             }),
             asset_kind: Some(AssetKind::Investment),
             quantity: dec!(10),

--- a/crates/core/src/portfolio/holdings/holdings_model.rs
+++ b/crates/core/src/portfolio/holdings/holdings_model.rs
@@ -158,6 +158,8 @@ pub struct HoldingListInstrument {
     pub exchange_mic: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub classifications: Option<AssetClassifications>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expense_ratio: Option<Decimal>,
 }
 
 /// List-oriented holding payload for app tables and dashboards.
@@ -201,6 +203,7 @@ pub struct HoldingListItem {
 impl From<Holding> for HoldingListItem {
     fn from(holding: Holding) -> Self {
         let isin = holding_metadata_isin(holding.metadata.as_ref());
+        let expense_ratio = holding_metadata_expense_ratio(holding.metadata.as_ref());
         let instrument = holding.instrument.map(|instrument| {
             let classifications = instrument
                 .classifications
@@ -222,6 +225,7 @@ impl From<Holding> for HoldingListItem {
                 isin,
                 exchange_mic: instrument.exchange_mic,
                 classifications,
+                expense_ratio,
             }
         });
 
@@ -271,4 +275,15 @@ fn holding_metadata_isin(metadata: Option<&Value>) -> Option<String> {
         .map(str::trim)
         .filter(|isin| !isin.is_empty())
         .map(ToOwned::to_owned)
+}
+
+fn holding_metadata_expense_ratio(metadata: Option<&Value>) -> Option<Decimal> {
+    metadata
+        .and_then(|metadata| metadata.pointer("/expenseRatio"))
+        .and_then(|value| {
+            value
+                .as_str()
+                .and_then(|s| s.parse::<Decimal>().ok())
+                .or_else(|| value.as_f64().and_then(Decimal::from_f64_retain))
+        })
 }


### PR DESCRIPTION
## Description

This is a small change to add expense ratio tracking to the asset metadata blob. In the UI, this field only appears for "ETF" and "MUTUALFUND" type assets. The data is stored in the asset metadata, so no DB migrations are needed. In the future, we should be able to pull this data from the finance APIs, but for now it's just a manual field. 

Screenshots:

<img width="500" height="900" alt="image" src="https://github.com/user-attachments/assets/efbab81a-712c-464d-bb05-6f21cacac338" />

I also added a small change so that this data is viewable in the holdings table:

<img width="1200" height="400" alt="image" src="https://github.com/user-attachments/assets/9019b168-7595-4aa8-8bb9-b7ea04d5240c" />
 



## Checklist

- [X] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
