### PR TITLE
feat(auth): auto-redirect to SSO when it is the only login method

### DIFF
--- a/apps/frontend/src/context/auth-context.tsx
+++ b/apps/frontend/src/context/auth-context.tsx
@@ -47,10 +47,22 @@ function resolveOidcError(t: TFunction, code: string): string {
 }
 
 /**
- * Set on logout so the login page offers the SSO button instead of bouncing the
- * user straight back into the IdP, which would make signing out impossible.
+ * One-shot per-tab guard for the automatic SSO redirect. Armed before every
+ * automatic redirect and on logout; cleared only once `/auth/me` confirms a
+ * session. While armed, the login page suppresses further automatic redirects
+ * (the manual SSO button is unaffected), so a callback that fails to establish
+ * a session — no cookie, `/auth/me` rejecting — lands on the login page once
+ * instead of looping through the IdP.
  */
-export const MANUAL_LOGIN_STORAGE_KEY = "wf.manual-login";
+export const SSO_REDIRECT_GUARD_STORAGE_KEY = "wf.sso-redirect-guard";
+
+function clearSsoRedirectGuard() {
+  try {
+    window.sessionStorage.removeItem(SSO_REDIRECT_GUARD_STORAGE_KEY);
+  } catch {
+    // noop – sessionStorage may be unavailable
+  }
+}
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
@@ -100,6 +112,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
               credentials: "same-origin",
             });
             if (meRes.ok && !cancelled) {
+              clearSsoRedirectGuard();
               setCookieSession(true);
             }
           } catch {
@@ -194,7 +207,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const logout = useCallback(() => {
     if (isWeb) {
       try {
-        window.sessionStorage.setItem(MANUAL_LOGIN_STORAGE_KEY, "1");
+        window.sessionStorage.setItem(SSO_REDIRECT_GUARD_STORAGE_KEY, "1");
       } catch {
         // noop – sessionStorage may be unavailable
       }

--- a/apps/frontend/src/context/auth-context.tsx
+++ b/apps/frontend/src/context/auth-context.tsx
@@ -46,6 +46,12 @@ function resolveOidcError(t: TFunction, code: string): string {
   return key ? t(key) : t("auth:context.oidcErrors.generic");
 }
 
+/**
+ * Set on logout so the login page offers the SSO button instead of bouncing the
+ * user straight back into the IdP, which would make signing out impossible.
+ */
+export const MANUAL_LOGIN_STORAGE_KEY = "wf.manual-login";
+
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
@@ -187,6 +193,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   const logout = useCallback(() => {
     if (isWeb) {
+      try {
+        window.sessionStorage.setItem(MANUAL_LOGIN_STORAGE_KEY, "1");
+      } catch {
+        // noop – sessionStorage may be unavailable
+      }
       if (oidcEnabled) {
         // Full-page navigation: the server clears the session (and OIDC id-token
         // cookie) and may redirect to the IdP for single logout.

--- a/apps/frontend/src/pages/auth/login-page.test.tsx
+++ b/apps/frontend/src/pages/auth/login-page.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SSO_REDIRECT_GUARD_STORAGE_KEY } from "@/context/auth-context";
+import { LoginPage } from "./login-page";
+
+const useAuthMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/context/auth-context", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/context/auth-context")>();
+  return { ...actual, useAuth: useAuthMock };
+});
+
+const SSO_LOGIN_URL = "/api/v1/auth/oidc/login";
+
+function ssoOnlyAuth(overrides: object = {}) {
+  return {
+    requiresAuth: true,
+    requiresPassword: false,
+    oidcEnabled: true,
+    isAuthenticated: false,
+    statusLoading: false,
+    loginLoading: false,
+    loginError: null,
+    login: vi.fn(),
+    logout: vi.fn(),
+    clearError: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("LoginPage automatic SSO redirect", () => {
+  const replaceMock = vi.fn();
+
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    useAuthMock.mockReturnValue(ssoOnlyAuth());
+    vi.stubGlobal("location", { href: "http://localhost/", replace: replaceMock });
+  });
+
+  afterEach(() => {
+    replaceMock.mockReset();
+    vi.unstubAllGlobals();
+    window.sessionStorage.clear();
+  });
+
+  it("arms the guard and redirects once when SSO is the only method", () => {
+    render(<LoginPage />);
+
+    expect(replaceMock).toHaveBeenCalledTimes(1);
+    expect(replaceMock).toHaveBeenCalledWith(SSO_LOGIN_URL);
+    expect(window.sessionStorage.getItem(SSO_REDIRECT_GUARD_STORAGE_KEY)).toBe("1");
+  });
+
+  it("offers the manual button instead of restarting SSO after a callback that failed to establish a session", () => {
+    // An armed guard is exactly what a failed round-trip leaves behind: the
+    // automatic redirect set it, the callback returned, but `/auth/me` never
+    // confirmed a session, so nothing cleared it.
+    window.sessionStorage.setItem(SSO_REDIRECT_GUARD_STORAGE_KEY, "1");
+
+    render(<LoginPage />);
+
+    expect(replaceMock).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Sign in with SSO" })).toBeInTheDocument();
+  });
+
+  it("lets the manual SSO button navigate while the guard is armed", async () => {
+    window.sessionStorage.setItem(SSO_REDIRECT_GUARD_STORAGE_KEY, "1");
+    const user = userEvent.setup();
+
+    render(<LoginPage />);
+    await user.click(screen.getByRole("button", { name: "Sign in with SSO" }));
+
+    expect(window.location.href).toBe(SSO_LOGIN_URL);
+    expect(window.sessionStorage.getItem(SSO_REDIRECT_GUARD_STORAGE_KEY)).toBe("1");
+  });
+
+  it("does not redirect while a login error is displayed", () => {
+    useAuthMock.mockReturnValue(ssoOnlyAuth({ loginError: "SSO sign-in failed." }));
+
+    render(<LoginPage />);
+
+    expect(replaceMock).not.toHaveBeenCalled();
+    expect(screen.getByRole("alert")).toHaveTextContent("SSO sign-in failed.");
+  });
+});

--- a/apps/frontend/src/pages/auth/login-page.tsx
+++ b/apps/frontend/src/pages/auth/login-page.tsx
@@ -1,4 +1,4 @@
-import { useAuth } from "@/context/auth-context";
+import { MANUAL_LOGIN_STORAGE_KEY, useAuth } from "@/context/auth-context";
 import {
   ApplicationShell,
   Button,
@@ -10,13 +10,54 @@ import {
   CardTitle,
   Input,
 } from "@wealthfolio/ui";
-import { FormEvent, useState } from "react";
+import { FormEvent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+
+const SSO_LOGIN_URL = "/api/v1/auth/oidc/login";
+const STORAGE_PROBE_KEY = "wf.storage-probe";
+
+function suppressesSsoRedirect(): boolean {
+  try {
+    window.sessionStorage.setItem(STORAGE_PROBE_KEY, "1");
+    const probe = window.sessionStorage.getItem(STORAGE_PROBE_KEY);
+    window.sessionStorage.removeItem(STORAGE_PROBE_KEY);
+    // Unusable storage cannot hold the logout marker, so redirecting would sign the
+    // user back in through their live IdP session and make signing out impossible.
+    if (probe !== "1") return true;
+    return window.sessionStorage.getItem(MANUAL_LOGIN_STORAGE_KEY) !== null;
+  } catch {
+    return true;
+  }
+}
+
+function clearManualLoginMarker() {
+  try {
+    window.sessionStorage.removeItem(MANUAL_LOGIN_STORAGE_KEY);
+  } catch {
+    // noop – sessionStorage may be unavailable
+  }
+}
 
 export function LoginPage() {
   const { t } = useTranslation();
-  const { login, loginLoading, loginError, clearError, requiresPassword, oidcEnabled } = useAuth();
+  const {
+    login,
+    loginLoading,
+    loginError,
+    clearError,
+    requiresPassword,
+    oidcEnabled,
+    statusLoading,
+  } = useAuth();
   const [password, setPassword] = useState("");
+
+  useEffect(() => {
+    if (statusLoading || !oidcEnabled || requiresPassword) return;
+    // Both guards break the logout/error redirect loop: without them the IdP hands
+    // the session straight back and the user can never reach this page.
+    if (loginError || suppressesSsoRedirect()) return;
+    window.location.href = SSO_LOGIN_URL;
+  }, [statusLoading, oidcEnabled, requiresPassword, loginError]);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -103,7 +144,8 @@ export function LoginPage() {
                     variant={requiresPassword ? "outline" : "default"}
                     className="w-full"
                     onClick={() => {
-                      window.location.href = "/api/v1/auth/oidc/login";
+                      clearManualLoginMarker();
+                      window.location.href = SSO_LOGIN_URL;
                     }}
                   >
                     {t("auth:login.signInWithSso")}

--- a/apps/frontend/src/pages/auth/login-page.tsx
+++ b/apps/frontend/src/pages/auth/login-page.tsx
@@ -1,4 +1,4 @@
-import { MANUAL_LOGIN_STORAGE_KEY, useAuth } from "@/context/auth-context";
+import { SSO_REDIRECT_GUARD_STORAGE_KEY, useAuth } from "@/context/auth-context";
 import {
   ApplicationShell,
   Button,
@@ -14,27 +14,22 @@ import { FormEvent, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 const SSO_LOGIN_URL = "/api/v1/auth/oidc/login";
-const STORAGE_PROBE_KEY = "wf.storage-probe";
 
-function suppressesSsoRedirect(): boolean {
+/**
+ * Arm the one-shot redirect guard before navigating. Returns false when the
+ * guard is already armed (a previous attempt has not been confirmed by
+ * `/auth/me` yet, or the user logged out) or when sessionStorage cannot hold
+ * it — in both cases the automatic redirect must not fire, or a failed
+ * callback would bounce through the IdP forever.
+ */
+function armSsoRedirectGuard(): boolean {
   try {
-    window.sessionStorage.setItem(STORAGE_PROBE_KEY, "1");
-    const probe = window.sessionStorage.getItem(STORAGE_PROBE_KEY);
-    window.sessionStorage.removeItem(STORAGE_PROBE_KEY);
-    // Unusable storage cannot hold the logout marker, so redirecting would sign the
-    // user back in through their live IdP session and make signing out impossible.
-    if (probe !== "1") return true;
-    return window.sessionStorage.getItem(MANUAL_LOGIN_STORAGE_KEY) !== null;
+    const storage = window.sessionStorage;
+    if (storage.getItem(SSO_REDIRECT_GUARD_STORAGE_KEY) !== null) return false;
+    storage.setItem(SSO_REDIRECT_GUARD_STORAGE_KEY, "1");
+    return storage.getItem(SSO_REDIRECT_GUARD_STORAGE_KEY) === "1";
   } catch {
-    return true;
-  }
-}
-
-function clearManualLoginMarker() {
-  try {
-    window.sessionStorage.removeItem(MANUAL_LOGIN_STORAGE_KEY);
-  } catch {
-    // noop – sessionStorage may be unavailable
+    return false;
   }
 }
 
@@ -53,10 +48,11 @@ export function LoginPage() {
 
   useEffect(() => {
     if (statusLoading || !oidcEnabled || requiresPassword) return;
-    // Both guards break the logout/error redirect loop: without them the IdP hands
-    // the session straight back and the user can never reach this page.
-    if (loginError || suppressesSsoRedirect()) return;
-    window.location.href = SSO_LOGIN_URL;
+    // An explicit callback error must stay visible instead of bouncing back out.
+    if (loginError) return;
+    if (!armSsoRedirectGuard()) return;
+    // replace() keeps the transient login page out of the back-button history.
+    window.location.replace(SSO_LOGIN_URL);
   }, [statusLoading, oidcEnabled, requiresPassword, loginError]);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
@@ -144,7 +140,8 @@ export function LoginPage() {
                     variant={requiresPassword ? "outline" : "default"}
                     className="w-full"
                     onClick={() => {
-                      clearManualLoginMarker();
+                      // Deliberate click: navigates regardless of the guard, which
+                      // only `/auth/me` confirming a session may clear.
                       window.location.href = SSO_LOGIN_URL;
                     }}
                   >


### PR DESCRIPTION
## Description

Closes #1343.

When the server reports `oidcEnabled: true` and `requiresPassword: false`, the login page currently renders a single "Sign in with SSO" button — a click with no decision behind it. With this change the page navigates straight to `/api/v1/auth/oidc/login` once auth status resolves, so a fresh visit lands in the app (or at the identity provider) with zero clicks.

A one-shot per-tab guard keeps the redirect from looping or hiding a failure:

- **One automatic attempt until a session is confirmed.** A `sessionStorage` guard (`wf.sso-redirect-guard`) is armed immediately before the automatic redirect and on logout, and cleared only once `/auth/me` confirms a session. While it is armed, automatic redirects are suppressed — a callback that returns without establishing a session (cookie unavailable, `/auth/me` failing) lands on the login page with the manual button instead of restarting OIDC.
- **Failed OIDC round-trips stay visible.** The redirect is also suppressed while `loginError` is set. The `?oidc_error=` query param is consumed into state and stripped via `history.replaceState` before auth status resolves, so the persisted state — not the URL — is the reliable signal.
- **The manual button always navigates.** A deliberate click on the SSO button is never blocked by the guard; it stays the recovery path after a failed automatic attempt.
- **Arming fails closed.** The guard is armed with a write + read-back; if `sessionStorage` is blocked or silently dropping writes, the automatic redirect is suppressed — the worst case in restricted browsers is exactly today's behavior, the interstitial with the button.

The automatic redirect uses `window.location.replace()` so the transient login page stays out of back-button history, and the button remains rendered as a fallback while the redirect happens.

Verification: the original submission was tested live on my self-hosted instance behind Authelia — a fresh visit with a valid IdP session reaches the dashboard with zero clicks (without one, the redirect lands on the IdP's login as expected), `/?oidc_error=access_denied` shows the error and does not redirect, and after logout the login page renders without redirecting while one SSO click signs back in. The guard rework on top is covered by the new `login-page.test.tsx` — the failed-session callback case (armed guard → no automatic redirect, manual button rendered), the arm-and-redirect happy path, manual navigation while the guard is armed, and error suppression — with type-check and lint clean.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](../blob/main/CLA.md)
