### PR TITLE
fix(quotes): refresh asset profiles on a schedule, not once at creation

### DIFF
--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -66,6 +66,9 @@ mod tests {
 async fn main() -> anyhow::Result<()> {
     let config = Config::from_env();
     init_tracing();
+    // Before build_state: it spawns the domain-event queue worker, which can reach
+    // the profile-enrichment freshness predicate and fix the TTL for the process.
+    let profile_enrichment = wealthfolio_core::quotes::scheduler::configure_profile_enrichment();
     let state = build_state(&config).await?;
 
     #[cfg(feature = "device-sync")]
@@ -121,6 +124,13 @@ async fn main() -> anyhow::Result<()> {
         )
         .await;
     });
+
+    // Start periodic asset profile enrichment (fundamentals; cadence read above)
+    wealthfolio_core::quotes::scheduler::start_periodic_profile_enrichment(
+        state.quote_service.clone(),
+        state.asset_service.clone(),
+        profile_enrichment,
+    );
 
     let static_dir = std::path::PathBuf::from(&config.static_dir);
     let index_file = static_dir.join("index.html");

--- a/apps/tauri/src/lib.rs
+++ b/apps/tauri/src/lib.rs
@@ -207,6 +207,14 @@ mod desktop {
             .await;
         });
 
+        // Start periodic asset profile enrichment (fundamentals). Same pair of calls
+        // as the server target, so the two cannot drift apart.
+        wealthfolio_core::quotes::scheduler::start_periodic_profile_enrichment(
+            Arc::clone(&context.quote_service),
+            Arc::clone(&context.asset_service),
+            wealthfolio_core::quotes::scheduler::configure_profile_enrichment(),
+        );
+
         // Start background device sync engine (self-skips when device is not READY).
         #[cfg(feature = "device-sync")]
         {
@@ -334,6 +342,12 @@ fn get_app_data_dir(handle: &AppHandle) -> Result<String, Box<dyn std::error::Er
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     dotenv().ok();
+
+    // Publish the profile-enrichment TTL before any context is initialized: the
+    // domain-event queue worker can reach the freshness predicate as soon as it
+    // starts, and the first reader fixes the TTL for the process. Re-read at the
+    // spawn site below, which returns the same values.
+    wealthfolio_core::quotes::scheduler::configure_profile_enrichment();
 
     let builder = tauri::Builder::default();
 

--- a/crates/core/src/assets/assets_service.rs
+++ b/crates/core/src/assets/assets_service.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use log::{debug, error, info, warn};
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
@@ -1241,6 +1242,18 @@ impl AssetService {
         }
         if let Some(week_52_low) = provider_profile.week_52_low {
             profile_metadata.insert("week52Low".to_string(), serde_json::json!(week_52_low));
+        }
+
+        // Stamp when these figures were fetched, so consumers can tell how old a
+        // ratio is. `assets.updated_at` cannot answer that: it is not written by the
+        // profile update path at all, and it also moves for unrelated edits such as
+        // a rename. Only stamped alongside real provider data — an empty profile
+        // gets no date, and must not be turned into a non-empty one by this.
+        if !profile_metadata.is_empty() {
+            profile_metadata.insert(
+                "enrichedAt".to_string(),
+                serde_json::Value::String(Utc::now().to_rfc3339()),
+            );
         }
 
         // Merge with existing metadata (preserving any non-profile fields like OptionSpec)

--- a/crates/core/src/quotes/mod.rs
+++ b/crates/core/src/quotes/mod.rs
@@ -62,8 +62,9 @@ pub use types::{quote_id, AssetId, Currency, Day, ProviderId, QuoteSource};
 
 // Re-export sync state types
 pub use sync_state::{
-    MarketSyncMode, ProviderSyncStats, QuoteSyncState, QuoteSyncStateUpdate, SymbolSyncPlan,
-    SyncCategory, SyncMode, SyncStateStore,
+    profile_enrichment_cutoff, profile_enrichment_ttl, set_profile_enrichment_ttl, MarketSyncMode,
+    ProviderSyncStats, QuoteSyncState, QuoteSyncStateUpdate, SymbolSyncPlan, SyncCategory,
+    SyncMode, SyncStateStore, DEFAULT_PROFILE_ENRICHMENT_TTL_DAYS,
 };
 
 // Re-export sync service types

--- a/crates/core/src/quotes/scheduler.rs
+++ b/crates/core/src/quotes/scheduler.rs
@@ -1,10 +1,118 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use log::{error, info};
+use log::{error, info, warn};
 
 use super::service::QuoteServiceTrait;
-use super::sync_state::SyncMode;
+use super::sync_state::{
+    profile_enrichment_ttl, set_profile_enrichment_ttl, SyncMode,
+    DEFAULT_PROFILE_ENRICHMENT_TTL_DAYS,
+};
+use crate::assets::AssetServiceTrait;
+
+/// Assets enriched per provider round, matching the queue worker's treatment of
+/// the same call (`apps/server/src/domain_events/queue_worker.rs`).
+const ENRICHMENT_CHUNK_SIZE: usize = 5;
+
+/// Timeout for one enrichment chunk, matching the queue worker.
+const ENRICHMENT_CHUNK_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Default gap between enrichment sweeps, in hours. The sweep is cheap when
+/// nothing is stale, so it runs more often than the TTL and spreads refreshes out
+/// rather than refreshing the whole portfolio in one burst.
+const DEFAULT_PROFILE_ENRICHMENT_INTERVAL_HOURS: u64 = 24;
+
+/// Delay before the first enrichment sweep. Longer than the quote sync's, so
+/// startup work (and any creation-triggered enrichment) settles first.
+const PROFILE_ENRICHMENT_INITIAL_DELAY: Duration = Duration::from_secs(300);
+
+/// How often profiles are refreshed, and how stale one must be to qualify.
+///
+/// Read from the environment so an operator can tune or disable the behaviour
+/// without a rebuild — both the server and Tauri startup paths use this, so the
+/// two stay in step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProfileEnrichmentConfig {
+    /// Gap between sweeps.
+    pub interval: Duration,
+    /// Age at which a profile is refetched. `None` disables periodic enrichment,
+    /// leaving the legacy behaviour: enrich once at asset creation, never again.
+    pub ttl: Option<chrono::Duration>,
+}
+
+impl Default for ProfileEnrichmentConfig {
+    fn default() -> Self {
+        Self {
+            interval: Duration::from_secs(DEFAULT_PROFILE_ENRICHMENT_INTERVAL_HOURS * 3600),
+            ttl: Some(chrono::Duration::days(DEFAULT_PROFILE_ENRICHMENT_TTL_DAYS)),
+        }
+    }
+}
+
+impl ProfileEnrichmentConfig {
+    /// Build from `WF_PROFILE_ENRICHMENT_TTL_DAYS` and
+    /// `WF_PROFILE_ENRICHMENT_INTERVAL_HOURS`.
+    ///
+    /// A TTL of `0` disables periodic enrichment. Unparseable or negative values
+    /// fall back to the defaults with a warning rather than failing startup.
+    pub fn from_env() -> Self {
+        let defaults = Self::default();
+
+        let ttl = match std::env::var("WF_PROFILE_ENRICHMENT_TTL_DAYS") {
+            Err(_) => defaults.ttl,
+            Ok(raw) => match raw.trim().parse::<i64>() {
+                Ok(0) => None,
+                Ok(days) if days > 0 => Some(chrono::Duration::days(days)),
+                _ => {
+                    warn!(
+                        "Ignoring invalid WF_PROFILE_ENRICHMENT_TTL_DAYS='{}'; using {} days",
+                        raw, DEFAULT_PROFILE_ENRICHMENT_TTL_DAYS
+                    );
+                    defaults.ttl
+                }
+            },
+        };
+
+        let interval = match std::env::var("WF_PROFILE_ENRICHMENT_INTERVAL_HOURS") {
+            Err(_) => defaults.interval,
+            Ok(raw) => match raw.trim().parse::<u64>() {
+                Ok(hours) if hours > 0 => Duration::from_secs(hours * 3600),
+                _ => {
+                    warn!(
+                        "Ignoring invalid WF_PROFILE_ENRICHMENT_INTERVAL_HOURS='{}'; using {}h",
+                        raw, DEFAULT_PROFILE_ENRICHMENT_INTERVAL_HOURS
+                    );
+                    defaults.interval
+                }
+            },
+        };
+
+        Self { interval, ttl }
+    }
+
+    /// Publish the TTL process-wide, so the freshness predicate and the repository
+    /// query both see it. Returns the TTL actually in force.
+    ///
+    /// Call this **before** building services: the domain-event queue worker can
+    /// reach `needs_profile_enrichment` as soon as it starts, and the first reader
+    /// fixes the TTL for the process. Losing that race would silently ignore the
+    /// operator's setting, so a mismatch is warned about rather than swallowed.
+    pub fn apply(&self) -> Option<chrono::Duration> {
+        if set_profile_enrichment_ttl(self.ttl) {
+            return self.ttl;
+        }
+
+        let effective = profile_enrichment_ttl();
+        if effective != self.ttl {
+            warn!(
+                "Profile enrichment TTL was already fixed at {:?} before configuration \
+                 was applied; ignoring the configured {:?}",
+                effective, self.ttl
+            );
+        }
+        effective
+    }
+}
 
 /// Runs periodic market data sync on a fixed interval.
 ///
