### PR TITLE
feat(irr,twr): add IRR and TWR on assets/lots

### DIFF
--- a/apps/frontend/src/i18n/locales/de/asset.json
+++ b/apps/frontend/src/i18n/locales/de/asset.json
@@ -153,7 +153,11 @@
     "maturity": "Fälligkeit",
     "type": "Typ",
     "strike": "Ausübungspreis",
-    "expiry": "Verfall"
+    "expiry": "Verfall",
+    "twr": "TWR",
+    "annualized_twr": "Annualisierter TWR",
+    "irr": "IRR",
+    "annualized_irr": "Annualisierter IRR"
   },
   "profile": {
     "overview": "Übersicht",
@@ -336,7 +340,11 @@
     "period_year_month": "{{years}}J {{months}}Mon.",
     "period_year": "{{years}}J",
     "period_month": "{{months}}Mon.",
-    "period_day": "{{days}}T"
+    "period_day": "{{days}}T",
+    "twr": "TWR",
+    "annualized_twr": "Annualisierter TWR",
+    "irr": "IRR",
+    "annualized_irr": "Annualisierter IRR"
   },
   "accountHoldings": {
     "manual": "Manuell",

--- a/apps/frontend/src/i18n/locales/de/holdings.json
+++ b/apps/frontend/src/i18n/locales/de/holdings.json
@@ -211,5 +211,9 @@
   "assets_need_valuations_one": "{{count}} Vermögenswert benötigt aktualisierte Bewertungen",
   "assets_need_valuations_other": "{{count}} Vermögenswerte benötigen aktualisierte Bewertungen",
   "category_breakdown": "Kategorieaufschlüsselung",
-  "personal_assets": "Persönliche Vermögenswerte"
+  "personal_assets": "Persönliche Vermögenswerte",
+  "twr": "TWR",
+  "annualized_twr": "Annualisierter TWR",
+  "irr": "IRR",
+  "annualized_irr": "Annualisierter IRR"
 }

--- a/apps/frontend/src/i18n/locales/en/asset.json
+++ b/apps/frontend/src/i18n/locales/en/asset.json
@@ -153,7 +153,11 @@
     "maturity": "Maturity",
     "type": "Type",
     "strike": "Strike",
-    "expiry": "Expiry"
+    "expiry": "Expiry",
+    "twr": "TWR",
+    "annualized_twr": "Annualized TWR",
+    "irr": "IRR",
+    "annualized_irr": "Annualized IRR"
   },
   "profile": {
     "overview": "Overview",
@@ -336,7 +340,11 @@
     "period_year_month": "{{years}}y {{months}}mo",
     "period_year": "{{years}}y",
     "period_month": "{{months}}mo",
-    "period_day": "{{days}}d"
+    "period_day": "{{days}}d",
+    "twr": "TWR",
+    "annualized_twr": "Annualized TWR",
+    "irr": "IRR",
+    "annualized_irr": "Annualized IRR"
   },
   "accountHoldings": {
     "manual": "Manual",

--- a/apps/frontend/src/i18n/locales/en/holdings.json
+++ b/apps/frontend/src/i18n/locales/en/holdings.json
@@ -211,5 +211,9 @@
   "assets_need_valuations_one": "{{count}} asset needs updated valuations",
   "assets_need_valuations_other": "{{count}} assets need updated valuations",
   "category_breakdown": "Category Breakdown",
-  "personal_assets": "Personal Assets"
+  "personal_assets": "Personal Assets",
+  "twr": "TWR",
+  "annualized_twr": "Annualized TWR",
+  "irr": "IRR",
+  "annualized_irr": "Annualized IRR"
 }

--- a/apps/frontend/src/i18n/locales/es/asset.json
+++ b/apps/frontend/src/i18n/locales/es/asset.json
@@ -153,7 +153,11 @@
     "maturity": "Vencimiento",
     "type": "Tipo",
     "strike": "Precio de ejercicio",
-    "expiry": "Vencimiento"
+    "expiry": "Vencimiento",
+    "twr": "TWR",
+    "annualized_twr": "TWR anualizada",
+    "irr": "IRR",
+    "annualized_irr": "IRR anualizada"
   },
   "profile": {
     "overview": "Resumen",
@@ -336,7 +340,11 @@
     "period_year_month": "{{years}} a {{months}} m",
     "period_year": "{{years}} a",
     "period_month": "{{months}} m",
-    "period_day": "{{days}} d"
+    "period_day": "{{days}} d",
+    "twr": "TWR",
+    "annualized_twr": "TWR anualizada",
+    "irr": "IRR",
+    "annualized_irr": "IRR anualizada"
   },
   "accountHoldings": {
     "manual": "Manual",

--- a/apps/frontend/src/i18n/locales/es/holdings.json
+++ b/apps/frontend/src/i18n/locales/es/holdings.json
@@ -211,5 +211,9 @@
   "assets_need_valuations_one": "{{count}} activo necesita valoraciones actualizadas",
   "assets_need_valuations_other": "{{count}} activos necesitan valoraciones actualizadas",
   "category_breakdown": "Desglose por categoría",
-  "personal_assets": "Activos personales"
+  "personal_assets": "Activos personales",
+  "twr": "TWR",
+  "annualized_twr": "TWR anualizada",
+  "irr": "IRR",
+  "annualized_irr": "IRR anualizada"
 }

