### PR TITLE
Net worth: expand the composition bar into a flow (Sankey) diagram

### DIFF
--- a/apps/frontend/src/globals.css
+++ b/apps/frontend/src/globals.css
@@ -1065,6 +1065,29 @@ summary {
   --chart-cursor: rgba(255, 255, 255, 0.06);
 }
 
+/* Net-worth category palette (composition bar, breakdown rows, detail-sheet
+   icons, net-worth flow diagram). Light values are the original hand-tuned
+   hexes; dark values keep the same hue and lift L by ~0.30-0.38 / add
+   ~0.04-0.06 chroma in OKLCH so they stay legible on the dark card surface. */
+:root {
+  --category-properties: #4b4137; /* warm dark taupe / charcoal */
+  --category-investments: #6f7544; /* muted olive green */
+  --category-cash: #d8c98f; /* pale cream / light gold */
+  --category-vehicles: #6d7c86; /* muted slate */
+  --category-other-assets: #928d83; /* medium warm gray */
+  --category-precious-metals: #b8923a; /* soft gold */
+  --category-collectibles: #8a6b49; /* muted brown */
+}
+.dark {
+  --category-properties: oklch(0.62 0.05 55);
+  --category-investments: oklch(0.78 0.09 110);
+  --category-cash: oklch(0.83 0.06 95);
+  --category-vehicles: oklch(0.72 0.04 240);
+  --category-other-assets: oklch(0.8 0.03 85);
+  --category-precious-metals: oklch(0.82 0.13 75);
+  --category-collectibles: oklch(0.74 0.09 68);
+}
+
 /* Events timeline — fallback tag color when an event type has no user-picked
    color, plus the "today" marker color. */
 :root {

--- a/apps/frontend/src/i18n/locales/en/insights.json
+++ b/apps/frontend/src/i18n/locales/en/insights.json
@@ -119,6 +119,15 @@
       "contributions": "Contributions",
       "equity_built": "Equity built",
       "per_month": "/mo"
+    },
+    "flow": {
+      "show": "Show flow",
+      "hide": "Hide flow",
+      "debts_label": "Debts",
+      "other_holdings_one": "{{count}} smaller holding",
+      "other_holdings_other": "{{count}} smaller holdings",
+      "unattributed": "Other",
+      "node_aria": "{{name}} — {{amount}}"
     }
   }
 }

--- a/apps/frontend/src/pages/net-worth/components/breakdown-table.tsx
+++ b/apps/frontend/src/pages/net-worth/components/breakdown-table.tsx
@@ -1,4 +1,6 @@
 import { DashboardCard } from "@/components/dashboard-card";
