### PR TITLE
fix(allocation): keep the rebalance planner reachable when allocations are in-band

### DIFF
--- a/apps/frontend/src/pages/allocation-targets/components/drift-drivers-card.tsx
+++ b/apps/frontend/src/pages/allocation-targets/components/drift-drivers-card.tsx
@@ -78,7 +78,7 @@ export function DriftDriversCard({
     .sort((a, b) => Math.abs(b.driftBps) - Math.abs(a.driftBps));
   const visibleRows = oobRows.slice(0, 3);
   const remainingRows = oobRows.slice(3);
-  const showRebalanceCta = oobRows.length > 0 && onRebalanceClick;
+  const showRebalanceCta = Boolean(onRebalanceClick);
 
   return (
     <Card className="flex h-full flex-col">


### PR DESCRIPTION
## Description

Closes #1444.

One-line change: the "Review rebalance →" CTA on the "Largest gaps" card now renders whenever the parent wires `onRebalanceClick`, instead of only when a category is out of band.

Rationale: drift is computed on invested value only, so idle cash never produces drift — after a deposit the planner was unreachable exactly when a cash-flow-only calculation is most useful. The planner itself already handles the in-band case correctly (it accepts the report and produces a plan that deploys available cash toward the target weights).

Nothing else changes: `isOutOfBand()`, the drift math, the suggested-moves list and the in-band status text ("All categories inside target. No action required.") behave exactly as before — the status text and the button now coexist. That coexistence is intentional rather than contradictory: the status describes tolerance-band drift, while the button also exposes cash-deployment planning, which is useful precisely when drift is zero but idle cash is not.

Tested on my self-hosted instance: with all categories in-band and idle cash on the account, the CTA renders, "Cash-flow only" mode calculates a plan whose buys sum exactly to the deployable cash, and with zero drift and zero cash the Calculate step stays disabled as before. `pnpm` frontend build, type-check and lint are clean.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](../blob/main/CLA.md)