@@ -35,5 +143,189 @@ pub async fn run_periodic_sync(
             }
         }
         tokio::time::sleep(interval).await;
+    }
+}
+
+/// Read the enrichment cadence from the environment and publish the TTL, before any
+/// service exists that could read it first.
+///
+/// Both startup paths call this as one of their first actions, then hand the result
+/// to [`start_periodic_profile_enrichment`] once services are built — so the two
+/// binaries cannot drift apart in cadence or in how the environment is read.
+pub fn configure_profile_enrichment() -> ProfileEnrichmentConfig {
+    let config = ProfileEnrichmentConfig::from_env();
+    let effective = config.apply();
+    ProfileEnrichmentConfig {
+        interval: config.interval,
+        ttl: effective,
+    }
+}
+
+/// Spawn periodic profile enrichment, or log why it is off.
+pub fn start_periodic_profile_enrichment(
+    quote_service: Arc<dyn QuoteServiceTrait>,
+    asset_service: Arc<dyn AssetServiceTrait>,
+    config: ProfileEnrichmentConfig,
+) {
+    let Some(ttl) = config.ttl else {
+        info!(
+            "Periodic asset profile enrichment disabled (WF_PROFILE_ENRICHMENT_TTL_DAYS=0); \
+             profiles will be enriched once at asset creation only"
+        );
+        return;
+    };
+
+    info!(
+        "Scheduling asset profile enrichment: refreshing profiles older than {}d, sweeping every {}h",
+        ttl.num_days(),
+        config.interval.as_secs() / 3600
+    );
+
+    tokio::spawn(run_periodic_profile_enrichment(
+        quote_service,
+        asset_service,
+        PROFILE_ENRICHMENT_INITIAL_DELAY,
+        config.interval,
+    ));
+}
+
+/// Runs periodic asset-profile enrichment on a fixed interval.
+///
+/// Without this, `plan_asset_enrichment` only reacts to `DomainEvent::AssetsCreated`,
+/// so `peRatio`, `dividendYield` and the 52-week range are captured once when an
+/// asset is first added and never refreshed again.
+///
+/// Same shape as [`run_periodic_sync`]: sleep, then loop, logging errors and
+/// continuing. Never panics.
+pub async fn run_periodic_profile_enrichment(
+    quote_service: Arc<dyn QuoteServiceTrait>,
+    asset_service: Arc<dyn AssetServiceTrait>,
+    initial_delay: Duration,
+    interval: Duration,
+) {
+    tokio::time::sleep(initial_delay).await;
+    info!(
+        "Periodic asset profile enrichment started (interval: {}h)",
+        interval.as_secs() / 3600
+    );
+
+    loop {
+        enrich_stale_profiles_once(&*quote_service, &*asset_service).await;
+        tokio::time::sleep(interval).await;
+    }
+}
+
+/// One enrichment sweep. Separated from the loop so the body stays readable and
+/// errors are contained to a single pass.
+async fn enrich_stale_profiles_once(
+    quote_service: &dyn QuoteServiceTrait,
+    asset_service: &dyn AssetServiceTrait,
+) {
+    let stale = match quote_service.get_assets_needing_profile_enrichment() {
+        Ok(stale) => stale,
+        Err(e) => {
+            error!("Periodic profile enrichment: failed to list stale profiles: {e}");
+            return;
+        }
+    };
+
+    let asset_ids: Vec<String> = stale.into_iter().map(|state| state.asset_id).collect();
+    if asset_ids.is_empty() {
+        info!("Periodic profile enrichment: no stale profiles, nothing to do");
+        return;
+    }
+
+    info!(
+        "Periodic profile enrichment: {} stale profile(s) to refresh",
+        asset_ids.len()
+    );
+
+    let (mut enriched, mut skipped, mut failed) = (0usize, 0usize, 0usize);
+
+    for chunk in asset_ids.chunks(ENRICHMENT_CHUNK_SIZE) {
+        match tokio::time::timeout(
+            ENRICHMENT_CHUNK_TIMEOUT,
+            asset_service.enrich_assets(chunk.to_vec()),
+        )
+        .await
+        {
+            Ok(Ok((chunk_enriched, chunk_skipped, chunk_failed))) => {
+                enriched += chunk_enriched;
+                skipped += chunk_skipped;
+                failed += chunk_failed;
+            }
+            Ok(Err(e)) => {
+                warn!("Periodic profile enrichment: chunk failed: {e}");
+                failed += chunk.len();
+            }
+            Err(_) => {
+                warn!(
+                    "Periodic profile enrichment: chunk timed out ({} asset(s))",
+                    chunk.len()
+                );
+                failed += chunk.len();
+            }
+        }
+    }
+
+    info!(
+        "Periodic profile enrichment completed: {enriched} enriched, {skipped} skipped, {failed} failed"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_enriches_weekly_and_sweeps_daily() {
+        let config = ProfileEnrichmentConfig::default();
+        assert_eq!(config.ttl, Some(chrono::Duration::days(7)));
+        assert_eq!(config.interval, Duration::from_secs(24 * 3600));
+    }
+
+    /// The sweep runs more often than the TTL on purpose: refreshes then spread
+    /// across days instead of arriving as one burst every TTL.
+    #[test]
+    fn sweep_interval_is_shorter_than_the_ttl() {
+        let config = ProfileEnrichmentConfig::default();
+        let ttl = config.ttl.expect("default ttl is enabled");
+        assert!(config.interval.as_secs() < ttl.num_seconds() as u64);
+    }
+
+    #[test]
+    fn enrichment_chunking_matches_the_queue_worker() {
+        assert_eq!(ENRICHMENT_CHUNK_SIZE, 5);
+        assert_eq!(ENRICHMENT_CHUNK_TIMEOUT, Duration::from_secs(30));
+    }
+
+    /// `apply` reports the TTL actually in force, not the one requested. Startup
+    /// calls it before services exist so the two always match; if something read the
+    /// TTL first, the caller must see the effective value rather than assume its own.
+    #[test]
+    fn apply_returns_the_ttl_actually_in_force() {
+        let config = ProfileEnrichmentConfig::default();
+        let effective = config.apply();
+
+        assert_eq!(
+            effective,
+            profile_enrichment_ttl(),
+            "apply must report what the predicate and the repository query will see"
+        );
+
+        // Idempotent: a second apply of the same config agrees with the first.
+        assert_eq!(config.apply(), effective);
+    }
+
+    /// Both startup paths route through this, so neither can invent its own cadence.
+    #[test]
+    fn configure_reports_the_effective_ttl_with_the_configured_interval() {
+        let configured = configure_profile_enrichment();
+
+        assert_eq!(configured.ttl, profile_enrichment_ttl());
+        assert_eq!(
+            configured.interval,
+            ProfileEnrichmentConfig::from_env().interval
+        );
     }
 }

--- a/crates/core/src/quotes/sync_state.rs
+++ b/crates/core/src/quotes/sync_state.rs
@@ -7,6 +7,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Duration, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::OnceLock;
 
 use crate::errors::Result;
 
@@ -339,6 +340,48 @@ pub struct SymbolSyncPlan {
     pub suppress_closed_fetch_errors: bool,
 }
 
+// =============================================================================
+// Profile Enrichment Freshness
+// =============================================================================
+
+/// Default maximum age of an asset profile before it is re-enriched, in days.
+///
+/// Fundamentals (P/E, dividend yield, 52-week range) move on quarterly earnings
+/// cycles, so a weekly refresh keeps them current at negligible provider cost.
+pub const DEFAULT_PROFILE_ENRICHMENT_TTL_DAYS: i64 = 7;
+
+static PROFILE_ENRICHMENT_TTL: OnceLock<Option<Duration>> = OnceLock::new();
+
+/// Set the process-wide profile-enrichment TTL. `None` disables periodic
+/// re-enrichment, leaving profiles enriched exactly once at asset creation.
+///
+/// Call once during startup, before any sync work begins. Later calls are ignored
+/// (returns `false`) so the value cannot change under a running scheduler.
+pub fn set_profile_enrichment_ttl(ttl: Option<Duration>) -> bool {
+    PROFILE_ENRICHMENT_TTL.set(ttl).is_ok()
+}
+
+/// The process-wide profile-enrichment TTL, defaulting to
+/// [`DEFAULT_PROFILE_ENRICHMENT_TTL_DAYS`] if startup never set one.
+pub fn profile_enrichment_ttl() -> Option<Duration> {
+    *PROFILE_ENRICHMENT_TTL
+        .get_or_init(|| Some(Duration::days(DEFAULT_PROFILE_ENRICHMENT_TTL_DAYS)))
+}
+
+/// The timestamp at or before which a profile counts as stale, or `None` when the
+/// TTL is disabled.
+///
+/// This is the SQL-side half of [`QuoteSyncState::needs_profile_enrichment_at`]:
+/// the repository selects `profile_enriched_at IS NULL OR profile_enriched_at <= cutoff`.
+/// The two must agree, or the scheduler selects assets that `enrich_assets` then
+/// skips and nothing ever refreshes.
+pub fn profile_enrichment_cutoff(
+    now: DateTime<Utc>,
+    max_age: Option<Duration>,
+) -> Option<DateTime<Utc>> {
+    max_age.map(|max_age| now - max_age)
+}
+
 /// Domain model for quote sync state.
 ///
 /// This table tracks sync coordination state per asset. It is NOT a cache of
@@ -395,9 +438,30 @@ impl QuoteSyncState {
         }
     }
 
