### PR TITLE
fix: Addon sandbox fails to load on WebKit (iOS) due to CSP `'self'` in sandboxed iframe

### DIFF
--- a/apps/frontend/addon-sandbox.html
+++ b/apps/frontend/addon-sandbox.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'none'; script-src 'self' 'unsafe-inline' blob: http://localhost:* http://127.0.0.1:* http://tauri.localhost https://tauri.localhost tauri: asset:; style-src 'self' 'unsafe-inline' http://localhost:* http://127.0.0.1:* http://tauri.localhost https://tauri.localhost tauri: asset:; img-src 'self' data: blob: http://localhost:* http://127.0.0.1:* http://tauri.localhost https://tauri.localhost tauri: asset:; font-src 'self' data: blob: http://localhost:* http://127.0.0.1:* http://tauri.localhost https://tauri.localhost tauri: asset:; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'"
+      content="default-src 'none'; script-src 'unsafe-inline' blob: https: http: tauri: asset:; style-src 'unsafe-inline' https: http: tauri: asset:; img-src data: blob: https: http: tauri: asset:; font-src data: blob: https: http: tauri: asset:; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'"
     />
     <script>
       (function () {

--- a/apps/server/src/api.rs
+++ b/apps/server/src/api.rs
@@ -85,21 +85,48 @@ pub async fn readyz() -> &'static str {
 pub struct ApiDoc;
 
 const SERVER_CSP: &str = "default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https://wealthfolio.app https://auth.wealthfolio.app https://connect.wealthfolio.app https://connect-staging.wealthfolio.app; frame-src 'self' blob: about:; child-src 'self' blob: about:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; worker-src 'self' blob:";
-const ADDON_SANDBOX_CSP: &str = "default-src 'none'; script-src 'self' 'unsafe-inline' blob:; style-src 'self' 'unsafe-inline'; img-src data: blob:; font-src 'self' data: blob:; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'";
+
+fn addon_sandbox_csp(origin: &str) -> String {
+    format!(
+        "default-src 'none'; script-src {} 'unsafe-inline' blob:; style-src {} 'unsafe-inline'; img-src data: blob:; font-src {} data: blob:; connect-src 'none'; object-src 'none'; base-uri 'none'; form-action 'none'",
+        origin, origin, origin
+    )
+}
 
 pub async fn security_headers(request: Request<Body>, next: Next) -> Response {
     let path = request.uri().path().to_string();
+    let origin = request
+        .headers()
+        .get("host")
+        .and_then(|h| h.to_str().ok())
+        .map(|host| {
+            let scheme = if request
+                .headers()
+                .get("x-forwarded-proto")
+                .and_then(|h| h.to_str().ok())
+                .unwrap_or("http")
+                == "https"
+            {
+                "https"
+            } else {
+                "http"
+            };
+            format!("{}://{}", scheme, host)
+        })
+        .unwrap_or_else(|| "'self'".to_string());
     let mut response = next.run(request).await;
     let headers = response.headers_mut();
-    let csp = if path.ends_with("/addon-sandbox.html") {
-        ADDON_SANDBOX_CSP
+    if path.ends_with("/addon-sandbox.html") {
+        let csp = addon_sandbox_csp(&origin);
+        if let Ok(value) = HeaderValue::from_str(&csp) {
+            headers.insert(HeaderName::from_static("content-security-policy"), value);
+        }
     } else {
-        SERVER_CSP
+        headers.insert(
+            HeaderName::from_static("content-security-policy"),
+            HeaderValue::from_static(SERVER_CSP),
+        );
     };
-    headers.insert(
-        HeaderName::from_static("content-security-policy"),
-        HeaderValue::from_static(csp),
-    );
     if !path.starts_with("/api/") && !path.starts_with("/mcp") {
         headers.insert(
             HeaderName::from_static("access-control-allow-origin"),


### PR DESCRIPTION
## Description

Addons fail to load on iOS browsers (Chrome/Safari) with a timeout error. The addon sandbox iframe never finishes bootstrapping because WebKit blocks all scripts and stylesheets.

**Console errors on iOS:**
```
Refused to load https://example.com/assets/addon-sandbox-m9pemPyl.js because it does not appear in the script-src directive of the Content Security Policy.
Refused to load https://example.com/addon-sandbox.css because it does not appear in the style-src directive of the Content Security Policy.
Failed to load addon rebalancer: Error: Timed out loading addon 'rebalancer' during sandbox document loaded
```

**Works on:** Desktop Chrome (Blink)  
**Broken on:** iOS Chrome, iOS Safari, any WebKit-based browser

### Root Cause

The addon sandbox iframe uses `sandbox="allow-scripts"` without `allow-same-origin`, which assigns the iframe an **opaque (null) origin**. The CSP for the sandbox used the `'self'` keyword in `script-src` and `style-src`.

**Blink (Chrome desktop)** resolves `'self'` against the document's URL even in sandboxed iframes — so it matches the server origin and loads assets fine.

**WebKit (Safari/iOS)** strictly resolves `'self'` against the document's effective origin, which is opaque/null for sandboxed iframes. This means `'self'` matches nothing, and all same-origin script/style loads are blocked.

### Fix

**1. api.rs** — Dynamic CSP for addon sandbox

Replaced the static `ADDON_SANDBOX_CSP` constant with a function that constructs the CSP using the actual request origin (from `Host` + `X-Forwarded-Proto` headers) instead of relying on `'self'`:

```rust
fn addon_sandbox_csp(origin: &str) -> String {
    format!(
        "default-src 'none'; script-src {} 'unsafe-inline' blob:; ...",
        origin, origin, origin
    )
}
```

This produces `script-src https://wealthfolio.example.com 'unsafe-inline' blob:` — which works correctly regardless of the browser's interpretation of `'self'` in sandboxed contexts.

**2. addon-sandbox.html** — Broadened meta tag CSP

The HTML meta tag CSP (used in Tauri mode where no HTTP server sets headers) was replaced:

```diff
- script-src 'self' 'unsafe-inline' blob: http://localhost:* http://127.0.0.1:* http://tauri.localhost https://tauri.localhost tauri: asset:
+ script-src 'unsafe-inline' blob: https: http: tauri: asset:
```

Removed `'self'` (broken on WebKit in sandboxed iframes) and the enumerated localhost origins. Replaced with scheme sources (`https:`, `http:`). This is safe because:

- In **web mode**: the server's HTTP header CSP (specific origin) intersects with the meta tag CSP (broad). Effective policy = the server's strict CSP.
- In **Tauri mode**: only the meta tag applies, but the sandbox still has `connect-src 'none'` (no network), `sandbox="allow-scripts"` only (no DOM/storage access), and addon code is loaded from local files.

### Security Impact

- `connect-src 'none'` remains — addons cannot make network requests
- `sandbox="allow-scripts"` without `allow-same-origin` remains — no access to parent cookies, localStorage, or DOM
- `form-action 'none'`, `object-src 'none'`, `base-uri 'none'` remain
- The effective CSP in web deployments is unchanged (server header is the binding constraint)

### Testing

Verified addon loading on iOS Safari (via Safari Web Inspector) — addon sandbox bootstraps and renders correctly. Desktop Chrome continues to work as before.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
