### PR TITLE
fix(allocation): absorb tiny classification residuals instead of "Unknown"

### DIFF
--- a/crates/core/src/portfolio/allocation/allocation_service.rs
+++ b/crates/core/src/portfolio/allocation/allocation_service.rs
@@ -19,6 +19,12 @@ use super::{
 
 const CUSTOM_GROUPS_TAXONOMY_ID: &str = "custom_groups";
 
+/// Largest assignment shortfall (in basis points) absorbed pro rata instead of surfacing as
+/// "Unknown". Provider asset-class breakdowns routinely land a few bps under 100% — an "other"
+/// sleeve we don't map, or the provider's own weights not summing to exactly 1.0 — and that
+/// noise should not become a top-level category. Larger gaps are real missing coverage.
+const RESIDUAL_TOLERANCE_BPS: i32 = 75;
+
 #[derive(Debug, Clone)]
 struct HoldingTaxonomyShare {
     category_id: String,
@@ -422,7 +428,16 @@ impl AllocationService {
             }];
         }
 
-        let weight_divisor = Decimal::from(total_active_weight.max(10000));
+        // A small shortfall is provider noise: rescale the assigned weights to fill it rather
+        // than attributing it to "Unknown".
+        let absorb_residual =
+            total_active_weight < 10000 && 10000 - total_active_weight <= RESIDUAL_TOLERANCE_BPS;
+
+        let weight_divisor = if absorb_residual {
+            Decimal::from(total_active_weight)
+        } else {
+            Decimal::from(total_active_weight.max(10000))
+        };
         let mut shares: Vec<HoldingTaxonomyShare> = Vec::new();
 
         for assignment in active_assignments {
@@ -443,7 +458,7 @@ impl AllocationService {
             });
         }
 
