### PR TITLE
Fix cash refund accounting and add contract tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8870,6 +8870,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "log",
+ "proptest",
  "regex",
  "rust_decimal",
  "serde",

--- a/apps/frontend/src/adapters/shared/activities.test.ts
+++ b/apps/frontend/src/adapters/shared/activities.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  logger: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("./platform", () => ({
+  invoke: mocks.invoke,
+  logger: mocks.logger,
+}));
+
+import { createActivity, saveActivities, updateActivity } from "./activities";
+
+const baseActivity = {
+  accountId: "account-1",
+  activityType: "CREDIT",
+  subtype: "REFUND",
+  activityDate: "2026-08-11T00:00:00.000Z",
+  currency: "USD",
+};
+
+describe("activity metadata serialization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.invoke.mockResolvedValue({});
+  });
+
+  it("serializes object metadata for creates without mutating the caller payload", async () => {
+    const activity = {
+      ...baseActivity,
+      metadata: { flow: { is_external: true } },
+    };
+
+    await createActivity(activity);
+
+    expect(activity.metadata).toEqual({ flow: { is_external: true } });
+    expect(mocks.invoke).toHaveBeenCalledWith("create_activity", {
+      activity: {
+        ...baseActivity,
+        metadata: '{"flow":{"is_external":true}}',
+      },
+    });
+  });
+
+  it("serializes object metadata for updates", async () => {
+    await updateActivity({
+      id: "activity-1",
+      ...baseActivity,
+      metadata: { raw_type: "merchant_refund", flow: { is_external: true } },
+    });
+
+    expect(mocks.invoke).toHaveBeenCalledWith("update_activity", {
+      activity: {
+        id: "activity-1",
+        ...baseActivity,
+        metadata: '{"raw_type":"merchant_refund","flow":{"is_external":true}}',
+      },
+    });
+  });
+
+  it("normalizes metadata in bulk creates and updates while preserving JSON strings", async () => {
+    await saveActivities({
+      creates: [{ ...baseActivity, metadata: { flow: { is_external: true } } }],
+      updates: [
+        {
+          id: "activity-1",
+          ...baseActivity,
+          metadata: '{"flow":{"is_external":false}}',
+        },
+      ],
+    });
+
+    expect(mocks.invoke).toHaveBeenCalledWith("save_activities", {
+      request: {
+        creates: [
+          {
+            ...baseActivity,
+            metadata: '{"flow":{"is_external":true}}',
+          },
+        ],
+        updates: [
+          {
+            id: "activity-1",
+            ...baseActivity,
+            metadata: '{"flow":{"is_external":false}}',
+          },
+        ],
+        deleteIds: [],
+      },
+    });
+  });
+});

--- a/apps/frontend/src/adapters/shared/activities.ts
+++ b/apps/frontend/src/adapters/shared/activities.ts
@@ -48,6 +48,17 @@ function normalizeStringArray(input?: string | string[]): string[] | undefined {
   return input.length > 0 ? [input] : undefined;
 }
 
