### PR TITLE
fix: cash dividend/interest edit validation and holdings-mode account page fixes

### DIFF
--- a/apps/frontend/src/pages/account/account-page.test.tsx
+++ b/apps/frontend/src/pages/account/account-page.test.tsx
@@ -460,6 +460,31 @@ describe("AccountPage", () => {
       "/activities?account=account-1",
     );
   });
+
+  it("defaults to the snapshots tab for holdings-mode accounts without a holdings tab", () => {
+    mockUseAccounts.mockReturnValue({
+      accounts: [{ ...createAccount(), trackingMode: "HOLDINGS" }],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useAccounts>);
+    mockUseValuationHistory.mockReturnValue({
+      valuationHistory: [createHistoricalValuation({ totalValue: 100 })],
+      isLoading: false,
+      error: null,
+    } as unknown as ReturnType<typeof useValuationHistory>);
+    mockUseCurrentValuation.mockReturnValue({
+      currentValuation: {
+        summary: createCurrentSummary({ totalValueBase: 125 }),
+        accounts: [createCurrentAccountValuation({ totalValue: 125 })],
+      },
+      isLoading: false,
+      isFetching: false,
+      error: null,
+    } as unknown as ReturnType<typeof useCurrentValuation>);
+
+    render(<AccountPage />);
+
+    expect(screen.getByText("snapshot-history")).toBeInTheDocument();
+  });
 });
 
 function createSettings(): Settings {

--- a/apps/frontend/src/pages/account/account-page.tsx
+++ b/apps/frontend/src/pages/account/account-page.tsx
@@ -273,9 +273,14 @@ const AccountPage = () => {
     return tabs;
   }, [account, hasNonCashHoldings, isCashOnlyAccount, shouldShowSnapshotHistory, t]);
 
+  // When the preferred tab isn't available (e.g. no "holdings" tab on a
+  // cash-only HOLDINGS-mode account), default to snapshots over activities:
+  // snapshots are the primary record for holdings-tracked accounts.
   const activeAccountDetailTab = accountDetailTabs.some((tab) => tab.value === accountDetailTab)
     ? accountDetailTab
-    : (accountDetailTabs[0]?.value ?? "activities");
+    : shouldShowSnapshotHistory
+      ? "snapshots"
+      : (accountDetailTabs[0]?.value ?? "activities");
 
   const isAccountActivitiesTabActive = activeAccountDetailTab === "activities";
   const accountActivityAccountIds = useMemo(

--- a/apps/frontend/src/pages/activity/components/forms/__tests__/form-schemas.test.ts
+++ b/apps/frontend/src/pages/activity/components/forms/__tests__/form-schemas.test.ts
@@ -367,6 +367,71 @@ describe("Form Schemas Validation", () => {
         expect(result.error.issues[0].message).toBe("Amount must be greater than 0.");
       }
     });
