### PR TITLE
fix: prevent holding details from overlapping performance

### DIFF
--- a/apps/frontend/src/pages/dashboard/top-holdings.test.tsx
+++ b/apps/frontend/src/pages/dashboard/top-holdings.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import { HoldingType } from "@/lib/constants";
+import type { Holding } from "@/lib/types";
+import { TopHoldings } from "./top-holdings";
+
+vi.mock("@/components/dashboard-card", () => ({
+  DashboardCard: ({ children, title }: { children: ReactNode; title: string }) => (
+    <section aria-label={title}>{children}</section>
+  ),
+}));
+
+vi.mock("@/components/holding-performance-percent", () => ({
+  HoldingPerformancePercent: () => <span>performance</span>,
+}));
+
+vi.mock("@/components/ticker-avatar", () => ({
+  TickerAvatar: ({ symbol }: { symbol: string }) => <span>{symbol}</span>,
+}));
+
+vi.mock("@/hooks/use-balance-privacy", () => ({
+  useBalancePrivacy: () => ({ isBalanceHidden: false }),
+}));
+
+vi.mock("@wealthfolio/ui", () => ({
+  AmountDisplay: ({ value }: { value: number }) => <span>{`amount:${value}`}</span>,
+  Button: ({ children }: { children: ReactNode }) => <button type="button">{children}</button>,
+  GainAmount: ({ value }: { value: number }) => <span>{`gain:${value}`}</span>,
+  Icons: {
+    ChevronRight: () => <span>chevron</span>,
+    ListFilter: () => <span>filter</span>,
+  },
+  usePersistentState: (_key: string, defaultValue: unknown) => [defaultValue, vi.fn()],
+}));
+
+vi.mock("@wealthfolio/ui/components/ui/popover", () => ({
+  Popover: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+const longQuantityHolding = {
+  id: "LONG",
+  holdingType: HoldingType.SECURITY,
+  accountId: "account-1",
+  quantity: 123_456_789,
+  localCurrency: "CNY",
+  baseCurrency: "CNY",
+  marketValue: { local: 1_487_443, base: 1_487_443 },
+  totalGain: { local: 381_583.22, base: 381_583.22 },
+  totalGainPct: -0.2034,
+  weight: 1,
+  asOfDate: "2026-08-13",
+} satisfies Holding;
+
+describe("TopHoldings", () => {
+  it("truncates a long quantity within the shrinkable holding details column", () => {
+    render(
+      <MemoryRouter>
+        <TopHoldings holdings={[longQuantityHolding]} isLoading={false} baseCurrency="CNY" />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("123,456,789 shares")).toHaveClass("truncate");
+  });
+});

--- a/apps/frontend/src/pages/dashboard/top-holdings.tsx
+++ b/apps/frontend/src/pages/dashboard/top-holdings.tsx
@@ -76,7 +76,7 @@ function HoldingRow({
         <TickerAvatar symbol={avatarSymbol} className="size-9 shrink-0" />
         <div className="flex min-w-0 flex-col">
           <span className="truncate text-sm font-semibold">{title}</span>
-          <span className="text-muted-foreground text-xs">{subtitle}</span>
+          <span className="text-muted-foreground truncate text-xs">{subtitle}</span>
         </div>
       </div>
       <div className="flex shrink-0 flex-col items-end gap-1">


### PR DESCRIPTION
## Description

Fixes #1438.

Long localized quantity text in a holdings row could overflow the shrinkable left column and paint over the fixed performance column when the desktop window is narrowed. This applies the existing `truncate` treatment to the quantity subtitle and adds a regression test using an intentionally long quantity.

## Validation

- `pnpm --filter frontend exec vitest run src/pages/dashboard/top-holdings.test.tsx`
- `pnpm --filter frontend lint`
- `pnpm --filter frontend type-check`
- `pnpm run build:types && pnpm --filter frontend build`

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
