### PR TITLE
feat(spending): Let users set a categorization rule's account scope

### DIFF
--- a/apps/frontend/src/features/spending/components/rule-edit-modal.tsx
+++ b/apps/frontend/src/features/spending/components/rule-edit-modal.tsx
@@ -8,7 +8,12 @@ import {
   DialogTitle,
 } from "@wealthfolio/ui";
 
-import { RuleForm, type RuleFormCategoryOption, type RuleFormValues } from "./rule-form";
+import {
+  RuleForm,
+  type RuleFormAccountOption,
+  type RuleFormCategoryOption,
+  type RuleFormValues,
+} from "./rule-form";
 import type { CategorizationRule } from "../types/rule";
 
 interface RuleEditModalProps {
@@ -16,6 +21,7 @@ interface RuleEditModalProps {
   onClose: () => void;
   rule?: CategorizationRule;
   categoryOptions: RuleFormCategoryOption[];
+  accountOptions: RuleFormAccountOption[];
   onSave: (values: RuleFormValues) => void;
   isLoading?: boolean;
 }
@@ -25,6 +31,7 @@ export function RuleEditModal({
   onClose,
   rule,
   categoryOptions,
+  accountOptions,
   onSave,
   isLoading,
 }: RuleEditModalProps) {
@@ -41,6 +48,7 @@ export function RuleEditModal({
         <RuleForm
           rule={rule}
           categoryOptions={categoryOptions}
+          accountOptions={accountOptions}
           onSubmit={onSave}
           onCancel={onClose}
           isLoading={isLoading}

--- a/apps/frontend/src/features/spending/components/rule-form.tsx
+++ b/apps/frontend/src/features/spending/components/rule-form.tsx
@@ -33,7 +33,8 @@ export interface RuleFormValues {
   categoryId?: string;
   activityType?: string;
   priority: number;
-  isGlobal: boolean;
+  /** null applies the rule to every account; a value scopes it to that account. */
+  accountId: string | null;
 }
 
 export interface RuleFormCategoryOption {
@@ -46,23 +47,38 @@ export interface RuleFormCategoryOption {
   parentName?: string | null;
 }
 
+export interface RuleFormAccountOption {
+  id: string;
+  name: string;
+}
+
 interface RuleFormProps {
   rule?: CategorizationRule;
   /** Flat list of activity-scope categories from spending, income, and savings taxonomies. */
   categoryOptions: RuleFormCategoryOption[];
+  /** Tracked spending accounts the rule can be scoped to. */
+  accountOptions: RuleFormAccountOption[];
   onSubmit: (values: RuleFormValues) => void;
   onCancel: () => void;
   isLoading?: boolean;
 }
 
 const NONE = "__none__";
+const ALL_ACCOUNTS = "__all__";
 
 const composite = (rule?: CategorizationRule): string => {
   if (rule?.taxonomyId && rule?.categoryId) return `${rule.taxonomyId}:${rule.categoryId}`;
   return "";
 };
 
-export function RuleForm({ rule, categoryOptions, onSubmit, onCancel, isLoading }: RuleFormProps) {
+export function RuleForm({
+  rule,
+  categoryOptions,
+  accountOptions,
+  onSubmit,
+  onCancel,
+  isLoading,
+}: RuleFormProps) {
   const { t } = useTranslation();
 
   const ruleFormSchema = useMemo(
@@ -76,7 +92,7 @@ export function RuleForm({ rule, categoryOptions, onSubmit, onCancel, isLoading 
           categoryId: z.string().optional(),
           activityType: z.string().optional(),
           priority: z.coerce.number().int().min(0),
-          isGlobal: z.boolean(),
+          accountId: z.string().nullable(),
         })
         .refine((data) => data.categoryId || data.activityType, {
           message: t("spending:rules.categoryOrTypeRequired"),
@@ -120,9 +136,20 @@ export function RuleForm({ rule, categoryOptions, onSubmit, onCancel, isLoading 
       categoryId: composite(rule), // we encode taxonomyId:categoryId in this single field
       activityType: rule?.activityType ?? "",
       priority: rule?.priority ?? 0,
-      isGlobal: rule ? Boolean(rule.isGlobal) : true,
+      accountId: rule && !rule.isGlobal ? (rule.accountId ?? null) : null,
     },
   });
+
+  // A rule can reference an account that is no longer tracked (or is archived and
+  // so absent from accountOptions). Keep it in the list so the trigger isn't blank
+  // and the id survives a save untouched.
+  const scopeOptions = useMemo(() => {
+    const scopedId = rule && !rule.isGlobal ? rule.accountId : null;
+    if (!scopedId || accountOptions.some((account) => account.id === scopedId)) {
+      return accountOptions;
+    }
+    return [...accountOptions, { id: scopedId, name: t("spending:rules.unknownAccount") }];
+  }, [accountOptions, rule, t]);
 
   const handleSubmit = (values: RuleFormValues) => {
     // Decode composite categoryId back into taxonomyId + categoryId
@@ -301,6 +328,36 @@ export function RuleForm({ rule, categoryOptions, onSubmit, onCancel, isLoading 
             }}
           />
         </div>
+
+        <FormField
+          control={form.control as never}
+          name="accountId"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t("spending:rules.scopeLabel")}</FormLabel>
+              <Select
+                onValueChange={(val) => field.onChange(val === ALL_ACCOUNTS ? null : val)}
+                value={(field.value as string | null) ?? ALL_ACCOUNTS}
+              >
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value={ALL_ACCOUNTS}>{t("common:component.all_accounts")}</SelectItem>
+                  {scopeOptions.map((account) => (
+                    <SelectItem key={account.id} value={account.id}>
+                      {account.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormDescription>{t("spending:rules.scopeHint")}</FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
 
         <FormField
           control={form.control as never}

--- a/apps/frontend/src/features/spending/components/rule-item.tsx
+++ b/apps/frontend/src/features/spending/components/rule-item.tsx
@@ -37,11 +37,20 @@ interface RuleItemProps {
   categoryMeta: Record<string, RuleCategoryMeta>;
   /** preset_id → display metadata. Missing entries fall back to the raw id. */
   presetMeta?: Record<string, RulePresetMeta>;
+  /** account_id → display name. Missing entries fall back to a generic label. */
+  accountMeta?: Record<string, string>;
   onEdit: (rule: CategorizationRule) => void;
   onDelete: (rule: CategorizationRule) => void;
 }
 
-export function RuleItem({ rule, categoryMeta, presetMeta, onEdit, onDelete }: RuleItemProps) {
+export function RuleItem({
+  rule,
+  categoryMeta,
+  presetMeta,
+  accountMeta,
+  onEdit,
+  onDelete,
+}: RuleItemProps) {
   const { t } = useTranslation();
   const MATCH_TYPE_LABELS = useMemo<Record<string, string>>(
     () => ({
@@ -99,6 +108,10 @@ export function RuleItem({ rule, categoryMeta, presetMeta, onEdit, onDelete }: R
     : rule.presetId
       ? t("spending:rules.fromPreset", { name: rule.presetId.toUpperCase() })
       : null;
+  const scopedAccountName =
+    !rule.isGlobal && rule.accountId
+      ? (accountMeta?.[rule.accountId] ?? t("spending:rules.unknownAccount"))
+      : null;
 
   return (
     <>
@@ -126,6 +139,15 @@ export function RuleItem({ rule, categoryMeta, presetMeta, onEdit, onDelete }: R
                     ·{t("spending:rules.edited")}
                   </span>
                 )}
+              </span>
+            ) : null}
+            {scopedAccountName ? (
+              <span
+                className="border-muted-foreground/20 text-muted-foreground inline-flex min-w-0 shrink items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px] leading-none"
+                title={t("spending:rules.scopedToAccount", { name: scopedAccountName })}
+                aria-label={t("spending:rules.scopedToAccount", { name: scopedAccountName })}
+              >
+                <span className="truncate">{scopedAccountName}</span>
               </span>
             ) : null}
             <span className="text-muted-foreground shrink-0 text-[11px]">

--- a/apps/frontend/src/i18n/locales/de/spending.json
+++ b/apps/frontend/src/i18n/locales/de/spending.json
@@ -94,7 +94,11 @@
     "priorityLabel": "Priorität",
     "priorityHint": "Regeln mit höherer Priorität werden zuerst geprüft (0-100).",
     "updateRule": "Regel aktualisieren",
-    "createRule": "Regel erstellen"
+    "createRule": "Regel erstellen",
+    "scopeLabel": "Gilt für",
+    "scopeHint": "Beschränken Sie diese Regel auf ein einzelnes Konto oder wenden Sie sie auf alle erfassten Ausgabenkonten an.",
+    "scopedToAccount": "Gilt nur für {{name}}",
+    "unknownAccount": "Unbekanntes Konto"
   },
   "transactions": {
     "deleteTitle_one": "Transaktion löschen",

--- a/apps/frontend/src/i18n/locales/en/spending.json
+++ b/apps/frontend/src/i18n/locales/en/spending.json
@@ -94,7 +94,11 @@
     "priorityLabel": "Priority",
     "priorityHint": "Higher priority rules are checked first (0-100).",
     "updateRule": "Update Rule",
-    "createRule": "Create Rule"
+    "createRule": "Create Rule",
+    "scopeLabel": "Applies To",
+    "scopeHint": "Limit this rule to a single account, or apply it to every tracked spending account.",
+    "scopedToAccount": "Only applies to {{name}}",
+    "unknownAccount": "Unknown account"
   },
   "transactions": {
     "deleteTitle_one": "Delete transaction",

--- a/apps/frontend/src/i18n/locales/es/spending.json
+++ b/apps/frontend/src/i18n/locales/es/spending.json
@@ -94,7 +94,11 @@
     "priorityLabel": "Prioridad",
     "priorityHint": "Las reglas de mayor prioridad se comprueban primero (0-100).",
     "updateRule": "Actualizar regla",
-    "createRule": "Crear regla"
+    "createRule": "Crear regla",
+    "scopeLabel": "Se aplica a",
+    "scopeHint": "Limita esta regla a una sola cuenta o aplícala a todas las cuentas de gastos rastreadas.",
+    "scopedToAccount": "Solo se aplica a {{name}}",
+    "unknownAccount": "Cuenta desconocida"
   },
   "transactions": {
     "deleteTitle_one": "Eliminar transacción",

--- a/apps/frontend/src/i18n/locales/fr/spending.json
+++ b/apps/frontend/src/i18n/locales/fr/spending.json
@@ -94,7 +94,11 @@
     "priorityLabel": "Priorité",
     "priorityHint": "Les règles de priorité supérieure sont vérifiées en premier (0-100).",
     "updateRule": "Mettre à jour la règle",
-    "createRule": "Créer la règle"
+    "createRule": "Créer la règle",
+    "scopeLabel": "S'applique à",
+    "scopeHint": "Limitez cette règle à un seul compte ou appliquez-la à tous les comptes de dépenses suivis.",
+    "scopedToAccount": "S'applique uniquement à {{name}}",
+    "unknownAccount": "Compte inconnu"
   },
   "transactions": {
     "deleteTitle_one": "Supprimer la transaction",

--- a/apps/frontend/src/i18n/locales/zh/spending.json
+++ b/apps/frontend/src/i18n/locales/zh/spending.json
@@ -94,7 +94,11 @@
     "priorityLabel": "优先级",
     "priorityHint": "优先级较高的规则会被优先检查（0-100）。",
     "updateRule": "更新规则",
-    "createRule": "创建规则"
+    "createRule": "创建规则",
+    "scopeLabel": "适用于",
+    "scopeHint": "将此规则限定为单个账户，或应用于所有已跟踪的支出账户。",
+    "scopedToAccount": "仅适用于 {{name}}",
+    "unknownAccount": "未知账户"
   },
   "transactions": {
     "deleteTitle_one": "删除交易",

--- a/apps/frontend/src/pages/settings/spending/rules/spending-rules-page.tsx
+++ b/apps/frontend/src/pages/settings/spending/rules/spending-rules-page.tsx
@@ -23,6 +23,7 @@ import {
   Skeleton,
 } from "@wealthfolio/ui";
 import { cn } from "@/lib/utils";
+import { useAccounts } from "@/hooks/use-accounts";
 import { useTaxonomy } from "@/hooks/use-taxonomies";
 import type { TaxonomyCategory } from "@/lib/types";
 
@@ -35,9 +36,11 @@ import {
 import { PRESET_FLAGS } from "@/features/spending/components/rule-preset-constants";
 import { RulePresetPicker } from "@/features/spending/components/rule-preset-picker";
 import type {
+  RuleFormAccountOption,
   RuleFormCategoryOption,
   RuleFormValues,
 } from "@/features/spending/components/rule-form";
+import { isSpendingAccountType } from "@/features/spending/lib/constants";
 import {
   useCategorizationRuleMutations,
   useCategorizationRules,
@@ -55,7 +58,8 @@ const SAVINGS_TAXONOMY = "savings_categories";
 
 export default function SpendingRulesPage() {
   const { t } = useTranslation();
-  const { isEnabled, isLoading: settingsLoading } = useSpendingSettings();
+  const { isEnabled, isLoading: settingsLoading, accountIds } = useSpendingSettings();
+  const { accounts } = useAccounts({ filterActive: false });
   const {
     data: rules = [],
     isLoading: rulesLoading,
@@ -133,6 +137,23 @@ export default function SpendingRulesPage() {
     return meta;
   }, [presets]);
 
+  const { accountOptions, accountMeta } = useMemo(() => {
+    // Only tracked spending accounts are offered: a rerun walks just those
+    // accounts, so a rule scoped anywhere else could never fire.
+    const tracked = new Set(accountIds);
+    const opts: RuleFormAccountOption[] = accounts
+      .filter((a) => isSpendingAccountType(a.accountType) && tracked.has(a.id))
+      .map((a) => ({ id: a.id, name: a.name }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+    // Names cover every account, not just the pickable ones, so a rule scoped to
+    // an account the user has since untracked still renders a real name.
+    const meta: Record<string, string> = {};
+    accounts.forEach((a) => {
+      meta[a.id] = a.name;
+    });
+    return { accountOptions: opts, accountMeta: meta };
+  }, [accounts, accountIds]);
+
   if (!settingsLoading && !isEnabled) {
     return <Navigate to="/settings/spending" replace />;
   }
@@ -164,7 +185,10 @@ export default function SpendingRulesPage() {
             categoryId: values.categoryId || null,
             activityType: values.activityType || null,
             priority: values.priority,
-            isGlobal: values.isGlobal,
+            // Always sent explicitly: null clears the column, an id sets it, and
+            // the backend rejects an isGlobal/accountId pair that disagrees.
+            isGlobal: values.accountId === null,
+            accountId: values.accountId,
           },
         },
         {
@@ -181,7 +205,8 @@ export default function SpendingRulesPage() {
           categoryId: values.categoryId || null,
           activityType: values.activityType || null,
           priority: values.priority,
-          isGlobal: values.isGlobal,
+          isGlobal: values.accountId === null,
+          accountId: values.accountId,
         },
         {
           onSuccess: () => setVisibleModal(false),
@@ -387,6 +412,7 @@ export default function SpendingRulesPage() {
                     rule={rule}
                     categoryMeta={categoryMeta}
                     presetMeta={presetMeta}
+                    accountMeta={accountMeta}
                     onEdit={handleEditRule}
                     onDelete={handleDeleteRule}
                   />
@@ -402,6 +428,7 @@ export default function SpendingRulesPage() {
         onClose={() => setVisibleModal(false)}
         rule={selectedRule}
         categoryOptions={categoryOptions}
+        accountOptions={accountOptions}
         onSave={handleSave}
         isLoading={create.isPending || update.isPending}
       />


### PR DESCRIPTION
### Description

Fixes #1350

The [docs](https://wealthfolio.app/docs/guide/spending-budgets/#rules) describe a rule **Scope** ("All accounts or a specific account"), and the whole backend supports it — but the rule editor never rendered a control, so the feature was unreachable. `RuleFormValues` carried `isGlobal` as a phantom field (hardcoded `true` on create, echoed back on edit) and never sent `accountId`. Result: every UI-created rule was global, and account-scoped rules created via the AI assistant were invisible in the list and silently un-editable.

The data layer was already complete and tested: `is_global` + `account_id` columns with a FK and a CHECK constraint, `validate_rule_scope` on create/update, matcher enforcement, and pass-through API/IPC. This PR is **frontend-only** — no schema, migration, or backend changes.

### Changes

- **`rule-form.tsx`** — replace the phantom `isGlobal` with a single nullable  `accountId` field and an "Applies To" select. `isGlobal` is derived at the  payload boundary (`accountId === null`), so the two fields can't disagree
- A rule pointing at an untracked/archived account keeps a synthetic option so its id survives an unrelated edit instead of the trigger going blank.
- **`spending-rules-page.tsx`** — feed the form tracked spending accounts only (a rerun walks just those, so a rule scoped elsewhere could never fire), and send `accountId` explicitly on both create and update.
- **`rule-item.tsx`** — show an account-name pill on scoped rules; global rules render nothing.
- **`rule-edit-modal.tsx`** — thread the account options through.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
