### PR TITLE
feat(spending): suggest categorization rules from manual categorizations

### DIFF
--- a/apps/frontend/src/adapters/web/core.ts
+++ b/apps/frontend/src/adapters/web/core.ts
@@ -221,6 +221,8 @@ export const COMMANDS: CommandMap = {
   list_rule_presets: { method: "GET", path: "/spending/rule-presets" },
   import_rule_preset: { method: "POST", path: "/spending/rule-presets" },
   remove_rule_preset: { method: "DELETE", path: "/spending/rule-presets" },
+  get_spending_rule_suggestions: { method: "GET", path: "/spending/rule-suggestions" },
+  apply_spending_rule_suggestion: { method: "POST", path: "/spending/rule-suggestions/apply" },
   // Spending events + event types
   list_event_types: { method: "GET", path: "/spending/event-types" },
   create_event_type: { method: "POST", path: "/spending/event-types" },
@@ -1451,6 +1453,13 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
     case "remove_rule_preset": {
       const { presetId } = payload as { presetId: string };
       url += `/${encodeURIComponent(presetId)}`;
+      break;
+    }
+    case "get_spending_rule_suggestions":
+      break;
+    case "apply_spending_rule_suggestion": {
+      const { request } = payload as { request: Record<string, unknown> };
+      body = JSON.stringify(request);
       break;
     }
     // Spending events + event types

--- a/apps/frontend/src/features/spending/adapters/suggestions.ts
+++ b/apps/frontend/src/features/spending/adapters/suggestions.ts
@@ -1,0 +1,23 @@
+import { invoke, logger } from "#platform";
+import type { CategorizationRule } from "../types/rule";
+import type { ApplySuggestionRequest, SuggestedRule } from "../types/suggestion";
+
+export const getSpendingRuleSuggestions = async (): Promise<SuggestedRule[]> => {
+  try {
+    return await invoke<SuggestedRule[]>("get_spending_rule_suggestions");
+  } catch (e) {
+    logger.error("Error loading rule suggestions.");
+    throw e;
+  }
+};
+
+export const applySpendingRuleSuggestion = async (
+  request: ApplySuggestionRequest,
+): Promise<CategorizationRule> => {
+  try {
+    return await invoke<CategorizationRule>("apply_spending_rule_suggestion", { request });
+  } catch (e) {
+    logger.error("Error applying rule suggestion.");
+    throw e;
+  }
+};

--- a/apps/frontend/src/features/spending/components/rule-suggestions-panel.tsx
+++ b/apps/frontend/src/features/spending/components/rule-suggestions-panel.tsx
@@ -1,0 +1,193 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import {
+  Badge,
+  Button,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  Icons,
+  Skeleton,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@wealthfolio/ui";
+import { cn } from "@/lib/utils";
+
+import { useSpendingRuleSuggestions } from "../hooks/use-spending-rule-suggestions";
+import type { RuleCategoryMeta } from "./rule-item";
+import type { SuggestedRule } from "../types/suggestion";
+
+interface RuleSuggestionsPanelProps {
+  /** taxonomyId:categoryId and bare categoryId → display metadata. */
+  categoryMeta: Record<string, RuleCategoryMeta>;
+}
+
+/**
+ * Rules the engine infers from how the user has categorized transactions by
+ * hand, shown above the rule list. Renders nothing while loading finds no
+ * suggestions, on error, or once every suggestion is applied or dismissed.
+ */
+export function RuleSuggestionsPanel({ categoryMeta }: RuleSuggestionsPanelProps) {
+  const { t } = useTranslation();
+  const { suggestions, isLoading, isError, dismiss, apply, applyingId } =
+    useSpendingRuleSuggestions();
+  const [open, setOpen] = useState(true);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-16 w-full" />
+      </div>
+    );
+  }
+  // Errors are non-blocking here — the rule list still works without suggestions.
+  if (isError || suggestions.length === 0) return null;
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="rounded-lg border border-dashed p-3">
+      <CollapsibleTrigger className="flex w-full items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Icons.Sparkles className="h-4 w-4 text-amber-500" aria-hidden="true" />
+          <span className="text-foreground text-sm font-medium">
+            {t("settings:spending.rules.suggestions.title", "Suggested rules")}
+          </span>
+          <Badge variant="secondary" className="tabular-nums">
+            {suggestions.length}
+          </Badge>
+        </div>
+        <Icons.ChevronDown
+          className={cn("text-muted-foreground h-4 w-4 transition-transform", open && "rotate-180")}
+          aria-hidden="true"
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent className="space-y-2 pt-3">
+        {suggestions.map((s) => (
+          <SuggestionCard
+            key={s.id}
+            suggestion={s}
+            categoryName={categoryMeta[s.categoryId]?.name ?? null}
+            applying={applyingId === s.id}
+            onApply={() => apply(s, categoryMeta[s.categoryId]?.name)}
+            onDismiss={() => dismiss(s.id)}
+          />
+        ))}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function SuggestionCard({
+  suggestion,
+  categoryName,
+  applying,
+  onApply,
+  onDismiss,
+}: {
+  suggestion: SuggestedRule;
+  categoryName: string | null;
+  applying: boolean;
+  onApply: () => void;
+  onDismiss: () => void;
+}) {
+  const { t } = useTranslation();
+  const [showExamples, setShowExamples] = useState(false);
+  const isExtend = suggestion.action.type === "extendRule";
+  const confidencePct = Math.round(suggestion.confidence * 100);
+  const merchantLabel = suggestion.merchants.join(", ");
+
+  return (
+    <div className="bg-card animate-in fade-in slide-in-from-top-1 rounded-md border p-3 duration-200">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1 space-y-1">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="text-foreground text-sm font-medium">{merchantLabel}</span>
+            <Icons.ArrowRight className="text-muted-foreground h-3 w-3" aria-hidden="true" />
+            <span className="text-foreground text-sm">{categoryName ?? suggestion.categoryId}</span>
+            {isExtend && suggestion.action.type === "extendRule" && (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Badge variant="outline" className="cursor-help text-[10px]">
+                      {t("settings:spending.rules.suggestions.extends", "Extends existing rule")}
+                    </Badge>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    <code className="text-xs">{suggestion.action.proposedPattern}</code>
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+          </div>
+          <div className="text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-0.5 text-xs">
+            {suggestion.uncategorizedMatchCount > 0 && (
+              <span>
+                {t("settings:spending.rules.suggestions.wouldCatch", {
+                  count: suggestion.uncategorizedMatchCount,
+                  defaultValue: "Catches {{count}} uncategorized",
+                })}
+              </span>
+            )}
+            <span className={confidenceClass(suggestion.confidence)}>
+              {t("settings:spending.rules.suggestions.confidence", {
+                pct: confidencePct,
+                defaultValue: "{{pct}}% confidence",
+              })}
+            </span>
+            {suggestion.examples.length > 0 && (
+              <button
+                type="button"
+                onClick={() => setShowExamples((v) => !v)}
+                className="hover:text-foreground underline-offset-2 hover:underline"
+              >
+                {showExamples
+                  ? t("settings:spending.rules.suggestions.hideExamples", "Hide examples")
+                  : t("settings:spending.rules.suggestions.showExamples", "Examples")}
+              </button>
+            )}
+          </div>
+          {showExamples && (
+            <ul className="text-muted-foreground mt-1 space-y-0.5 text-xs">
+              {suggestion.examples.map((ex) => (
+                <li key={ex} className="truncate font-mono">
+                  {ex}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <Button size="sm" onClick={onApply} disabled={applying}>
+            {applying ? (
+              <Icons.Spinner className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+            ) : (
+              <Icons.Plus className="mr-1 h-3.5 w-3.5" aria-hidden="true" />
+            )}
+            {isExtend
+              ? t("settings:spending.rules.suggestions.extend", "Extend")
+              : t("settings:spending.rules.suggestions.add", "Add rule")}
+          </Button>
+          <Button
+            size="icon"
+            variant="ghost"
+            onClick={onDismiss}
+            disabled={applying}
+            aria-label={t("settings:spending.rules.suggestions.dismiss", "Dismiss suggestion")}
+            className="h-8 w-8"
+          >
+            <Icons.X className="h-3.5 w-3.5" aria-hidden="true" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function confidenceClass(confidence: number): string {
+  if (confidence >= 0.8) return "text-success";
+  if (confidence >= 0.6) return "text-amber-600 dark:text-amber-500";
+  return "text-muted-foreground";
+}

--- a/apps/frontend/src/features/spending/components/rule-suggestions-panel.tsx
+++ b/apps/frontend/src/features/spending/components/rule-suggestions-panel.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import {
   Badge,
   Button,
+  Checkbox,
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
@@ -71,7 +72,9 @@ export function RuleSuggestionsPanel({ categoryMeta }: RuleSuggestionsPanelProps
             suggestion={s}
             categoryName={categoryMeta[s.categoryId]?.name ?? null}
             applying={applyingId === s.id}
-            onApply={() => apply(s, categoryMeta[s.categoryId]?.name)}
+            onApply={(useCaseInsensitive) =>
+              apply(s, categoryMeta[s.categoryId]?.name, useCaseInsensitive)
+            }
             onDismiss={() => dismiss(s.id)}
           />
         ))}
@@ -90,12 +93,14 @@ function SuggestionCard({
   suggestion: SuggestedRule;
   categoryName: string | null;
   applying: boolean;
-  onApply: () => void;
+  onApply: (useCaseInsensitive: boolean) => void;
   onDismiss: () => void;
 }) {
   const { t } = useTranslation();
   const [showExamples, setShowExamples] = useState(false);
+  const [useCaseInsensitive, setUseCaseInsensitive] = useState(false);
   const isExtend = suggestion.action.type === "extendRule";
+  const isCombine = suggestion.action.type === "combineRules";
   const confidencePct = Math.round(suggestion.confidence * 100);
   const merchantLabel = suggestion.merchants.join(", ");
 
@@ -118,6 +123,21 @@ function SuggestionCard({
                   <TooltipContent>
                     <code className="text-xs">{suggestion.action.proposedPattern}</code>
                   </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
+            {isCombine && suggestion.action.type === "combineRules" && (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Badge variant="outline" className="cursor-help text-[10px]">
+                      {t("settings:spending.rules.suggestions.combines", {
+                        count: suggestion.action.ruleIds.length,
+                        defaultValue: "Combines {{count}} existing rules",
+                      })}
+                    </Badge>
+                  </TooltipTrigger>
+                  <TooltipContent>{suggestion.action.ruleNames.join(", ")}</TooltipContent>
                 </Tooltip>
               </TooltipProvider>
             )}
@@ -158,9 +178,24 @@ function SuggestionCard({
               ))}
             </ul>
           )}
+          {suggestion.caseSensitive && suggestion.caseInsensitivePattern && (
+            <label className="text-muted-foreground mt-1.5 flex items-start gap-1.5 text-xs">
+              <Checkbox
+                checked={useCaseInsensitive}
+                onCheckedChange={(checked) => setUseCaseInsensitive(checked === true)}
+                className="mt-0.5"
+              />
+              <span>
+                {t(
+                  "settings:spending.rules.suggestions.switchCaseInsensitive",
+                  "This keeps your rule's case-sensitive matching. Also match regardless of case?",
+                )}
+              </span>
+            </label>
+          )}
         </div>
         <div className="flex shrink-0 items-center gap-1">
-          <Button size="sm" onClick={onApply} disabled={applying}>
+          <Button size="sm" onClick={() => onApply(useCaseInsensitive)} disabled={applying}>
             {applying ? (
               <Icons.Spinner className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
             ) : (
@@ -168,7 +203,9 @@ function SuggestionCard({
             )}
             {isExtend
               ? t("settings:spending.rules.suggestions.extend", "Extend")
-              : t("settings:spending.rules.suggestions.add", "Add rule")}
+              : isCombine
+                ? t("settings:spending.rules.suggestions.combine", "Combine")
+                : t("settings:spending.rules.suggestions.add", "Add rule")}
           </Button>
           <Button
             size="icon"

--- a/apps/frontend/src/features/spending/hooks/use-spending-rule-suggestions.ts
+++ b/apps/frontend/src/features/spending/hooks/use-spending-rule-suggestions.ts
@@ -58,12 +58,18 @@ export function useSpendingRuleSuggestions() {
     mutationFn: ({
       suggestion,
       categoryName,
+      useCaseInsensitive,
     }: {
       suggestion: SuggestedRule;
       categoryName?: string;
+      useCaseInsensitive?: boolean;
     }) => {
+      const pattern =
+        useCaseInsensitive && suggestion.caseInsensitivePattern
+          ? suggestion.caseInsensitivePattern
+          : suggestion.pattern;
       const request: ApplySuggestionRequest = {
-        pattern: suggestion.pattern,
+        pattern,
         taxonomyId: suggestion.taxonomyId,
         categoryId: suggestion.categoryId,
         categoryName: categoryName ?? null,
@@ -72,11 +78,16 @@ export function useSpendingRuleSuggestions() {
       return applySpendingRuleSuggestion(request);
     },
     onSuccess: (_rule, { suggestion }) => {
-      // The new/extended rule and the re-categorization it triggers touch rules,
-      // suggestions, and every downstream spending view.
+      // The new/extended/combined rule and the re-categorization it triggers
+      // touch rules, suggestions, and every downstream spending view.
       qc.invalidateQueries({ queryKey: [QueryKeys.SPENDING_RULES] });
       invalidateSpendingCaches(qc);
-      const verb = suggestion.action.type === "extendRule" ? "Extended" : "Added";
+      const verb =
+        suggestion.action.type === "extendRule"
+          ? "Extended"
+          : suggestion.action.type === "combineRules"
+            ? "Combined"
+            : "Added";
       toast.success(`${verb} rule for ${suggestion.merchants.join(", ")}.`);
     },
     onError: () => toast.error("Failed to apply suggestion."),
@@ -92,8 +103,8 @@ export function useSpendingRuleSuggestions() {
     isLoading: query.isLoading,
     isError: query.isError,
     dismiss,
-    apply: (suggestion: SuggestedRule, categoryName?: string) =>
-      applyMutation.mutate({ suggestion, categoryName }),
+    apply: (suggestion: SuggestedRule, categoryName?: string, useCaseInsensitive?: boolean) =>
+      applyMutation.mutate({ suggestion, categoryName, useCaseInsensitive }),
     applyingId:
       applyMutation.isPending && applyMutation.variables
         ? applyMutation.variables.suggestion.id

--- a/apps/frontend/src/features/spending/hooks/use-spending-rule-suggestions.ts
+++ b/apps/frontend/src/features/spending/hooks/use-spending-rule-suggestions.ts
@@ -1,0 +1,102 @@
+import { useCallback, useMemo, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
+import { QueryKeys } from "@/lib/query-keys";
+
+import { applySpendingRuleSuggestion, getSpendingRuleSuggestions } from "../adapters/suggestions";
+import { invalidateSpendingCaches } from "../lib/invalidation";
+import type { ApplySuggestionRequest, SuggestedRule } from "../types/suggestion";
+
+const DISMISSED_STORAGE_KEY = "wf.spending.dismissedRuleSuggestions";
+
+function readDismissed(): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  try {
+    const raw = window.localStorage.getItem(DISMISSED_STORAGE_KEY);
+    if (!raw) return new Set();
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed)
+      ? new Set(parsed.filter((v): v is string => typeof v === "string"))
+      : new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+function writeDismissed(ids: Set<string>): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(DISMISSED_STORAGE_KEY, JSON.stringify([...ids]));
+  } catch {
+    // A full or unavailable localStorage just means dismissals don't persist —
+    // not worth surfacing to the user.
+  }
+}
+
+export function useSpendingRuleSuggestions() {
+  const qc = useQueryClient();
+  const [dismissed, setDismissed] = useState<Set<string>>(readDismissed);
+
+  const query = useQuery<SuggestedRule[], Error>({
+    queryKey: [QueryKeys.SPENDING_RULES, "suggestions"],
+    queryFn: getSpendingRuleSuggestions,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  const dismiss = useCallback((id: string) => {
+    setDismissed((prev) => {
+      const next = new Set(prev);
+      next.add(id);
+      writeDismissed(next);
+      return next;
+    });
+  }, []);
+
+  const applyMutation = useMutation({
+    mutationFn: ({
+      suggestion,
+      categoryName,
+    }: {
+      suggestion: SuggestedRule;
+      categoryName?: string;
+    }) => {
+      const request: ApplySuggestionRequest = {
+        pattern: suggestion.pattern,
+        taxonomyId: suggestion.taxonomyId,
+        categoryId: suggestion.categoryId,
+        categoryName: categoryName ?? null,
+        action: suggestion.action,
+      };
+      return applySpendingRuleSuggestion(request);
+    },
+    onSuccess: (_rule, { suggestion }) => {
+      // The new/extended rule and the re-categorization it triggers touch rules,
+      // suggestions, and every downstream spending view.
+      qc.invalidateQueries({ queryKey: [QueryKeys.SPENDING_RULES] });
+      invalidateSpendingCaches(qc);
+      const verb = suggestion.action.type === "extendRule" ? "Extended" : "Added";
+      toast.success(`${verb} rule for ${suggestion.merchants.join(", ")}.`);
+    },
+    onError: () => toast.error("Failed to apply suggestion."),
+  });
+
+  const suggestions = useMemo(
+    () => (query.data ?? []).filter((s) => !dismissed.has(s.id)),
+    [query.data, dismissed],
+  );
+
+  return {
+    suggestions,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    dismiss,
+    apply: (suggestion: SuggestedRule, categoryName?: string) =>
+      applyMutation.mutate({ suggestion, categoryName }),
+    applyingId:
+      applyMutation.isPending && applyMutation.variables
+        ? applyMutation.variables.suggestion.id
+        : null,
+  };
+}

--- a/apps/frontend/src/features/spending/types/suggestion.ts
+++ b/apps/frontend/src/features/spending/types/suggestion.ts
@@ -9,6 +9,11 @@ export type SuggestionAction =
       existingRuleId: string;
       existingRuleName: string;
       proposedPattern: string;
+    }
+  | {
+      type: "combineRules";
+      ruleIds: string[];
+      ruleNames: string[];
     };
 
 export interface SuggestedRule {
@@ -28,6 +33,12 @@ export interface SuggestedRule {
   confidence: number;
   /** A few real transaction descriptions the pattern matches. */
   examples: string[];
+  /** True when `pattern` preserves a case-sensitive rule the user wrote,
+   * instead of the usual fully case-insensitive merge. */
+  caseSensitive: boolean;
+  /** Present only when `caseSensitive` is true: the same merge folded to
+   * fully case-insensitive, offered as an opt-in switch. */
+  caseInsensitivePattern: string | null;
   action: SuggestionAction;
 }
 

--- a/apps/frontend/src/features/spending/types/suggestion.ts
+++ b/apps/frontend/src/features/spending/types/suggestion.ts
@@ -1,0 +1,41 @@
+// Mirrors `wealthfolio_spending::suggestions::model`. Kept in sync by hand — the
+// backend serializes camelCase, and `SuggestionAction` is an internally-tagged
+// union on `type`.
+
+export type SuggestionAction =
+  | { type: "newRule" }
+  | {
+      type: "extendRule";
+      existingRuleId: string;
+      existingRuleName: string;
+      proposedPattern: string;
+    };
+
+export interface SuggestedRule {
+  /** Stable content hash — used to persist dismissals. */
+  id: string;
+  /** Proposed regex, e.g. `(?i)(aldi|coles|woolworths)`. */
+  pattern: string;
+  taxonomyId: string;
+  categoryId: string;
+  /** Merchant labels the pattern covers, for display. */
+  merchants: string[];
+  /** Hand-categorized transactions the pattern explains. */
+  matchCount: number;
+  /** Uncategorized transactions the pattern would newly catch. */
+  uncategorizedMatchCount: number;
+  /** 0.0–1.0. */
+  confidence: number;
+  /** A few real transaction descriptions the pattern matches. */
+  examples: string[];
+  action: SuggestionAction;
+}
+
+export interface ApplySuggestionRequest {
+  pattern: string;
+  taxonomyId: string;
+  categoryId: string;
+  /** New rule's name. Ignored when extending an existing rule. */
+  categoryName?: string | null;
+  action: SuggestionAction;
+}

--- a/apps/frontend/src/i18n/locales/en/settings.json
+++ b/apps/frontend/src/i18n/locales/en/settings.json
@@ -1159,7 +1159,18 @@
       "no_match_filter": "No rules match the current filter.",
       "clear_filters": "Clear filters",
       "recategorize_confirm_title": "Re-categorize all activities?",
-      "recategorize_confirm_desc": "This will re-run all rules against every activity in your spending accounts and may overwrite existing auto-categorized assignments. Manual categorizations are preserved."
+      "recategorize_confirm_desc": "This will re-run all rules against every activity in your spending accounts and may overwrite existing auto-categorized assignments. Manual categorizations are preserved.",
+      "suggestions": {
+        "title": "Suggested rules",
+        "extends": "Extends existing rule",
+        "wouldCatch": "Catches {{count}} uncategorized",
+        "confidence": "{{pct}}% confidence",
+        "showExamples": "Examples",
+        "hideExamples": "Hide examples",
+        "add": "Add rule",
+        "extend": "Extend",
+        "dismiss": "Dismiss suggestion"
+      }
     }
   },
   "addons_updates_critical_one": "({{count}} critical)",

--- a/apps/frontend/src/i18n/locales/en/settings.json
+++ b/apps/frontend/src/i18n/locales/en/settings.json
@@ -1163,13 +1163,16 @@
       "suggestions": {
         "title": "Suggested rules",
         "extends": "Extends existing rule",
+        "combines": "Combines {{count}} existing rules",
         "wouldCatch": "Catches {{count}} uncategorized",
         "confidence": "{{pct}}% confidence",
         "showExamples": "Examples",
         "hideExamples": "Hide examples",
         "add": "Add rule",
         "extend": "Extend",
-        "dismiss": "Dismiss suggestion"
+        "combine": "Combine",
+        "dismiss": "Dismiss suggestion",
+        "switchCaseInsensitive": "This keeps your rule's case-sensitive matching. Also match regardless of case?"
       }
     }
   },

--- a/apps/frontend/src/pages/settings/spending/rules/spending-rules-page.tsx
+++ b/apps/frontend/src/pages/settings/spending/rules/spending-rules-page.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/features/spending/components/rule-item";
 import { PRESET_FLAGS } from "@/features/spending/components/rule-preset-constants";
 import { RulePresetPicker } from "@/features/spending/components/rule-preset-picker";
+import { RuleSuggestionsPanel } from "@/features/spending/components/rule-suggestions-panel";
 import type {
   RuleFormCategoryOption,
   RuleFormValues,
@@ -299,6 +300,7 @@ export default function SpendingRulesPage() {
             <div className="bg-muted/30 rounded-lg border p-4">
               <RulePresetPicker />
             </div>
+            <RuleSuggestionsPanel categoryMeta={categoryMeta} />
             <EmptyPlaceholder>
               <EmptyPlaceholder.Icon name="ListFilter" />
               <EmptyPlaceholder.Title>
@@ -318,6 +320,8 @@ export default function SpendingRulesPage() {
             <div className="bg-muted/30 rounded-md border p-3">
               <RulePresetPicker compact />
             </div>
+
+            <RuleSuggestionsPanel categoryMeta={categoryMeta} />
 
             {/* Search + preset filter chips */}
             <div className="space-y-2">

--- a/apps/server/src/api/spending.rs
+++ b/apps/server/src/api/spending.rs
@@ -29,6 +29,7 @@ use wealthfolio_spending::categorization_rules::{
 use wealthfolio_spending::events::{Event, EventType, NewEvent, NewEventType, UpdateEvent};
 use wealthfolio_spending::insight::{SpendingInsight, SpendingInsightRequest};
 use wealthfolio_spending::settings::{SpendingSettings, SpendingSettingsUpdate};
+use wealthfolio_spending::suggestions::{ApplySuggestionRequest, SuggestedRule};
 
 const MAX_BULK_CATEGORY_ASSIGNMENTS: usize = 1_000;
 
@@ -381,6 +382,33 @@ async fn import_rule_preset(
         .await?;
     spawn_auto_categorize_for_opted_in_accounts(&state).await;
     Ok(Json(result))
+}
+
+async fn get_spending_rule_suggestions(
+    State(state): State<Arc<AppState>>,
+) -> ApiResult<Json<Vec<SuggestedRule>>> {
+    let s = state.spending_settings_service.get().await?;
+    if !s.enabled {
+        return Ok(Json(Vec::new()));
+    }
+    Ok(Json(
+        state
+            .categorization_rules_service
+            .suggest_rules(&s.account_ids)
+            .await?,
+    ))
+}
+
+async fn apply_spending_rule_suggestion(
+    State(state): State<Arc<AppState>>,
+    Json(request): Json<ApplySuggestionRequest>,
+) -> ApiResult<Json<CategorizationRule>> {
+    let rule = state
+        .categorization_rules_service
+        .apply_suggestion(request)
+        .await?;
+    spawn_auto_categorize_for_opted_in_accounts(&state).await;
+    Ok(Json(rule))
 }
 
 async fn list_event_types(State(state): State<Arc<AppState>>) -> ApiResult<Json<Vec<EventType>>> {
@@ -767,6 +795,14 @@ pub fn router() -> Router<Arc<AppState>> {
         .route(
             "/spending/rule-presets/{preset_id}",
             delete(remove_rule_preset),
+        )
+        .route(
+            "/spending/rule-suggestions",
+            get(get_spending_rule_suggestions),
+        )
+        .route(
+            "/spending/rule-suggestions/apply",
+            post(apply_spending_rule_suggestion),
         )
         .route(
             "/spending/event-types",

--- a/apps/tauri/src/commands/spending.rs
+++ b/apps/tauri/src/commands/spending.rs
@@ -25,6 +25,7 @@ use wealthfolio_spending::categorization_rules::{
 use wealthfolio_spending::events::{Event, EventType, NewEvent, NewEventType, UpdateEvent};
 use wealthfolio_spending::insight::{SpendingInsight, SpendingInsightRequest};
 use wealthfolio_spending::settings::{SpendingSettings, SpendingSettingsUpdate};
+use wealthfolio_spending::suggestions::{ApplySuggestionRequest, SuggestedRule};
 
 const MAX_BULK_CATEGORY_ASSIGNMENTS: usize = 1_000;
 
@@ -400,6 +401,39 @@ pub async fn remove_rule_preset(
         .remove_preset(&preset_id)
         .await
         .map_err(|e| format!("Failed to remove rule preset: {}", e))
+}
+
+#[tauri::command]
+pub async fn get_spending_rule_suggestions(
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<Vec<SuggestedRule>, String> {
+    let s = state
+        .spending_settings_service()
+        .get()
+        .await
+        .map_err(|e| format!("Failed to load spending settings: {}", e))?;
+    if !s.enabled {
+        return Ok(Vec::new());
+    }
+    state
+        .categorization_rules_service()
+        .suggest_rules(&s.account_ids)
+        .await
+        .map_err(|e| format!("Failed to build rule suggestions: {}", e))
+}
+
+#[tauri::command]
+pub async fn apply_spending_rule_suggestion(
+    request: ApplySuggestionRequest,
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<CategorizationRule, String> {
+    let rule = state
+        .categorization_rules_service()
+        .apply_suggestion(request)
+        .await
+        .map_err(|e| format!("Failed to apply rule suggestion: {}", e))?;
+    spawn_auto_categorize_for_opted_in_accounts(&state).await;
+    Ok(rule)
 }
 
 #[tauri::command]

--- a/apps/tauri/src/lib.rs
+++ b/apps/tauri/src/lib.rs
@@ -511,6 +511,8 @@ pub fn run() {
             commands::spending::list_rule_presets,
             commands::spending::import_rule_preset,
             commands::spending::remove_rule_preset,
+            commands::spending::get_spending_rule_suggestions,
+            commands::spending::apply_spending_rule_suggestion,
             commands::spending::list_event_types,
             commands::spending::create_event_type,
             commands::spending::update_event_type,

--- a/crates/spending/src/categorization_rules/service.rs
+++ b/crates/spending/src/categorization_rules/service.rs
@@ -15,6 +15,17 @@ use crate::activity_assignments::{
     ActivityTaxonomyAssignmentService, NewActivityTaxonomyAssignment,
 };
 use crate::error::SpendingError;
+use crate::suggestions::{
+    generate_suggestions, ApplySuggestionRequest, CategorizedSample, SuggestedRule,
+    SuggestionAction,
+};
+
+/// Activity-scope taxonomy that spending categories live under. Suggestions are
+/// derived from (and applied to) this taxonomy only.
+const SPENDING_TAXONOMY: &str = "spending_categories";
+/// Priority given to rules created from an accepted suggestion — below the
+/// bundled presets (70–95) but above the user-rule default (0).
+const SUGGESTED_RULE_PRIORITY: i32 = 50;
 
 pub struct CategorizationRulesService {
     repo: Arc<dyn CategorizationRulesRepositoryTrait>,
@@ -297,6 +308,108 @@ impl CategorizationRulesService {
             removed,
             kept_modified,
         })
+    }
+
+    /// Suggest categorization rules from the transactions the user has already
+    /// categorized by hand in the given accounts. Reads only; it never writes.
+    pub async fn suggest_rules(&self, account_ids: &[String]) -> Result<Vec<SuggestedRule>> {
+        if account_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let activities = self
+            .activity_repo
+            .get_activities_by_account_ids(account_ids)
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+
+        let ids: Vec<String> = activities.iter().map(|a| a.id.clone()).collect();
+        let assignments = self.assignment_service.list_for_activities(&ids).await?;
+
+        // Which activities already have a manual spending category, and which
+        // one. A `manual` assignment is the user's explicit choice — the signal
+        // suggestions are built from.
+        let mut manual_category: HashMap<&str, &str> = HashMap::new();
+        let mut has_spending_assignment: std::collections::HashSet<&str> =
+            std::collections::HashSet::new();
+        for a in &assignments {
+            if a.taxonomy_id != SPENDING_TAXONOMY {
+                continue;
+            }
+            has_spending_assignment.insert(a.activity_id.as_str());
+            if a.source == "manual" {
+                manual_category.insert(a.activity_id.as_str(), a.category_id.as_str());
+            }
+        }
+
+        let mut categorized: Vec<CategorizedSample> = Vec::new();
+        let mut uncategorized: Vec<String> = Vec::new();
+        for a in &activities {
+            let Some(notes) = a.notes.as_deref() else {
+                continue;
+            };
+            if notes.trim().is_empty() {
+                continue;
+            }
+            if let Some(category_id) = manual_category.get(a.id.as_str()) {
+                categorized.push(CategorizedSample {
+                    text: notes.to_string(),
+                    taxonomy_id: SPENDING_TAXONOMY.to_string(),
+                    category_id: category_id.to_string(),
+                });
+            } else if !has_spending_assignment.contains(a.id.as_str()) {
+                uncategorized.push(notes.to_string());
+            }
+        }
+
+        let rules = self.repo.list().await?;
+        Ok(generate_suggestions(&categorized, &uncategorized, &rules))
+    }
+
+    /// Accept a suggestion: create a new rule, or extend an existing alternation
+    /// rule in place. Returns the affected rule. Callers should re-run
+    /// categorization afterwards (as they do after any rule change).
+    pub async fn apply_suggestion(
+        &self,
+        req: ApplySuggestionRequest,
+    ) -> Result<CategorizationRule> {
+        match req.action {
+            SuggestionAction::NewRule => {
+                let name = req
+                    .category_name
+                    .filter(|n| !n.trim().is_empty())
+                    .unwrap_or_else(|| "Suggested rule".to_string());
+                self.create(NewCategorizationRule {
+                    id: None,
+                    name,
+                    pattern: req.pattern,
+                    match_type: RuleMatchType::Regex,
+                    taxonomy_id: Some(req.taxonomy_id),
+                    category_id: Some(req.category_id),
+                    activity_type: None,
+                    priority: SUGGESTED_RULE_PRIORITY,
+                    is_global: true,
+                    account_id: None,
+                    preset_id: None,
+                    preset_rule_key: None,
+                    preset_version: None,
+                })
+                .await
+            }
+            SuggestionAction::ExtendRule {
+                existing_rule_id,
+                proposed_pattern,
+                ..
+            } => {
+                self.update(
+                    &existing_rule_id,
+                    UpdateCategorizationRule {
+                        pattern: Some(proposed_pattern),
+                        match_type: Some(RuleMatchType::Regex),
+                        ..Default::default()
+                    },
+                )
+                .await
+            }
+        }
     }
 }
 

--- a/crates/spending/src/categorization_rules/service.rs
+++ b/crates/spending/src/categorization_rules/service.rs
@@ -364,9 +364,11 @@ impl CategorizationRulesService {
         Ok(generate_suggestions(&categorized, &uncategorized, &rules))
     }
 
-    /// Accept a suggestion: create a new rule, or extend an existing alternation
-    /// rule in place. Returns the affected rule. Callers should re-run
-    /// categorization afterwards (as they do after any rule change).
+    /// Accept a suggestion: create a new rule, extend an existing alternation
+    /// rule in place, or combine several existing rules into one (rewriting
+    /// the first, deleting the rest). Returns the affected rule. Callers
+    /// should re-run categorization afterwards (as they do after any rule
+    /// change).
     pub async fn apply_suggestion(
         &self,
         req: ApplySuggestionRequest,
@@ -395,19 +397,36 @@ impl CategorizationRulesService {
                 .await
             }
             SuggestionAction::ExtendRule {
-                existing_rule_id,
-                proposed_pattern,
-                ..
+                existing_rule_id, ..
             } => {
                 self.update(
                     &existing_rule_id,
                     UpdateCategorizationRule {
-                        pattern: Some(proposed_pattern),
+                        pattern: Some(req.pattern),
                         match_type: Some(RuleMatchType::Regex),
                         ..Default::default()
                     },
                 )
                 .await
+            }
+            SuggestionAction::CombineRules { rule_ids, .. } => {
+                let (anchor, rest) = rule_ids
+                    .split_first()
+                    .ok_or_else(|| anyhow::anyhow!("combine suggestion has no rules"))?;
+                let updated = self
+                    .update(
+                        anchor,
+                        UpdateCategorizationRule {
+                            pattern: Some(req.pattern),
+                            match_type: Some(RuleMatchType::Regex),
+                            ..Default::default()
+                        },
+                    )
+                    .await?;
+                for id in rest {
+                    self.delete(id).await?;
+                }
+                Ok(updated)
             }
         }
     }

--- a/crates/spending/src/lib.rs
+++ b/crates/spending/src/lib.rs
@@ -23,6 +23,7 @@
 //! - `budget` — monthly budget config and per-category allocations.
 //! - `analytics` — aggregations for the Spending overview / reports pages.
 //! - `insight` — reconciled period payload powering the Spending Insight dashboard.
+//! - `suggestions` — rule suggestions derived from hand-categorized transactions.
 
 mod activity_allocations;
 pub mod activity_assignments;
@@ -38,5 +39,6 @@ pub mod error;
 pub mod events;
 pub mod insight;
 pub mod settings;
+pub mod suggestions;
 
 pub use error::SpendingError;

--- a/crates/spending/src/suggestions/README.md
+++ b/crates/spending/src/suggestions/README.md
@@ -1,0 +1,67 @@
+# Rule suggestions
+
+This module looks at the transactions a user has categorized by hand and
+proposes categorization rules that would reproduce those choices and catch
+similar transactions in future. It favours one alternation rule per category
+(`(?i)(bristol|gelsons|heinens)`) and, when the user already has a rule of that
+shape, offers to add the new merchants to it instead of creating a second rule.
+
+## How it fits together
+
+The engine in `service.rs` is pure: it takes the hand-categorized samples, the
+uncategorized descriptions, and the current rule set, and returns a list of
+`SuggestedRule`. It does no I/O, so its logic is covered by unit tests in the
+same file.
+
+`CategorizationRulesService` (in `categorization_rules/service.rs`) supplies the
+two async methods that talk to the repositories:
+
+- `suggest_rules(account_ids)` reads the activities in the given accounts and
+  their category assignments, splits them into hand-categorized samples (source
+  `manual`, taxonomy `spending_categories`) and still-uncategorized
+  descriptions, then calls the engine. Read-only.
+- `apply_suggestion(request)` creates a new rule, or rewrites the pattern of an
+  existing alternation rule in place. It reuses the existing `create` / `update`
+  paths, so the same regex validation and scope checks apply.
+
+Applying a suggestion does not re-run categorization itself. The command layer
+triggers the same background categorize it already runs after any rule change.
+
+## Surfaces
+
+Tauri commands (`apps/tauri/src/commands/spending.rs`):
+
+- `get_spending_rule_suggestions`
+- `apply_spending_rule_suggestion`
+
+HTTP routes (`apps/server/src/api/spending.rs`):
+
+- `GET /spending/rule-suggestions`
+- `POST /spending/rule-suggestions/apply`
+
+Frontend (`apps/frontend/src/features/spending/`):
+
+- `types/suggestion.ts` mirrors the Rust model.
+- `adapters/suggestions.ts` calls the two commands through the shared `invoke`.
+- `hooks/use-spending-rule-suggestions.ts` fetches suggestions, applies them,
+  and remembers dismissals in `localStorage`.
+- `components/rule-suggestions-panel.tsx` renders the panel above the rule list
+  on the spending rules settings page.
+
+## Notes
+
+- No new crates, database migrations, or repository methods are required. The
+  engine reuses the crate's existing `regex` dependency and the rule/assignment
+  repositories already on `CategorizationRulesService`.
+- Suggestion ids are a content hash (FNV-1a) of the category and merchants, so
+  they are stable across refetches and usable as `localStorage` keys for
+  dismissals.
+- Accepted suggestions become global regex rules at priority 50, below the
+  bundled country presets (70–95) and above the user-rule default (0).
+
+## Tuning
+
+The thresholds live as constants at the top of `service.rs`:
+`MIN_MERCHANT_OCCURRENCES`, `MIN_MATCH_COUNT`, `MIN_TOKEN_LEN`,
+`CLUSTER_SIMILARITY`, and `MAX_SUGGESTIONS`. Raise them to be more conservative,
+lower them to surface more.

--- a/crates/spending/src/suggestions/README.md
+++ b/crates/spending/src/suggestions/README.md
@@ -5,6 +5,14 @@ proposes categorization rules that would reproduce those choices and catch
 similar transactions in future. It favours one alternation rule per category
 (`(?i)(bristol|gelsons|heinens)`) and, when the user already has a rule of that
 shape, offers to add the new merchants to it instead of creating a second rule.
+It also looks for categories where the user already has several separate
+simple rules and offers to fold them into one.
+
+Case sensitivity is respected, not overridden: a hand-written regex rule
+without `(?i)` stays case-sensitive by default — new alternatives are added as
+a scoped `(?i:...)` branch alongside it rather than forcing insensitivity onto
+the whole pattern. `SuggestedRule::case_insensitive_pattern` carries the fully
+case-insensitive alternative so the caller can offer switching to it.
 
 ## How it fits together
 
@@ -20,9 +28,13 @@ two async methods that talk to the repositories:
   their category assignments, splits them into hand-categorized samples (source
   `manual`, taxonomy `spending_categories`) and still-uncategorized
   descriptions, then calls the engine. Read-only.
-- `apply_suggestion(request)` creates a new rule, or rewrites the pattern of an
-  existing alternation rule in place. It reuses the existing `create` / `update`
-  paths, so the same regex validation and scope checks apply.
+- `apply_suggestion(request)` creates a new rule, rewrites the pattern of an
+  existing alternation rule in place, or — for a combine suggestion — rewrites
+  the first of the combined rules and deletes the rest. It reuses the existing
+  `create` / `update` / `delete` paths, so the same regex validation and scope
+  checks apply. The pattern written is always `request.pattern` (not whatever
+  the action embeds), so the caller can substitute
+  `SuggestedRule::case_insensitive_pattern` when the user opts to switch.
 
 Applying a suggestion does not re-run categorization itself. The command layer
 triggers the same background categorize it already runs after any rule change.

--- a/crates/spending/src/suggestions/mod.rs
+++ b/crates/spending/src/suggestions/mod.rs
@@ -1,0 +1,10 @@
+//! Rule suggestions — reads how the user has categorized transactions by hand
+//! and proposes categorization rules that would reproduce (and extend) those
+//! choices. The engine in [`service`] is pure; [`crate::categorization_rules`]
+//! wires it to the repositories and applies accepted suggestions.
+
+pub mod model;
+pub mod service;
+
+pub use model::{ApplySuggestionRequest, SuggestedRule, SuggestionAction};
+pub use service::{generate_suggestions, CategorizedSample};

--- a/crates/spending/src/suggestions/model.rs
+++ b/crates/spending/src/suggestions/model.rs
@@ -1,0 +1,62 @@
+use serde::{Deserialize, Serialize};
+
+/// A categorization rule the engine thinks the user would want, derived from
+/// how they have already been categorizing transactions by hand.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SuggestedRule {
+    /// Stable id derived from the suggestion's content. The frontend uses it to
+    /// remember dismissals across refetches, so it must not depend on wall-clock
+    /// time or iteration order.
+    pub id: String,
+    /// Proposed `regex` pattern, e.g. `(?i)(bristol|gelsons|heinens)`.
+    pub pattern: String,
+    pub taxonomy_id: String,
+    pub category_id: String,
+    /// Merchant labels the pattern covers, for display (e.g. `["Bristol Farms", "Gelsons"]`).
+    pub merchants: Vec<String>,
+    /// Hand-categorized transactions in this category the pattern explains.
+    pub match_count: usize,
+    /// Currently-uncategorized transactions the pattern would newly catch.
+    pub uncategorized_match_count: usize,
+    /// 0.0–1.0. Combines how much of the category the pattern explains with how
+    /// many uncategorized transactions it would pick up.
+    pub confidence: f64,
+    /// A few real transaction descriptions the pattern matches.
+    pub examples: Vec<String>,
+    pub action: SuggestionAction,
+}
+
+/// What accepting a suggestion does.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum SuggestionAction {
+    /// Create a brand-new rule from `SuggestedRule::pattern`.
+    NewRule,
+    /// Merge the new merchants into an existing alternation rule instead of
+    /// adding a second rule for the same category.
+    // `rename_all` on the enum renames the variants, not their fields — without
+    // this the fields would go out as snake_case.
+    #[serde(rename_all = "camelCase")]
+    ExtendRule {
+        existing_rule_id: String,
+        existing_rule_name: String,
+        /// The existing rule's `name_pattern` after merging in the new
+        /// merchants. Applying the suggestion writes this verbatim.
+        proposed_pattern: String,
+    },
+}
+
+/// Payload sent when the user accepts a suggestion.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ApplySuggestionRequest {
+    pub pattern: String,
+    pub taxonomy_id: String,
+    pub category_id: String,
+    /// Human-readable category label, used as the new rule's name. Ignored for
+    /// `ExtendRule` (the existing rule keeps its name).
+    #[serde(default)]
+    pub category_name: Option<String>,
+    pub action: SuggestionAction,
+}

--- a/crates/spending/src/suggestions/model.rs
+++ b/crates/spending/src/suggestions/model.rs
@@ -24,6 +24,12 @@ pub struct SuggestedRule {
     pub confidence: f64,
     /// A few real transaction descriptions the pattern matches.
     pub examples: Vec<String>,
+    /// True when `pattern` preserves a case-sensitive rule the user wrote (no
+    /// blanket `(?i)`) instead of the usual fully case-insensitive merge.
+    pub case_sensitive: bool,
+    /// Present only when `case_sensitive` is true: the same merge with
+    /// everything folded to case-insensitive, offered as an opt-in switch.
+    pub case_insensitive_pattern: Option<String>,
     pub action: SuggestionAction,
 }
 
@@ -41,9 +47,18 @@ pub enum SuggestionAction {
     ExtendRule {
         existing_rule_id: String,
         existing_rule_name: String,
-        /// The existing rule's `name_pattern` after merging in the new
-        /// merchants. Applying the suggestion writes this verbatim.
+        /// The default merge preview, for display only. Applying the
+        /// suggestion writes `ApplySuggestionRequest::pattern` instead, so the
+        /// caller can substitute `case_insensitive_pattern`.
         proposed_pattern: String,
+    },
+    /// Fold several existing rules for the same category into one alternation
+    /// rule. The first id in `rule_ids` is rewritten with the merged pattern;
+    /// the rest are deleted.
+    #[serde(rename_all = "camelCase")]
+    CombineRules {
+        rule_ids: Vec<String>,
+        rule_names: Vec<String>,
     },
 }
 

--- a/crates/spending/src/suggestions/service.rs
+++ b/crates/spending/src/suggestions/service.rs
@@ -3,7 +3,15 @@
 //! hand, the rules they already have, and the transactions still uncategorized,
 //! it proposes categorization rules — favouring one alternation rule per
 //! category (`(?i)(bristol|gelsons|heinens)`) and extending an existing
-//! alternation rule rather than adding a duplicate.
+//! alternation rule rather than adding a duplicate. It also looks for
+//! categories where the user has several separate simple rules and offers to
+//! fold them into one.
+//!
+//! Case sensitivity is respected rather than overridden: a `(?i)`-free regex
+//! rule the user wrote by hand stays case-sensitive in the merged pattern
+//! (new alternatives are added as a scoped `(?i:...)` branch alongside it),
+//! and `SuggestedRule::case_insensitive_pattern` carries the fully
+//! case-insensitive alternative so the caller can offer switching to it.
 
 use std::collections::BTreeMap;
 
@@ -62,6 +70,7 @@ pub fn generate_suggestions(
             out.push(suggestion);
         }
     }
+    out.extend(combine_suggestions(existing_rules));
 
     // Most useful first: biggest uncategorized win, then confidence. `id` breaks
     // ties so the order is stable across runs.
@@ -116,7 +125,7 @@ fn suggest_for_category(
     let existing = find_alternation_rule(existing_rules, taxonomy_id, category_id);
     let existing_tokens: Vec<String> = existing
         .as_ref()
-        .map(|(_, _, toks)| toks.clone())
+        .map(|(_, _, toks, _)| toks.clone())
         .unwrap_or_default();
 
     // Only propose merchants the existing rule doesn't already cover.
@@ -158,24 +167,27 @@ fn suggest_for_category(
     let opportunity = (uncategorized_match_count as f64 / OPPORTUNITY_SCALE).min(1.0);
     let confidence = (0.65 * coverage + 0.35 * opportunity).clamp(0.0, 1.0);
 
-    let (action, output_pattern) = match existing {
-        Some((rule_id, rule_name, mut merged)) => {
-            for t in &added_tokens {
-                merged.push(t.clone());
-            }
-            merged.sort();
-            merged.dedup();
-            let proposed = alternation_pattern(&merged);
+    let (action, output_pattern, case_sensitive, case_insensitive_pattern) = match existing {
+        Some((rule_id, rule_name, existing_tokens, existing_case_insensitive)) => {
+            let (default_pattern, insensitive_pattern) =
+                merge_tokens(&existing_tokens, existing_case_insensitive, &added_tokens);
             (
                 SuggestionAction::ExtendRule {
                     existing_rule_id: rule_id,
                     existing_rule_name: rule_name,
-                    proposed_pattern: proposed.clone(),
+                    proposed_pattern: default_pattern.clone(),
                 },
-                proposed,
+                default_pattern,
+                !existing_case_insensitive,
+                (!existing_case_insensitive).then_some(insensitive_pattern),
             )
         }
-        None => (SuggestionAction::NewRule, counting_pattern.clone()),
+        None => (
+            SuggestionAction::NewRule,
+            counting_pattern.clone(),
+            false,
+            None,
+        ),
     };
 
     let merchants_display: Vec<String> = {
@@ -197,8 +209,52 @@ fn suggest_for_category(
         uncategorized_match_count,
         confidence,
         examples,
+        case_sensitive,
+        case_insensitive_pattern,
         action,
     })
+}
+
+/// Merge new (always lowercase, always-matches-any-case) tokens into an
+/// existing alternation's tokens. If the existing rule was case-insensitive,
+/// everything folds into one `(?i)(...)` pattern as before. If it was
+/// case-sensitive, its alternatives are left exactly as the user wrote them
+/// and the new tokens are added as a scoped `(?i:...)` branch instead of
+/// forcing `(?i)` over the whole thing — the second element of the returned
+/// tuple is what that blanket-insensitive merge would have looked like, for
+/// callers that want to offer it as an opt-in switch.
+fn merge_tokens(
+    existing_tokens: &[String],
+    existing_case_insensitive: bool,
+    new_tokens: &[String],
+) -> (String, String) {
+    let fully_insensitive = {
+        let mut all: Vec<String> = existing_tokens
+            .iter()
+            .map(|t| t.to_lowercase())
+            .chain(new_tokens.iter().cloned())
+            .collect();
+        all.sort();
+        all.dedup();
+        alternation_pattern(&all)
+    };
+
+    if existing_case_insensitive {
+        return (fully_insensitive.clone(), fully_insensitive);
+    }
+
+    let mut existing_sorted = existing_tokens.to_vec();
+    existing_sorted.sort();
+    existing_sorted.dedup();
+    let mut new_sorted = new_tokens.to_vec();
+    new_sorted.sort();
+    new_sorted.dedup();
+    let default = format!(
+        "({}|(?i:{}))",
+        existing_sorted.join("|"),
+        new_sorted.join("|")
+    );
+    (default, fully_insensitive)
 }
 
 /// Group a category's samples into merchants, keeping only those seen enough
@@ -328,12 +384,13 @@ fn alternation_pattern(tokens: &[String]) -> String {
 }
 
 /// If the user already has a regex rule for this category shaped like our own
-/// alternations, return `(rule_id, rule_name, alternatives)` so we can extend it.
+/// alternations, return `(rule_id, rule_name, alternatives, case_insensitive)`
+/// so we can extend it.
 fn find_alternation_rule(
     rules: &[CategorizationRule],
     taxonomy_id: &str,
     category_id: &str,
-) -> Option<(String, String, Vec<String>)> {
+) -> Option<(String, String, Vec<String>, bool)> {
     rules.iter().find_map(|r| {
         if r.match_type != RuleMatchType::Regex {
             return None;
@@ -343,15 +400,16 @@ fn find_alternation_rule(
         {
             return None;
         }
-        let alts = parse_alternation(&r.pattern)?;
-        Some((r.id.clone(), r.name.clone(), alts))
+        let (alts, case_insensitive) = parse_alternation(&r.pattern)?;
+        Some((r.id.clone(), r.name.clone(), alts, case_insensitive))
     })
 }
 
-/// Parse `(?i)(a|b|c)` into `["a", "b", "c"]`. Returns `None` for anything that
-/// isn't a plain case-insensitive alternation, so we never try to splice into a
-/// pattern we don't fully understand.
-fn parse_alternation(pattern: &str) -> Option<Vec<String>> {
+/// Parse `(?i)(a|b|c)` or `(a|b|c)` into (`["a", "b", "c"]`, whether it had
+/// `(?i)`). Returns `None` for anything that isn't a plain alternation, so we
+/// never try to splice into a pattern we don't fully understand.
+fn parse_alternation(pattern: &str) -> Option<(Vec<String>, bool)> {
+    let case_insensitive = pattern.starts_with("(?i)");
     let body = pattern.strip_prefix("(?i)").unwrap_or(pattern);
     let inner = body.strip_prefix('(')?.strip_suffix(')')?;
     if inner.is_empty() {
@@ -364,7 +422,166 @@ fn parse_alternation(pattern: &str) -> Option<Vec<String>> {
     {
         return None;
     }
-    Some(alts)
+    Some((alts, case_insensitive))
+}
+
+/// Rule types eligible for the "combine multiple manual rules" suggestion.
+const COMBINABLE_MATCH_TYPES: [RuleMatchType; 2] = [RuleMatchType::Contains, RuleMatchType::Regex];
+
+/// Find categories with two or more separate simple rules and suggest folding
+/// them into one alternation rule. Independent of hand-categorized samples —
+/// this only looks at the rules the user already wrote. Presets are left
+/// alone; `Regex` rules are only combinable when they're already a plain
+/// alternation (parsed by [`parse_alternation`]) so we never mangle a
+/// hand-written pattern we don't fully understand.
+fn combine_suggestions(existing_rules: &[CategorizationRule]) -> Vec<SuggestedRule> {
+    let mut by_category: BTreeMap<(String, String), Vec<&CategorizationRule>> = BTreeMap::new();
+    for r in existing_rules {
+        if r.preset_id.is_some() || !COMBINABLE_MATCH_TYPES.contains(&r.match_type) {
+            continue;
+        }
+        let (Some(taxonomy_id), Some(category_id)) =
+            (r.taxonomy_id.as_deref(), r.category_id.as_deref())
+        else {
+            continue;
+        };
+        by_category
+            .entry((taxonomy_id.to_string(), category_id.to_string()))
+            .or_default()
+            .push(r);
+    }
+
+    by_category
+        .iter()
+        .filter_map(|((taxonomy_id, category_id), rules)| {
+            combine_for_category(taxonomy_id, category_id, rules)
+        })
+        .collect()
+}
+
+/// One alternative contributed by an existing rule, and whether it should
+/// stay case-sensitive in the combined pattern.
+struct RuleToken {
+    text: String,
+    case_insensitive: bool,
+}
+
+fn combine_for_category(
+    taxonomy_id: &str,
+    category_id: &str,
+    rules: &[&CategorizationRule],
+) -> Option<SuggestedRule> {
+    let mut included: Vec<&CategorizationRule> = Vec::new();
+    let mut tokens: Vec<RuleToken> = Vec::new();
+
+    for r in rules {
+        match r.match_type {
+            RuleMatchType::Contains => {
+                let text = r.pattern.trim();
+                if text.is_empty() {
+                    continue;
+                }
+                tokens.push(RuleToken {
+                    text: regex::escape(text),
+                    case_insensitive: true,
+                });
+                included.push(r);
+            }
+            RuleMatchType::Regex => {
+                let Some((alts, case_insensitive)) = parse_alternation(&r.pattern) else {
+                    continue;
+                };
+                tokens.extend(alts.into_iter().map(|text| RuleToken {
+                    text,
+                    case_insensitive,
+                }));
+                included.push(r);
+            }
+            _ => {}
+        }
+    }
+
+    if included.len() < 2 {
+        return None;
+    }
+
+    let dedup_sorted = |mut v: Vec<String>| {
+        v.sort();
+        v.dedup();
+        v
+    };
+    let ci_tokens = dedup_sorted(
+        tokens
+            .iter()
+            .filter(|t| t.case_insensitive)
+            .map(|t| t.text.clone())
+            .collect(),
+    );
+    let cs_tokens = dedup_sorted(
+        tokens
+            .iter()
+            .filter(|t| !t.case_insensitive)
+            .map(|t| t.text.clone())
+            .collect(),
+    );
+
+    let default_pattern = combine_pattern(&ci_tokens, &cs_tokens);
+    let case_sensitive = !cs_tokens.is_empty();
+    let case_insensitive_pattern = case_sensitive.then(|| {
+        let all_lower = dedup_sorted(
+            ci_tokens
+                .iter()
+                .chain(cs_tokens.iter())
+                .map(|t| t.to_lowercase())
+                .collect(),
+        );
+        alternation_pattern(&all_lower)
+    });
+
+    let rule_ids: Vec<String> = included.iter().map(|r| r.id.clone()).collect();
+    let rule_names: Vec<String> = included.iter().map(|r| r.name.clone()).collect();
+    let merchants = dedup_sorted(
+        included
+            .iter()
+            .map(|r| title_case(r.pattern.trim()))
+            .collect(),
+    );
+    let examples: Vec<String> = included.iter().map(|r| truncate(&r.pattern)).collect();
+
+    let action = SuggestionAction::CombineRules {
+        rule_ids: rule_ids.clone(),
+        rule_names,
+    };
+    let id = suggestion_id(taxonomy_id, category_id, &rule_ids, &action);
+
+    Some(SuggestedRule {
+        id,
+        pattern: default_pattern,
+        taxonomy_id: taxonomy_id.to_string(),
+        category_id: category_id.to_string(),
+        merchants,
+        // These consolidate rules the user already wrote rather than infer
+        // anything from transaction data, so there's nothing to count here.
+        match_count: 0,
+        uncategorized_match_count: 0,
+        confidence: 1.0,
+        examples,
+        case_sensitive,
+        case_insensitive_pattern,
+        action,
+    })
+}
+
+/// Combine case-insensitive and case-sensitive alternatives into one pattern.
+/// Case-sensitive alternatives (already alphanumeric-only, validated by
+/// [`parse_alternation`]) are left bare; case-insensitive ones are scoped
+/// with `(?i:...)` so they don't force insensitivity onto the rest.
+fn combine_pattern(ci_tokens: &[String], cs_tokens: &[String]) -> String {
+    match (ci_tokens.is_empty(), cs_tokens.is_empty()) {
+        (_, true) => alternation_pattern(ci_tokens),
+        (true, false) => format!("({})", cs_tokens.join("|")),
+        (false, false) => format!("((?i:{})|{})", ci_tokens.join("|"), cs_tokens.join("|")),
+    }
 }
 
 fn collect_examples(added: &[&Merchant], uncategorized_hits: &[&String]) -> Vec<String> {
@@ -422,6 +639,7 @@ fn suggestion_id(
     let kind = match action {
         SuggestionAction::NewRule => "new",
         SuggestionAction::ExtendRule { .. } => "extend",
+        SuggestionAction::CombineRules { .. } => "combine",
     };
     let seed = format!(
         "{taxonomy_id}\u{1}{category_id}\u{1}{}\u{1}{kind}",
@@ -642,5 +860,99 @@ mod tests {
         assert_eq!(jaro_winkler("gelsons", "gelsons"), 1.0);
         assert!(jaro_winkler("schnucks", "schnuck") >= CLUSTER_SIMILARITY);
         assert!(jaro_winkler("gelsons", "bristol") < CLUSTER_SIMILARITY);
+    }
+
+    fn contains_rule(id: &str, pattern: &str, cat: &str) -> CategorizationRule {
+        CategorizationRule {
+            match_type: RuleMatchType::Contains,
+            ..regex_rule(id, pattern, cat)
+        }
+    }
+
+    #[test]
+    fn extend_respects_case_sensitive_existing_rule() {
+        let categorized = vec![
+            sample("BRISTOL FARMS 552", "groceries"),
+            sample("BRISTOL FARMS STORE", "groceries"),
+        ];
+        let uncategorized = vec!["BRISTOL FARMS 9910".to_string()];
+        // No `(?i)` — the user wrote this case-sensitively.
+        let existing = vec![regex_rule("r1", "(Gelsons|Heinens)", "groceries")];
+        let out = generate_suggestions(&categorized, &uncategorized, &existing);
+        assert_eq!(out.len(), 1);
+        let s = &out[0];
+        assert!(s.case_sensitive);
+        // The user's original alternatives stay untouched and bare; the new
+        // merchant is added as a scoped case-insensitive branch instead of
+        // forcing `(?i)` over everything.
+        assert_eq!(s.pattern, "(Gelsons|Heinens|(?i:bristol))");
+        assert_eq!(
+            s.case_insensitive_pattern.as_deref(),
+            Some("(?i)(bristol|gelsons|heinens)")
+        );
+        match &s.action {
+            SuggestionAction::ExtendRule {
+                existing_rule_id, ..
+            } => assert_eq!(existing_rule_id, "r1"),
+            other => panic!("expected ExtendRule, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn combines_multiple_contains_rules() {
+        let existing = vec![
+            contains_rule("r1", "aldi", "groceries"),
+            contains_rule("r2", "coles", "groceries"),
+            contains_rule("r3", "woolworths", "groceries"),
+        ];
+        let out = generate_suggestions(&[], &[], &existing);
+        assert_eq!(out.len(), 1);
+        let s = &out[0];
+        assert!(!s.case_sensitive);
+        assert_eq!(s.case_insensitive_pattern, None);
+        assert_eq!(s.pattern, "(?i)(aldi|coles|woolworths)");
+        match &s.action {
+            SuggestionAction::CombineRules { rule_ids, .. } => {
+                let mut ids = rule_ids.clone();
+                ids.sort();
+                assert_eq!(ids, vec!["r1", "r2", "r3"]);
+            }
+            other => panic!("expected CombineRules, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn combine_respects_case_sensitive_regex_rule_and_offers_switch() {
+        let existing = vec![
+            contains_rule("r1", "aldi", "groceries"),
+            // Case-sensitive — no `(?i)`.
+            regex_rule("r2", "(Coles)", "groceries"),
+        ];
+        let out = generate_suggestions(&[], &[], &existing);
+        assert_eq!(out.len(), 1);
+        let s = &out[0];
+        assert!(s.case_sensitive);
+        assert_eq!(s.pattern, "((?i:aldi)|Coles)");
+        assert_eq!(
+            s.case_insensitive_pattern.as_deref(),
+            Some("(?i)(aldi|coles)")
+        );
+    }
+
+    #[test]
+    fn does_not_combine_a_single_rule() {
+        let existing = vec![contains_rule("r1", "aldi", "groceries")];
+        let out = generate_suggestions(&[], &[], &existing);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn does_not_combine_preset_rules() {
+        let mut r = contains_rule("r1", "aldi", "groceries");
+        r.preset_id = Some("preset-au".to_string());
+        let mut r2 = contains_rule("r2", "coles", "groceries");
+        r2.preset_id = Some("preset-au".to_string());
+        let out = generate_suggestions(&[], &[], &[r, r2]);
+        assert!(out.is_empty());
     }
 }

--- a/crates/spending/src/suggestions/service.rs
+++ b/crates/spending/src/suggestions/service.rs
@@ -1,0 +1,646 @@
+//! Rule-suggestion engine. Pure, deterministic, and free of I/O so it can be
+//! unit-tested on its own. Given the transactions a user has categorized by
+//! hand, the rules they already have, and the transactions still uncategorized,
+//! it proposes categorization rules — favouring one alternation rule per
+//! category (`(?i)(bristol|gelsons|heinens)`) and extending an existing
+//! alternation rule rather than adding a duplicate.
+
+use std::collections::BTreeMap;
+
+use super::model::{SuggestedRule, SuggestionAction};
+use crate::categorization_rules::{compile_regex_pattern, CategorizationRule, RuleMatchType};
+
+/// A transaction the user has already assigned to a category by hand.
+pub struct CategorizedSample {
+    /// The transaction description (`activity.notes`).
+    pub text: String,
+    pub taxonomy_id: String,
+    pub category_id: String,
+}
+
+/// A merchant needs to show up this many times in a category before it earns a
+/// slot in a suggested pattern. Keeps one-off assignments from spawning rules.
+const MIN_MERCHANT_OCCURRENCES: usize = 2;
+/// A suggestion has to explain at least this many hand-categorized transactions.
+const MIN_MATCH_COUNT: usize = 2;
+/// Merchant tokens shorter than this are too ambiguous to match on.
+const MIN_TOKEN_LEN: usize = 3;
+/// Two merchant tokens at or above this Jaro-Winkler similarity are treated as
+/// the same merchant (`schnucks` / `schnuck`).
+const CLUSTER_SIMILARITY: f64 = 0.90;
+/// Uncategorized hits are normalized against this for the confidence blend.
+const OPPORTUNITY_SCALE: f64 = 5.0;
+/// Cap on suggestions returned in one pass so the panel stays readable.
+const MAX_SUGGESTIONS: usize = 15;
+
+/// Build the suggestion list. `existing_rules` is the user's full rule set;
+/// only global-or-matching rules for the same category are considered for the
+/// extend-vs-new decision.
+pub fn generate_suggestions(
+    categorized: &[CategorizedSample],
+    uncategorized: &[String],
+    existing_rules: &[CategorizationRule],
+) -> Vec<SuggestedRule> {
+    // Bucket hand-categorized samples by (taxonomy, category).
+    let mut by_category: BTreeMap<(String, String), Vec<&CategorizedSample>> = BTreeMap::new();
+    for s in categorized {
+        by_category
+            .entry((s.taxonomy_id.clone(), s.category_id.clone()))
+            .or_default()
+            .push(s);
+    }
+
+    let mut out: Vec<SuggestedRule> = Vec::new();
+    for ((taxonomy_id, category_id), samples) in &by_category {
+        if let Some(suggestion) = suggest_for_category(
+            taxonomy_id,
+            category_id,
+            samples,
+            uncategorized,
+            existing_rules,
+        ) {
+            out.push(suggestion);
+        }
+    }
+
+    // Most useful first: biggest uncategorized win, then confidence. `id` breaks
+    // ties so the order is stable across runs.
+    out.sort_by(|a, b| {
+        b.uncategorized_match_count
+            .cmp(&a.uncategorized_match_count)
+            .then(
+                b.confidence
+                    .partial_cmp(&a.confidence)
+                    .unwrap_or(std::cmp::Ordering::Equal),
+            )
+            .then(a.id.cmp(&b.id))
+    });
+
+    if out.len() > MAX_SUGGESTIONS {
+        log::debug!(
+            "rule suggestions truncated from {} to {}",
+            out.len(),
+            MAX_SUGGESTIONS
+        );
+        out.truncate(MAX_SUGGESTIONS);
+    }
+    out
+}
+
+/// One merchant cluster: a canonical token, a display label, and an example of
+/// a transaction that seeded it.
+struct Merchant {
+    token: String,
+    label: String,
+    /// How often the user assigned this merchant to the category. Only the
+    /// clustering tests read it, so it isn't built into the release binary.
+    #[cfg(test)]
+    count: usize,
+    example: String,
+}
+
+fn suggest_for_category(
+    taxonomy_id: &str,
+    category_id: &str,
+    samples: &[&CategorizedSample],
+    uncategorized: &[String],
+    existing_rules: &[CategorizationRule],
+) -> Option<SuggestedRule> {
+    let merchants = cluster_merchants(samples);
+    if merchants.is_empty() {
+        return None;
+    }
+
+    // An existing alternation rule for this category, if any, decides whether we
+    // extend or create.
+    let existing = find_alternation_rule(existing_rules, taxonomy_id, category_id);
+    let existing_tokens: Vec<String> = existing
+        .as_ref()
+        .map(|(_, _, toks)| toks.clone())
+        .unwrap_or_default();
+
+    // Only propose merchants the existing rule doesn't already cover.
+    let added: Vec<&Merchant> = merchants
+        .iter()
+        .filter(|m| !existing_tokens.iter().any(|t| t == &m.token))
+        .collect();
+    if added.is_empty() {
+        return None;
+    }
+
+    let added_tokens: Vec<String> = {
+        let mut t: Vec<String> = added.iter().map(|m| m.token.clone()).collect();
+        t.sort();
+        t.dedup();
+        t
+    };
+    let counting_pattern = alternation_pattern(&added_tokens);
+    let matcher = compile_regex_pattern(&counting_pattern).ok()?;
+
+    let group_total = samples.len();
+    let match_count = samples.iter().filter(|s| matcher.is_match(&s.text)).count();
+    if match_count < MIN_MATCH_COUNT {
+        return None;
+    }
+    let uncategorized_hits: Vec<&String> = uncategorized
+        .iter()
+        .filter(|t| matcher.is_match(t))
+        .collect();
+    let uncategorized_match_count = uncategorized_hits.len();
+
+    // Worth surfacing if it either catches new transactions or folds several
+    // merchants into a single rule.
+    if uncategorized_match_count == 0 && added.len() < 2 {
+        return None;
+    }
+
+    let coverage = match_count as f64 / group_total.max(1) as f64;
+    let opportunity = (uncategorized_match_count as f64 / OPPORTUNITY_SCALE).min(1.0);
+    let confidence = (0.65 * coverage + 0.35 * opportunity).clamp(0.0, 1.0);
+
+    let (action, output_pattern) = match existing {
+        Some((rule_id, rule_name, mut merged)) => {
+            for t in &added_tokens {
+                merged.push(t.clone());
+            }
+            merged.sort();
+            merged.dedup();
+            let proposed = alternation_pattern(&merged);
+            (
+                SuggestionAction::ExtendRule {
+                    existing_rule_id: rule_id,
+                    existing_rule_name: rule_name,
+                    proposed_pattern: proposed.clone(),
+                },
+                proposed,
+            )
+        }
+        None => (SuggestionAction::NewRule, counting_pattern.clone()),
+    };
+
+    let merchants_display: Vec<String> = {
+        let mut labels: Vec<String> = added.iter().map(|m| m.label.clone()).collect();
+        labels.sort();
+        labels.dedup();
+        labels
+    };
+    let examples = collect_examples(&added, &uncategorized_hits);
+    let id = suggestion_id(taxonomy_id, category_id, &added_tokens, &action);
+
+    Some(SuggestedRule {
+        id,
+        pattern: output_pattern,
+        taxonomy_id: taxonomy_id.to_string(),
+        category_id: category_id.to_string(),
+        merchants: merchants_display,
+        match_count,
+        uncategorized_match_count,
+        confidence,
+        examples,
+        action,
+    })
+}
+
+/// Group a category's samples into merchants, keeping only those seen enough
+/// times to be worth a rule. Greedy Jaro-Winkler clustering folds near-identical
+/// tokens together (`schnucks` / `schnuck`).
+fn cluster_merchants(samples: &[&CategorizedSample]) -> Vec<Merchant> {
+    struct Cluster {
+        token: String,
+        count: usize,
+        label_counts: BTreeMap<String, usize>,
+        example: String,
+    }
+
+    let mut clusters: Vec<Cluster> = Vec::new();
+    for s in samples {
+        let normalized = normalize_description(&s.text);
+        let Some(token) = merchant_token(&normalized) else {
+            continue;
+        };
+        let existing = clusters
+            .iter_mut()
+            .find(|c| c.token == token || jaro_winkler(&c.token, &token) >= CLUSTER_SIMILARITY);
+        match existing {
+            Some(c) => {
+                c.count += 1;
+                *c.label_counts.entry(normalized.clone()).or_insert(0) += 1;
+            }
+            None => clusters.push(Cluster {
+                token: token.clone(),
+                count: 1,
+                label_counts: BTreeMap::from([(normalized.clone(), 1)]),
+                example: s.text.clone(),
+            }),
+        }
+    }
+
+    clusters
+        .into_iter()
+        .filter(|c| c.count >= MIN_MERCHANT_OCCURRENCES)
+        .map(|c| {
+            // Most common cleaned phrase becomes the display label.
+            let label = c
+                .label_counts
+                .iter()
+                .max_by(|a, b| a.1.cmp(b.1).then(b.0.cmp(a.0)))
+                .map(|(phrase, _)| title_case(phrase))
+                .unwrap_or_else(|| title_case(&c.token));
+            Merchant {
+                token: c.token,
+                label,
+                #[cfg(test)]
+                count: c.count,
+                example: c.example,
+            }
+        })
+        .collect()
+}
+
+/// Strip the noise banks bolt onto merchant names — casing, card/terminal
+/// numbers, `*POS`-style prefixes, trailing state codes, and generic payment
+/// words — leaving something close to the merchant name.
+fn normalize_description(raw: &str) -> String {
+    let lower = raw.to_lowercase();
+    let mut cleaned = String::with_capacity(lower.len());
+    for ch in lower.chars() {
+        if ch.is_ascii_alphanumeric() {
+            cleaned.push(ch);
+        } else {
+            cleaned.push(' ');
+        }
+    }
+
+    const STOPWORDS: &[&str] = &[
+        "pos",
+        "purchase",
+        "payment",
+        "visa",
+        "mastercard",
+        "debit",
+        "credit",
+        "card",
+        "value",
+        "date",
+        "ref",
+        "tap",
+        "contactless",
+        "the",
+        "usa",
+        "usd",
+        "inc",
+        "llc",
+        "corp",
+    ];
+
+    let mut words: Vec<&str> = Vec::new();
+    for word in cleaned.split_whitespace() {
+        // Drop pure numbers and mixed alphanumeric ids (card suffixes, store #s).
+        if word.chars().any(|c| c.is_ascii_digit()) {
+            continue;
+        }
+        // Anything shorter than a merchant token is state codes and noise — and
+        // could never be picked as the token anyway.
+        if word.len() < MIN_TOKEN_LEN {
+            continue;
+        }
+        if STOPWORDS.contains(&word) {
+            continue;
+        }
+        words.push(word);
+    }
+    words.join(" ")
+}
+
+/// The first meaningful word of a normalized description — the token an
+/// alternation rule matches on.
+fn merchant_token(normalized: &str) -> Option<String> {
+    normalized
+        .split_whitespace()
+        .find(|w| w.len() >= MIN_TOKEN_LEN)
+        .map(|w| w.to_string())
+}
+
+/// `["bristol", "gelsons"]` → `(?i)(bristol|gelsons)`. Tokens are alphanumeric by
+/// construction, so no escaping is needed.
+fn alternation_pattern(tokens: &[String]) -> String {
+    format!("(?i)({})", tokens.join("|"))
+}
+
+/// If the user already has a regex rule for this category shaped like our own
+/// alternations, return `(rule_id, rule_name, alternatives)` so we can extend it.
+fn find_alternation_rule(
+    rules: &[CategorizationRule],
+    taxonomy_id: &str,
+    category_id: &str,
+) -> Option<(String, String, Vec<String>)> {
+    rules.iter().find_map(|r| {
+        if r.match_type != RuleMatchType::Regex {
+            return None;
+        }
+        if r.taxonomy_id.as_deref() != Some(taxonomy_id)
+            || r.category_id.as_deref() != Some(category_id)
+        {
+            return None;
+        }
+        let alts = parse_alternation(&r.pattern)?;
+        Some((r.id.clone(), r.name.clone(), alts))
+    })
+}
+
+/// Parse `(?i)(a|b|c)` into `["a", "b", "c"]`. Returns `None` for anything that
+/// isn't a plain case-insensitive alternation, so we never try to splice into a
+/// pattern we don't fully understand.
+fn parse_alternation(pattern: &str) -> Option<Vec<String>> {
+    let body = pattern.strip_prefix("(?i)").unwrap_or(pattern);
+    let inner = body.strip_prefix('(')?.strip_suffix(')')?;
+    if inner.is_empty() {
+        return None;
+    }
+    let alts: Vec<String> = inner.split('|').map(|a| a.trim().to_string()).collect();
+    if alts
+        .iter()
+        .any(|a| a.is_empty() || a.chars().any(|c| !c.is_ascii_alphanumeric() && c != ' '))
+    {
+        return None;
+    }
+    Some(alts)
+}
+
+fn collect_examples(added: &[&Merchant], uncategorized_hits: &[&String]) -> Vec<String> {
+    let mut examples: Vec<String> = Vec::new();
+    // Lead with uncategorized hits — they show the payoff — then fall back to the
+    // hand-categorized examples that seeded the merchant.
+    for hit in uncategorized_hits.iter().take(3) {
+        push_unique(&mut examples, truncate(hit));
+    }
+    for m in added {
+        if examples.len() >= 3 {
+            break;
+        }
+        push_unique(&mut examples, truncate(&m.example));
+    }
+    examples
+}
+
+fn push_unique(v: &mut Vec<String>, item: String) {
+    if !v.contains(&item) {
+        v.push(item);
+    }
+}
+
+fn truncate(s: &str) -> String {
+    let trimmed = s.trim();
+    if trimmed.chars().count() <= 60 {
+        return trimmed.to_string();
+    }
+    let cut: String = trimmed.chars().take(57).collect();
+    format!("{cut}…")
+}
+
+fn title_case(s: &str) -> String {
+    s.split_whitespace()
+        .map(|w| {
+            let mut chars = w.chars();
+            match chars.next() {
+                Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Content-addressed id (FNV-1a, hex). Deterministic so the frontend can persist
+/// dismissals — no clock, no randomness.
+fn suggestion_id(
+    taxonomy_id: &str,
+    category_id: &str,
+    tokens: &[String],
+    action: &SuggestionAction,
+) -> String {
+    let kind = match action {
+        SuggestionAction::NewRule => "new",
+        SuggestionAction::ExtendRule { .. } => "extend",
+    };
+    let seed = format!(
+        "{taxonomy_id}\u{1}{category_id}\u{1}{}\u{1}{kind}",
+        tokens.join(",")
+    );
+    let mut hash: u64 = 0xcbf29ce484222325;
+    for byte in seed.as_bytes() {
+        hash ^= *byte as u64;
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
+}
+
+/// Jaro-Winkler similarity in `0.0..=1.0`. Implemented here to avoid a
+/// dependency; only used for merchant-token clustering.
+fn jaro_winkler(a: &str, b: &str) -> f64 {
+    let jaro = jaro(a, b);
+    // Winkler boost for a shared prefix (up to 4 chars), standard scaling 0.1.
+    let prefix = a
+        .chars()
+        .zip(b.chars())
+        .take(4)
+        .take_while(|(x, y)| x == y)
+        .count();
+    jaro + prefix as f64 * 0.1 * (1.0 - jaro)
+}
+
+fn jaro(a: &str, b: &str) -> f64 {
+    if a == b {
+        return 1.0;
+    }
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.is_empty() || b.is_empty() {
+        return 0.0;
+    }
+    let max_dist = (a.len().max(b.len()) / 2).saturating_sub(1);
+
+    let mut a_matches = vec![false; a.len()];
+    let mut b_matches = vec![false; b.len()];
+    let mut matches = 0;
+    for (i, &ca) in a.iter().enumerate() {
+        let start = i.saturating_sub(max_dist);
+        let end = (i + max_dist + 1).min(b.len());
+        for j in start..end {
+            if !b_matches[j] && b[j] == ca {
+                a_matches[i] = true;
+                b_matches[j] = true;
+                matches += 1;
+                break;
+            }
+        }
+    }
+    if matches == 0 {
+        return 0.0;
+    }
+
+    // Transpositions: count matched pairs that are out of order.
+    let mut transpositions = 0;
+    let mut k = 0;
+    for i in 0..a.len() {
+        if !a_matches[i] {
+            continue;
+        }
+        while !b_matches[k] {
+            k += 1;
+        }
+        if a[i] != b[k] {
+            transpositions += 1;
+        }
+        k += 1;
+    }
+    let matches = matches as f64;
+    let t = transpositions as f64 / 2.0;
+    (matches / a.len() as f64 + matches / b.len() as f64 + (matches - t) / matches) / 3.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn sample(text: &str, cat: &str) -> CategorizedSample {
+        CategorizedSample {
+            text: text.to_string(),
+            taxonomy_id: "spending_categories".to_string(),
+            category_id: cat.to_string(),
+        }
+    }
+
+    fn regex_rule(id: &str, pattern: &str, cat: &str) -> CategorizationRule {
+        CategorizationRule {
+            id: id.to_string(),
+            name: format!("rule {id}"),
+            pattern: pattern.to_string(),
+            match_type: RuleMatchType::Regex,
+            taxonomy_id: Some("spending_categories".to_string()),
+            category_id: Some(cat.to_string()),
+            activity_type: None,
+            priority: 50,
+            is_global: true,
+            account_id: None,
+            preset_id: None,
+            preset_rule_key: None,
+            preset_version: None,
+            preset_modified: false,
+            created_at: Utc::now().naive_utc(),
+            updated_at: Utc::now().naive_utc(),
+        }
+    }
+
+    #[test]
+    fn normalize_strips_noise() {
+        assert_eq!(normalize_description("GELSONS 1234 CA"), "gelsons");
+        assert_eq!(normalize_description("POS BRISTOL 5521 VALUE"), "bristol");
+        assert_eq!(
+            normalize_description("HEINENS FINE FOODS 09"),
+            "heinens fine foods"
+        );
+    }
+
+    #[test]
+    fn clusters_variants_of_same_merchant() {
+        let samples = [
+            sample("SCHNUCKS 1234 MO", "groceries"),
+            sample("SCHNUCKS MARKET 88", "groceries"),
+            sample("SCHNUCK ONLINE", "groceries"),
+        ];
+        let refs: Vec<&CategorizedSample> = samples.iter().collect();
+        let merchants = cluster_merchants(&refs);
+        assert_eq!(merchants.len(), 1, "schnucks variants should collapse");
+        assert_eq!(merchants[0].count, 3);
+    }
+
+    #[test]
+    fn multi_merchant_new_rule() {
+        let categorized = vec![
+            sample("BRISTOL FARMS 552 CA", "groceries"),
+            sample("BRISTOL FARMS STORE", "groceries"),
+            sample("GELSONS 1201", "groceries"),
+            sample("GELSONS MARKET", "groceries"),
+            sample("HEINENS FINE FOODS", "groceries"),
+            sample("HEINENS 88", "groceries"),
+        ];
+        let uncategorized = vec!["BRISTOL FARMS 9910 CA".to_string()];
+        let out = generate_suggestions(&categorized, &uncategorized, &[]);
+        assert_eq!(out.len(), 1);
+        let s = &out[0];
+        assert_eq!(s.pattern, "(?i)(bristol|gelsons|heinens)");
+        assert_eq!(s.action, SuggestionAction::NewRule);
+        assert_eq!(s.uncategorized_match_count, 1);
+        assert_eq!(s.merchants.len(), 3);
+    }
+
+    #[test]
+    fn extends_existing_alternation_rule() {
+        let categorized = vec![
+            sample("BRISTOL FARMS 552", "groceries"),
+            sample("BRISTOL FARMS STORE", "groceries"),
+        ];
+        let uncategorized = vec!["BRISTOL FARMS 9910".to_string()];
+        let existing = vec![regex_rule("r1", "(?i)(gelsons|heinens)", "groceries")];
+        let out = generate_suggestions(&categorized, &uncategorized, &existing);
+        assert_eq!(out.len(), 1);
+        let s = &out[0];
+        match &s.action {
+            SuggestionAction::ExtendRule {
+                existing_rule_id,
+                proposed_pattern,
+                ..
+            } => {
+                assert_eq!(existing_rule_id, "r1");
+                assert_eq!(proposed_pattern, "(?i)(bristol|gelsons|heinens)");
+                assert_eq!(&s.pattern, proposed_pattern);
+            }
+            other => panic!("expected ExtendRule, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn no_suggestion_when_already_covered() {
+        let categorized = vec![
+            sample("BRISTOL FARMS 552", "groceries"),
+            sample("BRISTOL FARMS STORE", "groceries"),
+        ];
+        // Existing alternation already contains the only merchant we'd propose.
+        let existing = vec![regex_rule("r1", "(?i)(bristol|gelsons)", "groceries")];
+        let out = generate_suggestions(&categorized, &[], &existing);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn single_merchant_with_no_opportunity_is_skipped() {
+        // One merchant, nothing uncategorized to catch → not worth a rule.
+        let categorized = vec![
+            sample("NETFLIX.COM", "streaming"),
+            sample("NETFLIX.COM", "streaming"),
+        ];
+        let out = generate_suggestions(&categorized, &[], &[]);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn ids_are_stable_across_runs() {
+        let categorized = vec![
+            sample("BRISTOL FARMS 1", "groceries"),
+            sample("BRISTOL FARMS 2", "groceries"),
+            sample("GELSONS 1", "groceries"),
+            sample("GELSONS 2", "groceries"),
+        ];
+        let a = generate_suggestions(&categorized, &[], &[]);
+        let b = generate_suggestions(&categorized, &[], &[]);
+        assert_eq!(a[0].id, b[0].id);
+    }
+
+    #[test]
+    fn jaro_winkler_sane_bounds() {
+        assert_eq!(jaro_winkler("gelsons", "gelsons"), 1.0);
+        assert!(jaro_winkler("schnucks", "schnuck") >= CLUSTER_SIMILARITY);
+        assert!(jaro_winkler("gelsons", "bristol") < CLUSTER_SIMILARITY);
+    }
+}

--- a/e2e/14-spending-rule-suggestions.spec.ts
+++ b/e2e/14-spending-rule-suggestions.spec.ts
@@ -1,0 +1,139 @@
+import { expect, Page, test } from "@playwright/test";
+import { BASE_URL, completeOnboardingIfNeeded, gotoAppPath } from "./helpers";
+
+// Covers PR #1344's manual test-plan checklist end to end against the web app
+// (Tauri desktop isn't Playwright-drivable — see e2e/README.md):
+//   - hand-categorizing a merchant surfaces a suggestion with a sensible pattern
+//   - accepting it creates the rule and future matches get picked up
+//   - hand-categorizing a new merchant in a category with an existing
+//     alternation rule offers to extend it instead of duplicating
+//   - dismissing a suggestion hides it, and it stays hidden after reload
+test.describe.configure({ mode: "serial" });
+
+test.describe("Spending rule suggestions", () => {
+  let page: Page;
+  let accountId: string;
+  const GROCERIES = { taxonomyId: "spending_categories", categoryId: "cat_groceries" };
+
+  async function apiPost<T>(path: string, data: unknown): Promise<T> {
+    const res = await page.request.post(`${BASE_URL}/api/v1${path}`, { data });
+    expect(res.ok(), `POST ${path} failed: ${await res.text().catch(() => "")}`).toBeTruthy();
+    return res.json();
+  }
+
+  async function apiPut<T>(path: string, data: unknown): Promise<T> {
+    const res = await page.request.put(`${BASE_URL}/api/v1${path}`, { data });
+    expect(res.ok(), `PUT ${path} failed: ${await res.text().catch(() => "")}`).toBeTruthy();
+    return res.json();
+  }
+
+  async function seedActivity(notes: string, categorize: boolean) {
+    const activity = await apiPost<{ id: string }>("/activities", {
+      accountId,
+      activityType: "WITHDRAWAL",
+      activityDate: new Date().toISOString(),
+      currency: "USD",
+      amount: 42.5,
+      notes,
+    });
+    if (categorize) {
+      await apiPut(`/spending/activities/${activity.id}/assignments`, GROCERIES);
+    }
+    return activity.id;
+  }
+
+  // The settings shell renders its content twice — a mobile copy and a
+  // desktop copy, toggled with responsive CSS rather than conditional
+  // mounting — so plain .bg-card matches twice. Scope to the visible one.
+  function suggestionCard(merchant: string) {
+    return page.locator(".bg-card:visible").filter({ hasText: merchant });
+  }
+
+  test.beforeAll(async ({ browser }) => {
+    test.setTimeout(180000);
+    page = await browser.newPage();
+    await completeOnboardingIfNeeded(page);
+
+    const account = await apiPost<{ id: string }>("/accounts", {
+      name: "Suggestions Test Account",
+      accountType: "CASH",
+      group: null,
+      currency: "USD",
+      isDefault: false,
+      isActive: true,
+      isArchived: false,
+      trackingMode: "TRANSACTIONS",
+      platformId: null,
+      accountNumber: null,
+      meta: null,
+      provider: null,
+      providerAccountId: null,
+    });
+    accountId = account.id;
+
+    await apiPut("/spending/settings", { enabled: true, accountIds: [accountId] });
+  });
+
+  test.afterAll(async () => {
+    await page.close();
+  });
+
+  test("1. Hand-categorizing a merchant surfaces a suggestion", async () => {
+    await seedActivity("BRISTOL FARMS 552", true);
+    await seedActivity("BRISTOL FARMS STORE", true);
+    // Not categorized — should be counted as an uncategorized match the
+    // suggested pattern would newly catch.
+    await seedActivity("BRISTOL FARMS 9910", false);
+
+    await gotoAppPath(page, "/settings/spending/rules");
+    await expect(page.getByRole("button", { name: /Suggested rules/i })).toBeVisible({
+      timeout: 15000,
+    });
+
+    const card = suggestionCard("Bristol Farms");
+    await expect(card).toBeVisible({ timeout: 10000 });
+    await expect(card).toContainText("Groceries");
+    await expect(card).toContainText("Catches 1 uncategorized");
+  });
+
+  test("2. Accepting the suggestion creates the rule", async () => {
+    const card = suggestionCard("Bristol Farms");
+    await card.getByRole("button", { name: "Add rule" }).click();
+
+    await expect(page.getByText(/Added rule for Bristol Farms\./)).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(card).not.toBeVisible({ timeout: 10000 });
+  });
+
+  test("3. A new merchant in the same category offers to extend the rule", async () => {
+    await seedActivity("GELSONS MARKET", true);
+    await seedActivity("GELSONS 1201", true);
+    await seedActivity("GELSONS 9812", false);
+
+    await page.reload();
+    const card = suggestionCard("Gelsons");
+    await expect(card).toBeVisible({ timeout: 15000 });
+    await expect(card.getByText("Extends existing rule")).toBeVisible();
+
+    await card.getByRole("button", { name: "Extend" }).click();
+    await expect(page.getByText(/Extended rule for Gelsons\./)).toBeVisible({ timeout: 10000 });
+    await expect(card).not.toBeVisible({ timeout: 10000 });
+  });
+
+  test("4. Dismissing a suggestion hides it, and it stays hidden after reload", async () => {
+    await seedActivity("HEINENS FINE FOODS", true);
+    await seedActivity("HEINENS 88", true);
+    await seedActivity("HEINENS 4471", false);
+
+    await page.reload();
+    const card = suggestionCard("Heinens");
+    await expect(card).toBeVisible({ timeout: 15000 });
+
+    await card.getByRole("button", { name: "Dismiss suggestion" }).click();
+    await expect(card).not.toBeVisible({ timeout: 5000 });
+
+    await page.reload();
+    await expect(suggestionCard("Heinens")).not.toBeVisible({ timeout: 10000 });
+  });
+});


### PR DESCRIPTION
<img width="866" height="720" alt="image" src="https://github.com/user-attachments/assets/5bf6656d-f911-4e08-8c3c-492e3b8b4d07" />

## Description

Once you've hand-categorized a few transactions, the same merchants keep coming
back and you either write the rule yourself or keep categorizing them one at a
time. This reads the categorizations you've already made and proposes rules that
would have made those choices for you.

- New engine in `crates/spending/src/suggestions`. It takes samples in and
  returns suggestions out with no I/O, so its behaviour is covered by unit tests
  in the same file.
- Merchant names are pulled out of the raw description by dropping branch codes,
  terminal ids, card suffixes and state codes. Near-identical stems are then
  clustered so `SCHNUCKS` and `SCHNUCK` count as the same merchant. The
  clustering uses a small Jaro-Winkler implementation rather than adding a
  dependency for it.
- Merchants in one category collapse into a single alternation, e.g.
  `(?i)(bristol|gelsons|heinens)`, rather than a rule per merchant. If a rule of
  that shape already exists for the category, the suggestion offers to extend it
  in place instead of adding a second rule for the same thing.
- The engine also looks at rules you've already written by hand. If two or more
  Contains/Regex rules exist for the same category (separate rules for Netflix
  and Spotify both filed under Streaming Services, say), it offers to combine
  them into one alternation rule and delete the redundant ones. This is
  independent of the merchant-clustering path above: it only reads the existing
  rule set, not transaction history, so there's no match count to show and
  confidence is fixed at 100%. Case sensitivity is preserved per rule when
  combining, so mixing a case-sensitive Regex rule with case-insensitive
  Contains rules produces something like `((?i:netflix)|Spotify)` rather than
  loosening the sensitive one.
- Candidates are scored on how much of the category they explain and how many
  uncategorized transactions they would newly catch. Anything explaining fewer
  than two hand-categorized transactions, or catching nothing new, is dropped.
- `CategorizationRulesService` gains `suggest_rules` and `apply_suggestion`,
  exposed over Tauri (`get_spending_rule_suggestions`,
  `apply_spending_rule_suggestion`) and HTTP
  (`GET`/`POST /spending/rule-suggestions`).
- The rules settings page shows the suggestions above the rule list. Dismissals
  live in localStorage, keyed by a content hash of the suggestion so they hold
  across refetches.

Accepted suggestions become global regex rules at priority 50, below the bundled
country presets (70-95) and above the default for hand-written rules (0). No new
crates, migrations or repository methods.

Thresholds are constants at the top of `suggestions/service.rs`
(`MIN_MERCHANT_OCCURRENCES`, `MIN_MATCH_COUNT`, `MIN_TOKEN_LEN`,
`CLUSTER_SIMILARITY`, `MAX_SUGGESTIONS`) if they turn out to be tuned wrong.

## Test plan

- [x] `cargo test -p wealthfolio-spending` (8 new tests under
      `suggestions::service`)
- [x] Categorize several transactions from the same merchant by hand, then open
      Settings -> Spending -> Rules and check a suggestion appears with a
      sensible pattern and merchant list
- [x] Accept it, and confirm the rule is created and the matching uncategorized
      transactions get picked up
- [x] Hand-categorize a new merchant in a category that already has an
      alternation rule, and confirm the suggestion offers to extend that rule
      rather than create a second one
- [x] Dismiss a suggestion, reload the page, and confirm it stays dismissed
- [x] Check both desktop (Tauri) and web (`pnpm run dev:web`) since the commands
      are wired separately

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
