### PR TITLE
Support broker multipliers and tracking-mode propagation

### DIFF
--- a/crates/connect/src/broker/models.rs
+++ b/crates/connect/src/broker/models.rs
@@ -499,6 +499,9 @@ pub struct HoldingsPosition {
     pub open_pnl: Option<f64>,
     pub average_purchase_price: Option<f64>,
     pub currency: Option<HoldingsCurrency>,
+    /// Number of underlying units represented by one position unit.
+    #[serde(default)]
+    pub contract_multiplier: Option<f64>,
     #[serde(default)]
     pub cash_equivalent: Option<bool>,
 }
@@ -519,6 +522,10 @@ pub struct HoldingsOptionSymbol {
     pub option_type: Option<String>,
     pub strike_price: Option<f64>,
     pub expiration_date: Option<String>,
+    /// Exact number of underlying units represented by one option contract.
+    #[serde(default)]
+    pub multiplier: Option<f64>,
+    /// Deprecated compatibility flag used when multiplier is absent.
     #[serde(default)]
     pub is_mini_option: Option<bool>,
     pub underlying_symbol: Option<HoldingsUnderlyingSymbol>,

--- a/crates/connect/src/broker/orchestrator.rs
+++ b/crates/connect/src/broker/orchestrator.rs
@@ -51,7 +51,13 @@ impl AccountSyncJob {
         let tracking_mode = match account.tracking_mode {
             TrackingMode::Holdings => BrokerTrackingMode::Holdings,
             TrackingMode::Transactions => BrokerTrackingMode::Transactions,
-            TrackingMode::NotSet => return None,
+            TrackingMode::NotSet => {
+                info!(
+                    "Skipping sync for account '{}' (trackingMode=NOT_SET)",
+                    account.name
+                );
+                return None;
+            }
         };
         Some(Self {
             account_id: account.id,
@@ -354,13 +360,6 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
         let mut activities_summary = SyncActivitiesResponse::default();
 
         for account in synced_accounts {
-            if account.tracking_mode == TrackingMode::NotSet {
-                info!(
-                    "Skipping sync for account '{}' (trackingMode=NOT_SET)",
-                    account.name
-                );
-                continue;
-            }
             let Some(job) = AccountSyncJob::from_account(account) else {
                 continue;
             };
@@ -402,13 +401,6 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
         let mut holdings_summary = SyncHoldingsResponse::default();
 
         for account in synced_accounts {
-            if account.tracking_mode == TrackingMode::NotSet {
-                info!(
-                    "Skipping sync for account '{}' (trackingMode=NOT_SET)",
-                    account.name
-                );
-                continue;
-            }
             let Some(job) = AccountSyncJob::from_account(account) else {
                 continue;
             };

--- a/crates/connect/src/broker/orchestrator.rs
+++ b/crates/connect/src/broker/orchestrator.rs
@@ -17,7 +17,7 @@ use super::models::{
     SyncResult,
 };
 use super::progress::SyncProgressReporter;
-use super::traits::{BrokerApiClient, BrokerSyncServiceTrait};
+use super::traits::{BrokerApiClient, BrokerSyncServiceTrait, BrokerTrackingMode};
 use wealthfolio_core::accounts::{Account, TrackingMode};
 
 /// Configuration for sync operations.
@@ -43,21 +43,26 @@ pub(super) struct AccountSyncJob {
     account_id: String,
     account_name: String,
     broker_account_id: String,
-    tracking_mode: TrackingMode,
+    tracking_mode: BrokerTrackingMode,
 }
 
 impl AccountSyncJob {
     fn from_account(account: Account) -> Option<Self> {
+        let tracking_mode = match account.tracking_mode {
+            TrackingMode::Holdings => BrokerTrackingMode::Holdings,
+            TrackingMode::Transactions => BrokerTrackingMode::Transactions,
+            TrackingMode::NotSet => return None,
+        };
         Some(Self {
             account_id: account.id,
             account_name: account.name,
             broker_account_id: account.provider_account_id?,
-            tracking_mode: account.tracking_mode,
+            tracking_mode,
         })
     }
 
     fn is_holdings_mode(&self) -> bool {
-        self.tracking_mode == TrackingMode::Holdings
+        self.tracking_mode == BrokerTrackingMode::Holdings
     }
 }
 
@@ -349,11 +354,18 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
         let mut activities_summary = SyncActivitiesResponse::default();
 
         for account in synced_accounts {
+            if account.tracking_mode == TrackingMode::NotSet {
+                info!(
+                    "Skipping sync for account '{}' (trackingMode=NOT_SET)",
+                    account.name
+                );
+                continue;
+            }
             let Some(job) = AccountSyncJob::from_account(account) else {
                 continue;
             };
 
-            if job.tracking_mode != TrackingMode::Transactions {
+            if job.tracking_mode != BrokerTrackingMode::Transactions {
                 continue;
             }
 
@@ -390,6 +402,13 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
         let mut holdings_summary = SyncHoldingsResponse::default();
 
         for account in synced_accounts {
+            if account.tracking_mode == TrackingMode::NotSet {
+                info!(
+                    "Skipping sync for account '{}' (trackingMode=NOT_SET)",
+                    account.name
+                );
+                continue;
+            }
             let Some(job) = AccountSyncJob::from_account(account) else {
                 continue;
             };
@@ -397,14 +416,6 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
             if !sync_enabled_broker_ids.contains(&job.broker_account_id) {
                 info!(
                     "Skipping sync for account '{}' (sync disabled)",
-                    job.account_name
-                );
-                continue;
-            }
-
-            if job.tracking_mode == TrackingMode::NotSet {
-                info!(
-                    "Skipping sync for account '{}' (trackingMode=NOT_SET)",
                     job.account_name
                 );
                 continue;
@@ -499,7 +510,8 @@ mod tests {
     struct MockBrokerApiClient {
         broker_accounts: Vec<BrokerAccount>,
         activity_pages: Mutex<Vec<PaginatedUniversalActivity>>,
-        activity_calls: Mutex<usize>,
+        activity_calls: Mutex<Vec<BrokerTrackingMode>>,
+        holdings_calls: Mutex<Vec<BrokerTrackingMode>>,
     }
 
     #[async_trait]
@@ -522,12 +534,13 @@ mod tests {
         async fn get_account_activities(
             &self,
             _account_id: &str,
+            tracking_mode: BrokerTrackingMode,
             _start_date: Option<&str>,
             _end_date: Option<&str>,
             _offset: Option<i64>,
             _limit: Option<i64>,
         ) -> Result<PaginatedUniversalActivity> {
-            *self.activity_calls.lock().unwrap() += 1;
+            self.activity_calls.lock().unwrap().push(tracking_mode);
             let mut pages = self.activity_pages.lock().unwrap();
             if pages.is_empty() {
                 return Ok(PaginatedUniversalActivity::default());
@@ -535,7 +548,12 @@ mod tests {
             Ok(pages.remove(0))
         }
 
-        async fn get_account_holdings(&self, _account_id: &str) -> Result<BrokerHoldingsResponse> {
+        async fn get_account_holdings(
+            &self,
+            _account_id: &str,
+            tracking_mode: BrokerTrackingMode,
+        ) -> Result<BrokerHoldingsResponse> {
+            self.holdings_calls.lock().unwrap().push(tracking_mode);
             Ok(BrokerHoldingsResponse::default())
         }
     }
@@ -861,9 +879,10 @@ mod tests {
         let mut provider_holdings_statuses = HashMap::new();
         provider_holdings_statuses.insert("broker-1".to_string(), ready_status("2026-05-22", None));
 
+        let api_client = MockBrokerApiClient::default();
         let (activities, holdings) = orchestrator(service.clone())
             .sync_account_data(
-                &MockBrokerApiClient::default(),
+                &api_client,
                 &HashSet::from(["broker-1".to_string()]),
                 &provider_transaction_statuses,
                 &provider_holdings_statuses,
@@ -882,6 +901,47 @@ mod tests {
             .activity_needs_review
             .iter()
             .any(|(_, warning, _)| warning.contains("Holdings synced")));
+        assert_eq!(
+            *api_client.holdings_calls.lock().unwrap(),
+            vec![BrokerTrackingMode::Holdings]
+        );
+    }
+
+    #[tokio::test]
+    async fn holdings_account_uses_holdings_mode_for_reference_activities_and_holdings() {
+        let service = Arc::new(MockSyncService {
+            accounts: vec![synced_account(
+                "account-1",
+                "broker-1",
+                TrackingMode::Holdings,
+            )],
+            ..MockSyncService::default()
+        });
+        let api_client = MockBrokerApiClient {
+            activity_pages: Mutex::new(vec![PaginatedUniversalActivity::default()]),
+            ..MockBrokerApiClient::default()
+        };
+        let provider_statuses =
+            HashMap::from([("broker-1".to_string(), ready_status("2026-05-22", None))]);
+
+        orchestrator(service)
+            .sync_account_data(
+                &api_client,
+                &HashSet::from(["broker-1".to_string()]),
+                &provider_statuses,
+                &provider_statuses,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            *api_client.activity_calls.lock().unwrap(),
+            vec![BrokerTrackingMode::Holdings]
+        );
+        assert_eq!(
+            *api_client.holdings_calls.lock().unwrap(),
+            vec![BrokerTrackingMode::Holdings]
+        );
     }
 
     #[tokio::test]
@@ -910,7 +970,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(activities.accounts_synced, 0);
-        assert_eq!(*api_client.activity_calls.lock().unwrap(), 0);
+        assert!(api_client.activity_calls.lock().unwrap().is_empty());
         let calls = service.calls.lock().unwrap();
         assert_eq!(calls.activity_successes.len(), 1);
         assert_eq!(calls.activity_successes[0].1, "2026-05-22T00:00:00+00:00");
@@ -952,7 +1012,10 @@ mod tests {
 
         assert_eq!(activities.accounts_synced, 1);
         assert_eq!(activities.activities_upserted, 1);
-        assert_eq!(*api_client.activity_calls.lock().unwrap(), 1);
+        assert_eq!(
+            *api_client.activity_calls.lock().unwrap(),
+            vec![BrokerTrackingMode::Transactions]
+        );
         assert_eq!(service.calls.lock().unwrap().save_holdings_calls, 0);
     }
 }

--- a/crates/connect/src/broker/orchestrator/activity_pagination.rs
+++ b/crates/connect/src/broker/orchestrator/activity_pagination.rs
@@ -3,6 +3,7 @@ use log::{debug, info};
 
 use super::super::progress::{SyncProgressPayload, SyncProgressReporter, SyncStatus};
 use super::super::traits::BrokerApiClient;
+use super::super::traits::BrokerTrackingMode;
 use super::{ActivityQueryWindow, ActivitySyncOutcome, SyncOrchestrator};
 
 impl<P: SyncProgressReporter> SyncOrchestrator<P> {
@@ -13,6 +14,7 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
         account_id: &str,
         account_name: &str,
         broker_account_id: &str,
+        tracking_mode: BrokerTrackingMode,
         start_date: Option<&str>,
         end_date: Option<&str>,
         import_run_id: Option<String>,
@@ -40,6 +42,7 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
             let page = api_client
                 .get_account_activities(
                     broker_account_id,
+                    tracking_mode,
                     start_date,
                     end_date,
                     Some(offset),

--- a/crates/connect/src/broker/orchestrator/activity_phase.rs
+++ b/crates/connect/src/broker/orchestrator/activity_phase.rs
@@ -351,6 +351,7 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
                 &job.account_id,
                 &job.account_name,
                 &job.broker_account_id,
+                job.tracking_mode,
                 query_window.start_date.as_deref(),
                 Some(query_window.end_date.as_str()),
                 result.activity_import_run_id.clone(),

--- a/crates/connect/src/broker/orchestrator/holdings_phase.rs
+++ b/crates/connect/src/broker/orchestrator/holdings_phase.rs
@@ -120,6 +120,7 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
                 &job.account_id,
                 &job.account_name,
                 &job.broker_account_id,
+                job.tracking_mode,
             )
             .await
         {
@@ -228,6 +229,7 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
         account_id: &str,
         account_name: &str,
         broker_account_id: &str,
+        tracking_mode: super::BrokerTrackingMode,
     ) -> Result<(HoldingsDiff, usize, Vec<String>), String> {
         info!(
             "Syncing holdings for account '{}' ({})",
@@ -240,7 +242,7 @@ impl<P: SyncProgressReporter> SyncOrchestrator<P> {
         );
 
         let holdings = api_client
-            .get_account_holdings(broker_account_id)
+            .get_account_holdings(broker_account_id, tracking_mode)
             .await
             .map_err(|e| e.to_string())?;
 

--- a/crates/connect/src/broker/service.rs
+++ b/crates/connect/src/broker/service.rs
@@ -7,8 +7,8 @@ use std::sync::{Arc, RwLock};
 use super::mapping;
 use super::models::{
     AccountUniversalActivity, BrokerAccount, BrokerConnection, HoldingsBalance, HoldingsDiff,
-    HoldingsOptionPosition, HoldingsPosition, NewAccountInfo, SyncAccountsResponse,
-    SyncConnectionsResponse,
+    HoldingsOptionPosition, HoldingsOptionSymbol, HoldingsPosition, NewAccountInfo,
+    SyncAccountsResponse, SyncConnectionsResponse,
 };
 use super::traits::{BrokerSyncServiceTrait, PlatformRepositoryTrait};
 use crate::broker_ingest::{
@@ -29,7 +29,7 @@ use wealthfolio_core::activities::{
 };
 use wealthfolio_core::assets::{
     build_option_metadata, parse_crypto_pair_symbol, parse_symbol_with_exchange_suffix,
-    AssetServiceTrait, AssetSpec, InstrumentType,
+    AssetServiceTrait, AssetSpec, InstrumentType, OptionSpec,
 };
 use wealthfolio_core::errors::Result;
 use wealthfolio_core::events::{DomainEvent, DomainEventSink, NoOpDomainEventSink};
@@ -55,6 +55,70 @@ fn normalize_holdings_money(amount: Decimal, currency: &str) -> (Decimal, String
     )
 }
 
+fn positive_contract_multiplier(value: Option<f64>, fallback: Decimal) -> Decimal {
+    value
+        .and_then(Decimal::from_f64)
+        .filter(|multiplier| *multiplier > Decimal::ZERO)
+        .unwrap_or(fallback)
+}
+
+fn normalize_regular_average_cost(
+    amount: Decimal,
+    currency: &str,
+    contract_multiplier: Decimal,
+) -> Decimal {
+    let normalized = normalize_holdings_money(amount, currency).0;
+    (normalized * contract_multiplier).round_dp(HOLDINGS_DECIMAL_PRECISION)
+}
+
+fn option_contract_multiplier(option: &HoldingsOptionSymbol) -> Decimal {
+    let legacy_fallback = if option.is_mini_option.unwrap_or(false) {
+        Decimal::from(10)
+    } else {
+        Decimal::from(100)
+    };
+    positive_contract_multiplier(option.multiplier, legacy_fallback)
+}
+
+fn holdings_option_metadata(
+    option: &HoldingsOptionSymbol,
+    ticker: &str,
+    multiplier: Decimal,
+) -> Option<serde_json::Value> {
+    if let Some(metadata) = build_option_metadata(ticker, multiplier) {
+        return Some(metadata);
+    }
+
+    // Non-OCC brokerage identifiers are still valid holdings. Build the option metadata from the
+    // structured contract fields so the position remains correctly valued and visible for review.
+    let underlying = option.underlying_symbol.as_ref()?.symbol.as_deref()?.trim();
+    if underlying.is_empty() {
+        return None;
+    }
+    let expiration =
+        NaiveDate::parse_from_str(option.expiration_date.as_deref()?, "%Y-%m-%d").ok()?;
+    let right = match option.option_type.as_deref()?.to_ascii_uppercase().as_str() {
+        "CALL" => "CALL",
+        "PUT" => "PUT",
+        _ => return None,
+    };
+    let strike = option
+        .strike_price
+        .and_then(Decimal::from_f64)
+        .filter(|value| *value >= Decimal::ZERO)?;
+
+    Some(serde_json::json!({
+        "option": OptionSpec {
+            underlying_asset_id: underlying.to_uppercase(),
+            expiration,
+            right: right.to_string(),
+            strike,
+            multiplier,
+            occ_symbol: None,
+        }
+    }))
+}
+
 #[derive(Debug, Clone)]
 struct HoldingsPositionData {
     spec_key: String,
@@ -63,6 +127,7 @@ struct HoldingsPositionData {
     quote_currency: String,
     average_cost: Option<Decimal>,
     position_currency: String,
+    contract_multiplier: Decimal,
 }
 
 /// Service for syncing broker data to the local database
@@ -788,10 +853,14 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 .round_dp(HOLDINGS_DECIMAL_PRECISION);
             let raw_price = Decimal::from_f64(pos.price.unwrap_or(0.0)).unwrap_or(Decimal::ZERO);
             let quote_price = raw_price.round_dp(HOLDINGS_DECIMAL_PRECISION);
+            let contract_multiplier =
+                positive_contract_multiplier(pos.contract_multiplier, Decimal::ONE);
             let avg_cost = pos
                 .average_purchase_price
                 .and_then(Decimal::from_f64)
-                .map(|value| normalize_holdings_money(value, &raw_quote_currency).0);
+                .map(|value| {
+                    normalize_regular_average_cost(value, &raw_quote_currency, contract_multiplier)
+                });
 
             position_data.push(HoldingsPositionData {
                 spec_key,
@@ -800,6 +869,7 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 quote_currency: raw_quote_currency,
                 average_cost: avg_cost,
                 position_currency,
+                contract_multiplier,
             });
         }
 
@@ -843,12 +913,8 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 .unwrap_or_else(|| account_currency.clone());
             let position_currency = normalize_currency_code(&raw_quote_currency).to_string();
 
-            let multiplier = if option_symbol.is_mini_option.unwrap_or(false) {
-                Decimal::from(10)
-            } else {
-                Decimal::from(100)
-            };
-            let metadata = build_option_metadata(&normalized_ticker, multiplier);
+            let multiplier = option_contract_multiplier(option_symbol);
+            let metadata = holdings_option_metadata(option_symbol, &normalized_ticker, multiplier);
 
             let asset_name = option_symbol
                 .underlying_symbol
@@ -895,6 +961,7 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 quote_currency: raw_quote_currency,
                 average_cost: avg_cost,
                 position_currency,
+                contract_multiplier: multiplier,
             });
         }
 
@@ -1016,13 +1083,6 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 }
             };
 
-            // Determine contract multiplier from the asset spec metadata
-            let contract_multiplier = spec_key_to_idx
-                .get(&position.spec_key)
-                .and_then(|idx| asset_specs.get(*idx))
-                .and_then(|spec| spec.option_multiplier())
-                .unwrap_or(Decimal::ONE);
-
             // Resolve cost against the combined quantity (all split rows for this asset) so the
             // prior-cost fallback works even when the broker splits the holding into rows.
             let combined_quantity = combined_quantities
@@ -1054,7 +1114,7 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 created_at: now,
                 last_updated: now,
                 is_alternative: false,
-                contract_multiplier,
+                contract_multiplier: position.contract_multiplier,
                 cost_basis_account: None,
                 cost_basis_base: None,
             };
@@ -1275,6 +1335,8 @@ impl BrokerSyncService {
             && a.total_cost_basis.round_dp(HOLDINGS_DECIMAL_PRECISION)
                 == b.total_cost_basis.round_dp(HOLDINGS_DECIMAL_PRECISION)
             && a.currency == b.currency
+            && a.contract_multiplier.round_dp(HOLDINGS_DECIMAL_PRECISION)
+                == b.contract_multiplier.round_dp(HOLDINGS_DECIMAL_PRECISION)
     }
 
     fn normalize_holdings_symbol(
@@ -1482,10 +1544,15 @@ mod tests {
     use wealthfolio_core::portfolio::snapshot::{AccountStateSnapshot, Position, SnapshotSource};
 
     use super::{
-        default_tracking_mode_for_broker_account_type, normalize_holdings_money, BrokerSyncService,
+        default_tracking_mode_for_broker_account_type, holdings_option_metadata,
+        normalize_holdings_money, normalize_regular_average_cost, option_contract_multiplier,
+        positive_contract_multiplier, BrokerSyncService,
+    };
+    use crate::broker::models::{
+        HoldingsOptionPosition, HoldingsOptionSymbol, HoldingsPosition, HoldingsUnderlyingSymbol,
     };
     use wealthfolio_core::accounts::{account_types, TrackingMode};
-    use wealthfolio_core::assets::{AssetSpec, InstrumentType};
+    use wealthfolio_core::assets::{AssetSpec, InstrumentType, OptionSpec};
 
     fn decimal(value: &str) -> Decimal {
         Decimal::from_str(value).expect("valid decimal")
@@ -1532,12 +1599,102 @@ mod tests {
             quote_currency: raw_quote_currency,
             average_cost: Some(normalize_holdings_money(decimal("82.5"), "GBp").0),
             position_currency,
+            contract_multiplier: Decimal::ONE,
         };
 
         assert_eq!(position.quote_price, decimal("85"));
         assert_eq!(position.quote_currency, "GBp");
         assert_eq!(position.average_cost, Some(decimal("0.825")));
         assert_eq!(position.position_currency, "GBP");
+    }
+
+    #[test]
+    fn regular_contract_average_cost_is_stored_per_position_unit() {
+        assert_eq!(
+            normalize_regular_average_cost(decimal("12.5"), "USD", decimal("50")),
+            decimal("625")
+        );
+        assert_eq!(
+            normalize_regular_average_cost(decimal("82.5"), "GBp", decimal("10")),
+            decimal("8.25")
+        );
+    }
+
+    #[test]
+    fn holdings_contract_multiplier_prefers_exact_value_with_safe_defaults() {
+        assert_eq!(
+            positive_contract_multiplier(Some(50.0), Decimal::ONE),
+            decimal("50")
+        );
+        assert_eq!(
+            positive_contract_multiplier(Some(0.0), Decimal::ONE),
+            Decimal::ONE
+        );
+
+        let adjusted = HoldingsOptionSymbol {
+            multiplier: Some(50.0),
+            ..Default::default()
+        };
+        let legacy_mini = HoldingsOptionSymbol {
+            is_mini_option: Some(true),
+            ..Default::default()
+        };
+        let standard = HoldingsOptionSymbol::default();
+
+        assert_eq!(option_contract_multiplier(&adjusted), decimal("50"));
+        assert_eq!(option_contract_multiplier(&legacy_mini), decimal("10"));
+        assert_eq!(option_contract_multiplier(&standard), decimal("100"));
+    }
+
+    #[test]
+    fn holdings_contract_deserializes_exact_multipliers() {
+        let position: HoldingsPosition = serde_json::from_value(serde_json::json!({
+            "contract_multiplier": 50
+        }))
+        .expect("regular holding");
+        let option: HoldingsOptionPosition = serde_json::from_value(serde_json::json!({
+            "symbol": {
+                "option_symbol": {
+                    "ticker": "AAPL  261218C00100000",
+                    "multiplier": 25,
+                    "is_mini_option": false
+                }
+            }
+        }))
+        .expect("option holding");
+
+        assert_eq!(position.contract_multiplier, Some(50.0));
+        assert_eq!(
+            option
+                .resolved_option_symbol()
+                .and_then(|value| value.multiplier),
+            Some(25.0)
+        );
+    }
+
+    #[test]
+    fn non_occ_option_uses_structured_metadata_and_exact_multiplier() {
+        let option = HoldingsOptionSymbol {
+            ticker: Some("BROKER-ADJUSTED-OPTION".to_string()),
+            option_type: Some("CALL".to_string()),
+            strike_price: Some(100.0),
+            expiration_date: Some("2026-12-18".to_string()),
+            multiplier: Some(50.0),
+            underlying_symbol: Some(HoldingsUnderlyingSymbol {
+                symbol: Some("AAPL".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let metadata = holdings_option_metadata(&option, "BROKER-ADJUSTED-OPTION", decimal("50"))
+            .expect("structured option metadata");
+        let spec: OptionSpec =
+            serde_json::from_value(metadata["option"].clone()).expect("valid option spec");
+
+        assert_eq!(spec.underlying_asset_id, "AAPL");
+        assert_eq!(spec.multiplier, decimal("50"));
+        assert_eq!(spec.occ_symbol, None);
     }
 
     fn position(
@@ -1902,6 +2059,7 @@ mod tests {
             quote_currency: "USD".to_string(),
             average_cost: None,
             position_currency: "USD".to_string(),
+            contract_multiplier: Decimal::ONE,
         };
         let position_data = vec![
             row("EQUITY:VTI", "32.005"),

--- a/crates/connect/src/broker/service.rs
+++ b/crates/connect/src/broker/service.rs
@@ -28,8 +28,8 @@ use wealthfolio_core::activities::{
     NewActivity, ACTIVITY_TYPE_BUY, ACTIVITY_TYPE_SELL,
 };
 use wealthfolio_core::assets::{
-    build_option_metadata, parse_crypto_pair_symbol, parse_symbol_with_exchange_suffix,
-    AssetServiceTrait, AssetSpec, InstrumentType, OptionSpec,
+    build_option_metadata, parse_crypto_pair_symbol, parse_symbol_with_exchange_suffix, Asset,
+    AssetServiceTrait, AssetSpec, InstrumentType, OptionSpec, CONTRACT_MULTIPLIER_METADATA_KEY,
 };
 use wealthfolio_core::errors::Result;
 use wealthfolio_core::events::{DomainEvent, DomainEventSink, NoOpDomainEventSink};
@@ -55,11 +55,14 @@ fn normalize_holdings_money(amount: Decimal, currency: &str) -> (Decimal, String
     )
 }
 
-fn positive_contract_multiplier(value: Option<f64>, fallback: Decimal) -> Decimal {
+fn exact_positive_contract_multiplier(value: Option<f64>) -> Option<Decimal> {
     value
         .and_then(Decimal::from_f64)
         .filter(|multiplier| *multiplier > Decimal::ZERO)
-        .unwrap_or(fallback)
+}
+
+fn positive_contract_multiplier(value: Option<f64>, fallback: Decimal) -> Decimal {
+    exact_positive_contract_multiplier(value).unwrap_or(fallback)
 }
 
 fn normalize_regular_average_cost(
@@ -118,9 +121,94 @@ fn holdings_option_metadata(
     option: &HoldingsOptionSymbol,
     ticker: &str,
     multiplier: Decimal,
-) -> Option<serde_json::Value> {
+) -> serde_json::Value {
     build_option_metadata(ticker, multiplier)
         .or_else(|| structured_holdings_option_metadata(option, multiplier))
+        .unwrap_or_else(|| top_level_contract_multiplier_metadata(multiplier))
+}
+
+fn top_level_contract_multiplier_metadata(multiplier: Decimal) -> serde_json::Value {
+    let mut metadata = serde_json::Map::new();
+    metadata.insert(
+        CONTRACT_MULTIPLIER_METADATA_KEY.to_string(),
+        serde_json::json!(multiplier),
+    );
+    serde_json::Value::Object(metadata)
+}
+
+fn regular_contract_multiplier_metadata(multiplier: Option<Decimal>) -> Option<serde_json::Value> {
+    multiplier
+        .filter(|multiplier| *multiplier != Decimal::ONE)
+        .map(top_level_contract_multiplier_metadata)
+}
+
+fn record_authoritative_multiplier(
+    multipliers: &mut HashMap<String, Decimal>,
+    spec_key: &str,
+    multiplier: Option<Decimal>,
+) -> bool {
+    let Some(multiplier) = multiplier else {
+        return false;
+    };
+    match multipliers.entry(spec_key.to_string()) {
+        Entry::Vacant(entry) => {
+            entry.insert(multiplier);
+            true
+        }
+        Entry::Occupied(entry) => {
+            if *entry.get() != multiplier {
+                warn!(
+                    "Broker returned inconsistent contract multipliers for {}; retaining the first",
+                    spec_key
+                );
+            }
+            false
+        }
+    }
+}
+
+fn contract_multiplier_metadata_update(
+    asset: &Asset,
+    incoming: Option<&serde_json::Value>,
+    multiplier: Decimal,
+) -> Option<serde_json::Value> {
+    if asset.contract_multiplier() == multiplier {
+        return None;
+    }
+
+    let mut metadata = asset
+        .metadata
+        .as_ref()
+        .and_then(serde_json::Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    if let Some(incoming) = incoming.and_then(serde_json::Value::as_object) {
+        metadata.extend(incoming.clone());
+    }
+
+    if asset.is_option() {
+        if let Some(option) = metadata
+            .get_mut("option")
+            .and_then(serde_json::Value::as_object_mut)
+        {
+            option.insert("multiplier".to_string(), serde_json::json!(multiplier));
+            metadata.remove(CONTRACT_MULTIPLIER_METADATA_KEY);
+        } else {
+            metadata.insert(
+                CONTRACT_MULTIPLIER_METADATA_KEY.to_string(),
+                serde_json::json!(multiplier),
+            );
+        }
+    } else if multiplier == Decimal::ONE {
+        metadata.remove(CONTRACT_MULTIPLIER_METADATA_KEY);
+    } else {
+        metadata.insert(
+            CONTRACT_MULTIPLIER_METADATA_KEY.to_string(),
+            serde_json::json!(multiplier),
+        );
+    }
+
+    Some(serde_json::Value::Object(metadata))
 }
 
 #[derive(Debug, Clone)]
@@ -766,6 +854,7 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
         let mut asset_specs: Vec<AssetSpec> = Vec::new();
         // Canonical instrument key → index into asset_specs
         let mut spec_key_to_idx: HashMap<String, usize> = HashMap::new();
+        let mut authoritative_multipliers: HashMap<String, Decimal> = HashMap::new();
         let mut position_data: Vec<HoldingsPositionData> = Vec::new();
 
         for pos in &positions {
@@ -824,13 +913,14 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
 
             let instrument_type =
                 map_broker_symbol_type(symbol_type_code.as_deref(), is_crypto_asset);
-            let contract_multiplier =
-                positive_contract_multiplier(pos.contract_multiplier, Decimal::ONE);
+            let exact_multiplier = exact_positive_contract_multiplier(pos.contract_multiplier);
+            let contract_multiplier = exact_multiplier.unwrap_or(Decimal::ONE);
 
             let asset_name = symbol_info.and_then(|s| s.name.clone().or(s.description.clone()));
 
             let spec = AssetSpec {
                 name: asset_name,
+                metadata: regular_contract_multiplier_metadata(exact_multiplier),
                 ..AssetSpec::market_instrument(
                     symbol.clone(),
                     symbol.clone(),
@@ -848,6 +938,16 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                     if is_crypto_asset { "CRYPTO" } else { "EQUITY" }
                 )
             });
+
+            if record_authoritative_multiplier(
+                &mut authoritative_multipliers,
+                &spec_key,
+                exact_multiplier,
+            ) {
+                if let Some(existing_idx) = spec_key_to_idx.get(&spec_key) {
+                    asset_specs[*existing_idx].metadata = spec.metadata.clone();
+                }
+            }
 
             if !spec_key_to_idx.contains_key(&spec_key) {
                 let idx = asset_specs.len();
@@ -921,6 +1021,7 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 .unwrap_or_else(|| account_currency.clone());
             let position_currency = normalize_currency_code(&raw_quote_currency).to_string();
 
+            let exact_multiplier = exact_positive_contract_multiplier(option_symbol.multiplier);
             let multiplier = option_contract_multiplier(option_symbol);
             let metadata = holdings_option_metadata(option_symbol, &normalized_ticker, multiplier);
 
@@ -931,7 +1032,7 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
 
             let spec = AssetSpec {
                 name: asset_name,
-                metadata,
+                metadata: Some(metadata),
                 ..AssetSpec::market_instrument(
                     normalized_ticker.clone(),
                     normalized_ticker.clone(),
@@ -944,6 +1045,16 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
             let spec_key = spec
                 .instrument_key()
                 .unwrap_or_else(|| format!("OPTION:{}", normalized_ticker.to_uppercase()));
+
+            if record_authoritative_multiplier(
+                &mut authoritative_multipliers,
+                &spec_key,
+                exact_multiplier,
+            ) {
+                if let Some(existing_idx) = spec_key_to_idx.get(&spec_key) {
+                    asset_specs[*existing_idx].metadata = spec.metadata.clone();
+                }
+            }
 
             if !spec_key_to_idx.contains_key(&spec_key) {
                 let idx = asset_specs.len();
@@ -1014,6 +1125,38 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 if let Some(asset_id) = key_to_asset_id.get(id) {
                     spec_key_to_asset_id.insert(spec_key.clone(), asset_id.clone());
                 }
+            }
+        }
+
+        // Broker multipliers are asset economics shared by every account. New assets already carry
+        // this metadata through AssetSpec; existing assets are updated only when the resolved value
+        // changes. A failed backfill is best-effort and will be retried by the next holdings sync.
+        for (spec_key, multiplier) in &authoritative_multipliers {
+            let Some(asset_id) = spec_key_to_asset_id.get(spec_key) else {
+                continue;
+            };
+            let Some(asset) = ensure_result.assets.get(asset_id) else {
+                continue;
+            };
+            let incoming_metadata = spec_key_to_idx
+                .get(spec_key)
+                .and_then(|idx| asset_specs.get(*idx))
+                .and_then(|spec| spec.metadata.as_ref());
+            let Some(metadata) =
+                contract_multiplier_metadata_update(asset, incoming_metadata, *multiplier)
+            else {
+                continue;
+            };
+
+            if let Err(error) = self
+                .asset_service
+                .update_asset_metadata(asset_id, metadata)
+                .await
+            {
+                warn!(
+                    "Could not persist broker contract multiplier for asset {}: {}",
+                    asset_id, error
+                );
             }
         }
 
@@ -1581,15 +1724,18 @@ mod tests {
     use wealthfolio_core::portfolio::snapshot::{AccountStateSnapshot, Position, SnapshotSource};
 
     use super::{
-        default_tracking_mode_for_broker_account_type, holdings_option_metadata,
-        normalize_holdings_money, normalize_regular_average_cost, option_contract_multiplier,
-        positive_contract_multiplier, BrokerSyncService,
+        contract_multiplier_metadata_update, default_tracking_mode_for_broker_account_type,
+        holdings_option_metadata, normalize_holdings_money, normalize_regular_average_cost,
+        option_contract_multiplier, positive_contract_multiplier,
+        regular_contract_multiplier_metadata, BrokerSyncService,
     };
     use crate::broker::models::{
         HoldingsOptionPosition, HoldingsOptionSymbol, HoldingsPosition, HoldingsUnderlyingSymbol,
     };
     use wealthfolio_core::accounts::{account_types, TrackingMode};
-    use wealthfolio_core::assets::{AssetSpec, InstrumentType, OptionSpec};
+    use wealthfolio_core::assets::{
+        Asset, AssetSpec, InstrumentType, OptionSpec, CONTRACT_MULTIPLIER_METADATA_KEY,
+    };
 
     fn decimal(value: &str) -> Decimal {
         Decimal::from_str(value).expect("valid decimal")
@@ -1659,6 +1805,74 @@ mod tests {
     }
 
     #[test]
+    fn regular_asset_metadata_stores_only_non_default_multiplier() {
+        assert!(regular_contract_multiplier_metadata(None).is_none());
+        assert!(regular_contract_multiplier_metadata(Some(Decimal::ONE)).is_none());
+
+        let metadata = regular_contract_multiplier_metadata(Some(decimal("50")))
+            .expect("non-default multiplier metadata");
+        let asset = Asset {
+            instrument_type: Some(InstrumentType::Equity),
+            metadata: Some(metadata),
+            ..Default::default()
+        };
+
+        assert_eq!(asset.contract_multiplier(), decimal("50"));
+    }
+
+    #[test]
+    fn asset_multiplier_update_compares_resolved_value() {
+        let asset = Asset {
+            instrument_type: Some(InstrumentType::Equity),
+            metadata: Some(serde_json::json!({
+                "contractMultiplier": "50",
+                "identifiers": { "isin": "US0378331005" }
+            })),
+            ..Default::default()
+        };
+
+        assert!(contract_multiplier_metadata_update(&asset, None, decimal("50")).is_none());
+
+        let updated = contract_multiplier_metadata_update(&asset, None, Decimal::ONE)
+            .expect("changed multiplier");
+        assert!(updated.get(CONTRACT_MULTIPLIER_METADATA_KEY).is_none());
+        assert_eq!(
+            updated["identifiers"],
+            asset.metadata.unwrap()["identifiers"]
+        );
+    }
+
+    #[test]
+    fn option_multiplier_update_changes_nested_spec() {
+        let asset = Asset {
+            instrument_type: Some(InstrumentType::Option),
+            metadata: Some(serde_json::json!({
+                "option": {
+                    "underlyingAssetId": "AAPL",
+                    "expiration": "2026-12-18",
+                    "right": "CALL",
+                    "strike": "150",
+                    "multiplier": "100"
+                },
+                "identifiers": { "occ": "AAPL  261218C00150000" }
+            })),
+            ..Default::default()
+        };
+
+        let updated = contract_multiplier_metadata_update(&asset, None, decimal("50"))
+            .expect("changed multiplier");
+        let spec: OptionSpec =
+            serde_json::from_value(updated["option"].clone()).expect("valid option spec");
+
+        assert_eq!(spec.multiplier, decimal("50"));
+        assert_eq!(
+            updated["identifiers"],
+            asset.metadata.unwrap()["identifiers"]
+        );
+        assert!(updated.get(CONTRACT_MULTIPLIER_METADATA_KEY).is_none());
+    }
+
+    #[test]
     fn holdings_contract_multiplier_prefers_exact_value_with_safe_defaults() {
         assert_eq!(
             positive_contract_multiplier(Some(50.0), Decimal::ONE),
@@ -1725,8 +1939,7 @@ mod tests {
             ..Default::default()
         };
 
-        let metadata = holdings_option_metadata(&option, "BROKER-ADJUSTED-OPTION", decimal("50"))
-            .expect("structured option metadata");
+        let metadata = holdings_option_metadata(&option, "BROKER-ADJUSTED-OPTION", decimal("50"));
         let spec: OptionSpec =
             serde_json::from_value(metadata["option"].clone()).expect("valid option spec");
 

--- a/crates/connect/src/broker/service.rs
+++ b/crates/connect/src/broker/service.rs
@@ -1843,6 +1843,18 @@ mod tests {
     }
 
     #[test]
+    fn fractional_asset_multiplier_is_value_stable() {
+        let asset = Asset {
+            instrument_type: Some(InstrumentType::Equity),
+            metadata: Some(serde_json::json!({ "contractMultiplier": 0.1 })),
+            ..Default::default()
+        };
+
+        assert_eq!(asset.contract_multiplier(), decimal("0.1"));
+        assert!(contract_multiplier_metadata_update(&asset, None, decimal("0.1")).is_none());
+    }
+
+    #[test]
     fn option_multiplier_update_changes_nested_spec() {
         let asset = Asset {
             instrument_type: Some(InstrumentType::Option),

--- a/crates/connect/src/broker/service.rs
+++ b/crates/connect/src/broker/service.rs
@@ -28,8 +28,9 @@ use wealthfolio_core::activities::{
     NewActivity, ACTIVITY_TYPE_BUY, ACTIVITY_TYPE_SELL,
 };
 use wealthfolio_core::assets::{
-    build_option_metadata, parse_crypto_pair_symbol, parse_symbol_with_exchange_suffix,
-    AssetServiceTrait, AssetSpec, InstrumentType, OptionSpec,
+    build_option_metadata, parse_crypto_pair_symbol, parse_symbol_with_exchange_suffix, Asset,
+    AssetServiceTrait, AssetSpec, InstrumentType, OptionSpec, UpdateAssetProfile,
+    CONTRACT_MULTIPLIER_METADATA_KEY,
 };
 use wealthfolio_core::errors::Result;
 use wealthfolio_core::events::{DomainEvent, DomainEventSink, NoOpDomainEventSink};
@@ -55,11 +56,14 @@ fn normalize_holdings_money(amount: Decimal, currency: &str) -> (Decimal, String
     )
 }
 
-fn positive_contract_multiplier(value: Option<f64>, fallback: Decimal) -> Decimal {
+fn exact_positive_contract_multiplier(value: Option<f64>) -> Option<Decimal> {
     value
         .and_then(Decimal::from_f64)
         .filter(|multiplier| *multiplier > Decimal::ZERO)
-        .unwrap_or(fallback)
+}
+
+fn positive_contract_multiplier(value: Option<f64>, fallback: Decimal) -> Decimal {
+    exact_positive_contract_multiplier(value).unwrap_or(fallback)
 }
 
 fn normalize_regular_average_cost(
@@ -80,15 +84,10 @@ fn option_contract_multiplier(option: &HoldingsOptionSymbol) -> Decimal {
     positive_contract_multiplier(option.multiplier, legacy_fallback)
 }
 
-fn holdings_option_metadata(
+fn structured_holdings_option_metadata(
     option: &HoldingsOptionSymbol,
-    ticker: &str,
     multiplier: Decimal,
 ) -> Option<serde_json::Value> {
-    if let Some(metadata) = build_option_metadata(ticker, multiplier) {
-        return Some(metadata);
-    }
-
     // Non-OCC brokerage identifiers are still valid holdings. Build the option metadata from the
     // structured contract fields so the position remains correctly valued and visible for review.
     let underlying = option.underlying_symbol.as_ref()?.symbol.as_deref()?.trim();
@@ -105,7 +104,7 @@ fn holdings_option_metadata(
     let strike = option
         .strike_price
         .and_then(Decimal::from_f64)
-        .filter(|value| *value >= Decimal::ZERO)?;
+        .filter(|value| *value > Decimal::ZERO)?;
 
     Some(serde_json::json!({
         "option": OptionSpec {
@@ -119,6 +118,72 @@ fn holdings_option_metadata(
     }))
 }
 
+fn metadata_with_contract_multiplier(
+    metadata: Option<serde_json::Value>,
+    multiplier: Decimal,
+) -> serde_json::Value {
+    let mut object = metadata
+        .and_then(|value| value.as_object().cloned())
+        .unwrap_or_default();
+    object.insert(
+        CONTRACT_MULTIPLIER_METADATA_KEY.to_string(),
+        serde_json::json!(multiplier),
+    );
+    serde_json::Value::Object(object)
+}
+
+fn holdings_option_metadata(
+    option: &HoldingsOptionSymbol,
+    ticker: &str,
+    multiplier: Decimal,
+) -> serde_json::Value {
+    let metadata = build_option_metadata(ticker, multiplier)
+        .or_else(|| structured_holdings_option_metadata(option, multiplier));
+    metadata_with_contract_multiplier(metadata, multiplier)
+}
+
+fn has_contract_multiplier_metadata(metadata: Option<&serde_json::Value>) -> bool {
+    metadata.is_some_and(|metadata| {
+        metadata.get(CONTRACT_MULTIPLIER_METADATA_KEY).is_some()
+            || metadata
+                .get("option")
+                .and_then(|option| option.get("multiplier"))
+                .is_some()
+    })
+}
+
+fn merged_broker_asset_metadata(
+    existing: Option<&serde_json::Value>,
+    incoming: Option<&serde_json::Value>,
+) -> Option<serde_json::Value> {
+    let incoming = incoming?.as_object()?;
+    let mut merged = existing
+        .and_then(serde_json::Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    for (key, value) in incoming {
+        merged.insert(key.clone(), value.clone());
+    }
+    let merged = serde_json::Value::Object(merged);
+    (existing != Some(&merged)).then_some(merged)
+}
+
+fn metadata_update_payload(asset: &Asset, metadata: serde_json::Value) -> UpdateAssetProfile {
+    UpdateAssetProfile {
+        name: asset.name.clone(),
+        display_code: asset.display_code.clone(),
+        notes: asset.notes.clone().unwrap_or_default(),
+        kind: Some(asset.kind.clone()),
+        quote_mode: Some(asset.quote_mode),
+        quote_ccy: Some(asset.quote_ccy.clone()),
+        instrument_type: asset.instrument_type.clone(),
+        instrument_symbol: asset.instrument_symbol.clone(),
+        instrument_exchange_mic: asset.instrument_exchange_mic.clone(),
+        provider_config: asset.provider_config.clone(),
+        metadata: Some(metadata),
+    }
+}
+
 #[derive(Debug, Clone)]
 struct HoldingsPositionData {
     spec_key: String,
@@ -128,6 +193,20 @@ struct HoldingsPositionData {
     average_cost: Option<Decimal>,
     position_currency: String,
     contract_multiplier: Decimal,
+    contract_multiplier_is_authoritative: bool,
+    rescale_average_cost_with_multiplier: bool,
+}
+
+fn apply_resolved_contract_multiplier(position: &mut HoldingsPositionData, multiplier: Decimal) {
+    if position.rescale_average_cost_with_multiplier {
+        if let Some(average_cost) = position.average_cost {
+            position.average_cost = Some(
+                (average_cost * multiplier / position.contract_multiplier)
+                    .round_dp(HOLDINGS_DECIMAL_PRECISION),
+            );
+        }
+    }
+    position.contract_multiplier = multiplier;
 }
 
 /// Service for syncing broker data to the local database
@@ -759,8 +838,9 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
 
         // 1. Build AssetSpecs and position data from broker positions
         let mut asset_specs: Vec<AssetSpec> = Vec::new();
-        // Keyed by (symbol, currency) → index into asset_specs
+        // Canonical instrument key → index into asset_specs
         let mut spec_key_to_idx: HashMap<String, usize> = HashMap::new();
+        let mut authoritative_multiplier_keys: HashSet<String> = HashSet::new();
         let mut position_data: Vec<HoldingsPositionData> = Vec::new();
 
         for pos in &positions {
@@ -819,11 +899,16 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
 
             let instrument_type =
                 map_broker_symbol_type(symbol_type_code.as_deref(), is_crypto_asset);
+            let exact_contract_multiplier =
+                exact_positive_contract_multiplier(pos.contract_multiplier);
+            let contract_multiplier = exact_contract_multiplier.unwrap_or(Decimal::ONE);
 
             let asset_name = symbol_info.and_then(|s| s.name.clone().or(s.description.clone()));
 
             let spec = AssetSpec {
                 name: asset_name,
+                metadata: exact_contract_multiplier
+                    .map(|multiplier| metadata_with_contract_multiplier(None, multiplier)),
                 ..AssetSpec::market_instrument(
                     symbol.clone(),
                     symbol.clone(),
@@ -842,10 +927,17 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 )
             });
 
-            if !spec_key_to_idx.contains_key(&spec_key) {
+            if let Some(existing_idx) = spec_key_to_idx.get(&spec_key) {
+                if exact_contract_multiplier.is_some() {
+                    asset_specs[*existing_idx].metadata = spec.metadata.clone();
+                }
+            } else {
                 let idx = asset_specs.len();
                 asset_specs.push(spec);
                 spec_key_to_idx.insert(spec_key.clone(), idx);
+            }
+            if exact_contract_multiplier.is_some() {
+                authoritative_multiplier_keys.insert(spec_key.clone());
             }
 
             let quantity = Decimal::from_f64(units)
@@ -853,8 +945,8 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 .round_dp(HOLDINGS_DECIMAL_PRECISION);
             let raw_price = Decimal::from_f64(pos.price.unwrap_or(0.0)).unwrap_or(Decimal::ZERO);
             let quote_price = raw_price.round_dp(HOLDINGS_DECIMAL_PRECISION);
-            let contract_multiplier =
-                positive_contract_multiplier(pos.contract_multiplier, Decimal::ONE);
+            // SnapTrade reports regular-position average cost per underlying unit. Store it per
+            // broker position unit so quantity * average_cost remains the complete cost basis.
             let avg_cost = pos
                 .average_purchase_price
                 .and_then(Decimal::from_f64)
@@ -870,6 +962,8 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 average_cost: avg_cost,
                 position_currency,
                 contract_multiplier,
+                contract_multiplier_is_authoritative: exact_contract_multiplier.is_some(),
+                rescale_average_cost_with_multiplier: true,
             });
         }
 
@@ -914,6 +1008,8 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
             let position_currency = normalize_currency_code(&raw_quote_currency).to_string();
 
             let multiplier = option_contract_multiplier(option_symbol);
+            let multiplier_is_authoritative =
+                exact_positive_contract_multiplier(option_symbol.multiplier).is_some();
             let metadata = holdings_option_metadata(option_symbol, &normalized_ticker, multiplier);
 
             let asset_name = option_symbol
@@ -923,7 +1019,7 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
 
             let spec = AssetSpec {
                 name: asset_name,
-                metadata,
+                metadata: Some(metadata),
                 ..AssetSpec::market_instrument(
                     normalized_ticker.clone(),
                     normalized_ticker.clone(),
@@ -937,10 +1033,17 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 .instrument_key()
                 .unwrap_or_else(|| format!("OPTION:{}", normalized_ticker.to_uppercase()));
 
-            if !spec_key_to_idx.contains_key(&spec_key) {
+            if let Some(existing_idx) = spec_key_to_idx.get(&spec_key) {
+                if multiplier_is_authoritative {
+                    asset_specs[*existing_idx].metadata = spec.metadata.clone();
+                }
+            } else {
                 let idx = asset_specs.len();
                 asset_specs.push(spec);
                 spec_key_to_idx.insert(spec_key.clone(), idx);
+            }
+            if multiplier_is_authoritative {
+                authoritative_multiplier_keys.insert(spec_key.clone());
             }
 
             let quantity = Decimal::from_f64(units)
@@ -949,6 +1052,8 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
             let raw_price =
                 Decimal::from_f64(opt_pos.price.unwrap_or(0.0)).unwrap_or(Decimal::ZERO);
             let quote_price = raw_price.round_dp(HOLDINGS_DECIMAL_PRECISION);
+            // The holdings aggregation API already reports option average cost per contract.
+            // Unlike regular contracts, applying the multiplier again would double-scale it.
             let avg_cost = opt_pos
                 .average_purchase_price
                 .and_then(Decimal::from_f64)
@@ -962,6 +1067,8 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 average_cost: avg_cost,
                 position_currency,
                 contract_multiplier: multiplier,
+                contract_multiplier_is_authoritative: multiplier_is_authoritative,
+                rescale_average_cost_with_multiplier: false,
             });
         }
 
@@ -1003,6 +1110,60 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 if let Some(asset_id) = key_to_asset_id.get(id) {
                     spec_key_to_asset_id.insert(spec_key.clone(), asset_id.clone());
                 }
+            }
+        }
+
+        // Persist broker economic metadata for assets that predate this sync. Missing multiplier
+        // fields are not authoritative and must not replace a previously known exact value.
+        let created_asset_ids: HashSet<&str> = ensure_result
+            .created_ids
+            .iter()
+            .map(String::as_str)
+            .collect();
+        let mut resolved_asset_multipliers: HashMap<String, Decimal> = ensure_result
+            .assets
+            .values()
+            .map(|asset| (asset.id.clone(), asset.contract_multiplier()))
+            .collect();
+        for (spec_key, idx) in &spec_key_to_idx {
+            let Some(asset_id) = spec_key_to_asset_id.get(spec_key) else {
+                continue;
+            };
+            if created_asset_ids.contains(asset_id.as_str()) {
+                continue;
+            }
+            let Some(asset) = ensure_result.assets.get(asset_id).cloned() else {
+                continue;
+            };
+            let incoming_metadata = asset_specs[*idx].metadata.as_ref();
+            let should_update = authoritative_multiplier_keys.contains(spec_key)
+                || !has_contract_multiplier_metadata(asset.metadata.as_ref());
+            if !should_update {
+                continue;
+            }
+            let Some(metadata) =
+                merged_broker_asset_metadata(asset.metadata.as_ref(), incoming_metadata)
+            else {
+                continue;
+            };
+            let updated = self
+                .asset_service
+                .update_asset_profile(&asset.id, metadata_update_payload(&asset, metadata))
+                .await?;
+            resolved_asset_multipliers.insert(updated.id.clone(), updated.contract_multiplier());
+        }
+
+        // When the current response omits a multiplier, reuse persisted asset metadata rather than
+        // reverting the snapshot to a generic 1/100 fallback.
+        for position in &mut position_data {
+            if position.contract_multiplier_is_authoritative {
+                continue;
+            }
+            let Some(asset_id) = spec_key_to_asset_id.get(&position.spec_key) else {
+                continue;
+            };
+            if let Some(multiplier) = resolved_asset_multipliers.get(asset_id) {
+                apply_resolved_contract_multiplier(position, *multiplier);
             }
         }
 
@@ -1096,6 +1257,8 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                     .and_then(|snapshot| snapshot.positions.get(&asset_id)),
                 combined_quantity,
                 &position.position_currency,
+                position.contract_multiplier,
+                position.rescale_average_cost_with_multiplier,
             );
             let position_cost_basis =
                 (position.quantity * avg_cost).round_dp(HOLDINGS_DECIMAL_PRECISION);
@@ -1251,6 +1414,8 @@ impl BrokerSyncService {
         latest_position: Option<&Position>,
         quantity: Decimal,
         currency: &str,
+        contract_multiplier: Decimal,
+        rescale_with_multiplier: bool,
     ) -> Decimal {
         if let Some(avg_cost) = broker_average_cost {
             return avg_cost.round_dp(HOLDINGS_DECIMAL_PRECISION);
@@ -1260,7 +1425,17 @@ impl BrokerSyncService {
             let same_quantity = previous.quantity.round_dp(HOLDINGS_DECIMAL_PRECISION)
                 == quantity.round_dp(HOLDINGS_DECIMAL_PRECISION);
             if same_quantity && previous.currency == currency {
-                return previous.average_cost.round_dp(HOLDINGS_DECIMAL_PRECISION);
+                let previous_average_cost = previous.average_cost;
+                if rescale_with_multiplier {
+                    let previous_multiplier = if previous.contract_multiplier > Decimal::ZERO {
+                        previous.contract_multiplier
+                    } else {
+                        Decimal::ONE
+                    };
+                    return (previous_average_cost * contract_multiplier / previous_multiplier)
+                        .round_dp(HOLDINGS_DECIMAL_PRECISION);
+                }
+                return previous_average_cost.round_dp(HOLDINGS_DECIMAL_PRECISION);
             }
         }
 
@@ -1274,6 +1449,18 @@ impl BrokerSyncService {
     /// cost basis are summed and the average cost is recomputed as a quantity-weighted average so
     /// the merged holding reflects the full position rather than a single lot.
     fn merge_broker_position(existing: &mut Position, incoming: Position) {
+        if existing
+            .contract_multiplier
+            .round_dp(HOLDINGS_DECIMAL_PRECISION)
+            != incoming
+                .contract_multiplier
+                .round_dp(HOLDINGS_DECIMAL_PRECISION)
+        {
+            warn!(
+                "Broker returned inconsistent contract multipliers for asset {}; retaining the first",
+                existing.asset_id
+            );
+        }
         let combined_quantity =
             (existing.quantity + incoming.quantity).round_dp(HOLDINGS_DECIMAL_PRECISION);
         let combined_cost_basis = (existing.total_cost_basis + incoming.total_cost_basis)
@@ -1600,6 +1787,8 @@ mod tests {
             average_cost: Some(normalize_holdings_money(decimal("82.5"), "GBp").0),
             position_currency,
             contract_multiplier: Decimal::ONE,
+            contract_multiplier_is_authoritative: false,
+            rescale_average_cost_with_multiplier: true,
         };
 
         assert_eq!(position.quote_price, decimal("85"));
@@ -1618,6 +1807,31 @@ mod tests {
             normalize_regular_average_cost(decimal("82.5"), "GBp", decimal("10")),
             decimal("8.25")
         );
+    }
+
+    #[test]
+    fn persisted_multiplier_rescales_regular_but_not_option_average_cost() {
+        let position = |rescale_average_cost_with_multiplier| super::HoldingsPositionData {
+            spec_key: "CONTRACT".to_string(),
+            quantity: decimal("2"),
+            quote_price: decimal("15"),
+            quote_currency: "USD".to_string(),
+            average_cost: Some(decimal("12.5")),
+            position_currency: "USD".to_string(),
+            contract_multiplier: Decimal::ONE,
+            contract_multiplier_is_authoritative: false,
+            rescale_average_cost_with_multiplier,
+        };
+        let mut regular = position(true);
+        let mut option = position(false);
+
+        super::apply_resolved_contract_multiplier(&mut regular, decimal("50"));
+        super::apply_resolved_contract_multiplier(&mut option, decimal("50"));
+
+        assert_eq!(regular.average_cost, Some(decimal("625")));
+        assert_eq!(option.average_cost, Some(decimal("12.5")));
+        assert_eq!(regular.contract_multiplier, decimal("50"));
+        assert_eq!(option.contract_multiplier, decimal("50"));
     }
 
     #[test]
@@ -1687,14 +1901,29 @@ mod tests {
             ..Default::default()
         };
 
-        let metadata = holdings_option_metadata(&option, "BROKER-ADJUSTED-OPTION", decimal("50"))
-            .expect("structured option metadata");
+        let metadata = holdings_option_metadata(&option, "BROKER-ADJUSTED-OPTION", decimal("50"));
         let spec: OptionSpec =
             serde_json::from_value(metadata["option"].clone()).expect("valid option spec");
 
         assert_eq!(spec.underlying_asset_id, "AAPL");
         assert_eq!(spec.multiplier, decimal("50"));
         assert_eq!(spec.occ_symbol, None);
+        assert_eq!(metadata["contractMultiplier"], serde_json::json!(50.0));
+    }
+
+    #[test]
+    fn broker_multiplier_metadata_merge_preserves_unrelated_fields() {
+        let existing = serde_json::json!({
+            "identifiers": { "isin": "US0378331005" },
+            "contractMultiplier": "100"
+        });
+        let incoming = serde_json::json!({ "contractMultiplier": "50" });
+
+        let merged = super::merged_broker_asset_metadata(Some(&existing), Some(&incoming))
+            .expect("changed metadata");
+
+        assert_eq!(merged["identifiers"], existing["identifiers"]);
+        assert_eq!(merged["contractMultiplier"], serde_json::json!("50"));
     }
 
     fn position(
@@ -1923,6 +2152,8 @@ mod tests {
             Some(&latest),
             decimal("10"),
             "USD",
+            decimal("50"),
+            true,
         );
 
         assert_eq!(resolved, decimal("125.50"));
@@ -1937,6 +2168,8 @@ mod tests {
             Some(&latest),
             decimal("10.0000000000004"),
             "USD",
+            Decimal::ONE,
+            true,
         );
 
         assert_eq!(resolved, decimal("100.25"));
@@ -1951,19 +2184,62 @@ mod tests {
             Some(&latest),
             decimal("11"),
             "USD",
+            Decimal::ONE,
+            true,
         );
         let currency_changed = BrokerSyncService::resolve_position_average_cost(
             None,
             Some(&latest),
             decimal("10"),
             "CAD",
+            Decimal::ONE,
+            true,
         );
-        let missing =
-            BrokerSyncService::resolve_position_average_cost(None, None, decimal("10"), "USD");
+        let missing = BrokerSyncService::resolve_position_average_cost(
+            None,
+            None,
+            decimal("10"),
+            "USD",
+            Decimal::ONE,
+            true,
+        );
 
         assert_eq!(quantity_changed, Decimal::ZERO);
         assert_eq!(currency_changed, Decimal::ZERO);
         assert_eq!(missing, Decimal::ZERO);
+    }
+
+    #[test]
+    fn resolve_position_average_cost_rescales_regular_cost_when_multiplier_changes() {
+        let latest = position("acc-1", "future", "2", "12.5", "25", "USD");
+
+        let resolved = BrokerSyncService::resolve_position_average_cost(
+            None,
+            Some(&latest),
+            decimal("2"),
+            "USD",
+            decimal("50"),
+            true,
+        );
+
+        assert_eq!(resolved, decimal("625"));
+    }
+
+    #[test]
+    fn resolve_position_average_cost_does_not_rescale_option_contract_cost() {
+        let mut latest = position("acc-1", "option", "2", "5000", "10000", "USD");
+        latest.contract_multiplier = decimal("100");
+
+        let resolved = BrokerSyncService::resolve_position_average_cost(
+            None,
+            Some(&latest),
+            decimal("2"),
+            "USD",
+            decimal("50"),
+            false,
+        );
+
+        assert_eq!(resolved, decimal("5000"));
     }
 
     #[test]
@@ -2060,6 +2336,8 @@ mod tests {
             average_cost: None,
             position_currency: "USD".to_string(),
             contract_multiplier: Decimal::ONE,
+            contract_multiplier_is_authoritative: false,
+            rescale_average_cost_with_multiplier: true,
         };
         let position_data = vec![
             row("EQUITY:VTI", "32.005"),
@@ -2089,12 +2367,16 @@ mod tests {
             Some(&latest),
             decimal("50.428"),
             "USD",
+            Decimal::ONE,
+            true,
         );
         let single_row = BrokerSyncService::resolve_position_average_cost(
             None,
             Some(&latest),
             decimal("32.005"),
             "USD",
+            Decimal::ONE,
+            true,
         );
 
         assert_eq!(combined, decimal("300"));

--- a/crates/connect/src/broker/service.rs
+++ b/crates/connect/src/broker/service.rs
@@ -28,9 +28,8 @@ use wealthfolio_core::activities::{
     NewActivity, ACTIVITY_TYPE_BUY, ACTIVITY_TYPE_SELL,
 };
 use wealthfolio_core::assets::{
-    build_option_metadata, parse_crypto_pair_symbol, parse_symbol_with_exchange_suffix, Asset,
-    AssetServiceTrait, AssetSpec, InstrumentType, OptionSpec, UpdateAssetProfile,
-    CONTRACT_MULTIPLIER_METADATA_KEY,
+    build_option_metadata, parse_crypto_pair_symbol, parse_symbol_with_exchange_suffix,
+    AssetServiceTrait, AssetSpec, InstrumentType, OptionSpec,
 };
 use wealthfolio_core::errors::Result;
 use wealthfolio_core::events::{DomainEvent, DomainEventSink, NoOpDomainEventSink};
@@ -56,14 +55,11 @@ fn normalize_holdings_money(amount: Decimal, currency: &str) -> (Decimal, String
     )
 }
 
-fn exact_positive_contract_multiplier(value: Option<f64>) -> Option<Decimal> {
+fn positive_contract_multiplier(value: Option<f64>, fallback: Decimal) -> Decimal {
     value
         .and_then(Decimal::from_f64)
         .filter(|multiplier| *multiplier > Decimal::ZERO)
-}
-
-fn positive_contract_multiplier(value: Option<f64>, fallback: Decimal) -> Decimal {
-    exact_positive_contract_multiplier(value).unwrap_or(fallback)
+        .unwrap_or(fallback)
 }
 
 fn normalize_regular_average_cost(
@@ -118,70 +114,13 @@ fn structured_holdings_option_metadata(
     }))
 }
 
-fn metadata_with_contract_multiplier(
-    metadata: Option<serde_json::Value>,
-    multiplier: Decimal,
-) -> serde_json::Value {
-    let mut object = metadata
-        .and_then(|value| value.as_object().cloned())
-        .unwrap_or_default();
-    object.insert(
-        CONTRACT_MULTIPLIER_METADATA_KEY.to_string(),
-        serde_json::json!(multiplier),
-    );
-    serde_json::Value::Object(object)
-}
-
 fn holdings_option_metadata(
     option: &HoldingsOptionSymbol,
     ticker: &str,
     multiplier: Decimal,
-) -> serde_json::Value {
-    let metadata = build_option_metadata(ticker, multiplier)
-        .or_else(|| structured_holdings_option_metadata(option, multiplier));
-    metadata_with_contract_multiplier(metadata, multiplier)
-}
-
-fn has_contract_multiplier_metadata(metadata: Option<&serde_json::Value>) -> bool {
-    metadata.is_some_and(|metadata| {
-        metadata.get(CONTRACT_MULTIPLIER_METADATA_KEY).is_some()
-            || metadata
-                .get("option")
-                .and_then(|option| option.get("multiplier"))
-                .is_some()
-    })
-}
-
-fn merged_broker_asset_metadata(
-    existing: Option<&serde_json::Value>,
-    incoming: Option<&serde_json::Value>,
 ) -> Option<serde_json::Value> {
-    let incoming = incoming?.as_object()?;
-    let mut merged = existing
-        .and_then(serde_json::Value::as_object)
-        .cloned()
-        .unwrap_or_default();
-    for (key, value) in incoming {
-        merged.insert(key.clone(), value.clone());
-    }
-    let merged = serde_json::Value::Object(merged);
-    (existing != Some(&merged)).then_some(merged)
-}
-
-fn metadata_update_payload(asset: &Asset, metadata: serde_json::Value) -> UpdateAssetProfile {
-    UpdateAssetProfile {
-        name: asset.name.clone(),
-        display_code: asset.display_code.clone(),
-        notes: asset.notes.clone().unwrap_or_default(),
-        kind: Some(asset.kind.clone()),
-        quote_mode: Some(asset.quote_mode),
-        quote_ccy: Some(asset.quote_ccy.clone()),
-        instrument_type: asset.instrument_type.clone(),
-        instrument_symbol: asset.instrument_symbol.clone(),
-        instrument_exchange_mic: asset.instrument_exchange_mic.clone(),
-        provider_config: asset.provider_config.clone(),
-        metadata: Some(metadata),
-    }
+    build_option_metadata(ticker, multiplier)
+        .or_else(|| structured_holdings_option_metadata(option, multiplier))
 }
 
 #[derive(Debug, Clone)]
@@ -193,20 +132,7 @@ struct HoldingsPositionData {
     average_cost: Option<Decimal>,
     position_currency: String,
     contract_multiplier: Decimal,
-    contract_multiplier_is_authoritative: bool,
     rescale_average_cost_with_multiplier: bool,
-}
-
-fn apply_resolved_contract_multiplier(position: &mut HoldingsPositionData, multiplier: Decimal) {
-    if position.rescale_average_cost_with_multiplier {
-        if let Some(average_cost) = position.average_cost {
-            position.average_cost = Some(
-                (average_cost * multiplier / position.contract_multiplier)
-                    .round_dp(HOLDINGS_DECIMAL_PRECISION),
-            );
-        }
-    }
-    position.contract_multiplier = multiplier;
 }
 
 /// Service for syncing broker data to the local database
@@ -840,7 +766,6 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
         let mut asset_specs: Vec<AssetSpec> = Vec::new();
         // Canonical instrument key → index into asset_specs
         let mut spec_key_to_idx: HashMap<String, usize> = HashMap::new();
-        let mut authoritative_multiplier_keys: HashSet<String> = HashSet::new();
         let mut position_data: Vec<HoldingsPositionData> = Vec::new();
 
         for pos in &positions {
@@ -899,16 +824,13 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
 
             let instrument_type =
                 map_broker_symbol_type(symbol_type_code.as_deref(), is_crypto_asset);
-            let exact_contract_multiplier =
-                exact_positive_contract_multiplier(pos.contract_multiplier);
-            let contract_multiplier = exact_contract_multiplier.unwrap_or(Decimal::ONE);
+            let contract_multiplier =
+                positive_contract_multiplier(pos.contract_multiplier, Decimal::ONE);
 
             let asset_name = symbol_info.and_then(|s| s.name.clone().or(s.description.clone()));
 
             let spec = AssetSpec {
                 name: asset_name,
-                metadata: exact_contract_multiplier
-                    .map(|multiplier| metadata_with_contract_multiplier(None, multiplier)),
                 ..AssetSpec::market_instrument(
                     symbol.clone(),
                     symbol.clone(),
@@ -927,17 +849,10 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 )
             });
 
-            if let Some(existing_idx) = spec_key_to_idx.get(&spec_key) {
-                if exact_contract_multiplier.is_some() {
-                    asset_specs[*existing_idx].metadata = spec.metadata.clone();
-                }
-            } else {
+            if !spec_key_to_idx.contains_key(&spec_key) {
                 let idx = asset_specs.len();
                 asset_specs.push(spec);
                 spec_key_to_idx.insert(spec_key.clone(), idx);
-            }
-            if exact_contract_multiplier.is_some() {
-                authoritative_multiplier_keys.insert(spec_key.clone());
             }
 
             let quantity = Decimal::from_f64(units)
@@ -962,7 +877,6 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 average_cost: avg_cost,
                 position_currency,
                 contract_multiplier,
-                contract_multiplier_is_authoritative: exact_contract_multiplier.is_some(),
                 rescale_average_cost_with_multiplier: true,
             });
         }
@@ -1008,8 +922,6 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
             let position_currency = normalize_currency_code(&raw_quote_currency).to_string();
 
             let multiplier = option_contract_multiplier(option_symbol);
-            let multiplier_is_authoritative =
-                exact_positive_contract_multiplier(option_symbol.multiplier).is_some();
             let metadata = holdings_option_metadata(option_symbol, &normalized_ticker, multiplier);
 
             let asset_name = option_symbol
@@ -1019,7 +931,7 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
 
             let spec = AssetSpec {
                 name: asset_name,
-                metadata: Some(metadata),
+                metadata,
                 ..AssetSpec::market_instrument(
                     normalized_ticker.clone(),
                     normalized_ticker.clone(),
@@ -1033,17 +945,10 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 .instrument_key()
                 .unwrap_or_else(|| format!("OPTION:{}", normalized_ticker.to_uppercase()));
 
-            if let Some(existing_idx) = spec_key_to_idx.get(&spec_key) {
-                if multiplier_is_authoritative {
-                    asset_specs[*existing_idx].metadata = spec.metadata.clone();
-                }
-            } else {
+            if !spec_key_to_idx.contains_key(&spec_key) {
                 let idx = asset_specs.len();
                 asset_specs.push(spec);
                 spec_key_to_idx.insert(spec_key.clone(), idx);
-            }
-            if multiplier_is_authoritative {
-                authoritative_multiplier_keys.insert(spec_key.clone());
             }
 
             let quantity = Decimal::from_f64(units)
@@ -1067,7 +972,6 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 average_cost: avg_cost,
                 position_currency,
                 contract_multiplier: multiplier,
-                contract_multiplier_is_authoritative: multiplier_is_authoritative,
                 rescale_average_cost_with_multiplier: false,
             });
         }
@@ -1110,60 +1014,6 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 if let Some(asset_id) = key_to_asset_id.get(id) {
                     spec_key_to_asset_id.insert(spec_key.clone(), asset_id.clone());
                 }
-            }
-        }
-
-        // Persist broker economic metadata for assets that predate this sync. Missing multiplier
-        // fields are not authoritative and must not replace a previously known exact value.
-        let created_asset_ids: HashSet<&str> = ensure_result
-            .created_ids
-            .iter()
-            .map(String::as_str)
-            .collect();
-        let mut resolved_asset_multipliers: HashMap<String, Decimal> = ensure_result
-            .assets
-            .values()
-            .map(|asset| (asset.id.clone(), asset.contract_multiplier()))
-            .collect();
-        for (spec_key, idx) in &spec_key_to_idx {
-            let Some(asset_id) = spec_key_to_asset_id.get(spec_key) else {
-                continue;
-            };
-            if created_asset_ids.contains(asset_id.as_str()) {
-                continue;
-            }
-            let Some(asset) = ensure_result.assets.get(asset_id).cloned() else {
-                continue;
-            };
-            let incoming_metadata = asset_specs[*idx].metadata.as_ref();
-            let should_update = authoritative_multiplier_keys.contains(spec_key)
-                || !has_contract_multiplier_metadata(asset.metadata.as_ref());
-            if !should_update {
-                continue;
-            }
-            let Some(metadata) =
-                merged_broker_asset_metadata(asset.metadata.as_ref(), incoming_metadata)
-            else {
-                continue;
-            };
-            let updated = self
-                .asset_service
-                .update_asset_profile(&asset.id, metadata_update_payload(&asset, metadata))
-                .await?;
-            resolved_asset_multipliers.insert(updated.id.clone(), updated.contract_multiplier());
-        }
-
-        // When the current response omits a multiplier, reuse persisted asset metadata rather than
-        // reverting the snapshot to a generic 1/100 fallback.
-        for position in &mut position_data {
-            if position.contract_multiplier_is_authoritative {
-                continue;
-            }
-            let Some(asset_id) = spec_key_to_asset_id.get(&position.spec_key) else {
-                continue;
-            };
-            if let Some(multiplier) = resolved_asset_multipliers.get(asset_id) {
-                apply_resolved_contract_multiplier(position, *multiplier);
             }
         }
 
@@ -1787,7 +1637,6 @@ mod tests {
             average_cost: Some(normalize_holdings_money(decimal("82.5"), "GBp").0),
             position_currency,
             contract_multiplier: Decimal::ONE,
-            contract_multiplier_is_authoritative: false,
             rescale_average_cost_with_multiplier: true,
         };
 
@@ -1807,31 +1656,6 @@ mod tests {
             normalize_regular_average_cost(decimal("82.5"), "GBp", decimal("10")),
             decimal("8.25")
         );
-    }
-
-    #[test]
-    fn persisted_multiplier_rescales_regular_but_not_option_average_cost() {
-        let position = |rescale_average_cost_with_multiplier| super::HoldingsPositionData {
-            spec_key: "CONTRACT".to_string(),
-            quantity: decimal("2"),
-            quote_price: decimal("15"),
-            quote_currency: "USD".to_string(),
-            average_cost: Some(decimal("12.5")),
-            position_currency: "USD".to_string(),
-            contract_multiplier: Decimal::ONE,
-            contract_multiplier_is_authoritative: false,
-            rescale_average_cost_with_multiplier,
-        };
-        let mut regular = position(true);
-        let mut option = position(false);
-
-        super::apply_resolved_contract_multiplier(&mut regular, decimal("50"));
-        super::apply_resolved_contract_multiplier(&mut option, decimal("50"));
-
-        assert_eq!(regular.average_cost, Some(decimal("625")));
-        assert_eq!(option.average_cost, Some(decimal("12.5")));
-        assert_eq!(regular.contract_multiplier, decimal("50"));
-        assert_eq!(option.contract_multiplier, decimal("50"));
     }
 
     #[test]
@@ -1901,29 +1725,14 @@ mod tests {
             ..Default::default()
         };
 
-        let metadata = holdings_option_metadata(&option, "BROKER-ADJUSTED-OPTION", decimal("50"));
+        let metadata = holdings_option_metadata(&option, "BROKER-ADJUSTED-OPTION", decimal("50"))
+            .expect("structured option metadata");
         let spec: OptionSpec =
             serde_json::from_value(metadata["option"].clone()).expect("valid option spec");
 
         assert_eq!(spec.underlying_asset_id, "AAPL");
         assert_eq!(spec.multiplier, decimal("50"));
         assert_eq!(spec.occ_symbol, None);
-        assert_eq!(metadata["contractMultiplier"], serde_json::json!(50.0));
-    }
-
-    #[test]
-    fn broker_multiplier_metadata_merge_preserves_unrelated_fields() {
-        let existing = serde_json::json!({
-            "identifiers": { "isin": "US0378331005" },
-            "contractMultiplier": "100"
-        });
-        let incoming = serde_json::json!({ "contractMultiplier": "50" });
-
-        let merged = super::merged_broker_asset_metadata(Some(&existing), Some(&incoming))
-            .expect("changed metadata");
-
-        assert_eq!(merged["identifiers"], existing["identifiers"]);
-        assert_eq!(merged["contractMultiplier"], serde_json::json!("50"));
     }
 
     fn position(
@@ -2336,7 +2145,6 @@ mod tests {
             average_cost: None,
             position_currency: "USD".to_string(),
             contract_multiplier: Decimal::ONE,
-            contract_multiplier_is_authoritative: false,
             rescale_average_cost_with_multiplier: true,
         };
         let position_data = vec![

--- a/crates/connect/src/broker/traits.rs
+++ b/crates/connect/src/broker/traits.rs
@@ -13,6 +13,22 @@ use crate::platform::Platform;
 use wealthfolio_core::accounts::Account;
 use wealthfolio_core::errors::Result;
 
+/// Account tracking modes accepted by Wealthfolio Connect account-scoped endpoints.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BrokerTrackingMode {
+    Holdings,
+    Transactions,
+}
+
+impl BrokerTrackingMode {
+    pub const fn as_header_value(self) -> &'static str {
+        match self {
+            Self::Holdings => "holdings",
+            Self::Transactions => "transactions",
+        }
+    }
+}
+
 /// Trait for fetching data from the cloud broker API
 #[async_trait]
 pub trait BrokerApiClient: Send + Sync {
@@ -40,6 +56,7 @@ pub trait BrokerApiClient: Send + Sync {
     async fn get_account_activities(
         &self,
         account_id: &str,
+        tracking_mode: BrokerTrackingMode,
         start_date: Option<&str>,
         end_date: Option<&str>,
         offset: Option<i64>,
@@ -53,7 +70,11 @@ pub trait BrokerApiClient: Send + Sync {
     /// * `account_id` - The broker account ID (provider's ID)
     ///
     /// Returns cash balances, stock/ETF positions, and option positions.
-    async fn get_account_holdings(&self, account_id: &str) -> Result<BrokerHoldingsResponse>;
+    async fn get_account_holdings(
+        &self,
+        account_id: &str,
+        tracking_mode: BrokerTrackingMode,
+    ) -> Result<BrokerHoldingsResponse>;
 }
 
 /// Trait for platform repository operations

--- a/crates/connect/src/client.rs
+++ b/crates/connect/src/client.rs
@@ -25,7 +25,6 @@ use super::broker::{BrokerApiClient, BrokerTrackingMode};
 /// Default timeout for API requests.
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
 
-pub const TRACKING_MODE_HEADER: &str = "X-Wealthfolio-Tracking-Mode";
 const TRACKING_MODE_HEADER_NAME: HeaderName =
     HeaderName::from_static("x-wealthfolio-tracking-mode");
 
@@ -203,18 +202,7 @@ impl ConnectApiClient {
 
     /// Make a GET request and parse the response.
     async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
-        let context = CloudRequestContext::new("GET", path, None);
-        let url = format!("{}{}", self.base_url, path);
-
-        let response = self
-            .client
-            .get(&url)
-            .headers(self.headers(&context.client_request_id)?)
-            .send()
-            .await
-            .map_err(|e| self.request_transport_error(&context, e))?;
-
-        self.parse_response(response, &context).await
+        self.get_with_tracking_mode(path, None).await
     }
 
     /// Make an account-scoped GET request with the account's configured tracking mode.
@@ -223,13 +211,27 @@ impl ConnectApiClient {
         path: &str,
         tracking_mode: BrokerTrackingMode,
     ) -> Result<T> {
+        self.get_with_tracking_mode(path, Some(tracking_mode)).await
+    }
+
+    async fn get_with_tracking_mode<T: DeserializeOwned>(
+        &self,
+        path: &str,
+        tracking_mode: Option<BrokerTrackingMode>,
+    ) -> Result<T> {
         let context = CloudRequestContext::new("GET", path, None);
         let url = format!("{}{}", self.base_url, path);
+        let headers = match tracking_mode {
+            Some(tracking_mode) => {
+                self.account_headers(&context.client_request_id, tracking_mode)?
+            }
+            None => self.headers(&context.client_request_id)?,
+        };
 
         let response = self
             .client
             .get(&url)
-            .headers(self.account_headers(&context.client_request_id, tracking_mode)?)
+            .headers(headers)
             .send()
             .await
             .map_err(|e| self.request_transport_error(&context, e))?;
@@ -724,7 +726,7 @@ mod tests {
             let headers = captured.lock().unwrap().clone().expect("captured request");
             assert_eq!(
                 headers
-                    .get(&TRACKING_MODE_HEADER.to_ascii_lowercase())
+                    .get(TRACKING_MODE_HEADER_NAME.as_str())
                     .map(String::as_str),
                 Some(expected)
             );
@@ -741,7 +743,7 @@ mod tests {
             let headers = captured.lock().unwrap().clone().expect("captured request");
             assert_eq!(
                 headers
-                    .get(&TRACKING_MODE_HEADER.to_ascii_lowercase())
+                    .get(TRACKING_MODE_HEADER_NAME.as_str())
                     .map(String::as_str),
                 Some(expected)
             );

--- a/crates/connect/src/client.rs
+++ b/crates/connect/src/client.rs
@@ -6,7 +6,7 @@
 
 use async_trait::async_trait;
 use log::{debug, info};
-use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 use serde::de::DeserializeOwned;
 use std::time::Duration;
 
@@ -20,10 +20,14 @@ use crate::request_metadata::{
 };
 use wealthfolio_core::errors::{Error, Result};
 
-use super::broker::BrokerApiClient;
+use super::broker::{BrokerApiClient, BrokerTrackingMode};
 
 /// Default timeout for API requests.
 const DEFAULT_TIMEOUT_SECS: u64 = 30;
+
+pub const TRACKING_MODE_HEADER: &str = "X-Wealthfolio-Tracking-Mode";
+const TRACKING_MODE_HEADER_NAME: HeaderName =
+    HeaderName::from_static("x-wealthfolio-tracking-mode");
 
 /// Default base URL for Wealthfolio Connect cloud service.
 pub const DEFAULT_CLOUD_API_URL: &str = "https://api.wealthfolio.app";
@@ -184,6 +188,19 @@ impl ConnectApiClient {
         Ok(headers)
     }
 
+    fn account_headers(
+        &self,
+        client_request_id: &str,
+        tracking_mode: BrokerTrackingMode,
+    ) -> Result<HeaderMap> {
+        let mut headers = self.headers(client_request_id)?;
+        headers.insert(
+            TRACKING_MODE_HEADER_NAME,
+            HeaderValue::from_static(tracking_mode.as_header_value()),
+        );
+        Ok(headers)
+    }
+
     /// Make a GET request and parse the response.
     async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
         let context = CloudRequestContext::new("GET", path, None);
@@ -193,6 +210,26 @@ impl ConnectApiClient {
             .client
             .get(&url)
             .headers(self.headers(&context.client_request_id)?)
+            .send()
+            .await
+            .map_err(|e| self.request_transport_error(&context, e))?;
+
+        self.parse_response(response, &context).await
+    }
+
+    /// Make an account-scoped GET request with the account's configured tracking mode.
+    async fn get_account_scoped<T: DeserializeOwned>(
+        &self,
+        path: &str,
+        tracking_mode: BrokerTrackingMode,
+    ) -> Result<T> {
+        let context = CloudRequestContext::new("GET", path, None);
+        let url = format!("{}{}", self.base_url, path);
+
+        let response = self
+            .client
+            .get(&url)
+            .headers(self.account_headers(&context.client_request_id, tracking_mode)?)
             .send()
             .await
             .map_err(|e| self.request_transport_error(&context, e))?;
@@ -279,6 +316,7 @@ impl ConnectApiClient {
     pub async fn get_account_activities(
         &self,
         account_id: &str,
+        tracking_mode: BrokerTrackingMode,
         start_date: Option<&str>,
         end_date: Option<&str>,
         offset: Option<i64>,
@@ -306,7 +344,7 @@ impl ConnectApiClient {
 
         debug!("[ConnectApi] Fetching activities from: {}", path);
 
-        self.get(&path).await
+        self.get_account_scoped(&path, tracking_mode).await
     }
 
     /// Fetch current holdings for a broker account.
@@ -314,12 +352,16 @@ impl ConnectApiClient {
     /// # Arguments
     ///
     /// * `account_id` - The broker account ID (provider's ID)
-    pub async fn get_account_holdings(&self, account_id: &str) -> Result<BrokerHoldingsResponse> {
+    pub async fn get_account_holdings(
+        &self,
+        account_id: &str,
+        tracking_mode: BrokerTrackingMode,
+    ) -> Result<BrokerHoldingsResponse> {
         let path = format!("/api/v1/sync/brokerage/accounts/{}/holdings", account_id);
 
         debug!("[ConnectApi] Fetching holdings from: {}", path);
 
-        self.get(&path).await
+        self.get_account_scoped(&path, tracking_mode).await
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -486,6 +528,7 @@ impl BrokerApiClient for ConnectApiClient {
     async fn get_account_activities(
         &self,
         account_id: &str,
+        tracking_mode: BrokerTrackingMode,
         start_date: Option<&str>,
         end_date: Option<&str>,
         offset: Option<i64>,
@@ -493,15 +536,25 @@ impl BrokerApiClient for ConnectApiClient {
     ) -> Result<PaginatedUniversalActivity> {
         // Delegate to the inherent method
         ConnectApiClient::get_account_activities(
-            self, account_id, start_date, end_date, offset, limit,
+            self,
+            account_id,
+            tracking_mode,
+            start_date,
+            end_date,
+            offset,
+            limit,
         )
         .await
     }
 
     /// Fetch current holdings for a broker account.
-    async fn get_account_holdings(&self, account_id: &str) -> Result<BrokerHoldingsResponse> {
+    async fn get_account_holdings(
+        &self,
+        account_id: &str,
+        tracking_mode: BrokerTrackingMode,
+    ) -> Result<BrokerHoldingsResponse> {
         // Delegate to the inherent method
-        ConnectApiClient::get_account_holdings(self, account_id).await
+        ConnectApiClient::get_account_holdings(self, account_id, tracking_mode).await
     }
 }
 
@@ -651,6 +704,49 @@ mod tests {
         assert!(is_log_safe_request_id(client_request_id));
         assert!(!headers.contains_key(SERVER_REQUEST_ID_HEADER));
         handle.join().expect("server thread");
+    }
+
+    #[tokio::test]
+    async fn account_scoped_requests_send_configured_tracking_mode() {
+        for (tracking_mode, expected) in [
+            (BrokerTrackingMode::Holdings, "holdings"),
+            (BrokerTrackingMode::Transactions, "transactions"),
+        ] {
+            let (base_url, captured, handle) =
+                start_one_request_server(200, r#"{"data":[],"pagination":{}}"#, None);
+            let client = ConnectApiClient::new(&base_url, "test-token").unwrap();
+
+            client
+                .get_account_activities("broker-account", tracking_mode, None, None, None, None)
+                .await
+                .unwrap();
+
+            let headers = captured.lock().unwrap().clone().expect("captured request");
+            assert_eq!(
+                headers
+                    .get(&TRACKING_MODE_HEADER.to_ascii_lowercase())
+                    .map(String::as_str),
+                Some(expected)
+            );
+            handle.join().expect("server thread");
+
+            let (base_url, captured, handle) = start_one_request_server(200, r#"{}"#, None);
+            let client = ConnectApiClient::new(&base_url, "test-token").unwrap();
+
+            client
+                .get_account_holdings("broker-account", tracking_mode)
+                .await
+                .unwrap();
+
+            let headers = captured.lock().unwrap().clone().expect("captured request");
+            assert_eq!(
+                headers
+                    .get(&TRACKING_MODE_HEADER.to_ascii_lowercase())
+                    .map(String::as_str),
+                Some(expected)
+            );
+            handle.join().expect("server thread");
+        }
     }
 
     #[tokio::test]

--- a/crates/core/src/assets/assets_model.rs
+++ b/crates/core/src/assets/assets_model.rs
@@ -153,6 +153,9 @@ pub struct OptionSpec {
     pub occ_symbol: Option<String>,
 }
 
+/// Top-level asset metadata key for instruments whose value is scaled per contract.
+pub const CONTRACT_MULTIPLIER_METADATA_KEY: &str = "contractMultiplier";
+
 /// Bond specification stored in Asset.metadata["bond"]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -410,10 +413,23 @@ impl Asset {
     /// Returns the contract multiplier for this asset.
     ///
     /// For options, this is the number of shares per contract (typically 100).
-    /// For all other instruments it is 1.
+    /// Other contract instruments can provide an explicit multiplier in asset metadata.
     pub fn contract_multiplier(&self) -> Decimal {
         if let Some(spec) = self.option_spec() {
             spec.multiplier
+        } else if let Some(multiplier) = self
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(CONTRACT_MULTIPLIER_METADATA_KEY))
+            .and_then(|value| {
+                value
+                    .as_f64()
+                    .and_then(Decimal::from_f64_retain)
+                    .or_else(|| value.as_str().and_then(|raw| raw.parse::<Decimal>().ok()))
+            })
+            .filter(|multiplier| *multiplier > Decimal::ZERO)
+        {
+            multiplier
         } else if self.is_option() {
             // Option without metadata — default to standard 100 multiplier
             Decimal::from(100)

--- a/crates/core/src/assets/assets_model.rs
+++ b/crates/core/src/assets/assets_model.rs
@@ -153,9 +153,6 @@ pub struct OptionSpec {
     pub occ_symbol: Option<String>,
 }
 
-/// Top-level asset metadata key for instruments whose value is scaled per contract.
-pub const CONTRACT_MULTIPLIER_METADATA_KEY: &str = "contractMultiplier";
-
 /// Bond specification stored in Asset.metadata["bond"]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -413,23 +410,10 @@ impl Asset {
     /// Returns the contract multiplier for this asset.
     ///
     /// For options, this is the number of shares per contract (typically 100).
-    /// Other contract instruments can provide an explicit multiplier in asset metadata.
+    /// For all other instruments it is 1.
     pub fn contract_multiplier(&self) -> Decimal {
         if let Some(spec) = self.option_spec() {
             spec.multiplier
-        } else if let Some(multiplier) = self
-            .metadata
-            .as_ref()
-            .and_then(|metadata| metadata.get(CONTRACT_MULTIPLIER_METADATA_KEY))
-            .and_then(|value| {
-                value
-                    .as_f64()
-                    .and_then(Decimal::from_f64_retain)
-                    .or_else(|| value.as_str().and_then(|raw| raw.parse::<Decimal>().ok()))
-            })
-            .filter(|multiplier| *multiplier > Decimal::ZERO)
-        {
-            multiplier
         } else if self.is_option() {
             // Option without metadata — default to standard 100 multiplier
             Decimal::from(100)

--- a/crates/core/src/assets/assets_model.rs
+++ b/crates/core/src/assets/assets_model.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use chrono::NaiveDateTime;
-use rust_decimal::Decimal;
+use rust_decimal::{prelude::FromPrimitive, Decimal};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -424,7 +424,7 @@ impl Asset {
             .and_then(|value| {
                 value
                     .as_f64()
-                    .and_then(Decimal::from_f64_retain)
+                    .and_then(Decimal::from_f64)
                     .or_else(|| value.as_str().and_then(|raw| raw.parse::<Decimal>().ok()))
             })
             .filter(|multiplier| *multiplier > Decimal::ZERO)

--- a/crates/core/src/assets/assets_model.rs
+++ b/crates/core/src/assets/assets_model.rs
@@ -153,6 +153,9 @@ pub struct OptionSpec {
     pub occ_symbol: Option<String>,
 }
 
+/// Top-level asset metadata key for instruments whose value is scaled per contract.
+pub const CONTRACT_MULTIPLIER_METADATA_KEY: &str = "contractMultiplier";
+
 /// Bond specification stored in Asset.metadata["bond"]
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -410,10 +413,23 @@ impl Asset {
     /// Returns the contract multiplier for this asset.
     ///
     /// For options, this is the number of shares per contract (typically 100).
-    /// For all other instruments it is 1.
+    /// Other contract instruments can provide an explicit multiplier in asset metadata.
     pub fn contract_multiplier(&self) -> Decimal {
         if let Some(spec) = self.option_spec() {
             spec.multiplier
+        } else if let Some(multiplier) = self
+            .metadata
+            .as_ref()
+            .and_then(|metadata| metadata.get(CONTRACT_MULTIPLIER_METADATA_KEY))
+            .and_then(|value| {
+                value
+                    .as_f64()
+                    .and_then(Decimal::from_f64_retain)
+                    .or_else(|| value.as_str().and_then(|raw| raw.parse::<Decimal>().ok()))
+            })
+            .filter(|multiplier| *multiplier > Decimal::ZERO)
+        {
+            multiplier
         } else if self.is_option() {
             // Option without metadata — default to standard 100 multiplier
             Decimal::from(100)
@@ -1124,6 +1140,23 @@ pub fn canonicalize_market_identity(
 }
 
 impl UpdateAssetProfile {
+    /// Builds a repository update that changes only metadata while preserving asset identity.
+    pub fn metadata_only(asset: &Asset, metadata: Value) -> Self {
+        Self {
+            name: asset.name.clone(),
+            display_code: asset.display_code.clone(),
+            notes: asset.notes.clone().unwrap_or_default(),
+            kind: Some(asset.kind.clone()),
+            quote_mode: Some(asset.quote_mode),
+            quote_ccy: Some(asset.quote_ccy.clone()),
+            instrument_type: asset.instrument_type.clone(),
+            instrument_symbol: asset.instrument_symbol.clone(),
+            instrument_exchange_mic: asset.instrument_exchange_mic.clone(),
+            provider_config: asset.provider_config.clone(),
+            metadata: Some(metadata),
+        }
+    }
+
     /// Validates the asset profile update data
     pub fn validate(&self) -> Result<()> {
         Ok(())

--- a/crates/core/src/assets/assets_model_tests.rs
+++ b/crates/core/src/assets/assets_model_tests.rs
@@ -241,10 +241,16 @@ mod tests {
             })),
             ..Default::default()
         };
+        let future = Asset {
+            instrument_type: Some(InstrumentType::Equity),
+            metadata: Some(json!({ "contractMultiplier": "50" })),
+            ..Default::default()
+        };
 
         assert_eq!(equity.contract_multiplier(), dec!(1));
         assert_eq!(bare_option.contract_multiplier(), dec!(100));
         assert_eq!(mini_option.contract_multiplier(), dec!(10));
+        assert_eq!(future.contract_multiplier(), dec!(50));
     }
 
     // Test InstrumentType

--- a/crates/core/src/assets/assets_model_tests.rs
+++ b/crates/core/src/assets/assets_model_tests.rs
@@ -241,16 +241,10 @@ mod tests {
             })),
             ..Default::default()
         };
-        let future = Asset {
-            instrument_type: Some(InstrumentType::Equity),
-            metadata: Some(json!({ "contractMultiplier": "50" })),
-            ..Default::default()
-        };
 
         assert_eq!(equity.contract_multiplier(), dec!(1));
         assert_eq!(bare_option.contract_multiplier(), dec!(100));
         assert_eq!(mini_option.contract_multiplier(), dec!(10));
-        assert_eq!(future.contract_multiplier(), dec!(50));
     }
 
     // Test InstrumentType

--- a/crates/core/src/assets/assets_service.rs
+++ b/crates/core/src/assets/assets_service.rs
@@ -1899,6 +1899,22 @@ impl AssetServiceTrait for AssetService {
         Ok(asset)
     }
 
+    async fn update_asset_metadata(
+        &self,
+        asset_id: &str,
+        metadata: serde_json::Value,
+    ) -> Result<Asset> {
+        let asset = self
+            .asset_repository
+            .update_metadata(asset_id, metadata)
+            .await?;
+
+        self.event_sink
+            .emit(DomainEvent::assets_updated(vec![asset.id.clone()]));
+
+        Ok(asset)
+    }
+
     /// Creates a new asset directly without network lookups.
     async fn create_asset(&self, mut new_asset: NewAsset) -> Result<Asset> {
         let canonical = canonicalize_market_identity(

--- a/crates/core/src/assets/assets_traits.rs
+++ b/crates/core/src/assets/assets_traits.rs
@@ -23,6 +23,19 @@ pub trait AssetServiceTrait: Send + Sync {
         asset_id: &str,
         payload: UpdateAssetProfile,
     ) -> Result<Asset>;
+    /// Updates only asset metadata. Implementations should avoid re-resolving market identity.
+    async fn update_asset_metadata(
+        &self,
+        asset_id: &str,
+        metadata: serde_json::Value,
+    ) -> Result<Asset> {
+        let asset = self.get_asset_by_id(asset_id)?;
+        self.update_asset_profile(
+            asset_id,
+            UpdateAssetProfile::metadata_only(&asset, metadata),
+        )
+        .await
+    }
     /// Creates a new asset directly without network lookups.
     /// Used for alternative assets and other manually created assets.
     async fn create_asset(&self, new_asset: NewAsset) -> Result<Asset>;
@@ -180,6 +193,14 @@ pub trait AssetRepositoryTrait: Send + Sync {
     /// Creates multiple assets in a single transaction. All-or-nothing.
     async fn create_batch(&self, new_assets: Vec<NewAsset>) -> Result<Vec<Asset>>;
     async fn update_profile(&self, asset_id: &str, payload: UpdateAssetProfile) -> Result<Asset>;
+    async fn update_metadata(&self, asset_id: &str, metadata: serde_json::Value) -> Result<Asset> {
+        let asset = self.get_by_id(asset_id)?;
+        self.update_profile(
+            asset_id,
+            UpdateAssetProfile::metadata_only(&asset, metadata),
+        )
+        .await
+    }
     async fn update_quote_mode(&self, asset_id: &str, quote_mode: &str) -> Result<Asset>;
     fn get_by_id(&self, asset_id: &str) -> Result<Asset>;
     fn list(&self) -> Result<Vec<Asset>>;

--- a/crates/core/src/assets/mod.rs
+++ b/crates/core/src/assets/mod.rs
@@ -37,6 +37,7 @@ pub use assets_model::{
     Asset, AssetKind, AssetMetadata, AssetProfile, AssetSpec, BondSpec, Country,
     EnsureAssetsResult, InstrumentId, InstrumentType, NewAsset, OptionSpec, ProviderProfile,
     QuoteCcyResolutionSource, QuoteMode, Sector, UpdateAssetProfile,
+    CONTRACT_MULTIPLIER_METADATA_KEY,
 };
 pub use assets_service::AssetService;
 pub use assets_traits::{AssetRepositoryTrait, AssetServiceTrait};

--- a/crates/core/src/assets/mod.rs
+++ b/crates/core/src/assets/mod.rs
@@ -37,7 +37,6 @@ pub use assets_model::{
     Asset, AssetKind, AssetMetadata, AssetProfile, AssetSpec, BondSpec, Country,
     EnsureAssetsResult, InstrumentId, InstrumentType, NewAsset, OptionSpec, ProviderProfile,
     QuoteCcyResolutionSource, QuoteMode, Sector, UpdateAssetProfile,
-    CONTRACT_MULTIPLIER_METADATA_KEY,
 };
 pub use assets_service::AssetService;
 pub use assets_traits::{AssetRepositoryTrait, AssetServiceTrait};

--- a/crates/core/src/portfolio/snapshot/snapshot_model.rs
+++ b/crates/core/src/portfolio/snapshot/snapshot_model.rs
@@ -201,7 +201,8 @@ impl AccountStateSnapshot {
     /// Returns true if the holdings are effectively the same, ignoring metadata
     /// like id, snapshot_date, calculated_at, source, etc.
     ///
-    /// For positions, compares: asset_id, quantity, average_cost, total_cost_basis.
+    /// For positions, compares: asset_id, quantity, average_cost, total_cost_basis,
+    /// currency, and contract_multiplier.
     /// Ignores: lots, timestamps, inception_date.
     pub fn is_content_equal(&self, other: &Self) -> bool {
         // Compare cash balances
@@ -237,5 +238,6 @@ impl AccountStateSnapshot {
             && a.average_cost == b.average_cost
             && a.total_cost_basis == b.total_cost_basis
             && a.currency == b.currency
+            && a.contract_multiplier == b.contract_multiplier
     }
 }

--- a/crates/core/src/portfolio/snapshot/snapshot_model_tests.rs
+++ b/crates/core/src/portfolio/snapshot/snapshot_model_tests.rs
@@ -327,6 +327,47 @@ mod tests {
     }
 
     #[test]
+    fn test_is_content_equal_detects_contract_multiplier_change() {
+        use crate::portfolio::snapshot::{AccountStateSnapshot, Position};
+        use chrono::Utc;
+        use rust_decimal::Decimal;
+        use std::collections::HashMap;
+
+        let now = Utc::now();
+        let position = Position {
+            id: "pos-1".to_string(),
+            account_id: "account-1".to_string(),
+            asset_id: "contract-1".to_string(),
+            quantity: Decimal::from(2),
+            average_cost: Decimal::from(500),
+            total_cost_basis: Decimal::from(1000),
+            currency: "USD".to_string(),
+            inception_date: now,
+            lots: Default::default(),
+            created_at: now,
+            last_updated: now,
+            is_alternative: false,
+            contract_multiplier: Decimal::ONE,
+            cost_basis_account: None,
+            cost_basis_base: None,
+        };
+
+        let mut first = AccountStateSnapshot::default();
+        first
+            .positions
+            .insert(position.asset_id.clone(), position.clone());
+
+        let mut second_position = position;
+        second_position.contract_multiplier = Decimal::from(50);
+        let second = AccountStateSnapshot {
+            positions: HashMap::from([(second_position.asset_id.clone(), second_position)]),
+            ..Default::default()
+        };
+
+        assert!(!first.is_content_equal(&second));
+    }
+
+    #[test]
     fn test_is_content_equal_different_position_count() {
         use crate::portfolio::snapshot::{AccountStateSnapshot, Position};
         use chrono::Utc;

--- a/crates/storage-sqlite/src/assets/repository.rs
+++ b/crates/storage-sqlite/src/assets/repository.rs
@@ -281,6 +281,23 @@ impl AssetRepositoryTrait for AssetRepository {
             .await
     }
 
+    async fn update_metadata(&self, asset_id: &str, metadata: serde_json::Value) -> Result<Asset> {
+        let asset_id_owned = asset_id.to_string();
+        let metadata_json = serde_json::to_string(&metadata)?;
+
+        self.writer
+            .exec_tx(move |tx| -> Result<Asset> {
+                let result_db = diesel::update(assets::table.filter(assets::id.eq(asset_id_owned)))
+                    .set(assets::metadata.eq(metadata_json))
+                    .get_result::<AssetDB>(tx.conn())
+                    .map_err(StorageError::from)?;
+                let payload_db = result_db.clone();
+                tx.update(&payload_db)?;
+                Ok(result_db.into())
+            })
+            .await
+    }
+
     /// Updates the quote mode of an asset (MARKET, MANUAL)
     async fn update_quote_mode(&self, asset_id: &str, quote_mode: &str) -> Result<Asset> {
         let asset_id_owned = asset_id.to_string();
@@ -643,6 +660,42 @@ mod tests {
             .select(assets::is_active)
             .first(conn)
             .expect("asset active flag")
+    }
+
+    #[tokio::test]
+    async fn metadata_update_preserves_asset_identity() {
+        let (pool, writer) = setup_db();
+        let repo = AssetRepository::new(pool.clone(), writer);
+        let mut conn = get_connection(&pool).expect("conn");
+        insert_asset(&mut conn, "custom-display");
+        diesel::update(assets::table.filter(assets::id.eq("custom-display")))
+            .set((
+                assets::name.eq("User name"),
+                assets::display_code.eq("MY-CODE"),
+                assets::instrument_symbol.eq("BROKER-SYMBOL"),
+            ))
+            .execute(&mut conn)
+            .expect("customize asset");
+        drop(conn);
+
+        let updated = repo
+            .update_metadata(
+                "custom-display",
+                serde_json::json!({ "contractMultiplier": "50" }),
+            )
+            .await
+            .expect("update metadata");
+
+        assert_eq!(updated.name.as_deref(), Some("User name"));
+        assert_eq!(updated.display_code.as_deref(), Some("MY-CODE"));
+        assert_eq!(updated.instrument_symbol.as_deref(), Some("BROKER-SYMBOL"));
+        assert_eq!(
+            updated
+                .metadata
+                .as_ref()
+                .and_then(|metadata| metadata.get("contractMultiplier")),
+            Some(&serde_json::json!("50"))
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- deserialize exact contract multipliers from the cloud holdings contract
- persist the canonical multiplier on the shared asset and capture it on each broker position snapshot
- create new assets with their resolved multiplier; update existing assets only when the effective decimal value changes
- preserve exact positive option multipliers, with legacy `is_mini_option` fallbacks of 10/100
- normalize regular-position average cost to the per-position-unit basis used by snapshots while keeping option average cost per contract
- include multiplier-only changes in snapshot equality so they are persisted
- build option metadata from structured fields when a broker identifier is not valid OCC
- send the account configured tracking mode on every account-scoped holdings and activity request

## Multiplier ownership

`Asset.contract_multiplier` is the canonical instrument property shared across accounts, including manually tracked and activity-derived accounts. `Position.contract_multiplier` captures the value applied to a specific historical snapshot so valuations remain self-contained.

New assets receive non-default regular multipliers or resolved option metadata through `AssetSpec`. For existing assets, holdings sync compares `Asset::contract_multiplier()` with the authoritative incoming decimal value:

- equal values are a no-op, including JSON representations such as `"50"` versus `50.0`
- a missing or invalid broker field never overwrites stored metadata
- ordinary `1x` equities use the asset default and do not trigger metadata writes
- changed values use a metadata-only repository update that preserves customized identity fields and emits `AssetsUpdated` so other accounts are recalculated
- failed metadata backfills warn and continue; the next sync retries them

## Tracking-mode propagation

The client sends `X-Wealthfolio-Tracking-Mode` with the local account configured value (`holdings` or `transactions`) on both holdings and activity requests. The cloud uses this only for privacy-safe aggregated broker-quality metrics; no user, account, symbol, balance, quantity, price, or transaction-amount data is added.

## Compatibility

This is the desktop companion for [wealthfolio-cloud#92](https://github.com/afadil/wealthfolio-cloud/pull/92). Older cloud responses remain supported: regular positions without a multiplier use 1, while options use `is_mini_option` (10 when true, otherwise 100). Ship this desktop change before or alongside the cloud PR so futures, CFDs, and non-standard option contracts are valued correctly when the expanded contract is served.

## Validation

- `cargo fmt --all --check`
- `cargo test -p wealthfolio-connect -p wealthfolio-core -p wealthfolio-storage-sqlite` (81 connect, 1,723 core, 12 property, 239 storage, and 5 storage integration tests passed)
- `cargo clippy -p wealthfolio-connect -p wealthfolio-core -p wealthfolio-storage-sqlite --all-targets -- -D warnings`
- regression coverage includes first-create metadata, resolved-value no-ops, fractional multiplier stability, nested option updates, multiplier-only snapshot changes, and identity-preserving metadata writes

