### PR TITLE
fix: retirement planner translations

### DIFF
--- a/apps/frontend/src/features/goals/retirement-planner/components/sidebar-configurator.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/components/sidebar-configurator.tsx
@@ -565,8 +565,24 @@ export function SidebarConfigurator({
             <ConfigRow label={t("goals:sidebar.plan.current_age")}>
               {draft.personal.currentAge}
             </ConfigRow>
-            <ConfigRow label={draftMode === "fire" ? t("goals:sidebar.plan.desired_retirement_age") : t("goals:sidebar.plan.retirement_age")}>{draft.personal.targetRetirementAge}</ConfigRow>
-            <ConfigRow label={draftMode === "fire" ? t("goals:sidebar.plan.horizon_age_fire") : t("goals:sidebar.plan.horizon_age_traditional")}>{draft.personal.planningHorizonAge}</ConfigRow>
+            <ConfigRow
+              label={
+                draftMode === "fire"
+                  ? t("goals:sidebar.plan.desired_retirement_age")
+                  : t("goals:sidebar.plan.retirement_age")
+              }
+            >
+              {draft.personal.targetRetirementAge}
+            </ConfigRow>
+            <ConfigRow
+              label={
+                draftMode === "fire"
+                  ? t("goals:sidebar.plan.horizon_age_fire")
+                  : t("goals:sidebar.plan.horizon_age_traditional")
+              }
+            >
+              {draft.personal.planningHorizonAge}
+            </ConfigRow>
             <ConfigRow label={t("goals:sidebar.plan.monthly_contribution_until_retirement")}>
               {formatAmount(draft.investment.monthlyContribution, currency)}
             </ConfigRow>
@@ -658,7 +674,11 @@ export function SidebarConfigurator({
               format={(v) => String(Math.round(v))}
             />
             <LeverRow
-              label={draftMode === "fire" ? t("goals:sidebar.plan.horizon_age_fire") : t("goals:sidebar.plan.horizon_age_traditional")}
+              label={
+                draftMode === "fire"
+                  ? t("goals:sidebar.plan.horizon_age_fire")
+                  : t("goals:sidebar.plan.horizon_age_traditional")
+              }
               hint={t("goals:sidebar.plan.horizon_hint")}
               value={draft.personal.planningHorizonAge}
               onChange={(v) =>

--- a/apps/frontend/src/features/goals/retirement-planner/components/sidebar-configurator.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/components/sidebar-configurator.tsx
@@ -566,8 +566,8 @@ export function SidebarConfigurator({
             <ConfigRow label={t("goals:sidebar.plan.current_age")}>
               {draft.personal.currentAge}
             </ConfigRow>
-            <ConfigRow label={L.targetAge}>{draft.personal.targetRetirementAge}</ConfigRow>
-            <ConfigRow label={L.horizonAge}>{draft.personal.planningHorizonAge}</ConfigRow>
+            <ConfigRow label={draftMode === "fire" ? t("goals:sidebar.plan.desired_retirement_age") : t("goals:sidebar.plan.retirement_age")}>{draft.personal.targetRetirementAge}</ConfigRow>
+            <ConfigRow label={draftMode === "fire" ? t("goals:sidebar.plan.horizon_age_fire") : t("goals:sidebar.plan.horizon_age_traditional")}>{draft.personal.planningHorizonAge}</ConfigRow>
             <ConfigRow label={t("goals:sidebar.plan.monthly_contribution_until_retirement")}>
               {formatAmount(draft.investment.monthlyContribution, currency)}
             </ConfigRow>
@@ -659,7 +659,7 @@ export function SidebarConfigurator({
               format={(v) => String(Math.round(v))}
             />
             <LeverRow
-              label={L.horizonAge}
+              label={draftMode === "fire" ? t("goals:sidebar.plan.horizon_age_fire") : t("goals:sidebar.plan.horizon_age_traditional")}
               hint={t("goals:sidebar.plan.horizon_hint")}
               value={draft.personal.planningHorizonAge}
               onChange={(v) =>

--- a/apps/frontend/src/features/goals/retirement-planner/components/sidebar-configurator.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/components/sidebar-configurator.tsx
@@ -28,7 +28,7 @@ import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { DEFAULT_DC_PAYOUT_ESTIMATE_RATE } from "../lib/constants";
-import { incomeStreamMonthlyAmount, modeLabel, type PlannerMode } from "../lib/dashboard-math";
+import { incomeStreamMonthlyAmount, type PlannerMode } from "../lib/dashboard-math";
 import {
   createExpenseItem,
   expenseAgeRangeLabel,
@@ -389,7 +389,6 @@ export function SidebarConfigurator({
   const [editingSection, setEditingSection] = useState<string | null>(null);
   const [expandedExpenseId, setExpandedExpenseId] = useState<string | null>(null);
   const [expandedIncomeId, setExpandedIncomeId] = useState<string | null>(null);
-  const L = modeLabel(draftMode);
   const moneyPrefix = formatCurrencySymbol(currency);
 
   const update = useCallback((updater: (d: RetirementPlan) => RetirementPlan) => {

--- a/apps/frontend/src/i18n/locales/de/goals.json
+++ b/apps/frontend/src/i18n/locales/de/goals.json
@@ -251,6 +251,8 @@
       "retirement_age": "Ruhestandsalter",
       "desired_retirement_age_hint": "Alter, in dem Sie finanziell unabhängig werden möchten.",
       "retirement_age_hint": "Alter, in dem Sie in Rente gehen möchten.",
+      "horizon_age_fire": "Planhorizont (Alter)",
+      "horizon_age_traditional": "Lebenserwartung",
       "horizon_hint": "Alter, bis zu dem der Plan reichen soll.",
       "monthly_contribution": "Monatlicher Beitrag",
       "monthly_contribution_hint": "Wie viel Sie jeden Monat bis zum Ruhestand hinzufügen.",

--- a/apps/frontend/src/i18n/locales/en/goals.json
+++ b/apps/frontend/src/i18n/locales/en/goals.json
@@ -251,6 +251,8 @@
       "retirement_age": "Retirement age",
       "desired_retirement_age_hint": "Age you want to become financially independent.",
       "retirement_age_hint": "Age you want to retire.",
+      "horizon_age_fire": "Plan through age",
+      "horizon_age_traditional": "Life expectancy",
       "horizon_hint": "Age the plan should cover through.",
       "monthly_contribution": "Monthly contribution",
       "monthly_contribution_hint": "How much you add each month until retirement.",

--- a/apps/frontend/src/i18n/locales/es/goals.json
+++ b/apps/frontend/src/i18n/locales/es/goals.json
@@ -251,6 +251,8 @@
       "retirement_age": "Edad de jubilación",
       "desired_retirement_age_hint": "Edad a la que quieres ser financieramente independiente.",
       "retirement_age_hint": "Edad a la que quieres jubilarte.",
+      "horizon_age_fire": "Horizonte del plan",
+      "horizon_age_traditional": "Esperanza de vida",
       "horizon_hint": "Edad hasta la que debe cubrir el plan.",
       "monthly_contribution": "Aportación mensual",
       "monthly_contribution_hint": "Cuánto añades cada mes hasta la jubilación.",

--- a/apps/frontend/src/i18n/locales/fr/goals.json
+++ b/apps/frontend/src/i18n/locales/fr/goals.json
@@ -251,6 +251,8 @@
       "retirement_age": "Âge de retraite",
       "desired_retirement_age_hint": "Âge auquel vous voulez devenir financièrement indépendant.",
       "retirement_age_hint": "Âge auquel vous voulez prendre votre retraite.",
+      "horizon_age_fire": "Horizon du plan",
+      "horizon_age_traditional": "Espérance de vie",
       "horizon_hint": "Âge que le plan doit couvrir.",
       "monthly_contribution": "Cotisation mensuelle",
       "monthly_contribution_hint": "Combien vous ajoutez chaque mois jusqu’à la retraite.",

--- a/apps/frontend/src/i18n/locales/ja/goals.json
+++ b/apps/frontend/src/i18n/locales/ja/goals.json
@@ -251,6 +251,8 @@
       "retirement_age": "退職年齢",
       "desired_retirement_age_hint": "経済的自立を達成したい年齢です。",
       "retirement_age_hint": "退職したい年齢です。",
+      "horizon_age_fire": "プラン終了年齢",
+      "horizon_age_traditional": "平均寿命",
       "horizon_hint": "プランがカバーする最終年齢です。",
       "monthly_contribution": "毎月の積立額",
       "monthly_contribution_hint": "退職まで毎月積み立てる金額です。",

--- a/apps/frontend/src/i18n/locales/ko/goals.json
+++ b/apps/frontend/src/i18n/locales/ko/goals.json
@@ -251,6 +251,8 @@
       "retirement_age": "은퇴 연령",
       "desired_retirement_age_hint": "경제적으로 자유로워지고 싶은 나이입니다.",
       "retirement_age_hint": "은퇴하고 싶은 나이입니다.",
+      "horizon_age_fire": "계획 종료 연령",
+      "horizon_age_traditional": "기대 수명",
       "horizon_hint": "계획이 대상으로 하는 최대 연령입니다.",
       "monthly_contribution": "월 납입액",
       "monthly_contribution_hint": "은퇴 전까지 매달 추가로 납입할 금액입니다.",

--- a/apps/frontend/src/i18n/locales/zh/goals.json
+++ b/apps/frontend/src/i18n/locales/zh/goals.json
@@ -251,6 +251,8 @@
       "retirement_age": "退休年龄",
       "desired_retirement_age_hint": "您希望实现财务独立的年龄。",
       "retirement_age_hint": "您希望退休的年龄。",
+      "horizon_age_fire": "计划终止年龄",
+      "horizon_age_traditional": "预期寿命",
       "horizon_hint": "计划应覆盖至的年龄。",
       "monthly_contribution": "每月供款",
       "monthly_contribution_hint": "退休前您每月增加的金额。",


### PR DESCRIPTION
fixes https://github.com/wealthfolio/wealthfolio/issues/1465

## Summary

- Replace `L.targetAge` and `L.horizonAge` (hardcoded English strings returned by `modeLabel()`) with direct `t()` calls in `sidebar-configurator.tsx`
- Add `horizon_age_fire` and `horizon_age_traditional` keys to `goals:sidebar.plan` in all 7 locale files

## Problem

In the retirement planner settings panel (*Paramètres du plan*), two labels were displayed in English regardless of the selected language:

- **"Desired retirement age"** (FIRE mode) / **"Retirement age"** (traditional mode)
- **"Plan through age"** (FIRE mode) / **"Life expectancy"** (traditional mode)

The root cause: `sidebar-configurator.tsx` consumed these labels from `modeLabel()`, a pure utility function that returns hardcoded English strings. Translation keys for `desired_retirement_age` and `retirement_age` already existed in `goals:sidebar.plan` but were unused in this context.

## Test plan

- [X] Switch app language to French — verify *"Âge de retraite souhaité"* and *"Horizon du plan"* appear in FIRE mode
- [X] Switch to traditional mode — verify *"Âge de retraite"* and *"Espérance de vie"* appear
- [X] Open the edit panel (LeverRow) — verify labels are translated in edit mode too
- [X] Verify EN is unchanged

## Validation

-  `cargo test -p wealthfolio-core`  — 1,741 unit tests plus 12 integration tests
- `cargo test -p wealthfolio-spending` — 102 tests
- `cargo test -p wealthfolio-connect` — 82 tests

## Checklist

- [X] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
