### PR TITLE
feat(spending): add Australia and New Zealand categorization rule presets

### DIFF
--- a/apps/frontend/src/features/spending/components/rule-preset-constants.ts
+++ b/apps/frontend/src/features/spending/components/rule-preset-constants.ts
@@ -3,4 +3,6 @@ export const PRESET_FLAGS: Record<string, string> = {
   ca: "🇨🇦",
   gb: "🇬🇧",
   es: "🇪🇸",
+  au: "🇦🇺",
+  nz: "🇳🇿",
 };

--- a/crates/spending/seeds/presets/au.json
+++ b/crates/spending/seeds/presets/au.json
@@ -1,0 +1,305 @@
+{
+  "presetId": "au",
+  "presetVersion": "2026-07.1",
+  "name": "Australia",
+  "description": "~40 expense rules for common Australian household transactions: supermarkets, fuel, transit, telecom, utilities, retail, health, and government payments. Merchant names follow how they usually appear on Australian bank and card statements.",
+  "language": "en-AU",
+  "rules": [
+    {
+      "key": "au.groceries.major_chains",
+      "name": "Groceries — major chains",
+      "pattern": "(?i)woolworths|\\bwoolies\\b|ww metro|\\bcoles\\b|\\baldi\\b|\\biga\\b|foodland|harris farm|drakes\\b|foodworks|\\bcostco\\b|supabarn",
+      "matchType": "regex",
+      "categoryKey": "groceries",
+      "priority": 80
+    },
+    {
+      "key": "au.coffee",
+      "name": "Coffee shops",
+      "pattern": "(?i)gloria jean|coffee club|zarraffa|muffin break|jamaica blue|starbucks|\\bcafe\\b|\\bcafé\\b|\\bespresso\\b|\\bcoffee\\b|\\bbaristas?\\b",
+      "matchType": "regex",
+      "categoryKey": "food_coffee",
+      "priority": 78
+    },
+    {
+      "key": "au.fastfood",
+      "name": "Fast food & casual dining",
+      "pattern": "(?i)mcdonald|\\bmacca'?s\\b|hungry jack|\\bhjs\\b|\\bkfc\\b|red rooster|\\bnando'?s\\b|frango'?s?|\\boporto\\b|domino|pizza hut|\\bsubway\\b|guzman y gomez|guzman|\\bgyg\\b|mad mex|zambrero|grill'?d|betty'?s burgers|schnitz|\\bboost juice\\b|\\bsushi\\b hub",
+      "matchType": "regex",
+      "categoryKey": "food_restaurants",
+      "priority": 75
+    },
+    {
+      "key": "au.food_delivery",
+      "name": "Food delivery",
+      "pattern": "(?i)uber ?eats|\\bmenulog\\b|doordash|deliveroo|hello ?fresh|marley spoon|dinnerly|youfoodz|\\beasydiner\\b",
+      "matchType": "regex",
+      "categoryKey": "food_delivery",
+      "priority": 85
+    },
+    {
+      "key": "au.alcohol",
+      "name": "Liquor & bottle shops",
+      "pattern": "(?i)dan murphy|\\bbws\\b|liquorland|first choice liquor|vintage cellars|\\bcellarbrations\\b|\\bthe bottle-?o\\b|\\bbottle shop\\b|\\biga liquor\\b|\\bpub\\b|\\btavern\\b|\\bhotel\\b bar",
+      "matchType": "regex",
+      "categoryKey": "food_alcohol",
+      "priority": 70
+    },
+    {
+      "key": "au.fuel",
+      "name": "Fuel stations",
+      "pattern": "(?i)\\bbp\\b|\\bshell\\b|\\bcaltex\\b|\\bampol\\b|\\bmobil\\b|7-?eleven|united petroleum|metro petroleum|reddy express|coles express|\\beg ampol\\b|\\bogr\\b|\\bliberty\\b fuel|\\bapco\\b",
+      "matchType": "regex",
+      "categoryKey": "transport_gas",
+      "priority": 80
+    },
+    {
+      "key": "au.transit",
+      "name": "Public transit",
+      "pattern": "(?i)\\bopal\\b|transport ?(?:for)? ?nsw|\\bmyki\\b|ptv\\b|public transport vic|\\bgo card\\b|translink|\\bmetrocard\\b|adelaide metro|transperth|smartrider|metro tasmania|\\bv/?line\\b|\\bnightrider\\b",
+      "matchType": "regex",
+      "categoryKey": "transport_public",
+      "priority": 80
+    },
+    {
+      "key": "au.rideshare",
+      "name": "Rideshare & taxi",
+      "pattern": "(?i)\\buber\\b|\\bdidi\\b|\\bola\\b|\\bbolt\\b|\\b13cabs\\b|\\bsilver service\\b|\\btaxi\\b|\\bcabcharge\\b|\\bggt\\b",
+      "matchType": "regex",
+      "categoryKey": "transport_rideshare",
+      "priority": 80
+    },
+    {
+      "key": "au.parking",
+      "name": "Parking & tolls",
+      "pattern": "(?i)wilson parking|secure parking|care park\\b|\\beasypark\\b|cellopark\\b|\\blinkt\\b|\\betoll\\b|\\bcity ?link\\b|\\beastlink\\b|\\bcar park\\b|parking fee",
+      "matchType": "regex",
+      "categoryKey": "transport_parking",
+      "priority": 85
+    },
+    {
+      "key": "au.car_maintenance",
+      "name": "Car maintenance & parts",
+      "pattern": "(?i)ultra ?tune|kmart tyre|\\bmycar\\b|bob jane|beaurepaires|\\bmidas\\b|supercheap auto|\\brepco\\b|\\bautobarn\\b|\\bjax tyres\\b|tyrepower|car wash|\\brego\\b check|roadworthy",
+      "matchType": "regex",
+      "categoryKey": "transport_maintenance",
+      "priority": 85
+    },
+    {
+      "key": "au.airlines",
+      "name": "Airlines",
+      "pattern": "(?i)qantas|jetstar|virgin australia|\\brex\\b airlines|regional express|\\bbonza\\b|\\bqf\\b flight",
+      "matchType": "regex",
+      "categoryKey": "travel",
+      "priority": 90
+    },
+    {
+      "key": "au.hotels",
+      "name": "Hotels & accommodation",
+      "pattern": "(?i)airbnb|\\bstayz\\b|\\bvrbo\\b|booking\\.com|\\bexpedia\\b|hotels\\.com|\\bagoda\\b|\\btrivago\\b|\\bibis\\b|\\bnovotel\\b|\\bmercure\\b|crown hotel|\\bmeriton\\b|quest apartments|\\bmotel\\b|\\bhotel\\b",
+      "matchType": "regex",
+      "categoryKey": "travel",
+      "priority": 85
+    },
+    {
+      "key": "au.streaming",
+      "name": "Streaming services",
+      "pattern": "(?i)netflix|\\bstan\\b|\\bbinge\\b|\\bkayo\\b|\\bfoxtel\\b|flash news|disney ?\\+|amazon prime video|prime video|paramount ?\\+|\\bbritbox\\b|apple\\.com/bill|apple music|spotify|youtube ?premium|\\baudible\\b",
+      "matchType": "regex",
+      "categoryKey": "entertainment_streaming",
+      "priority": 85
+    },
+    {
+      "key": "au.software_subs",
+      "name": "Software & cloud",
+      "pattern": "(?i)\\badobe\\b|microsoft ?\\*|\\bm365\\b|office 365|dropbox|\\bicloud\\b|google ?one|google ?storage|\\bnotion\\b|\\bslack\\b|\\bzoom\\.us\\b|\\bgithub\\b|jetbrains|chatgpt|openai|claude\\.ai|anthropic|\\bcanva\\b|grammarly|\\b1password\\b|\\bxero\\b|\\bmyob\\b",
+      "matchType": "regex",
+      "categoryKey": "bills_software",
+      "priority": 80
+    },
+    {
+      "key": "au.telecom",
+      "name": "Phone & internet",
+      "pattern": "(?i)\\btelstra\\b|\\boptus\\b|vodafone|\\btpg\\b|\\biinet\\b|aussie broadband|\\bbelong\\b|\\bboost\\b mobile|amaysim|\\bdodo\\b|\\bsuperloop\\b|\\bexetel\\b|\\bmoose\\b mobile|\\bfelix\\b mobile|\\bkogan\\b mobile|\\bmate\\b communicate",
+      "matchType": "regex",
+      "categoryKey": "bills_phone",
+      "priority": 80
+    },
+    {
+      "key": "au.utilities",
+      "name": "Utilities (electricity/gas/water)",
+      "pattern": "(?i)\\bagl\\b|origin energy|energy ?australia|red energy|\\balinta\\b|simply energy|\\bactewagl\\b|\\bmomentum\\b energy|\\bpowershop\\b|\\bergon\\b|sydney water|\\bsa water\\b|yarra valley water|water corporation|\\bunitywater\\b|\\bausgrid\\b",
+      "matchType": "regex",
+      "categoryKey": "housing_utilities",
+      "priority": 80
+    },
+    {
+      "key": "au.housing_rent_mortgage",
+      "name": "Rent & mortgage",
+      "pattern": "(?i)\\brent\\b|mortgage|home loan|body corporate|strata\\b|real estate|\\bltd re\\b|property management|\\bragent\\b|\\brealestate\\.com\\b|\\bdomain\\b rent",
+      "matchType": "regex",
+      "categoryKey": "housing_rent",
+      "priority": 88
+    },
+    {
+      "key": "au.online_marketplaces",
+      "name": "Online marketplaces",
+      "pattern": "(?i)amazon\\.com\\.au|amzn mktp au|\\bamzn\\b|\\bebay\\b|\\bcatch\\b\\.com|\\bkogan\\b|\\btemu\\b|\\bshein\\b|aliexpress|\\bgumtree\\b|\\bmightyape\\b|\\bthe iconic\\b",
+      "matchType": "regex",
+      "categoryKey": "shopping_online",
+      "priority": 70
+    },
+    {
+      "key": "au.shopping_clothing",
+      "name": "Clothing & department stores",
+      "pattern": "(?i)cotton on|\\bkmart\\b|\\btarget\\b australia|\\bbig w\\b|\\bmyer\\b|david jones|country road|\\buniqlo\\b|\\bh&m\\b|\\bzara\\b|jd sports|\\brebel\\b sport|\\bthe iconic\\b|\\bsportsgirl\\b|\\bglue store\\b|\\bgeneral pants\\b|\\bpeter alexander\\b|\\bbonds\\b",
+      "matchType": "regex",
+      "categoryKey": "shopping_clothing",
+      "priority": 80
+    },
+    {
+      "key": "au.shopping_electronics",
+      "name": "Electronics & office",
+      "pattern": "(?i)jb hi-?fi|harvey norman|officeworks|the good guys|apple store|\\bmwave\\b|\\bscorptec\\b|\\bpccasegear\\b|\\bcentre com\\b",
+      "matchType": "regex",
+      "categoryKey": "shopping_electronics",
+      "priority": 85
+    },
+    {
+      "key": "au.home_improvement",
+      "name": "Home improvement & furniture",
+      "pattern": "(?i)bunnings|mitre ?10|\\bikea\\b|\\bfreedom\\b furniture|fantastic furniture|\\bamart\\b|nick scali|\\badairs\\b|pillow talk|\\bhome co\\b|\\bbeacon lighting\\b|\\bspotlight\\b|\\bhouse\\b homewares",
+      "matchType": "regex",
+      "categoryKey": "shopping_home",
+      "priority": 80
+    },
+    {
+      "key": "au.pharmacy",
+      "name": "Pharmacy & chemists",
+      "pattern": "(?i)chemist warehouse|\\bpriceline\\b|terry white|\\bamcal\\b|\\bguardian\\b pharmacy|my chemist|\\bpharmacy\\b|good price pharmacy|\\bnational pharmacies\\b",
+      "matchType": "regex",
+      "categoryKey": "health_pharmacy",
+      "priority": 85
+    },
+    {
+      "key": "au.medical",
+      "name": "Medical & clinics",
+      "pattern": "(?i)\\bmedicare\\b|medical centre|\\bgp\\b clinic|\\bclinic\\b|\\bhospital\\b|\\bpathology\\b|\\bradiology\\b|physiotherapy|\\bphysio\\b|\\bchiro\\b|\\bhealthscope\\b|\\bipn\\b medical",
+      "matchType": "regex",
+      "categoryKey": "health_medical",
+      "priority": 86
+    },
+    {
+      "key": "au.dental",
+      "name": "Dental",
+      "pattern": "(?i)\\bdental\\b|\\bdentist\\b|orthodont|\\bpacific smiles\\b|\\bmaven dental\\b",
+      "matchType": "regex",
+      "categoryKey": "health_dental",
+      "priority": 86
+    },
+    {
+      "key": "au.vision",
+      "name": "Vision & optical",
+      "pattern": "(?i)specsavers|\\bopsm\\b|bailey nelson|\\boscar wylee\\b|laubman|\\boptometrist\\b|\\boptical\\b",
+      "matchType": "regex",
+      "categoryKey": "health_vision",
+      "priority": 86
+    },
+    {
+      "key": "au.health_insurance",
+      "name": "Private health insurance",
+      "pattern": "(?i)\\bmedibank\\b|\\bbupa\\b|\\bhcf\\b|\\bnib\\b|\\bahm\\b|\\bhbf\\b|\\bgmhba\\b|australian unity|\\bteachers health\\b|health insurance",
+      "matchType": "regex",
+      "categoryKey": "health_insurance",
+      "priority": 86
+    },
+    {
+      "key": "au.fitness",
+      "name": "Gyms & fitness",
+      "pattern": "(?i)anytime fitness|fitness first|\\bgoodlife\\b|\\bjetts\\b|\\bf45\\b|snap fitness|plus fitness|\\bcrunch\\b fitness|\\bgenesis\\b health|\\bpilates\\b|crossfit|\\borangetheory\\b",
+      "matchType": "regex",
+      "categoryKey": "health_fitness",
+      "priority": 85
+    },
+    {
+      "key": "au.movies_events",
+      "name": "Cinemas & live events",
+      "pattern": "(?i)event cinemas|\\bhoyts\\b|village cinemas|palace cinemas|\\bdendy\\b|\\breading cinemas\\b|\\bimax\\b|\\bticketek\\b|ticketmaster|\\bmoshtix\\b|\\boztix\\b",
+      "matchType": "regex",
+      "categoryKey": "entertainment_movies",
+      "priority": 85
+    },
+    {
+      "key": "au.gaming",
+      "name": "Gaming platforms",
+      "pattern": "(?i)\\bsteam\\b games|steamgames|\\bxbox\\b|playstation|\\bpsn\\b|nintendo|\\beb games\\b|epic games",
+      "matchType": "regex",
+      "categoryKey": "entertainment_games",
+      "priority": 85
+    },
+    {
+      "key": "au.discount_stores",
+      "name": "Discount & variety stores",
+      "pattern": "(?i)the reject shop|\\bdaiso\\b|\\bmy dollar\\b|\\bdollar king\\b|\\bsilly solly\\b|\\bhot dollar\\b|\\bcheap as chips\\b",
+      "matchType": "regex",
+      "categoryKey": "shopping",
+      "priority": 74
+    },
+    {
+      "key": "au.personal_care",
+      "name": "Personal care & beauty",
+      "pattern": "(?i)\\bmecca\\b|\\bsephora\\b|\\bulta\\b|\\bbarber\\b|hair salon|\\bnails\\b|\\bnail bar\\b|\\bday spa\\b|\\bspa\\b treatment|\\bwaxing\\b|\\bhaircut\\b",
+      "matchType": "regex",
+      "categoryKey": "personal",
+      "priority": 82
+    },
+    {
+      "key": "au.pets",
+      "name": "Pets & vets",
+      "pattern": "(?i)\\bpetbarn\\b|\\bpetstock\\b|pet circle|\\bpeto\\b|greencross vets|\\bvetwest\\b|\\bveterinary\\b|\\bvet clinic\\b|animal hospital|\\bpet supplies\\b",
+      "matchType": "regex",
+      "categoryKey": "personal",
+      "priority": 82
+    },
+    {
+      "key": "au.education_childcare",
+      "name": "Education & childcare",
+      "pattern": "(?i)\\btafe\\b|university|\\buni\\b sa|\\bchild ?care\\b|\\bgoodstart\\b|\\bkindergarten\\b|early learning|\\bschool fees\\b|\\bhecs\\b|\\bhelp\\b debt|coursera|udemy",
+      "matchType": "regex",
+      "categoryKey": "education",
+      "priority": 82
+    },
+    {
+      "key": "au.donations",
+      "name": "Donations & charities",
+      "pattern": "(?i)\\bgofundme\\b|\\braise\\b\\.ly|red cross|\\bunicef\\b|salvation army|\\bsalvos\\b|world vision|\\bvinnies\\b|cancer council|\\brspca\\b|\\bdonation\\b|\\bcharity\\b|\\bchurch\\b|\\btithe\\b",
+      "matchType": "regex",
+      "categoryKey": "gifts",
+      "priority": 82
+    },
+    {
+      "key": "au.bank_fees",
+      "name": "Bank & account fees",
+      "pattern": "(?i)account keeping fee|monthly (account )?fee|\\boverdrawn\\b fee|\\bdishonour\\b fee|international transaction fee|foreign (currency )?fee|\\batm\\b fee|\\bcash advance\\b fee|annual (card )?fee",
+      "matchType": "regex",
+      "categoryKey": "fees_bank",
+      "priority": 90
+    },
+    {
+      "key": "au.insurance_auto_home",
+      "name": "Car & home insurance",
+      "pattern": "(?i)\\bnrma\\b|\\bracv\\b|\\bracq\\b|\\bract\\b|\\braa\\b|\\bac\\b insurance|\\baami\\b|budget direct|\\byoui\\b|\\ballianz\\b|\\bsuncorp\\b|\\bgio\\b|\\bbingle\\b|\\bapia\\b|\\bqbe\\b|\\bwoolworths insurance\\b|\\bcoles insurance\\b",
+      "matchType": "regex",
+      "categoryKey": "transport_insurance",
+      "priority": 85
+    },
+    {
+      "key": "au.government",
+      "name": "Government & rego",
+      "pattern": "(?i)\\bato\\b payment|australian tax|services australia|\\bcentrelink\\b|\\bmedicare\\b levy|service nsw|\\bvicroads\\b|service vic|\\btmr\\b qld|\\bdotdirect\\b|\\bmygov\\b|department of transport|\\bcouncil rates\\b",
+      "matchType": "regex",
+      "categoryKey": "fees",
+      "priority": 90
+    }
+  ]
+}

