### PR TITLE
fix(custom-provider): strip R prefix so R$ (BRL) prices parse

### DIFF
--- a/crates/core/src/custom_provider/service.rs
+++ b/crates/core/src/custom_provider/service.rs
@@ -907,7 +907,7 @@ pub fn parse_number_string(s: &str, locale: Option<&str>) -> Option<f64> {
         .filter(|c| {
             !matches!(
                 c,
-                '$' | '€' | '£' | '¥' | '₹' | '₽' | '₿' | '%' | '+' | '\u{00a0}'
+                '$' | '€' | '£' | '¥' | '₹' | '₽' | '₿' | 'R' | '%' | '+' | '\u{00a0}'
             ) && !c.is_whitespace()
         })
         .collect();
@@ -1343,5 +1343,13 @@ mod tests {
             extract_table_value(body, "0:1", Some("en-US")),
             Some(123.45)
         );
+    }
+
+    #[test]
+    fn parse_number_string_strips_brl_prefix() {
+        // Before the fix, the leading "R" (from "R$") made the value fail
+        // the starts-with-digit check and return None, even though the
+        // rest already correctly auto-detects "1.234,56" as 1234.56.
+        assert_eq!(parse_number_string("R$ 1.234,56", None), Some(1234.56));
     }
 }


### PR DESCRIPTION
## Summary
- `parse_number_string` strips known currency symbols (`$ € £ ¥ ₹ ₽ ₿ %`) before checking that the value starts with a digit/`-`, but didn't strip the `R` used in the Brazilian Real's `R$` prefix.
- `"R$ 1.234,56"` became `"R1.234,56"` after stripping, which fails the starts-with-digit check and returns `None` — before ever reaching the locale-aware decimal parsing that already handles the `1.234,56` European-style format correctly.
- One-line fix: add `'R'` to the stripped-symbol set.

Fixes #1381

## Test plan
- [x] Added `parse_number_string_strips_brl_prefix` unit test asserting `"R$ 1.234,56"` parses to `1234.56`.
- [ ] CI test suite