### PR TITLE
Fix net worth breakdown categories not being translated

### DIFF
--- a/apps/frontend/src/i18n/locales/de/insights.json
+++ b/apps/frontend/src/i18n/locales/de/insights.json
@@ -93,6 +93,16 @@
       "liabilities": "Verbindlichkeiten",
       "net_worth": "Nettovermögen"
     },
+    "categories": {
+      "cash": "Bargeld",
+      "investments": "Investitionen",
+      "properties": "Immobilien",
+      "vehicles": "Fahrzeuge",
+      "collectibles": "Sammlerstücke",
+      "precious_metals": "Edelmetalle",
+      "other_assets": "Sonstige Vermögenswerte",
+      "liabilities": "Verbindlichkeiten"
+    },
     "category_sheet": {
       "over_period": "über {{period}}",
       "trend_period": "Trend · {{period}}",

--- a/apps/frontend/src/i18n/locales/en/insights.json
+++ b/apps/frontend/src/i18n/locales/en/insights.json
@@ -93,6 +93,16 @@
       "liabilities": "Liabilities",
       "net_worth": "Net Worth"
     },
+    "categories": {
+      "cash": "Cash",
+      "investments": "Investments",
+      "properties": "Properties",
+      "vehicles": "Vehicles",
+      "collectibles": "Collectibles",
+      "precious_metals": "Precious Metals",
+      "other_assets": "Other Assets",
+      "liabilities": "Liabilities"
+    },
     "category_sheet": {
       "over_period": "over {{period}}",
       "trend_period": "Trend · {{period}}",

--- a/apps/frontend/src/i18n/locales/es/insights.json
+++ b/apps/frontend/src/i18n/locales/es/insights.json
@@ -93,6 +93,16 @@
       "liabilities": "Pasivos",
       "net_worth": "Patrimonio neto"
     },
+    "categories": {
+      "cash": "Efectivo",
+      "investments": "Inversiones",
+      "properties": "Propiedades",
+      "vehicles": "Vehículos",
+      "collectibles": "Objetos de colección",
+      "precious_metals": "Metales preciosos",
+      "other_assets": "Otros activos",
+      "liabilities": "Pasivos"
+    },
     "category_sheet": {
       "over_period": "en {{period}}",
       "trend_period": "Tendencia · {{period}}",

--- a/apps/frontend/src/i18n/locales/fr/insights.json
+++ b/apps/frontend/src/i18n/locales/fr/insights.json
@@ -93,6 +93,16 @@
       "liabilities": "Passifs",
       "net_worth": "Valeur nette"
     },
+    "categories": {
+      "cash": "Liquidités",
+      "investments": "Investissements",
+      "properties": "Biens immobiliers",
+      "vehicles": "Véhicules",
+      "collectibles": "Objets de collection",
+      "precious_metals": "Métaux précieux",
+      "other_assets": "Autres actifs",
+      "liabilities": "Passifs"
+    },
     "category_sheet": {
       "over_period": "sur {{period}}",
       "trend_period": "Tendance · {{period}}",

--- a/apps/frontend/src/i18n/locales/ja/insights.json
+++ b/apps/frontend/src/i18n/locales/ja/insights.json
@@ -93,6 +93,16 @@
       "liabilities": "負債",
       "net_worth": "純資産"
     },
+    "categories": {
+      "cash": "現金",
+      "investments": "投資",
+      "properties": "不動産",
+      "vehicles": "車両",
+      "collectibles": "コレクション",
+      "precious_metals": "貴金属",
+      "other_assets": "その他の資産",
+      "liabilities": "負債"
+    },
     "category_sheet": {
       "over_period": "{{period}}の推移",
       "trend_period": "推移 · {{period}}",

--- a/apps/frontend/src/i18n/locales/ko/insights.json
+++ b/apps/frontend/src/i18n/locales/ko/insights.json
@@ -93,6 +93,16 @@
       "liabilities": "부채",
       "net_worth": "순자산"
     },
+    "categories": {
+      "cash": "현금",
+      "investments": "투자",
+      "properties": "부동산",
+      "vehicles": "차량",
+      "collectibles": "수집품",
+      "precious_metals": "귀금속",
+      "other_assets": "기타 자산",
+      "liabilities": "부채"
+    },
     "category_sheet": {
       "over_period": "{{period}} 동안",
       "trend_period": "추세 · {{period}}",

--- a/apps/frontend/src/i18n/locales/zh/insights.json
+++ b/apps/frontend/src/i18n/locales/zh/insights.json
@@ -93,6 +93,16 @@
       "liabilities": "负债",
       "net_worth": "净资产"
     },
