### PR TITLE
feat(insights): Extend range of performance chart to start date of the oldest series when plotting multiple items

### DIFF
--- a/apps/frontend/src/components/performance-chart-mobile.tsx
+++ b/apps/frontend/src/components/performance-chart-mobile.tsx
@@ -23,13 +23,18 @@ interface PerformanceChartMobileProps {
 }
 
 export function PerformanceChartMobile({ data }: PerformanceChartMobileProps) {
-  const formattedData = data[0]?.returns?.map((item) => {
-    const dataPoint: Record<string, number | string> = { date: item.date };
-    data.forEach((series) => {
-      const matchingPoint = series.returns?.find((p) => p.date === item.date);
-      if (matchingPoint) {
-        dataPoint[series.id] = matchingPoint.value;
-      }
+  const dates = [
+    ...new Set(data.flatMap((series) => series.returns.map((point) => point.date))),
+  ].sort((a, b) => a.localeCompare(b));
+  const valuesBySeries = data.map((series) => ({
+    id: series.id,
+    values: new Map(series.returns.map((point) => [point.date, point.value])),
+  }));
+  const formattedData = dates.map((date) => {
+    const dataPoint: Record<string, number | string> = { date };
+    valuesBySeries.forEach((series) => {
+      const value = series.values.get(date);
+      if (value !== undefined) dataPoint[series.id] = value;
     });
     return dataPoint;
   });

--- a/apps/frontend/src/components/performance-chart.tsx
+++ b/apps/frontend/src/components/performance-chart.tsx
@@ -23,13 +23,18 @@ interface PerformanceChartProps {
 }
 
 export function PerformanceChart({ data }: PerformanceChartProps) {
-  const formattedData = data[0]?.returns?.map((item) => {
-    const dataPoint: Record<string, number | string> = { date: item.date };
-    data.forEach((series) => {
-      const matchingPoint = series.returns?.find((p) => p.date === item.date);
-      if (matchingPoint) {
-        dataPoint[series.id] = matchingPoint.value;
-      }
+  const dates = [
+    ...new Set(data.flatMap((series) => series.returns.map((point) => point.date))),
+  ].sort((a, b) => a.localeCompare(b));
+  const valuesBySeries = data.map((series) => ({
+    id: series.id,
+    values: new Map(series.returns.map((point) => [point.date, point.value])),
+  }));
+  const formattedData = dates.map((date) => {
+    const dataPoint: Record<string, number | string> = { date };
+    valuesBySeries.forEach((series) => {
+      const value = series.values.get(date);
+      if (value !== undefined) dataPoint[series.id] = value;
     });
     return dataPoint;
   });

--- a/apps/frontend/src/i18n/locales/de/performance.json
+++ b/apps/frontend/src/i18n/locales/de/performance.json
@@ -50,6 +50,9 @@
   "print_report": "Bericht drucken",
   "no_performance_data": "Keine Performancedaten verfügbar",
   "no_performance_data_desc": "Fügen Sie Aktivitäten zu Ihrem Portfolio hinzu, um Performance-Kennzahlen zu sehen.",
+  "range": {
+    "common_description": "Ab dem frühesten Datum vergleichen, das alle dargestellten Reihen gemeinsam haben."
+  },
   "tracking_mode": {
     "mixed": "Gemischter Modus",
     "holdings": "Bestandsmodus"

--- a/apps/frontend/src/i18n/locales/en/performance.json
+++ b/apps/frontend/src/i18n/locales/en/performance.json
@@ -50,6 +50,9 @@
   "print_report": "Print Report",
   "no_performance_data": "No performance data available",
   "no_performance_data_desc": "Add activities to your portfolio to see performance metrics.",
+  "range": {
+    "common_description": "Compare from the earliest date shared by all plotted series."
+  },
   "tracking_mode": {
     "mixed": "Mixed mode",
     "holdings": "Holdings mode"

--- a/apps/frontend/src/i18n/locales/es/performance.json
+++ b/apps/frontend/src/i18n/locales/es/performance.json
@@ -50,6 +50,9 @@
   "print_report": "Imprimir informe",
   "no_performance_data": "No hay datos de rendimiento disponibles",
   "no_performance_data_desc": "Añade actividades a tu cartera para ver las métricas de rendimiento.",
+  "range": {
+    "common_description": "Comparar desde la fecha más antigua compartida por todas las series mostradas."
+  },
   "tracking_mode": {
     "mixed": "Modo mixto",
     "holdings": "Modo de posiciones"

--- a/apps/frontend/src/i18n/locales/fr/performance.json
+++ b/apps/frontend/src/i18n/locales/fr/performance.json
@@ -50,6 +50,9 @@
   "print_report": "Imprimer le rapport",
   "no_performance_data": "Aucune donnée de performance disponible",
   "no_performance_data_desc": "Ajoutez des activités à votre portefeuille pour voir les métriques de performance.",
+  "range": {
+    "common_description": "Comparer à partir de la première date commune à toutes les séries affichées."
+  },
   "tracking_mode": {
     "mixed": "Mode mixte",
     "holdings": "Mode avoirs"

--- a/apps/frontend/src/i18n/locales/zh/performance.json
+++ b/apps/frontend/src/i18n/locales/zh/performance.json
@@ -50,6 +50,9 @@
   "print_report": "打印报告",
   "no_performance_data": "暂无可用的表现数据",
   "no_performance_data_desc": "向您的投资组合添加活动以查看表现指标。",
+  "range": {
+    "common_description": "从所有已绘制序列共有的最早日期开始比较。"
+  },
   "tracking_mode": {
     "mixed": "混合模式",
     "holdings": "持仓模式"

--- a/apps/frontend/src/pages/performance/performance-chart-series.test.ts
+++ b/apps/frontend/src/pages/performance/performance-chart-series.test.ts
@@ -174,4 +174,37 @@ describe("comparablePerformanceChartData", () => {
 
     expect(data.map((item) => item.id)).toEqual(["portfolio", "SPY"]);
   });
+
+  it("keeps each series full history and rebases it independently for all-time comparison", () => {
+    const data = comparablePerformanceChartData(
+      [
+        result("older", "timeWeighted", { twr: 0.3 }, [
+          { date: "2026-01-01", value: 0.1 },
+          { date: "2026-01-02", value: 0.2 },
+          { date: "2026-01-03", value: 0.3 },
+        ]),
+        result("newer", "timeWeighted", { twr: 0.1 }, [
+          { date: "2026-01-02", value: 0.05 },
+          { date: "2026-01-03", value: 0.1 },
+        ]),
+        result("disjoint", "timeWeighted", { twr: 0.02 }, [
+          { date: "2026-02-01", value: 0.01 },
+          { date: "2026-02-02", value: 0.02 },
+        ]),
+      ],
+      "twr",
+      "older",
+      "all",
+    );
+
+    expect(data.map((item) => item.id)).toEqual(["older", "newer", "disjoint"]);
+    expect(data.map((item) => item.returns.map((point) => point.date))).toEqual([
+      ["2026-01-01", "2026-01-02", "2026-01-03"],
+      ["2026-01-02", "2026-01-03"],
+      ["2026-02-01", "2026-02-02"],
+    ]);
+    expect(data.map((item) => item.returns[0].value)).toEqual([0, 0, 0]);
+    expect(data[0].returns[2].value).toBeCloseTo(1.3 / 1.1 - 1);
+    expect(data[1].returns[1].value).toBeCloseTo(1.1 / 1.05 - 1);
+  });
 });

--- a/apps/frontend/src/pages/performance/performance-chart-series.ts
+++ b/apps/frontend/src/pages/performance/performance-chart-series.ts
@@ -1,6 +1,7 @@
 import type { PerformanceResult, ReturnData } from "@/lib/types";
 
 export type PerformanceMetric = "twr" | "irr" | "valueReturn" | "volatility" | "drawdown";
+export type PerformanceComparisonRange = "all" | "common";
 
 export interface ComparablePerformanceSeries extends PerformanceResult {
   id: string;
@@ -125,6 +126,7 @@ export function comparablePerformanceChartData(
   performanceData: (ComparablePerformanceSeries | null)[] | undefined,
   metric: PerformanceMetric,
   selectedItemId: string | null,
+  comparisonRange: PerformanceComparisonRange = "common",
 ): ComparableChartDataItem[] {
   if (metric !== "twr" && metric !== "valueReturn") return [];
   if (!performanceData) return [];
@@ -151,6 +153,28 @@ export function comparablePerformanceChartData(
   const comparableSeries = candidates
     .filter((entry) => entry.group === selectedGroup)
     .map(({ item }) => item);
+  if (comparisonRange === "all") {
+    const anchor = selectedItemId
+      ? (comparableSeries.find((item) => item.id === selectedItemId) ?? comparableSeries[0])
+      : comparableSeries[0];
+    if (!anchor || anchor.series.length < 2) return [];
+
+    return comparableSeries.flatMap((item) => {
+      const dates = [...new Set(item.series.map((point) => point.date))].sort((a, b) =>
+        a.localeCompare(b),
+      );
+      if (dates.length < 2) return [];
+      const returns = rebaseSeriesToDates(item.series, dates);
+      if (!returns) return [];
+      return {
+        id: item.id,
+        name: item.name,
+        returns,
+        isReference: item.mode === "symbolPriceBased",
+      };
+    });
+  }
+
   const selectedComparableSeries = selectComparableSeries(comparableSeries, selectedItemId);
   const commonDates = comparableDateIntersection(selectedComparableSeries);
   if (commonDates.length < 2) return [];

--- a/apps/frontend/src/pages/performance/performance-page.tsx
+++ b/apps/frontend/src/pages/performance/performance-page.tsx
@@ -69,6 +69,7 @@ import { useCalculatePerformanceHistory } from "./hooks/use-performance-data";
 import {
   comparablePerformanceChartData,
   type ComparableChartDataItem as ChartDataItem,
+  type PerformanceComparisonRange,
   type PerformanceMetric,
 } from "./performance-chart-series";
 import {
@@ -989,6 +990,10 @@ export default function PerformancePage() {
       to: new Date(),
     },
   );
+  const [comparisonRange, setComparisonRange] = usePersistentState<PerformanceComparisonRange>(
+    "performance:comparisonRange",
+    "all",
+  );
 
   useEffect(() => {
     if (!dateRange?.from || !dateRange?.to) return;
@@ -1009,6 +1014,7 @@ export default function PerformancePage() {
     [storedSelectedItems],
   );
   const selectedItemId = migratePerformanceSelectedItemId(storedSelectedItemId);
+  const effectiveComparisonRange = selectedItems.length > 1 ? comparisonRange : "all";
 
   useEffect(() => {
     if (selectedItems !== storedSelectedItems) {
@@ -1119,8 +1125,9 @@ export default function PerformancePage() {
       performanceData,
       selectedChartMetric,
       activeChartAnchorId ?? null,
+      effectiveComparisonRange,
     );
-  }, [activeChartAnchorId, performanceData, selectedChartMetric]);
+  }, [activeChartAnchorId, effectiveComparisonRange, performanceData, selectedChartMetric]);
 
   const chartColorMap = useMemo(() => {
     const map = new Map<string, string>();
@@ -1391,14 +1398,34 @@ export default function PerformancePage() {
     }
   };
 
+  const handleDateRangeChange = (range: DateRange | undefined) => {
+    setDateRange(range);
+    setComparisonRange("all");
+  };
+  const customDateRangePresets =
+    selectedItems.length > 1
+      ? [
+          {
+            label: "COMMON",
+            name: t("performance:range.common_description"),
+            onSelect: () => {
+              setDateRange(undefined);
+              setComparisonRange("common");
+            },
+          },
+        ]
+      : [];
+
   return (
     <>
       {/* Date range selector - fixed position in header area */}
       <div className="pointer-events-auto fixed right-2 top-4 z-20 hidden md:block lg:right-4">
         <DateRangeSelector
           value={dateRange}
-          onChange={setDateRange}
+          onChange={handleDateRangeChange}
           hiddenRanges={PERFORMANCE_HIDDEN_DATE_RANGES}
+          customPresets={customDateRangePresets}
+          selectedCustomPreset={effectiveComparisonRange === "common" ? "COMMON" : undefined}
         />
       </div>
 
@@ -1406,8 +1433,10 @@ export default function PerformancePage() {
         <div className="flex justify-end md:hidden">
           <DateRangeSelector
             value={dateRange}
-            onChange={setDateRange}
+            onChange={handleDateRangeChange}
             hiddenRanges={PERFORMANCE_HIDDEN_DATE_RANGES}
+            customPresets={customDateRangePresets}
+            selectedCustomPreset={effectiveComparisonRange === "common" ? "COMMON" : undefined}
           />
         </div>
 

--- a/packages/ui/src/components/common/date-range-selector.tsx
+++ b/packages/ui/src/components/common/date-range-selector.tsx
@@ -73,13 +73,27 @@ const ranges = [
 
 type DateRangePresetLabel = (typeof ranges)[number]["label"];
 
+interface CustomDateRangePreset {
+  label: string;
+  name: string;
+  onSelect: () => void;
+}
+
 interface DateRangeSelectorProps {
   value: DateRange | undefined;
   onChange: (range: DateRange | undefined) => void;
   hiddenRanges?: readonly DateRangePresetLabel[];
+  customPresets?: readonly CustomDateRangePreset[];
+  selectedCustomPreset?: string;
 }
 
-export function DateRangeSelector({ value, onChange, hiddenRanges = [] }: DateRangeSelectorProps) {
+export function DateRangeSelector({
+  value,
+  onChange,
+  hiddenRanges = [],
+  customPresets = [],
+  selectedCustomPreset,
+}: DateRangeSelectorProps) {
   const { t } = useTranslation();
   const locale = useDateFnsLocale();
   const isMobile = useIsMobile();
@@ -106,7 +120,7 @@ export function DateRangeSelector({ value, onChange, hiddenRanges = [] }: DateRa
     return selected?.label;
   };
 
-  const selectedLabel = getSelectedRange();
+  const selectedLabel = selectedCustomPreset ?? getSelectedRange();
   const isCustomRange = !selectedLabel;
   const isDraftRangeComplete = !draftRange || (!!draftRange.from && !!draftRange.to);
   const allTimeRange = visibleRanges.find((range) => range.label === "ALL")?.getValue();
@@ -146,11 +160,27 @@ export function DateRangeSelector({ value, onChange, hiddenRanges = [] }: DateRa
   return (
     <div className="flex items-center space-x-1">
       <AnimatedToggleGroup
-        items={visibleRanges.map((range) => ({
-          value: range.label,
-          label: range.label,
-          title: t("ui:dateRange.presets." + range.label, range.name),
-        }))}
+        items={[
+          ...visibleRanges
+            .filter((range) => range.label !== "ALL")
+            .map((range) => ({
+              value: range.label,
+              label: range.label,
+              title: t("ui:dateRange.presets." + range.label, range.name),
+            })),
+          ...customPresets.map((range) => ({
+            value: range.label,
+            label: range.label,
+            title: range.name,
+          })),
+          ...visibleRanges
+            .filter((range) => range.label === "ALL")
+            .map((range) => ({
+              value: range.label,
+              label: range.label,
+              title: t("ui:dateRange.presets." + range.label, range.name),
+            })),
+        ]}
         value={selectedLabel}
         onValueChange={(newValue) => {
           if (!newValue) {
@@ -159,7 +189,9 @@ export function DateRangeSelector({ value, onChange, hiddenRanges = [] }: DateRa
           const selectedRange = visibleRanges.find((r) => r.label === newValue);
           if (selectedRange) {
             onChange(selectedRange.getValue());
+            return;
           }
+          customPresets.find((range) => range.label === newValue)?.onSelect();
         }}
         size="sm"
         variant="secondary"


### PR DESCRIPTION
## Previous behaviour

Currently, in the `Performance` tab of the `Insights` section, we can plot multiple series together to compare them (e.g.: two accounts/portfolios). However, as explained in https://github.com/wealthfolio/wealthfolio/issues/1318, when we do that, the page restricts the selectable date range to the earliest common date between both series. This is true both when clicking the `ALL` button and when manually selecting a date range from the date picker. As far as I can see there's no real reason for this limitation, as the user may want to compare the evolution of multiple accounts/portfolios since the first one was created.

## What this change does

This PR lifts this limitation by allowing the selectable range to go as far back as the start date of the oldest series, rebasing them accordingly. It adds a new `COMMON` selector that implements the previous behaviour of the `ALL` button, and leaves the `ALL` button to select the true full selectable range.

<img width="1435" height="827" alt="common" src="https://github.com/user-attachments/assets/6e4d5731-e133-4ef4-9708-25e93f789c3a" />

<img width="1425" height="830" alt="all" src="https://github.com/user-attachments/assets/a105d4bf-4c78-4cc6-9bb2-181eab18b03d" />

Code changes stay fully on the frontend, so the Rust backend remains untouched. I have added tests, updated the translations with the new string and validated the UI behaviour in the narrower phone UI as well. All tests are passing.

## Quick summary of the implementation

1. `performance-chart-series.ts`: Introduces `PerformanceComparisonRange` with `all` and `common`, and preserves the previous common-date intersection behavior under `common`. Sorts, deduplicates and rebases each series independently from their first datapoint.

2. `performance-page.tsx`: Adds persistent `performance:comparisonRange` state, defaults the new behavior to `all` and forces `all` when only one item is selected. Passes the selected mode into `comparablePerformanceChartData` and adds the `COMMON` custom date-range preset when multiple items are selected (see point 3 below).

3. `date-range-selector.tsx`: Adds optional custom date-range presets, and allows a custom preset to supply its label, tooltip and selection callback. Adds externally controlled custom-preset selection so `COMMON` can appear active. I thought this was the cleanest implementation, as it allows selectively adding the `COMMON` option only in the pages where it makes sense (we would otherwise need to exclude it in every other page). Also opens up the possibility to introduce more custom ranges in the future. For instance, Portfolio Performance provides one-click buttons to set the start date of the chart to each of the start dates of the individual items, which I find very handy.

4. `performance-chart.tsx` and `performance-chart-mobile.tsx`: Now builds a sorted union of dates from every series, and uses per-series maps to insert values only where that series has a datapoint. Allows later-starting series to begin partway through the chart.

5. `performance-chart-series.test.ts` and translation files: Adds tests and translations for the new string.

This is my first submission to the project, so please be blunt if I did something terribly wrong here! Happy to learn and (hopefully) contribute more to this beautiful app.

- [X] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).