+import { useAccounts } from "@/hooks/use-accounts";
+import { useCurrentAccountValuations } from "@/hooks/use-current-account-valuations";
 import { useIsMobileViewport } from "@/hooks/use-platform";
 import { usePersistentState } from "@wealthfolio/ui";
 import {
@@ -19,6 +21,7 @@ import {
   deriveChange,
   formatChangePercent,
   seriesFor,
+  type BreakdownEntry,
   type Change,
   type ParsedHistoryPoint,
   type ParsedNetWorth,
@@ -139,16 +142,45 @@ export function BreakdownTable({
   // at-a-glance job and the diagram adds the structure it can't show.
   const [flowExpanded, setFlowExpanded] = usePersistentState<boolean>(FLOW_EXPANDED_STORAGE_KEY, false);
   const flowContentId = `nwf-content-${useId().replace(/:/g, "")}`;
+
+  // The Investments category deliberately has no per-holding children from the
+  // backend (hundreds of holdings; the allocation view owns that drill-down —
+  // see net_worth_service.rs). Fan the flow diagram's Investments node in by
+  // ACCOUNT instead, fetched client-side from current account valuations.
+  // `undefined` while accounts/valuations are still loading, which
+  // `buildNetWorthFlowGraph` treats as "no data" and falls back to today's
+  // flat Investments node.
+  const { accounts } = useAccounts();
+  const accountIds = useMemo(() => accounts.map((account) => account.id), [accounts]);
+  const { currentAccountValuations, isLoading: valuationsLoading } =
+    useCurrentAccountValuations(accountIds);
+  const investmentAccounts = useMemo((): BreakdownEntry[] | undefined => {
+    if (!currentAccountValuations || valuationsLoading) return undefined;
+    const accountNameById = new Map(accounts.map((account) => [account.id, account.name]));
+    return currentAccountValuations
+      .filter((valuation) => valuation.investmentMarketValueBase > 0)
+      .map((valuation) => ({
+        category: "investments",
+        name: accountNameById.get(valuation.accountId) ?? valuation.accountId,
+        value: valuation.investmentMarketValueBase,
+        assetId: valuation.accountId,
+      }));
+  }, [accounts, currentAccountValuations, valuationsLoading]);
+
   const flowGraph = useMemo(
     () =>
-      buildNetWorthFlowGraph(data, {
-        assets: t("insights:networth.breakdown_table.assets"),
-        netWorth: t("insights:networth.breakdown_table.net_worth"),
-        debts: t("insights:networth.flow.debts_label"),
-        otherHoldings: (count) => t("insights:networth.flow.other_holdings", { count }),
-        unattributed: t("insights:networth.flow.unattributed"),
-      }),
-    [data, t],
+      buildNetWorthFlowGraph(
+        data,
+        {
+          assets: t("insights:networth.breakdown_table.assets"),
+          netWorth: t("insights:networth.breakdown_table.net_worth"),
+          debts: t("insights:networth.flow.debts_label"),
+          otherHoldings: (count) => t("insights:networth.flow.other_holdings", { count }),
+          unattributed: t("insights:networth.flow.unattributed"),
+        },
+        investmentAccounts,
+      ),
+    [data, investmentAccounts, t],
   );
 
   return (

--- a/apps/frontend/src/pages/net-worth/components/breakdown-table.tsx
+++ b/apps/frontend/src/pages/net-worth/components/breakdown-table.tsx
@@ -140,7 +140,10 @@ export function BreakdownTable({
   // CompositionBar is the collapsed state of the Sankey flow diagram —
   // clicking it expands in place. Nothing is removed; the bar keeps its
   // at-a-glance job and the diagram adds the structure it can't show.
-  const [flowExpanded, setFlowExpanded] = usePersistentState<boolean>(FLOW_EXPANDED_STORAGE_KEY, false);
+  const [flowExpanded, setFlowExpanded] = usePersistentState<boolean>(
+    FLOW_EXPANDED_STORAGE_KEY,
+    false,
+  );
   const flowContentId = `nwf-content-${useId().replace(/:/g, "")}`;
 
   // The Investments category deliberately has no per-holding children from the
@@ -209,9 +212,11 @@ export function BreakdownTable({
           <div className="border-border/60 mb-1 mt-2.5 border-b pb-3">
             <Collapsible open={flowExpanded} onOpenChange={setFlowExpanded}>
               <CollapsibleTrigger
-                className="focus-visible:ring-[var(--theme)] focus-visible:ring-offset-background group flex w-full flex-col gap-1.5 rounded-md text-left outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+                className="focus-visible:ring-offset-background group flex w-full flex-col gap-1.5 rounded-md text-left outline-none focus-visible:ring-2 focus-visible:ring-[var(--theme)] focus-visible:ring-offset-2"
                 aria-controls={flowContentId}
-                aria-label={t(flowExpanded ? "insights:networth.flow.hide" : "insights:networth.flow.show")}
+                aria-label={t(
+                  flowExpanded ? "insights:networth.flow.hide" : "insights:networth.flow.show",
+                )}
               >
                 <CompositionBar data={data} />
                 <span

--- a/apps/frontend/src/pages/net-worth/components/breakdown-table.tsx
+++ b/apps/frontend/src/pages/net-worth/components/breakdown-table.tsx
@@ -1,14 +1,18 @@
 import { DashboardCard } from "@/components/dashboard-card";
+import { useIsMobileViewport } from "@/hooks/use-platform";
+import { usePersistentState } from "@wealthfolio/ui";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@wealthfolio/ui/components/ui/collapsible";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
-import { useState } from "react";
+import { useId, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { CompactAmount } from "./compact-amount";
 import { CompositionBar } from "./composition-bar";
+import { NetWorthFlowDiagram } from "./net-worth-flow-diagram";
+import { FLOW_EXPANDED_STORAGE_KEY, buildNetWorthFlowGraph } from "./net-worth-flow-utils";
 import {
   CARD_LABEL,
   CATEGORY_CSS_COLORS,
@@ -122,6 +126,7 @@ export function BreakdownTable({
   onSelect,
 }: BreakdownTableProps) {
   const { t } = useTranslation();
+  const isMobile = useIsMobileViewport();
   const hasLiabilities = data.liabilities.total > 0 || data.liabilities.breakdown.length > 0;
   const netWorthChange = deriveChange(
     history.map((point) => point.netWorth),
@@ -129,6 +134,22 @@ export function BreakdownTable({
   );
   const [assetsOpen, setAssetsOpen] = useState(true);
   const [liabilitiesOpen, setLiabilitiesOpen] = useState(true);
+  // CompositionBar is the collapsed state of the Sankey flow diagram —
+  // clicking it expands in place. Nothing is removed; the bar keeps its
+  // at-a-glance job and the diagram adds the structure it can't show.
+  const [flowExpanded, setFlowExpanded] = usePersistentState<boolean>(FLOW_EXPANDED_STORAGE_KEY, false);
+  const flowContentId = `nwf-content-${useId().replace(/:/g, "")}`;
+  const flowGraph = useMemo(
+    () =>
+      buildNetWorthFlowGraph(data, {
+        assets: t("insights:networth.breakdown_table.assets"),
+        netWorth: t("insights:networth.breakdown_table.net_worth"),
+        debts: t("insights:networth.flow.debts_label"),
+        otherHoldings: (count) => t("insights:networth.flow.other_holdings", { count }),
+        unattributed: t("insights:networth.flow.unattributed"),
+      }),
+    [data, t],
+  );
 
   return (
     <DashboardCard
@@ -149,9 +170,40 @@ export function BreakdownTable({
           </span>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          {/* Composition — proportion of assets (the rows below are its legend) */}
+          {/* Composition bar — click to expand in place into the Sankey flow
+              diagram. The bar keeps its at-a-glance job; the diagram (the same
+              category proportions, rotated, with flows attached) adds the
+              structure the bar alone can't show. */}
           <div className="border-border/60 mb-1 mt-2.5 border-b pb-3">
-            <CompositionBar data={data} />
+            <Collapsible open={flowExpanded} onOpenChange={setFlowExpanded}>
+              <CollapsibleTrigger
+                className="focus-visible:ring-[var(--theme)] focus-visible:ring-offset-background group flex w-full flex-col gap-1.5 rounded-md text-left outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+                aria-controls={flowContentId}
+                aria-label={t(flowExpanded ? "insights:networth.flow.hide" : "insights:networth.flow.show")}
+              >
+                <CompositionBar data={data} />
+                <span
+                  className={`${CARD_LABEL} group-hover:text-foreground flex items-center gap-1 transition-colors`}
+                >
+                  <Icons.ChevronRight
+                    className={`h-3 w-3 transition-transform ${flowExpanded ? "rotate-90" : ""}`}
+                  />
+                  {t(flowExpanded ? "insights:networth.flow.hide" : "insights:networth.flow.show")}
+                </span>
+              </CollapsibleTrigger>
+              <CollapsibleContent id={flowContentId}>
+                {flowGraph && (
+                  <div className="pt-3">
+                    <NetWorthFlowDiagram
+                      graph={flowGraph}
+                      currency={currency}
+                      onSelect={onSelect}
+                      isMobile={isMobile}
+                    />
+                  </div>
+                )}
+              </CollapsibleContent>
+            </Collapsible>
           </div>
 
           {/* Column labels */}

--- a/apps/frontend/src/pages/net-worth/components/net-worth-flow-diagram.tsx
+++ b/apps/frontend/src/pages/net-worth/components/net-worth-flow-diagram.tsx
@@ -3,7 +3,10 @@ import { formatCompactAmount } from "@wealthfolio/ui";
 import { useId, useMemo, useState, type KeyboardEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { ResponsiveContainer, Sankey } from "recharts";
-import type { LinkProps as RechartsLinkProps, NodeProps as RechartsNodeProps } from "recharts/types/chart/Sankey";
+import type {
+  LinkProps as RechartsLinkProps,
+  NodeProps as RechartsNodeProps,
+} from "recharts/types/chart/Sankey";
 import { shortenLeafName, type FlowNode, type NetWorthFlowGraph } from "./net-worth-flow-utils";
 import { THEME_COLOR, type SelectedCategory } from "./utils";
 
@@ -97,11 +100,15 @@ function FlowNodeShape({
   payload,
   ctx,
   t,
-}: RechartsNodeProps & { ctx: ShapeContext; t: (key: string, options?: Record<string, unknown>) => string }) {
+}: RechartsNodeProps & {
+  ctx: ShapeContext;
+  t: (key: string, options?: Record<string, unknown>) => string;
+}) {
   const node = payload as unknown as FlowNode;
   const selectable = isSelectable(node);
   const categoryKey = selectable ? node.selected.key : undefined;
-  const dimmed = ctx.hoveredCategory != null && categoryKey != null && ctx.hoveredCategory !== categoryKey;
+  const dimmed =
+    ctx.hoveredCategory != null && categoryKey != null && ctx.hoveredCategory !== categoryKey;
   const rectHeight = Math.max(height, 1.5);
   const rightAligned = RIGHT_ALIGNED_KINDS.has(node.kind);
   const showValue = VALUE_KINDS.has(node.kind);
@@ -150,7 +157,13 @@ function FlowNodeShape({
         <title>{`${node.name} — ${amountText}`}</title>
       </rect>
       {showLabel && (
-        <foreignObject x={labelX} y={y} width={labelWidth} height={Math.max(rectHeight, LABEL_BOX_HEIGHT)} style={{ overflow: "visible" }}>
+        <foreignObject
+          x={labelX}
+          y={y}
+          width={labelWidth}
+          height={Math.max(rectHeight, LABEL_BOX_HEIGHT)}
+          style={{ overflow: "visible" }}
+        >
           {/* No xmlns attribute needed: the app always parses this as HTML5,
               which puts foreignObject's children in the HTML namespace already. */}
           <div
@@ -196,7 +209,10 @@ function FlowLinkShape({
   ctx,
 }: RechartsLinkProps & { ctx: ShapeContext }) {
   const link = payload as unknown as { color: string; categoryKey?: string; target: FlowNode };
-  const dimmed = ctx.hoveredCategory != null && link.categoryKey != null && ctx.hoveredCategory !== link.categoryKey;
+  const dimmed =
+    ctx.hoveredCategory != null &&
+    link.categoryKey != null &&
+    ctx.hoveredCategory !== link.categoryKey;
   const hot = ctx.hoveredCategory != null && ctx.hoveredCategory === link.categoryKey;
   const convergesIntoAssets = link.categoryKey != null && link.target.kind === "assets";
   const stroke = convergesIntoAssets ? `url(#${ctx.uid}-converge-${link.categoryKey})` : link.color;
@@ -252,7 +268,12 @@ function leadingColumnNodeCount(graph: NetWorthFlowGraph): number {
  * the first place; it's folded into its category's bucket node upstream in
  * `buildNetWorthFlowGraph`.
  */
-export function NetWorthFlowDiagram({ graph, currency, onSelect, isMobile }: NetWorthFlowDiagramProps) {
+export function NetWorthFlowDiagram({
+  graph,
+  currency,
+  onSelect,
+  isMobile,
+}: NetWorthFlowDiagramProps) {
   const { t } = useTranslation();
   const { isBalanceHidden } = useBalancePrivacy();
   const [hoveredCategory, setHoveredCategory] = useState<string | null>(null);
@@ -323,7 +344,14 @@ export function NetWorthFlowDiagram({ graph, currency, onSelect, isMobile }: Net
               </pattern>
             ))}
             {categoryColors.map(({ key, color }) => (
-              <linearGradient key={`grad-${key}`} id={`${uid}-converge-${key}`} x1="0" y1="0" x2="1" y2="0">
+              <linearGradient
+                key={`grad-${key}`}
+                id={`${uid}-converge-${key}`}
+                x1="0"
+                y1="0"
+                x2="1"
+                y2="0"
+              >
                 <stop offset="0%" stopColor={color} />
                 <stop offset="100%" stopColor={THEME_COLOR} />
               </linearGradient>

--- a/apps/frontend/src/pages/net-worth/components/net-worth-flow-diagram.tsx
+++ b/apps/frontend/src/pages/net-worth/components/net-worth-flow-diagram.tsx
@@ -4,11 +4,24 @@ import { useId, useMemo, useState, type KeyboardEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { ResponsiveContainer, Sankey } from "recharts";
 import type { LinkProps as RechartsLinkProps, NodeProps as RechartsNodeProps } from "recharts/types/chart/Sankey";
-import type { FlowNode, NetWorthFlowGraph } from "./net-worth-flow-utils";
+import { shortenLeafName, type FlowNode, type NetWorthFlowGraph } from "./net-worth-flow-utils";
 import { THEME_COLOR, type SelectedCategory } from "./utils";
 
 const NODE_WIDTH = 8;
 const LABEL_GAP = 6;
+/**
+ * Minimum vertical distance guaranteed between the tops of two adjacent nodes
+ * in the same column — a floor independent of either node's value. This is
+ * `nodePadding`, and it's what makes label collisions structurally
+ * impossible rather than something detected and patched after layout: a
+ * two-line label (name + amount) needs ~24-26px, so leaving this much room
+ * around every node means a leaf's label always has a fully clear row, no
+ * matter how small the ribbon feeding it is. Mobile hides leaf/bucket labels
+ * entirely (see `showLabel`), so it only needs enough room for the sparser
+ * category/total labels.
+ */
+const ROW_PITCH_DESKTOP = 28;
+const ROW_PITCH_MOBILE = 14;
 
 interface NetWorthFlowDiagramProps {
   graph: NetWorthFlowGraph;
@@ -52,6 +65,16 @@ interface ShapeContext {
  * color (the same `--bar-stripe` overlay the budget meters use) to flag "this
  * is several holdings, not one" rather than rendering them as an
  * indistinguishable hairline.
+ *
+ * Every leaf/bucket label gets its own opaque per-line chip behind the text
+ * (rather than relying on empty space), so even a ribbon that happens to
+ * pass close to the label gutter can never visually cut through it. The real
+ * anti-overlap guarantee is structural, not visual: see `ROW_PITCH_DESKTOP`
+ * and `diagramHeight` in `NetWorthFlowDiagram` — labels never collide
+ * because every node in a column is spaced at least one label-height apart
+ * by construction, and `MAX_VISIBLE_LEAVES` (net-worth-flow-utils.ts) caps
+ * how many individually-labelled leaves a category can have in the first
+ * place, folding the rest into a bucket instead.
  */
 function FlowNodeShape({
   x,
@@ -69,10 +92,12 @@ function FlowNodeShape({
   const rectHeight = Math.max(height, 1.5);
   const rightAligned = RIGHT_ALIGNED_KINDS.has(node.kind);
   const showValue = VALUE_KINDS.has(node.kind);
+  const isLeafOrBucket = node.kind === "leaf" || node.kind === "bucket";
   // Leaf/bucket labels are dropped at narrow widths (embedded in the
   // breakdown card, roughly 700-760px) so the diagram degrades to
   // category -> Assets -> Net Worth / Debts instead of scrolling sideways.
-  const showLabel = !ctx.isMobile || (node.kind !== "leaf" && node.kind !== "bucket");
+  const showLabel = !ctx.isMobile || !isLeafOrBucket;
+  const displayName = isLeafOrBucket ? shortenLeafName(node.name) : node.name;
 
   const amountText = ctx.isBalanceHidden ? "••••" : formatCompactAmount(node.value, ctx.currency);
   const ariaLabel = selectable
@@ -112,18 +137,22 @@ function FlowNodeShape({
         <title>{`${node.name} — ${amountText}`}</title>
       </rect>
       {showLabel && (
-        <foreignObject x={labelX} y={y} width={labelWidth} height={Math.max(rectHeight, 26)}>
+        <foreignObject x={labelX} y={y} width={labelWidth} height={Math.max(rectHeight, 24)} style={{ overflow: "visible" }}>
           {/* No xmlns attribute needed: the app always parses this as HTML5,
               which puts foreignObject's children in the HTML namespace already. */}
           <div
-            className={`flex flex-col leading-tight ${rightAligned ? "items-end text-right" : "items-start text-left"}`}
+            className={`flex flex-col justify-center leading-tight ${rightAligned ? "items-end text-right" : "items-start text-left"}`}
+            style={{ minHeight: "100%" }}
           >
-            <span className="text-foreground truncate text-[11px] font-medium" style={{ maxWidth: labelWidth }}>
-              {node.name}
+            <span
+              className="bg-background/90 text-foreground inline-block truncate rounded-sm px-0.5 text-[11px] font-medium"
+              style={{ maxWidth: labelWidth }}
+            >
+              {displayName}
             </span>
             {showValue && (
               <span
-                className="text-muted-foreground/70 truncate text-[10px] tabular-nums"
+                className="bg-background/90 text-muted-foreground/70 inline-block truncate rounded-sm px-0.5 text-[10px] tabular-nums"
                 style={{ maxWidth: labelWidth, fontVariantNumeric: "tabular-nums" }}
               >
                 {amountText}
@@ -174,6 +203,17 @@ function FlowLinkShape({
 }
 
 /**
+ * Number of nodes stacked in the diagram's leftmost (most crowded) column —
+ * every leaf/bucket, plus any category with no itemized children (e.g. Cash,
+ * which links straight to Assets and therefore starts at the same depth as
+ * everyone else's leaves). Nodes are "leftmost" when nothing links into them.
+ */
+function leadingColumnNodeCount(graph: NetWorthFlowGraph): number {
+  const hasIncoming = new Set(graph.links.map((link) => link.target));
+  return graph.nodes.filter((_, index) => !hasIncoming.has(index)).length;
+}
+
+/**
  * Sankey diagram of how holdings roll up into categories, into total assets,
  * then into net worth (with debts branching off). Reads the same graph
  * `buildNetWorthFlowGraph` derives from `ParsedNetWorth` — no API call of its
@@ -188,12 +228,37 @@ function FlowLinkShape({
  * breakdown table's rows do; the Assets / Net Worth / Debts totals are
  * non-interactive, matching the breakdown table's own total row having no
  * click handler either.
+ *
+ * Labels never collide by construction, not by detecting and patching
+ * overlaps after the fact: `nodePadding` is fixed at `ROW_PITCH_DESKTOP`
+ * (independent of any node's value, so a $40K leaf gets exactly as much
+ * clearance as a $1.4M one), and the diagram's own height grows with the
+ * leftmost column's node count so that pitch always fits inside it — see
+ * `leadingColumnNodeCount` / `diagramHeight` below. A leaf that would need
+ * more rows than `MAX_VISIBLE_LEAVES` allows never reaches this component in
+ * the first place; it's folded into its category's bucket node upstream in
+ * `buildNetWorthFlowGraph`.
  */
 export function NetWorthFlowDiagram({ graph, currency, onSelect, isMobile }: NetWorthFlowDiagramProps) {
   const { t } = useTranslation();
   const { isBalanceHidden } = useBalancePrivacy();
   const [hoveredCategory, setHoveredCategory] = useState<string | null>(null);
   const uid = `nwf-${useId().replace(/:/g, "")}`;
+
+  const rowPitch = isMobile ? ROW_PITCH_MOBILE : ROW_PITCH_DESKTOP;
+  const leadingCount = useMemo(() => leadingColumnNodeCount(graph), [graph]);
+  // recharts' Sankey scales every node's thickness by ONE shared ratio,
+  // `(columnHeight - (n-1)*nodePadding) / sum(columnValues)`, taken as the
+  // min across all columns — so budgeting only just enough height for the
+  // pitch floor would starve every node's thickness to near-zero (the
+  // leftmost column has by far the most nodes to pad between). Reserve real
+  // room on top of the pitch floor so values still read as proportional
+  // ribbon thickness, not just as evenly-spaced hairlines.
+  const valueHeightBudget = isMobile ? 60 : 140;
+  const diagramHeight = Math.min(
+    680,
+    Math.max(isMobile ? 260 : 300, leadingCount * rowPitch + valueHeightBudget),
+  );
 
   const categoryColors = useMemo(
     () =>
@@ -214,12 +279,12 @@ export function NetWorthFlowDiagram({ graph, currency, onSelect, isMobile }: Net
   };
 
   return (
-    <div className="h-[300px] w-full overflow-x-auto md:h-[340px]">
+    <div className="w-full overflow-x-auto" style={{ height: diagramHeight }}>
       <ResponsiveContainer width="100%" height="100%" minWidth={320}>
         <Sankey
           data={{ nodes: graph.nodes, links: graph.links }}
           nodeWidth={NODE_WIDTH}
-          nodePadding={isMobile ? 8 : 12}
+          nodePadding={rowPitch}
           linkCurvature={0.55}
           iterations={32}
           margin={{ top: 8, right: 8, bottom: 8, left: 8 }}

--- a/apps/frontend/src/pages/net-worth/components/net-worth-flow-diagram.tsx
+++ b/apps/frontend/src/pages/net-worth/components/net-worth-flow-diagram.tsx
@@ -1,0 +1,254 @@
+import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
+import { formatCompactAmount } from "@wealthfolio/ui";
+import { useId, useMemo, useState, type KeyboardEvent } from "react";
+import { useTranslation } from "react-i18next";
+import { ResponsiveContainer, Sankey } from "recharts";
+import type { LinkProps as RechartsLinkProps, NodeProps as RechartsNodeProps } from "recharts/types/chart/Sankey";
+import type { FlowNode, NetWorthFlowGraph } from "./net-worth-flow-utils";
+import { THEME_COLOR, type SelectedCategory } from "./utils";
+
+const NODE_WIDTH = 8;
+const LABEL_GAP = 6;
+
+interface NetWorthFlowDiagramProps {
+  graph: NetWorthFlowGraph;
+  currency: string;
+  onSelect: (selected: SelectedCategory) => void;
+  isMobile: boolean;
+}
+
+/** Kinds whose node sits at the right edge of the diagram — their label reads to the left. */
+const RIGHT_ALIGNED_KINDS = new Set<FlowNode["kind"]>(["net-worth", "debts"]);
+/** Kinds that open the breakdown drawer on click/Enter/Space. */
+const SELECTABLE_KINDS = new Set<FlowNode["kind"]>(["leaf", "bucket", "category"]);
+/**
+ * Only the terminal totals show a value in the diagram — they appear nowhere
+ * else on the page in that shape. Every other node (and Net Worth, already
+ * the headline number in the Balance card above) shows its name only; exact
+ * values live in the breakdown table rows and the drawer the node opens, so
+ * this diagram never has its own number to disagree with theirs.
+ */
+const VALUE_KINDS = new Set<FlowNode["kind"]>(["assets", "debts"]);
+
+function isSelectable(node: FlowNode): node is FlowNode & { selected: SelectedCategory } {
+  return SELECTABLE_KINDS.has(node.kind);
+}
+
+interface ShapeContext {
+  currency: string;
+  isMobile: boolean;
+  hoveredCategory: string | null;
+  onHover: (key: string | null) => void;
+  onSelect: (selected: SelectedCategory) => void;
+  isBalanceHidden: boolean;
+  /** `nwf-<uid>` — shared prefix for this diagram's <defs> ids (bucket stripes, converge gradients). */
+  uid: string;
+}
+
+/**
+ * A node's rect + an HTML label rendered via foreignObject, so a holding name
+ * truncates like everywhere else in the app instead of SVG text overflowing
+ * with no ellipsis. Bucket nodes get a diagonal stripe in their category's own
+ * color (the same `--bar-stripe` overlay the budget meters use) to flag "this
+ * is several holdings, not one" rather than rendering them as an
+ * indistinguishable hairline.
+ */
+function FlowNodeShape({
+  x,
+  y,
+  width,
+  height,
+  payload,
+  ctx,
+  t,
+}: RechartsNodeProps & { ctx: ShapeContext; t: (key: string, options?: Record<string, unknown>) => string }) {
+  const node = payload as unknown as FlowNode;
+  const selectable = isSelectable(node);
+  const categoryKey = selectable ? node.selected.key : undefined;
+  const dimmed = ctx.hoveredCategory != null && categoryKey != null && ctx.hoveredCategory !== categoryKey;
+  const rectHeight = Math.max(height, 1.5);
+  const rightAligned = RIGHT_ALIGNED_KINDS.has(node.kind);
+  const showValue = VALUE_KINDS.has(node.kind);
+  // Leaf/bucket labels are dropped at narrow widths (embedded in the
+  // breakdown card, roughly 700-760px) so the diagram degrades to
+  // category -> Assets -> Net Worth / Debts instead of scrolling sideways.
+  const showLabel = !ctx.isMobile || (node.kind !== "leaf" && node.kind !== "bucket");
+
+  const amountText = ctx.isBalanceHidden ? "••••" : formatCompactAmount(node.value, ctx.currency);
+  const ariaLabel = selectable
+    ? t("insights:networth.flow.node_aria", { name: node.name, amount: amountText })
+    : undefined;
+
+  const handleClick = () => {
+    if (selectable) ctx.onSelect(node.selected);
+  };
+  const handleKeyDown = (event: KeyboardEvent<SVGGElement>) => {
+    if (!selectable) return;
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      ctx.onSelect(node.selected);
+    }
+  };
+
+  const labelWidth = ctx.isMobile ? 68 : 92;
+  const labelX = rightAligned ? x - LABEL_GAP - labelWidth : x + width + LABEL_GAP;
+  const fill = node.kind === "bucket" ? `url(#${ctx.uid}-stripe-${categoryKey})` : node.color;
+
+  return (
+    <g
+      className="nwf-node"
+      tabIndex={selectable ? 0 : undefined}
+      role={selectable ? "button" : undefined}
+      aria-label={ariaLabel}
+      style={{ cursor: selectable ? "pointer" : "default", opacity: dimmed ? 0.35 : 1 }}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      onMouseEnter={() => categoryKey && ctx.onHover(categoryKey)}
+      onMouseLeave={() => categoryKey && ctx.onHover(null)}
+      onFocus={() => categoryKey && ctx.onHover(categoryKey)}
+      onBlur={() => categoryKey && ctx.onHover(null)}
+    >
+      <rect x={x} y={y} width={width} height={rectHeight} rx={1.5} fill={fill}>
+        <title>{`${node.name} — ${amountText}`}</title>
+      </rect>
+      {showLabel && (
+        <foreignObject x={labelX} y={y} width={labelWidth} height={Math.max(rectHeight, 26)}>
+          {/* No xmlns attribute needed: the app always parses this as HTML5,
+              which puts foreignObject's children in the HTML namespace already. */}
+          <div
+            className={`flex flex-col leading-tight ${rightAligned ? "items-end text-right" : "items-start text-left"}`}
+          >
+            <span className="text-foreground truncate text-[11px] font-medium" style={{ maxWidth: labelWidth }}>
+              {node.name}
+            </span>
+            {showValue && (
+              <span
+                className="text-muted-foreground/70 truncate text-[10px] tabular-nums"
+                style={{ maxWidth: labelWidth, fontVariantNumeric: "tabular-nums" }}
+              >
+                {amountText}
+              </span>
+            )}
+          </div>
+        </foreignObject>
+      )}
+    </g>
+  );
+}
+
+/**
+ * A category -> Assets ribbon fades from the category color into the shared
+ * net-worth theme color as it converges — the same gradient trick the
+ * history sparkline above uses — so "everything converges into one number"
+ * reads visually, not just structurally.
+ */
+function FlowLinkShape({
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourceControlX,
+  targetControlX,
+  linkWidth,
+  payload,
+  ctx,
+}: RechartsLinkProps & { ctx: ShapeContext }) {
+  const link = payload as unknown as { color: string; categoryKey?: string; target: FlowNode };
+  const dimmed = ctx.hoveredCategory != null && link.categoryKey != null && ctx.hoveredCategory !== link.categoryKey;
+  const hot = ctx.hoveredCategory != null && ctx.hoveredCategory === link.categoryKey;
+  const convergesIntoAssets = link.categoryKey != null && link.target.kind === "assets";
+  const stroke = convergesIntoAssets ? `url(#${ctx.uid}-converge-${link.categoryKey})` : link.color;
+
+  return (
+    <path
+      d={`M${sourceX},${sourceY} C${sourceControlX},${sourceY} ${targetControlX},${targetY} ${targetX},${targetY}`}
+      fill="none"
+      stroke={stroke}
+      strokeWidth={Math.max(linkWidth, 1)}
+      strokeOpacity={dimmed ? 0.12 : hot ? 0.82 : 0.42}
+      style={{ transition: "stroke-opacity 120ms ease" }}
+      onMouseEnter={() => link.categoryKey && ctx.onHover(link.categoryKey)}
+      onMouseLeave={() => link.categoryKey && ctx.onHover(null)}
+    />
+  );
+}
+
+/**
+ * Sankey diagram of how holdings roll up into categories, into total assets,
+ * then into net worth (with debts branching off). Reads the same graph
+ * `buildNetWorthFlowGraph` derives from `ParsedNetWorth` — no API call of its
+ * own.
+ *
+ * Chrome-less by design: it's the expanded state of `CompositionBar` inside
+ * `BreakdownTable` (which owns the collapse trigger and persisted state), not
+ * a standalone card. It shows no values except on the Assets/Debts terminal
+ * nodes (which appear nowhere else on the page in that shape); the
+ * breakdown table rows are the ledger of exact values, percentages and
+ * change. Category and leaf/bucket nodes open the same detail drawer the
+ * breakdown table's rows do; the Assets / Net Worth / Debts totals are
+ * non-interactive, matching the breakdown table's own total row having no
+ * click handler either.
+ */
+export function NetWorthFlowDiagram({ graph, currency, onSelect, isMobile }: NetWorthFlowDiagramProps) {
+  const { t } = useTranslation();
+  const { isBalanceHidden } = useBalancePrivacy();
+  const [hoveredCategory, setHoveredCategory] = useState<string | null>(null);
+  const uid = `nwf-${useId().replace(/:/g, "")}`;
+
+  const categoryColors = useMemo(
+    () =>
+      graph.nodes
+        .filter((node) => node.kind === "category")
+        .map((node) => ({ key: node.selected.key, color: node.color })),
+    [graph.nodes],
+  );
+
+  const ctx: ShapeContext = {
+    currency,
+    isMobile,
+    hoveredCategory,
+    onHover: setHoveredCategory,
+    onSelect,
+    isBalanceHidden,
+    uid,
+  };
+
+  return (
+    <div className="h-[300px] w-full overflow-x-auto md:h-[340px]">
+      <ResponsiveContainer width="100%" height="100%" minWidth={320}>
+        <Sankey
+          data={{ nodes: graph.nodes, links: graph.links }}
+          nodeWidth={NODE_WIDTH}
+          nodePadding={isMobile ? 8 : 12}
+          linkCurvature={0.55}
+          iterations={32}
+          margin={{ top: 8, right: 8, bottom: 8, left: 8 }}
+          node={(props: RechartsNodeProps) => <FlowNodeShape {...props} ctx={ctx} t={t} />}
+          link={(props: RechartsLinkProps) => <FlowLinkShape {...props} ctx={ctx} />}
+        >
+          <defs>
+            {categoryColors.map(({ key, color }) => (
+              <pattern
+                key={`stripe-${key}`}
+                id={`${uid}-stripe-${key}`}
+                width={7}
+                height={7}
+                patternTransform="rotate(45)"
+                patternUnits="userSpaceOnUse"
+              >
+                <rect width={7} height={7} fill={color} />
+                <rect width={3.5} height={7} fill="var(--bar-stripe)" />
+              </pattern>
+            ))}
+            {categoryColors.map(({ key, color }) => (
+              <linearGradient key={`grad-${key}`} id={`${uid}-converge-${key}`} x1="0" y1="0" x2="1" y2="0">
+                <stop offset="0%" stopColor={color} />
+                <stop offset="100%" stopColor={THEME_COLOR} />
+              </linearGradient>
+            ))}
+          </defs>
+        </Sankey>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/net-worth/components/net-worth-flow-diagram.tsx
+++ b/apps/frontend/src/pages/net-worth/components/net-worth-flow-diagram.tsx
@@ -23,6 +23,19 @@ const LABEL_GAP = 6;
 const ROW_PITCH_DESKTOP = 28;
 const ROW_PITCH_MOBILE = 14;
 
+/**
+ * A leaf label is a fixed-height box anchored at its node's TOP edge (see the
+ * `foreignObject` in `FlowNodeShape`), so the bottom-most node's label extends
+ * this far BELOW the node itself. The chart's bottom margin must reserve at
+ * least this much or that last label is clipped by the SVG viewport — which is
+ * exactly what happened: every row rendered correctly except the last, whose
+ * text was sliced in half.
+ *
+ * Kept as its own constant, and used for both the margin and the height
+ * budget, so the two cannot drift apart.
+ */
+const LABEL_BOX_HEIGHT = 24;
+
 interface NetWorthFlowDiagramProps {
   graph: NetWorthFlowGraph;
   currency: string;
@@ -137,7 +150,7 @@ function FlowNodeShape({
         <title>{`${node.name} — ${amountText}`}</title>
       </rect>
       {showLabel && (
-        <foreignObject x={labelX} y={y} width={labelWidth} height={Math.max(rectHeight, 24)} style={{ overflow: "visible" }}>
+        <foreignObject x={labelX} y={y} width={labelWidth} height={Math.max(rectHeight, LABEL_BOX_HEIGHT)} style={{ overflow: "visible" }}>
           {/* No xmlns attribute needed: the app always parses this as HTML5,
               which puts foreignObject's children in the HTML namespace already. */}
           <div
@@ -255,9 +268,11 @@ export function NetWorthFlowDiagram({ graph, currency, onSelect, isMobile }: Net
   // room on top of the pitch floor so values still read as proportional
   // ribbon thickness, not just as evenly-spaced hairlines.
   const valueHeightBudget = isMobile ? 60 : 140;
+  // + LABEL_BOX_HEIGHT so the bottom margin below can reserve room for the last
+  // node's label without eating into the plotted area.
   const diagramHeight = Math.min(
-    680,
-    Math.max(isMobile ? 260 : 300, leadingCount * rowPitch + valueHeightBudget),
+    680 + LABEL_BOX_HEIGHT,
+    Math.max(isMobile ? 260 : 300, leadingCount * rowPitch + valueHeightBudget) + LABEL_BOX_HEIGHT,
   );
 
   const categoryColors = useMemo(
@@ -287,7 +302,9 @@ export function NetWorthFlowDiagram({ graph, currency, onSelect, isMobile }: Net
           nodePadding={rowPitch}
           linkCurvature={0.55}
           iterations={32}
-          margin={{ top: 8, right: 8, bottom: 8, left: 8 }}
+          // bottom reserves a full label box: labels hang BELOW their node's top
+          // edge, so the last row is clipped without it.
+          margin={{ top: 8, right: 8, bottom: LABEL_BOX_HEIGHT, left: 8 }}
           node={(props: RechartsNodeProps) => <FlowNodeShape {...props} ctx={ctx} t={t} />}
           link={(props: RechartsLinkProps) => <FlowLinkShape {...props} ctx={ctx} />}
         >

--- a/apps/frontend/src/pages/net-worth/components/net-worth-flow-utils.test.ts
+++ b/apps/frontend/src/pages/net-worth/components/net-worth-flow-utils.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import type { ParsedNetWorth } from "./utils";
-import { buildNetWorthFlowGraph, MAX_VISIBLE_LEAVES, type FlowLeafNode } from "./net-worth-flow-utils";
+import type { BreakdownEntry, ParsedNetWorth } from "./utils";
+import {
+  buildNetWorthFlowGraph,
+  MAX_VISIBLE_LEAVES,
+  shortenLeafName,
+  type FlowLeafNode,
+} from "./net-worth-flow-utils";
 
 const labels = {
   assets: "Assets",
@@ -192,5 +197,108 @@ describe("buildNetWorthFlowGraph", () => {
 
     const graph = buildNetWorthFlowGraph(data, labels)!;
     expect(graph.nodes.some((n) => n.name === "Car Collection")).toBe(false);
+  });
+
+  describe("investmentAccounts", () => {
+    function investmentData(total: number): ParsedNetWorth {
+      return netWorth({
+        netWorth: total,
+        assets: {
+          total,
+          // The backend never populates Investments' children — this is the
+          // real shape net-worth-content.tsx hands the graph builder.
+          breakdown: [{ category: "investments", name: "Investments", value: total }],
+        },
+      });
+    }
+
+    it("fans Investments in by account when provided, sorted by value descending", () => {
+      const accounts: BreakdownEntry[] = [
+        { category: "investments", name: "Roth IRA", value: 200, assetId: "acc-1" },
+        { category: "investments", name: "Personal Investments – 119", value: 500, assetId: "acc-2" },
+        { category: "investments", name: "Parametrics", value: 300, assetId: "acc-3" },
+      ];
+      const graph = buildNetWorthFlowGraph(investmentData(1000), labels, accounts)!;
+      const leaves = graph.nodes.filter((n) => n.kind === "leaf") as FlowLeafNode[];
+
+      expect(leaves.map((n) => n.name)).toEqual(["Personal Investments – 119", "Parametrics", "Roth IRA"]);
+    });
+
+    it("sums investment account leaves exactly to the Investments category total", () => {
+      const accounts: BreakdownEntry[] = [
+        { category: "investments", name: "Roth IRA", value: 200.11, assetId: "acc-1" },
+        { category: "investments", name: "Brokerage", value: 500.22, assetId: "acc-2" },
+      ];
+      const graph = buildNetWorthFlowGraph(investmentData(700.33), labels, accounts)!;
+      const leaves = graph.nodes.filter((n) => n.kind === "leaf" || n.kind === "bucket") as FlowLeafNode[];
+
+      const leafTotal = leaves.reduce((sum, n) => sum + n.value, 0);
+      expect(leafTotal).toBeCloseTo(700.33, 6);
+    });
+
+    it("adds a balancing leaf when accounts undercount the category total", () => {
+      const accounts: BreakdownEntry[] = [
+        { category: "investments", name: "Roth IRA", value: 200, assetId: "acc-1" },
+      ];
+      const graph = buildNetWorthFlowGraph(investmentData(1000), labels, accounts)!;
+      const leaves = graph.nodes.filter((n) => n.kind === "leaf") as FlowLeafNode[];
+
+      const balancing = leaves.find((n) => n.name === labels.unattributed);
+      expect(balancing).toBeDefined();
+      expect(balancing!.value).toBeCloseTo(800, 6);
+      const leafTotal = leaves.reduce((sum, n) => sum + n.value, 0);
+      expect(leafTotal).toBeCloseTo(1000, 6);
+    });
+
+    it("buckets accounts beyond MAX_VISIBLE_LEAVES the same way other categories do", () => {
+      const accounts: BreakdownEntry[] = Array.from({ length: 20 }, (_, i) => ({
+        category: "investments",
+        name: `Account ${i}`,
+        value: (i + 1) * 100,
+        assetId: `acc-${i}`,
+      }));
+      const total = accounts.reduce((sum, a) => sum + a.value, 0);
+      const graph = buildNetWorthFlowGraph(investmentData(total), labels, accounts)!;
+      const leaves = graph.nodes.filter((n) => n.kind === "leaf" || n.kind === "bucket") as FlowLeafNode[];
+
+      expect(leaves.filter((n) => n.kind === "leaf")).toHaveLength(MAX_VISIBLE_LEAVES - 1);
+      expect(leaves.some((n) => n.kind === "bucket")).toBe(true);
+      const leafTotal = leaves.reduce((sum, n) => sum + n.value, 0);
+      expect(leafTotal).toBeCloseTo(total, 6);
+    });
+
+    it("falls back to the flat Investments node when accounts overcount the category total", () => {
+      const accounts: BreakdownEntry[] = [
+        { category: "investments", name: "Roth IRA", value: 900, assetId: "acc-1" },
+        { category: "investments", name: "Brokerage", value: 500, assetId: "acc-2" },
+      ];
+      // Accounts sum to 1400, but the net-worth snapshot says 1000 — never fudge.
+      const graph = buildNetWorthFlowGraph(investmentData(1000), labels, accounts)!;
+      expect(graph.nodes.some((n) => n.kind === "leaf" || n.kind === "bucket")).toBe(false);
+      expect(graph.nodes.some((n) => n.kind === "category" && n.name === "Investments")).toBe(true);
+    });
+
+    it("falls back to the flat Investments node when no account data is supplied", () => {
+      const graph = buildNetWorthFlowGraph(investmentData(1000), labels)!;
+      expect(graph.nodes.some((n) => n.kind === "leaf" || n.kind === "bucket")).toBe(false);
+    });
+  });
+});
+
+describe("shortenLeafName", () => {
+  it("drops a trailing parenthetical suffix", () => {
+    expect(shortenLeafName("FundersClub ($236K Basis)")).toBe("FundersClub");
+  });
+
+  it("drops a trailing parenthetical and a trailing date suffix together", () => {
+    expect(shortenLeafName("FundersClub ($236K Basis) - 12/31/2024")).toBe("FundersClub");
+  });
+
+  it("leaves an ordinary name untouched", () => {
+    expect(shortenLeafName("Roth IRA")).toBe("Roth IRA");
+  });
+
+  it("never returns an empty string", () => {
+    expect(shortenLeafName("(100%)")).toBe("(100%)");
   });
 });

--- a/apps/frontend/src/pages/net-worth/components/net-worth-flow-utils.test.ts
+++ b/apps/frontend/src/pages/net-worth/components/net-worth-flow-utils.test.ts
@@ -96,7 +96,9 @@ describe("buildNetWorthFlowGraph", () => {
     });
 
     const graph = buildNetWorthFlowGraph(data, labels)!;
-    const leaves = graph.nodes.filter((n) => n.kind === "leaf" || n.kind === "bucket") as FlowLeafNode[];
+    const leaves = graph.nodes.filter(
+      (n) => n.kind === "leaf" || n.kind === "bucket",
+    ) as FlowLeafNode[];
     const bucket = leaves.find((n) => n.kind === "bucket")!;
 
     // MAX_VISIBLE_LEAVES - 1 individual leaves shown, the rest folded into one bucket.
@@ -104,7 +106,9 @@ describe("buildNetWorthFlowGraph", () => {
     expect(bucket.bucketedCount).toBe(8 - (MAX_VISIBLE_LEAVES - 1));
 
     // Bucket contains the smallest holdings and sums to exactly their total.
-    const smallest = children.slice(0, 8 - (MAX_VISIBLE_LEAVES - 1)).reduce((s, c) => s + c.value, 0);
+    const smallest = children
+      .slice(0, 8 - (MAX_VISIBLE_LEAVES - 1))
+      .reduce((s, c) => s + c.value, 0);
     expect(bucket.value).toBe(smallest);
 
     // Every leaf/bucket value sums to the category total — nothing dropped.
@@ -120,7 +124,10 @@ describe("buildNetWorthFlowGraph", () => {
     ];
     const data = netWorth({
       netWorth: 3,
-      assets: { total: 3, breakdown: [{ category: "properties", name: "Real Estate", value: 3, children }] },
+      assets: {
+        total: 3,
+        breakdown: [{ category: "properties", name: "Real Estate", value: 3, children }],
+      },
     });
 
     const graph = buildNetWorthFlowGraph(data, labels)!;
@@ -155,7 +162,10 @@ describe("buildNetWorthFlowGraph", () => {
     const data = netWorth({
       netWorth: 700,
       assets: { total: 1000, breakdown: [{ category: "cash", name: "Cash", value: 1000 }] },
-      liabilities: { total: 300, breakdown: [{ category: "liabilities", name: "Loan", value: 300 }] },
+      liabilities: {
+        total: 300,
+        breakdown: [{ category: "liabilities", name: "Loan", value: 300 }],
+      },
     });
 
     const graph = buildNetWorthFlowGraph(data, labels)!;
@@ -175,7 +185,10 @@ describe("buildNetWorthFlowGraph", () => {
     const data = netWorth({
       netWorth: -200,
       assets: { total: 100, breakdown: [{ category: "cash", name: "Cash", value: 100 }] },
-      liabilities: { total: 300, breakdown: [{ category: "liabilities", name: "Loan", value: 300 }] },
+      liabilities: {
+        total: 300,
+        breakdown: [{ category: "liabilities", name: "Loan", value: 300 }],
+      },
     });
 
     const graph = buildNetWorthFlowGraph(data, labels)!;
@@ -215,13 +228,22 @@ describe("buildNetWorthFlowGraph", () => {
     it("fans Investments in by account when provided, sorted by value descending", () => {
       const accounts: BreakdownEntry[] = [
         { category: "investments", name: "Roth IRA", value: 200, assetId: "acc-1" },
-        { category: "investments", name: "Personal Investments – 119", value: 500, assetId: "acc-2" },
+        {
+          category: "investments",
+          name: "Personal Investments – 119",
+          value: 500,
+          assetId: "acc-2",
+        },
         { category: "investments", name: "Parametrics", value: 300, assetId: "acc-3" },
       ];
       const graph = buildNetWorthFlowGraph(investmentData(1000), labels, accounts)!;
       const leaves = graph.nodes.filter((n) => n.kind === "leaf") as FlowLeafNode[];
 
-      expect(leaves.map((n) => n.name)).toEqual(["Personal Investments – 119", "Parametrics", "Roth IRA"]);
+      expect(leaves.map((n) => n.name)).toEqual([
+        "Personal Investments – 119",
+        "Parametrics",
+        "Roth IRA",
+      ]);
     });
 
     it("sums investment account leaves exactly to the Investments category total", () => {
@@ -230,7 +252,9 @@ describe("buildNetWorthFlowGraph", () => {
         { category: "investments", name: "Brokerage", value: 500.22, assetId: "acc-2" },
       ];
       const graph = buildNetWorthFlowGraph(investmentData(700.33), labels, accounts)!;
-      const leaves = graph.nodes.filter((n) => n.kind === "leaf" || n.kind === "bucket") as FlowLeafNode[];
+      const leaves = graph.nodes.filter(
+        (n) => n.kind === "leaf" || n.kind === "bucket",
+      ) as FlowLeafNode[];
 
       const leafTotal = leaves.reduce((sum, n) => sum + n.value, 0);
       expect(leafTotal).toBeCloseTo(700.33, 6);
@@ -259,7 +283,9 @@ describe("buildNetWorthFlowGraph", () => {
       }));
       const total = accounts.reduce((sum, a) => sum + a.value, 0);
       const graph = buildNetWorthFlowGraph(investmentData(total), labels, accounts)!;
-      const leaves = graph.nodes.filter((n) => n.kind === "leaf" || n.kind === "bucket") as FlowLeafNode[];
+      const leaves = graph.nodes.filter(
+        (n) => n.kind === "leaf" || n.kind === "bucket",
+      ) as FlowLeafNode[];
 
       expect(leaves.filter((n) => n.kind === "leaf")).toHaveLength(MAX_VISIBLE_LEAVES - 1);
       expect(leaves.some((n) => n.kind === "bucket")).toBe(true);

--- a/apps/frontend/src/pages/net-worth/components/net-worth-flow-utils.test.ts
+++ b/apps/frontend/src/pages/net-worth/components/net-worth-flow-utils.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+
+import type { ParsedNetWorth } from "./utils";
+import { buildNetWorthFlowGraph, MAX_VISIBLE_LEAVES, type FlowLeafNode } from "./net-worth-flow-utils";
+
+const labels = {
+  assets: "Assets",
+  netWorth: "Net Worth",
+  debts: "Debts",
+  otherHoldings: (count: number) => `${count} smaller holdings`,
+  unattributed: "Other",
+};
+
+function netWorth(overrides: Partial<ParsedNetWorth>): ParsedNetWorth {
+  return {
+    netWorth: 0,
+    assets: { total: 0, breakdown: [] },
+    liabilities: { total: 0, breakdown: [] },
+    ...overrides,
+  };
+}
+
+describe("buildNetWorthFlowGraph", () => {
+  it("returns null when there are no assets", () => {
+    expect(buildNetWorthFlowGraph(netWorth({}), labels)).toBeNull();
+  });
+
+  it("links leaves through their category into Assets and Net Worth", () => {
+    const data = netWorth({
+      netWorth: 900,
+      assets: {
+        total: 900,
+        breakdown: [
+          {
+            category: "properties",
+            name: "Real Estate",
+            value: 900,
+            children: [
+              { category: "properties", name: "House A", value: 500 },
+              { category: "properties", name: "House B", value: 400 },
+            ],
+          },
+        ],
+      },
+    });
+
+    const graph = buildNetWorthFlowGraph(data, labels);
+    expect(graph).not.toBeNull();
+    const { nodes, links } = graph!;
+
+    const houseA = nodes.find((n) => n.name === "House A")!;
+    const category = nodes.find((n) => n.kind === "category")!;
+    const assets = nodes.find((n) => n.kind === "assets")!;
+    const netWorthNode = nodes.find((n) => n.kind === "net-worth")!;
+
+    const idx = (n: (typeof nodes)[number]) => nodes.indexOf(n);
+    expect(links).toContainEqual(
+      expect.objectContaining({ source: idx(houseA), target: idx(category), value: 500 }),
+    );
+    expect(links).toContainEqual(
+      expect.objectContaining({ source: idx(category), target: idx(assets), value: 900 }),
+    );
+    expect(links).toContainEqual(
+      expect.objectContaining({ source: idx(assets), target: idx(netWorthNode), value: 900 }),
+    );
+  });
+
+  it("skips the leaf layer for a category with no itemized children", () => {
+    const data = netWorth({
+      netWorth: 100,
+      assets: { total: 100, breakdown: [{ category: "cash", name: "Cash", value: 100 }] },
+    });
+
+    const graph = buildNetWorthFlowGraph(data, labels)!;
+    expect(graph.nodes.some((n) => n.kind === "leaf" || n.kind === "bucket")).toBe(false);
+    expect(graph.nodes.some((n) => n.kind === "category" && n.name === "Cash")).toBe(true);
+  });
+
+  it("buckets holdings beyond MAX_VISIBLE_LEAVES and the bucket sums exactly", () => {
+    const children = Array.from({ length: 8 }, (_, i) => ({
+      category: "investments",
+      name: `Account ${i}`,
+      value: (i + 1) * 10, // 10..80, total 360
+    }));
+    const data = netWorth({
+      netWorth: 360,
+      assets: {
+        total: 360,
+        breakdown: [{ category: "investments", name: "Investments", value: 360, children }],
+      },
+    });
+
+    const graph = buildNetWorthFlowGraph(data, labels)!;
+    const leaves = graph.nodes.filter((n) => n.kind === "leaf" || n.kind === "bucket") as FlowLeafNode[];
+    const bucket = leaves.find((n) => n.kind === "bucket")!;
+
+    // MAX_VISIBLE_LEAVES - 1 individual leaves shown, the rest folded into one bucket.
+    expect(leaves.filter((n) => n.kind === "leaf")).toHaveLength(MAX_VISIBLE_LEAVES - 1);
+    expect(bucket.bucketedCount).toBe(8 - (MAX_VISIBLE_LEAVES - 1));
+
+    // Bucket contains the smallest holdings and sums to exactly their total.
+    const smallest = children.slice(0, 8 - (MAX_VISIBLE_LEAVES - 1)).reduce((s, c) => s + c.value, 0);
+    expect(bucket.value).toBe(smallest);
+
+    // Every leaf/bucket value sums to the category total — nothing dropped.
+    const leafTotal = leaves.reduce((sum, n) => sum + n.value, 0);
+    expect(leafTotal).toBeCloseTo(360, 6);
+  });
+
+  it("does not bucket when a category has MAX_VISIBLE_LEAVES or fewer holdings", () => {
+    const children = [
+      { category: "properties", name: "A", value: 1 },
+      { category: "properties", name: "B", value: 1 },
+      { category: "properties", name: "C", value: 1 },
+    ];
+    const data = netWorth({
+      netWorth: 3,
+      assets: { total: 3, breakdown: [{ category: "properties", name: "Real Estate", value: 3, children }] },
+    });
+
+    const graph = buildNetWorthFlowGraph(data, labels)!;
+    const leaves = graph.nodes.filter((n) => n.kind === "leaf" || n.kind === "bucket");
+    expect(leaves).toHaveLength(3);
+    expect(leaves.every((n) => n.kind === "leaf")).toBe(true);
+  });
+
+  it("surfaces an unattributed remainder rather than dropping it", () => {
+    const data = netWorth({
+      netWorth: 100,
+      assets: {
+        total: 100,
+        breakdown: [
+          {
+            category: "otherAssets",
+            name: "Other Assets",
+            value: 100,
+            children: [{ category: "otherAssets", name: "Item", value: 70 }],
+          },
+        ],
+      },
+    });
+
+    const graph = buildNetWorthFlowGraph(data, labels)!;
+    const unattributed = graph.nodes.find((n) => n.name === "Other") as FlowLeafNode | undefined;
+    expect(unattributed).toBeDefined();
+    expect(unattributed!.value).toBeCloseTo(30, 6);
+  });
+
+  it("adds a Debts branch off Assets, sized to the liabilities total", () => {
+    const data = netWorth({
+      netWorth: 700,
+      assets: { total: 1000, breakdown: [{ category: "cash", name: "Cash", value: 1000 }] },
+      liabilities: { total: 300, breakdown: [{ category: "liabilities", name: "Loan", value: 300 }] },
+    });
+
+    const graph = buildNetWorthFlowGraph(data, labels)!;
+    const assets = graph.nodes.find((n) => n.kind === "assets")!;
+    const debts = graph.nodes.find((n) => n.kind === "debts")!;
+    expect(debts.value).toBe(300);
+    expect(graph.links).toContainEqual(
+      expect.objectContaining({
+        source: graph.nodes.indexOf(assets),
+        target: graph.nodes.indexOf(debts),
+        value: 300,
+      }),
+    );
+  });
+
+  it("omits the Net Worth branch rather than drawing a negative flow", () => {
+    const data = netWorth({
+      netWorth: -200,
+      assets: { total: 100, breakdown: [{ category: "cash", name: "Cash", value: 100 }] },
+      liabilities: { total: 300, breakdown: [{ category: "liabilities", name: "Loan", value: 300 }] },
+    });
+
+    const graph = buildNetWorthFlowGraph(data, labels)!;
+    expect(graph.nodes.some((n) => n.kind === "net-worth")).toBe(false);
+    expect(graph.nodes.some((n) => n.kind === "debts")).toBe(true);
+  });
+
+  it("ignores zero-value categories", () => {
+    const data = netWorth({
+      netWorth: 100,
+      assets: {
+        total: 100,
+        breakdown: [
+          { category: "cash", name: "Cash", value: 100 },
+          { category: "vehicles", name: "Car Collection", value: 0 },
+        ],
+      },
+    });
+
+    const graph = buildNetWorthFlowGraph(data, labels)!;
+    expect(graph.nodes.some((n) => n.name === "Car Collection")).toBe(false);
+  });
+});

--- a/apps/frontend/src/pages/net-worth/components/net-worth-flow-utils.ts
+++ b/apps/frontend/src/pages/net-worth/components/net-worth-flow-utils.ts
@@ -1,4 +1,10 @@
-import { CATEGORY_CSS_COLORS, THEME_COLOR, type BreakdownEntry, type ParsedNetWorth, type SelectedCategory } from "./utils";
+import {
+  CATEGORY_CSS_COLORS,
+  THEME_COLOR,
+  type BreakdownEntry,
+  type ParsedNetWorth,
+  type SelectedCategory,
+} from "./utils";
 
 /** Individual holding, or the aggregate of the smaller holdings folded into one node. */
 export interface FlowLeafNode {
@@ -133,7 +139,11 @@ export function buildNetWorthFlowGraph(
     const selected = categorySelection(category);
 
     let rawChildren = category.children ?? [];
-    if (category.category === "investments" && investmentAccounts && investmentAccounts.length > 0) {
+    if (
+      category.category === "investments" &&
+      investmentAccounts &&
+      investmentAccounts.length > 0
+    ) {
       const candidateTotal = investmentAccounts.reduce((sum, child) => sum + child.value, 0);
       // Per-account values can disagree with the category total (different
       // valuation source/timing than the net-worth snapshot). An undercount
@@ -150,7 +160,8 @@ export function buildNetWorthFlowGraph(
     const leafIndices: number[] = [];
     if (children.length > 0) {
       const sorted = [...children].sort((a, b) => b.value - a.value);
-      const visibleCount = children.length > MAX_VISIBLE_LEAVES ? MAX_VISIBLE_LEAVES - 1 : children.length;
+      const visibleCount =
+        children.length > MAX_VISIBLE_LEAVES ? MAX_VISIBLE_LEAVES - 1 : children.length;
       const visible = sorted.slice(0, visibleCount);
       const bucketed = sorted.slice(visibleCount);
 
@@ -221,7 +232,12 @@ export function buildNetWorthFlowGraph(
       });
     }
 
-    categoryLinks.push({ index: categoryIndex, value: category.value, color, categoryKey: category.category });
+    categoryLinks.push({
+      index: categoryIndex,
+      value: category.value,
+      color,
+      categoryKey: category.category,
+    });
   }
 
   const assetsIndex = push({
@@ -253,7 +269,12 @@ export function buildNetWorthFlowGraph(
       value: data.netWorth,
       color: THEME_COLOR,
     });
-    links.push({ source: assetsIndex, target: netWorthIndex, value: data.netWorth, color: THEME_COLOR });
+    links.push({
+      source: assetsIndex,
+      target: netWorthIndex,
+      value: data.netWorth,
+      color: THEME_COLOR,
+    });
   }
 
   if (data.liabilities.total > EPSILON) {

--- a/apps/frontend/src/pages/net-worth/components/net-worth-flow-utils.ts
+++ b/apps/frontend/src/pages/net-worth/components/net-worth-flow-utils.ts
@@ -1,0 +1,242 @@
+import { CATEGORY_CSS_COLORS, THEME_COLOR, type BreakdownEntry, type ParsedNetWorth, type SelectedCategory } from "./utils";
+
+/** Individual holding, or the aggregate of the smaller holdings folded into one node. */
+export interface FlowLeafNode {
+  kind: "leaf" | "bucket";
+  id: string;
+  name: string;
+  value: number;
+  color: string;
+  /** Number of holdings folded into a bucket node (undefined for a plain leaf). */
+  bucketedCount?: number;
+  /** Opens the same drawer as clicking the parent category. */
+  selected: SelectedCategory;
+}
+
+/** A breakdown category (Investments, Real Estate, …). */
+export interface FlowCategoryNode {
+  kind: "category";
+  id: string;
+  name: string;
+  value: number;
+  color: string;
+  selected: SelectedCategory;
+}
+
+/** Assets / Net Worth / Debts — the non-interactive totals on the right of the diagram. */
+export interface FlowTotalNode {
+  kind: "assets" | "net-worth" | "debts";
+  id: string;
+  name: string;
+  value: number;
+  color: string;
+}
+
+export type FlowNode = FlowLeafNode | FlowCategoryNode | FlowTotalNode;
+
+export interface FlowLink {
+  source: number;
+  target: number;
+  value: number;
+  color: string;
+  /** Category key shared with its leaf/category nodes, for hover emphasis. Unset for the Assets -> Net Worth / Debts links. */
+  categoryKey?: string;
+}
+
+export interface NetWorthFlowGraph {
+  nodes: FlowNode[];
+  links: FlowLink[];
+}
+
+/**
+ * Cap on individually-drawn holdings per category before the smallest ones fold
+ * into a single "N others" bucket node. Keeps the diagram legible without ever
+ * silently dropping a holding — the bucket always carries the exact remainder.
+ */
+export const MAX_VISIBLE_LEAVES = 4;
+
+/**
+ * `usePersistentState` key for whether the Sankey (the expanded state of
+ * `CompositionBar`) is open. Defaults to closed — the composition bar is the
+ * current/default view; expanding into the flow diagram is opt-in.
+ */
+export const FLOW_EXPANDED_STORAGE_KEY = "net-worth:flow-expanded";
+
+const EPSILON = 0.005;
+
+export interface FlowLabels {
+  assets: string;
+  netWorth: string;
+  debts: string;
+  /** Pluralized label for a bucket node, e.g. "5 smaller holdings". */
+  otherHoldings: (count: number) => string;
+  /** Label for a remainder not itemized in the category's children. */
+  unattributed: string;
+}
+
+function categorySelection(category: BreakdownEntry): SelectedCategory {
+  return {
+    key: category.category,
+    name: category.name,
+    value: category.value,
+    isLiability: false,
+    isInvestment: category.category === "investments",
+    children: category.children ?? [],
+  };
+}
+
+/**
+ * Build the Sankey graph for the Net Worth Flow card from the same
+ * `ParsedNetWorth` the breakdown table renders. Pure and side-effect free so
+ * it can be unit tested without React or recharts.
+ *
+ * Layout: leaf holdings -> their category -> Assets -> Net Worth, with Assets
+ * also branching to Debts when there are liabilities. Categories with no
+ * itemized children (e.g. Cash) skip the leaf layer and link straight to
+ * Assets. Returns null when there is nothing to draw.
+ */
+export function buildNetWorthFlowGraph(
+  data: ParsedNetWorth,
+  labels: FlowLabels,
+): NetWorthFlowGraph | null {
+  const categories = data.assets.breakdown.filter((category) => category.value > EPSILON);
+  if (categories.length === 0) return null;
+
+  const nodes: FlowNode[] = [];
+  const links: FlowLink[] = [];
+  const push = (node: FlowNode) => nodes.push(node) - 1;
+
+  const categoryLinks: { index: number; value: number; color: string; categoryKey: string }[] = [];
+
+  for (const category of categories) {
+    const color = CATEGORY_CSS_COLORS[category.category] ?? "var(--muted-foreground)";
+    const selected = categorySelection(category);
+    const children = (category.children ?? []).filter((child) => child.value > EPSILON);
+
+    const leafIndices: number[] = [];
+    if (children.length > 0) {
+      const sorted = [...children].sort((a, b) => b.value - a.value);
+      const visibleCount = children.length > MAX_VISIBLE_LEAVES ? MAX_VISIBLE_LEAVES - 1 : children.length;
+      const visible = sorted.slice(0, visibleCount);
+      const bucketed = sorted.slice(visibleCount);
+
+      for (const child of visible) {
+        leafIndices.push(
+          push({
+            kind: "leaf",
+            id: `${category.category}:${child.assetId ?? child.name}`,
+            name: child.name,
+            value: child.value,
+            color,
+            selected,
+          }),
+        );
+      }
+
+      if (bucketed.length > 0) {
+        const bucketValue = bucketed.reduce((sum, child) => sum + child.value, 0);
+        leafIndices.push(
+          push({
+            kind: "bucket",
+            id: `${category.category}:bucket`,
+            name: labels.otherHoldings(bucketed.length),
+            value: bucketValue,
+            color,
+            bucketedCount: bucketed.length,
+            selected,
+          }),
+        );
+      }
+
+      // Children rarely sum to exactly the category total (e.g. a rounding
+      // remainder). Never let the diagram silently drop that difference —
+      // surface it as an explicit unattributed leaf.
+      const childrenTotal = children.reduce((sum, child) => sum + child.value, 0);
+      const remainder = category.value - childrenTotal;
+      if (Math.abs(remainder) > EPSILON) {
+        leafIndices.push(
+          push({
+            kind: "leaf",
+            id: `${category.category}:unattributed`,
+            name: labels.unattributed,
+            value: remainder,
+            color,
+            selected,
+          }),
+        );
+      }
+    }
+
+    const categoryIndex = push({
+      kind: "category",
+      id: category.category,
+      name: category.name,
+      value: category.value,
+      color,
+      selected,
+    });
+
+    for (const leafIndex of leafIndices) {
+      const leaf = nodes[leafIndex] as FlowLeafNode;
+      links.push({
+        source: leafIndex,
+        target: categoryIndex,
+        value: leaf.value,
+        color,
+        categoryKey: category.category,
+      });
+    }
+
+    categoryLinks.push({ index: categoryIndex, value: category.value, color, categoryKey: category.category });
+  }
+
+  const assetsIndex = push({
+    kind: "assets",
+    id: "assets",
+    name: labels.assets,
+    value: data.assets.total,
+    color: THEME_COLOR,
+  });
+  for (const link of categoryLinks) {
+    links.push({
+      source: link.index,
+      target: assetsIndex,
+      value: link.value,
+      color: link.color,
+      categoryKey: link.categoryKey,
+    });
+  }
+
+  // A Sankey flow can't carry a negative value, so a negative net worth (debts
+  // exceeding assets) has no honest "Assets -> Net Worth" ribbon to draw —
+  // omit that branch rather than fake one. The card's own total still shows
+  // the true (negative) figure in text.
+  if (data.netWorth > EPSILON) {
+    const netWorthIndex = push({
+      kind: "net-worth",
+      id: "net-worth",
+      name: labels.netWorth,
+      value: data.netWorth,
+      color: THEME_COLOR,
+    });
+    links.push({ source: assetsIndex, target: netWorthIndex, value: data.netWorth, color: THEME_COLOR });
+  }
+
+  if (data.liabilities.total > EPSILON) {
+    const debtsIndex = push({
+      kind: "debts",
+      id: "debts",
+      name: labels.debts,
+      value: data.liabilities.total,
+      color: "var(--destructive)",
+    });
+    links.push({
+      source: assetsIndex,
+      target: debtsIndex,
+      value: data.liabilities.total,
+      color: "var(--destructive)",
+    });
+  }
+
+  return { nodes, links };
+}

--- a/apps/frontend/src/pages/net-worth/components/net-worth-flow-utils.ts
+++ b/apps/frontend/src/pages/net-worth/components/net-worth-flow-utils.ts
@@ -86,6 +86,18 @@ function categorySelection(category: BreakdownEntry): SelectedCategory {
 }
 
 /**
+ * Strip a trailing parenthetical or date/detail suffix from a leaf's display
+ * name — "FundersClub ($236K Basis) - 12/31/2024" -> "FundersClub". Only
+ * affects what's rendered on the node label; callers keep the untouched name
+ * for the tooltip/aria-label so no information is actually lost.
+ */
+export function shortenLeafName(name: string): string {
+  const withoutParens = name.replace(/\s*\([^()]*\)\s*/g, " ").trim();
+  const withoutTrailingDetail = withoutParens.replace(/\s*[-–]\s*[\d/.:]+\s*$/, "").trim();
+  return withoutTrailingDetail || name;
+}
+
+/**
  * Build the Sankey graph for the Net Worth Flow card from the same
  * `ParsedNetWorth` the breakdown table renders. Pure and side-effect free so
  * it can be unit tested without React or recharts.
@@ -94,10 +106,18 @@ function categorySelection(category: BreakdownEntry): SelectedCategory {
  * also branching to Debts when there are liabilities. Categories with no
  * itemized children (e.g. Cash) skip the leaf layer and link straight to
  * Assets. Returns null when there is nothing to draw.
+ *
+ * @param investmentAccounts Per-account leaves for the Investments category
+ *   (the backend deliberately omits per-holding children there — see
+ *   `net_worth_service.rs`). Sourced client-side from current account
+ *   valuations. Only used when it doesn't overcount the Investments category
+ *   total (see the reconciliation note below); omit/undefined falls back to
+ *   today's flat Investments node.
  */
 export function buildNetWorthFlowGraph(
   data: ParsedNetWorth,
   labels: FlowLabels,
+  investmentAccounts?: BreakdownEntry[],
 ): NetWorthFlowGraph | null {
   const categories = data.assets.breakdown.filter((category) => category.value > EPSILON);
   if (categories.length === 0) return null;
@@ -111,7 +131,21 @@ export function buildNetWorthFlowGraph(
   for (const category of categories) {
     const color = CATEGORY_CSS_COLORS[category.category] ?? "var(--muted-foreground)";
     const selected = categorySelection(category);
-    const children = (category.children ?? []).filter((child) => child.value > EPSILON);
+
+    let rawChildren = category.children ?? [];
+    if (category.category === "investments" && investmentAccounts && investmentAccounts.length > 0) {
+      const candidateTotal = investmentAccounts.reduce((sum, child) => sum + child.value, 0);
+      // Per-account values can disagree with the category total (different
+      // valuation source/timing than the net-worth snapshot). An undercount
+      // is reconciled below with an explicit balancing leaf; an overcount
+      // can't be reconciled without fudging one of the two numbers, so fall
+      // back to the flat category node rather than show accounts that don't
+      // sum to the total directly beneath them in the breakdown table.
+      if (candidateTotal - category.value <= EPSILON) {
+        rawChildren = investmentAccounts;
+      }
+    }
+    const children = rawChildren.filter((child) => child.value > EPSILON);
 
     const leafIndices: number[] = [];
     if (children.length > 0) {

--- a/apps/frontend/src/pages/net-worth/components/utils.ts
+++ b/apps/frontend/src/pages/net-worth/components/utils.ts
@@ -26,17 +26,18 @@ export function toneFill(value: number): string {
 export const CARD_LABEL = "text-muted-foreground/70 text-xs font-semibold uppercase tracking-wide";
 
 // Muted, semantic category palette (tuned for the warm/cream theme). Used for
-// the composition bar, breakdown row dots, and the detail-sheet icons so they
-// stay consistent. Liabilities keep the semantic red.
-// NOTE: tuned for light mode — dark-mode variants would need theme-aware tokens.
+// the composition bar, breakdown row dots, the detail-sheet icons, and the
+// net-worth flow diagram, so they stay consistent. Liabilities keep the
+// semantic red. Values are theme-aware CSS custom properties — see the
+// `--category-*` tokens in globals.css for the light/dark pairs.
 export const CATEGORY_CSS_COLORS: Record<string, string> = {
-  properties: "#4b4137", // warm dark taupe / charcoal
-  investments: "#6f7544", // muted olive green
-  cash: "#d8c98f", // pale cream / light gold
-  vehicles: "#6d7c86", // muted slate
-  otherAssets: "#928d83", // medium warm gray
-  preciousMetals: "#b8923a", // soft gold
-  collectibles: "#8a6b49", // muted brown
+  properties: "var(--category-properties)",
+  investments: "var(--category-investments)",
+  cash: "var(--category-cash)",
+  vehicles: "var(--category-vehicles)",
+  otherAssets: "var(--category-other-assets)",
+  preciousMetals: "var(--category-precious-metals)",
+  collectibles: "var(--category-collectibles)",
   liabilities: "var(--destructive)",
 };
 


### PR DESCRIPTION
## Why

The Net Worth page tells you **what** you're worth and **what share** each category holds — but not **how** it composes. The composition bar shows four segments; it can't show that a category is one large holding versus a dozen small ones, or how assets and debts resolve into the final number.

This makes the composition bar expandable. Click it and it unrolls into a Sankey flow — the same bar, rotated, with its sources and destinations attached.

```mermaid
flowchart LR
  H1["Holding"] --> C1["Category"]
  H2["Holding"] --> C1
  H3["Holding"] --> C2["Category"]
  B1["N smaller holdings"] --> C2
  C1 --> A["Assets"]
  C2 --> A
  A --> NW["Net Worth"]
  A --> D["Debts"]
```

## What it does

- **Purely additive.** Nothing is removed or replaced. The composition bar keeps its at-a-glance job and gains a second state; collapsed is the default, so the page looks exactly as it does today until you ask for more.
- **No new dependency.** `recharts` already ships `Sankey`; this uses it with custom node/link renderers.
- **No new API call and no backend change.** The graph is built from the same `ParsedNetWorth` the breakdown table already consumes, plus existing account-valuation hooks.
- **No duplicated figures.** Leaf and category values live in tooltips; only Assets and Debts print a value, since that pair appears nowhere else on the page. Net Worth is labelled but not restated — it's already the headline above.
- **Clicking a node** opens the existing `CategoryDetailSheet`, the same drawer the breakdown rows open, showing the full unbucketed list.
- **State persists** via `usePersistentState`, matching how the Assets and Liabilities sections already remember their collapse.

## Design decisions worth reviewing

**Investments fan in by account, not by holding.** `net_worth_service.rs` deliberately omits per-item children for `AssetCategory::Investment` — hundreds of holdings, and the allocation view owns that drill-down. That's right for the table, but it left Investments as a flat node with nothing feeding it. Accounts are the granularity a flow diagram wants, so the frontend sources them from existing account-valuation hooks. **The backend is unchanged.**

Accounts must sum exactly to the category total: an undercount gets an explicit balancing leaf, and an overcount falls back to the flat node rather than display a figure that disagrees with the table directly below it.

**Label collisions are prevented structurally, not detected.** `nodePadding` is a fixed row pitch independent of any node's value, and the diagram's height grows with the leading column's node count so that pitch always fits. A leaf that can't be seated at full pitch is folded into a bucket instead — so every leaf that renders is guaranteed labellable, and there is no collision pass at all.

This was verified against recharts' actual thickness formula, `(columnHeight - (n-1) * nodePadding) / sum(values)`, rather than assumed: budgeting only the pitch floor starves every ribbon to a hairline, so the height reserves room for proportional thickness on top of it.

**Buckets are honest.** Beyond `MAX_VISIBLE_LEAVES`, remaining holdings fold into one "N smaller holdings" node carrying the true aggregate, marked with the existing `--bar-stripe` overlay so a group never reads as a single holding. Buckets sum exactly; nothing is silently dropped.

## Accessibility

Nodes are keyboard-reachable with `role="button"`, `tabIndex`, Enter/Space handling and a visible focus ring, mirroring `BreakdownRow`. Each carries an `aria-label` with its name and amount. Transitions respect `prefers-reduced-motion`.

## Theming

`CATEGORY_CSS_COLORS` carried a comment noting the palette was tuned for light mode and that dark variants would need theme-aware tokens. A TypeScript constant can't be theme-aware, so the categories move to CSS custom properties defined alongside the existing paired tokens in `globals.css`, following the same OKLCH lightness-lift recipe used by `--fi-stream-*` and `--heatmap-accent`.

## Responsive

Leaf labels drop at narrow widths so the diagram degrades to category → Assets → Net Worth / Debts rather than scrolling sideways, matching the breakdown table's own column-collapse behavior.

## Testing

- Unit tests for graph construction: bucket sums, exact category totals, the investments overcount fallback, name shortening, and empty input.
- Full net-worth suite passes.
- Rendered in a real browser at a realistic scale (20 investment accounts, 3 properties, 6 other assets, 7 vehicles) with a DOM-level pairwise bounding-box scan across every label: zero collisions, in both light and dark themes and at both desktop and mobile widths.

## Notes for the maintainer

- Happy to split the `CATEGORY_CSS_COLORS` token migration into its own PR if you'd prefer it separate from the feature.
- `MAX_VISIBLE_LEAVES` is a single constant if you'd rather see more or fewer named leaves per category.
- The account fan-in is deliberately frontend-only to avoid overturning the backend decision. If you'd rather the server provided account-level children for investments, that's a smaller change and I'm glad to do it that way instead.

Co-Authored-By: SageOx <ox@sageox.ai>