+
+    it("accepts a cash dividend edit with stored quantity/unitPrice of 0", () => {
+      // Regression: cash records persist quantity=0/unitPrice=0; editing them
+      // must not fail validation on these hidden fields.
+      const result = dividendFormSchema.safeParse({
+        accountId: "acc-123",
+        symbol: "AAPL",
+        activityDate: new Date(),
+        amount: 25.5,
+        quantity: 0,
+        unitPrice: 0,
+        subtype: null,
+        currency: "USD",
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("requires a positive quantity for asset-backed dividends", () => {
+      const base = {
+        accountId: "acc-123",
+        symbol: "AAPL",
+        activityDate: new Date(),
+        amount: 25.5,
+        unitPrice: 150,
+        subtype: ACTIVITY_SUBTYPES.DRIP,
+        currency: "USD",
+      };
+
+      const zeroQuantity = dividendFormSchema.safeParse({ ...base, quantity: 0 });
+      expect(zeroQuantity.success).toBe(false);
+      if (!zeroQuantity.success) {
+        expect(zeroQuantity.error.issues.map((issue) => issue.message)).toContain(
+          "Received quantity is required.",
+        );
+      }
+
+      const negativeQuantity = dividendFormSchema.safeParse({ ...base, quantity: -1 });
+      expect(negativeQuantity.success).toBe(false);
+      if (!negativeQuantity.success) {
+        expect(negativeQuantity.error.issues.map((issue) => issue.message)).toContain(
+          "Received quantity must be greater than 0.",
+        );
+      }
+    });
+
+    it("rejects a negative FMV per unit for asset-backed dividends", () => {
+      const result = dividendFormSchema.safeParse({
+        accountId: "acc-123",
+        symbol: "AAPL",
+        activityDate: new Date(),
+        amount: 25.5,
+        quantity: 2,
+        unitPrice: -150,
+        subtype: ACTIVITY_SUBTYPES.DRIP,
+        currency: "USD",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues.map((issue) => issue.message)).toContain(
+          "FMV per unit must be greater than 0.",
+        );
+      }
+    });
   });
 
   describe("transferFormSchema", () => {
@@ -767,6 +832,70 @@ describe("Form Schemas Validation", () => {
       if (!result.success) {
         expect(result.error.issues.map((issue) => issue.message)).toContain(
           "Withholding tax must be non-negative.",
+        );
+      }
+    });
+
+    it("accepts a cash interest edit with stored quantity/unitPrice of 0", () => {
+      // Regression: cash records persist quantity=0/unitPrice=0; editing them
+      // must not fail validation on these hidden fields.
+      const result = interestFormSchema.safeParse({
+        accountId: "acc-123",
+        activityDate: new Date(),
+        amount: 15.5,
+        quantity: 0,
+        unitPrice: 0,
+        subtype: null,
+        currency: "USD",
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it("requires a positive quantity for staking rewards", () => {
+      const base = {
+        accountId: "acc-123",
+        symbol: "BTC",
+        activityDate: new Date(),
+        amount: 15.5,
+        unitPrice: 100,
+        subtype: ACTIVITY_SUBTYPES.STAKING_REWARD,
+        currency: "USD",
+      };
+
+      const zeroQuantity = interestFormSchema.safeParse({ ...base, quantity: 0 });
+      expect(zeroQuantity.success).toBe(false);
+      if (!zeroQuantity.success) {
+        expect(zeroQuantity.error.issues.map((issue) => issue.message)).toContain(
+          "Received quantity is required.",
+        );
+      }
+
+      const negativeQuantity = interestFormSchema.safeParse({ ...base, quantity: -0.5 });
+      expect(negativeQuantity.success).toBe(false);
+      if (!negativeQuantity.success) {
+        expect(negativeQuantity.error.issues.map((issue) => issue.message)).toContain(
+          "Received quantity must be greater than 0.",
+        );
+      }
+    });
+
+    it("rejects a negative FMV per unit for staking rewards", () => {
+      const result = interestFormSchema.safeParse({
+        accountId: "acc-123",
+        symbol: "BTC",
+        activityDate: new Date(),
+        amount: 15.5,
+        quantity: 0.5,
+        unitPrice: -100,
+        subtype: ACTIVITY_SUBTYPES.STAKING_REWARD,
+        currency: "USD",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues.map((issue) => issue.message)).toContain(
+          "FMV per unit must be greater than 0.",
         );
       }
     });
@@ -1265,6 +1394,27 @@ describe("Form Schemas Validation", () => {
       });
 
       expect(result.success).toBe(true);
+    });
+
+    it("accepts cash dividend/interest edits with stored quantity/unitPrice of 0", () => {
+      // Regression: cash records persist quantity=0/unitPrice=0 (delivered as
+      // truthy "0" strings), so mobile edit defaults feed 0 into the form.
+      // Validation must not reject these hidden fields.
+      for (const activityType of ["DIVIDEND", "INTEREST"]) {
+        const result = newActivitySchema.safeParse({
+          accountId: "acc-123",
+          activityType,
+          activityDate: new Date(),
+          subtype: null,
+          amount: 25,
+          quantity: 0,
+          unitPrice: 0,
+          currency: "USD",
+          exchangeMic: null,
+        });
+
+        expect(result.success).toBe(true);
+      }
     });
 
     it("strips stale tax values from transfer activities", () => {

--- a/apps/frontend/src/pages/activity/components/forms/dividend-form.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/dividend-form.tsx
@@ -89,6 +89,9 @@ export const createDividendFormSchema = (t?: TFunction) =>
         })
         .optional(),
       subtype: z.string().optional().nullable(),
+      // Positivity for unitPrice/quantity is enforced in superRefine, only for
+      // asset-backed subtypes: cash records persist 0 for these hidden fields,
+      // and a top-level .positive() would reject editing them.
       unitPrice: z.coerce
         .number({
           invalid_type_error: msg(
@@ -97,9 +100,6 @@ export const createDividendFormSchema = (t?: TFunction) =>
             "FMV per unit must be a number.",
           ),
         })
-        .positive({
-          message: msg(t, "activity:form.err_fmv_gt_zero", "FMV per unit must be greater than 0."),
-        })
         .optional(),
       quantity: z.coerce
         .number({
@@ -107,13 +107,6 @@ export const createDividendFormSchema = (t?: TFunction) =>
             t,
             "activity:form.err_received_quantity_number",
             "Received quantity must be a number.",
-          ),
-        })
-        .positive({
-          message: msg(
-            t,
-            "activity:form.err_received_quantity_gt_zero",
-            "Received quantity must be greater than 0.",
           ),
         })
         .optional(),
@@ -136,6 +129,16 @@ export const createDividendFormSchema = (t?: TFunction) =>
             "Received quantity is required.",
           ),
         });
+      } else if (data.quantity < 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["quantity"],
+          message: msg(
+            t,
+            "activity:form.err_received_quantity_gt_zero",
+            "Received quantity must be greater than 0.",
+          ),
+        });
       }
       if (!data.unitPrice) {
         if (data.amount) return;
@@ -147,6 +150,12 @@ export const createDividendFormSchema = (t?: TFunction) =>
             "activity:form.err_enter_dividend_or_fmv",
             "Enter either dividend amount or FMV per unit.",
           ),
