### PR TITLE
feat: add configurable server URL for self-hosting

### DIFF
--- a/apps/frontend/src/lib/settings-provider.tsx
+++ b/apps/frontend/src/lib/settings-provider.tsx
@@ -21,6 +21,7 @@ interface ExtendedSettingsContextType extends SettingsContextType {
         | "onboardingCompleted"
         | "menuBarVisible"
         | "syncEnabled"
+        | "serverUrl"
       >
     >,
   ) => Promise<void>;
@@ -55,6 +56,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         | "onboardingCompleted"
         | "menuBarVisible"
         | "syncEnabled"
+        | "serverUrl"
       >
     >,
   ) => {

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -858,6 +858,7 @@ export interface Settings {
   autoUpdateCheckEnabled: boolean;
   menuBarVisible: boolean;
   syncEnabled: boolean;
+  serverUrl: string;
 }
 
 export interface SettingsContextType {

--- a/apps/frontend/src/pages/settings/general/general-page.tsx
+++ b/apps/frontend/src/pages/settings/general/general-page.tsx
@@ -6,6 +6,7 @@ import { AutoUpdateSettings } from "./auto-update-settings";
 import { BaseCurrencySettings } from "./currency-settings";
 import { ExchangeRatesSettings } from "./exchange-rates/exchange-rates-settings";
 import { LanguageRegionSettings } from "./language-region-settings";
+import { ServerUrlSettings } from "./server-url-settings";
 
 export default function GeneralSettingsPage() {
   const { t } = useTranslation();
@@ -22,6 +23,9 @@ export default function GeneralSettingsPage() {
       <LanguageRegionSettings />
       <div className="pt-6">
         <ExchangeRatesSettings />
+      </div>
+      <div className="pt-6">
+        <ServerUrlSettings />
       </div>
       {!isMobile && (
         <div className="pt-6">

--- a/apps/frontend/src/pages/settings/general/server-url-settings.tsx
+++ b/apps/frontend/src/pages/settings/general/server-url-settings.tsx
@@ -1,0 +1,195 @@
+import { Button } from "@wealthfolio/ui/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@wealthfolio/ui/components/ui/card";
+import { Input } from "@wealthfolio/ui/components/ui/input";
+import { Label } from "@wealthfolio/ui/components/ui/label";
+import { toast } from "@wealthfolio/ui/components/ui/use-toast";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useSettingsContext } from "@/lib/settings-provider";
+
+function isValidServerUrl(value: string): boolean {
+  if (!value.trim()) return true; // Empty is valid (means default)
+  try {
+    const url = new URL(value.trim());
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export function ServerUrlSettings() {
+  const { t } = useTranslation();
+  const { settings, updateSettings } = useSettingsContext();
+  const [serverUrl, setServerUrl] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [hasChanged, setHasChanged] = useState(false);
+
+  useEffect(() => {
+    if (settings) {
+      setServerUrl(settings.serverUrl || "");
+      setHasChanged(false);
+    }
+  }, [settings]);
+
+  const handleChange = (value: string) => {
+    setServerUrl(value);
+    setHasChanged(value !== (settings?.serverUrl || ""));
+  };
+
+  const handleSave = async () => {
+    const trimmed = serverUrl.trim();
+
+    if (trimmed && !isValidServerUrl(trimmed)) {
+      toast({
+        title: t("common:error"),
+        description:
+          t("settings:server_url_invalid") ||
+          "Please enter a valid URL (e.g. https://your-server.com)",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    // Normalize: remove trailing slash
+    const normalized = trimmed.replace(/\/+$/, "");
+
+    setIsSaving(true);
+    try {
+      await updateSettings({ serverUrl: normalized });
+      setHasChanged(false);
+      toast({
+        title: t("settings:settings_saved") || "Settings saved",
+        description:
+          t("settings:server_url_saved") ||
+          (normalized
+            ? `Server URL set to ${normalized}. Restart may be required for all features.`
+            : "Server URL reset to default. Restart may be required."),
+        variant: "success",
+        duration: 3000,
+      });
+    } catch (error) {
+      toast({
+        title: t("common:error") || "Error",
+        description:
+          t("settings:server_url_error") || "Failed to save server URL",
+        variant: "destructive",
+      });
+      console.error("Failed to save server URL:", error);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handleReset = async () => {
+    setServerUrl("");
+    setIsSaving(true);
+    try {
+      await updateSettings({ serverUrl: "" });
+      setHasChanged(false);
+      toast({
+        title: t("settings:settings_saved") || "Settings saved",
+        description:
+          t("settings:server_url_reset") || "Server URL reset to default",
+        variant: "success",
+      });
+    } catch (error) {
+      toast({
+        title: t("common:error") || "Error",
+        description:
+          t("settings:server_url_error") || "Failed to save server URL",
+        variant: "destructive",
+      });
+      console.error("Failed to reset server URL:", error);
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  if (!settings) return null;
+
+  const isValid = isValidServerUrl(serverUrl);
+  const showReset = Boolean(settings.serverUrl);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">
+          {t("settings:server_url_title") || "Server URL"}
+        </CardTitle>
+        <CardDescription>
+          {t("settings:server_url_description") ||
+            "Configure a custom server URL for self-hosting. Leave empty to use Wealthfolio's hosted server (https://api.wealthfolio.app). Requires app restart to fully apply."}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="server-url" className="text-sm font-medium">
+            {t("settings:server_url_label") || "Custom Server URL"}
+          </Label>
+          <div className="flex gap-2">
+            <Input
+              id="server-url"
+              type="url"
+              placeholder="https://your-server.com"
+              value={serverUrl}
+              onChange={(e) => handleChange(e.target.value)}
+              className={!isValid ? "border-destructive" : ""}
+            />
+            <Button
+              onClick={handleSave}
+              disabled={!hasChanged || !isValid || isSaving}
+              variant="default"
+            >
+              {isSaving
+                ? t("common:saving") || "Saving..."
+                : t("common:save") || "Save"}
+            </Button>
+            {showReset && (
+              <Button
+                onClick={handleReset}
+                disabled={isSaving}
+                variant="outline"
+              >
+                {t("common:reset") || "Reset"}
+              </Button>
+            )}
+          </div>
+          {!isValid && (
+            <p className="text-destructive text-xs">
+              {t("settings:server_url_invalid") ||
+                "Please enter a valid URL starting with http:// or https://"}
+            </p>
+          )}
+          {serverUrl && isValid && (
+            <p className="text-muted-foreground text-xs">
+              {t("settings:server_url_hint") ||
+                "Example: https://api.example.com or http://localhost:3000"}
+            </p>
+          )}
+        </div>
+        <div className="bg-muted/50 rounded-lg p-3">
+          <p className="text-muted-foreground text-xs">
+            <strong>
+              {t("settings:server_url_current") || "Current effective URL:"}
+            </strong>{" "}
+            {settings.serverUrl
+              ? settings.serverUrl
+              : "https://api.wealthfolio.app (default)"}
+          </p>
+          {settings.serverUrl && (
+            <p className="text-muted-foreground mt-1 text-xs">
+              {t("settings:server_url_restart_note") ||
+                "Restart the app after changing the server URL to ensure all services use the new URL."}
+            </p>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/server/src/features.rs
+++ b/apps/server/src/features.rs
@@ -21,5 +21,11 @@ pub fn cloud_api_base_url() -> Option<String> {
         .ok()
         .map(|v| v.trim().trim_end_matches('/').to_string())
         .filter(|v| !v.is_empty())
+        .or_else(|| {
+            std::env::var("WEALTHFOLIO_SERVER_URL")
+                .ok()
+                .map(|v| v.trim().trim_end_matches('/').to_string())
+                .filter(|v| !v.is_empty())
+        })
         .or_else(|| Some(DEFAULT_CLOUD_API_URL.to_string()))
 }

--- a/apps/tauri/src/commands/settings.rs
+++ b/apps/tauri/src/commands/settings.rs
@@ -56,6 +56,9 @@ pub async fn update_settings(
     let previous_base_currency = state.get_base_currency();
     let previous_timezone = state.get_timezone();
 
+    // Capture server_url before moving settings_update
+    let new_server_url = settings_update.server_url.clone();
+
     // Update settings in the database (this applies all changes in settings_update)
     service
         .update_settings(&settings_update)
@@ -67,6 +70,23 @@ pub async fn update_settings(
 
     let base_currency_changed = updated_settings.base_currency != previous_base_currency;
     let timezone_changed = updated_settings.timezone != previous_timezone;
+
+    // Update custom server URL cache if changed
+    if let Some(server_url) = new_server_url {
+        crate::services::set_custom_server_url(if server_url.trim().is_empty() {
+            None
+        } else {
+            Some(server_url)
+        });
+        debug!(
+            "Custom server URL updated to: {}",
+            if updated_settings.server_url.is_empty() {
+                "(default)"
+            } else {
+                &updated_settings.server_url
+            }
+        );
+    }
 
     if let Some(menu_visible) = settings_update.menu_bar_visible {
         #[cfg(not(any(target_os = "android", target_os = "ios")))]

--- a/apps/tauri/src/context/providers.rs
+++ b/apps/tauri/src/context/providers.rs
@@ -173,6 +173,10 @@ pub async fn initialize_context(
     let base_currency_string = settings.base_currency.clone();
     let base_currency = Arc::new(RwLock::new(base_currency_string.clone()));
     let timezone = Arc::new(RwLock::new(settings.timezone.clone()));
+    // Initialize custom server URL cache for self-hosting support
+    if !settings.server_url.trim().is_empty() {
+        crate::services::set_custom_server_url(Some(settings.server_url.clone()));
+    }
     let rating_instance_id = Arc::new(
         settings_service
             .get_setting_value("instance_id")?

--- a/apps/tauri/src/services/connect_service.rs
+++ b/apps/tauri/src/services/connect_service.rs
@@ -2,6 +2,9 @@
 //!
 //! This service wraps the ConnectApiClient with keyring token retrieval,
 //! providing a simple interface for cloud API operations.
+//! Supports custom server URL for self-hosting via settings or env var.
+
+use std::sync::{OnceLock, RwLock};
 
 use std::sync::Arc;
 
@@ -10,6 +13,42 @@ use wealthfolio_connect::{
     DEFAULT_CLOUD_API_URL,
 };
 use wealthfolio_core::secrets::SecretStore;
+
+/// Global cache for custom server URL set via settings UI.
+/// Allows runtime override for self-hosted instances without recompilation.
+static CUSTOM_SERVER_URL: OnceLock<RwLock<Option<String>>> = OnceLock::new();
+
+fn custom_server_url_cache() -> &'static RwLock<Option<String>> {
+    CUSTOM_SERVER_URL.get_or_init(|| RwLock::new(None))
+}
+
+/// Set custom server URL (called when settings are updated).
+/// Pass None or empty string to clear custom URL and use default.
+pub fn set_custom_server_url(url: Option<String>) {
+    let normalized = url
+        .map(|v| v.trim().trim_end_matches('/').to_string())
+        .filter(|v| !v.is_empty());
+
+    // Validate URL format - must be http(s):// or empty
+    if let Some(ref u) = normalized {
+        if !u.starts_with("http://") && !u.starts_with("https://") {
+            // Invalid URL, ignore - keep previous value
+            return;
+        }
+    }
+
+    if let Ok(mut guard) = custom_server_url_cache().write() {
+        *guard = normalized;
+    }
+}
+
+/// Get currently set custom server URL, if any.
+pub fn get_custom_server_url() -> Option<String> {
+    custom_server_url_cache()
+        .read()
+        .ok()
+        .and_then(|guard| guard.clone())
+}
 
 /// Returns true when broker/connect sync was compiled in.
 pub fn is_connect_sync_enabled() -> bool {
@@ -27,24 +66,72 @@ pub fn is_cloud_sync_enabled() -> bool {
 }
 
 /// Returns the cloud API base URL when a sync feature is enabled.
+///
+/// Priority order (highest first):
+/// 1. Custom URL set via settings UI (for self-hosting)
+/// 2. Runtime env var `CONNECT_API_URL` or `WEALTHFOLIO_SERVER_URL`
+/// 3. Compile-time env var `CONNECT_API_URL` (baked via build.rs)
+/// 4. Default hosted URL (https://api.wealthfolio.app)
 pub fn cloud_api_base_url() -> Option<String> {
     if !is_cloud_sync_enabled() {
         return None;
     }
 
-    option_env!("CONNECT_API_URL")
-        .map(|v| v.trim().trim_end_matches('/').to_string())
-        .filter(|v| !v.is_empty())
-        .or_else(|| Some(DEFAULT_CLOUD_API_URL.to_string()))
+    // 1. Custom URL from settings UI
+    if let Ok(guard) = custom_server_url_cache().read() {
+        if let Some(ref custom) = *guard {
+            if !custom.is_empty() {
+                return Some(custom.clone());
+            }
+        }
+    }
+
+    // 2. Runtime environment variables (allows Docker / env override without recompile)
+    if let Ok(val) = std::env::var("CONNECT_API_URL") {
+        let trimmed = val.trim().trim_end_matches('/').to_string();
+        if !trimmed.is_empty() {
+            return Some(trimmed);
+        }
+    }
+    if let Ok(val) = std::env::var("WEALTHFOLIO_SERVER_URL") {
+        let trimmed = val.trim().trim_end_matches('/').to_string();
+        if !trimmed.is_empty() {
+            return Some(trimmed);
+        }
+    }
+
+    // 3. Compile-time env (for backwards compatibility)
+    if let Some(val) = option_env!("CONNECT_API_URL") {
+        let trimmed = val.trim().trim_end_matches('/').to_string();
+        if !trimmed.is_empty() {
+            return Some(trimmed);
+        }
+    }
+
+    // 4. Default hosted
+    Some(DEFAULT_CLOUD_API_URL.to_string())
 }
 
 fn connect_auth_url() -> Option<String> {
+    // Runtime env takes precedence
+    if let Ok(val) = std::env::var("CONNECT_AUTH_URL") {
+        let trimmed = val.trim().trim_end_matches('/').to_string();
+        if !trimmed.is_empty() {
+            return Some(trimmed);
+        }
+    }
     option_env!("CONNECT_AUTH_URL")
         .map(|v| v.trim().trim_end_matches('/').to_string())
         .filter(|v| !v.is_empty())
 }
 
 fn connect_auth_publishable_key() -> Option<String> {
+    if let Ok(val) = std::env::var("CONNECT_AUTH_PUBLISHABLE_KEY") {
+        let trimmed = val.trim().to_string();
+        if !trimmed.is_empty() {
+            return Some(trimmed);
+        }
+    }
     option_env!("CONNECT_AUTH_PUBLISHABLE_KEY")
         .map(|v| v.trim().to_string())
         .filter(|v| !v.is_empty())
@@ -117,7 +204,7 @@ impl ConnectService {
     /// Check if the current user's plan includes broker sync.
     ///
     /// Returns `Ok(true)` only when the user has an active subscription
-    /// on a plan that includes broker sync (i.e. not "basic").
+    /// on a plan that includes broker sync (i.e. not \"basic\").
     pub async fn has_broker_sync(&self) -> Result<bool, String> {
         let client = self.get_api_client().await?;
         client.has_broker_sync().await.map_err(|e| e.to_string())

--- a/crates/core/src/settings/settings_model.rs
+++ b/crates/core/src/settings/settings_model.rs
@@ -15,6 +15,7 @@ pub struct Settings {
     pub menu_bar_visible: bool,
     pub sync_enabled: bool,
     pub default_return_metric: String,
+    pub server_url: String,
 }
 
 impl Default for Settings {
@@ -30,6 +31,7 @@ impl Default for Settings {
             menu_bar_visible: true,
             sync_enabled: true,
             default_return_metric: "twr".to_string(),
+            server_url: "".to_string(),
         }
     }
 }
@@ -47,6 +49,7 @@ pub struct SettingsUpdate {
     pub menu_bar_visible: Option<bool>,
     pub sync_enabled: Option<bool>,
     pub default_return_metric: Option<String>,
+    pub server_url: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/crates/storage-sqlite/src/settings/repository.rs
+++ b/crates/storage-sqlite/src/settings/repository.rs
@@ -54,6 +54,7 @@ impl SettingsRepositoryTrait for SettingsRepository {
                     settings.sync_enabled = value.parse().unwrap_or(true);
                 }
                 "default_return_metric" => settings.default_return_metric = value,
+                "server_url" => settings.server_url = value,
                 _ => {} // Ignore unknown settings
             }
         }
@@ -165,6 +166,16 @@ impl SettingsRepositoryTrait for SettingsRepository {
                         .map_err(StorageError::from)?;
                 }
 
+                if let Some(ref server_url) = settings.server_url {
+                    diesel::replace_into(app_settings)
+                        .values(&AppSettingDB {
+                            setting_key: "server_url".to_string(),
+                            setting_value: server_url.clone(),
+                        })
+                        .execute(conn)
+                        .map_err(StorageError::from)?;
+                }
+
                 Ok(())
             })
             .await
@@ -191,6 +202,7 @@ impl SettingsRepositoryTrait for SettingsRepository {
                     "menu_bar_visible" => "true",
                     "sync_enabled" => "true",
                     "default_return_metric" => "twr",
+                    "server_url" => "",
                     _ => return Err(StorageError::from(diesel::result::Error::NotFound).into()),
                 };
                 Ok(default_value.to_string())


### PR DESCRIPTION
## Summary
Currently the mobile/desktop Tauri app forces users to use Wealthfolio's hosted server (https://api.wealthfolio.app) and there is no way to point to a self-hosted server. This is a limitation for self-hosters running apps/server.

This PR adds a configurable Server URL setting so users can point the app to their own self-hosted instance.

## Changes
- **Core**: Add server_url field to Settings model (Settings + SettingsUpdate) with empty default = use hosted server
- **Storage**: Handle server_url key in SettingsRepository (get/update)
- **Tauri service** (connect_service.rs):
  - Add global cache for custom URL set via UI
  - cloud_api_base_url() now checks in order:
    1. Custom URL from settings UI (self-hosting)
    2. Runtime env vars CONNECT_API_URL / WEALTHFOLIO_SERVER_URL (Docker/env override)
    3. Compile-time CONNECT_API_URL (backwards compat)
    4. Default https://api.wealthfolio.app
  - Add set_custom_server_url() / get_custom_server_url() helpers
  - Auth URL and publishable key also check runtime env var first
- **Context**: Initialize custom URL cache from settings at startup
- **Settings command**: Update cache when server_url is changed via UI
- **Server**: Support WEALTHFOLIO_SERVER_URL alias in apps/server/src/features.rs
- **Frontend**:
  - Add serverUrl to Settings TS type and settings provider
  - New component ServerUrlSettings in General settings: input with validation, save/reset, current effective URL display
  - Included in GeneralSettingsPage

## UI
Field appears under Settings -> General -> Server URL
- Empty = use default hosted server
- Valid URL (http/https) = use self-hosted server
- Shows current effective URL and restart note

## Minimal & Safe
- Only necessary changes, no breaking changes
- Empty string = existing behavior preserved
- Validation ensures http/https scheme
- Backwards compatible with existing env-var flows

## Testing
- Manual: Set custom URL via UI, verify it persists and cloud_api_base_url() returns it
- Manual: Reset to empty, verify it falls back to default
- Manual: Env var override still works
- Should be covered by existing settings tests

Closes self-hosting limitation for mobile app.