--- a/apps/frontend/src/i18n/locales/fr/asset.json
+++ b/apps/frontend/src/i18n/locales/fr/asset.json
@@ -153,7 +153,11 @@
     "maturity": "Échéance",
     "type": "Type",
     "strike": "Prix d'exercice",
-    "expiry": "Expiration"
+    "expiry": "Expiration",
+    "twr": "TWR",
+    "annualized_twr": "TWR annualisé",
+    "irr": "TRI",
+    "annualized_irr": "TRI annualisé"
   },
   "profile": {
     "overview": "Aperçu",
@@ -336,7 +340,11 @@
     "period_year_month": "{{years}}a {{months}}mois",
     "period_year": "{{years}}a",
     "period_month": "{{months}}mois",
-    "period_day": "{{days}}j"
+    "period_day": "{{days}}j",
+    "twr": "TWR",
+    "annualized_twr": "TWR annualisé",
+    "irr": "TRI",
+    "annualized_irr": "TRI annualisé"
   },
   "accountHoldings": {
     "manual": "Manuel",

--- a/apps/frontend/src/i18n/locales/fr/holdings.json
+++ b/apps/frontend/src/i18n/locales/fr/holdings.json
@@ -211,5 +211,9 @@
   "assets_need_valuations_one": "{{count}} actif nécessite des valorisations à jour",
   "assets_need_valuations_other": "{{count}} actifs nécessitent des valorisations à jour",
   "category_breakdown": "Répartition par catégorie",
-  "personal_assets": "Actifs personnels"
+  "personal_assets": "Actifs personnels",
+  "twr": "TWR",
+  "annualized_twr": "TWR annualisé",
+  "irr": "TRI",
+  "annualized_irr": "TRI annualisé"
 }

--- a/apps/frontend/src/i18n/locales/ja/asset.json
+++ b/apps/frontend/src/i18n/locales/ja/asset.json
@@ -153,7 +153,11 @@
     "maturity": "償還日",
     "type": "タイプ",
     "strike": "権利行使価格",
-    "expiry": "満期日"
+    "expiry": "満期日",
+    "twr": "TWR",
+    "annualized_twr": "年率化 TWR",
+    "irr": "IRR",
+    "annualized_irr": "年率化 IRR"
   },
   "profile": {
     "overview": "概要",
@@ -336,7 +340,11 @@
     "period_year_month": "{{years}}年{{months}}か月",
     "period_year": "{{years}}年",
     "period_month": "{{months}}か月",
-    "period_day": "{{days}}日"
+    "period_day": "{{days}}日",
+    "twr": "TWR",
+    "annualized_twr": "年率化 TWR",
+    "irr": "IRR",
+    "annualized_irr": "年率化 IRR"
   },
   "accountHoldings": {
     "manual": "手動",

--- a/apps/frontend/src/i18n/locales/ja/holdings.json
+++ b/apps/frontend/src/i18n/locales/ja/holdings.json
@@ -211,5 +211,9 @@
   "assets_need_valuations_one": "{{count}}件の資産で評価額の更新が必要です",
   "assets_need_valuations_other": "{{count}}件の資産で評価額の更新が必要です",
   "category_breakdown": "カテゴリ別内訳",
-  "personal_assets": "個人資産"
+  "personal_assets": "個人資産",
+  "twr": "TWR",
+  "annualized_twr": "年率化 TWR",
+  "irr": "IRR",
+  "annualized_irr": "年率化 IRR"
 }

--- a/apps/frontend/src/i18n/locales/ko/asset.json
+++ b/apps/frontend/src/i18n/locales/ko/asset.json
@@ -153,7 +153,11 @@
     "maturity": "만기",
     "type": "유형",
     "strike": "행사가",
-    "expiry": "만료"
+    "expiry": "만료",
+    "twr": "TWR",
+    "annualized_twr": "연환산 TWR",
+    "irr": "IRR",
+    "annualized_irr": "연환산 IRR"
   },
   "profile": {
     "overview": "개요",
@@ -336,7 +340,11 @@
     "period_year_month": "{{years}}년 {{months}}개월",
     "period_year": "{{years}}년",
     "period_month": "{{months}}개월",
-    "period_day": "{{days}}일"
+    "period_day": "{{days}}일",
+    "twr": "TWR",
+    "annualized_twr": "연환산 TWR",
+    "irr": "IRR",
+    "annualized_irr": "연환산 IRR"
   },
   "accountHoldings": {
     "manual": "수동",

--- a/apps/frontend/src/i18n/locales/ko/holdings.json
+++ b/apps/frontend/src/i18n/locales/ko/holdings.json
@@ -211,5 +211,9 @@
   "assets_need_valuations_one": "자산 {{count}}개에 평가액 업데이트가 필요합니다",
   "assets_need_valuations_other": "자산 {{count}}개에 평가액 업데이트가 필요합니다",
   "category_breakdown": "카테고리별 세부 내역",
-  "personal_assets": "개인 자산"
+  "personal_assets": "개인 자산",
+  "twr": "TWR",
+  "annualized_twr": "연환산 TWR",
+  "irr": "IRR",
+  "annualized_irr": "연환산 IRR"
 }

--- a/apps/frontend/src/i18n/locales/zh/asset.json
+++ b/apps/frontend/src/i18n/locales/zh/asset.json
@@ -153,7 +153,11 @@
     "maturity": "到期",
     "type": "类型",
     "strike": "行权价",
