### PR TITLE
fix(addons): keep content above bottom navigation

### DIFF
--- a/apps/frontend/src/addons/iframe/addon-iframe-route.test.tsx
+++ b/apps/frontend/src/addons/iframe/addon-iframe-route.test.tsx
@@ -67,6 +67,14 @@ describe("AddonIframeRoute self-healing", () => {
     activationEpochStore.reset();
   });
 
+  it("marks the sandbox viewport for bottom-navigation clearance", () => {
+    const { container } = render(<AddonIframeRoute addonId="test-addon" routeId="test" />);
+
+    const viewport = container.querySelector('[data-addon-route-viewport="true"]');
+    const frameContainer = container.querySelector('[data-addon-route-id="test"]');
+    expect(viewport?.contains(frameContainer)).toBe(true);
+  });
+
   it("activates once and renders the route on mount", async () => {
     render(<AddonIframeRoute addonId="test-addon" routeId="test" />);
 

--- a/apps/frontend/src/addons/iframe/addon-iframe-route.tsx
+++ b/apps/frontend/src/addons/iframe/addon-iframe-route.tsx
@@ -120,7 +120,10 @@ export function AddonIframeRoute({ addonId, routeId }: AddonIframeRouteProps) {
   };
 
   return (
-    <div className="relative h-full min-h-0 w-full overflow-hidden">
+    <div
+      className="relative h-full min-h-0 w-full overflow-hidden"
+      data-addon-route-viewport="true"
+    >
       <div
         ref={containerRef}
         className={cn(

--- a/apps/frontend/src/globals.css
+++ b/apps/frontend/src/globals.css
@@ -673,6 +673,14 @@ body.qr-scan-active .scan-hide-target {
     padding-bottom: var(--mobile-nav-total-offset) !important;
   }
 
+  /* Add-on routes scroll inside their sandbox iframe, so host page padding
+     cannot create bottom-nav clearance. Keep the entire sandbox viewport,
+     including its loading/error states, above the floating navigation. */
+  [data-page-scroll-container][data-with-mobile-nav-offset="true"]
+    [data-addon-route-viewport="true"] {
+    height: calc(100% - var(--mobile-nav-total-offset));
+  }
+
   .touch-manipulation {
     touch-action: manipulation;
   }


### PR DESCRIPTION
## Summary

- keep add-on iframe content above bottom navigation
- apply the existing navigation offset to mobile, responsive web, and desktop floating-navigation layouts
- keep sidebar and focus-mode add-on layouts full height
- add regression coverage for the add-on viewport layout contract

## Root cause

The stacking fix in #1315 made host navigation visible above add-on iframes, but the iframe still occupied the complete route viewport. Normal host pages receive bottom-navigation clearance through `PageContent`; add-on content scrolls inside a separate sandbox document, so that padding cannot reach it.

The add-on route now exposes a host viewport marker. When its page scroll container declares a bottom-navigation offset, the host constrains the entire sandbox viewport—including loading and error states—using the existing safe-area-aware navigation offset. The iframe manager's existing `ResizeObserver` then updates the fixed iframe bounds.

## Impact

- fixes hidden controls and content at the bottom of add-on pages on mobile
- fixes the equivalent overlap with desktop floating navigation
- requires no changes to installed add-ons or the add-on SDK
- leaves desktop sidebar, focus mode, and iPad sidebar layouts unchanged

## Validation

- `pnpm check`
- `pnpm test --run` (1,108 tests)
- `pnpm build`
- `pnpm build:tauri`
- focused add-on route tests
- production CSS inspection
- browser geometry checks across portrait, landscape, desktop floating, sidebar, and live navigation-mode changes
- `git diff --check`