-        if total_active_weight < 10000 {
+        if total_active_weight < 10000 && !absorb_residual {
             shares.push(HoldingTaxonomyShare {
                 category_id: "__UNKNOWN__".to_string(),
                 assigned_category_id: "__UNKNOWN__".to_string(),
@@ -1702,6 +1717,102 @@ mod tests {
         assert_eq!(north_america.percentage, dec!(60));
         assert_eq!(unknown.value, dec!(400));
         assert_eq!(unknown.percentage, dec!(40));
+    }
+
+    /// Provider asset-class breakdowns routinely land a few bps under 100% (an "other" sleeve we
+    /// don't map, or provider weights not summing to exactly 1.0). That noise must be absorbed
+    /// pro rata, not promoted to an "Unknown" row sitting next to the same holding's real
+    /// categories. Weights here are VOO's actual provider-derived assignments.
+    #[test]
+    fn sub_tolerance_weight_shortfall_is_absorbed_instead_of_unknown() {
+        let svc = svc();
+        let holdings = vec![make_holding("VOO", dec!(1000))];
+        let categories = vec![
+            make_category("EQUITY", None),
+            make_category("CASH_BANK_DEPOSITS", None),
+        ];
+
+        // 99.57% equity + 0.22% cash = 99.79%, a 21 bp shortfall.
+        let mut assignments: HashMap<String, Vec<AssetTaxonomyAssignment>> = HashMap::new();
+        assignments.insert(
+            "VOO".to_string(),
+            vec![
+                make_assignment("VOO", "asset_classes", "EQUITY", 9957),
+                make_assignment("VOO", "asset_classes", "CASH_BANK_DEPOSITS", 22),
+            ],
+        );
+
+        let result = svc.aggregate_by_taxonomy(
+            &holdings,
+            "asset_classes",
+            "Asset Classes",
+            "#ccc",
+            &categories,
+            &assignments,
+            dec!(1000),
+            false,
+            &HashMap::new(),
+        );
+
+        assert!(
+            !result
+                .categories
+                .iter()
+                .any(|c| c.category_id == "__UNKNOWN__"),
+            "a 21 bp shortfall must not produce an Unknown category"
+        );
+
+        let total: Decimal = result.categories.iter().map(|c| c.value).sum();
+        assert!(
+            (total - dec!(1000)).abs() < dec!(0.0001),
+            "absorbed shares should still account for the full market value, got {total}"
+        );
+
+        let equity = result
+            .categories
+            .iter()
+            .find(|c| c.category_id == "EQUITY")
+            .expect("EQUITY category missing");
+        // 9957 / 9979 * 1000
+        assert!(
+            (equity.value - dec!(997.7954)).abs() < dec!(0.001),
+            "equity should absorb its pro-rata share of the shortfall, got {}",
+            equity.value
+        );
+    }
+
+    /// The tolerance is a boundary, not a blanket: a shortfall at the limit is absorbed, one
+    /// basis point past it is real missing coverage and still surfaces as Unknown.
+    #[test]
+    fn weight_shortfall_beyond_tolerance_still_reports_unknown() {
+        let svc = svc();
+        let holdings = vec![make_holding("AAPL", dec!(1000))];
+        let categories = vec![make_category("EQUITY", None)];
+
+        let has_unknown = |weight: i32| {
+            let mut assignments: HashMap<String, Vec<AssetTaxonomyAssignment>> = HashMap::new();
+            assignments.insert(
+                "AAPL".to_string(),
+                vec![make_assignment("AAPL", "asset_classes", "EQUITY", weight)],
+            );
+            svc.aggregate_by_taxonomy(
+                &holdings,
+                "asset_classes",
+                "Asset Classes",
+                "#ccc",
+                &categories,
+                &assignments,
+                dec!(1000),
+                false,
+                &HashMap::new(),
+            )
+            .categories
+            .iter()
+            .any(|c| c.category_id == "__UNKNOWN__")
+        };
+
+        assert!(!has_unknown(9925), "a 75 bp shortfall is within tolerance");
+        assert!(has_unknown(9924), "a 76 bp shortfall exceeds tolerance");
     }
 
     /// When an asset is assigned to both a parent region (Americas) and a child (United_States),

--- a/crates/core/src/portfolio/allocation/allocation_service.rs
+++ b/crates/core/src/portfolio/allocation/allocation_service.rs
@@ -23,7 +23,13 @@ const CUSTOM_GROUPS_TAXONOMY_ID: &str = "custom_groups";
 /// "Unknown". Provider asset-class breakdowns routinely land a few bps under 100% — an "other"
 /// sleeve we don't map, or the provider's own weights not summing to exactly 1.0 — and that
 /// noise should not become a top-level category. Larger gaps are real missing coverage.
+///
+/// Only applied to auto-classified `asset_classes` assignments: a shortfall a user entered by
+/// hand is intentional and must be reported as-is.
 const RESIDUAL_TOLERANCE_BPS: i32 = 75;
+
+/// `source` written by auto-classification (`crates/core/src/assets/auto_classification.rs`).
+const AUTO_SOURCE: &str = "AUTO";
 
 #[derive(Debug, Clone)]
 struct HoldingTaxonomyShare {
@@ -428,10 +434,15 @@ impl AllocationService {
             }];
         }
 
-        // A small shortfall is provider noise: rescale the assigned weights to fill it rather
-        // than attributing it to "Unknown".
-        let absorb_residual =
-            total_active_weight < 10000 && 10000 - total_active_weight <= RESIDUAL_TOLERANCE_BPS;
+        // A small shortfall in auto-classified asset-class weights is provider noise: rescale the
+        // assigned weights to fill it rather than attributing it to "Unknown". Manual and custom
+        // classifications are left alone — their shortfalls are deliberate.
+        let absorb_residual = taxonomy_id == "asset_classes"
+            && total_active_weight < 10000
+            && 10000 - total_active_weight <= RESIDUAL_TOLERANCE_BPS
+            && active_assignments
+                .iter()
+                .all(|a| a.source.eq_ignore_ascii_case(AUTO_SOURCE));
 
         let weight_divisor = if absorb_residual {
             Decimal::from(total_active_weight)
@@ -1540,6 +1551,18 @@ mod tests {
         }
     }
 
+    fn make_auto_assign(
+        asset_id: &str,
+        taxonomy_id: &str,
+        category_id: &str,
+        weight: i32,
+    ) -> AssetTaxonomyAssignment {
+        AssetTaxonomyAssignment {
+            source: AUTO_SOURCE.to_string(),
+            ..make_assignment(asset_id, taxonomy_id, category_id, weight)
+        }
+    }
+
     fn make_holding(asset_id: &str, base_value: Decimal) -> Holding {
         Holding {
             id: asset_id.to_string(),
@@ -1737,8 +1760,8 @@ mod tests {
         assignments.insert(
             "VOO".to_string(),
             vec![
-                make_assignment("VOO", "asset_classes", "EQUITY", 9957),
-                make_assignment("VOO", "asset_classes", "CASH_BANK_DEPOSITS", 22),
+                make_auto_assign("VOO", "asset_classes", "EQUITY", 9957),
+                make_auto_assign("VOO", "asset_classes", "CASH_BANK_DEPOSITS", 22),
             ],
         );
 
@@ -1793,7 +1816,7 @@ mod tests {
             let mut assignments: HashMap<String, Vec<AssetTaxonomyAssignment>> = HashMap::new();
             assignments.insert(
                 "AAPL".to_string(),
-                vec![make_assignment("AAPL", "asset_classes", "EQUITY", weight)],
+                vec![make_auto_assign("AAPL", "asset_classes", "EQUITY", weight)],
             );
             svc.aggregate_by_taxonomy(
                 &holdings,
@@ -1813,6 +1836,70 @@ mod tests {
 
         assert!(!has_unknown(9925), "a 75 bp shortfall is within tolerance");
         assert!(has_unknown(9924), "a 76 bp shortfall exceeds tolerance");
+    }
+
+    /// Absorption only applies to what auto-classification wrote into `asset_classes`. A shortfall
+    /// a user entered by hand is deliberate, and other taxonomies never carry provider composition
+    /// noise, so both must keep reporting Unknown.
+    #[test]
+    fn residual_absorption_is_scoped_to_auto_asset_class_assignments() {
+        let svc = svc();
+        let holdings = vec![make_holding("VOO", dec!(1000))];
+        let categories = vec![
+            make_category("EQUITY", None),
+            make_category("CASH_BANK_DEPOSITS", None),
+        ];
+
+        let has_unknown = |taxonomy_id: &str, holding_assignments: Vec<AssetTaxonomyAssignment>| {
+            let mut assignments: HashMap<String, Vec<AssetTaxonomyAssignment>> = HashMap::new();
+            assignments.insert("VOO".to_string(), holding_assignments);
+            svc.aggregate_by_taxonomy(
+                &holdings,
+                taxonomy_id,
+                "Taxonomy",
+                "#ccc",
+                &categories,
+                &assignments,
+                dec!(1000),
+                false,
+                &HashMap::new(),
+            )
+            .categories
+            .iter()
+            .any(|c| c.category_id == "__UNKNOWN__")
+        };
+
+        assert!(
+            !has_unknown(
+                "asset_classes",
+                vec![make_auto_assign("VOO", "asset_classes", "EQUITY", 9979)],
+            ),
+            "an AUTO asset-class residual is provider noise"
+        );
+        assert!(
+            has_unknown(
+                "asset_classes",
+                vec![make_assignment("VOO", "asset_classes", "EQUITY", 9979)],
+            ),
+            "a manual asset-class shortfall is intentional and must stay Unknown"
+        );
+        assert!(
+            has_unknown(
+                "asset_classes",
+                vec![
+                    make_auto_assign("VOO", "asset_classes", "EQUITY", 9957),
+                    make_assignment("VOO", "asset_classes", "CASH_BANK_DEPOSITS", 22),
+                ],
+            ),
+            "a hand-edited assignment opts the whole asset out of absorption"
+        );
+        assert!(
+            has_unknown(
+                "regions",
+                vec![make_auto_assign("VOO", "regions", "EQUITY", 9979)],
+            ),
+            "absorption must not apply outside the asset-class taxonomy"
+        );
     }
 
     /// When an asset is assigned to both a parent region (Americas) and a child (United_States),


### PR DESCRIPTION
Fixes #1439

On Insights → Breakdown → Allocation, an "Unknown" category appears containing holdings that
are _already_ correctly classified — the same tickers also show up, correctly, under Equity.
It is not a set of unclassified assets: it is a sliver of every look-through ETF whose
provider asset-class breakdown sums to slightly less than 100%.

Reproducible from an empty database with three of the most widely held ETFs (VOO, VTI, VXUS),
so any portfolio holding a mainstream broad-market index fund shows it.

## Root cause

Two behaviors compound.

**1. The provider's `other` sleeve is dropped and the remainder is not renormalized.**

The Yahoo provider emits exactly six asset-allocation labels (`crates/market-data/src/provider/yahoo/mod.rs`):
`stock`, `bond`, `cash`, `preferred`, `convertible`, `other`. Five map to taxonomy categories;
`map_provider_asset_class_to_taxonomy` returns `None` for `"OTHER"`, so that weight is silently
discarded. `weights_to_basis_points` then _preserves_ the resulting gap — it only scales to a
full 10000 when the provider weights sum to more than 100%:

```rust
let target_basis_points = if total_weight <= 1.0 {
    (total_weight * 10000.0).round() as i32   // 0.9979 -> 9979; the gap is kept
} else {
    10000                                      // only renormalizes when > 100%
};
```

For an index ETF the `other` sleeve is index futures used for cash equitization, securities-lending
collateral, and unclassifiable line items — economically equity exposure.

**2. The allocation service converts any shortfall into a synthetic `__UNKNOWN__` category.**

In `contribution_shares_for_holding`, `weight_divisor` was pinned at `total_active_weight.max(10000)`,
so a sum below 10000 was never scaled up and the missing basis points always landed in Unknown,
rendered as a first-class top-level row.

## Evidence

Stored `asset_classes` assignments, cross-checked against the live provider response
(`quoteSummary?modules=topHoldings`):

| Symbol | stock | bond | cash  | preferred | **other** | Provider total | Stored | Residual |
| ------ | ----- | ---- | ----- | --------- | --------- | -------------- | ------ | -------- |
| VOO    | .9957 | 0    | .0022 | 0         | **.0020** | 0.9999         | 9979   | 21 bps   |
| VTI    | .9931 | 0    | .0054 | 0         | **.0015** | 1.0000         | 9985   | 15 bps   |
| VXUS   | .9726 | 0    | .0257 | .0001     | **.0016** | 1.0000         | 9984   | 16 bps   |

VTI and VXUS match to the basis point — residual ≡ `other`. VOO is off by 1 bp because the
provider's own six positions sum to 0.9999 rather than 1.0, which is why a mapping-only fix
would not have been sufficient on its own.

(VXUS's 1 bp of `FIXED_INCOME` is not a bond — `bondPosition` is 0; it is `preferredPosition`,
since `"PREFERRED"` maps to `FIXED_INCOME`.)

## The fix

Read-side only, in `contribution_shares_for_holding`: when the assignment shortfall is within
75 bps, rescale the assigned weights to their own total instead of emitting `__UNKNOWN__`.

```rust
const RESIDUAL_TOLERANCE_BPS: i32 = 75;

let absorb_residual =
    total_active_weight < 10000 && 10000 - total_active_weight <= RESIDUAL_TOLERANCE_BPS;

let weight_divisor = if absorb_residual {
    Decimal::from(total_active_weight)
} else {
    Decimal::from(total_active_weight.max(10000))
};
```

Stored assignments are untouched and no re-classification or migration is needed. Assets with
no assignments, or with materially incomplete coverage, still report Unknown as before.

### Why a tolerance rather than mapping `"OTHER"`

Mapping `"OTHER"` to a category would fix most of the residual but not all of it — the provider's
positions do not always sum to 1.0 (VOO: 0.9999), so a 1 bp Unknown row would survive. It is also
a judgment call: for an index ETF the sleeve is mostly equity-index futures, so folding it pro rata
into the assigned categories represents the exposure better than parking it in its own bucket.


## Testing

Reproduced and verified end to end on a clean install — empty database, one account, three BUY
activities, nothing else. Container `wealthfolio/wealthfolio:3.6.3` for the before state and a
locally built server for the after state.

Auto-classification wrote 9979 / 9985 / 9984 bps in both cases (the fix does not change stored
weights). `GET /allocations`:

|              | Before      | After           |
| ------------ | ----------- | --------------- |
| Equity       | $117,145.30 | **$117,364.72** |
| Unknown      | **$220.42** | **— (gone)**    |
| Fixed Income | $0.88       | $0.88           |

`GET /allocations/holdings?categoryId=__UNKNOWN__` returned VOO $149.14 / VTI $57.27 /
VXUS $14.01 before the fix — the same three ETFs already under Equity, reconciling to the cent —
and `holdings: [], totalValue: 0.0` after.

The residual is redistributed, not discarded: equity absorbed $219.42, the cash sleeve ~$0.99,
fixed income a fraction of a cent.

**Genuine Unknowns still work.** Deleting one asset's assignments outright and re-querying returns
that asset at its full market value under Unknown, with the asset listed in the drill-down.

Unit tests added:

- `sub_tolerance_weight_shortfall_is_absorbed_instead_of_unknown` — VOO's real provider-derived
  weights (9957 + 22) produce no Unknown category, and the absorbed shares still account for the
  full market value.
- `weight_shortfall_beyond_tolerance_still_reports_unknown` — asserts the boundary: 9925 absorbed,
  9924 not.

Pre-existing Unknown-remainder tests pass unmodified (they use 40% shortfalls, well past tolerance).

Gate: `cargo fmt --check`, `cargo clippy -p wealthfolio-core --all-targets -- -D warnings`, and
`cargo test -p wealthfolio-core` (1724 passed, 0 failed) all clean.


## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