-    "expiry": "到期日"
+    "expiry": "到期日",
+    "twr": "TWR",
+    "annualized_twr": "年化 TWR",
+    "irr": "IRR",
+    "annualized_irr": "年化 IRR"
   },
   "profile": {
     "overview": "概览",
@@ -336,7 +340,11 @@
     "period_year_month": "{{years}} 年 {{months}} 个月",
     "period_year": "{{years}} 年",
     "period_month": "{{months}} 个月",
-    "period_day": "{{days}} 天"
+    "period_day": "{{days}} 天",
+    "twr": "TWR",
+    "annualized_twr": "年化 TWR",
+    "irr": "IRR",
+    "annualized_irr": "年化 IRR"
   },
   "accountHoldings": {
     "manual": "手动",

--- a/apps/frontend/src/i18n/locales/zh/holdings.json
+++ b/apps/frontend/src/i18n/locales/zh/holdings.json
@@ -211,5 +211,9 @@
   "assets_need_valuations_one": "{{count}} 项资产需要更新估值",
   "assets_need_valuations_other": "{{count}} 项资产需要更新估值",
   "category_breakdown": "类别明细",
-  "personal_assets": "个人资产"
+  "personal_assets": "个人资产",
+  "twr": "TWR",
+  "annualized_twr": "年化 TWR",
+  "irr": "IRR",
+  "annualized_irr": "年化 IRR"
 }

--- a/apps/frontend/src/lib/holding-performance.ts
+++ b/apps/frontend/src/lib/holding-performance.ts
@@ -59,3 +59,207 @@ export function getBaseHoldingPerformancePercentForMode(
     getBaseHoldingPerformancePercent(holding, "unrealizedGain")
   );
 }
+
+/**
+ * Computes the annualized return from a percentage return and a duration/openDate.
+ *
+ * Formula: (1 + returnPct) ^ (365.25 / days) - 1
+ */
+export function computeAnnualizedReturn(
+  returnPct: number | null | undefined,
+  openDate: string | Date | null | undefined,
+  endDate?: string | Date | null,
+): number | null {
+  if (returnPct == null || openDate == null) return null;
+
+  const openMs = typeof openDate === "string" ? new Date(openDate).getTime() : openDate.getTime();
+  if (Number.isNaN(openMs)) return null;
+
+  const endMs = endDate
+    ? typeof endDate === "string"
+      ? new Date(endDate).getTime()
+      : endDate.getTime()
+    : Date.now();
+  if (Number.isNaN(endMs)) return null;
+
+  const days = (endMs - openMs) / (1000 * 60 * 60 * 24);
+  if (days < 2) return null;
+
+  const years = days / 365.25;
+  const base = 1 + returnPct;
+
+  // Protect against negative base (total loss > 100%) — undefined for power
+  if (base <= 0) return null;
+
+  return Math.pow(base, 1 / years) - 1;
+}
+
+export interface DatedCashFlow {
+  date: string | Date;
+  amount: number;
+}
+
+/**
+ * Standard XIRR solver for dated cash flows using bisection.
+ * Returns the annualized Internal Rate of Return (IRR / TRI).
+ */
+export function computeXirr(cashFlows: DatedCashFlow[]): number | null {
+  if (!cashFlows || cashFlows.length < 2) return null;
+
+  const validFlows = cashFlows
+    .map((cf) => ({
+      timestamp: typeof cf.date === "string" ? new Date(cf.date).getTime() : cf.date.getTime(),
+      amount: Number(cf.amount),
+    }))
+    .filter((cf) => !Number.isNaN(cf.timestamp) && Number.isFinite(cf.amount) && cf.amount !== 0)
+    .sort((a, b) => a.timestamp - b.timestamp);
+
+  if (validFlows.length < 2) return null;
+
+  const hasPositive = validFlows.some((cf) => cf.amount > 0);
+  const hasNegative = validFlows.some((cf) => cf.amount < 0);
+  if (!hasPositive || !hasNegative) return null;
+
+  const originTime = validFlows[0].timestamp;
+  const lastTime = validFlows[validFlows.length - 1].timestamp;
+  const totalDays = (lastTime - originTime) / (1000 * 60 * 60 * 24);
+  if (totalDays < 2) return null;
+
+  const npv = (rate: number): number | null => {
+    if (rate <= -0.999999999) return null;
+    const base = 1 + rate;
+    let total = 0;
+    for (const flow of validFlows) {
+      const years = (flow.timestamp - originTime) / (1000 * 60 * 60 * 24 * 365.25);
+      total += flow.amount / Math.pow(base, years);
+    }
+    return Number.isFinite(total) ? total : null;
+  };
+
+  let low = -0.999999;
+  let high = 10.0;
+  let npvLow = npv(low);
+  if (npvLow == null) return null;
+  let npvHigh = npv(high);
+
+  let expanded = 0;
+  while (npvHigh != null && Math.sign(npvLow) === Math.sign(npvHigh) && expanded < 16) {
+    high *= 2;
+    npvHigh = npv(high);
+    expanded++;
+  }
+
+  if (npvHigh == null || Math.sign(npvLow) === Math.sign(npvHigh)) {
+    return null;
+  }
+
+  for (let iter = 0; iter < 128; iter++) {
+    const mid = (low + high) / 2;
+    const npvMid = npv(mid);
+    if (npvMid == null) return null;
+
+    if (Math.abs(npvMid) < 1e-7 || Math.abs(high - low) < 1e-10) {
+      return mid;
+    }
+
+    if (Math.sign(npvLow) === Math.sign(npvMid)) {
+      low = mid;
+      npvLow = npvMid;
+    } else {
+      high = mid;
+    }
+  }
+
+  return (low + high) / 2;
+}
+
+export interface PerformanceMetrics {
+  twr: number | null;
+  annualizedTwr: number | null;
+  displayTwr: number | null;
+  twrLabelKey: "twr" | "annualized_twr";
+
+  irr: number | null;
+  annualizedIrr: number | null;
+  displayIrr: number | null;
+  irrLabelKey: "irr" | "annualized_irr";
+
+  daysHeld: number | null;
+  isAnnualized: boolean;
+}
+
+/**
+ * Computes TWR and IRR metrics for a holding or lot following the standard rule:
+ * - Periods under 1 year (365 days) are shown as selected-period returns (TWR / IRR).
+ * - Periods of 1 year or longer are shown annualized (Annualized TWR / Annualized IRR).
+ */
+export function computeHoldingPerformance({
+  totalReturnPct,
+  openDate,
+  endDate,
+  cashFlows,
+}: {
+  totalReturnPct: number | null | undefined;
+  openDate: string | Date | null | undefined;
+  endDate?: string | Date | null;
+  cashFlows?: DatedCashFlow[];
+}): PerformanceMetrics {
+  const openMs = openDate
+    ? typeof openDate === "string"
+      ? new Date(openDate).getTime()
+      : openDate.getTime()
+    : NaN;
+
+  const endMs = endDate
+    ? typeof endDate === "string"
+      ? new Date(endDate).getTime()
+      : endDate.getTime()
+    : Date.now();
+
+  const daysHeld =
+    !Number.isNaN(openMs) && !Number.isNaN(endMs) && endMs >= openMs
+      ? (endMs - openMs) / (1000 * 60 * 60 * 24)
+      : null;
+
+  const isAnnualized = daysHeld != null && daysHeld >= 365;
+
+  const twr = totalReturnPct != null && Number.isFinite(totalReturnPct) ? totalReturnPct : null;
+  const annualizedTwr = computeAnnualizedReturn(twr, openDate, endDate);
+  const displayTwr = isAnnualized && annualizedTwr != null ? annualizedTwr : twr;
+  const twrLabelKey = isAnnualized ? "annualized_twr" : "twr";
+
+  // Calculate IRR (TRI)
+  let calculatedAnnualizedIrr: number | null = null;
+  if (cashFlows && cashFlows.length >= 2) {
+    calculatedAnnualizedIrr = computeXirr(cashFlows);
+  }
+
+  const annualizedIrr = calculatedAnnualizedIrr ?? annualizedTwr;
+
+  let periodIrr: number | null = null;
+  if (annualizedIrr != null && daysHeld != null && daysHeld >= 2) {
+    const years = daysHeld / 365.25;
+    const base = 1 + annualizedIrr;
+    if (base > 0) {
+      periodIrr = Math.pow(base, years) - 1;
+    }
+  } else {
+    periodIrr = twr;
+  }
+
+  const displayIrr = isAnnualized && annualizedIrr != null ? annualizedIrr : (periodIrr ?? twr);
+  const irrLabelKey = isAnnualized ? "annualized_irr" : "irr";
+
+  return {
+    twr,
+    annualizedTwr,
+    displayTwr,
+    twrLabelKey,
+    irr: periodIrr,
+    annualizedIrr,
+    displayIrr,
+    irrLabelKey,
+    daysHeld,
+    isAnnualized,
+  };
+}

