### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -844,6 +844,6 @@ licensed under AGPL-3.0; trademarks are not granted under that license.
 
 ## 🌟 Star History
 
-## [![Star History Chart](https://api.star-history.com/svg?repos=wealthfolio/wealthfolio&type=Timeline)](https://star-history.com/#wealthfolio/wealthfolio&Date)
+## [![Star History Chart](https://star-history.dera.page/svg?repos=wealthfolio/wealthfolio&type=Timeline)](https://star-history.dera.page/#wealthfolio/wealthfolio&Date)
 
 Enjoy managing your wealth with **Wealthfolio**! 🚀


### PR DESCRIPTION
The star history chart in the README is currently broken and does not render anymore, which leaves the project page without its stargazer history. This PR points the chart to a working instance so it displays correctly again.