### PR TITLE
Round cash balances before the zero check in net worth

### DIFF
--- a/crates/core/src/portfolio/net_worth/net_worth_service.rs
+++ b/crates/core/src/portfolio/net_worth/net_worth_service.rs
@@ -412,13 +412,16 @@ impl NetWorthServiceTrait for NetWorthService {
                     });
                 }
 
-                if !account_valuation.cash_balance_base.is_zero() {
+                // Round before the zero check: activity replay leaves residual
+                // balances around 1e-15 that are non-zero but display as $0.
+                let cash_base = account_valuation
+                    .cash_balance_base
+                    .round_dp(DECIMAL_PRECISION);
+                if !cash_base.is_zero() {
                     valuations.push(ValuationInfo {
                         asset_id: format!("CASH:{}", account.id),
                         name: Some(account.name.clone()),
-                        market_value_base: account_valuation
-                            .cash_balance_base
-                            .round_dp(DECIMAL_PRECISION),
+                        market_value_base: cash_base,
                         valuation_date: account_valuation.valuation_date,
                         category: AssetCategory::Cash,
                         is_cash_like: true,
@@ -527,9 +530,12 @@ impl NetWorthServiceTrait for NetWorthService {
             }
 
             if is_liability_account {
-                let cash_base_total = snapshot.cash_balances.iter().fold(
-                    Decimal::ZERO,
-                    |acc, (currency, &amount)| {
+                // Rounded before the sign checks so residual dust does not emit a
+                // phantom $0 liability (or cash) row for the account.
+                let cash_base_total = snapshot
+                    .cash_balances
+                    .iter()
+                    .fold(Decimal::ZERO, |acc, (currency, &amount)| {
                         if amount.is_zero() {
                             acc
                         } else {
@@ -540,14 +546,14 @@ impl NetWorthServiceTrait for NetWorthService {
                                 date,
                             )
                         }
-                    },
-                );
+                    })
+                    .round_dp(DECIMAL_PRECISION);
 
                 if cash_base_total < Decimal::ZERO {
                     valuations.push(ValuationInfo {
                         asset_id: format!("CREDIT_CARD:{}", account.id),
                         name: Some(account.name.clone()),
-                        market_value_base: cash_base_total.abs().round_dp(DECIMAL_PRECISION),
+                        market_value_base: cash_base_total.abs(),
                         valuation_date: snapshot.snapshot_date,
                         category: AssetCategory::Liability,
                         is_cash_like: true,
@@ -556,7 +562,7 @@ impl NetWorthServiceTrait for NetWorthService {
                     valuations.push(ValuationInfo {
                         asset_id: format!("CASH:{}", account.id),
                         name: Some(account.name.clone()),
-                        market_value_base: cash_base_total.round_dp(DECIMAL_PRECISION),
+                        market_value_base: cash_base_total,
                         valuation_date: snapshot.snapshot_date,
                         category: AssetCategory::Cash,
                         is_cash_like: true,
@@ -574,15 +580,23 @@ impl NetWorthServiceTrait for NetWorthService {
                     continue;
                 }
 
-                let cash_base =
-                    self.convert_cash_balance_to_base(amount, currency, &base_currency, date);
+                let cash_base = self
+                    .convert_cash_balance_to_base(amount, currency, &base_currency, date)
+                    .round_dp(DECIMAL_PRECISION);
+
+                // Long-closed accounts keep residual balances around 1e-15 that
+                // are non-zero yet round to nothing; skip them so the Cash
+                // drill-down does not fill up with $0 rows.
+                if cash_base.is_zero() {
+                    continue;
+                }
 
                 // Name by account (with currency suffix) so the Cash drill-down
                 // lists each account distinctly instead of repeating "Cash (USD)".
                 let (asset_id, name, market_value_base, category) = (
                     format!("CASH:{}:{}", account.id, currency),
                     Some(format!("{} ({})", account.name, currency)),
-                    cash_base.round_dp(DECIMAL_PRECISION),
+                    cash_base,
                     AssetCategory::Cash,
                 );
 

--- a/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
+++ b/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
@@ -1325,6 +1325,107 @@ async fn test_credit_card_multi_currency_nets_before_liability_split() {
 }
 
 #[tokio::test]
+async fn test_dust_cash_balance_excluded_from_cash_breakdown() {
+    let dusty = create_test_account("acc1", "SECURITIES", "USD");
+    let funded = create_test_account("acc2", "SECURITIES", "USD");
+    let mut dust = HashMap::new();
+    dust.insert("USD".to_string(), dec!(0.000000000000001));
+    let mut funds = HashMap::new();
+    funds.insert("USD".to_string(), dec!(2500));
+
+    let service = create_net_worth_service(
+        vec![dusty, funded],
+        vec![],
+        vec![
+            create_test_snapshot("acc1", vec![], dust),
+            create_test_snapshot("acc2", vec![], funds),
+        ],
+        vec![],
+    );
+
+    let date = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
+    let result = service.get_net_worth(date).await.unwrap();
+
+    assert_eq!(get_category_value(&result, "cash"), dec!(2500));
+
+    // The dusty account must not appear as a $0 row in the Cash drill-down.
+    let cash = result
+        .assets
+        .breakdown
+        .iter()
+        .find(|b| b.category == "cash")
+        .unwrap();
+    assert_eq!(cash.children.len(), 1);
+    assert_eq!(cash.children[0].name, "Test Account acc2 (USD)");
+}
+
+#[tokio::test]
+async fn test_real_small_cash_balance_still_included() {
+    let account = create_test_account("acc1", "SECURITIES", "USD");
+    let mut cash = HashMap::new();
+    cash.insert("USD".to_string(), dec!(0.02));
+    let snapshot = create_test_snapshot("acc1", vec![], cash);
+
+    let service = create_net_worth_service(vec![account], vec![], vec![snapshot], vec![]);
+
+    let date = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
+    let result = service.get_net_worth(date).await.unwrap();
+
+    assert_eq!(get_category_value(&result, "cash"), dec!(0.02));
+}
+
+#[tokio::test]
+async fn test_dust_stored_valuation_cash_excluded_from_cash_breakdown() {
+    let dusty = create_test_account("acc1", "SECURITIES", "USD");
+    let funded = create_test_account("acc2", "SECURITIES", "USD");
+    let date = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
+
+    let service = create_net_worth_service_with_valuations(
+        vec![dusty, funded],
+        vec![],
+        vec![
+            create_test_snapshot("acc1", vec![], HashMap::new()),
+            create_test_snapshot("acc2", vec![], HashMap::new()),
+        ],
+        vec![],
+        vec![
+            create_account_valuation("acc1", date, dec!(0.000000000000001)),
+            create_account_valuation("acc2", date, dec!(2500)),
+        ],
+    );
+
+    let result = service.get_net_worth(date).await.unwrap();
+
+    assert_eq!(get_category_value(&result, "cash"), dec!(2500));
+
+    let cash = result
+        .assets
+        .breakdown
+        .iter()
+        .find(|b| b.category == "cash")
+        .unwrap();
+    assert_eq!(cash.children.len(), 1);
+    assert_eq!(cash.children[0].name, "Test Account acc2");
+}
+
+#[tokio::test]
+async fn test_dust_credit_card_balance_produces_no_liability_row() {
+    let account = create_test_account("card1", "CREDIT_CARD", "USD");
+    let mut cash = HashMap::new();
+    cash.insert("USD".to_string(), dec!(-0.000000000000001));
+    let snapshot = create_test_snapshot("card1", vec![], cash);
+
+    let service = create_net_worth_service(vec![account], vec![], vec![snapshot], vec![]);
+
+    let date = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
+    let result = service.get_net_worth(date).await.unwrap();
+
+    assert!(result.liabilities.breakdown.is_empty());
+    assert_eq!(result.liabilities.total, Decimal::ZERO);
+    assert_eq!(result.net_worth, Decimal::ZERO);
+}
+
+#[tokio::test]
 async fn test_staleness_detection() {
     let account = create_test_account("acc1", "SECURITIES", "USD");
     let asset = create_test_asset("AAPL", AssetKind::Investment, "USD");


### PR DESCRIPTION
## Summary

Fixes #1459.

The Net Worth → Cash drill-down listed a row for every account that had ever held
cash, most of them rendering `$0` / `0.0%`. Accounts fully liquidated years ago
keep residual balances on the order of `1e-15`, which are non-zero and so emit a
full breakdown entry that only collapses to zero at render time.

`NetWorthService::get_net_worth` applied `round_dp(DECIMAL_PRECISION)` **after**
testing for zero rather than before. This moves the existing rounding ahead of
the zero and sign tests at all three cash-like emit sites:

| Site                           | Previous test                 | Symptom                                     |
| ------------------------------ | ----------------------------- | ------------------------------------------- |
| Stored-valuation cash branch   | `cash_balance_base.is_zero()` | phantom `$0` row in Cash                    |
| Liability branch net cash      | `cash_base_total < 0` / `> 0` | phantom `$0` row in **Liabilities**         |
| Snapshot cash-balance fallback | `amount.is_zero()`            | phantom `$0` row in Cash (the reported one) |

No new epsilon constant — the existing `.round_dp(DECIMAL_PRECISION)` calls
simply move earlier, so emitted values are unchanged.

## Scope

Deliberately narrow: this fixes the _display_ defect only.

The dust itself is generated in the storage layer — cash arithmetic is exact
`Decimal` throughout, but snapshot `cash_balances` persist as `serde-float` JSON
and the incremental recalc modes re-seed from that `f64` round-trip, so the noise
compounds across runs. That is a separate storage-layer change with a much wider
blast radius; it and the other exact-zero comparisons in `holdings_service` /
`portfolio.rs` are written up as follow-ups in #1459.

Also unchanged on purpose: hidden (`is_active = false`) accounts still count
toward the Cash total, per the documented contract in the account form — _"Hide
this account — keeps in Total & history"_. Filtering them out of the drawer would
make the listed items stop summing to the header. Archived accounts already never
reach this path.

## Behaviour change

Totals are numerically unaffected — discarded dust is ~`1e-11` on a portfolio
with a dozen contaminated accounts, so net worth and the Cash and Liabilities
headers are identical. The only change is that rows worth nothing stop being
listed.

Genuine sub-cent balances survive: a real `$0.01` residual on an active account
is money, not dust, and `DECIMAL_PRECISION = 8` sits far below the cent.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