+        });
+      } else if (data.unitPrice < 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["unitPrice"],
+          message: msg(t, "activity:form.err_fmv_gt_zero", "FMV per unit must be greater than 0."),
         });
       }
     });

--- a/apps/frontend/src/pages/activity/components/forms/interest-form.tsx
+++ b/apps/frontend/src/pages/activity/components/forms/interest-form.tsx
@@ -69,6 +69,9 @@ export const createInterestFormSchema = (t?: TFunction) =>
           ),
         })
         .default(0),
+      // Positivity for unitPrice/quantity is enforced in superRefine, only for
+      // the staking-reward subtype: cash records persist 0 for these hidden
+      // fields, and a top-level .positive() would reject editing them.
       unitPrice: z.coerce
         .number({
           invalid_type_error: msg(
@@ -77,9 +80,6 @@ export const createInterestFormSchema = (t?: TFunction) =>
             "FMV per unit must be a number.",
           ),
         })
-        .positive({
-          message: msg(t, "activity:form.err_fmv_gt_zero", "FMV per unit must be greater than 0."),
-        })
         .optional(),
       quantity: z.coerce
         .number({
@@ -87,13 +87,6 @@ export const createInterestFormSchema = (t?: TFunction) =>
             t,
             "activity:form.err_received_quantity_number",
             "Received quantity must be a number.",
-          ),
-        })
-        .positive({
-          message: msg(
-            t,
-            "activity:form.err_received_quantity_gt_zero",
-            "Received quantity must be greater than 0.",
           ),
         })
         .optional(),