-    /// Returns true if the asset profile needs enrichment (profile_enriched_at is None).
+    /// Returns true if the asset profile needs enrichment, using the process-wide
+    /// TTL (see [`profile_enrichment_ttl`]).
     pub fn needs_profile_enrichment(&self) -> bool {
-        self.profile_enriched_at.is_none()
+        self.needs_profile_enrichment_at(Utc::now(), profile_enrichment_ttl())
+    }
+
+    /// Freshness predicate, with `now` and the TTL injected so it is deterministic.
+    ///
+    /// A profile is stale when it has never been enriched, or when the last
+    /// enrichment is at least `max_age` old. `max_age` of `None` disables periodic
+    /// re-enrichment, restoring the legacy one-shot behaviour.
+    ///
+    /// An enrichment timestamp in the future (clock skew, restored backup) reads as
+    /// fresh rather than infinitely stale.
+    pub fn needs_profile_enrichment_at(
+        &self,
+        now: DateTime<Utc>,
+        max_age: Option<Duration>,
+    ) -> bool {
+        match (self.profile_enriched_at, max_age) {
+            (None, _) => true,
+            (Some(_), None) => false,
+            (Some(enriched_at), Some(max_age)) => now.signed_duration_since(enriched_at) >= max_age,
+        }
     }
 
     /// Mark profile as enriched.
