### PR TITLE
fix(holdings): exclude FX from holding return percentages

### DIFF
--- a/apps/frontend/src/components/holding-performance-percent.test.tsx
+++ b/apps/frontend/src/components/holding-performance-percent.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { HoldingPerformancePercent } from "./holding-performance-percent";
+
+vi.mock("@wealthfolio/ui", () => ({
+  GainPercent: ({ value }: { value: number }) => <span>{`percent:${value}`}</span>,
+}));
+
+describe("HoldingPerformancePercent", () => {
+  it("renders an unavailable marker instead of inventing zero percent", () => {
+    const { rerender } = render(<HoldingPerformancePercent value={null} />);
+
+    expect(screen.getByText("-")).toBeInTheDocument();
+    expect(screen.queryByText("percent:0")).not.toBeInTheDocument();
+
+    rerender(<HoldingPerformancePercent value={0.1} />);
+    expect(screen.getByText("percent:0.1")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/components/holding-performance-percent.tsx
+++ b/apps/frontend/src/components/holding-performance-percent.tsx
@@ -1,0 +1,19 @@
+import { cn } from "@/lib/utils";
+import { GainPercent } from "@wealthfolio/ui";
+import type { ComponentProps } from "react";
+
+type HoldingPerformancePercentProps = Omit<ComponentProps<typeof GainPercent>, "value"> & {
+  value?: number | null;
+};
+
+export function HoldingPerformancePercent({
+  value,
+  className,
+  ...props
+}: HoldingPerformancePercentProps) {
+  if (value == null) {
+    return <span className={cn("text-muted-foreground", className)}>-</span>;
+  }
+
+  return <GainPercent value={value} className={className} {...props} />;
+}

--- a/apps/frontend/src/features/ai-assistant/components/tool-uis/holdings-tool-semantics.ts
+++ b/apps/frontend/src/features/ai-assistant/components/tool-uis/holdings-tool-semantics.ts
@@ -21,7 +21,7 @@ interface DailyHoldingPerformanceAmounts {
 
 export interface DailyPortfolioPerformance {
   changeAmount: number;
-  changePct: number;
+  changePct: number | null;
 }
 
 function percentageFromGrossBasis(amount: number, grossBasis: number): number | null {
@@ -61,24 +61,28 @@ export function calculateBasePortfolioPerformance(
 export function calculateDailyPortfolioPerformance(
   holdings: DailyHoldingPerformanceAmounts[],
 ): DailyPortfolioPerformance {
-  const grossExposure = holdings.reduce(
-    (sum, holding) => sum + Math.abs(holding.marketValueBase),
-    0,
-  );
-  const changeAmount = holdings.reduce(
-    (sum, holding) => sum + Math.abs(holding.marketValueBase) * (holding.dayChangePct ?? 0),
-    0,
-  );
+  let grossExposure = 0;
+  let changeAmount = 0;
+  let hasDailyPerformance = false;
+
+  holdings.forEach((holding) => {
+    if (holding.dayChangePct == null) return;
+
+    const exposure = Math.abs(holding.marketValueBase);
+    hasDailyPerformance = true;
+    grossExposure += exposure;
+    changeAmount += exposure * holding.dayChangePct;
+  });
 
   return {
     changeAmount,
-    changePct: grossExposure > 0 ? changeAmount / grossExposure : 0,
+    changePct: grossExposure > 0 ? changeAmount / grossExposure : hasDailyPerformance ? 0 : null,
   };
 }
 
 export function getPortfolioChangePercent(
   returnType: ReturnType,
-  dailyChangePct: number,
+  dailyChangePct: number | null,
   totalPnlPct: number | null,
   totalReturnPct: number | null,
 ): number | null {

--- a/apps/frontend/src/features/ai-assistant/components/tool-uis/holdings-tool-semantics.ts
+++ b/apps/frontend/src/features/ai-assistant/components/tool-uis/holdings-tool-semantics.ts
@@ -1,0 +1,87 @@
+export type ReturnType = "daily" | "pnl" | "return";
+
+interface BaseHoldingPerformanceAmounts {
+  costBasisBase?: number | null;
+  totalGainBase?: number | null;
+  totalReturnBase?: number | null;
+  returnBasisBase?: number | null;
+}
+
+export interface BasePortfolioPerformance {
+  totalPnl: number;
+  totalPnlPct: number | null;
+  totalReturn: number;
+  totalReturnPct: number | null;
+}
+
+interface DailyHoldingPerformanceAmounts {
+  dayChangePct?: number | null;
+  marketValueBase: number;
+}
+
+export interface DailyPortfolioPerformance {
+  changeAmount: number;
+  changePct: number;
+}
+
+function percentageFromGrossBasis(amount: number, grossBasis: number): number | null {
+  if (grossBasis > 0) return amount / grossBasis;
+  return amount === 0 ? 0 : null;
+}
+
+export function calculateBasePortfolioPerformance(
+  holdings: BaseHoldingPerformanceAmounts[],
+): BasePortfolioPerformance {
+  let basis = 0;
+  let totalPnl = 0;
+  let totalReturn = 0;
+  let hasUnbasedPnl = false;
+  let hasUnbasedReturn = false;
+
+  holdings.forEach((holding) => {
+    const holdingBasis = Math.abs(holding.returnBasisBase ?? holding.costBasisBase ?? 0);
+    const holdingPnl = holding.totalGainBase ?? 0;
+    const holdingReturn = holding.totalReturnBase ?? holding.totalGainBase ?? 0;
+
+    basis += holdingBasis;
+    totalPnl += holdingPnl;
+    totalReturn += holdingReturn;
+    hasUnbasedPnl ||= holdingBasis === 0 && holdingPnl !== 0;
+    hasUnbasedReturn ||= holdingBasis === 0 && holdingReturn !== 0;
+  });
+
+  return {
+    totalPnl,
+    totalPnlPct: hasUnbasedPnl ? null : percentageFromGrossBasis(totalPnl, basis),
+    totalReturn,
+    totalReturnPct: hasUnbasedReturn ? null : percentageFromGrossBasis(totalReturn, basis),
+  };
+}
+
+export function calculateDailyPortfolioPerformance(
+  holdings: DailyHoldingPerformanceAmounts[],
+): DailyPortfolioPerformance {
+  const grossExposure = holdings.reduce(
+    (sum, holding) => sum + Math.abs(holding.marketValueBase),
+    0,
+  );
+  const changeAmount = holdings.reduce(
+    (sum, holding) => sum + Math.abs(holding.marketValueBase) * (holding.dayChangePct ?? 0),
+    0,
+  );
+
+  return {
+    changeAmount,
+    changePct: grossExposure > 0 ? changeAmount / grossExposure : 0,
+  };
+}
+
+export function getPortfolioChangePercent(
+  returnType: ReturnType,
+  dailyChangePct: number,
+  totalPnlPct: number | null,
+  totalReturnPct: number | null,
+): number | null {
+  if (returnType === "daily") return dailyChangePct;
+  return returnType === "return" ? totalReturnPct : totalPnlPct;
+}

--- a/apps/frontend/src/features/ai-assistant/components/tool-uis/holdings-tool-ui.test.ts
+++ b/apps/frontend/src/features/ai-assistant/components/tool-uis/holdings-tool-ui.test.ts
@@ -103,11 +103,31 @@ describe("calculateDailyPortfolioPerformance", () => {
     expect(performance.changeAmount).toBe(0);
     expect(performance.changePct).toBe(0);
   });
+
+  it("excludes holdings with unavailable daily returns from gross exposure", () => {
+    const performance = calculateDailyPortfolioPerformance([
+      { marketValueBase: 100, dayChangePct: 0.1 },
+      { marketValueBase: 100, dayChangePct: null },
+    ]);
+
+    expect(performance.changeAmount).toBe(10);
+    expect(performance.changePct).toBe(0.1);
+  });
+
+  it("returns an unavailable percentage when every daily return is unavailable", () => {
+    const performance = calculateDailyPortfolioPerformance([
+      { marketValueBase: 100, dayChangePct: null },
+    ]);
+
+    expect(performance.changeAmount).toBe(0);
+    expect(performance.changePct).toBeNull();
+  });
 });
 
 describe("getPortfolioChangePercent", () => {
   it("uses the weighted row value only for daily performance", () => {
     expect(getPortfolioChangePercent("daily", 0.03, 0.4, 0.5)).toBe(0.03);
+    expect(getPortfolioChangePercent("daily", null, 0.4, 0.5)).toBeNull();
   });
 
   it("uses base-currency aggregate returns for pnl and total return", () => {

--- a/apps/frontend/src/features/ai-assistant/components/tool-uis/holdings-tool-ui.test.ts
+++ b/apps/frontend/src/features/ai-assistant/components/tool-uis/holdings-tool-ui.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  calculateBasePortfolioPerformance,
+  calculateDailyPortfolioPerformance,
+  getPortfolioChangePercent,
+} from "./holdings-tool-semantics";
+
+describe("calculateBasePortfolioPerformance", () => {
+  it("uses gross exposure when long and short bases offset", () => {
+    const performance = calculateBasePortfolioPerformance([
+      { returnBasisBase: 100, totalGainBase: 10, totalReturnBase: 12 },
+      { returnBasisBase: -100, totalGainBase: 10, totalReturnBase: 8 },
+    ]);
+
+    expect(performance.totalPnl).toBe(20);
+    expect(performance.totalPnlPct).toBe(0.1);
+    expect(performance.totalReturn).toBe(20);
+    expect(performance.totalReturnPct).toBe(0.1);
+  });
+
+  it("returns zero percentages for an empty gross basis", () => {
+    const performance = calculateBasePortfolioPerformance([
+      { returnBasisBase: 0, totalGainBase: 0, totalReturnBase: 0 },
+    ]);
+
+    expect(performance.totalPnlPct).toBe(0);
+    expect(performance.totalReturnPct).toBe(0);
+  });
+
+  it("returns unavailable percentages for nonzero returns without gross basis", () => {
+    const performance = calculateBasePortfolioPerformance([
+      { returnBasisBase: 0, totalGainBase: 1, totalReturnBase: 2 },
+    ]);
+
+    expect(performance.totalPnlPct).toBeNull();
+    expect(performance.totalReturnPct).toBeNull();
+  });
+
+  it("does not dilute a nonzero unbased PnL into holdings with valid basis", () => {
+    const performance = calculateBasePortfolioPerformance([
+      { returnBasisBase: 100, totalGainBase: 10 },
+      { returnBasisBase: 0, totalGainBase: 20 },
+    ]);
+
+    expect(performance.totalPnl).toBe(30);
+    expect(performance.totalPnlPct).toBeNull();
+  });
+
+  it("tracks unavailable PnL and total return independently", () => {
+    const missingPnlBasis = calculateBasePortfolioPerformance([
+      { returnBasisBase: 100, totalGainBase: 10, totalReturnBase: 10 },
+      { totalGainBase: 20, totalReturnBase: 0 },
+    ]);
+    const missingReturnBasis = calculateBasePortfolioPerformance([
+      { returnBasisBase: 100, totalGainBase: 10, totalReturnBase: 10 },
+      { totalGainBase: 0, totalReturnBase: 20 },
+    ]);
+
+    expect(missingPnlBasis.totalPnlPct).toBeNull();
+    expect(missingPnlBasis.totalReturnPct).toBe(0.1);
+    expect(missingReturnBasis.totalPnlPct).toBe(0.1);
+    expect(missingReturnBasis.totalReturnPct).toBeNull();
+  });
+
+  it("does not invalidate percentages for zero returns without basis", () => {
+    const performance = calculateBasePortfolioPerformance([
+      { returnBasisBase: 100, totalGainBase: 10, totalReturnBase: 12 },
+      { totalGainBase: 0, totalReturnBase: 0 },
+    ]);
+
+    expect(performance.totalPnlPct).toBe(0.1);
+    expect(performance.totalReturnPct).toBe(0.12);
+  });
+});
+
+describe("calculateDailyPortfolioPerformance", () => {
+  it("uses gross exposure for long and short holdings", () => {
+    const performance = calculateDailyPortfolioPerformance([
+      { marketValueBase: 100, dayChangePct: 0.1 },
+      { marketValueBase: -100, dayChangePct: 0.2 },
+    ]);
+
+    expect(performance.changeAmount).toBe(30);
+    expect(performance.changePct).toBe(0.15);
+  });
+
+  it("keeps daily change available when net market value is zero", () => {
+    const performance = calculateDailyPortfolioPerformance([
+      { marketValueBase: 100, dayChangePct: 0.1 },
+      { marketValueBase: -100, dayChangePct: 0 },
+    ]);
+
+    expect(performance.changeAmount).toBe(10);
+    expect(performance.changePct).toBe(0.05);
+  });
+
+  it("returns zero daily performance when gross exposure is zero", () => {
+    const performance = calculateDailyPortfolioPerformance([
+      { marketValueBase: 0, dayChangePct: 0.1 },
+    ]);
+
+    expect(performance.changeAmount).toBe(0);
+    expect(performance.changePct).toBe(0);
+  });
+});
+
+describe("getPortfolioChangePercent", () => {
+  it("uses the weighted row value only for daily performance", () => {
+    expect(getPortfolioChangePercent("daily", 0.03, 0.4, 0.5)).toBe(0.03);
+  });
+
+  it("uses base-currency aggregate returns for pnl and total return", () => {
+    expect(getPortfolioChangePercent("pnl", 0.03, 0.4, 0.5)).toBe(0.4);
+    expect(getPortfolioChangePercent("return", 0.03, 0.4, 0.5)).toBe(0.5);
+  });
+});

--- a/apps/frontend/src/features/ai-assistant/components/tool-uis/holdings-tool-ui.tsx
+++ b/apps/frontend/src/features/ai-assistant/components/tool-uis/holdings-tool-ui.tsx
@@ -25,13 +25,18 @@ import { ResponsiveContainer, Treemap, Tooltip as ChartTooltip } from "recharts"
 import { useSettingsContext } from "@/lib/settings-provider";
 import { AnimatedToggleGroup } from "@wealthfolio/ui";
 import { CompactToolCard } from "./shared";
+import {
+  calculateBasePortfolioPerformance,
+  calculateDailyPortfolioPerformance,
+  getPortfolioChangePercent,
+  type ReturnType,
+} from "./holdings-tool-semantics";
 
 // ============================================================================
 // Types
 // ============================================================================
 
 type ViewMode = "table" | "treemap" | "both";
-type ReturnType = "daily" | "pnl" | "return";
 
 interface GetHoldingsArgs {
   accountId?: string;
@@ -385,34 +390,23 @@ function HoldingsContentImpl({ args, result, status }: HoldingsContentProps) {
     }
     const value =
       parsed?.totalValue ?? sortedHoldings.reduce((sum, h) => sum + h.marketValueBase, 0);
-    const basis = sortedHoldings.reduce(
-      (sum, h) => sum + (h.returnBasisBase ?? h.costBasisBase ?? 0),
-      0,
-    );
-    const pnl = sortedHoldings.reduce((sum, h) => sum + (h.totalGainBase ?? 0), 0);
-    const returnAmount = sortedHoldings.reduce(
-      (sum, h) => sum + (h.totalReturnBase ?? h.totalGainBase ?? 0),
-      0,
-    );
+    const performance = calculateBasePortfolioPerformance(sortedHoldings);
     return {
       totalValue: value,
-      totalPnl: pnl,
-      totalPnlPct: basis > 0 ? pnl / basis : 0,
-      totalReturn: returnAmount,
-      totalReturnPct: basis > 0 ? returnAmount / basis : 0,
+      ...performance,
     };
   }, [parsed?.totalValue, sortedHoldings]);
 
   // Prepare treemap data based on returnType
   // Note: dayChangePct and unrealizedGainPct from backend are in decimal form (e.g., -0.1579 for -15.79%)
-  const { treemapData, hasData, totalChange } = useMemo(() => {
+  const { treemapData, hasData, dailyChangeAmount, weightedDailyChange } = useMemo(() => {
     let maxGain = -Infinity;
     let minGain = Infinity;
-    let totalChangeAmount = 0;
     let hasAnyData = false;
+    const dailyPerformance = calculateDailyPortfolioPerformance(sortedHoldings);
 
     const data = sortedHoldings
-      .filter((h) => h.marketValueBase > 0)
+      .filter((h) => h.marketValueBase !== 0)
       .map((h) => {
         const gain =
           returnType === "daily"
@@ -425,12 +419,11 @@ function HoldingsContentImpl({ args, result, status }: HoldingsContentProps) {
           hasAnyData = true;
           maxGain = Math.max(maxGain, gain);
           minGain = Math.min(minGain, gain);
-          totalChangeAmount += h.marketValueBase * gain;
         }
         return {
           symbol: h.symbol,
           name: h.name,
-          marketValue: h.marketValueBase,
+          marketValue: Math.abs(h.marketValueBase),
           gain,
         };
       });
@@ -441,10 +434,20 @@ function HoldingsContentImpl({ args, result, status }: HoldingsContentProps) {
       minGain: minGain === Infinity ? 0 : minGain,
     }));
 
-    const totalChangePct = totalValue > 0 ? totalChangeAmount / totalValue : 0;
+    return {
+      treemapData,
+      hasData: hasAnyData,
+      dailyChangeAmount: dailyPerformance.changeAmount,
+      weightedDailyChange: dailyPerformance.changePct,
+    };
+  }, [sortedHoldings, returnType]);
 
-    return { treemapData, hasData: hasAnyData, totalChange: totalChangePct };
-  }, [sortedHoldings, totalValue, returnType]);
+  const portfolioChange = getPortfolioChangePercent(
+    returnType,
+    weightedDailyChange,
+    totalPnlPct,
+    totalReturnPct,
+  );
 
   const accountLabel = parsed?.accountScope ?? args?.accountId ?? "Portfolio";
   const isLoading = status?.type === "running";
@@ -577,16 +580,26 @@ function HoldingsContentImpl({ args, result, status }: HoldingsContentProps) {
             <p
               className={cn(
                 "text-sm font-medium",
-                totalChange >= 0 ? "text-success" : "text-destructive",
+                portfolioChange == null
+                  ? "text-muted-foreground"
+                  : portfolioChange >= 0
+                    ? "text-success"
+                    : "text-destructive",
               )}
             >
-              {totalChange > 0 ? "+" : ""}
-              {formatPercent(totalChange)}{" "}
-              {returnType === "daily"
-                ? t("ai:holdings.todaySuffix")
-                : returnType === "return"
-                  ? t("ai:holdings.returnSuffix")
-                  : t("ai:holdings.pnlSuffix")}
+              {portfolioChange == null ? (
+                "-"
+              ) : (
+                <>
+                  {portfolioChange > 0 ? "+" : ""}
+                  {formatPercent(portfolioChange)}{" "}
+                  {returnType === "daily"
+                    ? t("ai:holdings.todaySuffix")
+                    : returnType === "return"
+                      ? t("ai:holdings.returnSuffix")
+                      : t("ai:holdings.pnlSuffix")}
+                </>
+              )}
             </p>
           )}
         </div>
@@ -608,14 +621,9 @@ function HoldingsContentImpl({ args, result, status }: HoldingsContentProps) {
 
   // Table view component
   const TableView = ({ showHeader = true }: { showHeader?: boolean }) => {
-    const gainPct =
-      returnType === "daily" ? totalChange : returnType === "return" ? totalReturnPct : totalPnlPct;
+    const gainPct = portfolioChange;
     const gainAmount =
-      returnType === "daily"
-        ? totalValue * totalChange
-        : returnType === "return"
-          ? totalReturn
-          : totalPnl;
+      returnType === "daily" ? dailyChangeAmount : returnType === "return" ? totalReturn : totalPnl;
 
     return (
       <>
@@ -649,8 +657,16 @@ function HoldingsContentImpl({ args, result, status }: HoldingsContentProps) {
                   )}
                 >
                   {gainAmount > 0 ? "+" : ""}
-                  {formatAmount(gainAmount, currency)} ({gainPct > 0 ? "+" : ""}
-                  {formatPercent(gainPct)})
+                  {formatAmount(gainAmount, currency)} (
+                  {gainPct == null ? (
+                    "-"
+                  ) : (
+                    <>
+                      {gainPct > 0 ? "+" : ""}
+                      {formatPercent(gainPct)}
+                    </>
+                  )}
+                  )
                 </p>
               )}
             </div>

--- a/apps/frontend/src/lib/holding-performance.test.ts
+++ b/apps/frontend/src/lib/holding-performance.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { getBaseHoldingPerformancePercent } from "./holding-performance";
+import {
+  getBaseHoldingPerformancePercent,
+  getBaseHoldingPerformancePercentForMode,
+} from "./holding-performance";
 
 describe("getBaseHoldingPerformancePercent", () => {
   it("derives FX-inclusive percentages independently from local performance", () => {
@@ -32,5 +35,37 @@ describe("getBaseHoldingPerformancePercent", () => {
     expect(getBaseHoldingPerformancePercent(holding, "unrealizedGain")).toBe(0);
     expect(getBaseHoldingPerformancePercent(holding, "totalGain")).toBe(0);
     expect(getBaseHoldingPerformancePercent(holding, "totalReturn")).toBeNull();
+  });
+});
+
+describe("getBaseHoldingPerformancePercentForMode", () => {
+  it("uses base returns for pnl and return modes while preserving daily performance", () => {
+    const holding = {
+      costBasis: { local: 100, base: 100 },
+      dayChangePct: -0.02,
+      unrealizedGain: { local: -10, base: 10 },
+      realizedGain: null,
+      totalGain: { local: -10, base: 10 },
+      totalReturn: { local: -5, base: 12 },
+      returnBasis: { local: 100, base: 100 },
+    };
+
+    expect(getBaseHoldingPerformancePercentForMode(holding, "daily")).toBe(-0.02);
+    expect(getBaseHoldingPerformancePercentForMode(holding, "pnl")).toBe(0.1);
+    expect(getBaseHoldingPerformancePercentForMode(holding, "return")).toBe(0.12);
+  });
+
+  it("falls back to base total gain when total return is unavailable", () => {
+    const holding = {
+      costBasis: { local: 100, base: 100 },
+      dayChangePct: null,
+      unrealizedGain: { local: -10, base: 10 },
+      realizedGain: null,
+      totalGain: { local: -10, base: 10 },
+      totalReturn: null,
+      returnBasis: { local: 100, base: 100 },
+    };
+
+    expect(getBaseHoldingPerformancePercentForMode(holding, "return")).toBe(0.1);
   });
 });

--- a/apps/frontend/src/lib/holding-performance.test.ts
+++ b/apps/frontend/src/lib/holding-performance.test.ts
@@ -66,6 +66,21 @@ describe("getBaseHoldingPerformancePercentForMode", () => {
       returnBasis: { local: 100, base: 100 },
     };
 
+    expect(getBaseHoldingPerformancePercentForMode(holding, "daily")).toBeNull();
     expect(getBaseHoldingPerformancePercentForMode(holding, "return")).toBe(0.1);
+  });
+
+  it("falls back to base unrealized gain when total PnL is unavailable", () => {
+    const holding = {
+      costBasis: { local: 100, base: 100 },
+      dayChangePct: null,
+      unrealizedGain: { local: -10, base: 10 },
+      realizedGain: null,
+      totalGain: null,
+      totalReturn: null,
+      returnBasis: { local: 100, base: 100 },
+    };
+
+    expect(getBaseHoldingPerformancePercentForMode(holding, "pnl")).toBe(0.1);
   });
 });

--- a/apps/frontend/src/lib/holding-performance.test.ts
+++ b/apps/frontend/src/lib/holding-performance.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { getBaseHoldingPerformancePercent } from "./holding-performance";
+
+describe("getBaseHoldingPerformancePercent", () => {
+  it("derives FX-inclusive percentages independently from local performance", () => {
+    const holding = {
+      costBasis: { local: 100, base: 50 },
+      unrealizedGain: { local: 10, base: -20 },
+      realizedGain: { local: 20, base: 5 },
+      totalGain: { local: 30, base: -15 },
+      totalReturn: { local: 35, base: -13 },
+      returnBasis: { local: 150, base: 75 },
+    };
+
+    expect(getBaseHoldingPerformancePercent(holding, "unrealizedGain")).toBe(-0.4);
+    expect(getBaseHoldingPerformancePercent(holding, "realizedGain")).toBe(0.2);
+    expect(getBaseHoldingPerformancePercent(holding, "totalGain")).toBe(-0.2);
+    expect(getBaseHoldingPerformancePercent(holding, "totalReturn")).toBeCloseTo(-13 / 75);
+  });
+
+  it("matches the backend zero-basis behavior", () => {
+    const holding = {
+      costBasis: { local: 0, base: 0 },
+      unrealizedGain: { local: 0, base: 0 },
+      realizedGain: null,
+      totalGain: { local: 0, base: 0 },
+      totalReturn: { local: 0, base: 1 },
+      returnBasis: { local: 0, base: 0 },
+    };
+
+    expect(getBaseHoldingPerformancePercent(holding, "unrealizedGain")).toBe(0);
+    expect(getBaseHoldingPerformancePercent(holding, "totalGain")).toBe(0);
+    expect(getBaseHoldingPerformancePercent(holding, "totalReturn")).toBeNull();
+  });
+});

--- a/apps/frontend/src/lib/holding-performance.ts
+++ b/apps/frontend/src/lib/holding-performance.ts
@@ -6,10 +6,14 @@ export type HoldingPerformanceMetric =
   | "totalGain"
   | "totalReturn";
 
+export type HoldingPerformanceMode = "daily" | "pnl" | "return";
+
 type HoldingPerformanceValues = Pick<
   Holding,
   "costBasis" | "unrealizedGain" | "realizedGain" | "totalGain" | "totalReturn" | "returnBasis"
 >;
+
+type HoldingPerformanceModeValues = HoldingPerformanceValues & Pick<Holding, "dayChangePct">;
 
 function percentFromBasis(amount: number, basis: number): number | null {
   const exposure = Math.abs(basis);
@@ -36,4 +40,19 @@ export function getBaseHoldingPerformancePercent(
   const amount = metric === "totalReturn" ? holding.totalReturn : holding.totalGain;
   if (amount == null || holding.returnBasis == null) return null;
   return percentFromBasis(amount.base, holding.returnBasis.base);
+}
+
+/** Selects the percentage matching base-currency values for a performance mode. */
+export function getBaseHoldingPerformancePercentForMode(
+  holding: HoldingPerformanceModeValues,
+  mode: HoldingPerformanceMode,
+): number | null {
+  if (mode === "daily") return holding.dayChangePct ?? null;
+  if (mode === "return") {
+    return (
+      getBaseHoldingPerformancePercent(holding, "totalReturn") ??
+      getBaseHoldingPerformancePercent(holding, "totalGain")
+    );
+  }
+  return getBaseHoldingPerformancePercent(holding, "totalGain");
 }

--- a/apps/frontend/src/lib/holding-performance.ts
+++ b/apps/frontend/src/lib/holding-performance.ts
@@ -54,5 +54,8 @@ export function getBaseHoldingPerformancePercentForMode(
       getBaseHoldingPerformancePercent(holding, "totalGain")
     );
   }
-  return getBaseHoldingPerformancePercent(holding, "totalGain");
+  return (
+    getBaseHoldingPerformancePercent(holding, "totalGain") ??
+    getBaseHoldingPerformancePercent(holding, "unrealizedGain")
+  );
 }

--- a/apps/frontend/src/lib/holding-performance.ts
+++ b/apps/frontend/src/lib/holding-performance.ts
@@ -1,0 +1,39 @@
+import type { Holding } from "@/lib/types";
+
+export type HoldingPerformanceMetric =
+  | "unrealizedGain"
+  | "realizedGain"
+  | "totalGain"
+  | "totalReturn";
+
+type HoldingPerformanceValues = Pick<
+  Holding,
+  "costBasis" | "unrealizedGain" | "realizedGain" | "totalGain" | "totalReturn" | "returnBasis"
+>;
+
+function percentFromBasis(amount: number, basis: number): number | null {
+  const exposure = Math.abs(basis);
+  if (exposure > 0) return amount / exposure;
+  return amount === 0 ? 0 : null;
+}
+
+/** Returns the FX-inclusive performance percentage for a base-currency amount. */
+export function getBaseHoldingPerformancePercent(
+  holding: HoldingPerformanceValues,
+  metric: HoldingPerformanceMetric,
+): number | null {
+  if (metric === "unrealizedGain") {
+    if (holding.unrealizedGain == null || holding.costBasis == null) return null;
+    return percentFromBasis(holding.unrealizedGain.base, holding.costBasis.base);
+  }
+
+  if (metric === "realizedGain") {
+    if (holding.realizedGain == null || holding.returnBasis == null) return null;
+    const disposedBasis = holding.returnBasis.base - (holding.costBasis?.base ?? 0);
+    return percentFromBasis(holding.realizedGain.base, disposedBasis);
+  }
+
+  const amount = metric === "totalReturn" ? holding.totalReturn : holding.totalGain;
+  if (amount == null || holding.returnBasis == null) return null;
+  return percentFromBasis(amount.base, holding.returnBasis.base);
+}

--- a/apps/frontend/src/pages/asset/asset-detail-card.test.tsx
+++ b/apps/frontend/src/pages/asset/asset-detail-card.test.tsx
@@ -42,9 +42,54 @@ describe("AssetDetailCard", () => {
     );
 
     expect(screen.getByText("Income")).toBeInTheDocument();
+    expect(screen.queryByText("FX effect")).not.toBeInTheDocument();
     expect(screen.getByText("Total P&L")).toBeInTheDocument();
     expect(screen.getByText("Total Return")).toBeInTheDocument();
   });
+
+  it.each([
+    { currency: "USD", baseCurrency: "USD", fxEffect: 25, visible: false },
+    { currency: "USD", baseCurrency: "CAD", fxEffect: 0, visible: true },
+    { currency: "USD", baseCurrency: "CAD", fxEffect: 25, visible: true },
+  ])(
+    "renders the FX row only for available foreign-currency effects: $currency/$baseCurrency at $fxEffect",
+    ({ currency, baseCurrency, fxEffect, visible }) => {
+      render(
+        <AssetDetailCard
+          assetData={{
+            numShares: 10,
+            marketValue: 1250,
+            costBasis: 1000,
+            averagePrice: 100,
+            portfolioPercent: 0.25,
+            todaysReturn: null,
+            todaysReturnPercent: null,
+            unrealizedPnl: 200,
+            unrealizedPnlPercent: 0.2,
+            realizedPnl: null,
+            realizedPnlPercent: null,
+            income: 0,
+            fxEffect,
+            priceReturnPercent: 0.12,
+            totalPnl: 200,
+            totalPnlPercent: 0.2,
+            totalReturn: 200,
+            totalReturnPercent: 0.2,
+            currency,
+            baseCurrency,
+            quoteCurrency: null,
+            quote: null,
+          }}
+        />,
+      );
+
+      if (visible) {
+        expect(screen.getByText("FX effect")).toBeInTheDocument();
+      } else {
+        expect(screen.queryByText("FX effect")).not.toBeInTheDocument();
+      }
+    },
+  );
 
   it("uses option-specific quantity and average-cost labels", () => {
     render(

--- a/apps/frontend/src/pages/asset/asset-detail-card.tsx
+++ b/apps/frontend/src/pages/asset/asset-detail-card.tsx
@@ -216,7 +216,7 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
         <Separator className="my-3" />
         <div>
           <SectionHeader>{t("asset:detailCard.position")}</SectionHeader>
-          <div className="space-y-1.5 text-sm">
+          <div className="space-y-2 text-sm">
             {positionRows.map(({ label, value }, idx) => (
               <div key={idx} className="flex justify-between">
                 <span className="text-muted-foreground">{label}</span>
@@ -265,7 +265,7 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
             <Separator className="my-3" />
             <div>
               <SectionHeader>{t("asset:detailCard.day_range")}</SectionHeader>
-              <div className="grid grid-cols-2 gap-x-6 gap-y-2">
+              <div className="grid grid-cols-2 gap-x-6 gap-y-2.5">
                 <div className="flex flex-col">
                   <span className="text-muted-foreground text-xs">
                     {t("asset:detailCard.open")}

--- a/apps/frontend/src/pages/asset/asset-detail-card.tsx
+++ b/apps/frontend/src/pages/asset/asset-detail-card.tsx
@@ -100,6 +100,8 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
   const averageCostLabel = isOption
     ? t("asset:detailCard.average_premium")
     : t("asset:detailCard.average_cost");
+  const hasFxEffect =
+    fxEffect !== null && currency.trim().toUpperCase() !== baseCurrency.trim().toUpperCase();
 
   const amountTone = (amount: number | null) => {
     if (amount == null || amount === 0) return "";
@@ -157,13 +159,17 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
       percent: null,
       color: amountTone(income),
     },
-    {
-      label: t("asset:detailCard.fx_effect"),
-      amount: fxEffect,
-      currency: baseCurrency,
-      percent: null,
-      color: amountTone(fxEffect),
-    },
+    ...(hasFxEffect
+      ? [
+          {
+            label: t("asset:detailCard.fx_effect"),
+            amount: fxEffect,
+            currency: baseCurrency,
+            percent: null,
+            color: amountTone(fxEffect),
+          },
+        ]
+      : []),
     {
       label: t("asset:detailCard.price_return"),
       amount: null,

--- a/apps/frontend/src/pages/asset/asset-detail-card.tsx
+++ b/apps/frontend/src/pages/asset/asset-detail-card.tsx
@@ -265,7 +265,7 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
             <Separator className="my-3" />
             <div>
               <SectionHeader>{t("asset:detailCard.day_range")}</SectionHeader>
-              <div className="grid grid-cols-2 gap-x-6 gap-y-2.5">
+              <div className="grid grid-cols-2 gap-x-6 gap-y-2">
                 <div className="flex flex-col">
                   <span className="text-muted-foreground text-xs">
                     {t("asset:detailCard.open")}

--- a/apps/frontend/src/pages/asset/asset-detail-card.tsx
+++ b/apps/frontend/src/pages/asset/asset-detail-card.tsx
@@ -229,7 +229,7 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
         <Separator className="my-3" />
         <div>
           <SectionHeader>{t("asset:detailCard.performance")}</SectionHeader>
-          <div className="space-y-1.5 text-sm">
+          <div className="space-y-2 text-sm">
             {performanceRows.map(
               ({ label, amount, currency: rowCurrency, percent, color }, idx) => (
                 <div key={idx} className="flex items-center justify-between">

--- a/apps/frontend/src/pages/asset/asset-profile-page.tsx
+++ b/apps/frontend/src/pages/asset/asset-profile-page.tsx
@@ -774,7 +774,11 @@ export const AssetProfilePage = () => {
     const hasOpenTransactionLotWithBase = assetLots.some(
       (lot) => lot.source === "TRANSACTION_LOT" && !lot.isClosed && lot.costBasisBase != null,
     );
+    const isForeignCurrency =
+      displayCurrency.trim().toUpperCase() !==
+      (holding?.baseCurrency ?? baseCurrency).trim().toUpperCase();
     const fxEffect =
+      isForeignCurrency &&
       hasOpenTransactionLotWithBase &&
       holding?.unrealizedGain?.base != null &&
       holding?.unrealizedGain?.local != null &&

--- a/apps/frontend/src/pages/dashboard/top-holdings.tsx
+++ b/apps/frontend/src/pages/dashboard/top-holdings.tsx
@@ -3,7 +3,7 @@ import { HoldingPerformancePercent } from "@/components/holding-performance-perc
 import { TickerAvatar } from "@/components/ticker-avatar";
 import { Skeleton } from "@wealthfolio/ui/components/ui/skeleton";
 import { HoldingType, isAlternativeAssetKind } from "@/lib/constants";
-import { getBaseHoldingPerformancePercent } from "@/lib/holding-performance";
+import { getBaseHoldingPerformancePercentForMode } from "@/lib/holding-performance";
 import { parseOccSymbol } from "@/lib/occ-symbol";
 import { Holding } from "@/lib/types";
 import { cn } from "@/lib/utils";
@@ -62,14 +62,7 @@ function HoldingRow({
       : performanceMode === "pnl"
         ? (holding.totalGain?.base ?? holding.unrealizedGain?.base ?? 0)
         : (holding.dayChange?.base ?? 0);
-  const gainPercent =
-    performanceMode === "return"
-      ? (getBaseHoldingPerformancePercent(holding, "totalReturn") ??
-        getBaseHoldingPerformancePercent(holding, "totalGain"))
-      : performanceMode === "pnl"
-        ? (getBaseHoldingPerformancePercent(holding, "totalGain") ??
-          getBaseHoldingPerformancePercent(holding, "unrealizedGain"))
-        : (holding.dayChangePct ?? 0);
+  const gainPercent = getBaseHoldingPerformancePercentForMode(holding, performanceMode);
 
   return (
     <div

--- a/apps/frontend/src/pages/dashboard/top-holdings.tsx
+++ b/apps/frontend/src/pages/dashboard/top-holdings.tsx
@@ -1,18 +1,13 @@
 import { DashboardCard } from "@/components/dashboard-card";
+import { HoldingPerformancePercent } from "@/components/holding-performance-percent";
 import { TickerAvatar } from "@/components/ticker-avatar";
 import { Skeleton } from "@wealthfolio/ui/components/ui/skeleton";
 import { HoldingType, isAlternativeAssetKind } from "@/lib/constants";
+import { getBaseHoldingPerformancePercent } from "@/lib/holding-performance";
 import { parseOccSymbol } from "@/lib/occ-symbol";
 import { Holding } from "@/lib/types";
 import { cn } from "@/lib/utils";
-import {
-  AmountDisplay,
-  Button,
-  GainAmount,
-  GainPercent,
-  Icons,
-  usePersistentState,
-} from "@wealthfolio/ui";
+import { AmountDisplay, Button, GainAmount, Icons, usePersistentState } from "@wealthfolio/ui";
 import { Popover, PopoverContent, PopoverTrigger } from "@wealthfolio/ui/components/ui/popover";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
@@ -69,9 +64,11 @@ function HoldingRow({
         : (holding.dayChange?.base ?? 0);
   const gainPercent =
     performanceMode === "return"
-      ? (holding.totalReturnPct ?? holding.totalGainPct ?? 0)
+      ? (getBaseHoldingPerformancePercent(holding, "totalReturn") ??
+        getBaseHoldingPerformancePercent(holding, "totalGain"))
       : performanceMode === "pnl"
-        ? (holding.totalGainPct ?? holding.unrealizedGainPct ?? 0)
+        ? (getBaseHoldingPerformancePercent(holding, "totalGain") ??
+          getBaseHoldingPerformancePercent(holding, "unrealizedGain"))
         : (holding.dayChangePct ?? 0);
 
   return (
@@ -103,10 +100,10 @@ function HoldingRow({
             displayCurrency={false}
             className="text-xs"
           />
-          <GainPercent
+          <HoldingPerformancePercent
             value={gainPercent}
             variant="badge"
-            className="min-w-[60px] justify-center text-xs"
+            className="min-w-[60px] justify-center text-center text-xs"
           />
         </div>
       </div>

--- a/apps/frontend/src/pages/holdings/components/composition-chart.tsx
+++ b/apps/frontend/src/pages/holdings/components/composition-chart.tsx
@@ -1,5 +1,6 @@
 import { RenderableChartContainer } from "@/components/renderable-chart-container";
 import { usePersistentState } from "@/hooks/use-persistent-state";
+import { getBaseHoldingPerformancePercentForMode } from "@/lib/holding-performance";
 import { useSettingsContext } from "@/lib/settings-provider";
 import { Holding } from "@/lib/types";
 import { cn, parseLocalDate } from "@/lib/utils";
@@ -326,12 +327,7 @@ export function PortfolioComposition({ holdings, isLoading }: PortfolioCompositi
         const symbol = holding.instrument?.symbol;
         if (!symbol) return null; // Skip if no symbol
 
-        const gain =
-          returnType === "daily"
-            ? Number(holding.dayChangePct) || 0
-            : returnType === "return"
-              ? Number(holding.totalReturnPct) || 0
-              : Number(holding.totalGainPct) || 0;
+        const gain = getBaseHoldingPerformancePercentForMode(holding, returnType) ?? 0;
 
         const marketValue = Number(holding.marketValue?.base) || 0;
 

--- a/apps/frontend/src/pages/holdings/components/holdings-grouped-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-grouped-table.tsx
@@ -6,11 +6,13 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@wealthfolio/ui/components/ui/collapsible";
-import { AmountDisplay, GainPercent, QuantityDisplay } from "@wealthfolio/ui";
+import { AmountDisplay, QuantityDisplay } from "@wealthfolio/ui";
+import { HoldingPerformancePercent } from "@/components/holding-performance-percent";
 import { TickerAvatar } from "@/components/ticker-avatar";
 import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
 import { Holding, HOLDING_GROUP_ORDER } from "@/lib/types";
 import { AccountType, AssetKind, HoldingType } from "@/lib/constants";
+import { getBaseHoldingPerformancePercent } from "@/lib/holding-performance";
 import { cn, safeDivide } from "@/lib/utils";
 import { useSettingsContext } from "@/lib/settings-provider";
 import { useState, useMemo } from "react";
@@ -244,9 +246,14 @@ function HoldingRow({
           : (holding.dayChange?.local ?? 0);
   const gainPct =
     performanceMode === "return"
-      ? (holding.totalReturnPct ?? holding.totalGainPct)
+      ? showConvertedValues
+        ? (getBaseHoldingPerformancePercent(holding, "totalReturn") ??
+          getBaseHoldingPerformancePercent(holding, "totalGain"))
+        : (holding.totalReturnPct ?? holding.totalGainPct)
       : performanceMode === "pnl"
-        ? holding.totalGainPct
+        ? showConvertedValues
+          ? getBaseHoldingPerformancePercent(holding, "totalGain")
+          : holding.totalGainPct
         : holding.dayChangePct;
 
   return (
@@ -303,7 +310,7 @@ function HoldingRow({
                 isHidden={isBalanceHidden}
                 colorFormat={true}
               />
-              <GainPercent className="text-xs" value={gainPct ?? 0} />
+              <HoldingPerformancePercent className="text-xs" value={gainPct} />
             </>
           )}
           {holding.isLiability && <span className="text-muted-foreground text-sm">--</span>}

--- a/apps/frontend/src/pages/holdings/components/holdings-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table.tsx
@@ -14,8 +14,10 @@ import {
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
 
 import { TickerAvatar } from "@/components/ticker-avatar";
+import { HoldingPerformancePercent } from "@/components/holding-performance-percent";
 import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
 import { HoldingType } from "@/lib/constants";
+import { getBaseHoldingPerformancePercent } from "@/lib/holding-performance";
 import { useSettingsContext } from "@/lib/settings-provider";
 import { Holding } from "@/lib/types";
 import { AmountDisplay, PriceDisplay, QuantityDisplay, formatPercent } from "@wealthfolio/ui";
@@ -495,11 +497,14 @@ const getColumns = (
         ? (holding.totalGain?.base ?? 0)
         : (holding.totalGain?.local ?? 0);
       const currency = showConvertedValues ? holding.baseCurrency : holding.localCurrency;
+      const percentage = showConvertedValues
+        ? getBaseHoldingPerformancePercent(holding, "totalGain")
+        : holding.totalGainPct;
 
       return (
         <div className="flex min-h-[40px] flex-col items-end justify-center px-4">
           <AmountDisplay value={value} currency={currency} colorFormat={true} isHidden={isHidden} />
-          <GainPercent className="text-xs" value={holding.totalGainPct || 0} />
+          <HoldingPerformancePercent className="text-xs" value={percentage} />
         </div>
       );
     },
@@ -534,11 +539,14 @@ const getColumns = (
         ? (holding.totalReturn?.base ?? 0)
         : (holding.totalReturn?.local ?? 0);
       const currency = showConvertedValues ? holding.baseCurrency : holding.localCurrency;
+      const percentage = showConvertedValues
+        ? getBaseHoldingPerformancePercent(holding, "totalReturn")
+        : holding.totalReturnPct;
 
       return (
         <div className="flex min-h-[40px] flex-col items-end justify-center px-4">
           <AmountDisplay value={value} currency={currency} colorFormat={true} isHidden={isHidden} />
-          <GainPercent className="text-xs" value={holding.totalReturnPct || 0} />
+          <HoldingPerformancePercent className="text-xs" value={percentage} />
         </div>
       );
     },
@@ -602,11 +610,14 @@ const getColumns = (
         ? (holding.unrealizedGain?.base ?? 0)
         : (holding.unrealizedGain?.local ?? 0);
       const currency = showConvertedValues ? holding.baseCurrency : holding.localCurrency;
+      const percentage = showConvertedValues
+        ? getBaseHoldingPerformancePercent(holding, "unrealizedGain")
+        : holding.unrealizedGainPct;
 
       return (
         <div className="flex min-h-[40px] flex-col items-end justify-center px-4">
           <AmountDisplay value={value} currency={currency} colorFormat={true} isHidden={isHidden} />
-          <GainPercent className="text-xs" value={holding.unrealizedGainPct || 0} />
+          <HoldingPerformancePercent className="text-xs" value={percentage} />
         </div>
       );
     },
@@ -636,15 +647,14 @@ const getColumns = (
         ? (holding.realizedGain?.base ?? 0)
         : (holding.realizedGain?.local ?? 0);
       const currency = showConvertedValues ? holding.baseCurrency : holding.localCurrency;
+      const percentage = showConvertedValues
+        ? getBaseHoldingPerformancePercent(holding, "realizedGain")
+        : holding.realizedGainPct;
 
       return (
         <div className="flex min-h-[40px] flex-col items-end justify-center px-4">
           <AmountDisplay value={value} currency={currency} colorFormat={true} isHidden={isHidden} />
-          {holding.realizedGainPct == null ? (
-            <span className="text-muted-foreground text-xs">-</span>
-          ) : (
-            <GainPercent className="text-xs" value={holding.realizedGainPct} />
-          )}
+          <HoldingPerformancePercent className="text-xs" value={percentage} />
         </div>
       );
     },

--- a/crates/agent-tools/src/tools/holdings.rs
+++ b/crates/agent-tools/src/tools/holdings.rs
@@ -1,9 +1,10 @@
 //! Holdings tool - fetch portfolio holdings.
 
-use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::{prelude::ToPrimitive, Decimal};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use wealthfolio_core::accounts::{account_supports_purpose, AccountPurpose};
+use wealthfolio_core::holdings::Holding;
 
 use crate::constants::MAX_HOLDINGS;
 use crate::env::AgentEnvironment;
@@ -41,15 +42,19 @@ pub struct HoldingDto {
     pub quantity: f64,
     pub market_value_base: f64,
     pub cost_basis_base: Option<f64>,
+    /// Base-currency unrealized return, including FX effects.
     pub unrealized_gain_pct: Option<f64>,
     pub total_gain_base: Option<f64>,
+    /// Base-currency total gain return, including FX effects.
     pub total_gain_pct: Option<f64>,
     pub income_base: Option<f64>,
     pub total_return_base: Option<f64>,
+    /// Base-currency total return, including FX effects.
     pub total_return_pct: Option<f64>,
     pub return_basis_base: Option<f64>,
     pub day_change_pct: Option<f64>,
     pub weight: f64,
+    /// Portfolio base currency used by the monetary fields above.
     pub currency: String,
 }
 
@@ -72,6 +77,59 @@ pub struct GetHoldingsOutput {
 /// Tool to get portfolio holdings.
 pub struct GetHoldings;
 
+fn base_percentage(amount: Option<Decimal>, basis: Option<Decimal>) -> Option<f64> {
+    let amount = amount?;
+    let basis = basis?;
+    let exposure = basis.abs();
+    if exposure > Decimal::ZERO {
+        (amount / exposure).to_f64()
+    } else if amount.is_zero() {
+        Some(0.0)
+    } else {
+        None
+    }
+}
+
+fn holding_to_dto(h: Holding, account: String) -> HoldingDto {
+    let (symbol, name) = h
+        .instrument
+        .as_ref()
+        .map(|i| (i.symbol.clone(), i.name.clone()))
+        .unwrap_or_else(|| ("CASH".to_string(), None));
+
+    let holding_type = match h.holding_type {
+        wealthfolio_core::holdings::HoldingType::Cash => "Cash",
+        wealthfolio_core::holdings::HoldingType::Security => "Security",
+        wealthfolio_core::holdings::HoldingType::AlternativeAsset => "AlternativeAsset",
+    };
+
+    let cost_basis_base = h.cost_basis.as_ref().map(|value| value.base);
+    let return_basis_base = h.return_basis.as_ref().map(|value| value.base);
+    let unrealized_gain_base = h.unrealized_gain.as_ref().map(|value| value.base);
+    let total_gain_base = h.total_gain.as_ref().map(|value| value.base);
+    let total_return_base = h.total_return.as_ref().map(|value| value.base);
+
+    HoldingDto {
+        account,
+        symbol,
+        name,
+        holding_type: holding_type.to_string(),
+        quantity: h.quantity.to_f64().unwrap_or(0.0),
+        market_value_base: h.market_value.base.to_f64().unwrap_or(0.0),
+        cost_basis_base: cost_basis_base.and_then(|value| value.to_f64()),
+        unrealized_gain_pct: base_percentage(unrealized_gain_base, cost_basis_base),
+        total_gain_base: total_gain_base.and_then(|value| value.to_f64()),
+        total_gain_pct: base_percentage(total_gain_base, return_basis_base),
+        income_base: h.income.as_ref().and_then(|v| v.base.to_f64()),
+        total_return_base: total_return_base.and_then(|value| value.to_f64()),
+        total_return_pct: base_percentage(total_return_base, return_basis_base),
+        return_basis_base: return_basis_base.and_then(|value| value.to_f64()),
+        day_change_pct: h.day_change_pct.and_then(|d| d.to_f64()),
+        weight: h.weight.to_f64().unwrap_or(0.0),
+        currency: h.base_currency,
+    }
+}
+
 #[async_trait::async_trait]
 impl AgentTool for GetHoldings {
     fn name(&self) -> &'static str {
@@ -79,7 +137,7 @@ impl AgentTool for GetHoldings {
     }
 
     fn description(&self) -> &'static str {
-        "Get portfolio holdings for an account or all accounts. Returns symbol, quantity, market value, cost basis, and gain/loss for each holding. Omit accountId for aggregate holdings across all accounts. Use viewMode to control display: 'treemap' for visual composition chart with daily performance, 'table' for detailed list, or 'both' to show both views."
+        "Get portfolio holdings for an account or all accounts. Returns symbol, quantity, market value, cost basis, and gain/loss for each holding. Gain/loss amounts and percentages are expressed in the portfolio base currency and include FX effects. Omit accountId for aggregate holdings across all accounts. Use viewMode to control display: 'treemap' for visual composition chart with daily performance, 'table' for detailed list, or 'both' to show both views."
     }
 
     fn input_schema(&self) -> serde_json::Value {
@@ -167,44 +225,11 @@ impl AgentTool for GetHoldings {
             .filter(|h| h.holding_type != wealthfolio_core::holdings::HoldingType::Cash)
             .take(MAX_HOLDINGS)
             .map(|h| {
-                // Extract symbol and name from instrument
-                let (symbol, name) = h
-                    .instrument
-                    .as_ref()
-                    .map(|i| (i.symbol.clone(), i.name.clone()))
-                    .unwrap_or_else(|| ("CASH".to_string(), None));
-
-                // Convert HoldingType enum to string
-                let holding_type = match h.holding_type {
-                    wealthfolio_core::holdings::HoldingType::Cash => "Cash",
-                    wealthfolio_core::holdings::HoldingType::Security => "Security",
-                    wealthfolio_core::holdings::HoldingType::AlternativeAsset => "AlternativeAsset",
-                };
-
                 let account = account_names
                     .get(&h.account_id)
                     .cloned()
                     .unwrap_or_else(|| h.account_id.clone());
-
-                HoldingDto {
-                    account,
-                    symbol,
-                    name,
-                    holding_type: holding_type.to_string(),
-                    quantity: h.quantity.to_f64().unwrap_or(0.0),
-                    market_value_base: h.market_value.base.to_f64().unwrap_or(0.0),
-                    cost_basis_base: h.cost_basis.as_ref().and_then(|c| c.base.to_f64()),
-                    unrealized_gain_pct: h.unrealized_gain_pct.and_then(|d| d.to_f64()),
-                    total_gain_base: h.total_gain.as_ref().and_then(|v| v.base.to_f64()),
-                    total_gain_pct: h.total_gain_pct.and_then(|d| d.to_f64()),
-                    income_base: h.income.as_ref().and_then(|v| v.base.to_f64()),
-                    total_return_base: h.total_return.as_ref().and_then(|v| v.base.to_f64()),
-                    total_return_pct: h.total_return_pct.and_then(|d| d.to_f64()),
-                    return_basis_base: h.return_basis.as_ref().and_then(|v| v.base.to_f64()),
-                    day_change_pct: h.day_change_pct.and_then(|d| d.to_f64()),
-                    weight: h.weight.to_f64().unwrap_or(0.0),
-                    currency: h.local_currency,
-                }
+                holding_to_dto(h, account)
             })
             .collect();
 
@@ -228,5 +253,85 @@ impl AgentTool for GetHoldings {
         Ok(AgentToolResult {
             content: serde_json::to_value(output)?,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{base_percentage, holding_to_dto};
+    use chrono::NaiveDate;
+    use rust_decimal::Decimal;
+    use wealthfolio_core::holdings::{Holding, HoldingType, MonetaryValue};
+
+    #[test]
+    fn base_percentage_uses_signed_amount_and_absolute_basis() {
+        assert_eq!(
+            base_percentage(Some(Decimal::from(-20)), Some(Decimal::from(50))),
+            Some(-0.4)
+        );
+        assert_eq!(
+            base_percentage(Some(Decimal::from(20)), Some(Decimal::from(-50))),
+            Some(0.4)
+        );
+    }
+
+    #[test]
+    fn base_percentage_handles_zero_and_missing_basis() {
+        assert_eq!(
+            base_percentage(Some(Decimal::ZERO), Some(Decimal::ZERO)),
+            Some(0.0)
+        );
+        assert_eq!(
+            base_percentage(Some(Decimal::ONE), Some(Decimal::ZERO)),
+            None
+        );
+        assert_eq!(base_percentage(Some(Decimal::ONE), None), None);
+    }
+
+    #[test]
+    fn holding_dto_labels_base_currency_amounts_with_base_currency() {
+        let holding = Holding {
+            id: "holding-1".to_string(),
+            account_id: "account-1".to_string(),
+            holding_type: HoldingType::Security,
+            instrument: None,
+            asset_kind: None,
+            quantity: Decimal::ONE,
+            open_date: None,
+            lots: None,
+            contract_multiplier: Decimal::ONE,
+            local_currency: "USD".to_string(),
+            base_currency: "CAD".to_string(),
+            fx_rate: None,
+            market_value: MonetaryValue {
+                local: Decimal::from(80),
+                base: Decimal::from(100),
+            },
+            cost_basis: None,
+            price: None,
+            purchase_price: None,
+            unrealized_gain: None,
+            unrealized_gain_pct: None,
+            realized_gain: None,
+            realized_gain_pct: None,
+            total_gain: None,
+            total_gain_pct: None,
+            income: None,
+            total_return: None,
+            total_return_pct: None,
+            return_basis: None,
+            day_change: None,
+            day_change_pct: None,
+            prev_close_value: None,
+            weight: Decimal::ZERO,
+            as_of_date: NaiveDate::from_ymd_opt(2026, 7, 13).unwrap(),
+            metadata: None,
+            source_account_ids: Vec::new(),
+        };
+
+        let dto = holding_to_dto(holding, "Account".to_string());
+
+        assert_eq!(dto.market_value_base, 100.0);
+        assert_eq!(dto.currency, "CAD");
     }
 }

--- a/crates/core/src/portfolio/holdings/holdings_service.rs
+++ b/crates/core/src/portfolio/holdings/holdings_service.rs
@@ -654,7 +654,7 @@ impl HoldingsService {
                 base: totals.realized_base,
             };
             holding.realized_gain = Some(realized.clone());
-            holding.realized_gain_pct = gain_pct(realized.base, totals.disposed_cost_base);
+            holding.realized_gain_pct = gain_pct(realized.local, totals.disposed_cost_local);
 
             let mut total_gain = realized;
             if let Some(unrealized) = &holding.unrealized_gain {
@@ -678,7 +678,7 @@ impl HoldingsService {
                 base: open_cost_base + totals.disposed_cost_base,
             };
             holding.return_basis = Some(return_basis.clone());
-            holding.total_gain_pct = gain_pct(total_gain.base, return_basis.base);
+            holding.total_gain_pct = gain_pct(total_gain.local, return_basis.local);
         }
     }
 
@@ -715,12 +715,12 @@ impl HoldingsService {
             let Some(total_gain) = holding.total_gain.clone() else {
                 continue;
             };
-            let basis_base = holding
+            let basis_local = holding
                 .return_basis
                 .as_ref()
-                .map(|basis| basis.base)
+                .map(|basis| basis.local)
                 .unwrap_or(Decimal::ZERO);
-            holding.total_gain_pct = gain_pct(total_gain.base, basis_base);
+            holding.total_gain_pct = gain_pct(total_gain.local, basis_local);
         }
     }
 
@@ -791,11 +791,11 @@ impl HoldingsService {
     }
 }
 
-fn gain_pct(amount_base: Decimal, basis_base: Decimal) -> Option<Decimal> {
-    let exposure_base = basis_base.abs();
-    if exposure_base > Decimal::ZERO {
-        Some((amount_base / exposure_base).round_dp(DECIMAL_PRECISION))
-    } else if amount_base.is_zero() {
+fn gain_pct(amount: Decimal, basis: Decimal) -> Option<Decimal> {
+    let exposure = basis.abs();
+    if exposure > Decimal::ZERO {
+        Some((amount / exposure).round_dp(DECIMAL_PRECISION))
+    } else if amount.is_zero() {
         Some(Decimal::ZERO)
     } else {
         None
@@ -819,13 +819,13 @@ fn refresh_total_return(holding: &mut Holding) {
         }
     }
 
-    let basis_base = holding
+    let basis_local = holding
         .return_basis
         .as_ref()
-        .map(|basis| basis.base)
+        .map(|basis| basis.local)
         .unwrap_or(Decimal::ZERO);
     if let Some(total_gain) = &holding.total_gain {
-        holding.total_gain_pct = gain_pct(total_gain.base, basis_base);
+        holding.total_gain_pct = gain_pct(total_gain.local, basis_local);
     }
 
     let mut total_return = holding
@@ -836,7 +836,7 @@ fn refresh_total_return(holding: &mut Holding) {
         add_monetary(&mut total_return, income);
     }
     holding.total_return = Some(total_return.clone());
-    holding.total_return_pct = gain_pct(total_return.base, basis_base);
+    holding.total_return_pct = gain_pct(total_return.local, basis_local);
 }
 
 fn calculate_asset_income(
@@ -1312,33 +1312,29 @@ impl HoldingsServiceTrait for HoldingsService {
             a_cash.cmp(&b_cash).then_with(|| a.id.cmp(&b.id))
         });
 
-        // Recompute percentage fields from the summed base values.
+        // Recompute percentage fields from the summed local values.
         // The merge loop accumulates monetary values but percentages from the first
         // account seen are no longer correct for the aggregated position.
         for h in result.iter_mut() {
-            let basis_base = h
+            let basis_local = h
                 .return_basis
                 .as_ref()
-                .map(|basis| basis.base)
+                .map(|basis| basis.local)
                 .unwrap_or(Decimal::ZERO);
-            let open_cost_base = h
+            let open_cost_local = h
                 .cost_basis
                 .as_ref()
-                .map(|cost_basis| cost_basis.base)
+                .map(|cost_basis| cost_basis.local)
                 .unwrap_or(Decimal::ZERO);
-            let open_exposure_base = open_cost_base.abs();
-            if open_exposure_base > Decimal::ZERO {
-                h.unrealized_gain_pct = h
-                    .unrealized_gain
-                    .as_ref()
-                    .map(|v| (v.base / open_exposure_base).round_dp(DECIMAL_PRECISION));
-            } else {
-                h.unrealized_gain_pct = None;
-            }
-            h.total_gain_pct = h
-                .total_gain
+            h.unrealized_gain_pct = h
+                .unrealized_gain
                 .as_ref()
-                .and_then(|v| gain_pct(v.base, basis_base));
+                .and_then(|value| gain_pct(value.local, open_cost_local));
+            let disposed_cost_local = basis_local - open_cost_local;
+            h.realized_gain_pct = h
+                .realized_gain
+                .as_ref()
+                .and_then(|value| gain_pct(value.local, disposed_cost_local));
             refresh_total_return(h);
             let prev_close_base = h
                 .prev_close_value
@@ -1868,7 +1864,7 @@ mod tests {
                             };
                             holding.unrealized_gain = Some(unrealized.clone());
                             holding.unrealized_gain_pct =
-                                gain_pct(unrealized.base, cost_basis.base);
+                                gain_pct(unrealized.local, cost_basis.local);
                             holding.total_gain = Some(unrealized.clone());
                             holding.total_gain_pct = holding.unrealized_gain_pct;
                         }
@@ -3202,7 +3198,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn single_holding_computes_income_return_basis_and_total_return() {
+    async fn single_holding_percentages_use_local_values_when_fx_changes() {
         let account_id = "acc-1";
         let asset_id = "AAPL";
         let mut position = test_position(account_id, asset_id);
@@ -3214,27 +3210,23 @@ mod tests {
             positions: HashMap::from([(asset_id.to_string(), position)]),
             ..Default::default()
         };
-        let lot_repository = MockLotRepository::new(vec![test_lot_record(
-            account_id,
-            asset_id,
-            "USD",
-            dec!(100),
-        )])
-        .with_disposals(vec![test_lot_disposal(
-            account_id,
-            asset_id,
-            dec!(50),
-            dec!(50),
-            dec!(20),
-            dec!(20),
-        )]);
+        let lot_repository =
+            MockLotRepository::new(vec![test_lot_record(account_id, asset_id, "USD", dec!(50))])
+                .with_disposals(vec![test_lot_disposal(
+                    account_id,
+                    asset_id,
+                    dec!(50),
+                    dec!(20),
+                    dec!(20),
+                    dec!(10),
+                )]);
         let income_service = MockHoldingIncomeService::new(HashMap::from([(
             account_id.to_string(),
             HashMap::from([(
                 asset_id.to_string(),
                 MonetaryValue {
                     local: dec!(5),
-                    base: dec!(5),
+                    base: dec!(2),
                 },
             )]),
         )]));
@@ -3252,12 +3244,20 @@ mod tests {
         assert_eq!(*scopes.lock().unwrap(), vec![vec![account_id.to_string()]]);
         assert_eq!(holdings.len(), 1);
         let holding = &holdings[0];
-        assert_eq!(holding.unrealized_gain.as_ref().unwrap().base, dec!(30));
-        assert_eq!(holding.realized_gain.as_ref().unwrap().base, dec!(20));
-        assert_eq!(holding.total_gain.as_ref().unwrap().base, dec!(50));
-        assert_eq!(holding.income.as_ref().unwrap().base, dec!(5));
-        assert_eq!(holding.total_return.as_ref().unwrap().base, dec!(55));
-        assert_eq!(holding.return_basis.as_ref().unwrap().base, dec!(150));
+        assert_eq!(holding.unrealized_gain.as_ref().unwrap().local, dec!(30));
+        assert_eq!(holding.unrealized_gain.as_ref().unwrap().base, dec!(80));
+        assert_eq!(holding.unrealized_gain_pct, Some(dec!(0.3)));
+        assert_eq!(holding.realized_gain.as_ref().unwrap().local, dec!(20));
+        assert_eq!(holding.realized_gain.as_ref().unwrap().base, dec!(10));
+        assert_eq!(holding.realized_gain_pct, Some(dec!(0.4)));
+        assert_eq!(holding.total_gain.as_ref().unwrap().local, dec!(50));
+        assert_eq!(holding.total_gain.as_ref().unwrap().base, dec!(90));
+        assert_eq!(holding.income.as_ref().unwrap().local, dec!(5));
+        assert_eq!(holding.income.as_ref().unwrap().base, dec!(2));
+        assert_eq!(holding.total_return.as_ref().unwrap().local, dec!(55));
+        assert_eq!(holding.total_return.as_ref().unwrap().base, dec!(92));
+        assert_eq!(holding.return_basis.as_ref().unwrap().local, dec!(150));
+        assert_eq!(holding.return_basis.as_ref().unwrap().base, dec!(70));
         assert_eq!(holding.total_gain_pct, Some(dec!(0.33333333)));
         assert_eq!(holding.total_return_pct, Some(dec!(0.36666667)));
     }
@@ -3478,8 +3478,12 @@ mod tests {
             ..Default::default()
         };
         let lot_repository = MockLotRepository::new(vec![
-            test_lot_record(account_one, asset_id, "USD", dec!(100)),
-            test_lot_record(account_two, asset_id, "USD", dec!(100)),
+            test_lot_record(account_one, asset_id, "USD", dec!(50)),
+            test_lot_record(account_two, asset_id, "USD", dec!(50)),
+        ])
+        .with_disposals(vec![
+            test_lot_disposal(account_one, asset_id, dec!(40), dec!(20), dec!(4), dec!(2)),
+            test_lot_disposal(account_two, asset_id, dec!(60), dec!(30), dec!(18), dec!(9)),
         ]);
         let income_service = MockHoldingIncomeService::new(HashMap::from([
             (
@@ -3488,7 +3492,7 @@ mod tests {
                     asset_id.to_string(),
                     MonetaryValue {
                         local: dec!(5),
-                        base: dec!(5),
+                        base: dec!(2),
                     },
                 )]),
             ),
@@ -3498,7 +3502,7 @@ mod tests {
                     asset_id.to_string(),
                     MonetaryValue {
                         local: dec!(7),
-                        base: dec!(7),
+                        base: dec!(3),
                     },
                 )]),
             ),
@@ -3527,12 +3531,54 @@ mod tests {
         );
         assert_eq!(holdings.len(), 1);
         let holding = &holdings[0];
-        assert_eq!(holding.income.as_ref().unwrap().base, dec!(12));
-        assert_eq!(holding.total_gain.as_ref().unwrap().base, dec!(20));
-        assert_eq!(holding.total_return.as_ref().unwrap().base, dec!(32));
-        assert_eq!(holding.return_basis.as_ref().unwrap().base, dec!(200));
-        assert_eq!(holding.total_gain_pct, Some(dec!(0.1)));
-        assert_eq!(holding.total_return_pct, Some(dec!(0.16)));
+        assert_eq!(holding.income.as_ref().unwrap().local, dec!(12));
+        assert_eq!(holding.income.as_ref().unwrap().base, dec!(5));
+        assert_eq!(holding.realized_gain.as_ref().unwrap().local, dec!(22));
+        assert_eq!(holding.realized_gain.as_ref().unwrap().base, dec!(11));
+        assert_eq!(holding.realized_gain_pct, Some(dec!(0.22)));
+        assert_eq!(holding.total_gain.as_ref().unwrap().local, dec!(42));
+        assert_eq!(holding.total_gain.as_ref().unwrap().base, dec!(131));
+        assert_eq!(holding.total_return.as_ref().unwrap().local, dec!(54));
+        assert_eq!(holding.total_return.as_ref().unwrap().base, dec!(136));
+        assert_eq!(holding.return_basis.as_ref().unwrap().local, dec!(300));
+        assert_eq!(holding.return_basis.as_ref().unwrap().base, dec!(150));
+        assert_eq!(holding.total_gain_pct, Some(dec!(0.14)));
+        assert_eq!(holding.total_return_pct, Some(dec!(0.18)));
+    }
+
+    #[tokio::test]
+    async fn multi_account_aggregation_reports_zero_percent_for_zero_basis_and_gain() {
+        let account_one = "acc-1";
+        let account_two = "acc-2";
+        let asset_id = "AAPL";
+        let mut position = test_position(account_one, asset_id);
+        position.total_cost_basis = Decimal::ZERO;
+
+        let snapshot = AccountStateSnapshot {
+            account_id: account_one.to_string(),
+            currency: "USD".to_string(),
+            positions: HashMap::from([(asset_id.to_string(), position)]),
+            ..Default::default()
+        };
+        let service = test_service(
+            snapshot,
+            vec![test_asset(asset_id, "AAPL", InstrumentType::Equity)],
+            HashMap::from([(asset_id.to_string(), Decimal::ZERO)]),
+        );
+
+        let holdings = service
+            .get_holdings_for_accounts(
+                &[account_one.to_string(), account_two.to_string()],
+                "USD",
+                "portfolio",
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(holdings.len(), 1);
+        assert_eq!(holdings[0].unrealized_gain_pct, Some(Decimal::ZERO));
+        assert_eq!(holdings[0].total_gain_pct, Some(Decimal::ZERO));
+        assert_eq!(holdings[0].total_return_pct, Some(Decimal::ZERO));
     }
 
     #[test]

--- a/crates/core/src/portfolio/holdings/holdings_valuation_service.rs
+++ b/crates/core/src/portfolio/holdings/holdings_valuation_service.rs
@@ -18,11 +18,11 @@ pub trait HoldingsValuationServiceTrait: Send + Sync {
     async fn calculate_holdings_live_valuation(&self, holdings: &mut [Holding]) -> Result<()>;
 }
 
-fn gain_pct_from_basis(amount_base: Decimal, basis_base: Decimal) -> Option<Decimal> {
-    let exposure_base = basis_base.abs();
-    if exposure_base > Decimal::ZERO {
-        Some((amount_base / exposure_base).round_dp(4))
-    } else if amount_base.is_zero() {
+fn gain_pct_from_basis(amount: Decimal, basis: Decimal) -> Option<Decimal> {
+    let exposure = basis.abs();
+    if exposure > Decimal::ZERO {
+        Some((amount / exposure).round_dp(4))
+    } else if amount.is_zero() {
         Some(Decimal::ZERO)
     } else {
         None
@@ -271,12 +271,7 @@ impl HoldingsValuationService {
                     local: neg_local,
                     base: neg_base,
                 });
-                let exposure_base = cost_basis.base.abs();
-                if exposure_base != Decimal::ZERO {
-                    holding.unrealized_gain_pct = Some((neg_base / exposure_base).round_dp(4));
-                } else {
-                    holding.unrealized_gain_pct = Some(Decimal::ZERO);
-                }
+                holding.unrealized_gain_pct = gain_pct_from_basis(neg_local, cost_basis.local);
             } else {
                 holding.unrealized_gain = None;
                 holding.unrealized_gain_pct = None;
@@ -345,7 +340,7 @@ impl HoldingsValuationService {
                 });
 
                 holding.unrealized_gain_pct =
-                    gain_pct_from_basis(unrealized_gain_base, cost_basis_base);
+                    gain_pct_from_basis(unrealized_gain_local, cost_basis.local);
             } else {
                 holding.unrealized_gain = None;
                 holding.unrealized_gain_pct = None;
@@ -558,7 +553,7 @@ impl HoldingsValuationService {
                 });
 
                 holding.unrealized_gain_pct =
-                    gain_pct_from_basis(unrealized_gain_base, total_cost_base);
+                    gain_pct_from_basis(unrealized_gain_local, total_cost_local);
                 true
             } else if let Some(cost_basis) = &holding.cost_basis {
                 // Fall back to lot-based cost basis calculation
@@ -573,7 +568,7 @@ impl HoldingsValuationService {
                 });
 
                 holding.unrealized_gain_pct =
-                    gain_pct_from_basis(unrealized_gain_base, cost_basis_base);
+                    gain_pct_from_basis(unrealized_gain_local, cost_basis.local);
                 true
             } else {
                 // No purchase_price and no cost_basis - gain is N/A

--- a/crates/core/src/portfolio/holdings/holdings_valuation_service_tests.rs
+++ b/crates/core/src/portfolio/holdings/holdings_valuation_service_tests.rs
@@ -1037,6 +1037,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn issue_1277_transfer_in_fx_effect_does_not_change_holding_return_pct() {
+        let (fx_service, market_data_service, valuation_service) = setup_test_env();
+        fx_service.add_rate("USD", "MXN", dec!(17.46));
+
+        market_data_service.add_quote_pair(
+            "TRANSFERRED",
+            create_quote("2024-01-10", dec!(91.63), "USD"),
+            None,
+        );
+
+        let mut holdings = vec![create_holding(
+            "h-transfer-in",
+            HoldingType::Security,
+            "TRANSFERRED",
+            dec!(1),
+            "USD",
+            "MXN",
+            Some(dec!(91.50)),
+            Some("Transferred security"),
+        )];
+        // A TRANSFER_IN lot keeps the base cost recorded at the historical FX rate.
+        holdings[0].cost_basis.as_mut().unwrap().base = dec!(726.61);
+
+        valuation_service
+            .calculate_holdings_live_valuation(&mut holdings)
+            .await
+            .unwrap();
+
+        let holding = &holdings[0];
+        assert_monetary_value_approx(
+            holding.unrealized_gain.as_ref(),
+            dec!(0.13),
+            dec!(873.2498),
+            TOLERANCE,
+            "Unrealized Gain",
+        );
+        assert_eq!(holding.unrealized_gain_pct, Some(dec!(0.0014)));
+        assert_eq!(holding.total_gain_pct, Some(dec!(0.0014)));
+    }
+
+    #[tokio::test]
     async fn issue_408_preserves_historical_base_cost_basis() {
         let (fx_service, market_data_service, valuation_service) = setup_test_env();
         fx_service.add_rate("USD", "EUR", dec!(0.8));
@@ -1086,7 +1127,7 @@ mod tests {
         );
         assert_decimal_approx(
             holding.unrealized_gain_pct,
-            dec!(-0.1200),
+            dec!(0.1000),
             TOLERANCE,
             "Unrealized Gain Pct",
         );

--- a/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
@@ -7585,6 +7585,9 @@ mod tests {
         assert_eq!(pos_a.currency, "USD");
         // 100 CAD * 0.75 = 75 USD per share
         assert_eq!(pos_a.average_cost, dec!(75));
+        let source_lot = pos_a.lots[0].clone();
+        assert!(source_lot.fx_rate_to_base.is_some());
+        assert_eq!(source_lot.base_currency.as_deref(), Some("CAD"));
 
         // Transfer out from CAD account
         let transfer_out = create_transfer_activity(
@@ -7633,6 +7636,14 @@ mod tests {
         // Lots should preserve the original USD cost basis: 75 USD per share
         assert_eq!(pos_b.average_cost, dec!(75));
         assert_eq!(pos_b.total_cost_basis, dec!(750));
+        let transferred_lot = &pos_b.lots[0];
+        assert_eq!(transferred_lot.cost_basis, source_lot.cost_basis);
+        assert_eq!(
+            transferred_lot.acquisition_date,
+            source_lot.acquisition_date
+        );
+        assert_eq!(transferred_lot.fx_rate_to_base, source_lot.fx_rate_to_base);
+        assert_eq!(transferred_lot.base_currency, source_lot.base_currency);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- calculate holding return percentages from holding-currency gains and bases so FX movements do not distort security performance
- keep base-currency UI surfaces internally consistent by deriving FX-inclusive percentages beside base amounts
- recompute merged realized, unrealized, total gain, and total return percentages from aggregated values
- align the AI holdings widget with base-currency amounts, gross long/short exposure, missing-basis behavior, and currency labels
- add regression coverage for linked transfers, FX-divergent returns, aggregation, zero bases, shorts, and unavailable percentages

## Root cause

Linked security transfers correctly preserve the lot acquisition cost and historical base-currency FX metadata. The return calculation then divided a current base-currency gain by that historical base-currency basis. When exchange rates moved substantially, the percentage represented the security return plus the FX movement, producing results such as the reported +120% instead of the holding-currency return.

The core percentage contract now uses holding-currency amounts. Screens that explicitly show converted base amounts derive a matching base-currency percentage locally, so amount and percentage signs remain consistent.

## User impact

Transferred securities tracked across currencies now report their underlying holding-currency performance without the historical/current FX mismatch. Users can still see FX-inclusive performance wherever the UI displays converted base-currency amounts.

## Validation

- `pnpm lint` — passed with no errors; repository-existing warnings only
- `pnpm format:check` — passed
- `pnpm check` — passed
- `pnpm test` — 1,099 tests passed
- `cargo test -p wealthfolio-core --lib` — 1,647 tests passed
- `cargo test -p wealthfolio-agent-tools --lib` — 73 tests passed
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — passed

Closes #1277
