### PR TITLE
fix(activity): reject cash dividend/interest edits over hidden quantity/price fields

### DIFF
--- a/apps/frontend/src/pages/activity/components/forms/dividend-form.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/dividend-form.tsx
@@ -97,9 +97,6 @@ export const createDividendFormSchema = (t?: TFunction) =>
             "FMV per unit must be a number.",
           ),
         })
-        .positive({
-          message: msg(t, "activity:form.err_fmv_gt_zero", "FMV per unit must be greater than 0."),
-        })
         .optional(),
       quantity: z.coerce
         .number({
@@ -107,13 +104,6 @@ export const createDividendFormSchema = (t?: TFunction) =>
             t,
             "activity:form.err_received_quantity_number",
             "Received quantity must be a number.",
-          ),
-        })
-        .positive({
-          message: msg(
-            t,
-            "activity:form.err_received_quantity_gt_zero",
-            "Received quantity must be greater than 0.",
           ),
         })
         .optional(),
@@ -136,6 +126,16 @@ export const createDividendFormSchema = (t?: TFunction) =>
             "Received quantity is required.",
           ),
         });
+      } else if (data.quantity <= 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["quantity"],
+          message: msg(
+            t,
+            "activity:form.err_received_quantity_gt_zero",
+            "Received quantity must be greater than 0.",
+          ),
+        });
       }
       if (!data.unitPrice) {
         if (data.amount) return;
@@ -147,6 +147,12 @@ export const createDividendFormSchema = (t?: TFunction) =>
             "activity:form.err_enter_dividend_or_fmv",
             "Enter either dividend amount or FMV per unit.",
           ),
+        });
+      } else if (data.unitPrice <= 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["unitPrice"],
+          message: msg(t, "activity:form.err_fmv_gt_zero", "FMV per unit must be greater than 0."),
         });
       }
     });

--- a/apps/frontend/src/pages/activity/components/forms/interest-form.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/interest-form.tsx
@@ -77,9 +77,6 @@ export const createInterestFormSchema = (t?: TFunction) =>
             "FMV per unit must be a number.",
           ),
         })
-        .positive({
-          message: msg(t, "activity:form.err_fmv_gt_zero", "FMV per unit must be greater than 0."),
-        })
         .optional(),
       quantity: z.coerce
         .number({
@@ -87,13 +84,6 @@ export const createInterestFormSchema = (t?: TFunction) =>
             t,
             "activity:form.err_received_quantity_number",
             "Received quantity must be a number.",
-          ),
-        })
-        .positive({
-          message: msg(
-            t,
-            "activity:form.err_received_quantity_gt_zero",
-            "Received quantity must be greater than 0.",
           ),
         })
         .optional(),
@@ -139,6 +129,16 @@ export const createInterestFormSchema = (t?: TFunction) =>
             "Received quantity is required.",
           ),
         });
+      } else if (data.quantity <= 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["quantity"],
+          message: msg(
+            t,
+            "activity:form.err_received_quantity_gt_zero",
+            "Received quantity must be greater than 0.",
+          ),
+        });
       }
       if (!data.unitPrice) {
         if (data.amount) return;
@@ -150,6 +150,12 @@ export const createInterestFormSchema = (t?: TFunction) =>
             "activity:form.err_enter_interest_or_fmv",
             "Enter either interest amount or FMV per unit.",
           ),
+        });
+      } else if (data.unitPrice <= 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["unitPrice"],
+          message: msg(t, "activity:form.err_fmv_gt_zero", "FMV per unit must be greater than 0."),
         });
       }
     });


### PR DESCRIPTION
## Summary

Editing an existing Cash-type DIVIDEND or INTEREST activity failed to save with "Quantity: Received quantity must be greater than 0" and "Price: FMV per unit must be greater than 0", even though those fields are hidden in Cash mode.

Root cause: `quantity`/`unitPrice` were defined with a top-level `z.coerce.number().positive().optional()`, so `.positive()` ran unconditionally. `.optional()` only skips validation for `undefined`, not `0`, and existing cash-dividend/interest records store `quantity=0`/`unitPrice=0` in the DB, so the stale zero values always failed validation.

Fix: move the `positive()` checks into the existing `superRefine` block (already gated on `isAssetBacked` for dividend-form.tsx / `isStakingReward` for interest-form.tsx), so they only apply when the fields are actually shown (DRIP/DIVIDEND_IN_KIND for dividends, STAKING_REWARD for interest).

## Test plan

- [x] `vitest run` on `dividend-split-forms.test.tsx` (21 tests passing)
- [x] `tsc --noEmit` clean
- [x] Manually edit an existing Cash-type dividend/interest activity in the app and confirm it saves without spurious errors
