### PR TITLE
fix(activities): validate and prepare bulk creates per account

### DIFF
--- a/crates/core/src/activities/activities_service.rs
+++ b/crates/core/src/activities/activities_service.rs
@@ -4321,35 +4321,93 @@ impl ActivityServiceTrait for ActivityService {
             });
         }
 
-        // Use save preparation for all creates at once
+        // Use save preparation for the creates, one account at a time.
+        //
+        // Save preparation is account-scoped: it enforces the per-account-type
+        // activity rules and resolves symbols and currencies against the
+        // account currency. A bulk request may span accounts, so preparing
+        // every create against a single account would judge rows by an account
+        // they do not belong to (e.g. rejecting a bank DEPOSIT because an
+        // unrelated credit-card row happened to be listed first).
         if !request.creates.is_empty() {
-            // Get account from first create (all creates in a bulk request typically share the same account)
-            let account_id = &request.creates[0].account_id;
-            let account = self.account_service.get_account(account_id)?;
-
             // Store temp_ids for error reporting (prepare result uses indices)
             let temp_ids: Vec<Option<String>> =
                 request.creates.iter().map(|a| a.id.clone()).collect();
 
-            let prepare_result = self
-                .prepare_activities_for_save(request.creates, &account)
-                .await?;
-
-            // Convert preparation errors to bulk mutation errors
-            for (idx, error) in prepare_result.errors {
-                errors.push(ActivityBulkMutationError {
-                    id: temp_ids.get(idx).cloned().flatten(),
-                    action: "create".to_string(),
-                    message: error,
-                });
+            // Group creates by account, keeping each row's index in the
+            // original request so errors and prepared rows can be reported
+            // back in request order.
+            let mut grouped: Vec<(String, Vec<(usize, NewActivity)>)> = Vec::new();
+            let mut group_positions: HashMap<String, usize> = HashMap::new();
+            for (idx, activity) in request.creates.into_iter().enumerate() {
+                let account_id = activity.account_id.clone();
+                let position = match group_positions.get(&account_id) {
+                    Some(position) => *position,
+                    None => {
+                        group_positions.insert(account_id.clone(), grouped.len());
+                        grouped.push((account_id, Vec::new()));
+                        grouped.len() - 1
+                    }
+                };
+                grouped[position].1.push((idx, activity));
             }
 
-            // Extract prepared activities
-            prepared_creates = prepare_result
-                .prepared
-                .into_iter()
-                .map(|p| p.activity)
-                .collect();
+            let mut create_errors: Vec<(usize, ActivityBulkMutationError)> = Vec::new();
+            let mut ordered_creates: Vec<Option<NewActivity>> = vec![None; temp_ids.len()];
+
+            for (account_id, entries) in grouped {
+                let account = self.account_service.get_account(&account_id)?;
+                let indexes: Vec<usize> = entries.iter().map(|(idx, _)| *idx).collect();
+                let account_creates: Vec<NewActivity> =
+                    entries.into_iter().map(|(_, activity)| activity).collect();
+
+                let prepare_result = self
+                    .prepare_activities_for_save(account_creates, &account)
+                    .await?;
+
+                // Convert preparation errors to bulk mutation errors. Preparation
+                // reports indices within the group it was handed, so map each one
+                // back to its position in the original request.
+                let failed_offsets: HashSet<usize> = prepare_result
+                    .errors
+                    .iter()
+                    .map(|(offset, _)| *offset)
+                    .collect();
+                for (offset, error) in prepare_result.errors {
+                    let idx = indexes.get(offset).copied().unwrap_or(offset);
+                    create_errors.push((
+                        idx,
+                        ActivityBulkMutationError {
+                            id: temp_ids.get(idx).cloned().flatten(),
+                            action: "create".to_string(),
+                            message: error,
+                        },
+                    ));
+                }
+
+                // Preparation yields one prepared row per input row that did not
+                // error, in input order, so walking the surviving offsets puts
+                // each row back at its original request position.
+                let mut prepared = prepare_result.prepared.into_iter();
+                for (offset, idx) in indexes.into_iter().enumerate() {
+                    if failed_offsets.contains(&offset) {
+                        continue;
+                    }
+                    match prepared.next() {
+                        Some(prepared_activity) => {
+                            ordered_creates[idx] = Some(prepared_activity.activity);
+                        }
+                        None => break,
+                    }
+                }
+            }
+
+            // Report errors and prepared activities in request order, so the
+            // result does not depend on how the creates grouped by account.
+            create_errors.sort_by_key(|(idx, _)| *idx);
+            errors.extend(create_errors.into_iter().map(|(_, error)| error));
+
+            prepared_creates = ordered_creates.into_iter().flatten().collect();
         }
 
         // For updates: capture OLD values before preparing the update

--- a/crates/core/src/activities/activities_service_tests.rs
+++ b/crates/core/src/activities/activities_service_tests.rs
@@ -2592,6 +2592,218 @@ mod tests {
             .contains("BUY activities are not supported for credit card accounts"));
     }
 