+    "categories": {
+      "cash": "现金",
+      "investments": "投资",
+      "properties": "房产",
+      "vehicles": "车辆",
+      "collectibles": "收藏品",
+      "precious_metals": "贵金属",
+      "other_assets": "其他资产",
+      "liabilities": "负债"
+    },
     "category_sheet": {
       "over_period": "在 {{period}} 内",
       "trend_period": "趋势 · {{period}}",

--- a/apps/frontend/src/pages/net-worth/components/breakdown-table.tsx
+++ b/apps/frontend/src/pages/net-worth/components/breakdown-table.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from "react-i18next";
 import { CompactAmount } from "./compact-amount";
 import { CompositionBar } from "./composition-bar";
 import {
+  breakdownLabel,
   CARD_LABEL,
   CATEGORY_CSS_COLORS,
   deriveChange,
@@ -170,7 +171,7 @@ export function BreakdownTable({
             {data.assets.breakdown.map((item) => (
               <BreakdownRow
                 key={item.category}
-                name={item.name}
+                name={breakdownLabel(t, item)}
                 dotColor={CATEGORY_CSS_COLORS[item.category] ?? "var(--muted-foreground)"}
                 value={item.value}
                 percentOfSection={
@@ -181,7 +182,7 @@ export function BreakdownTable({
                 onClick={() =>
                   onSelect({
                     key: item.category,
-                    name: item.name,
+                    name: breakdownLabel(t, item),
                     value: item.value,
                     isLiability: false,
                     isInvestment: item.category === "investments",

--- a/apps/frontend/src/pages/net-worth/components/composition-bar.tsx
+++ b/apps/frontend/src/pages/net-worth/components/composition-bar.tsx
@@ -5,21 +5,23 @@ import {
   TooltipTrigger,
 } from "@wealthfolio/ui/components/ui/tooltip";
 import { useMemo } from "react";
-import { CATEGORY_CSS_COLORS, type ParsedNetWorth } from "./utils";
+import { useTranslation } from "react-i18next";
+import { breakdownLabel, CATEGORY_CSS_COLORS, type ParsedNetWorth } from "./utils";
 
 /** Slim stacked bar of asset composition (% of assets). The breakdown rows below act as its legend. */
 export function CompositionBar({ data, className }: { data: ParsedNetWorth; className?: string }) {
+  const { t } = useTranslation();
   const items = useMemo(() => {
     if (data.assets.total === 0) return [];
     return data.assets.breakdown
       .filter((item) => item.value > 0)
       .map((item) => ({
         category: item.category,
-        name: item.name,
+        name: breakdownLabel(t, item),
         percentage: (item.value / data.assets.total) * 100,
       }))
       .sort((a, b) => b.percentage - a.percentage);
-  }, [data]);
+  }, [data, t]);
 
   if (items.length === 0) return null;
 

--- a/apps/frontend/src/pages/net-worth/components/utils.test.ts
+++ b/apps/frontend/src/pages/net-worth/components/utils.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
+import i18n from "i18next";
 
 import type { NetWorthHistoryPoint, TaxonomyAllocation } from "@/lib/types";
+import frInsights from "@/i18n/locales/fr/insights.json";
 import {
   averageMonthlyChange,
+  breakdownLabel,
   computeMomentum,
   computeVelocity,
   deriveChange,
@@ -10,6 +13,12 @@ import {
   parseHistory,
   type ParsedHistoryPoint,
 } from "./utils";
+
+// The test setup initializes i18next with the English bundles; add French so we
+// can assert the labels actually localize.
+i18n.addResourceBundle("fr", "insights", frInsights);
+const en = i18n.getFixedT("en");
+const fr = i18n.getFixedT("fr");
 
 function rawPoint(overrides: Partial<NetWorthHistoryPoint>): NetWorthHistoryPoint {
   return {
@@ -72,6 +81,43 @@ describe("net worth utils", () => {
     expect(deriveChange([125, 100], true)).toEqual({ amount: 25, percent: 0.2 });
     expect(deriveChange([0, 25], false)).toEqual({ amount: 25, percent: 0 });
     expect(deriveChange([100], false)).toEqual({ amount: 0, percent: 0 });
+  });
+
+  // Category keys emitted by the backend (net_worth_service::category_key).
+  const CATEGORY_KEYS = [
+    "cash",
+    "investments",
+    "properties",
+    "vehicles",
+    "collectibles",
+    "preciousMetals",
+    "otherAssets",
+    "liabilities",
+  ];
+
+  it("translates every backend category key instead of showing its English name", () => {
+    for (const category of CATEGORY_KEYS) {
+      const entry = { category, name: "English name", value: 0 };
+      // Every key must resolve (a miss returns the raw key or the English name).
+      expect(breakdownLabel(en, entry)).not.toBe(entry.name);
+      expect(breakdownLabel(en, entry)).not.toContain("insights:");
+      // …and resolve to a genuinely localized string, not the English one.
+      expect(breakdownLabel(fr, entry)).not.toBe(breakdownLabel(en, entry));
+    }
+
+    expect(
+      breakdownLabel(fr, { category: "preciousMetals", name: "Precious Metals", value: 0 }),
+    ).toBe("Métaux précieux");
+  });
+
+  it("leaves user-named asset rows and unknown categories untouched", () => {
+    // Individual assets (liabilities, category children) carry an assetId.
+    expect(
+      breakdownLabel(fr, { category: "properties", name: "Beach House", value: 0, assetId: "a1" }),
+    ).toBe("Beach House");
+    expect(breakdownLabel(fr, { category: "unmapped", name: "Something New", value: 0 })).toBe(
+      "Something New",
+    );
   });
 
   it("decomposes monthly velocity into market gains, contributions, and equity built", () => {

--- a/apps/frontend/src/pages/net-worth/components/utils.ts
+++ b/apps/frontend/src/pages/net-worth/components/utils.ts
@@ -1,5 +1,6 @@
 import type { CategoryAllocation, NetWorthHistoryPoint, TaxonomyAllocation } from "@/lib/types";
 import { formatPercent } from "@/lib/utils";
+import type { TFunction } from "i18next";
 
 // Goldish orange net-worth theme (matches the history chart). Reserved for the
 // chart/brand; value numbers use semantic green/red tones (orange == warning).
@@ -46,6 +47,30 @@ export interface BreakdownEntry {
   value: number;
   assetId?: string;
   children?: BreakdownEntry[];
+}
+
+// The backend labels aggregate category rows with an English display name
+// ("Precious Metals", …); the stable `category` key is what we translate from.
+const CATEGORY_LABEL_KEYS: Record<string, string> = {
+  cash: "insights:networth.categories.cash",
+  investments: "insights:networth.categories.investments",
+  properties: "insights:networth.categories.properties",
+  vehicles: "insights:networth.categories.vehicles",
+  collectibles: "insights:networth.categories.collectibles",
+  preciousMetals: "insights:networth.categories.precious_metals",
+  otherAssets: "insights:networth.categories.other_assets",
+  liabilities: "insights:networth.categories.liabilities",
+};
+
+/**
+ * Display label for a breakdown row. Rows carrying an `assetId` are individual
+ * user-named assets (liabilities, category children), so their name is shown
+ * as-is; aggregate category rows get the translated category label.
+ */
+export function breakdownLabel(t: TFunction, entry: BreakdownEntry): string {
+  if (entry.assetId) return entry.name;
+  const key = CATEGORY_LABEL_KEYS[entry.category];
+  return key ? t(key) : entry.name;
 }
 
 /** A breakdown row selected for the detail drawer. */


### PR DESCRIPTION
Fixes #1453

The backend returns each breakdown row with a stable machine key (`category`:
`"investments"`, `"preciousMetals"`, …) and an English display name generated in
`net_worth_service.rs` (`name`: `"Investments"`, `"Precious Metals"`, …). The
frontend rendered `name` directly, so category labels on the Net Worth page
stayed in English in every non-English locale.

## Fix

`breakdownLabel(t, entry)` in `pages/net-worth/components/utils.ts` resolves the
stable `category` key through a lookup map instead of trusting the backend's
English string. Applied in the two places that render category names:

- `breakdown-table.tsx` — asset rows, plus the name passed to the detail sheet
- `composition-bar.tsx` — stacked-bar segment tooltips

Rows carrying an `assetId` are individual **user-named** assets (liabilities,
category children), so their name passes through untranslated. Unmapped
categories fall back to the backend name rather than rendering a raw key.

## Translations

New `networth.categories.*` keys in the `insights` namespace — the one the
net-worth page already uses — for all seven locales (en, fr, de, es, zh, ja, ko),
with values matching the equivalent `holdings:group_*` labels so wording stays
consistent with the Holdings page.

## Not included

`pages/holdings/components/net-worth-widget.tsx` has the same bug, but it's
exported and never rendered anywhere in the app. Happy to fold in the fix if
preferred.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