@@ -544,6 +608,150 @@ pub trait SyncStateStore: Send + Sync {
 
     /// Get sync states with errors (error_count > 0).
     fn get_with_errors(&self) -> Result<Vec<QuoteSyncState>>;
+}
+
+#[cfg(test)]
+mod profile_enrichment_tests {
+    use super::*;
+
+    fn state_enriched_at(at: Option<DateTime<Utc>>) -> QuoteSyncState {
+        let mut state = QuoteSyncState::new("AAPL".to_string(), "YAHOO".to_string());
+        state.profile_enriched_at = at;
+        state
+    }
+
+    fn now() -> DateTime<Utc> {
+        Utc::now()
+    }
+
+    #[test]
+    fn never_enriched_needs_enrichment() {
+        let state = state_enriched_at(None);
+        assert!(state.needs_profile_enrichment_at(now(), Some(Duration::days(7))));
+    }
+
+    #[test]
+    fn never_enriched_needs_enrichment_even_when_ttl_disabled() {
+        let state = state_enriched_at(None);
+        assert!(
+            state.needs_profile_enrichment_at(now(), None),
+            "a profile that was never enriched must be enriched once regardless of TTL"
+        );
+    }
+
+    #[test]
+    fn enriched_older_than_ttl_needs_enrichment() {
+        let now = now();
+        let state = state_enriched_at(Some(now - Duration::days(8)));
+        assert!(state.needs_profile_enrichment_at(now, Some(Duration::days(7))));
+    }
+
+    #[test]
+    fn enriched_within_ttl_does_not_need_enrichment() {
+        let now = now();
+        let state = state_enriched_at(Some(now - Duration::days(3)));
+        assert!(!state.needs_profile_enrichment_at(now, Some(Duration::days(7))));
+    }
+
+    /// Boundary direction is documented, not incidental: an age of exactly the TTL
+    /// counts as stale, so a daily loop with a 7-day TTL refreshes on day 7, not day 8.
+    #[test]
+    fn enriched_exactly_at_ttl_boundary_needs_enrichment() {
+        let now = now();
+        let state = state_enriched_at(Some(now - Duration::days(7)));
+        assert!(state.needs_profile_enrichment_at(now, Some(Duration::days(7))));
+    }
+
+    #[test]
+    fn enriched_one_second_inside_ttl_does_not_need_enrichment() {
+        let now = now();
+        let state = state_enriched_at(Some(now - Duration::days(7) + Duration::seconds(1)));
+        assert!(!state.needs_profile_enrichment_at(now, Some(Duration::days(7))));
+    }
+
+    /// Clock skew (or a restored backup) can leave a timestamp in the future.
+    /// That must not panic and must not be read as "infinitely stale".
+    #[test]
+    fn enriched_in_the_future_does_not_need_enrichment() {
+        let now = now();
+        let state = state_enriched_at(Some(now + Duration::days(30)));
+        assert!(!state.needs_profile_enrichment_at(now, Some(Duration::days(7))));
+    }
+
+    #[test]
+    fn ttl_none_restores_legacy_one_shot_behaviour() {
+        let now = now();
+        let state = state_enriched_at(Some(now - Duration::days(3650)));
+        assert!(
+            !state.needs_profile_enrichment_at(now, None),
+            "a disabled TTL must never re-enrich an already-enriched profile"
+        );
+    }
+
+    #[test]
+    fn cutoff_is_none_when_ttl_disabled() {
+        assert!(profile_enrichment_cutoff(now(), None).is_none());
+    }
+
+    #[test]
+    fn cutoff_is_ttl_before_now() {
+        let now = now();
+        assert_eq!(
+            profile_enrichment_cutoff(now, Some(Duration::days(7))),
+            Some(now - Duration::days(7))
+        );
+    }
+
+    /// The regression this unit exists to prevent, in the form it can actually take:
+    /// the scheduler selects stale assets with the SQL cutoff
+    /// (`profile_enriched_at IS NULL OR profile_enriched_at <= cutoff`), and
+    /// `enrich_assets` then re-checks each one with `needs_profile_enrichment`.
+    /// If the two disagree, the loop selects assets that are immediately skipped and
+    /// nothing ever refreshes — silently, exactly like today's bug.
+    #[test]
+    fn sql_cutoff_and_in_memory_predicate_agree() {
+        let now = now();
+        let ttl = Duration::days(7);
+        let cutoff = profile_enrichment_cutoff(now, Some(ttl)).expect("ttl enabled");
+
+        let ages_in_hours = [0, 1, 24, 167, 168, 169, 24 * 30, -24];
+        for hours in ages_in_hours {
+            let enriched_at = now - Duration::hours(hours);
+            let state = state_enriched_at(Some(enriched_at));
+
+            let selected_by_sql = enriched_at <= cutoff;
+            let accepted_by_predicate = state.needs_profile_enrichment_at(now, Some(ttl));
+
+            assert_eq!(
+                selected_by_sql, accepted_by_predicate,
+                "SQL cutoff and in-memory predicate disagree for a profile enriched {hours}h ago"
+            );
+        }
+    }
+
+    /// An asset enriched now, then aged past the TTL, becomes selectable again.
+    #[test]
+    fn enriched_asset_becomes_stale_again_after_the_ttl() {
+        let enriched_at = Utc::now();
+        let state = state_enriched_at(Some(enriched_at));
+        let ttl = Duration::days(7);
+
+        assert!(
+            !state.needs_profile_enrichment_at(enriched_at, Some(ttl)),
+            "freshly enriched profile must not be re-enriched immediately"
+        );
+
+        let later = enriched_at + Duration::days(8);
+        assert!(
+            state.needs_profile_enrichment_at(later, Some(ttl)),
+            "profile aged past the TTL must be enriched again \
+             — this is the permanent-staleness bug the unit fixes"
+        );
+        assert!(
+            profile_enrichment_cutoff(later, Some(ttl)).is_some_and(|cutoff| enriched_at <= cutoff),
+            "the repository query must select it too"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/storage-sqlite/src/market_data/quote_sync_state_repository.rs
+++ b/crates/storage-sqlite/src/market_data/quote_sync_state_repository.rs
@@ -12,7 +12,10 @@ use crate::db::{get_connection, WriteHandle};
 use crate::errors::StorageError;
 use crate::schema::quote_sync_state::dsl as qss_dsl;
 use crate::utils::chunk_for_sqlite;
-use wealthfolio_core::quotes::{ProviderSyncStats, QuoteSyncState, SyncStateStore};
+use wealthfolio_core::quotes::{
+    profile_enrichment_cutoff, profile_enrichment_ttl, ProviderSyncStats, QuoteSyncState,
+    SyncStateStore,
+};
 use wealthfolio_core::Result;
 
 pub struct QuoteSyncStateRepository {
@@ -470,9 +473,27 @@ impl SyncStateStore for QuoteSyncStateRepository {
     fn get_assets_needing_profile_enrichment(&self) -> Result<Vec<QuoteSyncState>> {
         let mut conn = get_connection(&self.pool)?;
 
-        // Get assets where profile_enriched_at is NULL
+        // Assets never enriched, plus those whose profile has aged past the TTL.
+        // The cutoff must match `QuoteSyncState::needs_profile_enrichment`, which
+        // `enrich_assets` re-applies to every id this returns — if the two diverge,
+        // selected assets are silently skipped and nothing ever refreshes.
+        //
+        // `profile_enriched_at` is stored as RFC3339 in UTC, so lexicographic
+        // comparison matches chronological order (same pattern as the
+        // `position_closed_date` grace cutoff above).
+        let cutoff = profile_enrichment_cutoff(Utc::now(), profile_enrichment_ttl())
+            .map(|cutoff| cutoff.to_rfc3339())
+            // TTL disabled: an empty cutoff sorts below every RFC3339 timestamp, so
+            // the `le` arm matches nothing and only never-enriched rows are returned
+            // — the legacy one-shot behaviour, with one query shape instead of two.
+            .unwrap_or_default();
+
         let results = qss_dsl::quote_sync_state
-            .filter(qss_dsl::profile_enriched_at.is_null())
+            .filter(
+                qss_dsl::profile_enriched_at
+                    .is_null()
+                    .or(qss_dsl::profile_enriched_at.le(cutoff)),
+            )
             .order(qss_dsl::sync_priority.desc())
             .load::<QuoteSyncStateDB>(&mut conn)
             .map_err(StorageError::from)?;


### PR DESCRIPTION
## Description

Asset profile enrichment runs **exactly once per asset, at creation, and never again** — so `peRatio`, `dividendYield` and the 52-week range are frozen at the moment an asset is first added.

`plan_asset_enrichment` (`apps/server/src/domain_events/planner.rs`) only matches `DomainEvent::AssetsCreated`. Nothing else triggers it: not quote sync, not "Update prices", not any user action. And there is no refresh path available to anyone — the server exposes `GET /assets/profile` and `PUT /assets/profile/{id}` (manual field edits, not a provider re-fetch), while `enrich_asset_profile` is internal and unexposed. Because enrichment never repeats, the `profile_enriched_at` guard never comes into play, which is why it reads NULL on every row of a long-lived instance.

Measured on a real instance before the change: fundamentals **6–7 weeks stale** against same-day quotes, and `profile_enriched_at` NULL on all 62 `quote_sync_state` rows.

### This mostly connects machinery that already exists

Very little here is new. `enrich_assets` already deduplicates, chunks, records sync state and skips non-`MARKET` quote modes. `get_assets_needing_profile_enrichment` already filters exactly the right rows — but **had no production caller**; its only other implementations were test mocks. This wires them together:

- **`needs_profile_enrichment` becomes age-aware.** The pure predicate takes `now` and the TTL so it is deterministic under test; the existing parameterless form keeps its signature and reads a process-wide TTL.
- **The repository query gains the matching cutoff.** These two *must* agree: `enrich_assets` re-checks every id the query returns, so any divergence would silently skip exactly the assets the sweep just selected — failing the same way the current bug does, invisibly. A test pins their agreement across a range of ages, including the boundary and a future timestamp.
- **A periodic sweep sits beside `run_periodic_sync`**, following that function's shape (initial delay, loop, log, never panic) and reusing the queue worker's chunk-of-5 with a 30s timeout.
- **Both startup paths** (server and Tauri) configure the cadence before building services and spawn the sweep afterwards, so the two binaries cannot drift apart.

Configuration is applied before `build_state` deliberately: that call spawns the domain-event queue worker, which can reach the freshness predicate as soon as it starts, and the first reader fixes the TTL for the process. Losing that race would silently ignore the operator's setting, so a mismatch is warned about rather than swallowed.

### Second commit: stamping when a profile was fetched

Once enrichment recurs, consumers need to know how old the figures are, and `assets.updated_at` cannot answer it — `update_profile` sets only the metadata column and never touches `updated_at`, which also moves for unrelated edits such as a rename. That was invisible while enrichment fired once at creation, because the two coincided.

The gap is not cosmetic. Between earnings publications a trailing P/E moves only with price, so `stored × (priceNow / priceAtAsOf)` recovers a current value — but anchored on a stale date it re-applies a move already reflected in a freshly fetched ratio, with an error that grows without bound as the dates diverge. Observed on a real portfolio: a holding whose true P/E was 20.96 computed as 19.56, and rising.

`profile.enrichedAt` is stamped only alongside real provider data, so a profile that came back empty is not turned into a non-empty one carrying just a date.

### Configuration

| Variable | Default | Effect |
|---|---|---|
| `WF_PROFILE_ENRICHMENT_TTL_DAYS` | `7` | Age at which a profile is refetched. **`0` disables it entirely**, restoring today's one-shot behaviour |
| `WF_PROFILE_ENRICHMENT_INTERVAL_HOURS` | `24` | Gap between sweeps |

Weekly, not daily: fundamentals move on quarterly earnings cycles. The sweep runs more often than the TTL so refreshes spread across days rather than arriving as one burst.

### Scope

No API surface, no UI, no schema change, no migration. Quote sync keeps its own 6h cycle untouched. Existing behaviour is reachable by setting the TTL to `0`.

### Verification

- `cargo test -p wealthfolio-core --lib quotes::` — 219 pass, including 15 new tests covering the freshness predicate (null, aged, within-TTL, exact boundary, future clock skew, disabled TTL) and the SQL/in-memory agreement.
- `cargo clippy -p wealthfolio-core --lib -- -D warnings` clean; `cargo fmt --check` clean.
- Both targets compile: `wealthfolio-server` and `wealthfolio-app`.
- **Observed working on a real instance.** After deploying, the sweep logged `62 stale profile(s) to refresh` → `61 enriched, 0 skipped, 1 failed`, and fundamentals frozen since 24 June refreshed to current values (LVMH 22.55 → 20.96, Hermès 37.87 → 36.77). The single failure was a stablecoin misclassified as a bond in that dataset — the loop logged it and continued, as intended. Failures leave `profile_enriched_at` NULL, so they are retried on the next sweep rather than being lost.

I am happy to split the two commits into separate PRs, drop the `enrichedAt` stamp, or change the defaults if you would prefer a different cadence.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