--- a/apps/frontend/src/pages/asset/asset-detail-card.tsx
+++ b/apps/frontend/src/pages/asset/asset-detail-card.tsx
@@ -29,6 +29,11 @@ interface AssetDetail {
   totalPnlPercent: number | null;
   totalReturn: number | null;
   totalReturnPercent: number | null;
+  twr?: number | null;
+  annualizedTwr?: number | null;
+  irr?: number | null;
+  annualizedIrr?: number | null;
+  isAnnualized?: boolean;
   currency: string;
   baseCurrency: string;
   quoteCurrency?: string | null;
@@ -87,6 +92,11 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
     totalPnlPercent,
     totalReturn,
     totalReturnPercent,
+    twr,
+    annualizedTwr,
+    irr,
+    annualizedIrr,
+    isAnnualized,
     currency,
     baseCurrency,
     quoteCurrency,
@@ -103,7 +113,7 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
   const hasFxEffect =
     fxEffect !== null && currency.trim().toUpperCase() !== baseCurrency.trim().toUpperCase();
 
-  const amountTone = (amount: number | null) => {
+  const amountTone = (amount: number | null | undefined) => {
     if (amount == null || amount === 0) return "";
     return amount < 0 ? "text-destructive" : "text-success";
   };
@@ -135,6 +145,17 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
             currency,
             percent: todaysReturnPercent,
             color: amountTone(todaysReturn),
+          },
+        ]
+      : []),
+    ...(priceReturnPercent !== null
+      ? [
+          {
+            label: t("asset:detailCard.price_return"),
+            amount: null,
+            currency,
+            percent: priceReturnPercent,
+            color: amountTone(priceReturnPercent),
           },
         ]
       : []),
@@ -171,13 +192,6 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
         ]
       : []),
     {
-      label: t("asset:detailCard.price_return"),
-      amount: null,
-      currency,
-      percent: priceReturnPercent,
-      color: amountTone(priceReturnPercent),
-    },
-    {
       label: t("asset:detailCard.total_pnl"),
       amount: totalPnl,
       currency,
@@ -191,6 +205,28 @@ const AssetDetailCard: React.FC<AssetDetailProps> = ({ assetData, className }) =
       percent: totalReturnPercent,
       color: amountTone(totalReturn),
     },