--- a/crates/spending/seeds/presets/nz.json
+++ b/crates/spending/seeds/presets/nz.json
@@ -1,0 +1,305 @@
+{
+  "presetId": "nz",
+  "presetVersion": "2026-07.1",
+  "name": "New Zealand",
+  "description": "~40 expense rules for common New Zealand household transactions: supermarkets, fuel, transit, telecom, power, retail, health, and government payments. Merchant names follow how they usually appear on New Zealand bank and card statements.",
+  "language": "en-NZ",
+  "rules": [
+    {
+      "key": "nz.groceries.major_chains",
+      "name": "Groceries — major chains",
+      "pattern": "(?i)countdown|pak'?n ?save|new world|four ?square|fresh ?choice|super ?value|\\bwoolworths\\b|the warehouse\\b food|\\bmoore wilson\\b|\\bfarro\\b",
+      "matchType": "regex",
+      "categoryKey": "groceries",
+      "priority": 80
+    },
+    {
+      "key": "nz.coffee",
+      "name": "Coffee shops",
+      "pattern": "(?i)\\bmojo\\b|coffee culture|\\bstarbucks\\b|\\besquires\\b|robert harris|\\bcaffe\\b|\\bcafé\\b|\\bcafe\\b|\\bespresso\\b|\\bcoffee\\b|\\bbaristas?\\b",
+      "matchType": "regex",
+      "categoryKey": "food_coffee",
+      "priority": 78
+    },
+    {
+      "key": "nz.fastfood",
+      "name": "Fast food & casual dining",
+      "pattern": "(?i)mcdonald|\\bkfc\\b|burger king|\\bwendy'?s\\b|carl'?s jr|\\bsubway\\b|domino|pizza hut|\\bhell\\b pizza|burger ?fuel|\\bnando'?s\\b|st pierre|\\bsushi\\b|\\btank\\b juice|\\bmovenpick\\b",
+      "matchType": "regex",
+      "categoryKey": "food_restaurants",
+      "priority": 75
+    },
+    {
+      "key": "nz.food_delivery",
+      "name": "Food delivery",
+      "pattern": "(?i)uber ?eats|\\bdelivereasy\\b|door ?dash|hello ?fresh|my food bag|\\bwoop\\b|\\bbargain box\\b",
+      "matchType": "regex",
+      "categoryKey": "food_delivery",
+      "priority": 85
+    },
+    {
+      "key": "nz.alcohol",
+      "name": "Liquor & bottle stores",
+      "pattern": "(?i)liquorland|super liquor|big barrel|black bull|\\bbottle-?o\\b|\\bbottle store\\b|thirsty liquor|\\bglengarry\\b|\\bpub\\b|\\btavern\\b|\\bbar\\b tab",
+      "matchType": "regex",
+      "categoryKey": "food_alcohol",
+      "priority": 70
+    },
+    {
+      "key": "nz.fuel",
+      "name": "Fuel stations",
+      "pattern": "(?i)\\bz energy\\b|\\bz\\b petrol|\\bbp\\b|\\bmobil\\b|\\bcaltex\\b|\\bgull\\b|\\bwaitomo\\b|\\bchallenge\\b fuel|\\bnpd\\b|\\ballied\\b petroleum|\\bgas\\b station",
+      "matchType": "regex",
+      "categoryKey": "transport_gas",
+      "priority": 80
+    },
+    {
+      "key": "nz.transit",
+      "name": "Public transit",
+      "pattern": "(?i)\\bat hop\\b|auckland transport|\\bbee card\\b|\\bmetlink\\b|\\bsnapper\\b|\\bmetrocard\\b|\\benvironment canterbury\\b|\\bgo bus\\b|\\bintercity\\b|\\bat mobile\\b",
+      "matchType": "regex",
+      "categoryKey": "transport_public",
+      "priority": 80
+    },
+    {
+      "key": "nz.rideshare",
+      "name": "Rideshare & taxi",
+      "pattern": "(?i)\\buber\\b|\\bola\\b|\\bzoomy\\b|\\bdidi\\b|\\bbolt\\b|\\btaxi\\b|\\bcorporate cabs\\b|\\bgreen cabs\\b|\\bkiwi cabs\\b",
+      "matchType": "regex",
+      "categoryKey": "transport_rideshare",
+      "priority": 80
+    },
+    {
+      "key": "nz.parking",
+      "name": "Parking & tolls",
+      "pattern": "(?i)wilson parking|\\bcare park\\b|tournament parking|\\bat parking\\b|\\beasypark\\b|\\bpaymywayparking\\b|\\bnzta\\b toll|\\btoll\\b road|\\bcar park\\b|parking fee",
+      "matchType": "regex",
+      "categoryKey": "transport_parking",
+      "priority": 85
+    },
+    {
+      "key": "nz.car_maintenance",
+      "name": "Car maintenance & parts",
+      "pattern": "(?i)\\bvtnz\\b|\\bwof\\b|\\brepco\\b|supercheap auto|beaurepaires|tony'?s tyre|\\bmidas\\b|\\bfirestone\\b|\\bbridgestone\\b|\\bpit stop\\b|car grooming|car wash|\\brego\\b",
+      "matchType": "regex",
+      "categoryKey": "transport_maintenance",
+      "priority": 85
+    },
+    {
+      "key": "nz.airlines",
+      "name": "Airlines",
+      "pattern": "(?i)air new zealand|\\bair nz\\b|jetstar|qantas|\\bnz\\b flight",
+      "matchType": "regex",
+      "categoryKey": "travel",
+      "priority": 90
+    },
+    {
+      "key": "nz.hotels",
+      "name": "Hotels & accommodation",
+      "pattern": "(?i)airbnb|\\bbookabach\\b|\\bvrbo\\b|booking\\.com|\\bexpedia\\b|hotels\\.com|\\bagoda\\b|\\btrivago\\b|\\bibis\\b|\\bnovotel\\b|\\bmercure\\b|\\brydges\\b|\\bsudima\\b|\\bmotel\\b|\\bhotel\\b|\\bholiday park\\b",
+      "matchType": "regex",
+      "categoryKey": "travel",
+      "priority": 85
+    },
+    {
+      "key": "nz.streaming",
+      "name": "Streaming services",
+      "pattern": "(?i)netflix|\\bneon\\b|sky ?go|sky tv|\\btvnz\\b\\+?|three ?now|disney ?\\+|amazon prime video|prime video|apple\\.com/bill|apple music|spotify|youtube ?premium|\\baudible\\b",
+      "matchType": "regex",
+      "categoryKey": "entertainment_streaming",
+      "priority": 85
+    },
+    {
+      "key": "nz.software_subs",
+      "name": "Software & cloud",
+      "pattern": "(?i)\\badobe\\b|microsoft ?\\*|\\bm365\\b|office 365|dropbox|\\bicloud\\b|google ?one|google ?storage|\\bnotion\\b|\\bslack\\b|\\bzoom\\.us\\b|\\bgithub\\b|jetbrains|chatgpt|openai|claude\\.ai|anthropic|\\bcanva\\b|grammarly|\\b1password\\b|\\bxero\\b",
+      "matchType": "regex",
+      "categoryKey": "bills_software",
+      "priority": 80
+    },
+    {
+      "key": "nz.telecom",
+      "name": "Phone & internet",
+      "pattern": "(?i)\\bspark\\b|\\bone nz\\b|vodafone|2degrees|\\bskinny\\b|\\bslingshot\\b|\\borcon\\b|\\bcontact\\b broadband|\\bnow\\b broadband|\\bmyrepublic\\b|\\bbigpipe\\b|\\bvoyager\\b|\\bstuff fibre\\b",
+      "matchType": "regex",
+      "categoryKey": "bills_phone",
+      "priority": 80
+    },
+    {
+      "key": "nz.utilities",
+      "name": "Utilities (power/gas/water)",
+      "pattern": "(?i)genesis energy|contact energy|\\bmercury\\b energy|\\bmeridian\\b|\\bnova\\b energy|electric kiwi|\\bpowershop\\b|\\bfrank\\b energy|\\bpulse\\b energy|\\bwatercare\\b|\\bwellington water\\b|\\bvector\\b",
+      "matchType": "regex",
+      "categoryKey": "housing_utilities",
+      "priority": 80
+    },
+    {
+      "key": "nz.housing_rent_mortgage",
+      "name": "Rent & mortgage",
+      "pattern": "(?i)\\brent\\b|mortgage|home loan|body corporate|property management|\\bbarfoot\\b|\\bray white\\b rent|\\bharcourts\\b rent|\\btrademe property\\b|\\brates\\b",
+      "matchType": "regex",
+      "categoryKey": "housing_rent",
+      "priority": 88
+    },
+    {
+      "key": "nz.online_marketplaces",
+      "name": "Online marketplaces",
+      "pattern": "(?i)\\btrade ?me\\b|\\btrademe\\b|amazon|\\bmighty ?ape\\b|\\bebay\\b|\\btemu\\b|\\bshein\\b|aliexpress|\\bthe market\\b|\\bonecard\\b",
+      "matchType": "regex",
+      "categoryKey": "shopping_online",
+      "priority": 70
+    },
+    {
+      "key": "nz.shopping_clothing",
+      "name": "Clothing & department stores",
+      "pattern": "(?i)cotton on|\\bglassons\\b|hallenstein|\\bbarkers\\b|\\bfarmers\\b|\\bkmart\\b|the warehouse\\b|\\buniqlo\\b|\\bh&m\\b|\\bzara\\b|\\bhuffer\\b|\\bkathmandu\\b|\\bmacpac\\b|\\brebel sport\\b|\\bnumber one shoes\\b|\\bhannahs\\b",
+      "matchType": "regex",
+      "categoryKey": "shopping_clothing",
+      "priority": 80
+    },
+    {
+      "key": "nz.shopping_electronics",
+      "name": "Electronics & office",
+      "pattern": "(?i)jb hi-?fi|harvey norman|noel leeming|\\bpb tech\\b|\\bpbtech\\b|\\bcomputer lounge\\b|apple store|\\bwarehouse stationery\\b|\\bofficemax\\b",
+      "matchType": "regex",
+      "categoryKey": "shopping_electronics",
+      "priority": 85
+    },
+    {
+      "key": "nz.home_improvement",
+      "name": "Home improvement & furniture",
+      "pattern": "(?i)bunnings|mitre ?10|\\bplacemakers\\b|\\bnido\\b|\\bfreedom\\b furniture|\\bbriscoes\\b|\\bnido\\b|\\bharvey norman\\b furniture|\\bbig save\\b|\\btarget furniture\\b|\\bspotlight\\b|\\bstevens\\b",
+      "matchType": "regex",
+      "categoryKey": "shopping_home",
+      "priority": 80
+    },
+    {
+      "key": "nz.pharmacy",
+      "name": "Pharmacy & chemists",
+      "pattern": "(?i)chemist warehouse|\\bunichem\\b|life pharmacy|bargain chemist|\\bpharmacy\\b|\\bchemist\\b",
+      "matchType": "regex",
+      "categoryKey": "health_pharmacy",
+      "priority": 85
+    },
+    {
+      "key": "nz.medical",
+      "name": "Medical & clinics",
+      "pattern": "(?i)medical centre|\\bgp\\b clinic|\\bclinic\\b|\\bhospital\\b|white cross|\\bhealthline\\b|\\bpathlab\\b|physiotherapy|\\bphysio\\b|\\bchiro\\b|\\bmedlab\\b|\\bradiology\\b",
+      "matchType": "regex",
+      "categoryKey": "health_medical",
+      "priority": 86
+    },
+    {
+      "key": "nz.dental",
+      "name": "Dental",
+      "pattern": "(?i)\\bdental\\b|\\bdentist\\b|orthodont|\\blumino\\b|\\bdentalcare\\b",
+      "matchType": "regex",
+      "categoryKey": "health_dental",
+      "priority": 86
+    },
+    {
+      "key": "nz.vision",
+      "name": "Vision & optical",
+      "pattern": "(?i)specsavers|\\bopsm\\b|\\bvisique\\b|bailey nelson|\\boptometrist\\b|\\boptical\\b|\\beye care\\b",
+      "matchType": "regex",
+      "categoryKey": "health_vision",
+      "priority": 86
+    },
+    {
+      "key": "nz.health_insurance",
+      "name": "Private health insurance",
+      "pattern": "(?i)southern cross|\\bnib\\b|\\baia\\b|\\baccuro\\b|\\bunimed\\b|health insurance|\\bpartners life\\b health",
+      "matchType": "regex",
+      "categoryKey": "health_insurance",
+      "priority": 86
+    },
+    {
+      "key": "nz.fitness",
+      "name": "Gyms & fitness",
+      "pattern": "(?i)les mills|anytime fitness|\\bcityfitness\\b|\\bjetts\\b|\\bf45\\b|snap fitness|\\bcontours\\b|\\bpilates\\b|crossfit|\\bexercise\\b",
+      "matchType": "regex",
+      "categoryKey": "health_fitness",
+      "priority": 85
+    },
+    {
+      "key": "nz.movies_events",
+      "name": "Cinemas & live events",
+      "pattern": "(?i)event cinemas|\\bhoyts\\b|reading cinemas|\\brialto\\b|\\bimax\\b|\\bticketek\\b|ticketmaster|\\biticket\\b|\\beventfinda\\b|\\bhumanitix\\b",
+      "matchType": "regex",
+      "categoryKey": "entertainment_movies",
+      "priority": 85
+    },
+    {
+      "key": "nz.gaming",
+      "name": "Gaming platforms",
+      "pattern": "(?i)\\bsteam\\b games|steamgames|\\bxbox\\b|playstation|\\bpsn\\b|nintendo|\\beb games\\b|epic games",
+      "matchType": "regex",
+      "categoryKey": "entertainment_games",
+      "priority": 85
+    },
+    {
+      "key": "nz.discount_stores",
+      "name": "Discount & variety stores",
+      "pattern": "(?i)\\bthe warehouse\\b|\\bdaiso\\b|\\b2 dollar\\b|\\bdollar store\\b|\\bsave barn\\b|\\bthe reject shop\\b|\\bcoin save\\b",
+      "matchType": "regex",
+      "categoryKey": "shopping",
+      "priority": 74
+    },
+    {
+      "key": "nz.personal_care",
+      "name": "Personal care & beauty",
+      "pattern": "(?i)\\bmecca\\b|\\bsephora\\b|\\bbarber\\b|hair salon|\\bnails\\b|\\bnail bar\\b|\\bday spa\\b|\\bspa\\b treatment|\\bwaxing\\b|\\bhaircut\\b|\\bcaci\\b",
+      "matchType": "regex",
+      "categoryKey": "personal",
+      "priority": 82
+    },
+    {
+      "key": "nz.pets",
+      "name": "Pets & vets",
+      "pattern": "(?i)\\banimates\\b|pet\\.co\\.nz|\\bpetdirect\\b|\\bvetora\\b|\\bvet clinic\\b|\\bveterinary\\b|animal hospital|\\bpet supplies\\b|\\bpetstock\\b",
+      "matchType": "regex",
+      "categoryKey": "personal",
+      "priority": 82
+    },
+    {
+      "key": "nz.education_childcare",
+      "name": "Education & childcare",
+      "pattern": "(?i)university|\\bpolytechnic\\b|\\bnzqa\\b|\\bchild ?care\\b|\\bkindergarten\\b|\\bkindercare\\b|early learning|\\bschool fees\\b|\\bstudylink\\b|\\bstudent loan\\b|coursera|udemy",
+      "matchType": "regex",
+      "categoryKey": "education",
+      "priority": 82
+    },
+    {
+      "key": "nz.donations",
+      "name": "Donations & charities",
+      "pattern": "(?i)\\bgivealittle\\b|\\bgofundme\\b|red cross|\\bunicef\\b|salvation army|\\bsalvation\\b|world vision|\\bspca\\b|\\bkidscan\\b|\\bdonation\\b|\\bcharity\\b|\\bchurch\\b|\\btithe\\b",
+      "matchType": "regex",
+      "categoryKey": "gifts",
+      "priority": 82
+    },
+    {
+      "key": "nz.bank_fees",
+      "name": "Bank & account fees",
+      "pattern": "(?i)account fee|monthly (base )?fee|\\bdishonour\\b fee|international transaction fee|foreign (currency )?fee|\\batm\\b fee|\\bcash advance\\b fee|\\bod\\b fee|annual (card )?fee",
+      "matchType": "regex",
+      "categoryKey": "fees_bank",
+      "priority": 90
+    },
+    {
+      "key": "nz.insurance_auto_home",
+      "name": "Car & home insurance",
+      "pattern": "(?i)\\baa\\b insurance|\\bstate\\b insurance|\\bami\\b insurance|\\btower\\b insurance|\\bvero\\b|\\bfmg\\b|\\bcove\\b insurance|\\btrade me insurance\\b|\\bprotecta\\b",
+      "matchType": "regex",
+      "categoryKey": "transport_insurance",
+      "priority": 85
+    },
+    {
+      "key": "nz.government",
+      "name": "Government & rates",
+      "pattern": "(?i)\\bird\\b payment|inland revenue|\\bnzta\\b|waka kotahi|\\bwork and income\\b|\\bwinz\\b|\\bacc\\b levy|\\bcouncil rates\\b|city council|district council|\\bmsd\\b",
+      "matchType": "regex",
+      "categoryKey": "fees",
+      "priority": 90
+    }
+  ]
+}