@@ -139,6 +132,16 @@ export const createInterestFormSchema = (t?: TFunction) =>
             "Received quantity is required.",
           ),
         });
+      } else if (data.quantity < 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["quantity"],
+          message: msg(
+            t,
+            "activity:form.err_received_quantity_gt_zero",
+            "Received quantity must be greater than 0.",
+          ),
+        });
       }
       if (!data.unitPrice) {
         if (data.amount) return;
@@ -150,6 +153,12 @@ export const createInterestFormSchema = (t?: TFunction) =>
             "activity:form.err_enter_interest_or_fmv",
             "Enter either interest amount or FMV per unit.",
           ),
+        });
+      } else if (data.unitPrice < 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["unitPrice"],
+          message: msg(t, "activity:form.err_fmv_gt_zero", "FMV per unit must be greater than 0."),
         });
       }
     });

--- a/apps/frontend/src/pages/activity/components/forms/schemas.ts
+++ b/apps/frontend/src/pages/activity/components/forms/schemas.ts
@@ -176,8 +176,11 @@ export const cashActivitySchema = baseActivitySchema.extend({
 export const incomeActivitySchema = baseActivitySchema.extend({
   activityType: z.enum([ActivityType.DIVIDEND, ActivityType.INTEREST]),
   assetId: z.string().min(1, { message: "Please select a security" }).optional(),
+  // No .positive() on unitPrice: cash records persist quantity/unitPrice as 0,
+  // so a top-level check would reject edits over these hidden fields. Positivity
+  // for asset-backed subtypes is enforced by validateAssetBackedIncomeFields.
   quantity: z.coerce.number().default(0),
-  unitPrice: z.coerce.number().positive().optional(),
+  unitPrice: z.coerce.number().optional(),
   amount: z.coerce
     .number({
       required_error: "Please enter a valid amount.",

--- a/crates/core/src/activities/compiler.rs
+++ b/crates/core/src/activities/compiler.rs
@@ -309,25 +309,113 @@ mod tests {
         assert_eq!(result[1].fee, Some(dec!(0)));
     }
 
+    /// Materializes the asset-income precedence rules:
+    /// - acquisition price: explicit positive unit_price → derived from net
+    ///   income (amount - fee - tax) / quantity → raw unit_price fallback
+    /// - income amount: non-zero amount → quantity * unit_price → raw amount
     #[test]
-    fn test_compile_drip_non_positive_unit_price_derives_from_amount() {
-        let compiler = DefaultActivityCompiler::new();
-        let mut activity = create_test_activity();
-        activity.activity_type = ACTIVITY_TYPE_DIVIDEND.to_string();
-        activity.subtype = Some(ACTIVITY_SUBTYPE_DRIP.to_string());
-        activity.quantity = Some(dec!(5));
-        activity.amount = Some(dec!(100));
+    fn test_compile_asset_income_price_and_amount_precedence() {
+        struct Case {
+            name: &'static str,
+            unit_price: Option<Decimal>,
+            amount: Option<Decimal>,
+            fee: Option<Decimal>,
+            tax: Option<Decimal>,
+            expected_income: Option<Decimal>,
+            expected_buy_price: Option<Decimal>,
+        }
 
-        // Stale zero from a form edit must not become a zero-cost acquisition.
-        for stale_price in [dec!(0), dec!(-20)] {
-            activity.unit_price = Some(stale_price);
+        // quantity is fixed at 5 for every case
+        let cases = [
+            Case {
+                name: "explicit positive price wins over derivable price",
+                unit_price: Some(dec!(30)),
+                amount: Some(dec!(100)),
+                fee: None,
+                tax: None,
+                expected_income: Some(dec!(100)),
+                expected_buy_price: Some(dec!(30)),
+            },
+            Case {
+                name: "missing price derives net of charges",
+                unit_price: None,
+                amount: Some(dec!(100)),
+                fee: Some(dec!(5)),
+                tax: Some(dec!(5)),
+                expected_income: Some(dec!(100)),
+                expected_buy_price: Some(dec!(18)),
+            },
+            Case {
+                name: "stale zero price loses to derivable price",
+                unit_price: Some(dec!(0)),
+                amount: Some(dec!(100)),
+                fee: None,
+                tax: None,
+                expected_income: Some(dec!(100)),
+                expected_buy_price: Some(dec!(20)),
+            },
+            Case {
+                name: "negative price loses to derivable price",
+                unit_price: Some(dec!(-20)),
+                amount: Some(dec!(100)),
+                fee: None,
+                tax: None,
+                expected_income: Some(dec!(100)),
+                expected_buy_price: Some(dec!(20)),
+            },
+            Case {
+                name: "zero price with nothing derivable stands (dust reward)",
+                unit_price: Some(dec!(0)),
+                amount: Some(dec!(0)),
+                fee: None,
+                tax: None,
+                expected_income: Some(dec!(0)),
+                expected_buy_price: Some(dec!(0)),
+            },
+            Case {
+                name: "no price and no amount yields no price",
+                unit_price: None,
+                amount: None,
+                fee: None,
+                tax: None,
+                expected_income: None,
+                expected_buy_price: None,
+            },
+            Case {
+                name: "zero amount with positive price derives income",
+                unit_price: Some(dec!(20)),
+                amount: Some(dec!(0)),
+                fee: None,
+                tax: None,
+                expected_income: Some(dec!(100)),
+                expected_buy_price: Some(dec!(20)),
+            },
+        ];
+
+        let compiler = DefaultActivityCompiler::new();
+        for case in cases {
+            let mut activity = create_test_activity();
+            activity.activity_type = ACTIVITY_TYPE_DIVIDEND.to_string();
+            activity.subtype = Some(ACTIVITY_SUBTYPE_DRIP.to_string());
+            activity.quantity = Some(dec!(5));
+            activity.unit_price = case.unit_price;
+            activity.amount = case.amount;
+            activity.fee = case.fee;
+            activity.tax = case.tax;
 
             let result = compiler.compile(&activity).unwrap();
 
-            assert_eq!(result.len(), 2);
-            assert_eq!(result[0].amount, Some(dec!(100)));
-            // BUY leg price derived from amount / quantity, not the stale value
-            assert_eq!(result[1].unit_price, Some(dec!(20)));
+            assert_eq!(result.len(), 2, "{}: legs", case.name);
+            assert_eq!(
+                result[0].amount, case.expected_income,
+                "{}: income",
+                case.name
+            );
+            assert_eq!(
+                result[1].unit_price, case.expected_buy_price,
+                "{}: buy price",
+                case.name
+            );
         }
     }
 

--- a/crates/core/src/activities/compiler.rs
+++ b/crates/core/src/activities/compiler.rs
@@ -140,16 +140,23 @@ impl DefaultActivityCompiler {
             .filter(|amount| !amount.is_zero())
             .or(derived_amount)
             .or(activity.amount);
-        let acquisition_unit_price = activity.unit_price.or_else(|| {
-            income_amount.and_then(|amount| {
-                let reinvested_amount = amount - activity.fee_amt() - activity.tax_amt();
-                if quantity.is_zero() || reinvested_amount <= Decimal::ZERO {
-                    None
-                } else {
-                    Some(reinvested_amount / quantity)
-                }
+        // A non-positive unit_price (forms can carry stale 0s) only stands as the
+        // acquisition price when no price can be derived from the income amount —
+        // e.g. a dust reward where FMV and amount are both genuinely zero.
+        let acquisition_unit_price = activity
+            .unit_price
+            .filter(|price| price.is_sign_positive() && !price.is_zero())
+            .or_else(|| {
+                income_amount.and_then(|amount| {
+                    let reinvested_amount = amount - activity.fee_amt() - activity.tax_amt();
+                    if quantity.is_zero() || reinvested_amount <= Decimal::ZERO {
+                        None
+                    } else {
+                        Some(reinvested_amount / quantity)
+                    }
+                })
             })
-        });
+            .or(activity.unit_price);
 
         // Leg 1: income recognition
         let mut income_leg = activity.clone();
@@ -300,6 +307,28 @@ mod tests {
         assert_eq!(result[1].unit_price, Some(dec!(20)));
         assert!(result[1].amount.is_none());
         assert_eq!(result[1].fee, Some(dec!(0)));
+    }
+
+    #[test]
+    fn test_compile_drip_non_positive_unit_price_derives_from_amount() {
+        let compiler = DefaultActivityCompiler::new();
+        let mut activity = create_test_activity();
+        activity.activity_type = ACTIVITY_TYPE_DIVIDEND.to_string();
+        activity.subtype = Some(ACTIVITY_SUBTYPE_DRIP.to_string());
+        activity.quantity = Some(dec!(5));
+        activity.amount = Some(dec!(100));
+
+        // Stale zero from a form edit must not become a zero-cost acquisition.
+        for stale_price in [dec!(0), dec!(-20)] {
+            activity.unit_price = Some(stale_price);
+
+            let result = compiler.compile(&activity).unwrap();
+
+            assert_eq!(result.len(), 2);
+            assert_eq!(result[0].amount, Some(dec!(100)));
+            // BUY leg price derived from amount / quantity, not the stale value
+            assert_eq!(result[1].unit_price, Some(dec!(20)));
+        }
     }
 
     #[test]

--- a/crates/core/src/portfolio/snapshot/manual_snapshot_service.rs
+++ b/crates/core/src/portfolio/snapshot/manual_snapshot_service.rs
@@ -304,8 +304,8 @@ impl ManualSnapshotService {
                     Ok(converted) => total += converted,
                     Err(e) => {
                         warn!(
-                            "Failed to convert cash {} {} to {}: {}. Using unconverted.",
-                            amount, currency, target_currency, e
+                            "Failed to convert cash balance {} to {}: {}. Using unconverted amount.",
+                            currency, target_currency, e
                         );
                         total += amount;
                     }

--- a/crates/core/src/portfolio/snapshot/manual_snapshot_service.rs
+++ b/crates/core/src/portfolio/snapshot/manual_snapshot_service.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use chrono::{NaiveDate, TimeZone, Utc};
-use log::debug;
+use log::{debug, warn};
 use rust_decimal::Decimal;
 use uuid::Uuid;
 
@@ -232,6 +232,21 @@ impl ManualSnapshotService {
 
         let total_cost_basis: Decimal = positions.values().map(|p| p.total_cost_basis).sum();
 
+        // Cache the cash totals on the keyframe: the daily holdings calculator
+        // only fills them on CALCULATED snapshots, and the snapshot history UI
+        // reads them straight off the keyframe.
+        let cash_total_account_currency = self.sum_cash_in_currency(
+            &cash_balances,
+            &request.account_currency,
+            request.snapshot_date,
+        );
+        let cash_total_base_currency = match request.base_currency.as_deref() {
+            Some(base_currency) => {
+                self.sum_cash_in_currency(&cash_balances, base_currency, request.snapshot_date)
+            }
+            None => Decimal::ZERO,
+        };
+
         let snapshot = AccountStateSnapshot {
             id: format!(
                 "{}_{}",
@@ -246,8 +261,8 @@ impl ManualSnapshotService {
             cost_basis: total_cost_basis,
             net_contribution: Decimal::ZERO,
             net_contribution_base: Decimal::ZERO,
-            cash_total_account_currency: Decimal::ZERO,
-            cash_total_base_currency: Decimal::ZERO,
+            cash_total_account_currency,
+            cash_total_base_currency,
             calculated_at: Utc::now().naive_utc(),
             source: request.source,
         };
@@ -264,6 +279,40 @@ impl ManualSnapshotService {
         asset_ids.dedup();
 
         Ok(asset_ids)
+    }
+
+    /// Sums cash balances converted into `target_currency` at `date`.
+    /// Falls back to the unconverted amount when no FX rate is available,
+    /// matching the holdings calculator's cash-total semantics.
+    fn sum_cash_in_currency(
+        &self,
+        cash_balances: &HashMap<String, Decimal>,
+        target_currency: &str,
+        date: NaiveDate,
+    ) -> Decimal {
+        let mut total = Decimal::ZERO;
+        for (currency, &amount) in cash_balances {
+            if currency == target_currency {
+                total += amount;
+            } else {
+                match self.fx_service.convert_currency_for_date(
+                    amount,
+                    currency,
+                    target_currency,
+                    date,
+                ) {
+                    Ok(converted) => total += converted,
+                    Err(e) => {
+                        warn!(
+                            "Failed to convert cash {} {} to {}: {}. Using unconverted.",
+                            amount, currency, target_currency, e
+                        );
+                        total += amount;
+                    }
+                }
+            }
+        }
+        total
     }
 
     /// Creates a quote from snapshot data to serve as a price fallback.


### PR DESCRIPTION
## Summary

Three small fixes: two for editing cash-type income activities, one pair for HOLDINGS-tracking-mode account pages.

### 1. Cash dividend/interest edits failed validation on hidden fields (desktop)

Editing an existing cash-type DIVIDEND or INTEREST activity failed with "Received quantity must be greater than 0" / "FMV per unit must be greater than 0", even though those fields are hidden in cash mode.

Cash records persist `quantity=0`/`unitPrice=0`, and the top-level `z.coerce.number().positive().optional()` ran unconditionally — `.optional()` only skips `undefined`, not `0` — so the stale zeros always failed. The positivity checks now live in the existing `superRefine` blocks, which are already gated on the asset-backed subtypes (DRIP / DIVIDEND_IN_KIND for dividends, STAKING_REWARD for interest).

### 2. Same bug on the mobile form

`incomeActivitySchema.unitPrice` had the same top-level `.positive()`. `ActivityDetails` delivers numbers as strings, so a stored `"0"` is truthy and the mobile edit defaults fed `0` into the form, tripping the check before submit. Dropped the `.positive()` — positivity for asset-backed subtypes is already enforced at submit by `validateAssetBackedIncomeFields`, and `applyMobileIncomeUpdateClears` nulls the stale zeros for cash updates before the payload is built.

The activity data grid was audited too and needs no change: its quantity/unitPrice checks are already gated on `isAssetBackedIncomeSubtype`.

### 3. Holdings-mode account page: wrong default tab + snapshot history showed Cash 0

- The account detail area defaulted to the Activities tab on cash-only HOLDINGS-mode accounts (the preferred `holdings` tab doesn't exist there, and the fallback picked the first tab). Snapshots are the primary record for holdings-tracked accounts, so the fallback now prefers the Snapshots tab when snapshot history is shown.
- Snapshot history displayed Cash as 0 for manual/CSV snapshots: `save_manual_snapshot` persisted the keyframe with `cash_total_account_currency = 0` even when cash balances were entered, because the cached totals are only computed by the daily holdings calculator for CALCULATED snapshots, while the snapshot list reads them straight off the keyframe. The totals are now computed at save time, converting foreign balances via FX with the same unconverted-amount fallback the holdings calculator uses. Existing keyframes are healed the next time the snapshot is edited and saved.

## Test plan

- [x] New regression tests: cash dividend/interest edits with stored zeros parse (desktop + mobile schemas); asset-backed subtypes still reject zero/negative quantity and negative FMV; holdings-mode account without a holdings tab defaults to the snapshots tab
- [x] Full frontend suite: 1116/1116 passing
- [x] `tsc --noEmit` clean
- [x] `cargo test -p wealthfolio-core --lib`: 1677/1677 passing
