### PR TITLE
chore(release): prepare v3.6.2

### DIFF
--- a/.env.web.example
+++ b/.env.web.example
@@ -127,6 +127,14 @@ WF_AUTH_PASSWORD_HASH=
 # WF_ADDONS_DIR=
 
 # =============================================================================
+# MCP CONFIGURATION (optional)
+# =============================================================================
+
+# Expose the MCP endpoint for external AI agents (default: false)
+# Authentication is required when the server listens on a non-loopback address
+WF_MCP_ENABLED=false
+
+# =============================================================================
 # VITE DEVELOPMENT SERVER CONFIGURATION
 # =============================================================================
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8560,7 +8560,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-agent-tools"
-version = "3.6.1"
+version = "3.6.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8577,7 +8577,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-ai"
-version = "3.6.1"
+version = "3.6.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8608,7 +8608,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-app"
-version = "3.6.1"
+version = "3.6.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8665,7 +8665,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-connect"
-version = "3.6.1"
+version = "3.6.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8683,7 +8683,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-core"
-version = "3.6.1"
+version = "3.6.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8728,7 +8728,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-device-sync"
-version = "3.6.1"
+version = "3.6.2"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8752,7 +8752,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-market-data"
-version = "3.6.1"
+version = "3.6.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8774,7 +8774,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-mcp"
-version = "3.6.1"
+version = "3.6.2"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8799,7 +8799,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-server"
-version = "3.6.1"
+version = "3.6.2"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8852,7 +8852,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-spending"
-version = "3.6.1"
+version = "3.6.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8870,7 +8870,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-storage-sqlite"
-version = "3.6.1"
+version = "3.6.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.6.1"
+version = "3.6.2"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "3.6.1",
+  "version": "3.6.2",
   "type": "module",
   "homepage": "https://wealthfolio.app",
   "repository": {

--- a/apps/frontend/src/pages/onboarding/onboarding-connect.tsx
+++ b/apps/frontend/src/pages/onboarding/onboarding-connect.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from "@/components/external-link";
 import { Card } from "@wealthfolio/ui/components/ui/card";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
 import React, { useMemo } from "react";
@@ -81,7 +82,7 @@ export const OnboardingConnect: React.FC = () => {
 
       {/* Learn more link */}
       <div className="flex justify-center">
-        <a
+        <ExternalLink
           href="https://wealthfolio.app/connect/"
           target="_blank"
           rel="noopener noreferrer"
@@ -89,7 +90,7 @@ export const OnboardingConnect: React.FC = () => {
         >
           {t("onboarding:connect.learnMore")}
           <Icons.ExternalLink className="h-3.5 w-3.5" />
-        </a>
+        </ExternalLink>
       </div>
     </div>
   );

--- a/apps/frontend/src/pages/onboarding/onboarding-page.tsx
+++ b/apps/frontend/src/pages/onboarding/onboarding-page.tsx
@@ -1,3 +1,4 @@
+import { ExternalLink } from "@/components/external-link";
 import { StartupError } from "@/components/startup-error";
 import { usePlatform } from "@/hooks/use-platform";
 import { useSettings } from "@/hooks/use-settings";
@@ -147,14 +148,14 @@ const OnboardingPage = () => {
               <div className="order-1 flex flex-col gap-2 sm:order-2 sm:flex-row sm:gap-3">
                 {!isMobile && (
                   <Button asChild variant="outline" className="order-2 sm:order-1">
-                    <a
+                    <ExternalLink
                       href={WEALTHFOLIO_CONNECT_PORTAL_URL}
                       target="_blank"
                       rel="noopener noreferrer"
                     >
                       {t("onboarding:buttons.subscribeConnect")}
                       <Icons.ExternalLink className="ml-1.5 h-4 w-4" />
-                    </a>
+                    </ExternalLink>
                   </Button>
                 )}
                 <Button

--- a/apps/tauri/tauri.conf.json
+++ b/apps/tauri/tauri.conf.json
@@ -40,7 +40,7 @@
   },
   "productName": "Wealthfolio",
   "mainBinaryName": "Wealthfolio",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "identifier": "com.teymz.wealthfolio",
   "plugins": {
     "updater": {

--- a/compose.yml
+++ b/compose.yml
@@ -67,6 +67,9 @@ services:
       # Required when auth is enabled — set to your app's origin, e.g. https://wealthfolio.example.com
       WF_CORS_ALLOW_ORIGINS: "${WF_CORS_ALLOW_ORIGINS:-}"
       WF_REQUEST_TIMEOUT_MS: "${WF_REQUEST_TIMEOUT_MS:-30000}"
+
+      # Set to "true" to expose the MCP endpoint for external AI agents
+      WF_MCP_ENABLED: "${WF_MCP_ENABLED:-false}"
     healthcheck:
       test:
         ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://127.0.0.1:8088/api/v1/healthz"]

--- a/crates/ai/src/provider_model.rs
+++ b/crates/ai/src/provider_model.rs
@@ -3,6 +3,16 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Preserve the distinction between an omitted update field and an explicit
+/// `null`, which clears the stored value.
+fn deserialize_nullable_update<'de, D, T>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+    T: Deserialize<'de>,
+{
+    Option::<T>::deserialize(deserializer).map(Some)
+}
+
 /// Current schema version for AI provider settings.
 /// Increment when making breaking changes to the settings structure.
 ///
@@ -493,11 +503,19 @@ pub struct UpdateProviderSettingsRequest {
     pub favorite_models: Option<Vec<String>>,
     /// Update tools allowlist.
     /// Use Some(None) to clear (all tools enabled), Some(Some([])) to set specific tools.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_nullable_update",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub tools_allowlist: Option<Option<Vec<String>>>,
     /// Update user tuning overrides.
     /// Use Some(None) to reset to catalog defaults, Some(Some(...)) to set overrides.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        default,
+        deserialize_with = "deserialize_nullable_update",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub tuning_overrides: Option<Option<ProviderTuningOverrides>>,
 }
 
@@ -608,6 +626,33 @@ mod tests {
     use super::*;
     use serde_json::json;
     use std::collections::HashMap;
+
+    #[test]
+    fn provider_update_preserves_nullable_field_intent() {
+        let omitted: UpdateProviderSettingsRequest =
+            serde_json::from_value(json!({ "providerId": "openai" })).unwrap();
+        assert_eq!(omitted.tools_allowlist, None);
+        assert_eq!(omitted.tuning_overrides, None);
+
+        let cleared: UpdateProviderSettingsRequest = serde_json::from_value(json!({
+            "providerId": "openai",
+            "toolsAllowlist": null,
+            "tuningOverrides": null
+        }))
+        .unwrap();
+        assert_eq!(cleared.tools_allowlist, Some(None));
+        assert_eq!(cleared.tuning_overrides, Some(None));
+
+        let restricted: UpdateProviderSettingsRequest = serde_json::from_value(json!({
+            "providerId": "openai",
+            "toolsAllowlist": ["get_accounts"]
+        }))
+        .unwrap();
+        assert_eq!(
+            restricted.tools_allowlist,
+            Some(Some(vec!["get_accounts".to_string()]))
+        );
+    }
 
     #[test]
     fn sanitized_for_provider_removes_unsupported_anthropic_sampling_overrides() {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wealthfolio-app",
   "private": true,
-  "version": "3.6.1",
+  "version": "3.6.2",
   "packageManager": "pnpm@10.33.4",
   "type": "module",
   "workspaces": [

--- a/packages/addon-dev-tools/package.json
+++ b/packages/addon-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/addon-dev-tools",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "Development tools for Wealthfolio addons - hot reload server and CLI",
   "main": "index.js",
   "bin": {

--- a/packages/addon-dev-tools/templates/manifest.json.template
+++ b/packages/addon-dev-tools/templates/manifest.json.template
@@ -5,8 +5,8 @@
   "description": "{{description}}",
   "author": "{{author}}",
   "main": "dist/addon.js",
-  "sdkVersion": "3.6.1",
-  "minWealthfolioVersion": "3.6.1",
+  "sdkVersion": "3.6.2",
+  "minWealthfolioVersion": "3.6.2",
   "enabled": true,
   "contributes": {
     "routes": [{ "id": "{{addonId}}" }],
@@ -24,7 +24,7 @@
   },
   "hostDependencies": {
     "@tanstack/react-query": "^5.90.0",
-    "@wealthfolio/addon-sdk": "^3.6.1",
+    "@wealthfolio/addon-sdk": "^3.6.2",
     "@wealthfolio/ui": "^3.6.0",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.561.0",

--- a/packages/addon-dev-tools/templates/package.json.template
+++ b/packages/addon-dev-tools/templates/package.json.template
@@ -18,7 +18,7 @@
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.90.0",
-    "@wealthfolio/addon-sdk": "^3.6.1",
+    "@wealthfolio/addon-sdk": "^3.6.2",
     "@wealthfolio/ui": "^3.6.0",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.561.0",
@@ -30,7 +30,7 @@
     "@tanstack/react-query": "^5.90.20",
     "@tailwindcss/vite": "^4.1.13",
     "@wealthfolio/addon-dev-tools": "^3.6.0",
-    "@wealthfolio/addon-sdk": "^3.6.1",
+    "@wealthfolio/addon-sdk": "^3.6.2",
     "@wealthfolio/ui": "^3.6.0",
     "@types/node": "^20.0.0",
     "@types/react": "^19.2.13",

--- a/packages/addon-sdk/package.json
+++ b/packages/addon-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/addon-sdk",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "type": "module",
   "description": "TypeScript SDK for building Wealthfolio addons with enhanced functionality and type safety",
   "main": "dist/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/ui",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "type": "module",
   "description": "Wealthfolio UI components based on shadcn/ui and Tailwind CSS",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- bump the application, Rust workspace, frontend packages, and addon scaffolding to v3.6.2
- use the shared `ExternalLink` component for onboarding Connect links
- document and forward `WF_MCP_ENABLED` in web and Docker configuration
- allow AI provider tool permissions and tuning overrides to be reset after customization

## Why

Raw `target="_blank"` anchors are not handled reliably by Tauri webviews, so the onboarding Connect actions could fail to open. Routing them through the platform-aware `ExternalLink` component uses the Tauri shell adapter while preserving normal anchor semantics.

Web deployments also need an explicit, opt-in way to expose the MCP endpoint through environment and Compose configuration.

AI provider settings use nullable update fields to distinguish "leave unchanged" from "reset to defaults." Default nested-`Option` deserialization collapsed an explicit JSON `null` into the omitted-field case, so re-enabling every provider permission sent a reset that the backend ignored. The update model now preserves the tri-state intent for tool permissions and tuning overrides.

## Impact

- release metadata consistently reports v3.6.2
- onboarding Connect links open correctly in Tauri
- Docker/web operators can enable MCP with `WF_MCP_ENABLED=true`
- MCP remains disabled by default and existing authentication safety checks remain unchanged
- deselected AI provider permissions can be selected again, including restoring unrestricted/default access
- resetting provider tuning overrides works through the same corrected nullable-update contract

## Validation

- `pnpm lint` (passes; repository baseline warnings only)
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo clippy -p wealthfolio-ai --all-targets --all-features -- -D warnings`
- `cargo test -p wealthfolio-ai`
- frontend type-check
- frontend tests: 1,085 passed
- `cargo check --workspace`
- Docker Compose configuration validation
- formatting, JSON validation, and `git diff --check`
