### PR TITLE
feat(insights): Implement valuation chart in performance page

### DIFF
--- a/apps/frontend/src/components/performance-chart-mobile.tsx
+++ b/apps/frontend/src/components/performance-chart-mobile.tsx
@@ -8,7 +8,7 @@ import {
 } from "@wealthfolio/ui/components/ui/chart";
 import { PERFORMANCE_CHART_COLORS } from "@/components/performance-chart-colors";
 import { ReturnData } from "@/lib/types";
-import { formatPercent } from "@wealthfolio/ui";
+import { formatAmount, formatCompactAmount, formatPercent } from "@wealthfolio/ui";
 import { differenceInDays, differenceInMonths, format, parseISO } from "date-fns";
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, XAxis, YAxis } from "recharts";
 import { NameType, ValueType } from "recharts/types/component/DefaultTooltipContent";
@@ -20,15 +20,30 @@ interface PerformanceChartMobileProps {
     returns: ReturnData[];
     isReference?: boolean;
   }[];
+  valueFormat?: "percent" | "amount";
+  currency?: string;
 }
 
-export function PerformanceChartMobile({ data }: PerformanceChartMobileProps) {
-  const formattedData = data[0]?.returns?.map((item) => {
-    const dataPoint: Record<string, number | string> = { date: item.date };
+export function PerformanceChartMobile({
+  data,
+  valueFormat = "percent",
+  currency = "USD",
+}: PerformanceChartMobileProps) {
+  const dates = [
+    ...new Set(data.flatMap((series) => series.returns.map((item) => item.date))),
+  ].sort((a, b) => a.localeCompare(b));
+  const formattedData = dates.map((date) => {
+    const dataPoint: Record<string, number | string> = { date };
     data.forEach((series) => {
-      const matchingPoint = series.returns?.find((p) => p.date === item.date);
+      const matchingPoint = series.returns?.find((point) => point.date === date);
       if (matchingPoint) {
         dataPoint[series.id] = matchingPoint.value;
+      } else if (
+        valueFormat === "amount" &&
+        series.returns[0]?.date &&
+        date < series.returns[0].date
+      ) {
+        dataPoint[series.id] = 0;
       }
     });
     return dataPoint;
@@ -89,7 +104,10 @@ export function PerformanceChartMobile({ data }: PerformanceChartMobileProps) {
     value: ValueType | undefined,
     name: NameType | undefined,
   ): [string, string] => {
-    const formattedValue = formatPercent(Number(value ?? 0));
+    const formattedValue =
+      valueFormat === "amount"
+        ? formatAmount(Number(value ?? 0), currency)
+        : formatPercent(Number(value ?? 0));
     return [formattedValue + " - ", (name ?? "").toString()];
   };
 
@@ -112,7 +130,11 @@ export function PerformanceChartMobile({ data }: PerformanceChartMobileProps) {
               tick={{ fontSize: 10 }}
             />
             <YAxis
-              tickFormatter={(value: number) => formatPercent(value)}
+              tickFormatter={(value: number) =>
+                valueFormat === "amount"
+                  ? formatCompactAmount(value, currency)
+                  : formatPercent(value)
+              }
               tickLine={false}
               axisLine={false}
               tickMargin={4}

--- a/apps/frontend/src/components/performance-chart.tsx
+++ b/apps/frontend/src/components/performance-chart.tsx
@@ -8,7 +8,7 @@ import {
   ChartTooltipContent,
 } from "@wealthfolio/ui/components/ui/chart";
 import { ReturnData } from "@/lib/types";
-import { formatPercent } from "@wealthfolio/ui";
+import { formatAmount, formatCompactAmount, formatPercent } from "@wealthfolio/ui";
 import { differenceInDays, differenceInMonths, format, parseISO } from "date-fns";
 import { CartesianGrid, Line, LineChart, ResponsiveContainer, XAxis, YAxis } from "recharts";
 import { NameType, ValueType } from "recharts/types/component/DefaultTooltipContent";
@@ -20,15 +20,30 @@ interface PerformanceChartProps {
     returns: ReturnData[];
     isReference?: boolean;
   }[];
+  valueFormat?: "percent" | "amount";
+  currency?: string;
 }
 
-export function PerformanceChart({ data }: PerformanceChartProps) {
-  const formattedData = data[0]?.returns?.map((item) => {
-    const dataPoint: Record<string, number | string> = { date: item.date };
+export function PerformanceChart({
+  data,
+  valueFormat = "percent",
+  currency = "USD",
+}: PerformanceChartProps) {
+  const dates = [
+    ...new Set(data.flatMap((series) => series.returns.map((item) => item.date))),
+  ].sort((a, b) => a.localeCompare(b));
+  const formattedData = dates.map((date) => {
+    const dataPoint: Record<string, number | string> = { date };
     data.forEach((series) => {
-      const matchingPoint = series.returns?.find((p) => p.date === item.date);
+      const matchingPoint = series.returns?.find((point) => point.date === date);
       if (matchingPoint) {
         dataPoint[series.id] = matchingPoint.value;
+      } else if (
+        valueFormat === "amount" &&
+        series.returns[0]?.date &&
+        date < series.returns[0].date
+      ) {
+        dataPoint[series.id] = 0;
       }
     });
     return dataPoint;
@@ -84,7 +99,10 @@ export function PerformanceChart({ data }: PerformanceChartProps) {
     value: ValueType | undefined,
     name: NameType | undefined,
   ): [string, string] => {
-    const formattedValue = formatPercent(Number(value ?? 0));
+    const formattedValue =
+      valueFormat === "amount"
+        ? formatAmount(Number(value ?? 0), currency)
+        : formatPercent(Number(value ?? 0));
     return [formattedValue + " - ", (name ?? "").toString()];
   };
 
@@ -106,7 +124,11 @@ export function PerformanceChart({ data }: PerformanceChartProps) {
               interval={getTickInterval()}
             />
             <YAxis
-              tickFormatter={(value: number) => formatPercent(value)}
+              tickFormatter={(value: number) =>
+                valueFormat === "amount"
+                  ? formatCompactAmount(value, currency)
+                  : formatPercent(value)
+              }
               tickLine={false}
               axisLine={false}
               tickMargin={8}

--- a/apps/frontend/src/i18n/locales/de/performance.json
+++ b/apps/frontend/src/i18n/locales/de/performance.json
@@ -43,6 +43,7 @@
   "best_day": "Bester Tag",
   "worst_day": "Schlechtester Tag",
   "chart_value": "Portfoliowert",
+  "chart_mode_value": "Wert",
   "chart_returns": "Renditen",
   "chart_contributions": "Einlagen",
   "chart_allocation": "Allokation",
@@ -59,11 +60,13 @@
     "no_series": "Für diesen Zeitraum ist keine Diagrammreihe verfügbar.",
     "holdings_not_twr": "Konten im Bestandsmodus verwenden die Wertrendite und werden nicht mit dem TWR dargestellt.",
     "transaction_not_value": "Konten im Transaktionsmodus verwenden den TWR und werden nicht mit der Wertrendite dargestellt.",
-    "no_overlap": "Keine überlappenden Diagrammdaten mit dem ausgewählten Element."
+    "no_overlap": "Keine überlappenden Diagrammdaten mit dem ausgewählten Element.",
+    "benchmark_value": "Benchmarks haben keinen Geldwert und werden im Wertmodus nicht dargestellt."
   },
   "comparison_notice": {
     "different_methods": "Unterschiedliche Renditemethoden können sich nicht dasselbe Diagramm teilen. Wählen Sie einen abgeblendeten Chip, um den Diagrammmodus zu wechseln.",
     "not_enough_overlap": "Diese ausgewählten Elemente haben nicht genügend überlappende Diagrammdaten mit dem aktiven Diagramm.",
+    "benchmark_value": "Benchmarks werden im Wertmodus nicht unterstützt",
     "not_plotted_count_one": "{{count}} ausgewähltes Element wird nicht dargestellt",
     "not_plotted_count_other": "{{count}} ausgewählte Elemente werden nicht dargestellt"
   },

--- a/apps/frontend/src/i18n/locales/en/performance.json
+++ b/apps/frontend/src/i18n/locales/en/performance.json
@@ -43,6 +43,7 @@
   "best_day": "Best Day",
   "worst_day": "Worst Day",
   "chart_value": "Portfolio Value",
+  "chart_mode_value": "Value",
   "chart_returns": "Returns",
   "chart_contributions": "Contributions",
   "chart_allocation": "Allocation",
@@ -59,11 +60,13 @@
     "no_series": "No chart series is available for this period.",
     "holdings_not_twr": "Holdings-mode accounts use Value Return and are not plotted with TWR.",
     "transaction_not_value": "Transaction-mode accounts use TWR and are not plotted with Value Return.",
-    "no_overlap": "No overlapping chart dates with the selected item."
+    "no_overlap": "No overlapping chart dates with the selected item.",
+    "benchmark_value": "Benchmarks do not have a monetary value and are not plotted in value mode."
   },
   "comparison_notice": {
     "different_methods": "Different return methods cannot share the same chart. Select a muted chip to switch the chart mode.",
     "not_enough_overlap": "These selected items do not have enough overlapping chart dates with the active chart.",
+    "benchmark_value": "Benchmarks are not supported in Value mode",
     "not_plotted_count_one": "{{count}} selected item is not plotted",
     "not_plotted_count_other": "{{count}} selected items are not plotted"
   },

--- a/apps/frontend/src/i18n/locales/es/performance.json
+++ b/apps/frontend/src/i18n/locales/es/performance.json
@@ -43,6 +43,7 @@
   "best_day": "Mejor día",
   "worst_day": "Peor día",
   "chart_value": "Valor de la cartera",
+  "chart_mode_value": "Valor",
   "chart_returns": "Rentabilidades",
   "chart_contributions": "Aportaciones",
   "chart_allocation": "Asignación",
@@ -59,11 +60,13 @@
     "no_series": "No hay ninguna serie del gráfico disponible para este periodo.",
     "holdings_not_twr": "Las cuentas en modo de posiciones usan Rentabilidad por valor y no se representan con TWR.",
     "transaction_not_value": "Las cuentas en modo de transacciones usan TWR y no se representan con Rentabilidad por valor.",
-    "no_overlap": "No hay fechas del gráfico que coincidan con el elemento seleccionado."
+    "no_overlap": "No hay fechas del gráfico que coincidan con el elemento seleccionado.",
+    "benchmark_value": "Los índices de referencia no tienen un valor monetario y no se representan en el modo de valor."
   },
   "comparison_notice": {
     "different_methods": "Los distintos métodos de rentabilidad no pueden compartir el mismo gráfico. Selecciona una etiqueta atenuada para cambiar el modo del gráfico.",
     "not_enough_overlap": "Estos elementos seleccionados no tienen suficientes fechas del gráfico que coincidan con el gráfico activo.",
+    "benchmark_value": "Los índices de referencia no son compatibles con el modo de valor",
     "not_plotted_count_one": "{{count}} elemento seleccionado no está representado",
     "not_plotted_count_other": "{{count}} elementos seleccionados no están representados"
   },

--- a/apps/frontend/src/i18n/locales/fr/performance.json
+++ b/apps/frontend/src/i18n/locales/fr/performance.json
@@ -43,6 +43,7 @@
   "best_day": "Meilleur jour",
   "worst_day": "Pire jour",
   "chart_value": "Valeur du portefeuille",
+  "chart_mode_value": "Valeur",
   "chart_returns": "Rendements",
   "chart_contributions": "Contributions",
   "chart_allocation": "Allocation",
@@ -59,11 +60,13 @@
     "no_series": "Aucune série de graphique n'est disponible pour cette période.",
     "holdings_not_twr": "Les comptes en mode avoirs utilisent le rendement en valeur et ne sont pas tracés avec le TWR.",
     "transaction_not_value": "Les comptes en mode transactions utilisent le TWR et ne sont pas tracés avec le rendement en valeur.",
-    "no_overlap": "Aucune date de graphique commune avec l'élément sélectionné."
+    "no_overlap": "Aucune date de graphique commune avec l'élément sélectionné.",
+    "benchmark_value": "Les indices de référence n'ont pas de valeur monétaire et ne sont pas tracés en mode valeur."
   },
   "comparison_notice": {
     "different_methods": "Des méthodes de rendement différentes ne peuvent pas partager le même graphique. Sélectionnez une pastille grisée pour changer le mode du graphique.",
     "not_enough_overlap": "Ces éléments sélectionnés n'ont pas suffisamment de dates de graphique communes avec le graphique actif.",
+    "benchmark_value": "Les indices de référence ne sont pas pris en charge en mode valeur",
     "not_plotted_count_one": "{{count}} élément sélectionné n'est pas tracé",
     "not_plotted_count_other": "{{count}} éléments sélectionnés ne sont pas tracés"
   },

--- a/apps/frontend/src/i18n/locales/zh/performance.json
+++ b/apps/frontend/src/i18n/locales/zh/performance.json
@@ -43,6 +43,7 @@
   "best_day": "最佳单日",
   "worst_day": "最差单日",
   "chart_value": "投资组合价值",
+  "chart_mode_value": "价值",
   "chart_returns": "回报",
   "chart_contributions": "投入",
   "chart_allocation": "配置",
@@ -59,11 +60,13 @@
     "no_series": "此时间段无可用的图表序列。",
     "holdings_not_twr": "持仓模式账户使用价值回报，不以 TWR 绘制。",
     "transaction_not_value": "交易模式账户使用 TWR，不以价值回报绘制。",
-    "no_overlap": "与所选项目无重叠的图表日期。"
+    "no_overlap": "与所选项目无重叠的图表日期。",
+    "benchmark_value": "基准没有货币价值，因此不会在价值模式下绘制。"
   },
   "comparison_notice": {
     "different_methods": "不同的收益计算方法无法共用同一图表。选择灰显的标签以切换图表模式。",
     "not_enough_overlap": "这些所选项目与当前图表没有足够重叠的图表日期。",
+    "benchmark_value": "价值模式暂不支持基准",
     "not_plotted_count_one": "{{count}} 个所选项目未绘制",
     "not_plotted_count_other": "{{count}} 个所选项目未绘制"
   },

--- a/apps/frontend/src/pages/performance/hooks/use-valuation-data.test.tsx
+++ b/apps/frontend/src/pages/performance/hooks/use-valuation-data.test.tsx
@@ -1,0 +1,96 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useValuationData } from "./use-valuation-data";
+
+const mocks = vi.hoisted(() => ({
+  getHistoricalValuations: vi.fn(),
+}));
+
+vi.mock("@/adapters", () => ({
+  getHistoricalValuations: mocks.getHistoricalValuations,
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useValuationData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getHistoricalValuations.mockResolvedValue([
+      {
+        valuationDate: "2026-03-09",
+        totalValueBase: 1250,
+      },
+    ]);
+  });
+
+  it("loads base-currency values for account scopes and ignores benchmarks", async () => {
+    const { result } = renderHook(
+      () =>
+        useValuationData({
+          selectedItems: [
+            {
+              id: "portfolio-1",
+              type: "account",
+              name: "Long term",
+              accountScope: { type: "portfolio", portfolioId: "portfolio-1" },
+            },
+            { id: "SPY", type: "symbol", name: "S&P 500" },
+          ],
+          dateRange: {
+            from: new Date(2026, 2, 4),
+            to: new Date(2026, 2, 10),
+          },
+          enabled: true,
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toHaveLength(1);
+    });
+
+    expect(mocks.getHistoricalValuations).toHaveBeenCalledTimes(1);
+    expect(mocks.getHistoricalValuations).toHaveBeenCalledWith(
+      { type: "portfolio", portfolioId: "portfolio-1" },
+      "2026-03-04",
+      "2026-03-10",
+    );
+    expect(result.current.data[0]).toEqual({
+      id: "portfolio-1",
+      name: "Long term",
+      returns: [{ date: "2026-03-09", value: 1250 }],
+    });
+  });
+
+  it("does not load valuations while value mode is disabled", async () => {
+    renderHook(
+      () =>
+        useValuationData({
+          selectedItems: [
+            {
+              id: "portfolio:all",
+              type: "account",
+              name: "All Portfolio",
+              accountScope: { type: "all" },
+            },
+          ],
+          dateRange: undefined,
+          enabled: false,
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(mocks.getHistoricalValuations).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/frontend/src/pages/performance/hooks/use-valuation-data.ts
+++ b/apps/frontend/src/pages/performance/hooks/use-valuation-data.ts
@@ -1,0 +1,73 @@
+import { getHistoricalValuations } from "@/adapters";
+import { QueryKeys } from "@/lib/query-keys";
+import type { DateRange, TrackedItem } from "@/lib/types";
+import { keepPreviousData, useQueries } from "@tanstack/react-query";
+import { format } from "date-fns";
+
+/**
+ * Hook to fetch base-currency valuation history for a list of comparison items.
+ * Symbol items are excluded because they do not have an inherent monetary value.
+ *
+ * @param selectedItems List of comparison items to fetch valuation history for.
+ * @param dateRange The date range for the valuation period.
+ * @param enabled Whether valuation queries should be enabled.
+ *
+ * @returns An object containing the monetary chart data,
+ *          a boolean indicating whether the data is loading,
+ *          a boolean indicating whether there are any errors,
+ *          and an array of error messages.
+ */
+export function useValuationData({
+  selectedItems,
+  dateRange,
+  enabled,
+}: {
+  selectedItems: TrackedItem[];
+  dateRange: DateRange | undefined;
+  enabled: boolean;
+}) {
+  const accountItems = selectedItems.filter((item) => item.type === "account" && item.accountScope);
+  const startDate = dateRange?.from ? format(dateRange.from, "yyyy-MM-dd") : undefined;
+  const endDate = dateRange?.to ? format(dateRange.to, "yyyy-MM-dd") : undefined;
+  const datesReady = dateRange === undefined || (!!startDate && !!endDate);
+
+  const valuationQueries = useQueries({
+    queries: accountItems.map((item) => ({
+      queryKey: [
+        ...QueryKeys.valuationHistory(item.accountScope),
+        "performance",
+        startDate ?? null,
+        endDate ?? null,
+      ],
+      queryFn: () => getHistoricalValuations(item.accountScope, startDate, endDate),
+      enabled: enabled && datesReady,
+      staleTime: 30 * 1000,
+      retry: false,
+      placeholderData: keepPreviousData,
+    })),
+  });
+
+  return {
+    data: valuationQueries.flatMap((query, index) => {
+      if (query.isError || !query.data?.length) return [];
+      const item = accountItems[index];
+      return [
+        {
+          id: item.id,
+          name: item.name,
+          returns: query.data.map((valuation) => ({
+            date: valuation.valuationDate,
+            value: valuation.totalValueBase,
+          })),
+        },
+      ];
+    }),
+    isLoading: enabled && valuationQueries.some((query) => query.isLoading),
+    hasErrors: enabled && valuationQueries.some((query) => query.isError),
+    errorMessages: valuationQueries
+      .filter((query) => query.isError)
+      .map((query) => query.error)
+      .filter(Boolean)
+      .map((error) => (error instanceof Error ? error.message : String(error))),
+  };
+}

--- a/apps/frontend/src/pages/performance/performance-page.tsx
+++ b/apps/frontend/src/pages/performance/performance-page.tsx
@@ -25,10 +25,12 @@ import {
   shouldDisplayAnnualizedPerformanceReturn,
 } from "@/lib/performance";
 import { getPerformanceDateRangeForRequest } from "@/lib/performance-date-range";
+import { useSettingsContext } from "@/lib/settings-provider";
 import { DateRange, PerformanceResult, TrackedItem } from "@/lib/types";
 import { cn, formatAmount } from "@/lib/utils";
 import {
   AlertFeedback,
+  AnimatedToggleGroup,
   Badge,
   Button,
   Card,
@@ -66,6 +68,7 @@ import { AccountSelector } from "../../components/account-selector";
 import { AccountSelectorMobile } from "../../components/account-selector-mobile";
 import { BenchmarkSymbolSelectorMobile } from "../../components/benchmark-symbol-selector-mobile";
 import { useCalculatePerformanceHistory } from "./hooks/use-performance-data";
+import { useValuationData } from "./hooks/use-valuation-data";
 import {
   comparablePerformanceChartData,
   type ComparableChartDataItem as ChartDataItem,
@@ -99,7 +102,11 @@ function trackingModeBadge(
   return null;
 }
 
-type ChartExclusionKind = "missingData" | "differentReturnMethod" | "dateOverlap";
+type ChartExclusionKind =
+  | "missingData"
+  | "differentReturnMethod"
+  | "dateOverlap"
+  | "benchmarkValue";
 
 interface ChartExclusion {
   kind: ChartExclusionKind;
@@ -144,6 +151,9 @@ function chartExclusion(
 }
 
 function comparisonNoticeMessage(kinds: ChartExclusionKind[], t: TFunction): string {
+  if (kinds.includes("benchmarkValue")) {
+    return t("performance:comparison_notice.benchmark_value");
+  }
   if (kinds.includes("differentReturnMethod")) {
     return t("performance:comparison_notice.different_methods");
   }
@@ -814,12 +824,16 @@ function PerformanceContent({
   hasErrors,
   errorMessages,
   isMobile,
+  valueFormat,
+  currency,
 }: {
   chartData: ChartDataItem[] | undefined;
   isLoading: boolean;
   hasErrors: boolean;
   errorMessages: string[];
   isMobile: boolean;
+  valueFormat: "percent" | "amount";
+  currency: string;
 }) {
   const { t } = useTranslation();
   return (
@@ -827,9 +841,13 @@ function PerformanceContent({
       {chartData && chartData.length > 0 && (
         <div className="min-h-0 w-full flex-1">
           {isMobile ? (
-            <PerformanceChartMobile data={chartData} />
+            <PerformanceChartMobile
+              data={chartData}
+              valueFormat={valueFormat}
+              currency={currency}
+            />
           ) : (
-            <PerformanceChart data={chartData} />
+            <PerformanceChart data={chartData} valueFormat={valueFormat} currency={currency} />
           )}
         </div>
       )}
@@ -971,8 +989,11 @@ const SelectedItemBadge = ({
   );
 };
 
+type PerformanceChartMode = "value" | "return";
+
 export default function PerformancePage() {
   const { t } = useTranslation();
+  const { settings } = useSettingsContext();
   const isMobile = useIsMobileViewport();
   const [storedSelectedItems, setSelectedItems] = usePersistentState<TrackedItem[]>(
     "performance:selectedItems",
@@ -988,6 +1009,10 @@ export default function PerformancePage() {
       from: subMonths(new Date(), 12),
       to: new Date(),
     },
+  );
+  const [chartMode, setChartMode] = usePersistentState<PerformanceChartMode>(
+    "performance:chartMode",
+    "return",
   );
 
   useEffect(() => {
@@ -1095,6 +1120,12 @@ export default function PerformancePage() {
     dateRange: getPerformanceDateRangeForRequest(dateRange),
   });
 
+  const valuationData = useValuationData({
+    selectedItems,
+    dateRange: getPerformanceDateRangeForRequest(dateRange),
+    enabled: chartMode === "value",
+  });
+
   const selectedPerformanceData = useMemo(() => {
     if (!performanceData?.length || !selectedItems) return null;
     const targetId = selectedItemId ?? performanceData.find((item) => item !== null)?.id; // Find first non-null item ID if none selected
@@ -1114,13 +1145,17 @@ export default function PerformancePage() {
   const activeChartAnchorId = selectedPerformanceData?.result.id ?? selectedItemId;
 
   // Calculate derived chart data
-  const chartData = useMemo(() => {
+  const returnChartData = useMemo(() => {
     return comparablePerformanceChartData(
       performanceData,
       selectedChartMetric,
       activeChartAnchorId ?? null,
     );
   }, [activeChartAnchorId, performanceData, selectedChartMetric]);
+  const chartData = chartMode === "value" ? valuationData.data : returnChartData;
+  const isLoadingChart = chartMode === "value" ? valuationData.isLoading : isLoadingPerformance;
+  const hasChartErrors = chartMode === "value" ? valuationData.hasErrors : hasErrors;
+  const chartErrorMessages = chartMode === "value" ? valuationData.errorMessages : errorMessages;
 
   const chartColorMap = useMemo(() => {
     const map = new Map<string, string>();
@@ -1142,10 +1177,23 @@ export default function PerformancePage() {
     return new Map(
       selectedItems.map((item) => {
         const isAnchor = item.id === activeChartAnchorId;
-        const isPlotted = isLoadingPerformance || hasErrors || isAnchor || chartedIds.has(item.id);
+        const isPlotted =
+          isLoadingChart ||
+          hasChartErrors ||
+          (chartMode === "return" && isAnchor) ||
+          chartedIds.has(item.id);
+        const valueModeExclusion: ChartExclusion =
+          item.type === "symbol"
+            ? {
+                kind: "benchmarkValue",
+                message: t("performance:exclusion.benchmark_value"),
+              }
+            : { kind: "missingData", message: t("performance:exclusion.no_data") };
         const exclusion = isPlotted
           ? undefined
-          : chartExclusion(resultById.get(item.id), selectedChartMetric, t);
+          : chartMode === "value"
+            ? valueModeExclusion
+            : chartExclusion(resultById.get(item.id), selectedChartMetric, t);
         const plotState: SelectedItemPlotState = {
           isPlotted,
           reason: exclusion?.message,
@@ -1157,8 +1205,9 @@ export default function PerformancePage() {
   }, [
     activeChartAnchorId,
     chartData,
-    hasErrors,
-    isLoadingPerformance,
+    chartMode,
+    hasChartErrors,
+    isLoadingChart,
     performanceData,
     selectedChartMetric,
     selectedItems,
@@ -1391,6 +1440,38 @@ export default function PerformancePage() {
     }
   };
 
+  const chartModeToggle = (
+    <AnimatedToggleGroup<PerformanceChartMode>
+      items={[
+        {
+          value: "value",
+          label: (
+            <>
+              <Icons.Coins className="h-4 w-4" />
+              <span className="sr-only">{t("performance:chart_mode_value")}</span>
+            </>
+          ),
+          title: t("performance:chart_mode_value"),
+          "data-testid": "performance-chart-value",
+        },
+        {
+          value: "return",
+          label: (
+            <>
+              <Icons.Percent className="h-4 w-4" />
+              <span className="sr-only">{t("performance:chart_returns")}</span>
+            </>
+          ),
+          title: t("performance:chart_returns"),
+          "data-testid": "performance-chart-returns",
+        },
+      ]}
+      value={chartMode}
+      onValueChange={setChartMode}
+      size="compact"
+      rounded="lg"
+    />
+  );
   return (
     <>
       {/* Date range selector - fixed position in header area */}
@@ -1410,6 +1491,8 @@ export default function PerformancePage() {
             hiddenRanges={PERFORMANCE_HIDDEN_DATE_RANGES}
           />
         </div>
+
+        <div className="flex justify-end md:hidden">{chartModeToggle}</div>
 
         {/* Mobile: Carousel + Plus button in same row */}
         <div className="flex items-center gap-2 md:hidden">
@@ -1478,16 +1561,16 @@ export default function PerformancePage() {
         </div>
 
         {/* Desktop: Full layout with separator */}
-        <div className="hidden md:flex md:flex-row md:items-center">
+        <div className="hidden min-w-0 gap-2 md:flex md:w-full md:flex-row md:items-center">
           {/* Selected items badges - horizontal scroll carousel */}
           {selectedItems.length > 0 && (
-            <div className="flex items-center gap-3">
+            <div className="flex min-w-0 items-center gap-3">
               <Carousel
                 opts={{
                   align: "start",
                   loop: false,
                 }}
-                className="w-full max-w-[calc(100vw-24rem)] md:max-w-[calc(100vw-28rem)]"
+                className="w-full min-w-0 max-w-[calc(100vw-24rem)] md:max-w-[calc(100vw-28rem)]"
               >
                 <CarouselContent className="-ml-2">
                   {selectedItems.map((item) => {
@@ -1531,6 +1614,7 @@ export default function PerformancePage() {
             />
             <BenchmarkSymbolSelector onSelect={handleSymbolSelect} />
           </div>
+          <div className="ml-auto shrink-0">{chartModeToggle}</div>
         </div>
 
         {/* Mobile sheets controlled by dropdown - rendered but hidden by Sheet component */}
@@ -1794,10 +1878,12 @@ export default function PerformancePage() {
                 <div className="min-h-0 flex-1">
                   <PerformanceContent
                     chartData={chartData}
-                    isLoading={isLoadingPerformance}
-                    hasErrors={hasErrors}
-                    errorMessages={errorMessages}
+                    isLoading={isLoadingChart}
+                    hasErrors={hasChartErrors}
+                    errorMessages={chartErrorMessages}
                     isMobile={isMobile}
+                    valueFormat={chartMode === "value" ? "amount" : "percent"}
+                    currency={settings?.baseCurrency ?? "USD"}
                   />
                 </div>
               </div>


### PR DESCRIPTION
## Description

This PR adds the option to switch to a valuation view (USD, EUR, etc.), as opposed to the existing returns view (%) to the Performance page in the Insights section, addressing the feature request described in https://github.com/wealthfolio/wealthfolio/issues/1319.

This has been implemented as a toggle switch right above the upper right corner of the chart, below the time range selector, and I've used the built-in `Icons.Coins` and `Icons.Percent` icons so no new assets are needed.

<img width="1436" height="931" alt="value_chart" src="https://github.com/user-attachments/assets/5af761b6-6710-40b8-a974-fd89dcda92f6" />


Only one new hook file (plus unit tests) was created: `pages/performance/hooks/use-valuation-data.ts`, which fetches the valuation of all relevant series in the base currency.

The rest of the changes only affect `performance-chart.tsx`, `performance-chart-mobile.tsx` and `performance-page.tsx`, plus the translation files. So purely frontend changes.

A couple of notes:
1. I made the selectable timerange of this chart go all the way back to the start date of the oldest series, as I think there's no reason to limit the comparison to overlapping dates here. The returns chart remains unchanged.
2. As a result, when a series is missing datapoints wthin the selectable range (because it didn't yet have any holdings for those dates), those datapoints are first set to zero so they can be plotted correctly, as you can see in the screenshot. Otherwise the newer series would just start mid-air later, which I don't think looks right in this kind of chart.
3. Benchmarks are excluded from this view as I don't think they would make any sense. They don't have monetary valuations, and even if we agreed on a convention (e.g.: give them a "lump sum" matching the starting value of the oldest series), successive transactions in the user accounts would quickly distort the comparison. If any benchmarks are selected, they're disabled ("Not plotted") and the standard banner is shown with this content:

<img width="1319" height="75" alt="benchmark_banner" src="https://github.com/user-attachments/assets/549122cc-6df7-43f2-9cdd-10f253edaf9d" />

All tests are passing, and I've tried to keep changes to a minimum.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).