### PR TITLE
Fix foreign-currency account gain display

### DIFF
--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -1030,6 +1030,7 @@ export interface CurrentAccountValuation {
   accountId: string;
   accountCurrency: string;
   baseCurrency: string;
+  fxRateToBase: number | null;
   cashBalance: number;
   investmentMarketValue: number;
   totalValue: number;

--- a/apps/frontend/src/pages/account/account-page.test.tsx
+++ b/apps/frontend/src/pages/account/account-page.test.tsx
@@ -578,6 +578,7 @@ function createCurrentAccountValuation(
     accountId: "account-1",
     accountCurrency: "USD",
     baseCurrency: "USD",
+    fxRateToBase: 1,
     cashBalance: 0,
     investmentMarketValue: overrides.totalValue ?? 125,
     totalValue: overrides.totalValue ?? 125,

--- a/apps/frontend/src/pages/dashboard/accounts-summary.test.tsx
+++ b/apps/frontend/src/pages/dashboard/accounts-summary.test.tsx
@@ -180,6 +180,7 @@ function createCurrentValuation(
     accountId: overrides.accountId ?? "account-1",
     accountCurrency: overrides.accountCurrency ?? "USD",
     baseCurrency: overrides.baseCurrency ?? "USD",
+    fxRateToBase: overrides.fxRateToBase === undefined ? 1 : overrides.fxRateToBase,
     cashBalance: overrides.cashBalance ?? 0,
     investmentMarketValue: overrides.investmentMarketValue ?? 0,
     totalValue: overrides.totalValue ?? 0,
@@ -306,6 +307,7 @@ function renderAccountsSummary({
       accountId: valuation.accountId,
       accountCurrency: valuation.accountCurrency,
       baseCurrency: valuation.baseCurrency,
+      fxRateToBase: valuation.fxRateToBase,
       cashBalance: valuation.cashBalance,
       investmentMarketValue: valuation.investmentMarketValue,
       totalValue: valuation.totalValue,
@@ -561,7 +563,8 @@ describe("AccountsSummary", () => {
           accountCurrency: "CAD",
           baseCurrency: "USD",
           totalValue: 150,
-          totalValueBase: 110,
+          totalValueBase: 120,
+          fxRateToBase: 0.8,
         }),
       ],
       performanceByAccountId: {
@@ -576,12 +579,39 @@ describe("AccountsSummary", () => {
     expect(row).not.toBeNull();
     // Value is shown in the account's own currency (CAD), not the USD base currency.
     expect(within(row as HTMLElement).getByText("value:CAD:150")).toBeInTheDocument();
-    expect(within(row as HTMLElement).queryByText("value:USD:110")).not.toBeInTheDocument();
+    expect(within(row as HTMLElement).queryByText("value:USD:120")).not.toBeInTheDocument();
     // Return percent is currency-agnostic and still shown.
     expect(within(row as HTMLElement).getByText("gain-percent:0.08")).toBeInTheDocument();
-    // P&L amount is only computed in base currency for foreign accounts, so it is
-    // omitted here rather than mislabeled as CAD.
+    // P&L is returned in base currency and converted with the live CAD-to-USD rate.
+    expect(within(row as HTMLElement).getByText("gain-amount:CAD:true:12.5")).toBeInTheDocument();
+  });
+
+  it("does not label base-currency P&L as account-currency P&L when FX is unavailable", () => {
+    renderAccountsSummary({
+      accounts: [createAccount({ id: "cad-account", name: "CAD Account", currency: "CAD" })],
+      valuations: [],
+      currentValuations: [
+        createCurrentValuation({
+          accountId: "cad-account",
+          accountCurrency: "CAD",
+          baseCurrency: "USD",
+          totalValue: 150,
+          totalValueBase: 120,
+          fxRateToBase: null,
+        }),
+      ],
+      performanceByAccountId: {
+        "cad-account": {
+          pnl: 10,
+          returnValue: 0.08,
+        },
+      },
+    });
+
+    const row = screen.getByText("CAD Account").closest("a");
+    expect(row).not.toBeNull();
     expect(within(row as HTMLElement).queryByText(/^gain-amount:/)).not.toBeInTheDocument();
+    expect(within(row as HTMLElement).getByText("gain-percent:0.08")).toBeInTheDocument();
   });
 
   it("keeps bad-data warnings for foreign-currency accounts when only base P&L is available", () => {

--- a/apps/frontend/src/pages/dashboard/accounts-summary.tsx
+++ b/apps/frontend/src/pages/dashboard/accounts-summary.tsx
@@ -477,7 +477,13 @@ export const AccountsSummary = React.memo(
           totalValueAccountCurrency,
           accountCurrency: valuation.accountCurrency,
           totalGainLossAmountAccountCurrency:
-            valuation.accountCurrency === valuation.baseCurrency ? gainLossBaseCurrency : null,
+            valuation.accountCurrency === valuation.baseCurrency
+              ? gainLossBaseCurrency
+              : gainLossBaseCurrency != null &&
+                  valuation.fxRateToBase != null &&
+                  valuation.fxRateToBase > 0
+                ? gainLossBaseCurrency / valuation.fxRateToBase
+                : null,
           totalGainLossPercent: gainPercent,
           accountId: acc.id,
           accountType: acc.accountType,

--- a/crates/core/src/portfolio/valuation/current_account_valuation.rs
+++ b/crates/core/src/portfolio/valuation/current_account_valuation.rs
@@ -369,6 +369,16 @@ where
     let mut summary_warnings = Vec::new();
     let mut account_warnings = Vec::new();
 
+    let account_fx_rate = latest_rate(&account.currency, base_currency).into();
+    valuation.fx_rate_to_base = account_fx_rate
+        .warning
+        .is_none()
+        .then_some(account_fx_rate.rate)
+        .filter(|rate| *rate > Decimal::ZERO);
+    if let Some(warning) = account_fx_rate.warning {
+        account_warnings.push(warning);
+    }
+
     for (cash_currency, amount) in &snapshot.cash_balances {
         let (normalized_amount, normalized_cash_currency) =
             normalize_amount(*amount, cash_currency);
@@ -508,6 +518,7 @@ fn zero_current_account_valuation(
         account_id: account.id.clone(),
         account_currency: account.currency.clone(),
         base_currency: base_currency.to_string(),
+        fx_rate_to_base: (account.currency == base_currency).then_some(Decimal::ONE),
         cash_balance: Decimal::ZERO,
         investment_market_value: Decimal::ZERO,
         total_value: Decimal::ZERO,

--- a/crates/core/src/portfolio/valuation/current_account_valuation_tests.rs
+++ b/crates/core/src/portfolio/valuation/current_account_valuation_tests.rs
@@ -233,6 +233,7 @@ fn current_account_valuation_uses_latest_snapshot_positions_without_mutating_dai
     assert_eq!(current[0].investment_market_value, dec!(150));
     assert_eq!(current[0].cash_balance, dec!(5));
     assert_eq!(current[0].total_value, dec!(155));
+    assert_eq!(current[0].fx_rate_to_base, Some(dec!(0.8)));
     assert_eq!(current[0].source_data_as_of, Some(quote_as_of));
     assert_eq!(current[0].calculated_at, calculated_at);
     assert_eq!(stale.total_value_base, dec!(100));
@@ -517,6 +518,7 @@ fn current_valuation_surfaces_fx_fallback_warnings() {
     assert!(response.accounts[0].warnings.contains(
         &"Some exchange rates are missing, so this value may be approximate.".to_string()
     ));
+    assert_eq!(response.accounts[0].fx_rate_to_base, Some(Decimal::ONE));
 }
 
 #[test]
@@ -570,6 +572,7 @@ fn current_valuation_keeps_account_currency_fx_warnings_off_summary() {
     assert!(response.accounts[0].warnings.contains(
         &"Some exchange rates are missing, so this value may be approximate.".to_string()
     ));
+    assert_eq!(response.accounts[0].fx_rate_to_base, None);
 }
 
 #[test]

--- a/crates/core/src/portfolio/valuation/valuation_model.rs
+++ b/crates/core/src/portfolio/valuation/valuation_model.rs
@@ -392,6 +392,11 @@ pub struct CurrentAccountValuation {
     pub account_id: String,
     pub account_currency: String,
     pub base_currency: String,
+    /// Latest conversion rate from the account currency to the base currency.
+    ///
+    /// `None` means the rate could not be resolved safely, so consumers must
+    /// not label base-currency amounts as account-currency amounts.
+    pub fx_rate_to_base: Option<Decimal>,
     pub cash_balance: Decimal,
     pub investment_market_value: Decimal,
     pub total_value: Decimal,


### PR DESCRIPTION
## Summary

Fixes #1426.

- carry a resolved account-to-base FX rate through the current account valuation
- display the gain/loss amount in the account currency only when that rate is valid
- preserve the percentage while omitting an amount that would otherwise be labeled with the wrong currency
- add frontend and Rust regression coverage for valid and missing FX rates

## Root cause

The dashboard received P&L in the base currency but had no safe way to convert it for an account with another currency. Rendering it directly would mislabel the amount, so the amount was hidden.

## Validation

- focused frontend Vitest: 12 passed
- TypeScript type check after workspace `build:types`
- changed-file ESLint and Prettier
- frontend production web build
- `cargo test -p wealthfolio-core`: 1,727 unit tests and 12 property tests passed
- `cargo fmt --check`
- `git diff --check`

## Checklist

- [x] I have read and agree to the Contributor License Agreement.