--- a/crates/spending/src/categorization_rules/presets.rs
+++ b/crates/spending/src/categorization_rules/presets.rs
@@ -89,6 +89,8 @@ const PRESET_JSONS: &[(&str, &str)] = &[
     ("ca", include_str!("../../seeds/presets/ca.json")),
     ("gb", include_str!("../../seeds/presets/gb.json")),
     ("es", include_str!("../../seeds/presets/es.json")),
+    ("au", include_str!("../../seeds/presets/au.json")),
+    ("nz", include_str!("../../seeds/presets/nz.json")),
 ];
 
 /// Parse all bundled presets. Bad JSON (or schema-mismatched files) is logged
@@ -150,7 +152,7 @@ mod tests {
 
     #[test]
     fn bundled_presets_have_unique_keys_and_valid_regexes() {
-        for preset_id in ["us", "ca", "gb", "es"] {
+        for preset_id in ["us", "ca", "gb", "es", "au", "nz"] {
             let preset = load_preset(preset_id).expect("preset should load");
             assert_eq!(preset.preset_id, preset_id);
             assert!(!preset.rules.is_empty(), "preset {preset_id} has no rules");


### PR DESCRIPTION
## Description

<!-- Describe your changes -->

Adds bundled categorization rule presets for Australia and New Zealand, next to
the existing US, CA, GB and ES ones.

- 37 rules each, covering supermarkets, fuel, public transit, telecom, power,
  retail, health and government payments, mapped to the category keys already in
  the seeds.
- Patterns are written against how these merchants actually turn up on local
  bank and card statements, including the shorthand people see rather than the
  legal trading name (`WOOLIES` and `WW METRO` alongside `WOOLWORTHS`, `MACCAS`
  alongside `MCDONALDS`, `PAK'N SAVE` with and without the space).
- Both are registered in `PRESET_JSONS`, added to the existing
  `bundled_presets_have_unique_keys_and_valid_regexes` test, and given flags in
  the preset picker.

No schema changes: these are the same shape as the presets already shipped, so
the loader, importer and version handling are untouched.

## Test plan

- [x] `cargo test -p wealthfolio-spending` (the bundled preset test now covers
      `au` and `nz`)
- [ ] Import the Australia preset from Settings -> Spending -> Rules and check
      the rules land against the right categories
- [ ] Same for New Zealand
- [ ] Import one of them over a set of real transactions and confirm the
      supermarket and fuel rules catch what you'd expect

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).