### PR TITLE
fix(addons): keep navigation above add-on views

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8560,7 +8560,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-agent-tools"
-version = "3.6.2"
+version = "3.6.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8577,7 +8577,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-ai"
-version = "3.6.2"
+version = "3.6.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8608,7 +8608,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-app"
-version = "3.6.2"
+version = "3.6.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8665,7 +8665,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-connect"
-version = "3.6.2"
+version = "3.6.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8683,7 +8683,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-core"
-version = "3.6.2"
+version = "3.6.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8728,7 +8728,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-device-sync"
-version = "3.6.2"
+version = "3.6.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8752,7 +8752,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-market-data"
-version = "3.6.2"
+version = "3.6.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8774,7 +8774,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-mcp"
-version = "3.6.2"
+version = "3.6.3"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -8799,7 +8799,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-server"
-version = "3.6.2"
+version = "3.6.3"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8852,7 +8852,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-spending"
-version = "3.6.2"
+version = "3.6.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8870,7 +8870,7 @@ dependencies = [
 
 [[package]]
 name = "wealthfolio-storage-sqlite"
-version = "3.6.2"
+version = "3.6.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.6.2"
+version = "3.6.3"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frontend",
   "private": true,
-  "version": "3.6.2",
+  "version": "3.6.3",
   "type": "module",
   "homepage": "https://wealthfolio.app",
   "repository": {

--- a/apps/frontend/public/splash.css
+++ b/apps/frontend/public/splash.css
@@ -25,12 +25,11 @@ body {
 }
 
 /*
- * Ensure root content sits above the background. NOTE: the z-index here pairs
- * with the addon parking layer's z-index in addon-iframe-manager.ts
- * (getParkingRoot) — if this changes, that must too.
+ * Keep the root positioned without creating a stacking context. Normal root
+ * content still paints above the body background, while fixed host navigation
+ * can layer above the body-level add-on iframe parking layer.
  */
 #root {
   position: relative;
-  z-index: 1;
   background-color: transparent;
 }

--- a/apps/frontend/src/addons/iframe/addon-iframe-manager.ts
+++ b/apps/frontend/src/addons/iframe/addon-iframe-manager.ts
@@ -269,10 +269,9 @@ function getParkingRoot() {
       overflow: "visible",
       pointerEvents: "none",
       position: "fixed",
-      // index.html gives #root `z-index: 1` (splash-screen layering), which
-      // paints the whole app above z-auto body siblings. Match it so this
-      // later sibling wins the tie and addon frames show above page content,
-      // while staying below dialog/toast portals (z-50+).
+      // #root intentionally has no z-index, so this layer paints above normal
+      // page content while fixed host navigation and portals (z-40+) remain
+      // above the add-on frame.
       zIndex: "1",
     });
     document.body.appendChild(root);

--- a/apps/tauri/gen/apple/wealthfolio-app_iOS/Info.plist
+++ b/apps/tauri/gen/apple/wealthfolio-app_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.6.0</string>
+	<string>3.6.3</string>
 	<key>CFBundleVersion</key>
-	<string>3.6.0</string>
+	<string>3.6.3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/apps/tauri/tauri.conf.json
+++ b/apps/tauri/tauri.conf.json
@@ -40,7 +40,7 @@
   },
   "productName": "Wealthfolio",
   "mainBinaryName": "Wealthfolio",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "identifier": "com.teymz.wealthfolio",
   "plugins": {
     "updater": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wealthfolio-app",
   "private": true,
-  "version": "3.6.2",
+  "version": "3.6.3",
   "packageManager": "pnpm@10.33.4",
   "type": "module",
   "workspaces": [

--- a/packages/addon-dev-tools/package.json
+++ b/packages/addon-dev-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/addon-dev-tools",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "description": "Development tools for Wealthfolio addons - hot reload server and CLI",
   "main": "index.js",
   "bin": {

--- a/packages/addon-dev-tools/templates/manifest.json.template
+++ b/packages/addon-dev-tools/templates/manifest.json.template
@@ -5,8 +5,8 @@
   "description": "{{description}}",
   "author": "{{author}}",
   "main": "dist/addon.js",
-  "sdkVersion": "3.6.2",
-  "minWealthfolioVersion": "3.6.2",
+  "sdkVersion": "3.6.3",
+  "minWealthfolioVersion": "3.6.3",
   "enabled": true,
   "contributes": {
     "routes": [{ "id": "{{addonId}}" }],
@@ -24,7 +24,7 @@
   },
   "hostDependencies": {
     "@tanstack/react-query": "^5.90.0",
-    "@wealthfolio/addon-sdk": "^3.6.2",
+    "@wealthfolio/addon-sdk": "^3.6.3",
     "@wealthfolio/ui": "^3.6.0",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.561.0",

--- a/packages/addon-dev-tools/templates/package.json.template
+++ b/packages/addon-dev-tools/templates/package.json.template
@@ -18,7 +18,7 @@
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.90.0",
-    "@wealthfolio/addon-sdk": "^3.6.2",
+    "@wealthfolio/addon-sdk": "^3.6.3",
     "@wealthfolio/ui": "^3.6.0",
     "date-fns": "^4.1.0",
     "lucide-react": "^0.561.0",
@@ -30,7 +30,7 @@
     "@tanstack/react-query": "^5.90.20",
     "@tailwindcss/vite": "^4.1.13",
     "@wealthfolio/addon-dev-tools": "^3.6.0",
-    "@wealthfolio/addon-sdk": "^3.6.2",
+    "@wealthfolio/addon-sdk": "^3.6.3",
     "@wealthfolio/ui": "^3.6.0",
     "@types/node": "^20.0.0",
     "@types/react": "^19.2.13",

--- a/packages/addon-sdk/package.json
+++ b/packages/addon-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/addon-sdk",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "type": "module",
   "description": "TypeScript SDK for building Wealthfolio addons with enhanced functionality and type safety",
   "main": "dist/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wealthfolio/ui",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "type": "module",
   "description": "Wealthfolio UI components based on shadcn/ui and Tailwind CSS",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- keep mobile and floating host navigation above sandboxed add-on views
- preserve add-on iframe layering above normal route content and below host navigation/dialog portals
- bump Wealthfolio and published workspace packages to 3.6.3

## Root cause

The React root and the body-level add-on parking layer both created stacking contexts at `z-index: 1`. Because the add-on layer is appended after `#root`, it painted above the entire application, including mobile navigation with an internal higher z-index. The iframe also intercepted pointer input, leaving users unable to navigate away.

Removing the `#root` stacking context lets normal app content remain below the add-on iframe while fixed host navigation (`z-40`/`z-50`) and portal UI remain above it. The behavior applies consistently to iOS, desktop launch-bar mode, and responsive web layouts.

This is an alternative to #1238's portal-based approach and avoids moving navigation outside its existing React layout.

## Validation

- `pnpm check`
- `pnpm test --run` (1,107 tests)
- `pnpm build`
- `pnpm build:tauri`
- `cargo check --locked`
- `cargo test --workspace --locked`
- JSON/plist/Cargo metadata validation
- `git diff --check`

Closes #1313
Closes #1273