+function serializeActivityMetadata<T extends ActivityCreate | ActivityUpdate>(activity: T): T {
+  if (activity.metadata === undefined || typeof activity.metadata === "string") {
+    return activity;
+  }
+
+  return {
+    ...activity,
+    metadata: JSON.stringify(activity.metadata),
+  };
+}
+
 export const getActivities = async (accountId?: string): Promise<ActivityDetails[]> => {
   try {
     const response = await searchActivities(
@@ -106,7 +117,9 @@ export const searchActivities = async (
 
 export const createActivity = async (activity: ActivityCreate): Promise<Activity> => {
   try {
-    return await invoke<Activity>("create_activity", { activity });
+    return await invoke<Activity>("create_activity", {
+      activity: serializeActivityMetadata(activity),
+    });
   } catch (err) {
     logger.error("Error creating activity.");
     throw err;
@@ -115,7 +128,9 @@ export const createActivity = async (activity: ActivityCreate): Promise<Activity
 
 export const updateActivity = async (activity: ActivityUpdate): Promise<Activity> => {
   try {
-    return await invoke<Activity>("update_activity", { activity });
+    return await invoke<Activity>("update_activity", {
+      activity: serializeActivityMetadata(activity),
+    });
   } catch (err) {
     logger.error("Error updating activity.");
     throw err;
@@ -126,8 +141,8 @@ export const saveActivities = async (
   request: ActivityBulkMutationRequest,
 ): Promise<ActivityBulkMutationResult> => {
   const payload: ActivityBulkMutationRequest = {
-    creates: request.creates ?? [],
-    updates: request.updates ?? [],
+    creates: (request.creates ?? []).map(serializeActivityMetadata),
+    updates: (request.updates ?? []).map(serializeActivityMetadata),
     deleteIds: request.deleteIds ?? [],
   };
   try {

--- a/apps/frontend/src/features/spending/components/cash-activity-form.tsx
+++ b/apps/frontend/src/features/spending/components/cash-activity-form.tsx
@@ -60,7 +60,10 @@ import { useSpendingSettings } from "../hooks/use-spending-settings";
 import { QuickCategorizePopover } from "./quick-categorize-popover";
 import { QuickEventPopover } from "./quick-event-popover";
 import type { CashFlowBucket } from "../types/cash-activity";
-import { resolveCashActivitySubtype } from "../lib/cash-activity-form-utils";
+import {
+  cashActivityFlowMetadata,
+  resolveCashActivitySubtype,
+} from "../lib/cash-activity-form-utils";
 
 const SPENDING_TAXONOMY = "spending_categories";
 const INCOME_TAXONOMY = "income_sources";
@@ -327,6 +330,7 @@ export function CashActivityForm({
           amount: values.amount,
           currency,
           comment: values.notes ?? null,
+          metadata: cashActivityFlowMetadata(values.activityType, subtype, activity?.metadata),
         };
         saved = await updateActivity(update);
       } else {
@@ -338,6 +342,7 @@ export function CashActivityForm({
           amount: values.amount,
           currency,
           comment: values.notes ?? null,
+          metadata: cashActivityFlowMetadata(values.activityType, subtype),
         };
         saved = await createActivity(create);
       }

--- a/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
+++ b/apps/frontend/src/features/spending/components/spending-transactions-tab.tsx
@@ -58,6 +58,7 @@ import {
   isCreditCardAccountType,
   isSpendingAccountType,
 } from "../lib/constants";
+import { cashActivityFlowMetadata } from "../lib/cash-activity-form-utils";
 import {
   isTransferCashActivity,
   stableArr,
@@ -547,15 +548,30 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
     const { mutate: duplicateTransaction } = useMutation({
       mutationFn: async (row: TransactionRowVM) => {
         const a = row.activity;
+        const activityType = getEffectiveCashActivityType(a);
+        const supportsBoundary =
+          activityType === ActivityType.CREDIT ||
+          activityType === ActivityType.TRANSFER_IN ||
+          activityType === ActivityType.TRANSFER_OUT;
+        const flow = a.metadata?.flow as Record<string, unknown> | undefined;
+        const boundaryMetadata =
+          supportsBoundary && typeof flow?.is_external === "boolean"
+            ? { flow: { is_external: flow.is_external } }
+            : undefined;
         return createActivity({
           idempotencyKey: generateId("manual-duplicate"),
           accountId: a.accountId,
-          activityType: getEffectiveCashActivityType(a),
+          activityType,
+          subtype: a.subtype,
           currency: a.currency,
           amount: a.amount,
           activityDate:
             typeof a.activityDate === "string" ? a.activityDate : new Date().toISOString(),
           comment: t("spending:txTab.duplicatedComment"),
+          metadata:
+            activityType === ActivityType.CREDIT
+              ? cashActivityFlowMetadata(activityType, a.subtype, boundaryMetadata)
+              : boundaryMetadata,
         });
       },
       onSuccess: () => {
@@ -584,6 +600,7 @@ export const SpendingTransactionsTab = forwardRef<SpendingTransactionsTabHandle>
           amount: Math.abs(Number.parseFloat(a.amount ?? "0")),
           currency: a.currency,
           comment: a.notes ?? null,
+          metadata: cashActivityFlowMetadata("CREDIT", "REIMBURSEMENT", a.metadata),
         });
       },
       onSuccess: (_, row) => {

--- a/apps/frontend/src/features/spending/lib/cash-activity-form-utils.test.ts
+++ b/apps/frontend/src/features/spending/lib/cash-activity-form-utils.test.ts
@@ -1,6 +1,6 @@
 import { AccountType } from "@/lib/constants";
 
-import { resolveCashActivitySubtype } from "./cash-activity-form-utils";
+import { cashActivityFlowMetadata, resolveCashActivitySubtype } from "./cash-activity-form-utils";
 
 describe("resolveCashActivitySubtype", () => {
   it("sets reimbursement subtype for new cash-account credits", () => {
@@ -32,5 +32,76 @@ describe("resolveCashActivitySubtype", () => {
         existingSubtype: "BONUS",
       }),
     ).toBeNull();
+  });
+});
+
+describe("cashActivityFlowMetadata", () => {
+  it("marks CREDIT/REIMBURSEMENT as crossing the performance boundary", () => {
+    expect(cashActivityFlowMetadata("CREDIT", "REIMBURSEMENT")).toEqual({
+      flow: { is_external: true },
+    });
+  });
+
+  it.each(["REFUND", "REBATE"])("does not infer CREDIT/%s as external", (subtype) => {
+    expect(cashActivityFlowMetadata("CREDIT", subtype)).toBeUndefined();
+  });
+
+  it("does not mark unrelated cash activity types as external", () => {
+    expect(cashActivityFlowMetadata("CREDIT", "BONUS")).toBeUndefined();
+    expect(cashActivityFlowMetadata("WITHDRAWAL", "REFUND")).toBeUndefined();
+  });
+
+  it("preserves existing metadata when adding the reimbursement boundary marker", () => {
+    expect(
+      cashActivityFlowMetadata("CREDIT", "REIMBURSEMENT", {
+        raw_type: "merchant_refund",
+        flow: { confidence: 0.9 },
+      }),
+    ).toEqual({
+      raw_type: "merchant_refund",
+      flow: { confidence: 0.9, is_external: true },
+    });
+  });
+
+  it.each([true, false])("preserves an explicit %s boundary override", (isExternal) => {
+    expect(
+      cashActivityFlowMetadata("CREDIT", "REFUND", {
+        raw_type: "merchant_refund",
+        flow: { confidence: 0.9, is_external: isExternal },
+      }),
+    ).toEqual({
+      raw_type: "merchant_refund",
+      flow: { confidence: 0.9, is_external: isExternal },
+    });
+  });
+
+  it("preserves an explicit false BONUS override instead of restoring the subtype default", () => {
+    expect(
+      cashActivityFlowMetadata("CREDIT", "BONUS", {
+        flow: { is_external: false },
+      }),
+    ).toEqual({
+      flow: { is_external: false },
+    });
+  });
+
+  it("removes only the stale boundary marker when the activity stops being a credit", () => {
+    expect(
+      cashActivityFlowMetadata("DEPOSIT", "BONUS", {
+        raw_type: "cash_bonus",
+        flow: { confidence: 0.9, is_external: true },
+      }),
+    ).toEqual({
+      raw_type: "cash_bonus",
+      flow: { confidence: 0.9 },
+    });
+  });
+
+  it("returns empty metadata when the stale marker was the only value", () => {
+    expect(
+      cashActivityFlowMetadata("DEPOSIT", "BONUS", {
+        flow: { is_external: true },
+      }),
+    ).toEqual({});
   });
 });

--- a/apps/frontend/src/features/spending/lib/cash-activity-form-utils.ts
+++ b/apps/frontend/src/features/spending/lib/cash-activity-form-utils.ts
@@ -23,3 +23,45 @@ export function resolveCashActivitySubtype({
 
   return "REIMBURSEMENT";
 }
+
+export function cashActivityFlowMetadata(
+  activityType: string,
+  subtype?: string | null,
+  existingMetadata?: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const normalizedSubtype = subtype?.trim().toUpperCase();
+  const supportsCreditBoundary = activityType === "CREDIT";
+
+  const existingFlow = existingMetadata?.flow;
+  const hasFlowObject =
+    typeof existingFlow === "object" && existingFlow !== null && !Array.isArray(existingFlow);
+  const flow = hasFlowObject ? { ...(existingFlow as Record<string, unknown>) } : {};
+  const hasExplicitBoundary = typeof flow.is_external === "boolean";
+
+  if (supportsCreditBoundary && hasExplicitBoundary) {
+    return {
+      ...existingMetadata,
+      flow,
+    };
+  }
+
+  if (activityType === "CREDIT" && normalizedSubtype === "REIMBURSEMENT") {
+    return {
+      ...existingMetadata,
+      flow: { ...flow, is_external: true },
+    };
+  }
+
+  if (!hasFlowObject || !("is_external" in flow)) {
+    return undefined;
+  }
+
+  delete flow.is_external;
+  const metadata = { ...existingMetadata };
+  if (Object.keys(flow).length > 0) {
+    metadata.flow = flow;
+  } else {
+    delete metadata.flow;
+  }
+  return metadata;
+}

--- a/apps/frontend/src/lib/activity-utils.test.ts
+++ b/apps/frontend/src/lib/activity-utils.test.ts
@@ -16,6 +16,7 @@ import {
   calculateActivityCashImpact,
   canonicalizeActivitySubtype,
   formatSplitRatio,
+  supportsPerformanceBoundary,
 } from "./activity-utils";
 import { ActivityDetails } from "./types";
 
@@ -44,6 +45,22 @@ describe("Activity Utilities", () => {
       expect(isIncomeActivity(ActivityType.DEPOSIT)).toBe(false);
       expect(isIncomeActivity(ActivityType.WITHDRAWAL)).toBe(false);
     });
+  });
+
+  describe("supportsPerformanceBoundary", () => {
+    it.each([ActivityType.CREDIT, ActivityType.TRANSFER_IN, ActivityType.TRANSFER_OUT])(
+      "allows an explicit boundary for %s",
+      (activityType) => {
+        expect(supportsPerformanceBoundary(activityType)).toBe(true);
+      },
+    );
+
+    it.each([ActivityType.DEPOSIT, ActivityType.WITHDRAWAL, ActivityType.FEE, undefined])(
+      "does not expose a boundary for %s",
+      (activityType) => {
+        expect(supportsPerformanceBoundary(activityType)).toBe(false);
+      },
+    );
   });
 
   describe("isCashTransfer", () => {

--- a/apps/frontend/src/lib/activity-utils.ts
+++ b/apps/frontend/src/lib/activity-utils.ts
@@ -49,6 +49,16 @@ export const isCashActivity = (activityType: string): boolean => {
   return !(SYMBOL_REQUIRED_TYPES as readonly string[]).includes(activityType);
 };
 
+/** Whether an activity can explicitly cross the tracked-account performance boundary. */
+export const supportsPerformanceBoundary = (activityType?: string | null): boolean => {
+  const normalizedActivityType = activityType?.trim().toUpperCase();
+  return (
+    normalizedActivityType === ActivityType.CREDIT ||
+    normalizedActivityType === ActivityType.TRANSFER_IN ||
+    normalizedActivityType === ActivityType.TRANSFER_OUT
+  );
+};
+
 /**
  * Determines if an activity is an income activity based on its type
  * @param activityType The activity type to check

--- a/apps/frontend/src/lib/schemas.ts
+++ b/apps/frontend/src/lib/schemas.ts
@@ -216,8 +216,8 @@ export const importActivitySchema = z
     fxRate: decimalLikeSchema.nullable().optional(),
     subtype: z.string().optional(),
     forceImport: z.boolean().default(false),
-    /** True when a TRANSFER_IN/OUT crosses the tracked-account boundary
-     * (e.g. RSU grant deposit). Persisted as `metadata.flow.is_external` on the activity. */
+    /** Whether a transfer or credit crosses the tracked-account boundary.
+     * Persisted as `metadata.flow.is_external` on the activity. */
     isExternal: z.boolean().optional(),
   })
   .refine(

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.test.ts
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.test.ts
@@ -470,6 +470,69 @@ describe("activity-utils", () => {
       expect(result.creates[0].idempotencyKey).toBe("manual-duplicate-123");
     });
 
+    it.each([true, false])(
+      "should preserve only an explicit %s credit boundary for a new duplicate",
+      (isExternal) => {
+        const transactions: LocalTransaction[] = [
+          createMockTransaction({
+            id: "temp-credit-1",
+            isNew: true,
+            activityType: ActivityType.CREDIT,
+            subtype: ACTIVITY_SUBTYPES.REIMBURSEMENT,
+            assetId: undefined,
+            assetSymbol: undefined,
+            amount: "100",
+            isExternal,
+            metadata: {
+              raw_type: "merchant_refund",
+              flow: { confidence: 0.9, is_external: isExternal },
+            },
+          }),
+        ];
+
+        const result = buildSavePayload(
+          transactions,
+          new Set(["temp-credit-1"]),
+          new Set(),
+          mockResolveTransactionCurrency,
+          dirtyCurrencyLookup,
+          assetCurrencyLookup,
+          "USD",
+        );
+
+        expect(JSON.parse(result.creates[0].metadata ?? "{}")).toEqual({
+          flow: { is_external: isExternal },
+        });
+      },
+    );
+
+    it("should leave credit metadata absent when no boundary was specified", () => {
+      const transactions: LocalTransaction[] = [
+        createMockTransaction({
+          id: "temp-credit-1",
+          isNew: true,
+          activityType: ActivityType.CREDIT,
+          subtype: ACTIVITY_SUBTYPES.REFUND,
+          assetId: undefined,
+          assetSymbol: undefined,
+          amount: "100",
+          isExternal: undefined,
+        }),
+      ];
+
+      const result = buildSavePayload(
+        transactions,
+        new Set(["temp-credit-1"]),
+        new Set(),
+        mockResolveTransactionCurrency,
+        dirtyCurrencyLookup,
+        assetCurrencyLookup,
+        "USD",
+      );
+
+      expect(result.creates[0].metadata).toBeUndefined();
+    });
+
     it("should include existing asset id selected from search for new market activities", () => {
       const transactions: LocalTransaction[] = [
         createMockTransaction({

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.ts
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.ts
@@ -467,6 +467,7 @@ export function buildSavePayload(
     const isTransfer =
       transaction.activityType === ActivityType.TRANSFER_IN ||
       transaction.activityType === ActivityType.TRANSFER_OUT;
+    const supportsBoundary = isTransfer || transaction.activityType === ActivityType.CREDIT;
     const assetSymbol = (transaction.assetSymbol || "").trim();
     const isCash = isTransfer
       ? isCashTransfer(transaction.activityType, assetSymbol) || !assetSymbol
@@ -478,11 +479,12 @@ export function buildSavePayload(
 
     const isNew = transaction.isNew === true;
 
-    // Build metadata JSON if needed (e.g., for isExternal flag on transfers)
+    // Build metadata JSON if an explicit performance boundary is present.
     let metadataJson: string | undefined;
-    if (isTransfer && transaction.isExternal != null) {
-      // Merge with existing metadata if present
-      const existingMeta = typeof transaction.metadata === "object" ? transaction.metadata : {};
+    if (supportsBoundary && transaction.isExternal != null) {
+      // Existing updates retain metadata. New manual duplicates carry only the boundary marker.
+      const existingMeta =
+        !isNew && typeof transaction.metadata === "object" ? transaction.metadata : {};
       const newMeta = {
         ...existingMeta,
         flow: {

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.ts
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/activity-utils.ts
@@ -371,7 +371,7 @@ export function applyTransactionUpdate(params: TransactionUpdateParams): LocalTr
     }
     updated = applyCashDefaults(updated, resolveTransactionCurrency, fallbackCurrency);
   } else if (field === "isExternal") {
-    // isExternal flag for TRANSFER_IN/TRANSFER_OUT (stored in metadata.flow.is_external)
+    // Explicit performance boundary stored in metadata.flow.is_external.
     updated = { ...updated, isExternal: Boolean(value) };
   } else if (field === "instrumentType") {
     // Instrument type (EQUITY, OPTION, BOND, etc.) — also set pendingInstrumentType for save payload

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/types.test.ts
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/types.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import type { ActivityDetails } from "@/lib/types";
+
+import { toLocalTransaction } from "./types";
+
+function activityWithBoundary(isExternal?: boolean): ActivityDetails {
+  return {
+    id: "activity-1",
+    accountId: "account-1",
+    accountName: "Cash",
+    accountCurrency: "USD",
+    activityType: "CREDIT",
+    subtype: "REIMBURSEMENT",
+    date: new Date("2026-08-12T12:00:00Z"),
+    quantity: null,
+    unitPrice: null,
+    amount: "100",
+    fee: null,
+    currency: "USD",
+    needsReview: false,
+    createdAt: new Date("2026-08-12T12:00:00Z"),
+    updatedAt: new Date("2026-08-12T12:00:00Z"),
+    assetId: "",
+    assetSymbol: "",
+    metadata: typeof isExternal === "boolean" ? { flow: { is_external: isExternal } } : undefined,
+  };
+}
+
+describe("toLocalTransaction", () => {
+  it.each([true, false])("preserves an explicit %s boundary", (isExternal) => {
+    expect(toLocalTransaction(activityWithBoundary(isExternal)).isExternal).toBe(isExternal);
+  });
+
+  it("keeps a missing boundary distinct from explicit false", () => {
+    expect(toLocalTransaction(activityWithBoundary()).isExternal).toBeUndefined();
+  });
+});

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/types.ts
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/types.ts
@@ -20,7 +20,7 @@ export interface LocalTransaction extends ActivityDetails {
   pendingProviderSymbol?: string;
   /** Persisted asset id selected from symbol search, if the result already exists */
   pendingAssetId?: string;
-  /** Whether this transfer is external (from/to outside tracked accounts). Stored in metadata.flow.is_external */
+  /** Explicit performance boundary marker stored in metadata.flow.is_external. */
   isExternal?: boolean;
   /** Original asset symbol from server - used to detect symbol changes for updates */
   _originalAssetSymbol?: string;
@@ -46,9 +46,9 @@ export function toLocalTransaction(activity: ActivityDetails): LocalTransaction 
   if (isLocalTransaction(activity)) {
     return activity;
   }
-  // Extract isExternal from metadata.flow.is_external
+  // Preserve both explicit boundary values; absence must remain distinguishable from false.
   const flowMeta = activity.metadata?.flow as Record<string, unknown> | undefined;
-  const isExternal = flowMeta?.is_external === true;
+  const isExternal = typeof flowMeta?.is_external === "boolean" ? flowMeta.is_external : undefined;
   return {
     ...activity,
     isNew: false,

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/types.ts
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/types.ts
@@ -145,7 +145,7 @@ interface ActivityBasePayload {
   tax?: string | null;
   fxRate?: string | null;
   notes?: string | null;
-  /** JSON blob for metadata (e.g., flow.is_external for transfers) */
+  /** JSON blob for metadata, including explicit transfer and credit boundaries. */
   metadata?: string;
 }
 

--- a/apps/frontend/src/pages/activity/components/activity-data-grid/use-activity-columns.tsx
+++ b/apps/frontend/src/pages/activity/components/activity-data-grid/use-activity-columns.tsx
@@ -5,6 +5,7 @@ import {
   isCashActivity,
   localizeActivitySubtypeName,
   localizeActivityTypeName,
+  supportsPerformanceBoundary,
 } from "@/lib/activity-utils";
 import {
   ActivityStatus,
@@ -251,7 +252,7 @@ export function useActivityColumns({
           },
         },
       },
-      // 7. External (checkbox for TRANSFER_IN/TRANSFER_OUT only)
+      // 7. Explicit performance boundary for transfers and credits
       {
         id: "isExternal",
         accessorKey: "isExternal",
@@ -262,14 +263,9 @@ export function useActivityColumns({
         meta: {
           cell: {
             variant: "checkbox",
-            // Only enabled for transfer types
             isDisabled: (rowData: unknown) => {
               const row = rowData as LocalTransaction;
-              const activityType = row.activityType?.toUpperCase();
-              return (
-                activityType !== ActivityType.TRANSFER_IN &&
-                activityType !== ActivityType.TRANSFER_OUT
-              );
+              return !supportsPerformanceBoundary(row.activityType);
             },
           },
         },

--- a/apps/frontend/src/pages/activity/hooks/use-activity-mutations.test.tsx
+++ b/apps/frontend/src/pages/activity/hooks/use-activity-mutations.test.tsx
@@ -153,6 +153,36 @@ describe("useActivityMutations", () => {
     );
   });
 
+  it.each([true, false])(
+    "preserves only an explicit %s performance boundary when duplicating",
+    async (isExternal) => {
+      const { result } = renderHook(() => useActivityMutations(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.duplicateActivityMutation.mutateAsync({
+          id: "activity-1",
+          accountId: "acc-1",
+          activityType: ActivityType.CREDIT,
+          subtype: "REIMBURSEMENT",
+          date: "2026-04-30T16:00:00Z",
+          amount: "100",
+          currency: "USD",
+          metadata: {
+            raw_type: "merchant_refund",
+            flow: { confidence: 0.9, is_external: isExternal },
+          },
+        } as any);
+      });
+
+      expect(adapterMocks.createActivity).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subtype: "REIMBURSEMENT",
+          metadata: { flow: { is_external: isExternal } },
+        }),
+      );
+    },
+  );
+
   it("copies bond trade amounts when duplicating buy and sell activities", async () => {
     const { result } = renderHook(() => useActivityMutations(), { wrapper: createWrapper() });
     const bondActivity = (

--- a/apps/frontend/src/pages/activity/hooks/use-activity-mutations.ts
+++ b/apps/frontend/src/pages/activity/hooks/use-activity-mutations.ts
@@ -349,6 +349,15 @@ export function useActivityMutations(
       isBondTrade ||
       (!isBuyOrSell &&
         !isSecuritiesTransfer(restOfActivityData.activityType, assetSymbol, _assetId));
+    const supportsBoundary =
+      restOfActivityData.activityType === ActivityType.CREDIT ||
+      restOfActivityData.activityType === ActivityType.TRANSFER_IN ||
+      restOfActivityData.activityType === ActivityType.TRANSFER_OUT;
+    const flow = activityToDuplicate.metadata?.flow as Record<string, unknown> | undefined;
+    const boundaryMetadata =
+      supportsBoundary && typeof flow?.is_external === "boolean"
+        ? { flow: { is_external: flow.is_external } }
+        : undefined;
 
     // For duplicating, use nested asset object
     const createPayload: ActivityCreate = {
@@ -365,6 +374,7 @@ export function useActivityMutations(
       fxRate: restOfActivityData.fxRate ?? undefined,
       activityDate: date,
       comment: "Duplicated",
+      metadata: boundaryMetadata,
       asset: buildAssetResolutionInput({
         id: _assetId,
         symbol: assetSymbol,

--- a/apps/frontend/src/pages/activity/import/components/import-columns.tsx
+++ b/apps/frontend/src/pages/activity/import/components/import-columns.tsx
@@ -7,6 +7,7 @@ import {
   localizeActivitySubtypeName,
   localizeActivityTypeName,
   needsImportAssetResolution,
+  supportsPerformanceBoundary,
 } from "@/lib/activity-utils";
 import { ActivityTypeBadge } from "../../components/activity-type-badge";
 
@@ -237,7 +238,7 @@ export function useImportColumns<T extends ImportRowData>({
       },
     });
 
-    // 7. External (checkbox for TRANSFER_IN/TRANSFER_OUT only)
+    // 7. Explicit performance boundary for transfers and credits
     columns.push({
       id: "isExternal",
       accessorKey: "isExternal",
@@ -250,11 +251,7 @@ export function useImportColumns<T extends ImportRowData>({
           variant: "checkbox",
           isDisabled: (rowData: unknown) => {
             const row = rowData as ImportRowData;
-            const activityType = row.activityType?.toUpperCase();
-            return (
-              activityType !== ActivityType.TRANSFER_IN &&
-              activityType !== ActivityType.TRANSFER_OUT
-            );
+            return !supportsPerformanceBoundary(row.activityType);
           },
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } as any,

--- a/apps/frontend/src/pages/activity/import/components/import-review-grid.tsx
+++ b/apps/frontend/src/pages/activity/import/components/import-review-grid.tsx
@@ -18,6 +18,7 @@ import {
   localizeActivitySubtypeName,
   localizeActivityTypeName,
   needsImportAssetResolution,
+  supportsPerformanceBoundary,
 } from "@/lib/activity-utils";
 import { quoteModeFromSearchResult } from "@/lib/asset-utils";
 import { ActivityTypeBadge } from "../../components/activity-type-badge";
@@ -321,7 +322,7 @@ function useImportReviewColumns({
           },
         },
       },
-      // 7. External (checkbox for TRANSFER_IN/TRANSFER_OUT only)
+      // 7. Explicit performance boundary for transfers and credits
       {
         id: "isExternal",
         accessorKey: "isExternal",
@@ -332,14 +333,9 @@ function useImportReviewColumns({
         meta: {
           cell: {
             variant: "checkbox",
-            // Only enabled for transfer types
             isDisabled: (rowData: unknown) => {
               const row = rowData as DraftActivity;
-              const activityType = row.activityType?.toUpperCase();
-              return (
-                activityType !== ActivityType.TRANSFER_IN &&
-                activityType !== ActivityType.TRANSFER_OUT
-              );
+              return !supportsPerformanceBoundary(row.activityType);
             },
           },
         },

--- a/apps/frontend/src/pages/activity/import/context/import-context.tsx
+++ b/apps/frontend/src/pages/activity/import/context/import-context.tsx
@@ -63,8 +63,10 @@ export interface DraftActivity {
   comment?: string;
   subtype?: string;
   fxRate?: string | null;
-  /** Whether this is an external transfer (for TRANSFER_IN/TRANSFER_OUT) */
+  /** Whether a transfer or credit crosses the tracked-account boundary. */
   isExternal?: boolean;
+  /** Draft-only provenance used to safely recompute an inferred credit boundary. */
+  boundaryInference?: "expense-reversal";
 
   isin?: string;
 

--- a/apps/frontend/src/pages/activity/import/steps/review-step.tsx
+++ b/apps/frontend/src/pages/activity/import/steps/review-step.tsx
@@ -17,7 +17,7 @@ import {
   type DraftActivity,
 } from "../context";
 import { buildImportAssetCandidateFromDraft } from "../utils/asset-review-utils";
-import { validateDraft } from "../utils/draft-utils";
+import { reconcileExpenseReversalBoundary, validateDraft } from "../utils/draft-utils";
 import { getActivityImportProfileForResolvedAccountIds } from "../utils/activity-import-profile";
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -235,6 +235,11 @@ export function ReviewStep() {
       // Find the current draft and merge with updates
       const currentDraft = draftActivities.find((d) => d.rowIndex === rowIndex);
       if (currentDraft) {
+        const reconciledUpdates = reconcileExpenseReversalBoundary(
+          currentDraft,
+          updates,
+          accountTypeById,
+        );
         const changesAssetIdentity = [
           "symbol",
           "exchangeMic",
@@ -244,10 +249,10 @@ export function ReviewStep() {
           "isin",
           "accountId",
           "activityType",
-        ].some((field) => field in updates);
+        ].some((field) => field in reconciledUpdates);
         const mergedDraft = {
           ...currentDraft,
-          ...updates,
+          ...reconciledUpdates,
         } as DraftActivity;
         const nextCandidate = buildImportAssetCandidateFromDraft(mergedDraft);
         // Re-validate the merged draft
@@ -256,7 +261,7 @@ export function ReviewStep() {
         const shouldRevalidateStatus = currentDraft.status !== "skipped";
         dispatch(
           updateDraft(rowIndex, {
-            ...updates,
+            ...reconciledUpdates,
             ...(changesAssetIdentity
               ? {
                   assetId: undefined,
@@ -311,17 +316,19 @@ export function ReviewStep() {
         const currentDraft = draftActivities.find((draft) => draft.rowIndex === rowIndex);
         if (!currentDraft) continue;
 
-        const mergedDraft = {
-          ...currentDraft,
-          accountId: newAccountId,
-        } as DraftActivity;
+        const accountUpdates = reconcileExpenseReversalBoundary(
+          currentDraft,
+          { accountId: newAccountId },
+          accountTypeById,
+        );
+        const mergedDraft = { ...currentDraft, ...accountUpdates } as DraftActivity;
         const nextCandidate = buildImportAssetCandidateFromDraft(mergedDraft);
         const validation = validateDraft(mergedDraft, accountTypeById);
         const shouldRevalidateStatus = currentDraft.status !== "skipped";
 
         dispatch(
           updateDraft(rowIndex, {
-            accountId: newAccountId,
+            ...accountUpdates,
             assetId: undefined,
             importAssetKey: undefined,
             assetCandidateKey: nextCandidate?.key,

--- a/apps/frontend/src/pages/activity/import/utils/draft-utils.test.ts
+++ b/apps/frontend/src/pages/activity/import/utils/draft-utils.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from "vitest";
 import { ACTIVITY_SUBTYPES, AccountType, ActivityType, ImportFormat } from "@/lib/constants";
-import { createDraftActivities, draftToActivityImport } from "./draft-utils";
+import {
+  createDraftActivities,
+  draftToActivityImport,
+  reconcileExpenseReversalBoundary,
+} from "./draft-utils";
 import { getActivityImportProfileForAccountType } from "./activity-import-profile";
 import { applyAssetResolution } from "./asset-review-utils";
+import type { DraftActivity } from "../context";
 
 const headers = [
   ImportFormat.DATE,
@@ -47,6 +52,107 @@ function createSingleDraftWithMapping(row: string[], activityMappings: Record<st
   expect(draft).toBeDefined();
   return draft;
 }
+
+describe("expense reversal boundary reconciliation", () => {
+  const accountTypes = new Map([
+    ["cash-account", AccountType.CASH],
+    ["securities-account", AccountType.SECURITIES],
+  ]);
+  const reimbursementDraft: DraftActivity = {
+    rowIndex: 0,
+    rawRow: [],
+    activityDate: "2026-08-11T00:00:00.000Z",
+    accountId: "cash-account",
+    activityType: ActivityType.CREDIT,
+    subtype: ACTIVITY_SUBTYPES.REIMBURSEMENT,
+    isExternal: true,
+    boundaryInference: "expense-reversal",
+    currency: "USD",
+    status: "valid",
+    errors: {},
+    warnings: {},
+    isEdited: false,
+  };
+
+  it("clears the inferred boundary when a cash reimbursement moves to a securities account", () => {
+    expect(
+      reconcileExpenseReversalBoundary(
+        reimbursementDraft,
+        { accountId: "securities-account" },
+        accountTypes,
+      ),
+    ).toEqual({ accountId: "securities-account", isExternal: undefined });
+  });
+
+  it("adds the inferred boundary when a securities reimbursement moves to a cash account", () => {
+    expect(
+      reconcileExpenseReversalBoundary(
+        { ...reimbursementDraft, accountId: "securities-account", isExternal: undefined },
+        { accountId: "cash-account" },
+        accountTypes,
+      ),
+    ).toEqual({ accountId: "cash-account", isExternal: true });
+  });
+
+  it("clears a stale boundary when a reimbursement is reclassified as a refund", () => {
+    expect(
+      reconcileExpenseReversalBoundary(
+        reimbursementDraft,
+        { subtype: ACTIVITY_SUBTYPES.REFUND },
+        accountTypes,
+      ),
+    ).toEqual({
+      subtype: ACTIVITY_SUBTYPES.REFUND,
+      isExternal: undefined,
+      boundaryInference: undefined,
+    });
+  });
+
+  it("recomputes an inferred merchant refund when its account changes", () => {
+    const merchantRefundDraft: DraftActivity = {
+      ...reimbursementDraft,
+      subtype: ACTIVITY_SUBTYPES.REFUND,
+    };
+
+    const movedToSecurities = reconcileExpenseReversalBoundary(
+      merchantRefundDraft,
+      { accountId: "securities-account" },
+      accountTypes,
+    );
+    expect(movedToSecurities).toEqual({
+      accountId: "securities-account",
+      isExternal: undefined,
+    });
+
+    expect(
+      reconcileExpenseReversalBoundary(
+        { ...merchantRefundDraft, ...movedToSecurities },
+        { accountId: "cash-account" },
+        accountTypes,
+      ),
+    ).toEqual({ accountId: "cash-account", isExternal: true });
+  });
+
+  it("preserves an explicit boundary edit", () => {
+    expect(
+      reconcileExpenseReversalBoundary(
+        reimbursementDraft,
+        { accountId: "securities-account", isExternal: true },
+        accountTypes,
+      ),
+    ).toEqual({ accountId: "securities-account", isExternal: true });
+  });
+
+  it("preserves an explicit false boundary across later edits", () => {
+    expect(
+      reconcileExpenseReversalBoundary(
+        { ...reimbursementDraft, isExternal: false },
+        { accountId: "securities-account" },
+        accountTypes,
+      ),
+    ).toEqual({ accountId: "securities-account" });
+  });
+});
 
 describe("createDraftActivities explicit activity mapping", () => {
   it("uses the resolved asset currency for security rows when the CSV has no currency column", () => {
@@ -587,7 +693,7 @@ describe("createDraftActivities explicit activity mapping", () => {
     expect(drafts[1].isExternal).toBe(false);
   });
 
-  it("does not serialize stale external flags for non-transfer rows", () => {
+  it("does not serialize stale external flags for activities without boundary semantics", () => {
     const draft = createSingleDraftWithMapping(["2024-03-15", "TRANSFER", "250.00", "USD"], {
       [ActivityType.TRANSFER_IN]: ["TRANSFER"],
     });
@@ -596,9 +702,106 @@ describe("createDraftActivities explicit activity mapping", () => {
     expect(
       draftToActivityImport({
         ...draft,
-        activityType: ActivityType.CREDIT,
+        activityType: ActivityType.DEPOSIT,
       }).isExternal,
     ).toBeUndefined();
+  });
+
+  it("infers external boundaries from unambiguous cash-account reversal labels", () => {
+    const labels = ["MERCHANT REFUND", "CASH BACK", "REIMBURSEMENT"];
+    const drafts = createDraftActivities(
+      labels.map((label) => ["2024-03-15", label, "25.00", "USD"]),
+      headers,
+      {
+        ...baseMapping,
+        activityMappings: { [ActivityType.CREDIT]: labels },
+      },
+      parseConfig,
+      "account-1",
+      undefined,
+      new Map([["account-1", AccountType.CASH]]),
+    );
+
+    expect(drafts.map((draft) => draft.subtype)).toEqual([
+      ACTIVITY_SUBTYPES.REFUND,
+      ACTIVITY_SUBTYPES.REBATE,
+      ACTIVITY_SUBTYPES.REIMBURSEMENT,
+    ]);
+    expect(drafts.every((draft) => draft.isExternal === true)).toBe(true);
+    expect(drafts.every((draft) => draft.boundaryInference === "expense-reversal")).toBe(true);
+    expect(drafts.every((draft) => draftToActivityImport(draft).isExternal === true)).toBe(true);
+  });
+
+  it("keeps ambiguous cash-account refund and rebate labels internal by default", () => {
+    const labels = ["REFUND", "REBATE"];
+    const drafts = createDraftActivities(
+      labels.map((label) => ["2024-03-15", label, "25.00", "USD"]),
+      headers,
+      {
+        ...baseMapping,
+        activityMappings: { [ActivityType.CREDIT]: labels },
+      },
+      parseConfig,
+      "account-1",
+      undefined,
+      new Map([["account-1", AccountType.CASH]]),
+    );
+
+    expect(drafts.map((draft) => draft.subtype)).toEqual([
+      ACTIVITY_SUBTYPES.REFUND,
+      ACTIVITY_SUBTYPES.REBATE,
+    ]);
+    expect(drafts.every((draft) => draft.isExternal === undefined)).toBe(true);
+  });
+
+  it("shows the BONUS default and preserves an explicit false import override", () => {
+    const [draft] = createDraftActivities(
+      [["2024-03-15", "CREDIT", "25.00", "USD", "BONUS"]],
+      [...headers, ImportFormat.SUBTYPE],
+      {
+        ...baseMapping,
+        fieldMappings: {
+          ...baseMapping.fieldMappings,
+          [ImportFormat.SUBTYPE]: ImportFormat.SUBTYPE,
+        },
+        activityMappings: { [ActivityType.CREDIT]: ["CREDIT"] },
+      },
+      parseConfig,
+      "account-1",
+      undefined,
+      new Map([["account-1", AccountType.CASH]]),
+    );
+
+    expect(draft.subtype).toBe(ACTIVITY_SUBTYPES.BONUS);
+    expect(draft.isExternal).toBe(true);
+    expect(draftToActivityImport({ ...draft, isExternal: false }).isExternal).toBe(false);
+  });
+
+  it("serializes an explicit boundary for any credit subtype", () => {
+    const draft = createSingleDraftWithMapping(["2024-03-15", "CREDIT", "25.00", "USD"], {
+      [ActivityType.CREDIT]: ["CREDIT"],
+    });
+
+    expect(draftToActivityImport({ ...draft, isExternal: true }).isExternal).toBe(true);
+  });
+
+  it("keeps the same refund internal when imported into a securities account", () => {
+    const [draft] = createDraftActivities(
+      [["2024-03-15", "REFUND", "25.00", "USD"]],
+      headers,
+      {
+        ...baseMapping,
+        activityMappings: { [ActivityType.CREDIT]: ["REFUND"] },
+      },
+      parseConfig,
+      "account-1",
+      undefined,
+      new Map([["account-1", AccountType.SECURITIES]]),
+    );
+
+    expect(draft.subtype).toBe(ACTIVITY_SUBTYPES.REFUND);
+    expect(draft.isExternal).toBeUndefined();
+    expect(draftToActivityImport(draft).isExternal).toBeUndefined();
   });
 
   it("accepts a positive split ratio from the amount column", () => {

--- a/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
+++ b/apps/frontend/src/pages/activity/import/utils/draft-utils.ts
@@ -79,6 +79,116 @@ export function hasDuplicateWarning(draft: DraftActivity): boolean {
   );
 }
 
+function defaultCreditBoundary(
+  activityType: string | undefined,
+  subtype: string | undefined,
+): boolean | undefined {
+  if (activityType?.trim().toUpperCase() !== ActivityType.CREDIT) {
+    return undefined;
+  }
+
+  const canonicalSubtype = canonicalizeActivitySubtype(activityType, subtype?.trim());
+  return canonicalSubtype === ACTIVITY_SUBTYPES.BONUS ? true : undefined;
+}
+
+function hasExpenseReversalInference(
+  activityType: string | undefined,
+  subtype: string | undefined,
+  rawType?: string,
+  rawSubtype?: string,
+): boolean {
+  if (activityType?.trim().toUpperCase() !== ActivityType.CREDIT) return false;
+
+  const canonicalSubtype = canonicalizeActivitySubtype(activityType, subtype?.trim());
+  return (
+    canonicalSubtype === ACTIVITY_SUBTYPES.REIMBURSEMENT ||
+    [rawType, rawSubtype].some((label) =>
+      EXTERNAL_EXPENSE_REVERSAL_LABELS.has(normalizeSignAwareActivityLabel(label)),
+    )
+  );
+}
+
+export function inferExpenseReversalBoundary(
+  activityType: string | undefined,
+  subtype: string | undefined,
+  accountType: string | undefined,
+  rawType?: string,
+  rawSubtype?: string,
+): boolean | undefined {
+  if (activityType?.trim().toUpperCase() !== ActivityType.CREDIT) {
+    return undefined;
+  }
+
+  const defaultBoundary = defaultCreditBoundary(activityType, subtype);
+  if (defaultBoundary !== undefined) return defaultBoundary;
+  if (accountType !== AccountType.CASH) {
+    return undefined;
+  }
+
+  return hasExpenseReversalInference(activityType, subtype, rawType, rawSubtype) ? true : undefined;
+}
+
+export function reconcileExpenseReversalBoundary(
+  currentDraft: DraftActivity,
+  updates: Partial<DraftActivity>,
+  accountTypeById: ReadonlyMap<string, AccountType>,
+): Partial<DraftActivity> {
+  const changesBoundaryInputs = ["accountId", "activityType", "subtype"].some(
+    (field) => field in updates,
+  );
+  if (!changesBoundaryInputs || "isExternal" in updates) {
+    return updates;
+  }
+  if (currentDraft.isExternal === false) {
+    return updates;
+  }
+
+  const mergedDraft = { ...currentDraft, ...updates };
+  const currentIsCredit = currentDraft.activityType?.trim().toUpperCase() === ActivityType.CREDIT;
+  const mergedIsCredit = mergedDraft.activityType?.trim().toUpperCase() === ActivityType.CREDIT;
+  if (!currentIsCredit && !mergedIsCredit) {
+    return updates;
+  }
+
+  let boundaryInference = currentDraft.boundaryInference;
+  if (
+    boundaryInference === undefined &&
+    currentIsCredit &&
+    canonicalizeActivitySubtype(currentDraft.activityType, currentDraft.subtype?.trim()) ===
+      ACTIVITY_SUBTYPES.REIMBURSEMENT
+  ) {
+    boundaryInference = "expense-reversal";
+  }
+
+  if ("activityType" in updates && !mergedIsCredit) {
+    boundaryInference = undefined;
+  }
+  if ("subtype" in updates) {
+    boundaryInference =
+      mergedIsCredit &&
+      canonicalizeActivitySubtype(mergedDraft.activityType, mergedDraft.subtype?.trim()) ===
+        ACTIVITY_SUBTYPES.REIMBURSEMENT
+        ? "expense-reversal"
+        : undefined;
+  }
+
+  const isExternal =
+    defaultCreditBoundary(mergedDraft.activityType, mergedDraft.subtype) ??
+    (mergedIsCredit &&
+    boundaryInference === "expense-reversal" &&
+    accountTypeById.get(mergedDraft.accountId) === AccountType.CASH
+      ? true
+      : undefined);
+  const reconciled: Partial<DraftActivity> = {
+    ...updates,
+    isExternal,
+  };
+  if (boundaryInference !== currentDraft.boundaryInference) {
+    reconciled.boundaryInference = boundaryInference;
+  }
+  return reconciled;
+}
+
 /**
  * Parse a date value using the configured format (priority) then auto-detection fallback.
  * Returns a full ISO datetime string preserving any time component from the source.
@@ -147,6 +257,26 @@ const REIMBURSEMENT_LABELS = new Set([
   "REIMBURSED",
   "REIMBURSE",
   "EXPENSEREIMBURSEMENT",
+]);
+
+const REFUND_LABELS = new Set([
+  "REFUND",
+  "RETURN",
+  "REVERSAL",
+  "STATEMENTCREDIT",
+  "CREDITADJUSTMENT",
+  "MERCHANTREFUND",
+  "PURCHASEREFUND",
+  "PURCHASERETURN",
+]);
+
+const REBATE_LABELS = new Set(["REBATE", "CASHBACK", "REWARDS"]);
+const EXTERNAL_EXPENSE_REVERSAL_LABELS = new Set([
+  ...REIMBURSEMENT_LABELS,
+  "MERCHANTREFUND",
+  "PURCHASEREFUND",
+  "PURCHASERETURN",
+  "CASHBACK",
 ]);
 
 function normalizeSignAwareActivityLabel(value: string | undefined): string {
@@ -649,12 +779,19 @@ export function createDraftActivities(
     const rawTypePositionIntentSubtype = rawTypePositionIntentType ? rawType : undefined;
     const trimmedRawSubtype = rawSubtype?.trim();
     const normalizedSubtype = trimmedRawSubtype || rawTypePositionIntentSubtype || signedFxSubtype;
+    const normalizedRawType = normalizeSignAwareActivityLabel(rawType);
+    const normalizedRawSubtype = normalizeSignAwareActivityLabel(rawSubtype);
     const inferredCreditSubtype =
-      activityType === ActivityType.CREDIT &&
-      (REIMBURSEMENT_LABELS.has(normalizeSignAwareActivityLabel(rawType)) ||
-        REIMBURSEMENT_LABELS.has(normalizeSignAwareActivityLabel(rawSubtype)))
-        ? ACTIVITY_SUBTYPES.REIMBURSEMENT
-        : undefined;
+      activityType !== ActivityType.CREDIT
+        ? undefined
+        : REIMBURSEMENT_LABELS.has(normalizedRawType) ||
+            REIMBURSEMENT_LABELS.has(normalizedRawSubtype)
+          ? ACTIVITY_SUBTYPES.REIMBURSEMENT
+          : REFUND_LABELS.has(normalizedRawType) || REFUND_LABELS.has(normalizedRawSubtype)
+            ? ACTIVITY_SUBTYPES.REFUND
+            : REBATE_LABELS.has(normalizedRawType) || REBATE_LABELS.has(normalizedRawSubtype)
+              ? ACTIVITY_SUBTYPES.REBATE
+              : undefined;
     const canonicalSubtype =
       normalizedSubtype && normalizedSubtype.toUpperCase() !== activityType
         ? canonicalizeActivitySubtype(activityType ?? "", normalizedSubtype)
@@ -687,13 +824,22 @@ export function createDraftActivities(
     }
     const resolved = resolveCashActivityFields(activityType, quantity, amount, unitPrice, subtype);
 
-    // Infer isExternal for transfers: external unless the raw CSV label says "INTERNAL"
+    // Infer boundary semantics for transfers and cash-account expense reversals.
     const isTransfer =
       activityType === ActivityType.TRANSFER_IN || activityType === ActivityType.TRANSFER_OUT;
+    const accountType = accountTypeById?.get(accountId);
     const isExternal = isTransfer
       ? signedFxTransferType
         ? false
         : !rawType?.trim().toUpperCase().includes("INTERNAL")
+      : inferExpenseReversalBoundary(activityType, subtype, accountType, rawType, rawSubtype);
+    const boundaryInference = hasExpenseReversalInference(
+      activityType,
+      subtype,
+      rawType,
+      rawSubtype,
+    )
+      ? "expense-reversal"
       : undefined;
 
     // Create draft object
@@ -733,6 +879,7 @@ export function createDraftActivities(
       fxRate,
       subtype,
       isExternal,
+      boundaryInference,
       accountId,
       comment,
       isEdited: false,
@@ -757,6 +904,7 @@ export function draftToActivityImport(draft: DraftActivity): ActivityImport {
   const subtype = canonicalizeActivitySubtype(draft.activityType ?? "", draft.subtype?.trim());
   const isTransfer =
     activityType === ActivityType.TRANSFER_IN || activityType === ActivityType.TRANSFER_OUT;
+  const isCredit = activityType === ActivityType.CREDIT;
 
   return {
     id: undefined,
@@ -789,6 +937,6 @@ export function draftToActivityImport(draft: DraftActivity): ActivityImport {
     isDraft: false,
     comment: draft.comment,
     forceImport: draft.forceImport ?? false,
-    isExternal: isTransfer ? draft.isExternal : undefined,
+    isExternal: isTransfer || isCredit ? draft.isExternal : undefined,
   };
 }

--- a/crates/connect/src/broker/mapping.rs
+++ b/crates/connect/src/broker/mapping.rs
@@ -118,15 +118,17 @@ fn normalize_source_system(value: Option<&str>) -> Option<String> {
 pub fn build_activity_metadata(activity: &AccountUniversalActivity) -> Option<String> {
     let mut metadata = serde_json::Map::new();
 
-    // Add flow.is_external for transfers
+    // Preserve an explicit performance-boundary classification from the provider.
     if let Some(ref mapping_meta) = activity.mapping_metadata {
         if let Some(ref flow) = mapping_meta.flow {
-            metadata.insert(
-                "flow".to_string(),
-                serde_json::json!({
-                    "is_external": flow.is_external
-                }),
-            );
+            if let Some(is_external) = flow.is_external {
+                metadata.insert(
+                    "flow".to_string(),
+                    serde_json::json!({
+                        "is_external": is_external
+                    }),
+                );
+            }
         }
 
         // Add confidence score
@@ -597,7 +599,7 @@ mod tests {
     use crate::broker::models::{
         AccountUniversalActivityCurrency, AccountUniversalActivityExchange,
         AccountUniversalActivityOptionSymbol, AccountUniversalActivitySymbol,
-        AccountUniversalActivitySymbolType, AccountUniversalActivityUnderlyingSymbol,
+        AccountUniversalActivitySymbolType, AccountUniversalActivityUnderlyingSymbol, FlowMetadata,
         MappingMetadata,
     };
 
@@ -621,6 +623,10 @@ mod tests {
         }
     }
 
+    fn map_test_activity(activity: &AccountUniversalActivity) -> NewActivity {
+        map_broker_activity(activity, "acct-1", Some("USD"), Some("USD")).unwrap()
+    }
+
     #[test]
     fn test_needs_review_unknown_type() {
         let activity = AccountUniversalActivity {
@@ -628,6 +634,33 @@ mod tests {
             ..Default::default()
         };
         assert!(needs_review(&activity));
+    }
+
+    #[test]
+    fn preserves_only_explicit_provider_flow_metadata() {
+        for is_external in [Some(true), Some(false), None] {
+            let activity = AccountUniversalActivity {
+                id: Some(format!("activity-{is_external:?}")),
+                activity_type: Some(activities::ACTIVITY_TYPE_CREDIT.to_string()),
+                subtype: Some(activities::ACTIVITY_SUBTYPE_REFUND.to_string()),
+                amount: Some(100.0),
+                mapping_metadata: Some(MappingMetadata {
+                    flow: Some(FlowMetadata { is_external }),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+
+            let mapped = map_test_activity(&activity);
+            match is_external {
+                Some(expected) => {
+                    let metadata: serde_json::Value =
+                        serde_json::from_str(mapped.metadata.as_deref().unwrap()).unwrap();
+                    assert_eq!(metadata["flow"]["is_external"], expected);
+                }
+                None => assert_eq!(mapped.metadata, None),
+            }
+        }
     }
 
     #[test]
@@ -677,7 +710,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mapped = map_broker_activity(&activity, "acct-1", Some("USD"), Some("USD")).unwrap();
+        let mapped = map_test_activity(&activity);
 
         assert_eq!(mapped.source_system.as_deref(), Some("SNAPTRADE"));
         assert_eq!(mapped.source_record_id.as_deref(), Some("ext-123"));
@@ -701,7 +734,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mapped = map_broker_activity(&activity, "acct-1", Some("USD"), Some("USD")).unwrap();
+        let mapped = map_test_activity(&activity);
 
         assert_eq!(mapped.amount.unwrap().round_dp(4), decimal("997.6000"));
         assert_eq!(mapped.fee.unwrap().round_dp(4), decimal("4.9000"));
@@ -720,7 +753,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mapped = map_broker_activity(&activity, "acct-1", Some("USD"), Some("USD")).unwrap();
+        let mapped = map_test_activity(&activity);
 
         assert_eq!(mapped.amount.unwrap().round_dp(2), decimal("990.00"));
         let asset = mapped.asset.expect("bond activity should produce an asset");
@@ -743,7 +776,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mapped = map_broker_activity(&activity, "acct-1", Some("USD"), Some("USD")).unwrap();
+        let mapped = map_test_activity(&activity);
 
         assert_eq!(mapped.amount.unwrap().round_dp(2), decimal("600.00"));
     }
@@ -757,7 +790,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mapped = map_broker_activity(&activity, "acct-1", Some("USD"), Some("USD")).unwrap();
+        let mapped = map_test_activity(&activity);
 
         assert_eq!(mapped.amount.unwrap().round_dp(2), decimal("12.34"));
     }
@@ -782,7 +815,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mapped = map_broker_activity(&activity, "acct-1", Some("USD"), Some("USD")).unwrap();
+        let mapped = map_test_activity(&activity);
         let symbol = mapped
             .asset
             .expect("option activities should produce symbol");
@@ -807,7 +840,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mapped = map_broker_activity(&activity, "acct-1", Some("USD"), Some("USD")).unwrap();
+        let mapped = map_test_activity(&activity);
 
         assert_eq!(mapped.activity_type, activities::ACTIVITY_TYPE_SELL);
         assert_eq!(mapped.subtype.as_deref(), Some("POSITION_OPEN"));
@@ -829,7 +862,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mapped = map_broker_activity(&activity, "acct-1", Some("USD"), Some("USD")).unwrap();
+        let mapped = map_test_activity(&activity);
 
         assert_eq!(mapped.activity_type, activities::ACTIVITY_TYPE_SELL);
         assert_eq!(mapped.subtype.as_deref(), Some("POSITION_OPEN"));
@@ -850,7 +883,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mapped = map_broker_activity(&activity, "acct-1", Some("USD"), Some("USD")).unwrap();
+        let mapped = map_test_activity(&activity);
 
         assert_eq!(mapped.activity_type, activities::ACTIVITY_TYPE_BUY);
         assert_eq!(mapped.subtype.as_deref(), Some("POSITION_CLOSE"));
@@ -870,7 +903,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mapped = map_broker_activity(&activity, "acct-1", Some("USD"), Some("USD")).unwrap();
+        let mapped = map_test_activity(&activity);
         let symbol = mapped.asset.expect("equity activity should produce symbol");
 
         assert_eq!(symbol.symbol.as_deref(), Some("AAPL"));
@@ -891,8 +924,7 @@ mod tests {
                 ..Default::default()
             };
 
-            let mapped =
-                map_broker_activity(&activity, "acct-1", Some("USD"), Some("USD")).unwrap();
+            let mapped = map_test_activity(&activity);
             assert!(
                 mapped.asset.is_none(),
                 "expected no asset for never-asset type {}",
@@ -914,7 +946,7 @@ mod tests {
             ..Default::default()
         };
 
-        let mapped = map_broker_activity(&activity, "acct-1", Some("USD"), Some("USD")).unwrap();
+        let mapped = map_test_activity(&activity);
         assert_eq!(
             mapped.asset.and_then(|s| s.symbol),
             Some("AAPL".to_string())

--- a/crates/connect/src/broker/models.rs
+++ b/crates/connect/src/broker/models.rs
@@ -307,18 +307,18 @@ pub struct AccountUniversalActivityOptionSymbol {
     pub underlying_symbol: Option<AccountUniversalActivityUnderlyingSymbol>,
 }
 
-/// Flow metadata for transfer activities
+/// Performance-boundary metadata for transfer and credit activities.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct FlowMetadata {
-    /// Whether the transfer is external (to/from outside the brokerage)
-    #[serde(default)]
-    pub is_external: bool,
+    /// Whether the activity crosses the tracked-account performance boundary.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub is_external: Option<bool>,
 }
 
 /// Mapping metadata from the API describing how the activity was classified
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct MappingMetadata {
-    /// Flow information for transfer activities
+    /// Performance-boundary information for transfer and credit activities.
     pub flow: Option<FlowMetadata>,
     /// Reasons/warnings from the mapping process
     #[serde(default)]

--- a/crates/core/proptest-regressions/portfolio/snapshot/holdings_calculator_tests.txt
+++ b/crates/core/proptest-regressions/portfolio/snapshot/holdings_calculator_tests.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc a8649d1b68a7b0d0410442e54f152a1813bac8af46b73cfba8c656b296944554 # shrinks to purchase_minor = 1, refund_seed = 1049963

--- a/crates/core/src/activities/activities_model.rs
+++ b/crates/core/src/activities/activities_model.rs
@@ -1007,7 +1007,7 @@ pub struct ActivityImport {
     /// DB unique constraint is not violated. Set by the user in the review step.
     #[serde(default)]
     pub force_import: bool,
-    /// True when a TRANSFER_IN/OUT crosses the tracked-account boundary (e.g. RSU grant deposit).
+    /// Whether a transfer or credit crosses the tracked-account boundary.
     /// Persisted as `metadata.flow.is_external` so net-contribution and flow classification work.
     #[serde(default)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1894,14 +1894,18 @@ impl From<ActivityImport> for NewActivity {
             Some(ActivityStatus::Posted)
         };
 
-        // Persist `is_external` as flow metadata so net_contribution and flow classification
-        // see this transfer the same way the manual activity form would.
+        // Persist boundary metadata so imported activities and manually entered activities
+        // have the same net-contribution and flow-classification semantics.
         let is_transfer = import.activity_type == ACTIVITY_TYPE_TRANSFER_IN
             || import.activity_type == ACTIVITY_TYPE_TRANSFER_OUT;
-        let metadata = if is_transfer && import.is_external == Some(true) {
-            Some(serde_json::json!({ "flow": { "is_external": true } }).to_string())
-        } else {
-            None
+        let metadata = match (import.activity_type.as_str(), import.is_external) {
+            (ACTIVITY_TYPE_CREDIT, Some(is_external)) => {
+                Some(serde_json::json!({ "flow": { "is_external": is_external } }).to_string())
+            }
+            (_, Some(true)) if is_transfer => {
+                Some(serde_json::json!({ "flow": { "is_external": true } }).to_string())
+            }
+            _ => None,
         };
 
         NewActivity {

--- a/crates/core/src/activities/activities_model_tests.rs
+++ b/crates/core/src/activities/activities_model_tests.rs
@@ -965,6 +965,56 @@ mod tests {
     }
 
     #[test]
+    fn test_activity_import_to_new_activity_preserves_credit_boundary_metadata() {
+        for (subtype, is_external) in [("REFUND", true), ("BONUS", false)] {
+            let import = ActivityImport {
+                id: None,
+                date: "2024-01-15".to_string(),
+                symbol: String::new(),
+                activity_type: "CREDIT".to_string(),
+                quantity: None,
+                unit_price: None,
+                currency: "USD".to_string(),
+                fee: None,
+                tax: None,
+                amount: Some(dec!(100)),
+                comment: None,
+                account_id: Some("acc-1".to_string()),
+                account_name: None,
+                symbol_name: None,
+                exchange_mic: None,
+                quote_ccy: None,
+                instrument_type: None,
+                quote_mode: None,
+                provider_id: None,
+                provider_symbol: None,
+                errors: None,
+                warnings: None,
+                duplicate_of_id: None,
+                duplicate_of_line_number: None,
+                is_draft: false,
+                is_valid: true,
+                line_number: Some(1),
+                fx_rate: None,
+                subtype: Some(subtype.to_string()),
+                asset_id: None,
+                isin: None,
+                force_import: false,
+                is_external: Some(is_external),
+            };
+
+            let converted = NewActivity::from(import);
+            let metadata = converted.metadata.expect("credit metadata should be set");
+            let parsed: serde_json::Value = serde_json::from_str(&metadata).unwrap();
+            assert_eq!(
+                parsed["flow"]["is_external"],
+                serde_json::Value::Bool(is_external),
+                "credit subtype: {subtype}"
+            );
+        }
+    }
+
+    #[test]
     fn test_activity_import_to_new_activity_omits_metadata_when_not_external() {
         let import = ActivityImport {
             id: None,

--- a/crates/core/src/portfolio/performance/flow_classifier.rs
+++ b/crates/core/src/portfolio/performance/flow_classifier.rs
@@ -16,14 +16,17 @@ fn transfer_match_tolerance() -> Decimal {
     Decimal::new(1, 6)
 }
 
-pub fn is_external_transfer(activity: &Activity) -> bool {
+fn explicit_external_boundary(activity: &Activity) -> Option<bool> {
     activity
         .metadata
         .as_ref()
         .and_then(|m| m.get("flow"))
         .and_then(|flow| flow.get("is_external"))
         .and_then(|v| v.as_bool())
-        .unwrap_or(false)
+}
+
+pub fn is_external_transfer(activity: &Activity) -> bool {
+    explicit_external_boundary(activity).unwrap_or(false)
 }
 
 /// Flow type for performance calculation
@@ -51,13 +54,14 @@ pub enum PerformanceScope {
 ///
 /// External flows:
 /// - DEPOSIT, WITHDRAWAL (money entering/leaving portfolio)
-/// - CREDIT with subtype BONUS (promotional credits = new money)
+/// - CREDIT explicitly marked external
+/// - CREDIT with subtype BONUS (external by subtype semantics)
 ///
 /// Internal flows:
 /// - BUY, SELL, DIVIDEND, INTEREST, SPLIT (asset reallocation)
 /// - TRANSFER_IN, TRANSFER_OUT (money moving between accounts)
 /// - FEE, TAX (deductions from existing money)
-/// - CREDIT with other subtypes (REBATE, REFUND = not new money)
+/// - CREDIT with other subtypes by default (REBATE, REFUND = not new money)
 pub fn classify_flow_for_scope(activity: &Activity, scope: PerformanceScope) -> FlowType {
     let effective_type = activity.effective_type();
 
@@ -68,8 +72,16 @@ pub fn classify_flow_for_scope(activity: &Activity, scope: PerformanceScope) -> 
 
     // CREDIT: depends on subtype
     if effective_type == ACTIVITY_TYPE_CREDIT {
+        if let Some(is_external) = explicit_external_boundary(activity) {
+            return if is_external {
+                FlowType::External
+            } else {
+                FlowType::Internal
+            };
+        }
+
         return match activity.subtype.as_deref() {
-            // BONUS is external (new money entering portfolio)
+            // BONUS is external (new money entering portfolio).
             Some(subtype) if subtype.eq_ignore_ascii_case(ACTIVITY_SUBTYPE_BONUS) => {
                 FlowType::External
             }
@@ -259,7 +271,38 @@ mod tests {
     use super::*;
     use crate::activities::ActivityStatus;
     use chrono::{TimeZone, Utc};
+    use serde::Deserialize;
     use serde_json::json;
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct AccountingContract {
+        cases: Vec<AccountingContractCase>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct AccountingContractCase {
+        name: String,
+        activity_type: String,
+        subtype: Option<String>,
+        is_external: Option<bool>,
+        expected: AccountingContractExpected,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct AccountingContractExpected {
+        external_flow: bool,
+    }
+
+    fn accounting_contract() -> AccountingContract {
+        serde_json::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../tests/fixtures/accounting/activity_semantics.json"
+        )))
+        .expect("accounting activity contract should be valid JSON")
+    }
 
     fn create_test_activity(activity_type: &str) -> Activity {
         Activity {
@@ -327,6 +370,42 @@ mod tests {
         let mut activity = create_test_activity("CREDIT");
         activity.subtype = Some("bonus".to_string());
         assert_eq!(classify_flow(&activity), FlowType::External);
+    }
+
+    #[test]
+    fn accounting_contract_classifies_external_flows_consistently() {
+        for case in accounting_contract().cases {
+            let mut activity = create_test_activity(&case.activity_type);
+            activity.subtype = case.subtype;
+            activity.metadata = case
+                .is_external
+                .map(|is_external| json!({ "flow": { "is_external": is_external } }));
+
+            let expected = if case.expected.external_flow {
+                FlowType::External
+            } else {
+                FlowType::Internal
+            };
+            assert_eq!(
+                classify_flow(&activity),
+                expected,
+                "accounting contract case: {}",
+                case.name
+            );
+        }
+    }
+
+    #[test]
+    fn explicit_credit_boundary_overrides_subtype_default() {
+        let mut bonus = create_test_activity("CREDIT");
+        bonus.subtype = Some("BONUS".to_string());
+        bonus.metadata = Some(json!({ "flow": { "is_external": false } }));
+        assert_eq!(classify_flow(&bonus), FlowType::Internal);
+
+        let mut refund = create_test_activity("CREDIT");
+        refund.subtype = Some("REFUND".to_string());
+        refund.metadata = Some(json!({ "flow": { "is_external": true } }));
+        assert_eq!(classify_flow(&refund), FlowType::External);
     }
 
     // Internal flow tests

--- a/crates/core/src/portfolio/snapshot/holdings_calculator/handlers/cash_flows.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator/handlers/cash_flows.rs
@@ -3,6 +3,7 @@ use super::super::economics::*;
 use super::super::HoldingsCalculator;
 use crate::activities::{Activity, ActivityType};
 use crate::errors::Result;
+use crate::portfolio::performance::affects_net_contribution;
 use crate::portfolio::snapshot::AccountStateSnapshot;
 use log::warn;
 use rust_decimal::Decimal;
@@ -109,8 +110,8 @@ impl HoldingsCalculator {
     /// Books cash inflow in ACTIVITY currency.
     ///
     /// Net contribution behavior:
-    /// - CREDIT/BONUS: external flow (new capital), updates net_contribution like DEPOSIT
-    /// - CREDIT/REBATE, CREDIT/REFUND, other: internal flow, no net_contribution change
+    /// - External CREDIT: updates net_contribution like DEPOSIT
+    /// - Internal CREDIT: no net_contribution change
     /// - DIVIDEND, INTEREST: no net_contribution change
     pub(crate) fn handle_income(
         &self,
@@ -118,8 +119,6 @@ impl HoldingsCalculator {
         state: &mut AccountStateSnapshot,
         account_currency: &str,
     ) -> Result<()> {
-        use crate::activities::{ACTIVITY_SUBTYPE_BONUS, ACTIVITY_TYPE_CREDIT};
-
         let activity_currency = &activity.currency;
         let activity_amount = activity.amt();
 
@@ -128,11 +127,7 @@ impl HoldingsCalculator {
         let net_amount = activity_amount - activity.fee_amt() - activity.tax_amt();
         add_cash(state, activity_currency, net_amount);
 
-        // CREDIT/BONUS is external contribution (new capital entering portfolio)
-        // Other CREDIT subtypes (REBATE, REFUND) and income types don't affect net_contribution
-        if activity.effective_type() == ACTIVITY_TYPE_CREDIT
-            && activity.subtype.as_deref() == Some(ACTIVITY_SUBTYPE_BONUS)
-        {
+        if affects_net_contribution(activity) {
             let activity_date = self.activity_local_date(activity);
 
             // Convert to account currency for net_contribution
@@ -140,7 +135,7 @@ impl HoldingsCalculator {
                 activity_amount,
                 activity,
                 account_currency,
-                "Credit Bonus",
+                "External Credit",
             );
 
             // Convert to base currency for net_contribution_base
@@ -154,7 +149,7 @@ impl HoldingsCalculator {
                 Ok(c) => c,
                 Err(e) => {
                     warn!(
-                        "Holdings Calc (NetContrib Credit Bonus {}): Failed conversion {} {}->{} on {}: {}. Base contribution not updated.",
+                        "Holdings Calc (NetContrib External Credit {}): Failed conversion {} {}->{} on {}: {}. Base contribution not updated.",
                         activity.id,
                         activity_amount,
                         activity_currency,

--- a/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
+++ b/crates/core/src/portfolio/snapshot/holdings_calculator_tests.rs
@@ -15,19 +15,104 @@ mod tests {
         NewExchangeRate,
     };
     use crate::lots::{LotClosure, LotDisposal, LotRecord};
+    use crate::portfolio::economic_events::BasisStatus;
+    use crate::portfolio::performance::PerformanceService;
     use crate::portfolio::snapshot::holdings_calculator::{HoldingsCalculator, ProjectionRun};
     use crate::portfolio::snapshot::{
         AccountStateSnapshot, HoldingsCalculationResult, Lot, Position, SnapshotSource,
     };
+    use crate::portfolio::valuation::{DailyAccountValuation, ExternalFlowSource, ValuationStatus};
     use async_trait;
-    use chrono::{DateTime, NaiveDate, TimeZone, Utc};
+    use chrono::{DateTime, Duration, NaiveDate, TimeZone, Utc};
+    use proptest::prelude::*;
     use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
+    use serde::Deserialize;
+    use serde_json::json;
     use std::collections::HashMap;
     use std::collections::VecDeque;
     use std::str::FromStr;
     use std::sync::Arc;
     use std::sync::RwLock;
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct AccountingContract {
+        cases: Vec<AccountingContractCase>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct AccountingContractCase {
+        name: String,
+        account_type: String,
+        activity_type: String,
+        subtype: Option<String>,
+        is_external: Option<bool>,
+        amount: String,
+        expected: AccountingContractExpected,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct AccountingContractExpected {
+        cash_delta: String,
+        net_contribution_delta: String,
+        gain_delta: String,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct LedgerContract {
+        scenarios: Vec<LedgerScenario>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct LedgerScenario {
+        name: String,
+        account_type: String,
+        activities: Vec<LedgerActivity>,
+        expected: LedgerExpected,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct LedgerActivity {
+        day: i64,
+        activity_type: String,
+        subtype: Option<String>,
+        is_external: Option<bool>,
+        amount: String,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct LedgerExpected {
+        ending_cash: String,
+        net_contribution: String,
+        gain: String,
+    }
+
+    fn accounting_contract() -> AccountingContract {
+        serde_json::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../tests/fixtures/accounting/activity_semantics.json"
+        )))
+        .expect("accounting activity contract should be valid JSON")
+    }
+
+    fn ledger_contract() -> LedgerContract {
+        serde_json::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../tests/fixtures/accounting/ledger_scenarios.json"
+        )))
+        .expect("accounting ledger contract should be valid JSON")
+    }
+
+    fn contract_decimal(value: &str) -> Decimal {
+        Decimal::from_str(value).expect("accounting contract decimal should be valid")
+    }
 
     // --- Mock AssetRepository ---
     #[derive(Clone)]
@@ -510,6 +595,87 @@ mod tests {
             created_at: Utc::now(),
             updated_at: Utc::now(),
         }
+    }
+
+    fn create_contract_activity(
+        id: &str,
+        activity_type: &str,
+        subtype: Option<&str>,
+        is_external: Option<bool>,
+        amount: Decimal,
+        date: NaiveDate,
+    ) -> Activity {
+        let mut activity = create_cash_activity(
+            id,
+            ActivityType::from_str(activity_type)
+                .expect("accounting contract activity type should be valid"),
+            amount,
+            Decimal::ZERO,
+            "USD",
+            &date.to_string(),
+        );
+        activity.subtype = subtype.map(str::to_string);
+        activity.metadata =
+            is_external.map(|is_external| json!({ "flow": { "is_external": is_external } }));
+        activity
+    }
+
+    fn apply_contract_activity(
+        calculator: &mut CalcHarness,
+        previous_snapshot: &AccountStateSnapshot,
+        account_type: &str,
+        activity: Activity,
+        date: NaiveDate,
+    ) -> AccountStateSnapshot {
+        calculator
+            .calculate_next_holdings_for_account_type(
+                previous_snapshot,
+                &[activity],
+                date,
+                Some(account_type),
+            )
+            .expect("accounting contract activity should calculate")
+            .snapshot
+    }
+
+    fn valuation_from_snapshot(snapshot: &AccountStateSnapshot) -> DailyAccountValuation {
+        DailyAccountValuation {
+            id: format!("valuation-{}", snapshot.snapshot_date),
+            account_id: snapshot.account_id.clone(),
+            valuation_date: snapshot.snapshot_date,
+            account_currency: snapshot.currency.clone(),
+            base_currency: snapshot.currency.clone(),
+            fx_rate_to_base: Decimal::ONE,
+            cash_balance: snapshot.cash_total_account_currency,
+            investment_market_value: Decimal::ZERO,
+            total_value: snapshot.cash_total_account_currency,
+            cost_basis: snapshot.cost_basis,
+            book_basis: snapshot.cost_basis,
+            net_contribution: snapshot.net_contribution,
+            cash_balance_base: snapshot.cash_total_account_currency,
+            investment_market_value_base: Decimal::ZERO,
+            total_value_base: snapshot.cash_total_account_currency,
+            cost_basis_base: snapshot.cost_basis,
+            book_basis_base: snapshot.cost_basis,
+            net_contribution_base: snapshot.net_contribution_base,
+            external_inflow_base: Decimal::ZERO,
+            external_outflow_base: Decimal::ZERO,
+            external_flow_source: ExternalFlowSource::NoFlow,
+            performance_eligible_value_base: snapshot.cash_total_account_currency,
+            value_status: ValuationStatus::Complete,
+            basis_status: BasisStatus::NotApplicable,
+            calculated_at: Utc::now(),
+        }
+    }
+
+    fn simple_gain(snapshot: &AccountStateSnapshot) -> Decimal {
+        PerformanceService::calculate_simple_performance(
+            &valuation_from_snapshot(snapshot),
+            None,
+            None,
+        )
+        .total_gain_loss_amount
+        .expect("simple gain should be available")
     }
 
     fn create_initial_snapshot(
@@ -9191,5 +9357,145 @@ mod tests {
         // The account-currency scalar matches the snapshot's own account cost
         // basis field (both anchored to acquisition-date FX).
         assert_eq!(snapshot.cost_basis, dec!(2300));
+    }
+
+    #[test]
+    fn accounting_contract_reconciles_cash_contributions_and_performance() {
+        let date = NaiveDate::from_ymd_opt(2025, 1, 2).unwrap();
+
+        for case in accounting_contract().cases {
+            let base_currency = Arc::new(RwLock::new("USD".to_string()));
+            let mut calculator = create_calculator(Arc::new(MockFxService::new()), base_currency);
+            let initial = create_initial_snapshot("acc_1", "USD", "2025-01-01");
+            let activity = create_contract_activity(
+                &format!("contract-{}", case.name),
+                &case.activity_type,
+                case.subtype.as_deref(),
+                case.is_external,
+                contract_decimal(&case.amount),
+                date,
+            );
+            let snapshot = apply_contract_activity(
+                &mut calculator,
+                &initial,
+                &case.account_type,
+                activity,
+                date,
+            );
+
+            assert_eq!(
+                snapshot.cash_total_account_currency,
+                contract_decimal(&case.expected.cash_delta),
+                "accounting contract cash case: {}",
+                case.name
+            );
+            assert_eq!(
+                snapshot.net_contribution,
+                contract_decimal(&case.expected.net_contribution_delta),
+                "accounting contract contribution case: {}",
+                case.name
+            );
+            assert_eq!(
+                simple_gain(&snapshot),
+                contract_decimal(&case.expected.gain_delta),
+                "accounting contract gain case: {}",
+                case.name
+            );
+        }
+    }
+
+    #[test]
+    fn ledger_contract_reconciles_cash_contributions_and_performance() {
+        let start = NaiveDate::from_ymd_opt(2025, 1, 1).unwrap();
+
+        for scenario in ledger_contract().scenarios {
+            let base_currency = Arc::new(RwLock::new("USD".to_string()));
+            let mut calculator = create_calculator(Arc::new(MockFxService::new()), base_currency);
+            let mut snapshot = create_initial_snapshot("acc_1", "USD", "2025-01-01");
+
+            for (index, entry) in scenario.activities.into_iter().enumerate() {
+                let date = start + Duration::days(entry.day);
+                let activity = create_contract_activity(
+                    &format!("ledger-{index}"),
+                    &entry.activity_type,
+                    entry.subtype.as_deref(),
+                    entry.is_external,
+                    contract_decimal(&entry.amount),
+                    date,
+                );
+                snapshot = apply_contract_activity(
+                    &mut calculator,
+                    &snapshot,
+                    &scenario.account_type,
+                    activity,
+                    date,
+                );
+            }
+
+            assert_eq!(
+                snapshot.cash_total_account_currency,
+                contract_decimal(&scenario.expected.ending_cash),
+                "accounting ledger cash scenario: {}",
+                scenario.name
+            );
+            assert_eq!(
+                snapshot.net_contribution,
+                contract_decimal(&scenario.expected.net_contribution),
+                "accounting ledger contribution scenario: {}",
+                scenario.name
+            );
+            assert_eq!(
+                simple_gain(&snapshot),
+                contract_decimal(&scenario.expected.gain),
+                "accounting ledger gain scenario: {}",
+                scenario.name
+            );
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(100))]
+
+        #[test]
+        fn external_purchase_refunds_never_create_performance_gain(
+            purchase_minor in 1i64..10_000_000,
+            refund_seed in 0i64..10_000_000,
+        ) {
+            let refund_minor = refund_seed % (purchase_minor + 1);
+            let purchase = Decimal::new(purchase_minor, 2);
+            let refund = Decimal::new(refund_minor, 2);
+            let start = NaiveDate::from_ymd_opt(2025, 1, 1).unwrap();
+            let base_currency = Arc::new(RwLock::new("USD".to_string()));
+            let mut calculator =
+                create_calculator(Arc::new(MockFxService::new()), base_currency);
+            let mut snapshot = create_initial_snapshot("acc_1", "USD", "2025-01-01");
+
+            for (day, activity_type, subtype, is_external, amount) in [
+                (1, "DEPOSIT", None, None, purchase),
+                (2, "WITHDRAWAL", None, None, purchase),
+                (3, "CREDIT", Some("REFUND"), Some(true), refund),
+            ] {
+                let date = start + Duration::days(day);
+                let activity = create_contract_activity(
+                    &format!("property-{day}"),
+                    activity_type,
+                    subtype,
+                    is_external,
+                    amount,
+                    date,
+                );
+                snapshot = apply_contract_activity(
+                    &mut calculator,
+                    &snapshot,
+                    account_types::CASH,
+                    activity,
+                    date,
+                );
+            }
+
+            prop_assert_eq!(snapshot.cash_total_account_currency, refund);
+            prop_assert_eq!(snapshot.net_contribution, refund);
+            prop_assert_eq!(simple_gain(&snapshot), Decimal::ZERO);
+        }
     }
 }

--- a/crates/spending/Cargo.toml
+++ b/crates/spending/Cargo.toml
@@ -25,3 +25,4 @@ wealthfolio-core = { path = "../core" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+proptest = "1.4"

--- a/crates/spending/src/activity_classification.rs
+++ b/crates/spending/src/activity_classification.rs
@@ -140,11 +140,88 @@ pub(crate) fn decimal_to_f64(amount: Decimal) -> f64 {
 #[cfg(test)]
 mod tests {
     use chrono::Utc;
+    use proptest::prelude::*;
     use rust_decimal::Decimal;
+    use serde::Deserialize;
     use serde_json::Value;
+    use std::str::FromStr;
     use wealthfolio_core::activities::{Activity, ActivityStatus};
 
     use super::*;
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct AccountingContract {
+        cases: Vec<AccountingContractCase>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct AccountingContractCase {
+        name: String,
+        account_type: String,
+        activity_type: String,
+        subtype: Option<String>,
+        amount: String,
+        expected: AccountingContractExpected,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct AccountingContractExpected {
+        spending_delta: Option<String>,
+        income_delta: Option<String>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct LedgerContract {
+        scenarios: Vec<LedgerScenario>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct LedgerScenario {
+        name: String,
+        account_type: String,
+        activities: Vec<LedgerActivity>,
+        expected: LedgerExpected,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct LedgerActivity {
+        activity_type: String,
+        subtype: Option<String>,
+        amount: String,
+    }
+
+    #[derive(Debug, Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    struct LedgerExpected {
+        net_spending: String,
+        income: String,
+    }
+
+    fn accounting_contract() -> AccountingContract {
+        serde_json::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../tests/fixtures/accounting/activity_semantics.json"
+        )))
+        .expect("accounting activity contract should be valid JSON")
+    }
+
+    fn ledger_contract() -> LedgerContract {
+        serde_json::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../tests/fixtures/accounting/ledger_scenarios.json"
+        )))
+        .expect("accounting ledger contract should be valid JSON")
+    }
+
+    fn decimal(value: &str) -> Decimal {
+        Decimal::from_str(value).expect("accounting contract decimal should be valid")
+    }
 
     fn activity(activity_type: &str, source_group_id: Option<&str>) -> Activity {
         activity_with_subtype(activity_type, None, source_group_id)
@@ -184,6 +261,93 @@ mod tests {
             needs_review: false,
             created_at: Utc::now(),
             updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn accounting_contract_reconciles_spending_and_income_semantics() {
+        for case in accounting_contract().cases {
+            let (Some(expected_spending), Some(expected_income)) = (
+                case.expected.spending_delta.as_deref(),
+                case.expected.income_delta.as_deref(),
+            ) else {
+                continue;
+            };
+            let amount = decimal(&case.amount);
+            let activity =
+                activity_with_subtype(&case.activity_type, case.subtype.as_deref(), None);
+            let classification = classify_activity(&activity, &case.account_type);
+
+            assert_eq!(
+                classification.spending_amount(amount),
+                decimal(expected_spending),
+                "accounting contract spending case: {}",
+                case.name
+            );
+            assert_eq!(
+                classification.income_amount(amount),
+                decimal(expected_income),
+                "accounting contract income case: {}",
+                case.name
+            );
+        }
+    }
+
+    #[test]
+    fn ledger_contract_reconciles_spending_and_income_totals() {
+        for scenario in ledger_contract().scenarios {
+            let mut spending = Decimal::ZERO;
+            let mut income = Decimal::ZERO;
+
+            for entry in scenario.activities {
+                let amount = decimal(&entry.amount);
+                let activity =
+                    activity_with_subtype(&entry.activity_type, entry.subtype.as_deref(), None);
+                let classification = classify_activity(&activity, &scenario.account_type);
+                spending += classification.spending_amount(amount);
+                income += classification.income_amount(amount);
+            }
+
+            assert_eq!(
+                spending,
+                decimal(&scenario.expected.net_spending),
+                "accounting ledger spending scenario: {}",
+                scenario.name
+            );
+            assert_eq!(
+                income,
+                decimal(&scenario.expected.income),
+                "accounting ledger income scenario: {}",
+                scenario.name
+            );
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(100))]
+
+        #[test]
+        fn purchase_refunds_reduce_spending_by_exactly_the_refunded_amount(
+            purchase_minor in 1i64..10_000_000,
+            refund_seed in 0i64..10_000_000,
+        ) {
+            let refund_minor = refund_seed % (purchase_minor + 1);
+            let purchase = Decimal::new(purchase_minor, 2);
+            let refund = Decimal::new(refund_minor, 2);
+            let withdrawal = classify_activity(
+                &activity("WITHDRAWAL", None),
+                account_types::CASH,
+            );
+            let refund_credit = classify_activity(
+                &activity_with_subtype("CREDIT", Some("REFUND"), None),
+                account_types::CASH,
+            );
+
+            prop_assert_eq!(
+                withdrawal.spending_amount(purchase)
+                    + refund_credit.spending_amount(refund),
+                purchase - refund
+            );
         }
     }
 

--- a/tests/fixtures/accounting/README.md
+++ b/tests/fixtures/accounting/README.md
@@ -1,0 +1,29 @@
+# Accounting contract fixtures
+
+These fixtures are the shared accounting contract for activity semantics.
+
+- `activity_semantics.json` defines the expected cash, net-contribution,
+  performance, spending, and income effect of one activity.
+- `ledger_scenarios.json` defines whole-ledger reconciliations. These catch
+  individually plausible classifications that produce an impossible result
+  when combined.
+
+The core flow classifier, holdings calculator, performance calculation, and
+spending classifier consume the same cases. Import and form tests verify that
+the boundary metadata required by those cases survives activity creation.
+
+## Required invariants
+
+- `gain = ending cash + investment value - net contribution` for the simple
+  cash scenarios represented here.
+- A fully reversed external purchase has zero net spending and zero gain.
+- An explicit `metadata.flow.is_external` value overrides a credit subtype's
+  default performance boundary.
+- Brokerage refunds without an explicit external boundary remain internal.
+- Cash-account expense reversals created by supported entry paths carry an
+  explicit external boundary.
+
+When adding or changing an accounting activity, update the atomic contract,
+add a ledger scenario when the activity reverses or pairs with another entry,
+and cover its import or form path. Randomized tests should enforce invariants;
+they should not duplicate the production formula as their oracle.

--- a/tests/fixtures/accounting/README.md
+++ b/tests/fixtures/accounting/README.md
@@ -5,8 +5,8 @@ These fixtures are the shared accounting contract for activity semantics.
 - `activity_semantics.json` defines the expected cash, net-contribution,
   performance, spending, and income effect of one activity.
 - `ledger_scenarios.json` defines whole-ledger reconciliations. These catch
-  individually plausible classifications that produce an impossible result
-  when combined.
+  individually plausible classifications that produce an impossible result when
+  combined.
 
 The core flow classifier, holdings calculator, performance calculation, and
 spending classifier consume the same cases. Import and form tests verify that
@@ -14,8 +14,8 @@ the boundary metadata required by those cases survives activity creation.
 
 ## Required invariants
 
-- `gain = ending cash + investment value - net contribution` for the simple
-  cash scenarios represented here.
+- `gain = ending cash + investment value - net contribution` for the simple cash
+  scenarios represented here.
 - A fully reversed external purchase has zero net spending and zero gain.
 - An explicit `metadata.flow.is_external` value overrides a credit subtype's
   default performance boundary.
@@ -23,7 +23,7 @@ the boundary metadata required by those cases survives activity creation.
 - Cash-account expense reversals created by supported entry paths carry an
   explicit external boundary.
 
-When adding or changing an accounting activity, update the atomic contract,
-add a ledger scenario when the activity reverses or pairs with another entry,
-and cover its import or form path. Randomized tests should enforce invariants;
-they should not duplicate the production formula as their oracle.
+When adding or changing an accounting activity, update the atomic contract, add
+a ledger scenario when the activity reverses or pairs with another entry, and
+cover its import or form path. Randomized tests should enforce invariants; they
+should not duplicate the production formula as their oracle.

--- a/tests/fixtures/accounting/activity_semantics.json
+++ b/tests/fixtures/accounting/activity_semantics.json
@@ -1,0 +1,191 @@
+{
+  "version": 1,
+  "cases": [
+    {
+      "name": "cash deposit is external income",
+      "accountType": "CASH",
+      "activityType": "DEPOSIT",
+      "amount": "100.00",
+      "expected": {
+        "cashDelta": "100.00",
+        "netContributionDelta": "100.00",
+        "gainDelta": "0.00",
+        "externalFlow": true,
+        "spendingDelta": "0.00",
+        "incomeDelta": "100.00"
+      }
+    },
+    {
+      "name": "cash withdrawal is an external expense",
+      "accountType": "CASH",
+      "activityType": "WITHDRAWAL",
+      "amount": "100.00",
+      "expected": {
+        "cashDelta": "-100.00",
+        "netContributionDelta": "-100.00",
+        "gainDelta": "0.00",
+        "externalFlow": true,
+        "spendingDelta": "100.00",
+        "incomeDelta": "0.00"
+      }
+    },
+    {
+      "name": "cash interest is internal income",
+      "accountType": "CASH",
+      "activityType": "INTEREST",
+      "amount": "100.00",
+      "expected": {
+        "cashDelta": "100.00",
+        "netContributionDelta": "0.00",
+        "gainDelta": "100.00",
+        "externalFlow": false,
+        "spendingDelta": "0.00",
+        "incomeDelta": "100.00"
+      }
+    },
+    {
+      "name": "cash fee is an internal cost",
+      "accountType": "CASH",
+      "activityType": "FEE",
+      "amount": "100.00",
+      "expected": {
+        "cashDelta": "-100.00",
+        "netContributionDelta": "0.00",
+        "gainDelta": "-100.00",
+        "externalFlow": false,
+        "spendingDelta": "100.00",
+        "incomeDelta": "0.00"
+      }
+    },
+    {
+      "name": "cash tax is an internal cost",
+      "accountType": "CASH",
+      "activityType": "TAX",
+      "amount": "100.00",
+      "expected": {
+        "cashDelta": "-100.00",
+        "netContributionDelta": "0.00",
+        "gainDelta": "-100.00",
+        "externalFlow": false,
+        "spendingDelta": "100.00",
+        "incomeDelta": "0.00"
+      }
+    },
+    {
+      "name": "cash bonus is external income",
+      "accountType": "CASH",
+      "activityType": "CREDIT",
+      "subtype": "BONUS",
+      "amount": "100.00",
+      "expected": {
+        "cashDelta": "100.00",
+        "netContributionDelta": "100.00",
+        "gainDelta": "0.00",
+        "externalFlow": true,
+        "spendingDelta": "0.00",
+        "incomeDelta": "100.00"
+      }
+    },
+    {
+      "name": "cash reimbursement is an external expense reversal",
+      "accountType": "CASH",
+      "activityType": "CREDIT",
+      "subtype": "REIMBURSEMENT",
+      "isExternal": true,
+      "amount": "100.00",
+      "expected": {
+        "cashDelta": "100.00",
+        "netContributionDelta": "100.00",
+        "gainDelta": "0.00",
+        "externalFlow": true,
+        "spendingDelta": "-100.00",
+        "incomeDelta": "0.00"
+      }
+    },
+    {
+      "name": "cash merchant refund can explicitly cross the boundary",
+      "accountType": "CASH",
+      "activityType": "CREDIT",
+      "subtype": "REFUND",
+      "isExternal": true,
+      "amount": "100.00",
+      "expected": {
+        "cashDelta": "100.00",
+        "netContributionDelta": "100.00",
+        "gainDelta": "0.00",
+        "externalFlow": true,
+        "spendingDelta": "-100.00",
+        "incomeDelta": "0.00"
+      }
+    },
+    {
+      "name": "cash merchant rebate can explicitly cross the boundary",
+      "accountType": "CASH",
+      "activityType": "CREDIT",
+      "subtype": "REBATE",
+      "isExternal": true,
+      "amount": "100.00",
+      "expected": {
+        "cashDelta": "100.00",
+        "netContributionDelta": "100.00",
+        "gainDelta": "0.00",
+        "externalFlow": true,
+        "spendingDelta": "-100.00",
+        "incomeDelta": "0.00"
+      }
+    },
+    {
+      "name": "securities refund defaults to an internal correction",
+      "accountType": "SECURITIES",
+      "activityType": "CREDIT",
+      "subtype": "REFUND",
+      "amount": "100.00",
+      "expected": {
+        "cashDelta": "100.00",
+        "netContributionDelta": "0.00",
+        "gainDelta": "100.00",
+        "externalFlow": false
+      }
+    },
+    {
+      "name": "securities rebate defaults to internal income",
+      "accountType": "SECURITIES",
+      "activityType": "CREDIT",
+      "subtype": "REBATE",
+      "amount": "100.00",
+      "expected": {
+        "cashDelta": "100.00",
+        "netContributionDelta": "0.00",
+        "gainDelta": "100.00",
+        "externalFlow": false
+      }
+    },
+    {
+      "name": "securities dividend is internal income",
+      "accountType": "SECURITIES",
+      "activityType": "DIVIDEND",
+      "amount": "100.00",
+      "expected": {
+        "cashDelta": "100.00",
+        "netContributionDelta": "0.00",
+        "gainDelta": "100.00",
+        "externalFlow": false
+      }
+    },
+    {
+      "name": "unknown cash credit is ignored by spending and internal to performance",
+      "accountType": "CASH",
+      "activityType": "CREDIT",
+      "subtype": "ADJUSTMENT",
+      "amount": "100.00",
+      "expected": {
+        "cashDelta": "100.00",
+        "netContributionDelta": "0.00",
+        "gainDelta": "100.00",
+        "externalFlow": false,
+        "spendingDelta": "0.00",
+        "incomeDelta": "0.00"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/accounting/ledger_scenarios.json
+++ b/tests/fixtures/accounting/ledger_scenarios.json
@@ -1,0 +1,122 @@
+{
+  "version": 1,
+  "scenarios": [
+    {
+      "name": "cash purchase fully refunded",
+      "accountType": "CASH",
+      "activities": [
+        { "day": 1, "activityType": "DEPOSIT", "amount": "100.00" },
+        { "day": 2, "activityType": "WITHDRAWAL", "amount": "100.00" },
+        {
+          "day": 3,
+          "activityType": "CREDIT",
+          "subtype": "REFUND",
+          "isExternal": true,
+          "amount": "100.00"
+        }
+      ],
+      "expected": {
+        "endingCash": "100.00",
+        "netContribution": "100.00",
+        "gain": "0.00",
+        "netSpending": "0.00",
+        "income": "100.00"
+      }
+    },
+    {
+      "name": "cash purchase partially refunded",
+      "accountType": "CASH",
+      "activities": [
+        { "day": 1, "activityType": "DEPOSIT", "amount": "100.00" },
+        { "day": 2, "activityType": "WITHDRAWAL", "amount": "100.00" },
+        {
+          "day": 3,
+          "activityType": "CREDIT",
+          "subtype": "REFUND",
+          "isExternal": true,
+          "amount": "40.00"
+        }
+      ],
+      "expected": {
+        "endingCash": "40.00",
+        "netContribution": "40.00",
+        "gain": "0.00",
+        "netSpending": "60.00",
+        "income": "100.00"
+      }
+    },
+    {
+      "name": "cash purchase reimbursed",
+      "accountType": "CASH",
+      "activities": [
+        { "day": 1, "activityType": "DEPOSIT", "amount": "100.00" },
+        { "day": 2, "activityType": "WITHDRAWAL", "amount": "100.00" },
+        {
+          "day": 3,
+          "activityType": "CREDIT",
+          "subtype": "REIMBURSEMENT",
+          "isExternal": true,
+          "amount": "100.00"
+        }
+      ],
+      "expected": {
+        "endingCash": "100.00",
+        "netContribution": "100.00",
+        "gain": "0.00",
+        "netSpending": "0.00",
+        "income": "100.00"
+      }
+    },
+    {
+      "name": "cash fee correction is internal",
+      "accountType": "CASH",
+      "activities": [
+        { "day": 1, "activityType": "DEPOSIT", "amount": "100.00" },
+        { "day": 2, "activityType": "FEE", "amount": "20.00" },
+        {
+          "day": 3,
+          "activityType": "CREDIT",
+          "subtype": "REFUND",
+          "amount": "20.00"
+        }
+      ],
+      "expected": {
+        "endingCash": "100.00",
+        "netContribution": "100.00",
+        "gain": "0.00",
+        "netSpending": "0.00",
+        "income": "100.00"
+      }
+    },
+    {
+      "name": "cash interest is performance income",
+      "accountType": "CASH",
+      "activities": [
+        { "day": 1, "activityType": "DEPOSIT", "amount": "100.00" },
+        { "day": 2, "activityType": "INTEREST", "amount": "10.00" }
+      ],
+      "expected": {
+        "endingCash": "110.00",
+        "netContribution": "100.00",
+        "gain": "10.00",
+        "netSpending": "0.00",
+        "income": "110.00"
+      }
+    },
+    {
+      "name": "cash fee is a performance cost",
+      "accountType": "CASH",
+      "activities": [
+        { "day": 1, "activityType": "DEPOSIT", "amount": "100.00" },
+        { "day": 2, "activityType": "FEE", "amount": "10.00" }
+      ],
+      "expected": {
+        "endingCash": "90.00",
+        "netContribution": "100.00",
+        "gain": "-10.00",
+        "netSpending": "10.00",
+        "income": "100.00"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- define shared activity and ledger accounting contracts for cash flows, refunds, reimbursements, fees, interest, bonuses, and securities-account credits
- honor explicit `metadata.flow.is_external` boundaries for CREDIT activities in performance classification and holdings net-contribution calculations
- preserve explicit true, false, and omitted boundaries through broker sync, manual create/edit, bulk save, duplication, and CSV import
- expose explicit CREDIT boundary controls in the activity grid and CSV review so inferred values can be corrected
- infer cash-account expense reversals conservatively while leaving generic and securities-account credits internal by default
- add example-based, cross-engine, integration, frontend transport, and property-based regression coverage

## Root cause

CREDIT accounting was split across subtype-only rules and transport paths that treated `flow.is_external` as transfer-only. A refund could therefore reduce spending while still being counted as portfolio gain instead of reversing the original external withdrawal.

This PR makes the explicit boundary marker authoritative for CREDIT activities and exercises the same contract across spending, performance, holdings, imports, and sync.

## Compatibility

- no database migration
- existing activities retain the previous subtype defaults when no explicit boundary exists
- compatible with Cloud responses that omit the boundary marker

## Validation

- `cargo test -p wealthfolio-core` — 1,741 unit tests plus 12 integration tests
- `cargo test -p wealthfolio-spending` — 102 tests
- `cargo test -p wealthfolio-connect` — 82 tests
- full frontend Vitest suite — 1,210 tests
- frontend TypeScript check and ESLint
- Rustfmt, Prettier, and diff whitespace checks

Fixes #1403