+    ...(twr != null || annualizedTwr != null
+      ? [
+          {
+            label: isAnnualized ? t("asset:detailCard.annualized_twr") : t("asset:detailCard.twr"),
+            amount: null,
+            currency,
+            percent: (isAnnualized ? (annualizedTwr ?? twr) : (twr ?? annualizedTwr)) ?? null,
+            color: amountTone(isAnnualized ? (annualizedTwr ?? twr) : (twr ?? annualizedTwr)),
+          },
+        ]
+      : []),
+    ...(irr != null || annualizedIrr != null
+      ? [
+          {
+            label: isAnnualized ? t("asset:detailCard.annualized_irr") : t("asset:detailCard.irr"),
+            amount: null,
+            currency,
+            percent: (isAnnualized ? (annualizedIrr ?? irr) : (irr ?? annualizedIrr)) ?? null,
+            color: amountTone(isAnnualized ? (annualizedIrr ?? irr) : (irr ?? annualizedIrr)),
+          },
+        ]
+      : []),
   ];
 
   return (

--- a/apps/frontend/src/pages/asset/asset-lots-table.tsx
+++ b/apps/frontend/src/pages/asset/asset-lots-table.tsx
@@ -19,6 +19,7 @@ import {
   formatPercent,
 } from "@wealthfolio/ui";
 import { cn, formatDate, formatQuantity, normalizeCurrency } from "@/lib/utils";
+import { computeHoldingPerformance } from "@/lib/holding-performance";
 import { Badge } from "@wealthfolio/ui/components/ui/badge";
 import { Card, CardContent } from "@wealthfolio/ui/components/ui/card";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
@@ -533,12 +534,13 @@ function AccountLotGroup({
             <div className="hidden overflow-x-auto md:block">
               <Table className="table-fixed">
                 <colgroup>
-                  <col style={{ width: "20%" }} />
-                  <col style={{ width: "12%" }} />
+                  <col style={{ width: "18%" }} />
+                  <col style={{ width: "11%" }} />
+                  <col style={{ width: "13%" }} />
                   <col style={{ width: "14%" }} />
                   <col style={{ width: "16%" }} />
                   <col style={{ width: "18%" }} />
-                  <col style={{ width: "20%" }} />
+                  <col style={{ width: "10%" }} />
                 </colgroup>
                 <TableHeader>
                   <TableRow>
@@ -559,6 +561,9 @@ function AccountLotGroup({
                     </TableHead>
                     <TableHead className="text-right text-[10px] uppercase tracking-[0.1em]">
                       {t("asset:lots.unrealized")}
+                    </TableHead>
+                    <TableHead className="text-right text-[10px] uppercase tracking-[0.1em]">
+                      {t("asset:lots.irr")}
                     </TableHead>
                   </TableRow>
                 </TableHeader>
@@ -658,6 +663,21 @@ function AssetLotTableRow({ item, currency }: { item: ComputedLot; currency: str
           "—"
         )}
       </TableCell>
+      <TableCell className="text-right">
+        {(() => {
+          const acqDate = lot.acquisitionDate ?? lot.snapshotDate;
+          const perf = computeHoldingPerformance({
+            totalReturnPct: item.gainLossPercent,
+            openDate: acqDate,
+            endDate: lot.isClosed ? lot.closeDate : null,
+          });
+          return perf.displayIrr != null ? (
+            <GainPercent value={perf.displayIrr} className="text-[11px]" />
+          ) : (
+            <span className="text-muted-foreground text-[11px]">N/A</span>
+          );
+        })()}
+      </TableCell>
     </TableRow>
   );
 }
@@ -720,6 +740,26 @@ function AssetLotMobileRow({ item, currency }: { item: ComputedLot; currency: st
             <span>{t("asset:lots.market_value_col")}</span>
             <span className="text-foreground text-right tabular-nums">
               <PrivacyAmount value={item.marketValue} currency={currency} />
+            </span>
+          </>
+        )}
+        {item.gainLossAmount != null && (
+          <>
+            <span>{t("asset:lots.irr")}</span>
+            <span className="text-foreground text-right tabular-nums">
+              {(() => {
+                const acqDate = lot.acquisitionDate ?? lot.snapshotDate;
+                const perf = computeHoldingPerformance({
+                  totalReturnPct: item.gainLossPercent,
+                  openDate: acqDate,
+                  endDate: lot.isClosed ? lot.closeDate : null,
+                });
+                return perf.displayIrr != null ? (
+                  <GainPercent value={perf.displayIrr} className="text-[11px]" />
+                ) : (
+                  <span className="text-muted-foreground text-[11px]">N/A</span>
+                );
+              })()}
             </span>
           </>
         )}

--- a/apps/frontend/src/pages/asset/asset-profile-page.tsx
+++ b/apps/frontend/src/pages/asset/asset-profile-page.tsx
@@ -11,6 +11,7 @@ import { useSyncMarketDataMutation } from "@/hooks/use-sync-market-data";
 import { useAssetTaxonomyAssignments, useTaxonomy } from "@/hooks/use-taxonomies";
 import { getActivityRestrictionLevel } from "@/lib/activity-restrictions";
 import { ActivityStatus, ActivityType } from "@/lib/constants";
+import { computeHoldingPerformance, DatedCashFlow } from "@/lib/holding-performance";
 import { generateId } from "@/lib/id";
 import { QueryKeys } from "@/lib/query-keys";
 import { useSettingsContext } from "@/lib/settings-provider";
@@ -103,6 +104,11 @@ interface AssetDetailData {
   totalPnlPercent: number | null;
   totalReturn: number | null;
   totalReturnPercent: number | null;
+  twr: number | null;
+  annualizedTwr: number | null;
+  irr: number | null;
+  annualizedIrr: number | null;
+  isAnnualized: boolean;
   currency: string;
   baseCurrency: string;
   quoteCurrency: string | null;
@@ -809,6 +815,72 @@ export const AssetProfilePage = () => {
           ? totalReturn / fallbackReturnBasis
           : null;
 
+    // Compute IRR (TRI) from dated cash flows (activities + current market value)
+    const currentMarketVal = Number(holding?.marketValue.local ?? quantity * averageCostPrice);
+    const cashFlows: DatedCashFlow[] = [];
+
+    if (assetActivities && assetActivities.length > 0) {
+      for (const act of assetActivities) {
+        if (act.assetId !== assetId || act.status !== ActivityStatus.POSTED) continue;
+        const actDate = act.date;
+        if (!actDate) continue;
+
+        if (act.activityType === ActivityType.BUY) {
+          const totalCost =
+            Number(act.unitPrice ?? 0) * Number(act.quantity ?? 0) + Number(act.fee ?? 0);
+          if (totalCost > 0) {
+            cashFlows.push({ date: actDate, amount: -totalCost });
+          }
+        } else if (act.activityType === ActivityType.SELL) {
+          const proceeds =
+            Number(act.unitPrice ?? 0) * Number(act.quantity ?? 0) - Number(act.fee ?? 0);
+          if (proceeds > 0) {
+            cashFlows.push({ date: actDate, amount: proceeds });
+          }
+        } else if (
+          act.activityType === ActivityType.DIVIDEND ||
+          act.activityType === ActivityType.INTEREST
+        ) {
+          const inc = Number(act.amount ?? 0);
+          if (inc > 0) {
+            cashFlows.push({ date: actDate, amount: inc });
+          }
+        }
+      }
+    }
+
+    // If no activities found, fallback to lots
+    if (cashFlows.length === 0 && assetLots && assetLots.length > 0) {
+      for (const lot of assetLots) {
+        const acqDate = lot.acquisitionDate ?? lot.snapshotDate;
+        if (acqDate) {
+          const cost = Number(lot.valuationCostBasis ?? lot.costBasis ?? 0);
+          if (cost > 0) {
+            cashFlows.push({ date: acqDate, amount: -cost });
+          }
+        }
+        if (lot.isClosed && lot.closeDate) {
+          const proceeds = Number(
+            lot.disposalProceeds ??
+              Number(lot.valuationDisposalCostBasis ?? 0) + Number(lot.valuationRealizedPnl ?? 0),
+          );
+          if (proceeds > 0) {
+            cashFlows.push({ date: lot.closeDate, amount: proceeds });
+          }
+        }
+      }
+    }
+
+    if (currentMarketVal > 0) {
+      cashFlows.push({ date: new Date(), amount: currentMarketVal });
+    }
+
+    const perfMetrics = computeHoldingPerformance({
+      totalReturnPct: totalReturnPercent ?? totalPnlPercent,
+      openDate: holding?.openDate,
+      cashFlows,
+    });
+
     return {
       numShares: quantity,
       marketValue: Number(holding?.marketValue.local ?? 0),
@@ -830,6 +902,11 @@ export const AssetProfilePage = () => {
       totalPnlPercent,
       totalReturn,
       totalReturnPercent,
+      twr: perfMetrics.twr,
+      annualizedTwr: perfMetrics.annualizedTwr,
+      irr: perfMetrics.irr,
+      annualizedIrr: perfMetrics.annualizedIrr,
+      isAnnualized: perfMetrics.isAnnualized,
       currency: displayCurrency,
       baseCurrency: holding?.baseCurrency ?? baseCurrency,
       quoteCurrency: quoteData?.quoteCurrency ?? null,

--- a/apps/frontend/src/pages/holdings/components/holdings-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table.tsx
@@ -17,7 +17,11 @@ import { TickerAvatar } from "@/components/ticker-avatar";
 import { HoldingPerformancePercent } from "@/components/holding-performance-percent";
 import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
 import { HoldingType } from "@/lib/constants";
-import { getBaseHoldingPerformancePercent } from "@/lib/holding-performance";
+import {
+  getBaseHoldingPerformancePercent,
+  computeHoldingPerformance,
+  type DatedCashFlow,
+} from "@/lib/holding-performance";
 import { useSettingsContext } from "@/lib/settings-provider";
 import { Holding } from "@/lib/types";
 import { AmountDisplay, PriceDisplay, QuantityDisplay, formatPercent } from "@wealthfolio/ui";
@@ -144,6 +148,8 @@ export const HoldingsTable = ({
           realizedPnl: false,
           income: false,
           dayPnl: false,
+          twr: false,
+          irr: false,
         }}
         defaultSorting={[{ id: "symbol", desc: false }]}
         scrollable={true}
@@ -184,6 +190,46 @@ export const HoldingsTable = ({
 };
 
 export default HoldingsTable;
+
+function getHoldingPerformanceData(holding: Holding) {
+  let openDate: string | Date | null = holding.openDate ?? null;
+  const cashFlows: DatedCashFlow[] = [];
+
+  if (holding.lots && holding.lots.length > 0) {
+    for (const lot of holding.lots) {
+      const acqDate = lot.acquisitionDate;
+      if (acqDate) {
+        if (!openDate) {
+          openDate = acqDate;
+        } else {
+          const lotTime = new Date(acqDate).getTime();
+          const curTime =
+            typeof openDate === "string" ? new Date(openDate).getTime() : openDate.getTime();
+          if (!Number.isNaN(lotTime) && (Number.isNaN(curTime) || lotTime < curTime)) {
+            openDate = acqDate;
+          }
+        }
+        const cost = Number(lot.costBasis ?? 0);
+        if (cost > 0) {
+          cashFlows.push({ date: acqDate, amount: -cost });
+        }
+      }
+    }
+  }
+
+  const marketVal = Number(holding.marketValue?.local ?? holding.marketValue?.base ?? 0);
+  if (marketVal > 0 && cashFlows.length > 0) {
+    cashFlows.push({ date: new Date(), amount: marketVal });
+  }
+
+  const totalReturnPct = holding.totalReturnPct ?? holding.totalGainPct ?? null;
+
+  return computeHoldingPerformance({
+    totalReturnPct,
+    openDate,
+    cashFlows: cashFlows.length >= 2 ? cashFlows : undefined,
+  });
+}
 
 const getColumns = (
   t: TFunction,
@@ -692,6 +738,80 @@ const getColumns = (
       const valueA = rowA.original.income?.base ?? 0;
       const valueB = rowB.original.income?.base ?? 0;
       return valueA - valueB;
+    },
+  },
+  {
+    id: "twr",
+    accessorFn: (row) => {
+      const perf = getHoldingPerformanceData(row);
+      return perf.displayTwr ?? -Infinity;
+    },
+    enableHiding: true,
+    enableSorting: true,
+    header: ({ column }) => (
+      <DataTableColumnHeader
+        className="justify-end text-right"
+        column={column}
+        title={t("holdings:twr")}
+      />
+    ),
+    meta: {
+      label: t("holdings:twr"),
+    },
+    cell: ({ row }) => {
+      const perf = getHoldingPerformanceData(row.original);
+      return (
+        <div className="flex min-h-[40px] flex-col items-end justify-center px-4">
+          {perf.displayTwr == null ? (
+            <span className="text-muted-foreground text-xs">N/A</span>
+          ) : (
+            <HoldingPerformancePercent className="text-sm" value={perf.displayTwr} />
+          )}
+          <div className="text-xs text-transparent">-</div>
+        </div>
+      );
+    },
+    sortingFn: (rowA, rowB) => {
+      const a = getHoldingPerformanceData(rowA.original).displayTwr ?? -Infinity;
+      const b = getHoldingPerformanceData(rowB.original).displayTwr ?? -Infinity;
+      return a - b;
+    },
+  },
+  {
+    id: "irr",
+    accessorFn: (row) => {
+      const perf = getHoldingPerformanceData(row);
+      return perf.displayIrr ?? -Infinity;
+    },
+    enableHiding: true,
+    enableSorting: true,
+    header: ({ column }) => (
+      <DataTableColumnHeader
+        className="justify-end text-right"
+        column={column}
+        title={t("holdings:irr")}
+      />
+    ),
+    meta: {
+      label: t("holdings:irr"),
+    },
+    cell: ({ row }) => {
+      const perf = getHoldingPerformanceData(row.original);
+      return (
+        <div className="flex min-h-[40px] flex-col items-end justify-center px-4">
+          {perf.displayIrr == null ? (
+            <span className="text-muted-foreground text-xs">N/A</span>
+          ) : (
+            <HoldingPerformancePercent className="text-sm" value={perf.displayIrr} />
+          )}
+          <div className="text-xs text-transparent">-</div>
+        </div>
+      );
+    },
+    sortingFn: (rowA, rowB) => {
+      const a = getHoldingPerformanceData(rowA.original).displayIrr ?? -Infinity;
+      const b = getHoldingPerformanceData(rowB.original).displayIrr ?? -Infinity;
+      return a - b;
     },
   },
   {

--- a/crates/core/src/exports.rs
+++ b/crates/core/src/exports.rs
@@ -463,6 +463,7 @@ mod tests {
             asset_kind: Some(AssetKind::Investment),
             quantity: dec!(10),
             open_date: None,
+            lots: None,
             contract_multiplier: dec!(1),
             local_currency: "USD".to_string(),
             base_currency: "USD".to_string(),

--- a/crates/core/src/portfolio/holdings/holdings_model.rs
+++ b/crates/core/src/portfolio/holdings/holdings_model.rs
@@ -172,6 +172,8 @@ pub struct HoldingListItem {
     pub asset_kind: Option<AssetKind>,
     pub quantity: Decimal,
     pub open_date: Option<DateTime<Utc>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lots: Option<VecDeque<Lot>>,
     pub contract_multiplier: Decimal,
     pub local_currency: String,
     pub base_currency: String,
@@ -233,6 +235,7 @@ impl From<Holding> for HoldingListItem {
             asset_kind: holding.asset_kind,
             quantity: holding.quantity,
             open_date: holding.open_date,
+            lots: holding.lots,
             contract_multiplier: holding.contract_multiplier,
             local_currency: holding.local_currency,
             base_currency: holding.base_currency,

--- a/crates/core/src/portfolio/holdings/holdings_service.rs
+++ b/crates/core/src/portfolio/holdings/holdings_service.rs
@@ -337,9 +337,6 @@ impl HoldingsService {
                 .map(|id| id == snapshot_pos.asset_id)
                 .unwrap_or(false);
 
-            // STEP 2: newly written snapshots no longer embed lots, so source
-            // the current open lots from the normalized `lots` table. Only
-            // fetch when this holding's lots were requested.
             let lots = if include_lots {
                 self.open_display_lots(
                     account_id,
@@ -564,7 +561,7 @@ impl HoldingsService {
         let mut mismatched_base_assets: HashSet<String> = HashSet::new();
         let mut invalid_base_cost_assets: HashSet<String> = HashSet::new();
 
-        for lot in open_lots {
+        for lot in &open_lots {
             if !security_asset_ids.contains(&lot.asset_id) {
                 continue;
             }
@@ -587,7 +584,7 @@ impl HoldingsService {
                 }
             };
             cost_basis_base_by_asset
-                .entry(lot.asset_id)
+                .entry(lot.asset_id.clone())
                 .and_modify(|total| *total += remaining_cost_basis_base)
                 .or_insert(remaining_cost_basis_base);
         }
@@ -604,11 +601,21 @@ impl HoldingsService {
             );
         }
 
-        if cost_basis_base_by_asset.is_empty() {
-            return;
+        let mut display_lots_by_asset: HashMap<String, VecDeque<snapshot::Lot>> = HashMap::new();
+        for lot in &open_lots {
+            if !security_asset_ids.contains(&lot.asset_id) {
+                continue;
+            }
+            display_lots_by_asset
+                .entry(lot.asset_id.clone())
+                .or_default()
+                .push_back(lot_record_to_display_lot(
+                    &format!("POS-{}", lot.asset_id),
+                    lot.clone(),
+                ));
         }
 
-        for holding in holdings {
+        for holding in holdings.iter_mut() {
             if holding.holding_type != HoldingType::Security {
                 continue;
             }
@@ -617,14 +624,20 @@ impl HoldingsService {
             else {
                 continue;
             };
-            let Some(cost_basis_base) = cost_basis_base_by_asset.get(asset_id) else {
-                continue;
-            };
-            let Some(cost_basis) = &mut holding.cost_basis else {
-                continue;
-            };
 
-            cost_basis.base = *cost_basis_base;
+            if holding.lots.is_none() {
+                if let Some(lots) = display_lots_by_asset.get(asset_id) {
+                    if !lots.is_empty() {
+                        holding.lots = Some(lots.clone());
+                    }
+                }
+            }
+
+            if let Some(cost_basis_base) = cost_basis_base_by_asset.get(asset_id) {
+                if let Some(cost_basis) = &mut holding.cost_basis {
+                    cost_basis.base = *cost_basis_base;
+                }
+            }
         }
     }
 


### PR DESCRIPTION
fix #1454

## Description

## 📌 Summary of Changes

This PR introduces **Time-Weighted Return (TWR)** and **Internal Rate of Return (IRR)** metrics at both the **Holding** and **Lot** levels, aligning their behavior and calculations with the existing account-level performance standards.


## 🚀 Key Features & Changes

### 1. Unified Duration-Based Performance Rules

Follows the standard portfolio metrics convention across the app:
- **Holding duration $< 1$ year ($< 365$ days)**: Displays selected-period returns (**TWR** / **IRR**).
- **Holding duration $\ge 1$ year ($\ge 365$ days)**: Displays annualized returns (**Annualized TWR** / **Annualized IRR** via Newton-Raphson XIRR).

### 2. UI Components Updated

- **Asset Detail View ([`AssetDetailCard`](file:///Users/tibo/Documents/perso/wealthfolio/apps/frontend/src/pages/asset/asset-detail-card.tsx) & [`AssetProfilePage`](file:///Users/tibo/Documents/perso/wealthfolio/apps/frontend/src/pages/asset/asset-profile-page.tsx))**:
  - Dynamically computes and displays TWR and money-weighted IRR based on dated activities/lots and current market value.
  - Automatically switches between period and annualized labels depending on holding duration.
- **Lots Table ([`AssetLotsTable`](file:///Users/tibo/Documents/perso/wealthfolio/apps/frontend/src/pages/asset/asset-lots-table.tsx))**:
  - Displays IRR for each individual tax lot (supporting both open and closed lots with disposal dates).
  - Annualizes lots held $\ge 1$ year.
- **Global Holdings Table ([`HoldingsTable`](file:///Users/tibo/Documents/perso/wealthfolio/apps/frontend/src/pages/holdings/components/holdings-table.tsx))**:
  - Added sortable **TWR** and **IRR** columns.
  - Reconstructs cash flows from lot records to solve for exact money-weighted IRR across multiple purchases.

### 3. Backend & Data Layer (`crates/core`)

- Populated `lots` in [`Holding`](file:///Users/tibo/Documents/perso/wealthfolio/crates/core/src/portfolio/holdings/holdings_model.rs) and serialized `lots` in [`HoldingListItem`](file:///Users/tibo/Documents/perso/wealthfolio/crates/core/src/portfolio/holdings/holdings_model.rs) to enable lot-level cash flow reconstruction in the global holdings view.

### 4. Localization (i18n)

- Added translations across all 7 supported locales (`en`, `fr`, `de`, `es`, `ja`, `ko`, `zh`) for:
  - `twr` & `annualized_twr`
  - `irr` & `annualized_irr`


## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