+    /// Cash-only create for the mixed-account bulk tests below. `currency` is
+    /// passed through verbatim so a test can leave it empty and observe which
+    /// account currency preparation falls back to.
+    fn create_test_cash_create(
+        id: &str,
+        account_id: &str,
+        activity_type: &str,
+        currency: &str,
+    ) -> NewActivity {
+        NewActivity {
+            id: Some(id.to_string()),
+            account_id: account_id.to_string(),
+            asset: None,
+            activity_type: activity_type.to_string(),
+            subtype: None,
+            activity_date: "2024-01-15".to_string(),
+            quantity: None,
+            unit_price: None,
+            currency: currency.to_string(),
+            fee: Some(dec!(0)),
+            tax: None,
+            amount: Some(dec!(100)),
+            status: None,
+            notes: None,
+            fx_rate: None,
+            metadata: None,
+            needs_review: None,
+            source_system: None,
+            source_record_id: Some(id.to_string()),
+            source_group_id: None,
+            idempotency_key: None,
+            import_run_id: None,
+        }
+    }
+
+    fn mixed_account_service() -> Arc<MockAccountService> {
+        let account_service = Arc::new(MockAccountService::new());
+
+        let mut card = create_test_account("card-1", "USD");
+        card.account_type = "CREDIT_CARD".to_string();
+        account_service.add_account(card);
+
+        let mut bank = create_test_account("bank-1", "USD");
+        bank.account_type = "CASH".to_string();
+        account_service.add_account(bank);
+
+        account_service
+    }
+
+    /// A credit-card row must not disqualify a later row that belongs to a
+    /// different account. Regression test: preparation used to validate the
+    /// whole batch against the first create's account, so this ordering failed
+    /// with "DEPOSIT activities are not supported for credit card accounts".
+    #[tokio::test]
+    async fn bulk_create_validates_each_row_against_its_own_account() {
+        let activity_service = ActivityService::new(
+            Arc::new(MockActivityRepository::new()),
+            mixed_account_service(),
+            Arc::new(MockAssetService::new()),
+            Arc::new(MockFxService::new()),
+            Arc::new(MockQuoteService),
+        );
+
+        let result = activity_service
+            .bulk_mutate_activities(ActivityBulkMutationRequest {
+                creates: vec![
+                    create_test_cash_create("card-purchase", "card-1", "WITHDRAWAL", "USD"),
+                    create_test_cash_create("bank-deposit", "bank-1", "DEPOSIT", "USD"),
+                ],
+                updates: vec![],
+                delete_ids: vec![],
+            })
+            .await
+            .expect("mixed-account bulk create should succeed");
+
+        assert!(
+            result.errors.is_empty(),
+            "expected no errors, got {:?}",
+            result.errors
+        );
+        assert_eq!(result.created.len(), 2);
+        assert_eq!(
+            result
+                .created
+                .iter()
+                .map(|activity| activity.account_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["card-1", "bank-1"],
+            "created rows should stay in request order"
+        );
+    }
+
+    /// The same two rows in the opposite order must behave identically.
+    #[tokio::test]
+    async fn bulk_create_mixed_accounts_is_order_independent() {
+        let activity_service = ActivityService::new(
+            Arc::new(MockActivityRepository::new()),
+            mixed_account_service(),
+            Arc::new(MockAssetService::new()),
+            Arc::new(MockFxService::new()),
+            Arc::new(MockQuoteService),
+        );
+
+        let result = activity_service
+            .bulk_mutate_activities(ActivityBulkMutationRequest {
+                creates: vec![
+                    create_test_cash_create("bank-deposit", "bank-1", "DEPOSIT", "USD"),
+                    create_test_cash_create("card-purchase", "card-1", "WITHDRAWAL", "USD"),
+                ],
+                updates: vec![],
+                delete_ids: vec![],
+            })
+            .await
+            .expect("mixed-account bulk create should succeed in either order");
+
+        assert!(
+            result.errors.is_empty(),
+            "expected no errors, got {:?}",
+            result.errors
+        );
+        assert_eq!(result.created.len(), 2);
+        assert_eq!(
+            result
+                .created
+                .iter()
+                .map(|activity| activity.account_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["bank-1", "card-1"],
+            "created rows should stay in request order"
+        );
+    }
+
+    /// Per-account validation must still reject a row that its own account
+    /// disallows, and report it against that row rather than the batch.
+    #[tokio::test]
+    async fn bulk_create_still_rejects_row_invalid_for_its_own_account() {
+        let activity_service = ActivityService::new(
+            Arc::new(MockActivityRepository::new()),
+            mixed_account_service(),
+            Arc::new(MockAssetService::new()),
+            Arc::new(MockFxService::new()),
+            Arc::new(MockQuoteService),
+        );
+
+        let result = activity_service
+            .bulk_mutate_activities(ActivityBulkMutationRequest {
+                creates: vec![
+                    create_test_cash_create("bank-deposit", "bank-1", "DEPOSIT", "USD"),
+                    create_test_cash_create("card-deposit", "card-1", "DEPOSIT", "USD"),
+                ],
+                updates: vec![],
+                delete_ids: vec![],
+            })
+            .await
+            .expect("bulk mutation should return structured errors");
+
+        assert!(result.created.is_empty());
+        assert_eq!(result.errors.len(), 1);
+        assert_eq!(result.errors[0].id.as_deref(), Some("card-deposit"));
+        assert!(
+            result.errors[0]
+                .message
+                .contains("DEPOSIT activities are not supported for credit card accounts"),
+            "unexpected message: {}",
+            result.errors[0].message
+        );
+    }
+
+    /// Preparation also resolves a missing activity currency from the account,
+    /// so a mixed-currency batch must fall back per row, not per batch.
+    #[tokio::test]
+    async fn bulk_create_resolves_missing_currency_from_each_row_account() {
+        let account_service = Arc::new(MockAccountService::new());
+        account_service.add_account(create_test_account("acc-usd", "USD"));
+        account_service.add_account(create_test_account("acc-eur", "EUR"));
+
+        let activity_service = ActivityService::new(
+            Arc::new(MockActivityRepository::new()),
+            account_service,
+            Arc::new(MockAssetService::new()),
+            Arc::new(MockFxService::new()),
+            Arc::new(MockQuoteService),
+        );
+
+        let result = activity_service
+            .bulk_mutate_activities(ActivityBulkMutationRequest {
+                creates: vec![
+                    create_test_cash_create("usd-deposit", "acc-usd", "DEPOSIT", ""),
+                    create_test_cash_create("eur-deposit", "acc-eur", "DEPOSIT", ""),
+                ],
+                updates: vec![],
+                delete_ids: vec![],
+            })
+            .await
+            .expect("mixed-currency bulk create should succeed");
+
+        assert!(
+            result.errors.is_empty(),
+            "expected no errors, got {:?}",
+            result.errors
+        );
+        assert_eq!(
+            result
+                .created
+                .iter()
+                .map(|activity| (activity.account_id.as_str(), activity.currency.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("acc-usd", "USD"), ("acc-eur", "EUR")],
+            "each row should inherit its own account currency"
+        );
+    }
+
     #[tokio::test]
     async fn credit_card_accounts_reject_investment_activity_updates() {
         let account_service = Arc::new(MockAccountService::new());


### PR DESCRIPTION
Fixes #1356.

`bulk_mutate_activities` prepared every entry in `request.creates` against the account of the **first** entry:

```rust
// Get account from first create (all creates in a bulk request typically share the same account)
let account_id = &request.creates[0].account_id;
let account = self.account_service.get_account(account_id)?;
```

Save preparation is account-scoped — it enforces the per-account-type activity rules and resolves symbols and currencies against the account currency — but a bulk request may span accounts. Judging every row by an account it does not belong to produces three failures, all dependent on nothing but row order.

## What goes wrong

**1. Valid rows rejected.** A bank `DEPOSIT` listed behind a credit-card row fails with `DEPOSIT activities are not supported for credit card accounts`. The endpoint is all-or-nothing, so one misordered row discards the whole batch.

**2. Invalid rows accepted, silently.** The mirror image: a credit-card `DEPOSIT` listed *behind* a bank row is validated against the bank account and created, writing an activity type the credit-card rules forbid. HTTP 200, empty `errors`. Confirmed by querying SQLite directly, since `POST /activities/search` did not return the row afterwards:

```
Bank   CASH         DEPOSIT    amount=100
Card   CREDIT_CARD  DEPOSIT    amount=100   <-- FORBIDDEN for this account type
```

This is the most damaging of the three — existing databases may already hold such rows. An audit query:

```sql
SELECT a.name, ac.activity_type, COUNT(*)
FROM activities ac JOIN accounts a ON a.id = ac.account_id
WHERE a.account_type = 'CREDIT_CARD'
  AND ac.activity_type NOT IN ('WITHDRAWAL','TRANSFER_IN','CREDIT','FEE','INTEREST')
GROUP BY 1, 2;
```

**3. Wrong currency persisted, silently.** `account_currency` came from the first row's account, so a row whose own account is in another currency is normalised against the wrong one. Two rows with `currency` omitted, one per account, are both stored with whichever account is listed first. Sent alone, each resolves correctly — which is what makes it a leak rather than a base-currency fallback.

## The fix

Group the creates by `account_id`, resolve each group's own account, and prepare one group at a time — mirroring the group-by-account approach already used by `check_activities_import`. Each row keeps its index in the original request, so errors and prepared activities are reported back in request order and the response does not depend on how rows happened to group.

Grouping fixes the currency half in the same stroke: each group is prepared against its own `&Account`, so `resolve_currency`, `resolve_symbols_batch_single_currency`, `build_asset_spec` and the FX-pair collection all see the right currency. Threading a per-activity account through `prepare_activities_internal` would not have been sufficient — `resolve_symbols_batch_single_currency` is single-currency by construction, so it would have required currency-grouping inside that function anyway.

`prepare_activities_for_import` and `prepare_activities_for_sync` are legitimately single-account (CSV import and broker sync target one account), so their signatures and the shared `prepare_activities_internal` are unchanged.

**Cost:** one `ensure_assets`/`ensure_fx_pairs` round per distinct account. The single-account case, which is the common one, is unaffected.

## Tests

Added beside the existing credit-card cases in `activities_service_tests.rs`:

| Test | Covers |
|---|---|
| `bulk_create_validates_each_row_against_its_own_account` | card row then bank `DEPOSIT`; both created |
| `bulk_create_mixed_accounts_is_order_independent` | the same two rows reversed |
| `bulk_create_still_rejects_row_invalid_for_its_own_account` | bank `DEPOSIT` then card `DEPOSIT`; exactly one error, attributed to the card row, nothing created |
| `bulk_create_resolves_missing_currency_from_each_row_account` | USD and EUR accounts, empty `currency`; each inherits its own |

Three of the four fail before the change. The third exists specifically to stop the bug being "fixed" by weakening validation.

## Verification

Unit, on the pinned 1.95.0 toolchain:

```
cargo test -p wealthfolio-core --lib    # 1650 passed, 0 failed
cargo fmt -p wealthfolio-core -- --check                          # clean
cargo clippy -p wealthfolio-core --lib --all-targets -- -D warnings  # clean
cargo check -p wealthfolio-server                                 # clean
```

End-to-end, against a server image built from this commit, compared with 3.6.2:

| Scenario | 3.6.2 | This branch |
|---|---|---|
| card row first, then bank `DEPOSIT` | `created: 0` + bogus card error | `created: 2` |
| same rows reversed | `created: 2` | `created: 2` |
| EUR row first, then USD row | USD row stored as `EUR` | `USD`→`USD`, `EUR`→`EUR` |
| USD row first, then EUR row | EUR row stored as `USD` | `USD`→`USD`, `EUR`→`EUR` |
| bank row first, then card `DEPOSIT` | `created: 2`, forbidden row persisted | `created: 0` + correct error |

And confirming the fix does not simply loosen validation, checked in SQLite rather than via the API:

```
A) bank DEPOSIT + card DEPOSIT    -> created: 0, error: DEPOSIT not supported for credit card accounts
B) bank DEPOSIT + card WITHDRAWAL -> created: 2, errors: 0
--- rows actually in the DB ---
    Bank   CASH         DEPOSIT     amount=100
    Card   CREDIT_CARD  WITHDRAWAL  amount=100
--- forbidden rows persisted: 0
```

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
