### PR TITLE
Show average cost line on holding history chart

### DIFF
--- a/apps/frontend/src/components/history-chart-symbol.tsx
+++ b/apps/frontend/src/components/history-chart-symbol.tsx
@@ -8,6 +8,7 @@ import {
   Area,
   AreaChart,
   ReferenceDot,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -65,6 +66,7 @@ export default function HistoryChart({
   interval,
   activityMarkers = [],
   onActivityMarkerClick,
+  averageCost,
   height = 350,
 }: {
   data: HistoryChartData[];
@@ -72,6 +74,7 @@ export default function HistoryChart({
   height?: number;
   activityMarkers?: HistoryChartActivityMarker[];
   onActivityMarkerClick?: (marker: HistoryChartActivityMarker) => void;
+  averageCost?: number;
 }) {
   const [hoveredMarker, setHoveredMarker] = useState(false);
   const markerByTimestamp = useMemo(() => {
@@ -142,6 +145,21 @@ export default function HistoryChart({
               fillOpacity={1}
               fill="url(#colorUv)"
             />
+            {averageCost != null && averageCost > 0 && (
+              <ReferenceLine
+                y={averageCost}
+                stroke="var(--foreground)"
+                strokeDasharray="4 3"
+                strokeWidth={1}
+                ifOverflow="extendDomain"
+                label={{
+                  value: formatPrice(averageCost, data[0]?.currency ?? "", false),
+                  position: "insideBottomLeft",
+                  fill: "var(--foreground)",
+                  fontSize: 11,
+                }}
+              />
+            )}
             {activityMarkers.map((marker) => {
               return (
                 <ReferenceDot

--- a/apps/frontend/src/i18n/locales/de/asset.json
+++ b/apps/frontend/src/i18n/locales/de/asset.json
@@ -295,11 +295,11 @@
     "as_of": "Stand:",
     "refreshing_quotes": "Kurse werden aktualisiert...",
     "refresh_quotes": "Kurse aktualisieren",
-    "hide_activity_markers": "Aktivitätsmarkierungen ausblenden",
-    "show_activity_markers": "Aktivitätsmarkierungen anzeigen",
+    "hide_activity_markers": "Aktivitätsmarkierungen und Durchschnittskostenlinie ausblenden",
+    "show_activity_markers": "Aktivitätsmarkierungen und Durchschnittskostenlinie anzeigen",
     "hide": "Ausblenden",
     "show": "Anzeigen",
-    "activity_markers_suffix": "Aktivitätsmarkierungen"
+    "activity_markers_suffix": "Aktivitätsmarkierungen und Durchschnittskostenlinie"
   },
   "lots": {
     "lots_by_account": "Lose nach Konto",

--- a/apps/frontend/src/i18n/locales/en/asset.json
+++ b/apps/frontend/src/i18n/locales/en/asset.json
@@ -295,11 +295,11 @@
     "as_of": "As of:",
     "refreshing_quotes": "Refreshing quotes...",
     "refresh_quotes": "Refresh Quotes",
-    "hide_activity_markers": "Hide activity markers",
-    "show_activity_markers": "Show activity markers",
+    "hide_activity_markers": "Hide activity markers and average cost line",
+    "show_activity_markers": "Show activity markers and average cost line",
     "hide": "Hide",
     "show": "Show",
-    "activity_markers_suffix": "activity markers"
+    "activity_markers_suffix": "activity markers and average cost line"
   },
   "lots": {
     "lots_by_account": "Lots by account",

--- a/apps/frontend/src/i18n/locales/es/asset.json
+++ b/apps/frontend/src/i18n/locales/es/asset.json
@@ -295,11 +295,11 @@
     "as_of": "A fecha de:",
     "refreshing_quotes": "Actualizando cotizaciones...",
     "refresh_quotes": "Actualizar cotizaciones",
-    "hide_activity_markers": "Ocultar marcadores de actividad",
-    "show_activity_markers": "Mostrar marcadores de actividad",
+    "hide_activity_markers": "Ocultar marcadores de actividad y línea de coste medio",
+    "show_activity_markers": "Mostrar marcadores de actividad y línea de coste medio",
     "hide": "Ocultar",
     "show": "Mostrar",
-    "activity_markers_suffix": "marcadores de actividad"
+    "activity_markers_suffix": "marcadores de actividad y línea de coste medio"
   },
   "lots": {
     "lots_by_account": "Lotes por cuenta",

--- a/apps/frontend/src/i18n/locales/fr/asset.json
+++ b/apps/frontend/src/i18n/locales/fr/asset.json
@@ -295,11 +295,11 @@
     "as_of": "Au :",
     "refreshing_quotes": "Actualisation des cotations...",
     "refresh_quotes": "Actualiser les cotations",
-    "hide_activity_markers": "Masquer les marqueurs d'activité",
-    "show_activity_markers": "Afficher les marqueurs d'activité",
+    "hide_activity_markers": "Masquer les marqueurs d'activité et la ligne de coût moyen",
+    "show_activity_markers": "Afficher les marqueurs d'activité et la ligne de coût moyen",
     "hide": "Masquer",
     "show": "Afficher",
-    "activity_markers_suffix": "les marqueurs d'activité"
+    "activity_markers_suffix": "les marqueurs d'activité et la ligne de coût moyen"
   },
   "lots": {
     "lots_by_account": "Lots par compte",

--- a/apps/frontend/src/i18n/locales/zh/asset.json
+++ b/apps/frontend/src/i18n/locales/zh/asset.json
@@ -295,11 +295,11 @@
     "as_of": "截至：",
     "refreshing_quotes": "正在刷新报价……",
     "refresh_quotes": "刷新报价",
-    "hide_activity_markers": "隐藏活动标记",
-    "show_activity_markers": "显示活动标记",
+    "hide_activity_markers": "隐藏活动标记和平均成本线",
+    "show_activity_markers": "显示活动标记和平均成本线",
     "hide": "隐藏",
     "show": "显示",
-    "activity_markers_suffix": "活动标记"
+    "activity_markers_suffix": "活动标记和平均成本线"
   },
   "lots": {
     "lots_by_account": "按账户列示的批次",

--- a/apps/frontend/src/pages/asset/asset-history-card.tsx
+++ b/apps/frontend/src/pages/asset/asset-history-card.tsx
@@ -32,7 +32,7 @@ import {
   TooltipTrigger,
 } from "@wealthfolio/ui";
 import { format, subMonths } from "date-fns";
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   ASSET_MARKER_ACTIVITY_TYPES,
@@ -43,6 +43,8 @@ import {
 } from "./asset-history-markers";
 import { RefreshQuotesConfirmDialog } from "./refresh-quotes-confirm-dialog";
 
+const SHOW_ACTIVITY_MARKERS_STORAGE_KEY = "history-chart-show-activity-markers";
+
 interface AssetHistoryProps {
   marketPrice: number;
   totalGainAmount: number;
@@ -50,6 +52,7 @@ interface AssetHistoryProps {
   currency: string;
   quoteHistory: Quote[];
   assetId: string;
+  averageCost?: number;
   className?: string;
 }
 
@@ -60,13 +63,27 @@ const AssetHistoryCard: React.FC<AssetHistoryProps> = ({
   currency,
   quoteHistory,
   assetId,
+  averageCost,
   className,
 }) => {
   const { t } = useTranslation();
   const syncMarketDataMutation = useSyncMarketDataMutation(true);
   const { isBalanceHidden } = useBalancePrivacy();
   const [refreshConfirmOpen, setRefreshConfirmOpen] = useState(false);
-  const [showActivityMarkers, setShowActivityMarkers] = useState(false);
+  const [showActivityMarkers, setShowActivityMarkers] = useState<boolean>(() => {
+    try {
+      return window.localStorage.getItem(SHOW_ACTIVITY_MARKERS_STORAGE_KEY) === "true";
+    } catch {
+      return false;
+    }
+  });
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(SHOW_ACTIVITY_MARKERS_STORAGE_KEY, String(showActivityMarkers));
+    } catch {
+      // localStorage unavailable (e.g. private browsing); the toggle just won't persist.
+    }
+  }, [showActivityMarkers]);
   const [selectedActivityDate, setSelectedActivityDate] = useState<string | null>(null);
   const [isActivitySheetOpen, setIsActivitySheetOpen] = useState(false);
 
@@ -270,6 +287,7 @@ const AssetHistoryCard: React.FC<AssetHistoryProps> = ({
           <HistoryChart
             data={chartData}
             activityMarkers={activityMarkers}
+            averageCost={showActivityMarkers ? averageCost : undefined}
             onActivityMarkerClick={(marker) => {
               setSelectedActivityDate(dateKey(marker.point));
               setIsActivitySheetOpen(true);

--- a/apps/frontend/src/pages/asset/asset-history-card.tsx
+++ b/apps/frontend/src/pages/asset/asset-history-card.tsx
@@ -287,7 +287,7 @@ const AssetHistoryCard: React.FC<AssetHistoryProps> = ({
           <HistoryChart
             data={chartData}
             activityMarkers={activityMarkers}
-            averageCost={showActivityMarkers ? averageCost : undefined}
+            averageCost={showActivityMarkers && !isBalanceHidden ? averageCost : undefined}
             onActivityMarkerClick={(marker) => {
               setSelectedActivityDate(dateKey(marker.point));
               setIsActivitySheetOpen(true);

--- a/apps/frontend/src/pages/asset/asset-profile-page.tsx
+++ b/apps/frontend/src/pages/asset/asset-profile-page.tsx
@@ -1500,6 +1500,11 @@ export const AssetProfilePage = () => {
                   totalGainAmount={profile.totalGainAmount}
                   totalGainPercent={profile.totalGainPercent}
                   quoteHistory={quoteHistory ?? []}
+                  averageCost={
+                    symbolHolding && symbolHolding.numShares > 0
+                      ? symbolHolding.averagePrice
+                      : undefined
+                  }
                   className={`col-span-1 ${symbolHolding ? "md:col-span-2" : "md:col-span-3"}`}
                 />
                 {symbolHolding && (
@@ -1528,6 +1533,11 @@ export const AssetProfilePage = () => {
                   totalGainAmount={profile.totalGainAmount}
                   totalGainPercent={profile.totalGainPercent}
                   quoteHistory={quoteHistory ?? []}
+                  averageCost={
+                    symbolHolding && symbolHolding.numShares > 0
+                      ? symbolHolding.averagePrice
+                      : undefined
+                  }
                   className={`col-span-1 ${symbolHolding ? "md:col-span-2" : "md:col-span-3"}`}
                 />
                 {symbolHolding && (


### PR DESCRIPTION
## Summary
- Add a dashed average-cost (PRU) reference line to the symbol/holding history chart (`var(--foreground)`, adapts to light/dark theme), rendered via a new optional `averageCost` prop on `HistoryChart`
- Fold this into the chart's existing buy/sell activity marker toggle so a single button shows both together, instead of adding a second control
- Persist the toggle choice locally so it survives reloads
- Wire `averageCost` from the already-computed holding average price into both the desktop and mobile `AssetHistoryCard` render paths; the line is only shown when the position has shares (skipped for fully closed positions)

## Test plan
- [x] Open a holding with buy/sell activity and a non-zero average cost; toggle the History icon on the chart and confirm both the buy/sell markers and the dashed average-cost line appear together
- [x] Reload the page/app and confirm the toggle state persists
- [x] Verify the average-cost line is not shown for holdings with zero shares (e.g. fully closed positions)
- [x] Check appearance in both light and dark theme


<img width="1195" height="639" alt="image" src="https://github.com/user-attachments/assets/7ddb92a9-1d2b-4a59-a1e6-e3d107601dc4" />
