### PR TITLE
fix: add spacing between mobile header nav pills and actions

### DIFF
--- a/apps/frontend/src/components/page/swipable-page.tsx
+++ b/apps/frontend/src/components/page/swipable-page.tsx
@@ -251,13 +251,15 @@ export function SwipablePage({
                   />
                 </div>
                 {mobileActionsInHeader ? (
-                  <div className="flex min-w-0 shrink-0 justify-end">{currentActions}</div>
+                  <div className="flex min-w-0 shrink-0 items-center justify-end gap-2">
+                    {currentActions}
+                  </div>
                 ) : (
                   <div />
                 )}
               </div>
               {currentActions && !mobileActionsInHeader && (
-                <div className="flex min-w-0 justify-end">{currentActions}</div>
+                <div className="flex min-w-0 items-center justify-end gap-2">{currentActions}</div>
               )}
             </div>
 


### PR DESCRIPTION
## Summary
- On mobile, the header actions row (health status indicator, privacy toggle, dashboard menu) had no `gap` class, so the icons rendered flush against each other and against the tab navigation pills.
- Adds `gap-2` and `items-center` to the two mobile action containers in `SwipablePage`, matching the spacing already used in the desktop header (`flex items-center gap-2`).

## Test plan
- [x] `eslint` on the changed file passes with no errors
- [ ] Visually confirm on a mobile viewport that the health status icon, privacy toggle, and menu button now have breathing room next to the tab pills (investments / net worth / spending)