### PR TITLE
fix(health): surface price sync retry outcomes

### DIFF
--- a/apps/frontend/src/hooks/use-health.ts
+++ b/apps/frontend/src/hooks/use-health.ts
@@ -126,8 +126,15 @@ export function useExecuteHealthFix() {
         toast.success("Fix applied successfully");
       }
     },
-    onError: (error: Error) => {
-      toast.error("Fix failed", { description: error.message });
+    onError: (error: Error, action) => {
+      if (action.id === "sync_prices" || action.id === "retry_sync") {
+        toast.error("Market Data Sync Failed", {
+          id: "market-sync-error",
+          description: `${error.message}. Please try again later.`,
+        });
+      } else {
+        toast.error("Fix failed", { description: error.message });
+      }
     },
   });
 }

--- a/apps/frontend/src/use-global-event-listener.ts
+++ b/apps/frontend/src/use-global-event-listener.ts
@@ -28,6 +28,7 @@ import { toast } from "sonner";
 
 const TOAST_IDS = {
   marketSyncStart: "market-sync-start",
+  marketSyncError: "market-sync-error",
   portfolioUpdateStart: "portfolio-update-start",
   portfolioUpdateError: "portfolio-update-error",
 
@@ -106,7 +107,7 @@ const useGlobalEventListener = () => {
       if (failed_syncs && failed_syncs.length > 0) {
         const count = failed_syncs.length;
         toast.error(`Price update failed for ${count} asset${count === 1 ? "" : "s"}`, {
-          id: "market-sync-error",
+          id: TOAST_IDS.marketSyncError,
           duration: 10000,
           action: {
             label: "View",
@@ -138,6 +139,7 @@ const useGlobalEventListener = () => {
         toast.dismiss(TOAST_IDS.marketSyncStart);
       }
       toast.error("Market Data Sync Failed", {
+        id: TOAST_IDS.marketSyncError,
         description: `${errorMsg}. Please try again later.`,
         duration: 10000,
       });

--- a/apps/frontend/src/use-global-event-listener.ts
+++ b/apps/frontend/src/use-global-event-listener.ts
@@ -42,10 +42,15 @@ const POST_LOGIN_REQUIRED_LISTENERS = new Set(["broker-sync-complete", "broker-s
 interface MarketSyncCompletePayload {
   failed_syncs?: [string, string][];
   skipped_reasons?: [string, string][];
+  show_skipped_reasons?: boolean;
 }
 
 function getSyncFailures(payload?: MarketSyncCompletePayload | null): [string, string][] {
   return Array.isArray(payload?.failed_syncs) ? payload.failed_syncs : [];
+}
+
+function getSyncSkips(payload?: MarketSyncCompletePayload | null): [string, string][] {
+  return Array.isArray(payload?.skipped_reasons) ? payload.skipped_reasons : [];
 }
 
 const useGlobalEventListener = () => {
@@ -89,6 +94,7 @@ const useGlobalEventListener = () => {
 
     const handleMarketSyncComplete = (event: { payload: MarketSyncCompletePayload | null }) => {
       const failed_syncs = getSyncFailures(event.payload);
+      const skipped_reasons = getSyncSkips(event.payload);
 
       if (isMobileViewportRef.current && syncContextRef.current) {
         syncContextRef.current.setIdle();
@@ -101,6 +107,20 @@ const useGlobalEventListener = () => {
         const count = failed_syncs.length;
         toast.error(`Price update failed for ${count} asset${count === 1 ? "" : "s"}`, {
           id: "market-sync-error",
+          duration: 10000,
+          action: {
+            label: "View",
+            onClick: () => navigateRef.current("/health"),
+          },
+        });
+      }
+
+      if (event.payload?.show_skipped_reasons && skipped_reasons.length > 0) {
+        const count = skipped_reasons.length;
+        const reasons = [...new Set(skipped_reasons.map(([, reason]) => reason))];
+        toast.warning(`Price update skipped for ${count} asset${count === 1 ? "" : "s"}`, {
+          id: "market-sync-skipped",
+          description: reasons.slice(0, 2).join("; "),
           duration: 10000,
           action: {
             label: "View",

--- a/apps/server/src/api/health.rs
+++ b/apps/server/src/api/health.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use crate::{
     api::shared::{process_portfolio_job, PortfolioJobConfig},
     error::{ApiError, ApiResult},
-    events::{ServerEvent, MARKET_SYNC_COMPLETE, MARKET_SYNC_ERROR, MARKET_SYNC_START},
+    events::{
+        MarketSyncResult, ServerEvent, MARKET_SYNC_COMPLETE, MARKET_SYNC_ERROR, MARKET_SYNC_START,
+    },
     main_lib::AppState,
 };
 use axum::{
@@ -154,12 +156,6 @@ async fn execute_health_fix(
             ));
         }
 
-        state
-            .quote_service
-            .reset_sync_errors(&asset_ids)
-            .await
-            .map_err(|e| anyhow::anyhow!("Failed to reset sync errors: {}", e))?;
-
         state.event_bus.publish(ServerEvent::new(MARKET_SYNC_START));
 
         match state
@@ -178,10 +174,10 @@ async fn execute_health_fix(
                     .collect();
                 state.event_bus.publish(ServerEvent::with_payload(
                     MARKET_SYNC_COMPLETE,
-                    json!({
-                        "failed_syncs": result.failures,
-                        "skipped_reasons": skipped_reasons,
-                        "show_skipped_reasons": true,
+                    json!(MarketSyncResult {
+                        failed_syncs: result.failures,
+                        skipped_reasons,
+                        show_skipped_reasons: true,
                     }),
                 ));
             }

--- a/apps/server/src/api/health.rs
+++ b/apps/server/src/api/health.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::{
     api::shared::{process_portfolio_job, PortfolioJobConfig},
     error::{ApiError, ApiResult},
+    events::{ServerEvent, MARKET_SYNC_COMPLETE, MARKET_SYNC_ERROR, MARKET_SYNC_START},
     main_lib::AppState,
 };
 use axum::{
@@ -11,6 +12,7 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
+use serde_json::json;
 use wealthfolio_core::{
     health::{FixAction, HealthConfig, HealthStatus},
     portfolio::{snapshot::SnapshotRecalcMode, valuation::ValuationRecalcMode},
@@ -154,12 +156,43 @@ async fn execute_health_fix(
 
         state
             .quote_service
+            .reset_sync_errors(&asset_ids)
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to reset sync errors: {}", e))?;
+
+        state.event_bus.publish(ServerEvent::new(MARKET_SYNC_START));
+
+        match state
+            .quote_service
             .sync(
                 wealthfolio_core::quotes::SyncMode::Incremental,
                 Some(asset_ids),
             )
             .await
-            .map_err(|e| anyhow::anyhow!("Market data sync failed: {}", e))?;
+        {
+            Ok(result) => {
+                let skipped_reasons: Vec<(String, String)> = result
+                    .skipped_reasons
+                    .into_iter()
+                    .map(|(asset_id, reason)| (asset_id, reason.to_string()))
+                    .collect();
+                state.event_bus.publish(ServerEvent::with_payload(
+                    MARKET_SYNC_COMPLETE,
+                    json!({
+                        "failed_syncs": result.failures,
+                        "skipped_reasons": skipped_reasons,
+                        "show_skipped_reasons": true,
+                    }),
+                ));
+            }
+            Err(error) => {
+                let message = format!("Market data sync failed: {}", error);
+                state
+                    .event_bus
+                    .publish(ServerEvent::with_payload(MARKET_SYNC_ERROR, json!(message)));
+                return Err(anyhow::anyhow!(message).into());
+            }
+        }
 
         state.health_service.clear_cache().await;
         return Ok(());

--- a/apps/server/src/api/shared.rs
+++ b/apps/server/src/api/shared.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::{
     error::{ApiError, ApiResult},
     events::{
-        ServerEvent, MARKET_SYNC_COMPLETE, MARKET_SYNC_ERROR, MARKET_SYNC_START,
+        MarketSyncResult, ServerEvent, MARKET_SYNC_COMPLETE, MARKET_SYNC_ERROR, MARKET_SYNC_START,
         PORTFOLIO_UPDATE_COMPLETE, PORTFOLIO_UPDATE_ERROR, PORTFOLIO_UPDATE_START,
     },
     main_lib::AppState,
@@ -214,9 +214,10 @@ pub async fn process_portfolio_job(
                     .collect();
                 event_bus.publish(ServerEvent::with_payload(
                     MARKET_SYNC_COMPLETE,
-                    json!({
-                        "failed_syncs": result.failures,
-                        "skipped_reasons": skipped_reasons,
+                    json!(MarketSyncResult {
+                        failed_syncs: result.failures,
+                        skipped_reasons,
+                        show_skipped_reasons: false,
                     }),
                 ));
                 tracing::info!("Market data sync completed in {:?}", sync_start.elapsed());

--- a/apps/server/src/domain_events/queue_worker.rs
+++ b/apps/server/src/domain_events/queue_worker.rs
@@ -306,7 +306,7 @@ async fn run_portfolio_job(
     config: crate::api::shared::PortfolioJobConfig,
 ) {
     use crate::events::{
-        ServerEvent, MARKET_SYNC_COMPLETE, MARKET_SYNC_ERROR, MARKET_SYNC_START,
+        MarketSyncResult, ServerEvent, MARKET_SYNC_COMPLETE, MARKET_SYNC_ERROR, MARKET_SYNC_START,
         PORTFOLIO_UPDATE_COMPLETE, PORTFOLIO_UPDATE_ERROR, PORTFOLIO_UPDATE_START,
     };
     use serde_json::json;
@@ -386,9 +386,10 @@ async fn run_portfolio_job(
                     .collect();
                 event_bus.publish(ServerEvent::with_payload(
                     MARKET_SYNC_COMPLETE,
-                    json!({
-                        "failed_syncs": result.failures,
-                        "skipped_reasons": skipped_reasons,
+                    json!(MarketSyncResult {
+                        failed_syncs: result.failures,
+                        skipped_reasons,
+                        show_skipped_reasons: false,
                     }),
                 ));
                 tracing::info!("Market data sync completed in {:?}", sync_start.elapsed());

--- a/apps/server/src/events.rs
+++ b/apps/server/src/events.rs
@@ -17,6 +17,14 @@ pub const BROKER_SYNC_START: &str = "broker:sync-start";
 pub const BROKER_SYNC_COMPLETE: &str = "broker:sync-complete";
 pub const BROKER_SYNC_ERROR: &str = "broker:sync-error";
 
+/// Payload published when a market data sync completes.
+#[derive(Debug, serde::Serialize)]
+pub struct MarketSyncResult {
+    pub failed_syncs: Vec<(String, String)>,
+    pub skipped_reasons: Vec<(String, String)>,
+    pub show_skipped_reasons: bool,
+}
+
 /// Serializable envelope that carries event names and optional payloads.
 #[derive(Clone, Debug)]
 pub struct ServerEvent {

--- a/apps/tauri/src/commands/health.rs
+++ b/apps/tauri/src/commands/health.rs
@@ -142,13 +142,6 @@ pub async fn execute_health_fix(
             asset_ids
         );
 
-        // Reset error counts so the sync won't skip these assets
-        let quote_service = state.quote_service();
-        quote_service
-            .reset_sync_errors(&asset_ids)
-            .await
-            .map_err(|e| format!("Failed to reset sync errors: {}", e))?;
-
         if let Err(e) = app_handle.emit(MARKET_SYNC_START, &()) {
             error!("Failed to emit market:sync-start event: {}", e);
         }

--- a/apps/tauri/src/commands/health.rs
+++ b/apps/tauri/src/commands/health.rs
@@ -172,6 +172,7 @@ pub async fn execute_health_fix(
                 let result_payload = MarketSyncResult {
                     failed_syncs: result.failures,
                     skipped_reasons,
+                    show_skipped_reasons: true,
                 };
                 if let Err(e) = app_handle.emit(MARKET_SYNC_COMPLETE, &result_payload) {
                     error!("Failed to emit market:sync-complete event: {}", e);

--- a/apps/tauri/src/domain_events/queue_worker.rs
+++ b/apps/tauri/src/domain_events/queue_worker.rs
@@ -382,6 +382,7 @@ async fn run_portfolio_job(
                 let result_payload = MarketSyncResult {
                     failed_syncs,
                     skipped_reasons,
+                    show_skipped_reasons: false,
                 };
                 if let Err(e) = app_handle.emit(MARKET_SYNC_COMPLETE, &result_payload) {
                     error!("Failed to emit market:sync-complete event: {}", e);

--- a/apps/tauri/src/events.rs
+++ b/apps/tauri/src/events.rs
@@ -34,6 +34,8 @@ pub struct MarketSyncResult {
     pub failed_syncs: Vec<(String, String)>,
     /// List of (asset_id, reason) tuples for skipped syncs.
     pub skipped_reasons: Vec<(String, String)>,
+    /// Whether the frontend should display skipped reasons to the user.
+    pub show_skipped_reasons: bool,
 }
 
 /// Event emitted when the market data sync process encounters an error.

--- a/apps/tauri/src/listeners.rs
+++ b/apps/tauri/src/listeners.rs
@@ -136,6 +136,7 @@ fn handle_portfolio_request(handle: AppHandle, payload_str: &str, force_recalc: 
                                 let result_payload = MarketSyncResult {
                                     failed_syncs,
                                     skipped_reasons,
+                                    show_skipped_reasons: false,
                                 };
                                 if let Err(e) =
                                     handle_clone.emit(MARKET_SYNC_COMPLETE, &result_payload)

--- a/crates/core/src/quotes/sync.rs
+++ b/crates/core/src/quotes/sync.rs
@@ -133,10 +133,16 @@ fn should_treat_fetch_error_as_non_fatal(
 
     matches!(
         error,
-        Error::MarketData(MarketDataError::NoData)
-            | Error::MarketData(MarketDataError::NotFound(_))
+        Error::MarketData(MarketDataError::NotFound(_))
             | Error::MarketData(MarketDataError::ProviderExhausted(_))
     )
+}
+
+fn fetch_error_skip_reason(error: &Error) -> Option<AssetSkipReason> {
+    match error {
+        Error::MarketData(MarketDataError::NoData) => Some(AssetSkipReason::NoDataForRange),
+        _ => None,
+    }
 }
 
 fn error_message_contains_provider_id(message: &str) -> bool {
@@ -340,6 +346,8 @@ pub struct AssetSyncResult {
     pub status: SyncStatus,
     /// Optional error message if sync failed.
     pub error: Option<String>,
+    /// Structured reason when the sync was skipped.
+    pub skip_reason: Option<AssetSkipReason>,
 }
 
 /// Status of a sync operation.
@@ -372,6 +380,8 @@ pub enum AssetSkipReason {
     TooManyErrors,
     /// No fetchable quote window remains for the requested sync.
     NoQuoteWindow,
+    /// Providers returned no quotes for the requested date range.
+    NoDataForRange,
     /// Bond has matured — price is par, no further sync needed.
     MaturedBond,
     /// Option has expired — no further quotes available.
@@ -389,6 +399,9 @@ impl std::fmt::Display for AssetSkipReason {
             AssetSkipReason::SyncInProgress => write!(f, "Sync already in progress"),
             AssetSkipReason::TooManyErrors => write!(f, "Too many consecutive sync failures"),
             AssetSkipReason::NoQuoteWindow => write!(f, "No quote refresh needed"),
+            AssetSkipReason::NoDataForRange => {
+                write!(f, "No data for requested date range")
+            }
             AssetSkipReason::MaturedBond => write!(f, "Bond has matured (price is par)"),
             AssetSkipReason::ExpiredOption => write!(f, "Option has expired"),
         }
@@ -444,6 +457,10 @@ impl SyncResult {
             }
             SyncStatus::Skipped => {
                 self.skipped += 1;
+                if let Some(reason) = result.skip_reason {
+                    self.skipped_reasons
+                        .push((result.asset_id.0.clone(), reason));
+                }
             }
             SyncStatus::Failed => {
                 self.failed += 1;
@@ -836,7 +853,8 @@ where
                     asset_id,
                     quotes_added: 0,
                     status: SyncStatus::Skipped,
-                    error: Some("Sync already in progress".to_string()),
+                    error: None,
+                    skip_reason: Some(AssetSkipReason::SyncInProgress),
                 };
             }
         };
@@ -919,6 +937,7 @@ where
                                 quotes_added: quotes_count,
                                 status: SyncStatus::Success,
                                 error: None,
+                                skip_reason: None,
                             }
                         }
                         Err(e) => {
@@ -938,24 +957,37 @@ where
                                 quotes_added: 0,
                                 status: SyncStatus::Failed,
                                 error: Some(format!("Storage error: {}", e)),
+                                skip_reason: None,
                             }
                         }
                     }
                 } else {
                     debug!("No quotes returned for {}", asset.id);
-                    if let Err(e) = self.sync_state_store.update_after_sync(&asset.id).await {
-                        warn!("Failed to update sync state for {}: {:?}", asset.id, e);
-                    }
                     AssetSyncResult {
                         asset_id,
                         quotes_added: 0,
-                        status: SyncStatus::Success,
+                        status: SyncStatus::Skipped,
                         error: None,
+                        skip_reason: Some(AssetSkipReason::NoDataForRange),
                     }
                 }
             }
             Err(fetch_error) => {
                 let error = fetch_error.error;
+                if let Some(skip_reason) = fetch_error_skip_reason(&error) {
+                    debug!(
+                        "No quotes available for {} in the requested range",
+                        asset.id
+                    );
+                    return AssetSyncResult {
+                        asset_id,
+                        quotes_added: 0,
+                        status: SyncStatus::Skipped,
+                        error: None,
+                        skip_reason: Some(skip_reason),
+                    };
+                }
+
                 let sync_failure_message =
                     format_sync_failure_message(&error, fetch_error.provider_id.as_deref());
 
@@ -977,6 +1009,7 @@ where
                         quotes_added: 0,
                         status: SyncStatus::Success,
                         error: None,
+                        skip_reason: None,
                     };
                 }
 
@@ -999,6 +1032,7 @@ where
                     quotes_added: 0,
                     status: SyncStatus::Failed,
                     error: Some(sync_failure_message),
+                    skip_reason: None,
                 }
             }
         }
@@ -1051,6 +1085,7 @@ where
                                 quotes_added: 0,
                                 status: SyncStatus::Failed,
                                 error: Some("Asset not found".to_string()),
+                                skip_reason: None,
                             }
                         }
                     }
@@ -1751,13 +1786,12 @@ mod tests {
     }
 
     #[test]
-    fn test_backfill_no_data_error_is_non_fatal() {
+    fn test_no_data_error_is_a_neutral_skip() {
         let err = Error::MarketData(MarketDataError::NoData);
-        assert!(should_treat_fetch_error_as_non_fatal(
-            &SyncCategory::NeedsBackfill,
-            &err,
-            false
-        ));
+        assert_eq!(
+            fetch_error_skip_reason(&err),
+            Some(AssetSkipReason::NoDataForRange)
+        );
     }
 
     #[test]
@@ -1779,36 +1813,6 @@ mod tests {
             &SyncCategory::NeedsBackfill,
             &err,
             false
-        ));
-    }
-
-    #[test]
-    fn test_closed_history_no_data_error_is_non_fatal() {
-        let err = Error::MarketData(MarketDataError::NoData);
-        assert!(should_treat_fetch_error_as_non_fatal(
-            &SyncCategory::Closed,
-            &err,
-            true
-        ));
-    }
-
-    #[test]
-    fn test_targeted_closed_history_no_data_error_remains_fatal() {
-        let err = Error::MarketData(MarketDataError::NoData);
-        assert!(!should_treat_fetch_error_as_non_fatal(
-            &SyncCategory::Closed,
-            &err,
-            false
-        ));
-    }
-
-    #[test]
-    fn test_active_no_data_error_remains_fatal() {
-        let err = Error::MarketData(MarketDataError::NoData);
-        assert!(!should_treat_fetch_error_as_non_fatal(
-            &SyncCategory::Active,
-            &err,
-            true
         ));
     }
 
@@ -2049,12 +2053,32 @@ mod tests {
             quotes_added: 10,
             status: SyncStatus::Success,
             error: None,
+            skip_reason: None,
         };
 
         assert_eq!(result.asset_id.as_str(), "AAPL");
         assert_eq!(result.quotes_added, 10);
         assert_eq!(result.status, SyncStatus::Success);
         assert!(result.error.is_none());
+        assert!(result.skip_reason.is_none());
+    }
+
+    #[test]
+    fn test_skipped_result_records_structured_reason() {
+        let mut result = SyncResult::default();
+        result.add_result(AssetSyncResult {
+            asset_id: AssetId::new("SPARSE"),
+            quotes_added: 0,
+            status: SyncStatus::Skipped,
+            error: None,
+            skip_reason: Some(AssetSkipReason::NoDataForRange),
+        });
+
+        assert_eq!(result.skipped, 1);
+        assert_eq!(
+            result.skipped_reasons,
+            vec![("SPARSE".to_string(), AssetSkipReason::NoDataForRange)]
+        );
     }
 
     #[test]
@@ -2080,6 +2104,10 @@ mod tests {
         assert_eq!(
             AssetSkipReason::NoQuoteWindow.to_string(),
             "No quote refresh needed"
+        );
+        assert_eq!(
+            AssetSkipReason::NoDataForRange.to_string(),
+            "No data for requested date range"
         );
     }
 

--- a/crates/core/src/quotes/sync.rs
+++ b/crates/core/src/quotes/sync.rs
@@ -217,6 +217,12 @@ fn should_include_closed_positions(mode: SyncMode, targeted_sync: bool) -> bool 
         )
 }
 
+fn should_skip_for_error_limit(mode: SyncMode, targeted_sync: bool, error_count: i32) -> bool {
+    !targeted_sync
+        && !matches!(mode, SyncMode::BackfillHistory { .. })
+        && error_count >= MAX_SYNC_ERRORS
+}
+
 fn min_optional_date(left: Option<NaiveDate>, right: Option<NaiveDate>) -> Option<NaiveDate> {
     match (left, right) {
         (Some(left), Some(right)) => Some(left.min(right)),
@@ -1426,17 +1432,15 @@ where
             let fetch_end_date =
                 market_fetch_end_date(now, asset.instrument_exchange_mic.as_deref());
 
-            // Skip assets with too many consecutive errors (unless full resync)
-            if !matches!(mode, SyncMode::BackfillHistory { .. }) {
-                if let Some(ref s) = state {
-                    if s.error_count >= MAX_SYNC_ERRORS {
-                        debug!(
-                            "Skipping {} - too many consecutive errors ({})",
-                            asset.id, s.error_count
-                        );
-                        result.add_skipped(asset.id.clone(), AssetSkipReason::TooManyErrors);
-                        continue;
-                    }
+            // Explicit targeted retries bypass the broad-sync error cutoff.
+            if let Some(ref s) = state {
+                if should_skip_for_error_limit(mode, targeted_sync, s.error_count) {
+                    debug!(
+                        "Skipping {} - too many consecutive errors ({})",
+                        asset.id, s.error_count
+                    );
+                    result.add_skipped(asset.id.clone(), AssetSkipReason::TooManyErrors);
+                    continue;
                 }
             }
 
@@ -2118,6 +2122,20 @@ mod tests {
         assert!(!is_targeted_asset_sync(None));
         assert!(!is_targeted_asset_sync(Some(&empty_ids)));
         assert!(is_targeted_asset_sync(Some(&targeted_ids)));
+    }
+
+    #[test]
+    fn test_targeted_sync_bypasses_error_limit() {
+        assert!(!should_skip_for_error_limit(
+            SyncMode::Incremental,
+            true,
+            MAX_SYNC_ERRORS,
+        ));
+        assert!(should_skip_for_error_limit(
+            SyncMode::Incremental,
+            false,
+            MAX_SYNC_ERRORS,
+        ));
     }
 
     #[test]

--- a/crates/market-data/src/registry/provider_registry.rs
+++ b/crates/market-data/src/registry/provider_registry.rs
@@ -783,6 +783,7 @@ impl ProviderRegistry {
         }
 
         let mut last_error: Option<MarketDataError> = None;
+        let mut saw_no_data = false;
 
         for provider in providers {
             let provider_id: ProviderId = Cow::Borrowed(provider.id());
@@ -819,7 +820,7 @@ impl ProviderRegistry {
                             provider_id.clone(),
                             "No data returned for requested range".to_string(),
                         );
-                        last_error = Some(MarketDataError::NoDataForRange);
+                        saw_no_data = true;
                         continue;
                     }
 
@@ -836,7 +837,7 @@ impl ProviderRegistry {
                         }
                     }
 
-                    if valid_quotes.is_empty() && original_count > 0 {
+                    if valid_quotes.is_empty() {
                         diagnostics.record_error(
                             provider_id.clone(),
                             "All quotes failed validation".to_string(),
@@ -852,6 +853,14 @@ impl ProviderRegistry {
                     return (Ok(valid_quotes), diagnostics);
                 }
                 Err(MarketDataError::NotSupported { .. }) => continue,
+                Err(MarketDataError::NoDataForRange) => {
+                    diagnostics.record_error(
+                        provider_id,
+                        "No data returned for requested range".to_string(),
+                    );
+                    saw_no_data = true;
+                    continue;
+                }
                 Err(e) => {
                     let retry_class = e.retry_class();
                     diagnostics.record_error(provider_id.clone(), format!("{:?}", e));
@@ -875,10 +884,14 @@ impl ProviderRegistry {
             "All providers failed. Diagnostics: {}",
             diagnostics.summary()
         );
-        (
-            Err(last_error.unwrap_or(MarketDataError::AllProvidersFailed)),
-            diagnostics,
-        )
+        let error = last_error.unwrap_or_else(|| {
+            if saw_no_data {
+                MarketDataError::NoDataForRange
+            } else {
+                MarketDataError::AllProvidersFailed
+            }
+        });
+        (Err(error), diagnostics)
     }
 
     /// Fetch latest quote for an instrument with diagnostics.
@@ -1207,6 +1220,38 @@ mod tests {
             .await;
 
         assert!(matches!(result, Err(MarketDataError::NoDataForRange)));
+    }
+
+    #[tokio::test]
+    async fn test_empty_result_does_not_mask_provider_error() {
+        let providers: Vec<Arc<dyn MarketDataProvider>> = vec![
+            Arc::new(MockProvider::new("FAILING", 0, true)),
+            Arc::new(EmptyHistoricalProvider {
+                call_count: Arc::new(AtomicUsize::new(0)),
+            }),
+        ];
+        let registry = ProviderRegistry::new(providers, Arc::new(MockResolver));
+        let context = QuoteContext {
+            instrument: InstrumentId::Equity {
+                ticker: Arc::from("TEST"),
+                mic: Some(Cow::Borrowed("XNAS")),
+            },
+            identifiers: Default::default(),
+            overrides: None,
+            currency_hint: None,
+            preferred_provider: None,
+            bond_metadata: None,
+            custom_provider_code: None,
+        };
+
+        let (result, _) = registry
+            .fetch_quotes_with_diagnostics(&context, Utc::now(), Utc::now())
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(MarketDataError::ProviderError { provider, .. }) if provider == "FAILING"
+        ));
     }
 
     #[test]

--- a/crates/market-data/src/registry/provider_registry.rs
+++ b/crates/market-data/src/registry/provider_registry.rs
@@ -813,9 +813,16 @@ impl ProviderRegistry {
                 .await
             {
                 Ok(mut quotes) => {
-                    self.circuit_breaker.record_success(&provider_id);
-
                     let original_count = quotes.len();
+                    if original_count == 0 {
+                        diagnostics.record_error(
+                            provider_id.clone(),
+                            "No data returned for requested range".to_string(),
+                        );
+                        last_error = Some(MarketDataError::NoDataForRange);
+                        continue;
+                    }
+
                     let mut valid_quotes = Vec::with_capacity(original_count);
                     for quote in quotes.drain(..) {
                         match self
@@ -840,6 +847,7 @@ impl ProviderRegistry {
                         continue;
                     }
 
+                    self.circuit_breaker.record_success(&provider_id);
                     diagnostics.record_success(provider_id);
                     return (Ok(valid_quotes), diagnostics);
                 }
@@ -1088,6 +1096,117 @@ mod tests {
         ) -> Option<Currency> {
             Some(Cow::Borrowed("USD"))
         }
+    }
+
+    struct EmptyHistoricalProvider {
+        call_count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait::async_trait]
+    impl MarketDataProvider for EmptyHistoricalProvider {
+        fn id(&self) -> &'static str {
+            "EMPTY"
+        }
+
+        fn priority(&self) -> u8 {
+            1
+        }
+
+        fn capabilities(&self) -> ProviderCapabilities {
+            ProviderCapabilities {
+                instrument_kinds: &[InstrumentKind::Equity],
+                coverage: Coverage::global_best_effort(),
+                supports_latest: false,
+                supports_historical: true,
+                supports_search: false,
+                supports_profile: false,
+                supports_dividends: false,
+            }
+        }
+
+        fn rate_limit(&self) -> RateLimit {
+            RateLimit::default()
+        }
+
+        async fn get_latest_quote(
+            &self,
+            _: &QuoteContext,
+            _: ProviderInstrument,
+        ) -> Result<Quote, MarketDataError> {
+            unreachable!()
+        }
+
+        async fn get_historical_quotes(
+            &self,
+            _: &QuoteContext,
+            _: ProviderInstrument,
+            _: DateTime<Utc>,
+            _: DateTime<Utc>,
+        ) -> Result<Vec<Quote>, MarketDataError> {
+            self.call_count.fetch_add(1, Ordering::SeqCst);
+            Ok(Vec::new())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_empty_historical_result_falls_back_to_next_provider() {
+        let empty_calls = Arc::new(AtomicUsize::new(0));
+        let fallback = Arc::new(MockProvider::new("FALLBACK", 10, false));
+        let providers: Vec<Arc<dyn MarketDataProvider>> = vec![
+            Arc::new(EmptyHistoricalProvider {
+                call_count: empty_calls.clone(),
+            }),
+            fallback.clone(),
+        ];
+        let registry = ProviderRegistry::new(providers, Arc::new(MockResolver));
+        let context = QuoteContext {
+            instrument: InstrumentId::Equity {
+                ticker: Arc::from("TEST"),
+                mic: Some(Cow::Borrowed("XNAS")),
+            },
+            identifiers: Default::default(),
+            overrides: None,
+            currency_hint: None,
+            preferred_provider: None,
+            bond_metadata: None,
+            custom_provider_code: None,
+        };
+
+        let (result, _) = registry
+            .fetch_quotes_with_diagnostics(&context, Utc::now(), Utc::now())
+            .await;
+        let quotes = result.unwrap();
+
+        assert_eq!(empty_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(fallback.call_count.load(Ordering::SeqCst), 1);
+        assert_eq!(quotes.len(), 1);
+        assert_eq!(quotes[0].source, "FALLBACK");
+    }
+
+    #[tokio::test]
+    async fn test_empty_historical_result_returns_no_data_without_fallback() {
+        let providers: Vec<Arc<dyn MarketDataProvider>> = vec![Arc::new(EmptyHistoricalProvider {
+            call_count: Arc::new(AtomicUsize::new(0)),
+        })];
+        let registry = ProviderRegistry::new(providers, Arc::new(MockResolver));
+        let context = QuoteContext {
+            instrument: InstrumentId::Equity {
+                ticker: Arc::from("TEST"),
+                mic: Some(Cow::Borrowed("XNAS")),
+            },
+            identifiers: Default::default(),
+            overrides: None,
+            currency_hint: None,
+            preferred_provider: None,
+            bond_metadata: None,
+            custom_provider_code: None,
+        };
+
+        let (result, _) = registry
+            .fetch_quotes_with_diagnostics(&context, Utc::now(), Utc::now())
+            .await;
+
+        assert!(matches!(result, Err(MarketDataError::NoDataForRange)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- align web and desktop health price retries by publishing the same market-sync lifecycle events and inspecting the full sync result
- let explicit targeted retries bypass the consecutive-error cutoff without clearing their existing error state first
- show skipped-asset reasons only for user-initiated health fixes, keeping routine background syncs quiet
- treat empty historical responses as provider-level no-data so the registry can try the next provider
- classify exhausted no-data as a structured neutral skip: it neither increments nor resets `error_count`
- keep real provider failures from being masked by a later empty response
- centralize the server market-sync completion payload and deduplicate sync error toasts
- add regression coverage for targeted retry policy, structured no-data skips, provider failover, and provider-error precedence

## Root cause

The web health-fix path discarded `SyncResult` details and emitted no market-sync events, so a fix that skipped every asset appeared successful. The provider registry also accepted `Ok([])` as a successful historical fetch, allowing sync state to be cleared even though no quotes were stored.

A blanket conversion of empty history into a failed asset would overcorrect this behavior: legitimate no-data windows can occur for sparse, suspended, newly listed, or delisted assets. This PR therefore separates provider failover from asset outcome semantics. Empty results trigger provider failover, while an all-provider no-data result becomes a neutral skip. Actual symbol, validation, network, and provider failures remain failures.

## Impact

Health retries now behave consistently in desktop and web modes. Users receive an actionable skip reason when an explicit retry finds no data, but normal background syncs do not emit warning noise. Legitimate empty windows no longer accumulate errors or trigger repeated failure toasts, and a successful later retry still clears prior errors through the normal success path.

The Yahoo `CASH:` empty-result path remains safe because cash assets are excluded by sync planning before provider dispatch.

## Validation

- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p wealthfolio-core quotes::sync::tests` — 68 passed
- `cargo test -p wealthfolio-market-data registry::provider_registry::tests` — 11 passed
- `pnpm test` — 1,107 passed
- `pnpm type-check`
- `cargo check -p wealthfolio-server`
- `cargo check -p wealthfolio-app`
- `git diff --check`

Fixes #740