### PR TITLE
feat: add asset price alerts and in-app notifications

### DIFF
--- a/apps/frontend/src/adapters/shared/price-alerts.ts
+++ b/apps/frontend/src/adapters/shared/price-alerts.ts
@@ -1,0 +1,26 @@
+import type { NewPriceAlert, PriceAlert, PriceAlertEvent } from "@/lib/types";
+
+import { invoke } from "./platform";
+
+export const getPriceAlerts = (): Promise<PriceAlert[]> => invoke<PriceAlert[]>("get_price_alerts");
+
+export const getPriceAlertEvents = (unacknowledgedOnly = false): Promise<PriceAlertEvent[]> =>
+  invoke<PriceAlertEvent[]>("get_price_alert_events", { unacknowledgedOnly });
+
+export const getUnacknowledgedPriceAlertCount = (): Promise<number> =>
+  invoke<number>("get_unacknowledged_price_alert_count");
+
+export const createPriceAlert = (input: NewPriceAlert): Promise<PriceAlert> =>
+  invoke<PriceAlert>("create_price_alert", { input });
+
+export const pausePriceAlert = (id: string): Promise<PriceAlert> =>
+  invoke<PriceAlert>("pause_price_alert", { id });
+
+export const rearmPriceAlert = (id: string): Promise<PriceAlert> =>
+  invoke<PriceAlert>("rearm_price_alert", { id });
+
+export const deletePriceAlert = (id: string): Promise<void> =>
+  invoke<void>("delete_price_alert", { id });
+
+export const acknowledgePriceAlertEvents = (eventIds?: string[]): Promise<number> =>
+  invoke<number>("acknowledge_price_alert_events", { eventIds });

--- a/apps/frontend/src/adapters/tauri/events.ts
+++ b/apps/frontend/src/adapters/tauri/events.ts
@@ -85,6 +85,13 @@ export async function listenMarketSyncError<T>(handler: EventCallback<T>): Promi
   return adaptUnlisten(unlisten);
 }
 
+export async function listenPriceAlertsTriggered<T>(
+  handler: EventCallback<T>,
+): Promise<UnlistenFn> {
+  const unlisten = await listen<T>("price-alerts:triggered", adaptCallback(handler));
+  return adaptUnlisten(unlisten);
+}
+
 export async function listenAssetClassificationsChanged<T>(
   handler: EventCallback<T>,
 ): Promise<UnlistenFn> {

--- a/apps/frontend/src/adapters/tauri/index.ts
+++ b/apps/frontend/src/adapters/tauri/index.ts
@@ -96,6 +96,9 @@ export { parseCsv } from "./activities";
 // Portfolio Commands
 export * from "../shared/portfolio";
 
+// Price Alert Commands
+export * from "../shared/price-alerts";
+
 // Market Data Commands
 export * from "../shared/market-data";
 
@@ -225,6 +228,7 @@ export {
   listenPortfolioUpdateError,
   listenAssetClassificationsChanged,
   listenMarketSyncComplete,
+  listenPriceAlertsTriggered,
   listenMarketSyncStart,
   listenMarketSyncError,
   listenBrokerSyncStart,

--- a/apps/frontend/src/adapters/web/core.ts
+++ b/apps/frontend/src/adapters/web/core.ts
@@ -141,6 +141,21 @@ export const COMMANDS: CommandMap = {
   update_contribution_limit: { method: "PUT", path: "/limits" },
   delete_contribution_limit: { method: "DELETE", path: "/limits" },
   calculate_deposits_for_contribution_limit: { method: "GET", path: "/limits" },
+  // Price alerts
+  get_price_alerts: { method: "GET", path: "/price-alerts" },
+  create_price_alert: { method: "POST", path: "/price-alerts" },
+  pause_price_alert: { method: "POST", path: "/price-alerts" },
+  rearm_price_alert: { method: "POST", path: "/price-alerts" },
+  delete_price_alert: { method: "DELETE", path: "/price-alerts" },
+  get_price_alert_events: { method: "GET", path: "/price-alert-events" },
+  get_unacknowledged_price_alert_count: {
+    method: "GET",
+    path: "/price-alert-events/unread-count",
+  },
+  acknowledge_price_alert_events: {
+    method: "POST",
+    path: "/price-alert-events/acknowledge",
+  },
   // Asset profile
   get_assets: { method: "GET", path: "/assets" },
   create_asset: { method: "POST", path: "/assets" },
@@ -974,6 +989,34 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
     case "delete_contribution_limit": {
       const { id } = payload as { id: string };
       url += `/${encodeURIComponent(id)}`;
+      break;
+    }
+    case "create_price_alert": {
+      const { input } = payload as { input: Record<string, unknown> };
+      body = JSON.stringify(input);
+      break;
+    }
+    case "pause_price_alert":
+    case "rearm_price_alert":
+    case "delete_price_alert": {
+      const { id } = payload as { id: string };
+      const suffix =
+        command === "pause_price_alert"
+          ? "/pause"
+          : command === "rearm_price_alert"
+            ? "/rearm"
+            : "";
+      url += `/${encodeURIComponent(id)}${suffix}`;
+      break;
+    }
+    case "get_price_alert_events": {
+      const { unacknowledgedOnly } = payload as { unacknowledgedOnly?: boolean };
+      if (unacknowledgedOnly) url += "?unacknowledgedOnly=true";
+      break;
+    }
+    case "acknowledge_price_alert_events": {
+      const { eventIds } = payload as { eventIds?: string[] };
+      body = JSON.stringify({ eventIds });
       break;
     }
     case "create_asset": {

--- a/apps/frontend/src/adapters/web/events.ts
+++ b/apps/frontend/src/adapters/web/events.ts
@@ -144,6 +144,10 @@ export const listenMarketSyncError = <T>(handler: EventCallback<T>): Promise<Unl
   return portfolioEventBridge.listen("market:sync-error", handler);
 };
 
+export const listenPriceAlertsTriggered = <T>(handler: EventCallback<T>): Promise<UnlistenFn> => {
+  return portfolioEventBridge.listen("price-alerts:triggered", handler);
+};
+
 export const listenAssetClassificationsChanged = <T>(
   handler: EventCallback<T>,
 ): Promise<UnlistenFn> => {

--- a/apps/frontend/src/adapters/web/index.ts
+++ b/apps/frontend/src/adapters/web/index.ts
@@ -202,6 +202,9 @@ export {
   updatePortfolio,
 } from "../shared/portfolio";
 
+// Price Alert Commands
+export * from "../shared/price-alerts";
+
 // Market Data Commands
 export {
   checkQuotesImport,
@@ -407,6 +410,7 @@ export {
   listenFileDropCancelled,
   listenFileDropHover,
   listenMarketSyncComplete,
+  listenPriceAlertsTriggered,
   listenMarketSyncError,
   listenMarketSyncStart,
   listenNavigateToRoute,

--- a/apps/frontend/src/features/price-alerts/components/create-price-alert-dialog.tsx
+++ b/apps/frontend/src/features/price-alerts/components/create-price-alert-dialog.tsx
@@ -1,0 +1,263 @@
+import type { Asset, PriceAlertCondition } from "@/lib/types";
+import { useLatestQuotes } from "@/pages/asset/hooks/use-latest-quotes";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  SearchableSelect,
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  formatPrice,
+} from "@wealthfolio/ui";
+import { useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { usePriceAlertMutations, usePriceAlerts } from "../hooks/use-price-alerts";
+import {
+  PRICE_PRESETS,
+  conditionForPercent,
+  sanitizeTargetInput,
+  targetFromPercent,
+  validatePriceAlertTarget,
+} from "../lib/price-alert-form";
+
+interface CreatePriceAlertDialogProps {
+  assets: Asset[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initialAssetId?: string;
+}
+
+export function CreatePriceAlertDialog({
+  assets,
+  open,
+  onOpenChange,
+  initialAssetId,
+}: CreatePriceAlertDialogProps) {
+  const { t } = useTranslation();
+  const { createMutation } = usePriceAlertMutations();
+  const { data: existingAlerts = [] } = usePriceAlerts();
+  const [assetId, setAssetId] = useState(initialAssetId ?? "");
+  const [condition, setCondition] = useState<PriceAlertCondition>("ABOVE");
+  const [targetPrice, setTargetPrice] = useState("");
+  const [targetTouched, setTargetTouched] = useState(false);
+  const quoteAssetIds = useMemo(() => (assetId ? [assetId] : []), [assetId]);
+  const { data: latestQuotes = {} } = useLatestQuotes(quoteAssetIds);
+
+  useEffect(() => {
+    if (open) setAssetId(initialAssetId ?? "");
+  }, [initialAssetId, open]);
+
+  const options = useMemo(
+    () =>
+      assets.map((asset) => ({
+        value: asset.id,
+        label: [asset.displayCode ?? asset.instrumentSymbol, asset.name]
+          .filter(Boolean)
+          .join(" - "),
+      })),
+    [assets],
+  );
+  const selectedAsset = assets.find((asset) => asset.id === assetId);
+  const latestQuote = assetId ? latestQuotes[assetId]?.quote : undefined;
+  const currentPrice = latestQuote?.close;
+  const targetValidation = validatePriceAlertTarget({
+    assetId,
+    condition,
+    targetPrice,
+    currentPrice,
+    existingAlerts,
+  });
+  const isValid = Boolean(assetId) && !targetValidation.error;
+  const targetError =
+    (targetTouched || targetValidation.error === "DUPLICATE") && Boolean(targetValidation.error);
+  const assetIsFixed = Boolean(initialAssetId);
+
+  const reset = () => {
+    setAssetId(initialAssetId ?? "");
+    setCondition("ABOVE");
+    setTargetPrice("");
+    setTargetTouched(false);
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!isValid) return;
+    try {
+      await createMutation.mutateAsync({ assetId, condition, targetPrice: targetPrice.trim() });
+      reset();
+      onOpenChange(false);
+    } catch {
+      // The mutation displays the backend validation error and leaves the form editable.
+    }
+  };
+
+  const handlePreset = (percent: number) => {
+    if (currentPrice == null) return;
+    setCondition(conditionForPercent(percent));
+    setTargetPrice(targetFromPercent(currentPrice, percent));
+    setTargetTouched(false);
+  };
+
+  const handleTargetChange = (value: string) => {
+    setTargetPrice(sanitizeTargetInput(value));
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && !createMutation.isPending) reset();
+        onOpenChange(nextOpen);
+      }}
+    >
+      <DialogContent className="w-[calc(100vw-2rem)] max-w-md overflow-x-hidden">
+        <form onSubmit={handleSubmit} className="min-w-0 space-y-6">
+          <DialogHeader>
+            <DialogTitle>{t("common:price_alerts.create.title")}</DialogTitle>
+            <DialogDescription>{t("common:price_alerts.create.description")}</DialogDescription>
+          </DialogHeader>
+
+          <div className="min-w-0 space-y-2">
+            <Label>{t("common:price_alerts.create.asset")}</Label>
+            {assetIsFixed ? (
+              <div className="bg-muted/40 flex min-h-10 items-center rounded-md border px-3 text-sm">
+                <span className="truncate">
+                  {selectedAsset
+                    ? [
+                        selectedAsset.displayCode ?? selectedAsset.instrumentSymbol,
+                        selectedAsset.name,
+                      ]
+                        .filter(Boolean)
+                        .join(" - ")
+                    : t("common:price_alerts.create.select_asset")}
+                </span>
+                {selectedAsset && (
+                  <span className="text-muted-foreground ml-auto pl-3 text-xs">
+                    {selectedAsset.quoteCcy}
+                  </span>
+                )}
+              </div>
+            ) : (
+              <SearchableSelect
+                options={options}
+                value={assetId}
+                onValueChange={setAssetId}
+                placeholder={t("common:price_alerts.create.select_asset")}
+                searchPlaceholder={t("common:price_alerts.create.search_assets")}
+                emptyMessage={t("common:price_alerts.create.no_assets")}
+                className="w-full min-w-0"
+              />
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label>{t("common:price_alerts.create.condition")}</Label>
+            <Tabs
+              value={condition}
+              onValueChange={(value) => {
+                setCondition(value as PriceAlertCondition);
+                if (targetPrice) setTargetTouched(true);
+              }}
+            >
+              <TabsList className="grid w-full grid-cols-2">
+                <TabsTrigger value="ABOVE">{t("common:price_alerts.condition.above")}</TabsTrigger>
+                <TabsTrigger value="BELOW">{t("common:price_alerts.condition.below")}</TabsTrigger>
+              </TabsList>
+            </Tabs>
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <Label htmlFor="price-alert-target">{t("common:price_alerts.create.target")}</Label>
+              {latestQuote && (
+                <span className="text-muted-foreground text-xs tabular-nums">
+                  {t("common:price_alerts.create.latest_price", {
+                    price: formatPrice(latestQuote.close, latestQuote.currency),
+                  })}
+                </span>
+              )}
+            </div>
+            <div className="grid min-w-0 grid-cols-4 gap-2">
+              {PRICE_PRESETS.map((percent) => (
+                <Button
+                  key={percent}
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  disabled={currentPrice == null}
+                  onClick={() => handlePreset(percent)}
+                  className="min-w-0 px-2 tabular-nums"
+                >
+                  {percent > 0 ? `+${percent}%` : `${percent}%`}
+                </Button>
+              ))}
+            </div>
+            <div className="relative">
+              <Input
+                id="price-alert-target"
+                inputMode="decimal"
+                type="text"
+                value={targetPrice}
+                onBlur={() => setTargetTouched(true)}
+                onChange={(event) => handleTargetChange(event.target.value)}
+                placeholder="0.00"
+                aria-invalid={targetError}
+                className={`pr-16 tabular-nums ${targetError ? "border-destructive focus-visible:ring-destructive" : ""}`}
+              />
+              {selectedAsset && (
+                <span className="text-muted-foreground pointer-events-none absolute inset-y-0 right-3 flex items-center text-xs font-medium">
+                  {selectedAsset.quoteCcy}
+                </span>
+              )}
+            </div>
+            {targetError ? (
+              <p className="text-destructive text-xs">
+                {targetValidation.error === "REQUIRED"
+                  ? t("common:price_alerts.create.target_required")
+                  : targetValidation.error === "ALREADY_SATISFIED"
+                    ? t(
+                        condition === "ABOVE"
+                          ? "common:price_alerts.create.target_above_current"
+                          : "common:price_alerts.create.target_below_current",
+                        {
+                          price: currentPrice
+                            ? formatPrice(
+                                currentPrice,
+                                latestQuote?.currency ?? selectedAsset?.quoteCcy ?? "USD",
+                              )
+                            : "",
+                        },
+                      )
+                    : targetValidation.error === "DUPLICATE"
+                      ? t("common:price_alerts.create.duplicate")
+                      : t("common:price_alerts.create.target_invalid")}
+              </p>
+            ) : (
+              <p className="text-muted-foreground text-xs">
+                {t("common:price_alerts.create.one_shot_hint")}
+              </p>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              {t("common:cancel")}
+            </Button>
+            <Button type="submit" disabled={!isValid || createMutation.isPending}>
+              {createMutation.isPending
+                ? t("common:price_alerts.create.creating")
+                : t("common:price_alerts.create.submit")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/frontend/src/features/price-alerts/hooks/use-price-alerts.ts
+++ b/apps/frontend/src/features/price-alerts/hooks/use-price-alerts.ts
@@ -1,0 +1,100 @@
+import {
+  acknowledgePriceAlertEvents,
+  createPriceAlert,
+  deletePriceAlert,
+  getPriceAlertEvents,
+  getPriceAlerts,
+  getUnacknowledgedPriceAlertCount,
+  pausePriceAlert,
+  rearmPriceAlert,
+} from "@/adapters";
+import { QueryKeys } from "@/lib/query-keys";
+import type { NewPriceAlert, PriceAlert, PriceAlertEvent } from "@/lib/types";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+
+export const priceAlertQueryKeys = {
+  alerts: [QueryKeys.PRICE_ALERTS] as const,
+  events: [QueryKeys.PRICE_ALERT_EVENTS] as const,
+  unreadCount: [QueryKeys.PRICE_ALERT_UNREAD_COUNT] as const,
+};
+
+export function usePriceAlerts() {
+  return useQuery<PriceAlert[], Error>({
+    queryKey: priceAlertQueryKeys.alerts,
+    queryFn: getPriceAlerts,
+  });
+}
+
+export function usePriceAlertEvents(unacknowledgedOnly = false) {
+  return useQuery<PriceAlertEvent[], Error>({
+    queryKey: [...priceAlertQueryKeys.events, { unacknowledgedOnly }],
+    queryFn: () => getPriceAlertEvents(unacknowledgedOnly),
+  });
+}
+
+export function usePriceAlertUnreadCount() {
+  return useQuery<number, Error>({
+    queryKey: priceAlertQueryKeys.unreadCount,
+    queryFn: getUnacknowledgedPriceAlertCount,
+  });
+}
+
+export function usePriceAlertMutations() {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+
+  const invalidateAll = () => {
+    void queryClient.invalidateQueries({ queryKey: priceAlertQueryKeys.alerts });
+    void queryClient.invalidateQueries({ queryKey: priceAlertQueryKeys.events });
+    void queryClient.invalidateQueries({ queryKey: priceAlertQueryKeys.unreadCount });
+  };
+
+  const createMutation = useMutation({
+    mutationFn: (input: NewPriceAlert) => createPriceAlert(input),
+    onSuccess: () => {
+      invalidateAll();
+      toast.success(t("common:price_alerts.toast.created"));
+    },
+    onError: (error) =>
+      toast.error(t("common:price_alerts.toast.create_failed"), {
+        description: error instanceof Error ? error.message : String(error),
+      }),
+  });
+
+  const pauseMutation = useMutation({
+    mutationFn: (id: string) => pausePriceAlert(id),
+    onSuccess: invalidateAll,
+    onError: () => toast.error(t("common:price_alerts.toast.update_failed")),
+  });
+
+  const rearmMutation = useMutation({
+    mutationFn: (id: string) => rearmPriceAlert(id),
+    onSuccess: () => {
+      invalidateAll();
+      toast.success(t("common:price_alerts.toast.rearmed"));
+    },
+    onError: () => toast.error(t("common:price_alerts.toast.update_failed")),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => deletePriceAlert(id),
+    onSuccess: invalidateAll,
+    onError: () => toast.error(t("common:price_alerts.toast.delete_failed")),
+  });
+
+  const acknowledgeMutation = useMutation({
+    mutationFn: (eventIds?: string[]) => acknowledgePriceAlertEvents(eventIds),
+    onSuccess: invalidateAll,
+    onError: () => toast.error(t("common:price_alerts.toast.update_failed")),
+  });
+
+  return {
+    createMutation,
+    pauseMutation,
+    rearmMutation,
+    deleteMutation,
+    acknowledgeMutation,
+  };
+}

--- a/apps/frontend/src/features/price-alerts/lib/price-alert-form.test.ts
+++ b/apps/frontend/src/features/price-alerts/lib/price-alert-form.test.ts
@@ -1,0 +1,68 @@
+import type { PriceAlert } from "@/lib/types";
+import { describe, expect, it } from "vitest";
+import {
+  conditionForPercent,
+  sanitizeTargetInput,
+  targetFromPercent,
+  validatePriceAlertTarget,
+} from "./price-alert-form";
+
+function alert(overrides: Partial<PriceAlert> = {}): PriceAlert {
+  return {
+    id: "alert-1",
+    assetId: "asset-1",
+    condition: "ABOVE",
+    targetPrice: "105",
+    currency: "USD",
+    status: "ACTIVE",
+    armedAt: "2026-08-16T12:00:00Z",
+    armedMarketDate: "2026-08-16",
+    createdAt: "2026-08-16T12:00:00Z",
+    updatedAt: "2026-08-16T12:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("price alert form rules", () => {
+  it("calculates percentage presets and their directions", () => {
+    expect(targetFromPercent(84.33, -10)).toBe("75.9");
+    expect(targetFromPercent(84.33, 5)).toBe("88.55");
+    expect(conditionForPercent(-5)).toBe("BELOW");
+    expect(conditionForPercent(10)).toBe("ABOVE");
+  });
+
+  it("preserves one decimal separator while sanitizing input", () => {
+    expect(sanitizeTargetInput("$1,234.5.6abc")).toBe("1234.56");
+  });
+
+  it("rejects empty, non-positive, and already-satisfied targets", () => {
+    const validate = (condition: "ABOVE" | "BELOW", targetPrice: string) =>
+      validatePriceAlertTarget({
+        assetId: "asset-1",
+        condition,
+        targetPrice,
+        currentPrice: 100,
+        existingAlerts: [],
+      }).error;
+
+    expect(validate("ABOVE", "")).toBe("REQUIRED");
+    expect(validate("ABOVE", "0")).toBe("INVALID");
+    expect(validate("ABOVE", "90")).toBe("ALREADY_SATISFIED");
+    expect(validate("BELOW", "110")).toBe("ALREADY_SATISFIED");
+  });
+
+  it("blocks only an identical asset, direction, and target", () => {
+    const existingAlerts = [alert()];
+    const validate = (targetPrice: string) =>
+      validatePriceAlertTarget({
+        assetId: "asset-1",
+        condition: "ABOVE",
+        targetPrice,
+        currentPrice: 100,
+        existingAlerts,
+      }).error;
+
+    expect(validate("105.00")).toBe("DUPLICATE");
+    expect(validate("110")).toBeUndefined();
+  });
+});

--- a/apps/frontend/src/features/price-alerts/lib/price-alert-form.ts
+++ b/apps/frontend/src/features/price-alerts/lib/price-alert-form.ts
@@ -1,0 +1,61 @@
+import type { PriceAlert, PriceAlertCondition } from "@/lib/types";
+
+export const PRICE_PRESETS = [-10, -5, 5, 10] as const;
+
+export type PriceAlertTargetError = "REQUIRED" | "INVALID" | "ALREADY_SATISFIED" | "DUPLICATE";
+
+export function targetFromPercent(currentPrice: number, percent: number) {
+  const target = currentPrice * (1 + percent / 100);
+  const precision = target < 1 ? 6 : 2;
+  return target.toFixed(precision).replace(/\.?0+$/, "");
+}
+
+export function conditionForPercent(percent: number): PriceAlertCondition {
+  return percent < 0 ? "BELOW" : "ABOVE";
+}
+
+export function sanitizeTargetInput(value: string) {
+  const sanitized = value.replace(/[^0-9.]/g, "");
+  const [whole, ...fractionParts] = sanitized.split(".");
+  return fractionParts.length > 0 ? `${whole}.${fractionParts.join("")}` : whole;
+}
+
+interface ValidateTargetInput {
+  assetId: string;
+  condition: PriceAlertCondition;
+  targetPrice: string;
+  currentPrice?: number;
+  existingAlerts: PriceAlert[];
+}
+
+export function validatePriceAlertTarget({
+  assetId,
+  condition,
+  targetPrice,
+  currentPrice,
+  existingAlerts,
+}: ValidateTargetInput): { parsedTarget: number; error?: PriceAlertTargetError } {
+  if (targetPrice.trim().length === 0) {
+    return { parsedTarget: Number.NaN, error: "REQUIRED" };
+  }
+
+  const parsedTarget = Number(targetPrice);
+  if (!Number.isFinite(parsedTarget) || parsedTarget <= 0) {
+    return { parsedTarget, error: "INVALID" };
+  }
+
+  if (
+    currentPrice != null &&
+    (condition === "ABOVE" ? parsedTarget <= currentPrice : parsedTarget >= currentPrice)
+  ) {
+    return { parsedTarget, error: "ALREADY_SATISFIED" };
+  }
+
+  const duplicate = existingAlerts.some(
+    (alert) =>
+      alert.assetId === assetId &&
+      alert.condition === condition &&
+      Number(alert.targetPrice) === parsedTarget,
+  );
+  return duplicate ? { parsedTarget, error: "DUPLICATE" } : { parsedTarget };
+}

--- a/apps/frontend/src/features/price-alerts/pages/price-alerts-page.tsx
+++ b/apps/frontend/src/features/price-alerts/pages/price-alerts-page.tsx
@@ -1,0 +1,308 @@
+import { useAssets } from "@/pages/asset/hooks/use-assets";
+import type { Asset, PriceAlert, PriceAlertEvent } from "@/lib/types";
+import { formatDateTime } from "@/lib/utils";
+import {
+  Badge,
+  Button,
+  Page,
+  PageContent,
+  PageHeader,
+  Skeleton,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  formatPrice,
+} from "@wealthfolio/ui";
+import { Icons } from "@wealthfolio/ui/components/ui/icons";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { CreatePriceAlertDialog } from "../components/create-price-alert-dialog";
+import {
+  usePriceAlertEvents,
+  usePriceAlertMutations,
+  usePriceAlerts,
+} from "../hooks/use-price-alerts";
+
+function assetLabel(asset?: Asset) {
+  if (!asset) return "-";
+  return asset.displayCode ?? asset.instrumentSymbol ?? asset.name ?? asset.id;
+}
+
+function timestampLabel(value: string) {
+  const formatted = formatDateTime(value);
+  return `${formatted.date} ${formatted.time}`;
+}
+
+function Target({ alert }: { alert: PriceAlert }) {
+  const { t } = useTranslation();
+  return (
+    <span className="font-medium tabular-nums">
+      {t(`common:price_alerts.condition.${alert.condition.toLowerCase()}`)}{" "}
+      {formatPrice(alert.targetPrice, alert.currency)}
+    </span>
+  );
+}
+
+function EmptyState({ triggered }: { triggered?: boolean }) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 py-20 text-center">
+      <Icons.Bell className="text-muted-foreground h-8 w-8" />
+      <div>
+        <p className="font-medium">
+          {t(
+            triggered
+              ? "common:price_alerts.empty.triggered_title"
+              : "common:price_alerts.empty.active_title",
+          )}
+        </p>
+        <p className="text-muted-foreground mt-1 text-sm">
+          {t(
+            triggered
+              ? "common:price_alerts.empty.triggered_description"
+              : "common:price_alerts.empty.active_description",
+          )}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default function PriceAlertsPage() {
+  const { t } = useTranslation();
+  const { assets, isLoading: assetsLoading } = useAssets();
+  const alertsQuery = usePriceAlerts();
+  const eventsQuery = usePriceAlertEvents();
+  const { pauseMutation, rearmMutation, deleteMutation, acknowledgeMutation } =
+    usePriceAlertMutations();
+  const [createOpen, setCreateOpen] = useState(false);
+
+  const assetsById = useMemo(() => new Map(assets.map((asset) => [asset.id, asset])), [assets]);
+  const alertsById = useMemo(
+    () => new Map((alertsQuery.data ?? []).map((alert) => [alert.id, alert])),
+    [alertsQuery.data],
+  );
+  const managedAlerts = (alertsQuery.data ?? []).filter((alert) => alert.status !== "TRIGGERED");
+  const events = eventsQuery.data ?? [];
+  const unreadEvents = events.filter((event) => !event.acknowledgedAt);
+  const isLoading = assetsLoading || alertsQuery.isLoading || eventsQuery.isLoading;
+
+  return (
+    <Page>
+      <PageHeader
+        heading={t("common:price_alerts.title")}
+        text={t("common:price_alerts.subtitle")}
+        actions={
+          <Button size="sm" onClick={() => setCreateOpen(true)}>
+            <Icons.Plus className="mr-2 h-4 w-4" />
+            {t("common:price_alerts.new_alert")}
+          </Button>
+        }
+      />
+      <PageContent>
+        {isLoading ? (
+          <div className="space-y-3">
+            <Skeleton className="h-10 w-64" />
+            <Skeleton className="h-64 w-full" />
+          </div>
+        ) : (
+          <Tabs defaultValue="active">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <TabsList>
+                <TabsTrigger value="active">
+                  {t("common:price_alerts.tabs.active")}
+                  <Badge variant="secondary" className="ml-1 px-1.5 py-0 text-[10px]">
+                    {managedAlerts.length}
+                  </Badge>
+                </TabsTrigger>
+                <TabsTrigger value="triggered">
+                  {t("common:price_alerts.tabs.triggered")}
+                  {unreadEvents.length > 0 && (
+                    <Badge className="ml-1 px-1.5 py-0 text-[10px]">{unreadEvents.length}</Badge>
+                  )}
+                </TabsTrigger>
+              </TabsList>
+              {unreadEvents.length > 0 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => acknowledgeMutation.mutate(unreadEvents.map((event) => event.id))}
+                  disabled={acknowledgeMutation.isPending}
+                >
+                  <Icons.Check className="mr-2 h-4 w-4" />
+                  {t("common:price_alerts.mark_all_read")}
+                </Button>
+              )}
+            </div>
+
+            <TabsContent value="active" className="mt-5">
+              {managedAlerts.length === 0 ? (
+                <EmptyState />
+              ) : (
+                <div className="overflow-x-auto rounded-md border">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>{t("common:price_alerts.columns.asset")}</TableHead>
+                        <TableHead>{t("common:price_alerts.columns.target")}</TableHead>
+                        <TableHead>{t("common:price_alerts.columns.status")}</TableHead>
+                        <TableHead>{t("common:price_alerts.columns.created")}</TableHead>
+                        <TableHead className="w-28 text-right">
+                          {t("common:price_alerts.columns.actions")}
+                        </TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {managedAlerts.map((alert) => (
+                        <TableRow key={alert.id}>
+                          <TableCell>
+                            <div className="font-medium">
+                              {assetLabel(assetsById.get(alert.assetId))}
+                            </div>
+                            <div className="text-muted-foreground text-xs">
+                              {assetsById.get(alert.assetId)?.name}
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            <Target alert={alert} />
+                          </TableCell>
+                          <TableCell>
+                            <Badge variant={alert.status === "ACTIVE" ? "default" : "secondary"}>
+                              {t(`common:price_alerts.status.${alert.status.toLowerCase()}`)}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="text-muted-foreground whitespace-nowrap text-sm">
+                            {timestampLabel(alert.createdAt)}
+                          </TableCell>
+                          <TableCell>
+                            <div className="flex justify-end gap-1">
+                              {alert.status === "ACTIVE" ? (
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  title={t("common:price_alerts.actions.pause")}
+                                  onClick={() => pauseMutation.mutate(alert.id)}
+                                >
+                                  <Icons.Pause className="h-4 w-4" />
+                                </Button>
+                              ) : (
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  title={t("common:price_alerts.actions.rearm")}
+                                  onClick={() => rearmMutation.mutate(alert.id)}
+                                >
+                                  <Icons.RotateCcw className="h-4 w-4" />
+                                </Button>
+                              )}
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                title={t("common:delete")}
+                                onClick={() => deleteMutation.mutate(alert.id)}
+                              >
+                                <Icons.Trash2 className="text-destructive h-4 w-4" />
+                              </Button>
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+            </TabsContent>
+
+            <TabsContent value="triggered" className="mt-5">
+              {events.length === 0 ? (
+                <EmptyState triggered />
+              ) : (
+                <div className="overflow-x-auto rounded-md border">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead>{t("common:price_alerts.columns.asset")}</TableHead>
+                        <TableHead>{t("common:price_alerts.columns.target")}</TableHead>
+                        <TableHead>{t("common:price_alerts.columns.observed")}</TableHead>
+                        <TableHead>{t("common:price_alerts.columns.triggered")}</TableHead>
+                        <TableHead className="w-28 text-right">
+                          {t("common:price_alerts.columns.actions")}
+                        </TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {events.map((event: PriceAlertEvent) => {
+                        const alert = alertsById.get(event.alertId);
+                        return (
+                          <TableRow
+                            key={event.id}
+                            className={!event.acknowledgedAt ? "bg-muted/30" : undefined}
+                          >
+                            <TableCell>
+                              <div className="flex items-center gap-2 font-medium">
+                                {!event.acknowledgedAt && (
+                                  <span className="bg-primary h-2 w-2 rounded-full" />
+                                )}
+                                {assetLabel(assetsById.get(event.assetId))}
+                              </div>
+                            </TableCell>
+                            <TableCell className="font-medium tabular-nums">
+                              {alert ? (
+                                <Target alert={alert} />
+                              ) : (
+                                formatPrice(event.targetPrice, event.currency)
+                              )}
+                            </TableCell>
+                            <TableCell className="tabular-nums">
+                              {formatPrice(event.observedClose, event.currency)}
+                            </TableCell>
+                            <TableCell className="text-muted-foreground whitespace-nowrap text-sm">
+                              {timestampLabel(event.triggeredAt)}
+                            </TableCell>
+                            <TableCell>
+                              <div className="flex justify-end gap-1">
+                                {!event.acknowledgedAt && (
+                                  <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    title={t("common:price_alerts.actions.mark_read")}
+                                    onClick={() => acknowledgeMutation.mutate([event.id])}
+                                  >
+                                    <Icons.Check className="h-4 w-4" />
+                                  </Button>
+                                )}
+                                {alert && (
+                                  <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    title={t("common:price_alerts.actions.rearm")}
+                                    onClick={() => rearmMutation.mutate(alert.id)}
+                                  >
+                                    <Icons.RotateCcw className="h-4 w-4" />
+                                  </Button>
+                                )}
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+            </TabsContent>
+          </Tabs>
+        )}
+      </PageContent>
+
+      <CreatePriceAlertDialog assets={assets} open={createOpen} onOpenChange={setCreateOpen} />
+    </Page>
+  );
+}

--- a/apps/frontend/src/i18n/locales/en/common.json
+++ b/apps/frontend/src/i18n/locales/en/common.json
@@ -63,6 +63,77 @@
   "login": "Login",
   "income": "Income",
   "dashboard": "Dashboard",
+  "price_alerts": {
+    "title": "Price Alerts",
+    "subtitle": "Track price targets for your investments.",
+    "nav_label": "Monitor investment price targets",
+    "new_alert": "New alert",
+    "mark_all_read": "Mark all read",
+    "tabs": {
+      "active": "Managed",
+      "triggered": "Triggered"
+    },
+    "condition": {
+      "above": "At or above",
+      "below": "At or below"
+    },
+    "status": {
+      "active": "Active",
+      "triggered": "Triggered",
+      "paused": "Paused"
+    },
+    "columns": {
+      "asset": "Investment",
+      "target": "Target",
+      "status": "Status",
+      "created": "Created",
+      "observed": "Closing price",
+      "triggered": "Triggered",
+      "actions": "Actions"
+    },
+    "create": {
+      "title": "Create price alert",
+      "description": "You will be notified after fresh market data reaches this price.",
+      "asset": "Investment",
+      "select_asset": "Select an investment",
+      "search_assets": "Search investments...",
+      "no_assets": "No market-priced investments found.",
+      "condition": "Trigger when price is",
+      "target": "Target price",
+      "latest_price": "Latest: {{price}}",
+      "target_required": "Enter a target price.",
+      "target_invalid": "Enter a price greater than zero.",
+      "target_above_current": "For an upward alert, enter a target above {{price}}.",
+      "target_below_current": "For a downward alert, enter a target below {{price}}.",
+      "duplicate": "An identical price alert already exists.",
+      "one_shot_hint": "This alert triggers once and then moves to Triggered.",
+      "creating": "Creating...",
+      "submit": "Create alert"
+    },
+    "actions": {
+      "pause": "Pause alert",
+      "rearm": "Re-arm alert",
+      "mark_read": "Mark as read"
+    },
+    "empty": {
+      "active_title": "No managed alerts",
+      "active_description": "Create an alert for an investment you want to watch.",
+      "triggered_title": "No triggered alerts",
+      "triggered_description": "Triggered price targets will appear here."
+    },
+    "toast": {
+      "created": "Price alert created.",
+      "rearmed": "Price alert re-armed.",
+      "create_failed": "Could not create price alert.",
+      "update_failed": "Could not update price alert.",
+      "delete_failed": "Could not delete price alert.",
+      "triggered_one": "A price alert was triggered",
+      "triggered_other": "{{count}} price alerts were triggered",
+      "unread_one": "You have an unread price alert",
+      "unread_other": "You have {{count}} unread price alerts",
+      "view": "View alerts"
+    }
+  },
   "symbol": "Symbol",
   "shares": "Shares",
   "fee": "Fee",

--- a/apps/frontend/src/lib/query-keys.ts
+++ b/apps/frontend/src/lib/query-keys.ts
@@ -60,6 +60,9 @@ export const QueryKeys = {
   ASSET_DATA: "asset_data",
   ASSETS: "assets",
   LATEST_QUOTES: "latest_quotes",
+  PRICE_ALERTS: "priceAlerts",
+  PRICE_ALERT_EVENTS: "priceAlertEvents",
+  PRICE_ALERT_UNREAD_COUNT: "priceAlertUnreadCount",
   IMPORT_MAPPING: "import_mapping",
   IMPORT_TEMPLATES: "import_templates",
 

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -809,6 +809,44 @@ export interface Asset {
   updatedAt: string; // ISO date string
 }
 
+export type PriceAlertCondition = "ABOVE" | "BELOW";
+export type PriceAlertStatus = "ACTIVE" | "TRIGGERED" | "PAUSED";
+
+export interface PriceAlert {
+  id: string;
+  assetId: string;
+  condition: PriceAlertCondition;
+  targetPrice: string;
+  currency: string;
+  status: PriceAlertStatus;
+  armedAt: string;
+  armedMarketDate: string;
+  pauseReason?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface NewPriceAlert {
+  assetId: string;
+  condition: PriceAlertCondition;
+  targetPrice: string;
+}
+
+export interface PriceAlertEvent {
+  id: string;
+  alertId: string;
+  assetId: string;
+  quoteId: string;
+  targetPrice: string;
+  observedClose: string;
+  observedHigh: string;
+  observedLow: string;
+  currency: string;
+  quoteTimestamp: string;
+  triggeredAt: string;
+  acknowledgedAt?: string | null;
+}
+
 export interface Quote {
   id: string;
   createdAt: string;

--- a/apps/frontend/src/pages/asset/asset-profile-page.tsx
+++ b/apps/frontend/src/pages/asset/asset-profile-page.tsx
@@ -55,6 +55,7 @@ import { useAssetProfileMutations } from "./hooks/use-asset-profile-mutations";
 import { RefreshQuotesConfirmDialog } from "./refresh-quotes-confirm-dialog";
 import { useQuoteMutations } from "./hooks/use-quote-mutations";
 import { QuoteHistoryDataGrid } from "./quote-history-data-grid";
+import { CreatePriceAlertDialog } from "@/features/price-alerts/components/create-price-alert-dialog";
 
 // Alternative asset kinds that should use ValueHistoryDataGrid
 const ALTERNATIVE_ASSET_KINDS: AssetKind[] = [
@@ -1029,6 +1030,7 @@ export const AssetProfilePage = () => {
 
   const isLoading = isHoldingLoading || isQuotesLoading || isAssetProfileLoading;
   const [refreshConfirmOpen, setRefreshConfirmOpen] = useState(false);
+  const [priceAlertOpen, setPriceAlertOpen] = useState(false);
 
   const handleUpdateQuotes = useCallback(() => {
     if (!profile?.id) return;
@@ -1232,6 +1234,17 @@ export const AssetProfilePage = () => {
         onBack={handleBack}
         actions={
           <div className="flex items-center gap-2">
+            {!isAltAsset && (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPriceAlertOpen(true)}
+                title={t("common:price_alerts.create.title")}
+              >
+                <Icons.Bell className="mr-2 h-4 w-4" />
+                <span className="hidden sm:inline">{t("common:price_alerts.new_alert")}</span>
+              </Button>
+            )}
             {isAltAsset && (
               <div className="hidden sm:flex">
                 <AnimatedToggleGroup
@@ -1412,6 +1425,14 @@ export const AssetProfilePage = () => {
           </div>
         </div>
       </PageHeader>
+      {assetProfile && !isAltAsset && (
+        <CreatePriceAlertDialog
+          assets={[assetProfile]}
+          initialAssetId={assetProfile.id}
+          open={priceAlertOpen}
+          onOpenChange={setPriceAlertOpen}
+        />
+      )}
       <PageContent>
         <AssetHealthBanner
           context={healthContext}

--- a/apps/frontend/src/pages/layouts/navigation/app-navigation.tsx
+++ b/apps/frontend/src/pages/layouts/navigation/app-navigation.tsx
@@ -56,6 +56,13 @@ function buildStaticNavigation(t: TFunction): NavigationProps {
         label: t("common:nav.label_activities"),
       },
       {
+        icon: <Icons.Bell className="size-6" />,
+        title: t("common:price_alerts.title"),
+        href: "/alerts",
+        keywords: ["alerts", "prices", "targets", "buy", "sell"],
+        label: t("common:price_alerts.nav_label"),
+      },
+      {
         icon: <Icons.Goals className="size-6" />,
         title: t("common:goals"),
         href: "/goals",

--- a/apps/frontend/src/routes.tsx
+++ b/apps/frontend/src/routes.tsx
@@ -54,6 +54,7 @@ import GoalsDashboardPage from "@/features/goals/pages/goals-dashboard-page";
 import GoalNewPage from "@/features/goals/pages/goal-new-page";
 import GoalDetailPage from "@/features/goals/pages/goal-detail-page";
 import GoalRetirementGuidePage from "@/features/goals/pages/goal-retirement-guide-page";
+import PriceAlertsPage from "@/features/price-alerts/pages/price-alerts-page";
 
 function NavigationEventBridge() {
   useNavigationEventListener();
@@ -102,6 +103,7 @@ export function AppRoutes() {
           <Route path="activities" element={<ActivityPage />} />
           <Route path="activities/manage" element={<ActivityManagerPage />} />
           <Route path="holdings" element={<HoldingsPage />} />
+          <Route path="alerts" element={<PriceAlertsPage />} />
           <Route path="holdings/:assetId" element={<AssetProfilePage />} />
           <Route path="import" element={<ActivityImportPage />} />
           <Route path="accounts/:id" element={<AccountPage />} />

--- a/apps/frontend/src/use-global-event-listener.ts
+++ b/apps/frontend/src/use-global-event-listener.ts
@@ -1,6 +1,7 @@
 // useGlobalEventListener.ts
 import {
   isDesktop,
+  getPriceAlertEvents,
   listenAssetClassificationsChanged,
   listenBrokerSyncComplete,
   listenBrokerSyncError,
@@ -11,6 +12,7 @@ import {
   listenPortfolioUpdateComplete,
   listenPortfolioUpdateError,
   listenPortfolioUpdateStart,
+  listenPriceAlertsTriggered,
   logger,
   updatePortfolio,
 } from "@/adapters";
@@ -21,6 +23,8 @@ import {
   shouldInvalidateAfterPortfolioUpdate,
   type AssetClassificationsChangedPayload,
 } from "@/lib/query-invalidation";
+import { QueryKeys } from "@/lib/query-keys";
+import type { PriceAlertEvent } from "@/lib/types";
 import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -33,6 +37,7 @@ const TOAST_IDS = {
   portfolioUpdateStart: "portfolio-update-start",
   portfolioUpdateError: "portfolio-update-error",
   portfolioInvalidSnapshotError: "portfolio-invalid-snapshot-error",
+  priceAlertsUnread: "price-alerts-unread",
 
   brokerSyncStart: "broker-sync-start",
 } as const;
@@ -62,6 +67,8 @@ const useGlobalEventListener = () => {
   const navigate = useNavigate();
   const [areListenersReady, setAreListenersReady] = useState(false);
   const hasTriggeredInitialUpdate = useRef(false);
+  const hasShownInitialAlertSummary = useRef(false);
+  const shownPriceAlertEventIds = useRef(new Set<string>());
   const isDesktopEnv = isDesktop;
   const isMobileViewport = useIsMobileViewport();
   const syncContext = usePortfolioSyncOptional();
@@ -218,6 +225,62 @@ const useGlobalEventListener = () => {
       logger.error("Portfolio Update Error: " + errorMessage);
     };
 
+    const showInitialUnreadPriceAlerts = async () => {
+      if (hasShownInitialAlertSummary.current) return;
+      hasShownInitialAlertSummary.current = true;
+
+      try {
+        const unreadEvents = await getPriceAlertEvents(true);
+        const unseenEvents = unreadEvents.filter(
+          (event) => !shownPriceAlertEventIds.current.has(event.id),
+        );
+        if (unseenEvents.length === 0) return;
+
+        toast.info(
+          translationRef.current("common:price_alerts.toast.unread", {
+            count: unseenEvents.length,
+          }),
+          {
+            id: TOAST_IDS.priceAlertsUnread,
+            duration: Infinity,
+            action: {
+              label: translationRef.current("common:price_alerts.toast.view"),
+              onClick: () => navigateRef.current("/alerts"),
+            },
+          },
+        );
+      } catch (error) {
+        logger.warn("Failed to load unread price alerts: " + String(error));
+      }
+    };
+
+    const handlePriceAlertsTriggered = (event: { payload: PriceAlertEvent[] | null }) => {
+      const triggeredEvents = Array.isArray(event.payload) ? event.payload : [];
+      if (triggeredEvents.length === 0) return;
+
+      triggeredEvents.forEach((triggeredEvent) =>
+        shownPriceAlertEventIds.current.add(triggeredEvent.id),
+      );
+      void queryClientRef.current.invalidateQueries({ queryKey: [QueryKeys.PRICE_ALERTS] });
+      void queryClientRef.current.invalidateQueries({ queryKey: [QueryKeys.PRICE_ALERT_EVENTS] });
+      void queryClientRef.current.invalidateQueries({
+        queryKey: [QueryKeys.PRICE_ALERT_UNREAD_COUNT],
+      });
+
+      toast.info(
+        translationRef.current("common:price_alerts.toast.triggered", {
+          count: triggeredEvents.length,
+        }),
+        {
+          duration: Infinity,
+          action: {
+            label: translationRef.current("common:price_alerts.toast.view"),
+            onClick: () => navigateRef.current("/alerts"),
+          },
+        },
+      );
+    };
+
     const handlePortfolioUpdateComplete = () => {
       if (isMobileViewportRef.current && syncContextRef.current) {
         syncContextRef.current.setIdle();
@@ -227,6 +290,7 @@ const useGlobalEventListener = () => {
       queryClientRef.current.invalidateQueries({
         predicate: (query) => shouldInvalidateAfterPortfolioUpdate(query.queryKey),
       });
+      void showInitialUnreadPriceAlerts();
     };
 
     const handleDatabaseRestored = () => {
@@ -358,6 +422,7 @@ const useGlobalEventListener = () => {
         ["market-sync-start", listenMarketSyncStart(handleMarketSyncStart)],
         ["market-sync-complete", listenMarketSyncComplete(handleMarketSyncComplete)],
         ["market-sync-error", listenMarketSyncError(handleMarketSyncError)],
+        ["price-alerts-triggered", listenPriceAlertsTriggered(handlePriceAlertsTriggered)],
         [
           "asset-classifications-changed",
           listenAssetClassificationsChanged(handleAssetClassificationsChanged),

--- a/apps/server/src/api.rs
+++ b/apps/server/src/api.rs
@@ -58,6 +58,7 @@ mod net_worth;
 mod performance;
 mod portfolio;
 mod portfolios;
+mod price_alerts;
 mod secrets;
 mod settings;
 pub mod shared;
@@ -140,6 +141,7 @@ pub fn app_router(state: Arc<AppState>, config: &Config) -> Router {
     let mut protected_api = Router::new()
         .merge(accounts::router())
         .merge(portfolios::router())
+        .merge(price_alerts::router())
         .merge(settings::router())
         .merge(data_exports::router())
         .merge(database_backups::router())

--- a/apps/server/src/api/market_data.rs
+++ b/apps/server/src/api/market_data.rs
@@ -120,7 +120,20 @@ async fn update_quote(
 ) -> ApiResult<StatusCode> {
     // Ensure asset_id matches path parameter
     quote.asset_id = symbol;
+    let asset_id = quote.asset_id.clone();
     state.quote_service.update_quote(quote).await?;
+    let events = state
+        .price_alert_service
+        .evaluate(Some(vec![asset_id]))
+        .await?;
+    if !events.is_empty() {
+        state
+            .event_bus
+            .publish(crate::events::ServerEvent::with_payload(
+                crate::events::PRICE_ALERTS_TRIGGERED,
+                serde_json::json!(events),
+            ));
+    }
     // Manual quote update - no market sync needed, but force full recalculation
     // so historical valuations are recomputed with the updated quotes
     enqueue_portfolio_job(
@@ -197,6 +210,15 @@ async fn import_quotes_csv(
         .quote_service
         .import_quotes(body.quotes, body.overwrite_existing)
         .await?;
+    let events = state.price_alert_service.evaluate(None).await?;
+    if !events.is_empty() {
+        state
+            .event_bus
+            .publish(crate::events::ServerEvent::with_payload(
+                crate::events::PRICE_ALERTS_TRIGGERED,
+                serde_json::json!(events),
+            ));
+    }
 
     // Quote import - no market sync needed, but force full recalculation
     // so historical valuations are recomputed with the imported quotes

--- a/apps/server/src/api/price_alerts.rs
+++ b/apps/server/src/api/price_alerts.rs
@@ -1,0 +1,98 @@
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    routing::{delete, get, post},
+    Json, Router,
+};
+use serde::Deserialize;
+use wealthfolio_core::price_alerts::{NewPriceAlert, PriceAlert, PriceAlertEvent};
+
+use crate::{error::ApiResult, main_lib::AppState};
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EventQuery {
+    #[serde(default)]
+    unacknowledged_only: bool,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AcknowledgeBody {
+    event_ids: Option<Vec<String>>,
+}
+
+async fn list_alerts(State(state): State<Arc<AppState>>) -> ApiResult<Json<Vec<PriceAlert>>> {
+    Ok(Json(state.price_alert_service.get_alerts()?))
+}
+
+async fn create_alert(
+    State(state): State<Arc<AppState>>,
+    Json(input): Json<NewPriceAlert>,
+) -> ApiResult<Json<PriceAlert>> {
+    Ok(Json(state.price_alert_service.create_alert(input).await?))
+}
+
+async fn pause_alert(
+    Path(id): Path<String>,
+    State(state): State<Arc<AppState>>,
+) -> ApiResult<Json<PriceAlert>> {
+    Ok(Json(state.price_alert_service.pause_alert(&id).await?))
+}
+
+async fn rearm_alert(
+    Path(id): Path<String>,
+    State(state): State<Arc<AppState>>,
+) -> ApiResult<Json<PriceAlert>> {
+    Ok(Json(state.price_alert_service.rearm_alert(&id).await?))
+}
+
+async fn delete_alert(
+    Path(id): Path<String>,
+    State(state): State<Arc<AppState>>,
+) -> ApiResult<StatusCode> {
+    state.price_alert_service.delete_alert(&id).await?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn list_events(
+    Query(query): Query<EventQuery>,
+    State(state): State<Arc<AppState>>,
+) -> ApiResult<Json<Vec<PriceAlertEvent>>> {
+    Ok(Json(
+        state
+            .price_alert_service
+            .get_events(query.unacknowledged_only)?,
+    ))
+}
+
+async fn unread_count(State(state): State<Arc<AppState>>) -> ApiResult<Json<i64>> {
+    Ok(Json(
+        state.price_alert_service.count_unacknowledged_events()?,
+    ))
+}
+
+async fn acknowledge_events(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<AcknowledgeBody>,
+) -> ApiResult<Json<usize>> {
+    Ok(Json(
+        state
+            .price_alert_service
+            .acknowledge_events(body.event_ids)
+            .await?,
+    ))
+}
+
+pub fn router() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/price-alerts", get(list_alerts).post(create_alert))
+        .route("/price-alerts/{id}", delete(delete_alert))
+        .route("/price-alerts/{id}/pause", post(pause_alert))
+        .route("/price-alerts/{id}/rearm", post(rearm_alert))
+        .route("/price-alert-events", get(list_events))
+        .route("/price-alert-events/unread-count", get(unread_count))
+        .route("/price-alert-events/acknowledge", post(acknowledge_events))
+}

--- a/apps/server/src/api/shared.rs
+++ b/apps/server/src/api/shared.rs
@@ -5,6 +5,7 @@ use crate::{
     events::{
         MarketSyncResult, ServerEvent, MARKET_SYNC_COMPLETE, MARKET_SYNC_ERROR, MARKET_SYNC_START,
         PORTFOLIO_UPDATE_COMPLETE, PORTFOLIO_UPDATE_ERROR, PORTFOLIO_UPDATE_START,
+        PRICE_ALERTS_TRIGGERED,
     },
     main_lib::AppState,
 };
@@ -207,6 +208,7 @@ pub async fn process_portfolio_job(
 
         let sync_start = std::time::Instant::now();
         let asset_ids = config.market_sync_mode.asset_ids().cloned();
+        let alert_asset_ids = asset_ids.clone();
 
         // Convert MarketSyncMode to SyncMode for the quote service
         let sync_result = match config.market_sync_mode.to_sync_mode() {
@@ -220,6 +222,30 @@ pub async fn process_portfolio_job(
 
         match sync_result {
             Ok(result) => {
+                if alert_asset_ids.is_none() {
+                    match state.price_alert_service.get_active_asset_ids() {
+                        Ok(ids) if !ids.is_empty() => {
+                            if let Err(err) = state
+                                .quote_service
+                                .sync(wealthfolio_core::quotes::SyncMode::Incremental, Some(ids))
+                                .await
+                            {
+                                tracing::warn!("Failed to sync active price-alert assets: {}", err);
+                            }
+                        }
+                        Ok(_) => {}
+                        Err(err) => {
+                            tracing::warn!("Failed to list active price-alert assets: {}", err)
+                        }
+                    }
+                }
+                match state.price_alert_service.evaluate(alert_asset_ids).await {
+                    Ok(events) if !events.is_empty() => event_bus.publish(
+                        ServerEvent::with_payload(PRICE_ALERTS_TRIGGERED, json!(events)),
+                    ),
+                    Ok(_) => {}
+                    Err(err) => tracing::warn!("Failed to evaluate price alerts: {}", err),
+                }
                 let skipped_reasons: Vec<(String, String)> = result
                     .skipped_reasons
                     .into_iter()

--- a/apps/server/src/domain_events/queue_worker.rs
+++ b/apps/server/src/domain_events/queue_worker.rs
@@ -47,6 +47,8 @@ pub struct QueueWorkerDeps {
     pub snapshot_repository:
         Arc<dyn wealthfolio_core::portfolio::snapshot::SnapshotRepositoryTrait + Send + Sync>,
     pub quote_service: Arc<dyn wealthfolio_core::quotes::QuoteServiceTrait + Send + Sync>,
+    pub price_alert_service:
+        Arc<dyn wealthfolio_core::price_alerts::PriceAlertServiceTrait + Send + Sync>,
     pub valuation_service:
         Arc<dyn wealthfolio_core::portfolio::valuation::ValuationServiceTrait + Send + Sync>,
     pub account_service: Arc<wealthfolio_core::accounts::AccountService>,
@@ -308,6 +310,7 @@ async fn run_portfolio_job(
     use crate::events::{
         MarketSyncResult, ServerEvent, MARKET_SYNC_COMPLETE, MARKET_SYNC_ERROR, MARKET_SYNC_START,
         PORTFOLIO_UPDATE_COMPLETE, PORTFOLIO_UPDATE_ERROR, PORTFOLIO_UPDATE_START,
+        PRICE_ALERTS_TRIGGERED,
     };
     use serde_json::json;
     use wealthfolio_core::accounts::AccountServiceTrait;
@@ -379,6 +382,7 @@ async fn run_portfolio_job(
 
         let sync_start = std::time::Instant::now();
         let asset_ids = config.market_sync_mode.asset_ids().cloned();
+        let alert_asset_ids = asset_ids.clone();
 
         let sync_result = match config.market_sync_mode.to_sync_mode() {
             Some(sync_mode) => deps.quote_service.sync(sync_mode, asset_ids).await,
@@ -390,6 +394,30 @@ async fn run_portfolio_job(
 
         match sync_result {
             Ok(result) => {
+                if alert_asset_ids.is_none() {
+                    match deps.price_alert_service.get_active_asset_ids() {
+                        Ok(ids) if !ids.is_empty() => {
+                            if let Err(err) = deps
+                                .quote_service
+                                .sync(wealthfolio_core::quotes::SyncMode::Incremental, Some(ids))
+                                .await
+                            {
+                                tracing::warn!("Failed to sync active price-alert assets: {}", err);
+                            }
+                        }
+                        Ok(_) => {}
+                        Err(err) => {
+                            tracing::warn!("Failed to list active price-alert assets: {}", err)
+                        }
+                    }
+                }
+                match deps.price_alert_service.evaluate(alert_asset_ids).await {
+                    Ok(events) if !events.is_empty() => event_bus.publish(
+                        ServerEvent::with_payload(PRICE_ALERTS_TRIGGERED, json!(events)),
+                    ),
+                    Ok(_) => {}
+                    Err(err) => tracing::warn!("Failed to evaluate price alerts: {}", err),
+                }
                 let skipped_reasons: Vec<(String, String)> = result
                     .skipped_reasons
                     .into_iter()

--- a/apps/server/src/domain_events/sink.rs
+++ b/apps/server/src/domain_events/sink.rs
@@ -69,6 +69,9 @@ impl WebDomainEventSink {
             dyn wealthfolio_core::portfolio::snapshot::SnapshotRepositoryTrait + Send + Sync,
         >,
         quote_service: Arc<dyn wealthfolio_core::quotes::QuoteServiceTrait + Send + Sync>,
+        price_alert_service: Arc<
+            dyn wealthfolio_core::price_alerts::PriceAlertServiceTrait + Send + Sync,
+        >,
         valuation_service: Arc<
             dyn wealthfolio_core::portfolio::valuation::ValuationServiceTrait + Send + Sync,
         >,
@@ -100,6 +103,7 @@ impl WebDomainEventSink {
             snapshot_service,
             snapshot_repository,
             quote_service,
+            price_alert_service,
             valuation_service,
             account_service,
             goal_service,

--- a/apps/server/src/events.rs
+++ b/apps/server/src/events.rs
@@ -5,6 +5,7 @@ use tokio::sync::broadcast;
 pub const MARKET_SYNC_START: &str = "market:sync-start";
 pub const MARKET_SYNC_COMPLETE: &str = "market:sync-complete";
 pub const MARKET_SYNC_ERROR: &str = "market:sync-error";
+pub const PRICE_ALERTS_TRIGGERED: &str = "price-alerts:triggered";
 pub const PORTFOLIO_UPDATE_START: &str = "portfolio:update-start";
 pub const PORTFOLIO_UPDATE_COMPLETE: &str = "portfolio:update-complete";
 pub const PORTFOLIO_UPDATE_ERROR: &str = "portfolio:update-error";

--- a/apps/server/src/main_lib.rs
+++ b/apps/server/src/main_lib.rs
@@ -39,6 +39,7 @@ use wealthfolio_core::{
         valuation::{ValuationService, ValuationServiceTrait},
     },
     portfolios::{PortfolioService, PortfolioServiceTrait},
+    price_alerts::{PriceAlertService, PriceAlertServiceTrait},
     quotes::{QuoteService, QuoteServiceTrait},
     secrets::SecretStore,
     settings::{SettingsRepositoryTrait, SettingsService, SettingsServiceTrait},
@@ -60,6 +61,7 @@ use wealthfolio_storage_sqlite::{
     market_data::{MarketDataRepository, QuoteSyncStateRepository},
     portfolio::{snapshot::SnapshotRepository, valuation::ValuationRepository},
     portfolios::PortfolioRepository,
+    price_alerts::PriceAlertRepository,
     settings::SettingsRepository,
     sync::{AppSyncRepository, BrokerSyncStateRepository, ImportRunRepository, PlatformRepository},
     taxonomies::TaxonomyRepository,
@@ -77,6 +79,7 @@ pub struct AppState {
     pub valuation_service: Arc<dyn ValuationServiceTrait + Send + Sync>,
     pub allocation_service: Arc<dyn AllocationServiceTrait + Send + Sync>,
     pub quote_service: Arc<dyn QuoteServiceTrait + Send + Sync>,
+    pub price_alert_service: Arc<dyn PriceAlertServiceTrait + Send + Sync>,
     pub base_currency: Arc<RwLock<String>>,
     pub timezone: Arc<RwLock<String>>,
     pub snapshot_service: Arc<dyn SnapshotServiceTrait + Send + Sync>,
@@ -380,6 +383,13 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
         )
         .await?,
     );
+    let price_alert_repository = Arc::new(PriceAlertRepository::new(pool.clone(), writer.clone()));
+    let price_alert_service: Arc<dyn PriceAlertServiceTrait + Send + Sync> =
+        Arc::new(PriceAlertService::new(
+            price_alert_repository,
+            asset_repository.clone(),
+            quote_service.clone(),
+        ));
     let custom_provider_service = Arc::new(
         wealthfolio_core::custom_provider::CustomProviderService::new(
             custom_provider_repository.clone(),
@@ -797,6 +807,7 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
         snapshot_service.clone(),
         snapshot_repository.clone(),
         quote_service.clone(),
+        price_alert_service.clone(),
         valuation_service.clone(),
         account_service.clone(),
         goal_service.clone(),
@@ -839,6 +850,7 @@ pub async fn build_state(config: &Config) -> anyhow::Result<Arc<AppState>> {
         valuation_service,
         allocation_service,
         quote_service,
+        price_alert_service,
         base_currency,
         timezone,
         snapshot_service,

--- a/apps/tauri/src/commands/market_data.rs
+++ b/apps/tauri/src/commands/market_data.rs
@@ -5,11 +5,12 @@ use crate::{
     context::ServiceContext,
     events::{
         emit_portfolio_trigger_recalculate, emit_portfolio_trigger_update, PortfolioRequestPayload,
+        PRICE_ALERTS_TRIGGERED,
     },
 };
 
 use log::{debug, error, warn};
-use tauri::{AppHandle, State};
+use tauri::{AppHandle, Emitter, State};
 use wealthfolio_core::quotes::{
     service::ProviderInfo, FetchDividendsParams, LatestQuoteSnapshot, MarketSyncMode, Quote,
     QuoteImport, SymbolSearchResult,
@@ -56,12 +57,26 @@ pub async fn sync_market_data(
 }
 
 #[tauri::command]
-pub async fn synch_quotes(state: State<'_, Arc<ServiceContext>>) -> Result<(), String> {
+pub async fn synch_quotes(
+    state: State<'_, Arc<ServiceContext>>,
+    handle: AppHandle,
+) -> Result<(), String> {
     let result = state
         .quote_service()
         .resync(None)
         .await
         .map_err(|e| e.to_string())?;
+
+    let events = state
+        .price_alert_service()
+        .evaluate(None)
+        .await
+        .map_err(|e| e.to_string())?;
+    if !events.is_empty() {
+        handle
+            .emit(PRICE_ALERTS_TRIGGERED, &events)
+            .map_err(|e| e.to_string())?;
+    }
     if result.failed > 0 {
         warn!("resync reported {} failures", result.failed);
     }
@@ -81,6 +96,17 @@ pub async fn update_quote(
         .await
         .map(|_| ())
         .map_err(|e| e.to_string())?;
+
+    let events = state
+        .price_alert_service()
+        .evaluate(Some(vec![quote.asset_id.clone()]))
+        .await
+        .map_err(|e| e.to_string())?;
+    if !events.is_empty() {
+        handle
+            .emit(PRICE_ALERTS_TRIGGERED, &events)
+            .map_err(|e| e.to_string())?;
+    }
 
     // Manual quote update - no market sync needed, but force full recalculation
     // so historical valuations are recomputed with the updated quotes
@@ -200,6 +226,21 @@ pub async fn import_quotes_csv(
             error!("TAURI COMMAND: import_quotes_csv failed: {}", e);
             format!("Failed to import CSV quotes: {}", e)
         })?;
+
+    let mut imported_asset_ids: Vec<String> =
+        result.iter().map(|quote| quote.symbol.clone()).collect();
+    imported_asset_ids.sort();
+    imported_asset_ids.dedup();
+    let events = state
+        .price_alert_service()
+        .evaluate(Some(imported_asset_ids))
+        .await
+        .map_err(|e| e.to_string())?;
+    if !events.is_empty() {
+        handle
+            .emit(PRICE_ALERTS_TRIGGERED, &events)
+            .map_err(|e| e.to_string())?;
+    }
 
     // Quote import - no market sync needed, just recalculate
     let handle = handle.clone();

--- a/apps/tauri/src/commands/mod.rs
+++ b/apps/tauri/src/commands/mod.rs
@@ -24,6 +24,7 @@ pub mod mcp;
 pub mod platform;
 pub mod portfolio;
 pub mod portfolios;
+pub mod price_alerts;
 pub mod providers_settings;
 pub mod secrets;
 pub mod settings;

--- a/apps/tauri/src/commands/price_alerts.rs
+++ b/apps/tauri/src/commands/price_alerts.rs
@@ -1,0 +1,97 @@
+use std::sync::Arc;
+
+use tauri::State;
+use wealthfolio_core::price_alerts::{NewPriceAlert, PriceAlert, PriceAlertEvent};
+
+use crate::context::ServiceContext;
+
+#[tauri::command]
+pub async fn get_price_alerts(
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<Vec<PriceAlert>, String> {
+    state
+        .price_alert_service()
+        .get_alerts()
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn get_price_alert_events(
+    unacknowledged_only: bool,
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<Vec<PriceAlertEvent>, String> {
+    state
+        .price_alert_service()
+        .get_events(unacknowledged_only)
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn get_unacknowledged_price_alert_count(
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<i64, String> {
+    state
+        .price_alert_service()
+        .count_unacknowledged_events()
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn create_price_alert(
+    input: NewPriceAlert,
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<PriceAlert, String> {
+    state
+        .price_alert_service()
+        .create_alert(input)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn pause_price_alert(
+    id: String,
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<PriceAlert, String> {
+    state
+        .price_alert_service()
+        .pause_alert(&id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn rearm_price_alert(
+    id: String,
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<PriceAlert, String> {
+    state
+        .price_alert_service()
+        .rearm_alert(&id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn delete_price_alert(
+    id: String,
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<(), String> {
+    state
+        .price_alert_service()
+        .delete_alert(&id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn acknowledge_price_alert_events(
+    event_ids: Option<Vec<String>>,
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<usize, String> {
+    state
+        .price_alert_service()
+        .acknowledge_events(event_ids)
+        .await
+        .map_err(|e| e.to_string())
+}

--- a/apps/tauri/src/context/providers.rs
+++ b/apps/tauri/src/context/providers.rs
@@ -31,6 +31,7 @@ use wealthfolio_core::{
         valuation::ValuationService,
     },
     portfolios::PortfolioService,
+    price_alerts::PriceAlertService,
     quotes::{QuoteService, QuoteServiceTrait},
     settings::{SettingsRepositoryTrait, SettingsService, SettingsServiceTrait},
     taxonomies::TaxonomyService,
@@ -54,6 +55,7 @@ use wealthfolio_storage_sqlite::{
         valuation::ValuationRepository,
     },
     portfolios::PortfolioRepository,
+    price_alerts::PriceAlertRepository,
     settings::SettingsRepository,
     sync::{AppSyncRepository, BrokerSyncStateRepository, ImportRunRepository, PlatformRepository},
     taxonomies::TaxonomyRepository,
@@ -207,6 +209,12 @@ pub async fn initialize_context(
         )
         .await?,
     );
+    let price_alert_repository = Arc::new(PriceAlertRepository::new(pool.clone(), writer.clone()));
+    let price_alert_service = Arc::new(PriceAlertService::new(
+        price_alert_repository,
+        asset_repository.clone(),
+        quote_service.clone(),
+    ));
 
     // Portfolio service
     let portfolio_repository = Arc::new(PortfolioRepository::new(pool.clone(), writer.clone()));
@@ -616,6 +624,7 @@ pub async fn initialize_context(
             asset_service,
             goal_service,
             quote_service,
+            price_alert_service,
             limits_service,
             fx_service,
             performance_service,

--- a/apps/tauri/src/context/registry.rs
+++ b/apps/tauri/src/context/registry.rs
@@ -8,7 +8,7 @@ use wealthfolio_core::{
     events::DomainEventSink,
     fx, goals, health, limits,
     lots::LotRepositoryTrait,
-    portfolio, portfolios, quotes, settings, taxonomies,
+    portfolio, portfolios, price_alerts, quotes, settings, taxonomies,
 };
 use wealthfolio_device_sync::{engine::DeviceSyncRuntimeState, DeviceEnrollService};
 use wealthfolio_spending::analytics::AnalyticsService;
@@ -47,6 +47,7 @@ pub struct ServiceContext {
     pub goal_service: Arc<dyn goals::GoalServiceTrait>,
     pub asset_service: Arc<dyn assets::AssetServiceTrait>,
     pub quote_service: Arc<dyn quotes::QuoteServiceTrait>,
+    pub price_alert_service: Arc<dyn price_alerts::PriceAlertServiceTrait>,
     pub limits_service: Arc<dyn limits::ContributionLimitServiceTrait>,
     pub fx_service: Arc<dyn fx::FxServiceTrait>,
     pub performance_service: Arc<dyn portfolio::performance::PerformanceServiceTrait>,
@@ -155,6 +156,10 @@ impl ServiceContext {
 
     pub fn quote_service(&self) -> Arc<dyn quotes::QuoteServiceTrait> {
         Arc::clone(&self.quote_service)
+    }
+
+    pub fn price_alert_service(&self) -> Arc<dyn price_alerts::PriceAlertServiceTrait> {
+        Arc::clone(&self.price_alert_service)
     }
 
     pub fn limits_service(&self) -> Arc<dyn limits::ContributionLimitServiceTrait> {

--- a/apps/tauri/src/domain_events/queue_worker.rs
+++ b/apps/tauri/src/domain_events/queue_worker.rs
@@ -33,7 +33,7 @@ use crate::events::{
     MarketSyncResult, PortfolioRequestPayload, ASSET_CLASSIFICATIONS_CHANGED,
     ASSET_ENRICHMENT_COMPLETE, ASSET_ENRICHMENT_PROGRESS, ASSET_ENRICHMENT_START,
     MARKET_SYNC_COMPLETE, MARKET_SYNC_ERROR, MARKET_SYNC_START, PORTFOLIO_UPDATE_COMPLETE,
-    PORTFOLIO_UPDATE_ERROR, PORTFOLIO_UPDATE_START,
+    PORTFOLIO_UPDATE_ERROR, PORTFOLIO_UPDATE_START, PRICE_ALERTS_TRIGGERED,
 };
 
 /// Debounce window duration in milliseconds.
@@ -363,6 +363,7 @@ async fn run_portfolio_job(
 
         let sync_start = std::time::Instant::now();
         let asset_ids = market_sync_mode.asset_ids().cloned();
+        let alert_asset_ids = asset_ids.clone();
 
         // Convert MarketSyncMode to SyncMode for the quote service
         let sync_result = match market_sync_mode.to_sync_mode() {
@@ -377,6 +378,33 @@ async fn run_portfolio_job(
 
         match sync_result {
             Ok(result) => {
+                if alert_asset_ids.is_none() {
+                    match context.price_alert_service().get_active_asset_ids() {
+                        Ok(ids) if !ids.is_empty() => {
+                            if let Err(e) = market_data_service
+                                .sync(wealthfolio_core::quotes::SyncMode::Incremental, Some(ids))
+                                .await
+                            {
+                                warn!("Failed to sync active price-alert assets: {}", e);
+                            }
+                        }
+                        Ok(_) => {}
+                        Err(e) => warn!("Failed to list active price-alert assets: {}", e),
+                    }
+                }
+                match context
+                    .price_alert_service()
+                    .evaluate(alert_asset_ids)
+                    .await
+                {
+                    Ok(events) if !events.is_empty() => {
+                        if let Err(e) = app_handle.emit(PRICE_ALERTS_TRIGGERED, &events) {
+                            error!("Failed to emit price-alerts:triggered event: {}", e);
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(e) => warn!("Failed to evaluate price alerts: {}", e),
+                }
                 let failed_syncs = result.failures;
                 let skipped_reasons = result
                     .skipped_reasons

--- a/apps/tauri/src/events.rs
+++ b/apps/tauri/src/events.rs
@@ -41,6 +41,9 @@ pub struct MarketSyncResult {
 /// Event emitted when the market data sync process encounters an error.
 pub const MARKET_SYNC_ERROR: &str = "market:sync-error";
 
+/// Event emitted when one or more price alerts trigger.
+pub const PRICE_ALERTS_TRIGGERED: &str = "price-alerts:triggered";
+
 /// Event emitted when asset taxonomy assignments change.
 pub const ASSET_CLASSIFICATIONS_CHANGED: &str = "asset:classifications-changed";
 

--- a/apps/tauri/src/lib.rs
+++ b/apps/tauri/src/lib.rs
@@ -197,14 +197,60 @@ mod desktop {
         });
 
         // Start periodic market data sync (6h interval, 2min initial delay)
-        let periodic_quote_service = Arc::clone(&context.quote_service);
+        let periodic_context = Arc::clone(&context);
+        let periodic_handle = handle.clone();
         tauri::async_runtime::spawn(async move {
-            wealthfolio_core::quotes::scheduler::run_periodic_sync(
-                periodic_quote_service,
-                std::time::Duration::from_secs(120),
-                std::time::Duration::from_secs(6 * 3600),
-            )
-            .await;
+            tokio::time::sleep(std::time::Duration::from_secs(120)).await;
+            let interval = std::time::Duration::from_secs(6 * 3600);
+            loop {
+                match periodic_context
+                    .quote_service()
+                    .sync(wealthfolio_core::quotes::SyncMode::Incremental, None)
+                    .await
+                {
+                    Ok(_) => {
+                        match periodic_context
+                            .price_alert_service()
+                            .get_active_asset_ids()
+                        {
+                            Ok(ids) if !ids.is_empty() => {
+                                if let Err(err) = periodic_context
+                                    .quote_service()
+                                    .sync(
+                                        wealthfolio_core::quotes::SyncMode::Incremental,
+                                        Some(ids),
+                                    )
+                                    .await
+                                {
+                                    log::warn!(
+                                        "Failed to sync periodic price-alert assets: {}",
+                                        err
+                                    );
+                                }
+                            }
+                            Ok(_) => {}
+                            Err(err) => {
+                                log::warn!("Failed to list periodic price-alert assets: {}", err)
+                            }
+                        }
+                        match periodic_context.price_alert_service().evaluate(None).await {
+                            Ok(events) if !events.is_empty() => {
+                                if let Err(err) = periodic_handle
+                                    .emit(crate::events::PRICE_ALERTS_TRIGGERED, &events)
+                                {
+                                    log::warn!("Failed to emit periodic price alerts: {}", err);
+                                }
+                            }
+                            Ok(_) => {}
+                            Err(err) => {
+                                log::warn!("Failed to evaluate periodic price alerts: {}", err)
+                            }
+                        }
+                    }
+                    Err(err) => log::warn!("Periodic market data sync failed: {}", err),
+                }
+                tokio::time::sleep(interval).await;
+            }
         });
 
         // Start background device sync engine (self-skips when device is not READY).
@@ -510,6 +556,15 @@ pub fn run() {
             commands::goal::get_retirement_overview,
             commands::goal::get_save_up_overview,
             commands::goal::preview_save_up_overview,
+            // Price alert commands
+            commands::price_alerts::get_price_alerts,
+            commands::price_alerts::get_price_alert_events,
+            commands::price_alerts::get_unacknowledged_price_alert_count,
+            commands::price_alerts::create_price_alert,
+            commands::price_alerts::pause_price_alert,
+            commands::price_alerts::rearm_price_alert,
+            commands::price_alerts::delete_price_alert,
+            commands::price_alerts::acknowledge_price_alert_events,
             // Portfolios (saved reporting scopes)
             commands::portfolios::get_portfolios,
             commands::portfolios::get_portfolio,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod lots;
 pub mod planning;
 pub mod portfolio;
 pub mod portfolios;
+pub mod price_alerts;
 pub mod quotes;
 pub mod secrets;
 pub mod settings;

--- a/crates/core/src/price_alerts/mod.rs
+++ b/crates/core/src/price_alerts/mod.rs
@@ -1,0 +1,9 @@
+//! Asset price alerts and durable trigger history.
+
+mod model;
+mod service;
+mod traits;
+
+pub use model::*;
+pub use service::PriceAlertService;
+pub use traits::{PriceAlertRepositoryTrait, PriceAlertServiceTrait};

--- a/crates/core/src/price_alerts/model.rs
+++ b/crates/core/src/price_alerts/model.rs
@@ -1,0 +1,124 @@
+use chrono::{DateTime, NaiveDate, Utc};
+use serde::{Deserialize, Serialize};
+use std::str::FromStr;
+
+use crate::errors::ValidationError;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum PriceAlertCondition {
+    Above,
+    Below,
+}
+
+impl PriceAlertCondition {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Above => "ABOVE",
+            Self::Below => "BELOW",
+        }
+    }
+}
+
+impl FromStr for PriceAlertCondition {
+    type Err = ValidationError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "ABOVE" => Ok(Self::Above),
+            "BELOW" => Ok(Self::Below),
+            _ => Err(ValidationError::InvalidInput(format!(
+                "Unknown price alert condition: {value}"
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum PriceAlertStatus {
+    Active,
+    Triggered,
+    Paused,
+}
+
+impl PriceAlertStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "ACTIVE",
+            Self::Triggered => "TRIGGERED",
+            Self::Paused => "PAUSED",
+        }
+    }
+}
+
+impl FromStr for PriceAlertStatus {
+    type Err = ValidationError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "ACTIVE" => Ok(Self::Active),
+            "TRIGGERED" => Ok(Self::Triggered),
+            "PAUSED" => Ok(Self::Paused),
+            _ => Err(ValidationError::InvalidInput(format!(
+                "Unknown price alert status: {value}"
+            ))),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PriceAlert {
+    pub id: String,
+    pub asset_id: String,
+    pub condition: PriceAlertCondition,
+    pub target_price: String,
+    pub currency: String,
+    pub status: PriceAlertStatus,
+    pub armed_at: DateTime<Utc>,
+    pub armed_market_date: NaiveDate,
+    pub pause_reason: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct NewPriceAlert {
+    pub asset_id: String,
+    pub condition: PriceAlertCondition,
+    pub target_price: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PriceAlertEvent {
+    pub id: String,
+    pub alert_id: String,
+    pub asset_id: String,
+    pub quote_id: String,
+    pub target_price: String,
+    pub observed_close: String,
+    pub observed_high: String,
+    pub observed_low: String,
+    pub currency: String,
+    pub quote_timestamp: DateTime<Utc>,
+    pub triggered_at: DateTime<Utc>,
+    pub acknowledged_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct NewPriceAlertEvent {
+    pub id: String,
+    pub alert_id: String,
+    pub asset_id: String,
+    pub quote_id: String,
+    pub target_price: String,
+    pub observed_close: String,
+    pub observed_high: String,
+    pub observed_low: String,
+    pub currency: String,
+    pub quote_timestamp: DateTime<Utc>,
+    pub triggered_at: DateTime<Utc>,
+}

--- a/crates/core/src/price_alerts/service.rs
+++ b/crates/core/src/price_alerts/service.rs
@@ -1,0 +1,325 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use chrono::Utc;
+use rust_decimal::Decimal;
+
+use crate::{
+    assets::AssetRepositoryTrait,
+    errors::{Result, ValidationError},
+    quotes::{Quote, QuoteServiceTrait},
+    utils::time_utils,
+};
+
+use super::{
+    NewPriceAlert, NewPriceAlertEvent, PriceAlert, PriceAlertCondition, PriceAlertEvent,
+    PriceAlertRepositoryTrait, PriceAlertServiceTrait, PriceAlertStatus,
+};
+
+pub struct PriceAlertService {
+    repository: Arc<dyn PriceAlertRepositoryTrait>,
+    asset_repository: Arc<dyn AssetRepositoryTrait>,
+    quote_service: Arc<dyn QuoteServiceTrait>,
+}
+
+impl PriceAlertService {
+    pub fn new(
+        repository: Arc<dyn PriceAlertRepositoryTrait>,
+        asset_repository: Arc<dyn AssetRepositoryTrait>,
+        quote_service: Arc<dyn QuoteServiceTrait>,
+    ) -> Self {
+        Self {
+            repository,
+            asset_repository,
+            quote_service,
+        }
+    }
+
+    fn parsed_target(alert: &PriceAlert) -> Result<Decimal> {
+        Ok(alert.target_price.parse::<Decimal>()?)
+    }
+
+    fn quote_triggers(alert: &PriceAlert, quote: &Quote) -> Result<bool> {
+        if !quote.currency.eq_ignore_ascii_case(&alert.currency) {
+            return Ok(false);
+        }
+
+        let quote_day = quote.timestamp.date_naive();
+        if quote_day < alert.armed_market_date {
+            return Ok(false);
+        }
+
+        let target = Self::parsed_target(alert)?;
+        let observed = if quote_day == alert.armed_market_date {
+            quote.close
+        } else {
+            match alert.condition {
+                PriceAlertCondition::Above => quote.high,
+                PriceAlertCondition::Below => quote.low,
+            }
+        };
+
+        Ok(match alert.condition {
+            PriceAlertCondition::Above => observed >= target,
+            PriceAlertCondition::Below => observed <= target,
+        })
+    }
+
+    fn latest_close_satisfies(alert: &PriceAlert, quote: &Quote) -> Result<bool> {
+        let target = Self::parsed_target(alert)?;
+        Ok(match alert.condition {
+            PriceAlertCondition::Above => quote.close >= target,
+            PriceAlertCondition::Below => quote.close <= target,
+        })
+    }
+}
+
+#[async_trait]
+impl PriceAlertServiceTrait for PriceAlertService {
+    fn get_alerts(&self) -> Result<Vec<PriceAlert>> {
+        self.repository.list_alerts()
+    }
+
+    fn get_events(&self, unacknowledged_only: bool) -> Result<Vec<PriceAlertEvent>> {
+        self.repository.list_events(unacknowledged_only)
+    }
+
+    fn count_unacknowledged_events(&self) -> Result<i64> {
+        self.repository.count_unacknowledged_events()
+    }
+
+    fn get_active_asset_ids(&self) -> Result<Vec<String>> {
+        let mut ids: Vec<String> = self
+            .repository
+            .list_active_alerts(None)?
+            .into_iter()
+            .map(|alert| alert.asset_id)
+            .collect();
+        ids.sort();
+        ids.dedup();
+        Ok(ids)
+    }
+
+    async fn create_alert(&self, mut input: NewPriceAlert) -> Result<PriceAlert> {
+        let target = input.target_price.trim().parse::<Decimal>()?;
+        if target <= Decimal::ZERO {
+            return Err(ValidationError::InvalidInput(
+                "target_price must be greater than zero".to_string(),
+            )
+            .into());
+        }
+        input.target_price = target.normalize().to_string();
+
+        let duplicate_exists = self.repository.list_alerts()?.into_iter().any(|alert| {
+            alert.asset_id == input.asset_id
+                && alert.condition == input.condition
+                && alert.target_price == input.target_price
+        });
+        if duplicate_exists {
+            return Err(ValidationError::InvalidInput(
+                "An identical price alert already exists".to_string(),
+            )
+            .into());
+        }
+
+        let asset = self.asset_repository.get_by_id(&input.asset_id)?;
+        if let Ok(current) = self.quote_service.get_latest_quote(&asset.id) {
+            let already_satisfied = match input.condition {
+                PriceAlertCondition::Above => current.close >= target,
+                PriceAlertCondition::Below => current.close <= target,
+            };
+            if already_satisfied {
+                return Err(ValidationError::InvalidInput(
+                    "The target is already satisfied by the latest price".to_string(),
+                )
+                .into());
+            }
+        }
+
+        let armed_market_date =
+            time_utils::market_effective_date(Utc::now(), asset.instrument_exchange_mic.as_deref());
+        self.repository
+            .create_alert(input, asset.quote_ccy, armed_market_date)
+            .await
+    }
+
+    async fn pause_alert(&self, alert_id: &str) -> Result<PriceAlert> {
+        self.repository
+            .set_status(
+                alert_id,
+                PriceAlertStatus::Paused,
+                Some("USER_PAUSED".to_string()),
+                None,
+            )
+            .await
+    }
+
+    async fn rearm_alert(&self, alert_id: &str) -> Result<PriceAlert> {
+        let alert = self
+            .repository
+            .list_alerts()?
+            .into_iter()
+            .find(|alert| alert.id == alert_id)
+            .ok_or_else(|| ValidationError::InvalidInput("Price alert not found".to_string()))?;
+        let asset = self.asset_repository.get_by_id(&alert.asset_id)?;
+        if let Ok(current) = self.quote_service.get_latest_quote(&asset.id) {
+            if Self::latest_close_satisfies(&alert, &current)? {
+                return Err(ValidationError::InvalidInput(
+                    "The target is already satisfied by the latest price".to_string(),
+                )
+                .into());
+            }
+        }
+        let armed_market_date =
+            time_utils::market_effective_date(Utc::now(), asset.instrument_exchange_mic.as_deref());
+        self.repository
+            .set_status(
+                alert_id,
+                PriceAlertStatus::Active,
+                None,
+                Some(armed_market_date),
+            )
+            .await
+    }
+
+    async fn delete_alert(&self, alert_id: &str) -> Result<()> {
+        self.repository.delete_alert(alert_id).await
+    }
+
+    async fn acknowledge_events(&self, event_ids: Option<Vec<String>>) -> Result<usize> {
+        self.repository.acknowledge_events(event_ids).await
+    }
+
+    async fn evaluate(&self, asset_ids: Option<Vec<String>>) -> Result<Vec<PriceAlertEvent>> {
+        let alerts = self.repository.list_active_alerts(asset_ids.as_deref())?;
+        let mut triggered = Vec::new();
+
+        for alert in alerts {
+            let mut quotes = self.quote_service.get_historical_quotes(&alert.asset_id)?;
+            quotes.sort_by_key(|quote| quote.timestamp);
+            for quote in quotes {
+                if !Self::quote_triggers(&alert, &quote)? {
+                    continue;
+                }
+
+                let event = NewPriceAlertEvent {
+                    id: format!("{}:{}", alert.id, quote.id),
+                    alert_id: alert.id.clone(),
+                    asset_id: alert.asset_id.clone(),
+                    quote_id: quote.id.clone(),
+                    target_price: alert.target_price.clone(),
+                    observed_close: quote.close.to_string(),
+                    observed_high: quote.high.to_string(),
+                    observed_low: quote.low.to_string(),
+                    currency: quote.currency.clone(),
+                    quote_timestamp: quote.timestamp,
+                    triggered_at: Utc::now(),
+                };
+                if let Some(event) = self.repository.trigger_alert(&alert.id, event).await? {
+                    triggered.push(event);
+                }
+                break;
+            }
+        }
+
+        Ok(triggered)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{TimeZone, Utc};
+    use rust_decimal_macros::dec;
+
+    fn alert(condition: PriceAlertCondition, armed_market_date: chrono::NaiveDate) -> PriceAlert {
+        PriceAlert {
+            id: "alert-1".to_string(),
+            asset_id: "asset-1".to_string(),
+            condition,
+            target_price: "100".to_string(),
+            currency: "USD".to_string(),
+            status: PriceAlertStatus::Active,
+            armed_at: Utc::now(),
+            armed_market_date,
+            pause_reason: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn quote(day: u32, close: Decimal, high: Decimal, low: Decimal) -> Quote {
+        Quote {
+            id: format!("quote-{day}"),
+            asset_id: "asset-1".to_string(),
+            timestamp: Utc.with_ymd_and_hms(2026, 8, day, 20, 0, 0).unwrap(),
+            open: close,
+            high,
+            low,
+            close,
+            adjclose: close,
+            volume: Decimal::ZERO,
+            currency: "USD".to_string(),
+            data_source: "TEST".to_string(),
+            created_at: Utc::now(),
+            notes: None,
+        }
+    }
+
+    #[test]
+    fn ignores_historical_quotes_before_alert_was_armed() {
+        let alert = alert(
+            PriceAlertCondition::Above,
+            chrono::NaiveDate::from_ymd_opt(2026, 8, 10).unwrap(),
+        );
+        assert!(!PriceAlertService::quote_triggers(
+            &alert,
+            &quote(9, dec!(90), dec!(120), dec!(80))
+        )
+        .unwrap());
+    }
+
+    #[test]
+    fn uses_close_on_the_day_the_alert_was_armed() {
+        let alert = alert(
+            PriceAlertCondition::Above,
+            chrono::NaiveDate::from_ymd_opt(2026, 8, 10).unwrap(),
+        );
+        assert!(!PriceAlertService::quote_triggers(
+            &alert,
+            &quote(10, dec!(95), dec!(110), dec!(90))
+        )
+        .unwrap());
+    }
+
+    #[test]
+    fn uses_daily_high_and_low_after_the_armed_day() {
+        let armed = chrono::NaiveDate::from_ymd_opt(2026, 8, 10).unwrap();
+        assert!(PriceAlertService::quote_triggers(
+            &alert(PriceAlertCondition::Above, armed),
+            &quote(11, dec!(95), dec!(100), dec!(90))
+        )
+        .unwrap());
+        assert!(PriceAlertService::quote_triggers(
+            &alert(PriceAlertCondition::Below, armed),
+            &quote(11, dec!(105), dec!(110), dec!(100))
+        )
+        .unwrap());
+    }
+
+    #[test]
+    fn latest_close_satisfaction_matches_condition() {
+        let armed = chrono::NaiveDate::from_ymd_opt(2026, 8, 10).unwrap();
+        let latest = quote(10, dec!(100), dec!(101), dec!(99));
+        assert!(PriceAlertService::latest_close_satisfies(
+            &alert(PriceAlertCondition::Above, armed),
+            &latest,
+        )
+        .unwrap());
+        assert!(PriceAlertService::latest_close_satisfies(
+            &alert(PriceAlertCondition::Below, armed),
+            &latest,
+        )
+        .unwrap());
+    }
+}

--- a/crates/core/src/price_alerts/traits.rs
+++ b/crates/core/src/price_alerts/traits.rs
@@ -1,0 +1,47 @@
+use async_trait::async_trait;
+
+use crate::errors::Result;
+
+use super::{NewPriceAlert, NewPriceAlertEvent, PriceAlert, PriceAlertEvent};
+
+#[async_trait]
+pub trait PriceAlertRepositoryTrait: Send + Sync {
+    fn list_alerts(&self) -> Result<Vec<PriceAlert>>;
+    fn list_active_alerts(&self, asset_ids: Option<&[String]>) -> Result<Vec<PriceAlert>>;
+    fn list_events(&self, unacknowledged_only: bool) -> Result<Vec<PriceAlertEvent>>;
+    fn count_unacknowledged_events(&self) -> Result<i64>;
+    async fn create_alert(
+        &self,
+        input: NewPriceAlert,
+        currency: String,
+        armed_market_date: chrono::NaiveDate,
+    ) -> Result<PriceAlert>;
+    async fn set_status(
+        &self,
+        alert_id: &str,
+        status: super::PriceAlertStatus,
+        pause_reason: Option<String>,
+        armed_market_date: Option<chrono::NaiveDate>,
+    ) -> Result<PriceAlert>;
+    async fn delete_alert(&self, alert_id: &str) -> Result<()>;
+    async fn acknowledge_events(&self, event_ids: Option<Vec<String>>) -> Result<usize>;
+    async fn trigger_alert(
+        &self,
+        alert_id: &str,
+        event: NewPriceAlertEvent,
+    ) -> Result<Option<PriceAlertEvent>>;
+}
+
+#[async_trait]
+pub trait PriceAlertServiceTrait: Send + Sync {
+    fn get_alerts(&self) -> Result<Vec<PriceAlert>>;
+    fn get_events(&self, unacknowledged_only: bool) -> Result<Vec<PriceAlertEvent>>;
+    fn count_unacknowledged_events(&self) -> Result<i64>;
+    fn get_active_asset_ids(&self) -> Result<Vec<String>>;
+    async fn create_alert(&self, input: NewPriceAlert) -> Result<PriceAlert>;
+    async fn pause_alert(&self, alert_id: &str) -> Result<PriceAlert>;
+    async fn rearm_alert(&self, alert_id: &str) -> Result<PriceAlert>;
+    async fn delete_alert(&self, alert_id: &str) -> Result<()>;
+    async fn acknowledge_events(&self, event_ids: Option<Vec<String>>) -> Result<usize>;
+    async fn evaluate(&self, asset_ids: Option<Vec<String>>) -> Result<Vec<PriceAlertEvent>>;
+}

--- a/crates/storage-sqlite/migrations/2026-08-16-000001_price_alerts/down.sql
+++ b/crates/storage-sqlite/migrations/2026-08-16-000001_price_alerts/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE price_alert_events;
+DROP TABLE price_alerts;

--- a/crates/storage-sqlite/migrations/2026-08-16-000001_price_alerts/up.sql
+++ b/crates/storage-sqlite/migrations/2026-08-16-000001_price_alerts/up.sql
@@ -1,0 +1,36 @@
+CREATE TABLE price_alerts (
+    id TEXT PRIMARY KEY NOT NULL,
+    asset_id TEXT NOT NULL,
+    condition TEXT NOT NULL CHECK (condition IN ('ABOVE', 'BELOW')),
+    target_price TEXT NOT NULL,
+    currency TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('ACTIVE', 'TRIGGERED', 'PAUSED')),
+    armed_at TEXT NOT NULL,
+    armed_market_date TEXT NOT NULL,
+    pause_reason TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY (asset_id) REFERENCES assets(id) ON DELETE CASCADE
+);
+
+CREATE INDEX price_alerts_asset_status_idx ON price_alerts(asset_id, status);
+
+CREATE TABLE price_alert_events (
+    id TEXT PRIMARY KEY NOT NULL,
+    alert_id TEXT NOT NULL,
+    asset_id TEXT NOT NULL,
+    quote_id TEXT NOT NULL,
+    target_price TEXT NOT NULL,
+    observed_close TEXT NOT NULL,
+    observed_high TEXT NOT NULL,
+    observed_low TEXT NOT NULL,
+    currency TEXT NOT NULL,
+    quote_timestamp TEXT NOT NULL,
+    triggered_at TEXT NOT NULL,
+    acknowledged_at TEXT,
+    FOREIGN KEY (alert_id) REFERENCES price_alerts(id) ON DELETE CASCADE,
+    FOREIGN KEY (asset_id) REFERENCES assets(id) ON DELETE CASCADE
+);
+
+CREATE INDEX price_alert_events_unread_idx
+    ON price_alert_events(acknowledged_at, triggered_at);

--- a/crates/storage-sqlite/migrations/2026-08-16-000002_price_alert_dedup/down.sql
+++ b/crates/storage-sqlite/migrations/2026-08-16-000002_price_alert_dedup/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX price_alerts_unique_target_idx;

--- a/crates/storage-sqlite/migrations/2026-08-16-000002_price_alert_dedup/up.sql
+++ b/crates/storage-sqlite/migrations/2026-08-16-000002_price_alert_dedup/up.sql
@@ -1,0 +1,27 @@
+CREATE TEMP TABLE duplicate_price_alert_ids (id TEXT PRIMARY KEY NOT NULL);
+
+INSERT INTO duplicate_price_alert_ids (id)
+SELECT duplicate.id
+FROM price_alerts AS duplicate
+WHERE EXISTS (
+    SELECT 1
+    FROM price_alerts AS keeper
+    WHERE keeper.asset_id = duplicate.asset_id
+      AND keeper.condition = duplicate.condition
+      AND keeper.target_price = duplicate.target_price
+      AND (
+          keeper.created_at < duplicate.created_at
+          OR (keeper.created_at = duplicate.created_at AND keeper.id < duplicate.id)
+      )
+);
+
+DELETE FROM price_alert_events
+WHERE alert_id IN (SELECT id FROM duplicate_price_alert_ids);
+
+DELETE FROM price_alerts
+WHERE id IN (SELECT id FROM duplicate_price_alert_ids);
+
+DROP TABLE duplicate_price_alert_ids;
+
+CREATE UNIQUE INDEX price_alerts_unique_target_idx
+    ON price_alerts(asset_id, condition, target_price);

--- a/crates/storage-sqlite/src/lib.rs
+++ b/crates/storage-sqlite/src/lib.rs
@@ -45,6 +45,7 @@ pub mod lots;
 pub mod market_data;
 pub mod portfolio;
 pub mod portfolios;
+pub mod price_alerts;
 pub mod settings;
 pub mod spending;
 pub mod sync;

--- a/crates/storage-sqlite/src/price_alerts/mod.rs
+++ b/crates/storage-sqlite/src/price_alerts/mod.rs
@@ -1,0 +1,5 @@
+mod model;
+mod repository;
+
+pub use model::{PriceAlertDB, PriceAlertEventDB};
+pub use repository::PriceAlertRepository;

--- a/crates/storage-sqlite/src/price_alerts/model.rs
+++ b/crates/storage-sqlite/src/price_alerts/model.rs
@@ -1,0 +1,85 @@
+use std::str::FromStr;
+
+use chrono::{DateTime, NaiveDate, Utc};
+use diesel::prelude::*;
+use wealthfolio_core::{
+    errors::Result,
+    price_alerts::{PriceAlert, PriceAlertCondition, PriceAlertEvent, PriceAlertStatus},
+};
+
+#[derive(Debug, Clone, Queryable, Selectable, Identifiable)]
+#[diesel(table_name = crate::schema::price_alerts)]
+pub struct PriceAlertDB {
+    pub id: String,
+    pub asset_id: String,
+    pub condition: String,
+    pub target_price: String,
+    pub currency: String,
+    pub status: String,
+    pub armed_at: String,
+    pub armed_market_date: String,
+    pub pause_reason: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl TryFrom<PriceAlertDB> for PriceAlert {
+    type Error = wealthfolio_core::Error;
+
+    fn try_from(db: PriceAlertDB) -> Result<Self> {
+        Ok(Self {
+            id: db.id,
+            asset_id: db.asset_id,
+            condition: PriceAlertCondition::from_str(&db.condition)?,
+            target_price: db.target_price,
+            currency: db.currency,
+            status: PriceAlertStatus::from_str(&db.status)?,
+            armed_at: DateTime::parse_from_rfc3339(&db.armed_at)?.with_timezone(&Utc),
+            armed_market_date: NaiveDate::parse_from_str(&db.armed_market_date, "%Y-%m-%d")?,
+            pause_reason: db.pause_reason,
+            created_at: DateTime::parse_from_rfc3339(&db.created_at)?.with_timezone(&Utc),
+            updated_at: DateTime::parse_from_rfc3339(&db.updated_at)?.with_timezone(&Utc),
+        })
+    }
+}
+
+#[derive(Debug, Clone, Queryable, Selectable, Identifiable)]
+#[diesel(table_name = crate::schema::price_alert_events)]
+pub struct PriceAlertEventDB {
+    pub id: String,
+    pub alert_id: String,
+    pub asset_id: String,
+    pub quote_id: String,
+    pub target_price: String,
+    pub observed_close: String,
+    pub observed_high: String,
+    pub observed_low: String,
+    pub currency: String,
+    pub quote_timestamp: String,
+    pub triggered_at: String,
+    pub acknowledged_at: Option<String>,
+}
+
+impl TryFrom<PriceAlertEventDB> for PriceAlertEvent {
+    type Error = wealthfolio_core::Error;
+
+    fn try_from(db: PriceAlertEventDB) -> Result<Self> {
+        Ok(Self {
+            id: db.id,
+            alert_id: db.alert_id,
+            asset_id: db.asset_id,
+            quote_id: db.quote_id,
+            target_price: db.target_price,
+            observed_close: db.observed_close,
+            observed_high: db.observed_high,
+            observed_low: db.observed_low,
+            currency: db.currency,
+            quote_timestamp: DateTime::parse_from_rfc3339(&db.quote_timestamp)?.with_timezone(&Utc),
+            triggered_at: DateTime::parse_from_rfc3339(&db.triggered_at)?.with_timezone(&Utc),
+            acknowledged_at: db
+                .acknowledged_at
+                .map(|value| DateTime::parse_from_rfc3339(&value).map(|dt| dt.with_timezone(&Utc)))
+                .transpose()?,
+        })
+    }
+}

--- a/crates/storage-sqlite/src/price_alerts/repository.rs
+++ b/crates/storage-sqlite/src/price_alerts/repository.rs
@@ -1,0 +1,482 @@
+use async_trait::async_trait;
+use chrono::Utc;
+use diesel::prelude::*;
+use std::sync::Arc;
+use uuid::Uuid;
+use wealthfolio_core::{
+    price_alerts::{
+        NewPriceAlert, NewPriceAlertEvent, PriceAlert, PriceAlertEvent, PriceAlertRepositoryTrait,
+        PriceAlertStatus,
+    },
+    Result,
+};
+
+use super::model::{PriceAlertDB, PriceAlertEventDB};
+use crate::{
+    db::{get_connection, DbPool, WriteHandle},
+    errors::StorageError,
+    schema::{price_alert_events, price_alerts},
+};
+
+pub struct PriceAlertRepository {
+    pool: Arc<DbPool>,
+    writer: WriteHandle,
+}
+
+impl PriceAlertRepository {
+    pub fn new(pool: Arc<DbPool>, writer: WriteHandle) -> Self {
+        Self { pool, writer }
+    }
+
+    fn convert_alerts(rows: Vec<PriceAlertDB>) -> Result<Vec<PriceAlert>> {
+        rows.into_iter().map(PriceAlert::try_from).collect()
+    }
+
+    fn convert_events(rows: Vec<PriceAlertEventDB>) -> Result<Vec<PriceAlertEvent>> {
+        rows.into_iter().map(PriceAlertEvent::try_from).collect()
+    }
+}
+
+#[async_trait]
+impl PriceAlertRepositoryTrait for PriceAlertRepository {
+    fn list_alerts(&self) -> Result<Vec<PriceAlert>> {
+        let mut conn = get_connection(&self.pool)?;
+        let rows = price_alerts::table
+            .order(price_alerts::created_at.desc())
+            .select(PriceAlertDB::as_select())
+            .load(&mut conn)
+            .map_err(StorageError::from)?;
+        Self::convert_alerts(rows)
+    }
+
+    fn list_active_alerts(&self, asset_ids: Option<&[String]>) -> Result<Vec<PriceAlert>> {
+        let mut conn = get_connection(&self.pool)?;
+        let mut query = price_alerts::table
+            .filter(price_alerts::status.eq(PriceAlertStatus::Active.as_str()))
+            .into_boxed();
+        if let Some(ids) = asset_ids {
+            query = query.filter(price_alerts::asset_id.eq_any(ids));
+        }
+        let rows = query
+            .select(PriceAlertDB::as_select())
+            .load(&mut conn)
+            .map_err(StorageError::from)?;
+        Self::convert_alerts(rows)
+    }
+
+    fn list_events(&self, unacknowledged_only: bool) -> Result<Vec<PriceAlertEvent>> {
+        let mut conn = get_connection(&self.pool)?;
+        let mut query = price_alert_events::table.into_boxed();
+        if unacknowledged_only {
+            query = query.filter(price_alert_events::acknowledged_at.is_null());
+        }
+        let rows = query
+            .order(price_alert_events::triggered_at.desc())
+            .select(PriceAlertEventDB::as_select())
+            .load(&mut conn)
+            .map_err(StorageError::from)?;
+        Self::convert_events(rows)
+    }
+
+    fn count_unacknowledged_events(&self) -> Result<i64> {
+        let mut conn = get_connection(&self.pool)?;
+        price_alert_events::table
+            .filter(price_alert_events::acknowledged_at.is_null())
+            .count()
+            .get_result(&mut conn)
+            .map_err(StorageError::from)
+            .map_err(Into::into)
+    }
+
+    async fn create_alert(
+        &self,
+        input: NewPriceAlert,
+        currency: String,
+        armed_market_date: chrono::NaiveDate,
+    ) -> Result<PriceAlert> {
+        self.writer
+            .exec(move |conn| {
+                let target_price = input.target_price.trim().to_string();
+                let existing = price_alerts::table
+                    .filter(price_alerts::asset_id.eq(&input.asset_id))
+                    .filter(price_alerts::condition.eq(input.condition.as_str()))
+                    .filter(price_alerts::target_price.eq(&target_price))
+                    .select(PriceAlertDB::as_select())
+                    .first(conn)
+                    .optional()
+                    .map_err(StorageError::from)?;
+                if let Some(existing) = existing {
+                    return PriceAlert::try_from(existing);
+                }
+
+                let now = Utc::now().to_rfc3339();
+                let db = diesel::insert_into(price_alerts::table)
+                    .values((
+                        price_alerts::id.eq(Uuid::now_v7().to_string()),
+                        price_alerts::asset_id.eq(input.asset_id),
+                        price_alerts::condition.eq(input.condition.as_str()),
+                        price_alerts::target_price.eq(target_price),
+                        price_alerts::currency.eq(currency),
+                        price_alerts::status.eq(PriceAlertStatus::Active.as_str()),
+                        price_alerts::armed_at.eq(&now),
+                        price_alerts::armed_market_date.eq(armed_market_date.to_string()),
+                        price_alerts::pause_reason.eq::<Option<String>>(None),
+                        price_alerts::created_at.eq(&now),
+                        price_alerts::updated_at.eq(&now),
+                    ))
+                    .returning(PriceAlertDB::as_returning())
+                    .get_result(conn)
+                    .map_err(StorageError::from)?;
+                PriceAlert::try_from(db)
+            })
+            .await
+    }
+
+    async fn set_status(
+        &self,
+        alert_id: &str,
+        status: PriceAlertStatus,
+        pause_reason: Option<String>,
+        armed_market_date: Option<chrono::NaiveDate>,
+    ) -> Result<PriceAlert> {
+        let alert_id = alert_id.to_string();
+        self.writer
+            .exec(move |conn| {
+                let now = Utc::now().to_rfc3339();
+                let target = price_alerts::table.find(alert_id);
+                let db = if let Some(armed_market_date) = armed_market_date {
+                    diesel::update(target)
+                        .set((
+                            price_alerts::status.eq(status.as_str()),
+                            price_alerts::pause_reason.eq(pause_reason),
+                            price_alerts::armed_at.eq(&now),
+                            price_alerts::armed_market_date.eq(armed_market_date.to_string()),
+                            price_alerts::updated_at.eq(&now),
+                        ))
+                        .returning(PriceAlertDB::as_returning())
+                        .get_result(conn)
+                        .map_err(StorageError::from)?
+                } else {
+                    diesel::update(target)
+                        .set((
+                            price_alerts::status.eq(status.as_str()),
+                            price_alerts::pause_reason.eq(pause_reason),
+                            price_alerts::updated_at.eq(&now),
+                        ))
+                        .returning(PriceAlertDB::as_returning())
+                        .get_result(conn)
+                        .map_err(StorageError::from)?
+                };
+                PriceAlert::try_from(db)
+            })
+            .await
+    }
+
+    async fn delete_alert(&self, alert_id: &str) -> Result<()> {
+        let alert_id = alert_id.to_string();
+        self.writer
+            .exec(move |conn| {
+                diesel::delete(price_alerts::table.find(alert_id))
+                    .execute(conn)
+                    .map_err(StorageError::from)?;
+                Ok(())
+            })
+            .await
+    }
+
+    async fn acknowledge_events(&self, event_ids: Option<Vec<String>>) -> Result<usize> {
+        self.writer
+            .exec(move |conn| {
+                let now = Utc::now().to_rfc3339();
+                let count = match event_ids {
+                    Some(ids) if ids.is_empty() => 0,
+                    Some(ids) => diesel::update(
+                        price_alert_events::table.filter(price_alert_events::id.eq_any(ids)),
+                    )
+                    .set(price_alert_events::acknowledged_at.eq(Some(now)))
+                    .execute(conn)
+                    .map_err(StorageError::from)?,
+                    None => diesel::update(
+                        price_alert_events::table
+                            .filter(price_alert_events::acknowledged_at.is_null()),
+                    )
+                    .set(price_alert_events::acknowledged_at.eq(Some(now)))
+                    .execute(conn)
+                    .map_err(StorageError::from)?,
+                };
+                Ok(count)
+            })
+            .await
+    }
+
+    async fn trigger_alert(
+        &self,
+        alert_id: &str,
+        event: NewPriceAlertEvent,
+    ) -> Result<Option<PriceAlertEvent>> {
+        let alert_id = alert_id.to_string();
+        self.writer
+            .exec_tx(move |tx| {
+                let conn = tx.conn();
+                let status = price_alerts::table
+                    .find(&alert_id)
+                    .select(price_alerts::status)
+                    .first::<String>(conn)
+                    .map_err(StorageError::from)?;
+                if status != PriceAlertStatus::Active.as_str() {
+                    return Ok(None);
+                }
+
+                let exists = price_alert_events::table
+                    .find(&event.id)
+                    .select(price_alert_events::id)
+                    .first::<String>(conn)
+                    .optional()
+                    .map_err(StorageError::from)?
+                    .is_some();
+                if exists {
+                    return Ok(None);
+                }
+
+                let db = diesel::insert_into(price_alert_events::table)
+                    .values((
+                        price_alert_events::id.eq(event.id),
+                        price_alert_events::alert_id.eq(&event.alert_id),
+                        price_alert_events::asset_id.eq(event.asset_id),
+                        price_alert_events::quote_id.eq(event.quote_id),
+                        price_alert_events::target_price.eq(event.target_price),
+                        price_alert_events::observed_close.eq(event.observed_close),
+                        price_alert_events::observed_high.eq(event.observed_high),
+                        price_alert_events::observed_low.eq(event.observed_low),
+                        price_alert_events::currency.eq(event.currency),
+                        price_alert_events::quote_timestamp.eq(event.quote_timestamp.to_rfc3339()),
+                        price_alert_events::triggered_at.eq(event.triggered_at.to_rfc3339()),
+                        price_alert_events::acknowledged_at.eq::<Option<String>>(None),
+                    ))
+                    .returning(PriceAlertEventDB::as_returning())
+                    .get_result(conn)
+                    .map_err(StorageError::from)?;
+
+                diesel::update(price_alerts::table.find(&alert_id))
+                    .set((
+                        price_alerts::status.eq(PriceAlertStatus::Triggered.as_str()),
+                        price_alerts::updated_at.eq(Utc::now().to_rfc3339()),
+                    ))
+                    .execute(conn)
+                    .map_err(StorageError::from)?;
+
+                Ok(Some(PriceAlertEvent::try_from(db)?))
+            })
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{create_pool, get_connection, init, run_migrations, write_actor::spawn_writer};
+    use chrono::{TimeZone, Utc};
+    use diesel::{sql_query, sql_types::Text};
+    use tempfile::tempdir;
+    use wealthfolio_core::price_alerts::{NewPriceAlert, PriceAlertCondition};
+
+    fn setup_repository() -> PriceAlertRepository {
+        std::env::set_var("CONNECT_API_URL", "http://test.local");
+        let app_data = tempdir()
+            .expect("tempdir")
+            .keep()
+            .to_string_lossy()
+            .to_string();
+        let db_path = init(&app_data).expect("init db");
+        run_migrations(&db_path).expect("migrate db");
+        let pool = create_pool(&db_path).expect("create pool");
+        let writer = spawn_writer(pool.as_ref().clone()).expect("spawn writer");
+
+        let mut conn = get_connection(&pool).expect("connection");
+        sql_query(
+            "INSERT INTO assets (
+                id, kind, name, display_code, is_active, quote_mode, quote_ccy,
+                created_at, updated_at
+             ) VALUES (?, 'INVESTMENT', 'Apple', 'AAPL', 1, 'MARKET', 'USD',
+                CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+        )
+        .bind::<Text, _>("asset-1")
+        .execute(&mut conn)
+        .expect("insert asset");
+        drop(conn);
+
+        PriceAlertRepository::new(pool, writer)
+    }
+
+    #[tokio::test]
+    async fn triggering_is_atomic_and_deduplicated() {
+        let repository = setup_repository();
+        let alert = repository
+            .create_alert(
+                NewPriceAlert {
+                    asset_id: "asset-1".to_string(),
+                    condition: PriceAlertCondition::Above,
+                    target_price: "100".to_string(),
+                },
+                "USD".to_string(),
+                chrono::NaiveDate::from_ymd_opt(2026, 8, 16).unwrap(),
+            )
+            .await
+            .expect("create alert");
+        let event = NewPriceAlertEvent {
+            id: format!("{}:quote-1", alert.id),
+            alert_id: alert.id.clone(),
+            asset_id: alert.asset_id.clone(),
+            quote_id: "quote-1".to_string(),
+            target_price: alert.target_price.clone(),
+            observed_close: "101".to_string(),
+            observed_high: "102".to_string(),
+            observed_low: "99".to_string(),
+            currency: "USD".to_string(),
+            quote_timestamp: Utc.with_ymd_and_hms(2026, 8, 17, 20, 0, 0).unwrap(),
+            triggered_at: Utc.with_ymd_and_hms(2026, 8, 17, 20, 1, 0).unwrap(),
+        };
+
+        assert!(repository
+            .trigger_alert(&alert.id, event.clone())
+            .await
+            .expect("first trigger")
+            .is_some());
+        assert!(repository
+            .trigger_alert(&alert.id, event)
+            .await
+            .expect("duplicate trigger")
+            .is_none());
+
+        let stored = repository.list_alerts().expect("list alerts");
+        assert_eq!(stored[0].status, PriceAlertStatus::Triggered);
+        assert_eq!(repository.count_unacknowledged_events().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn identical_alert_creation_is_idempotent() {
+        let repository = setup_repository();
+        let input = NewPriceAlert {
+            asset_id: "asset-1".to_string(),
+            condition: PriceAlertCondition::Above,
+            target_price: "100".to_string(),
+        };
+        let market_date = chrono::NaiveDate::from_ymd_opt(2026, 8, 16).unwrap();
+
+        let first = repository
+            .create_alert(input.clone(), "USD".to_string(), market_date)
+            .await
+            .expect("first create");
+        let duplicate = repository
+            .create_alert(input, "USD".to_string(), market_date)
+            .await
+            .expect("duplicate create");
+
+        assert_eq!(duplicate.id, first.id);
+        assert_eq!(repository.list_alerts().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn pause_preserves_arming_date_and_rearm_updates_it() {
+        let repository = setup_repository();
+        let original_market_date = chrono::NaiveDate::from_ymd_opt(2026, 8, 15).unwrap();
+        let alert = repository
+            .create_alert(
+                NewPriceAlert {
+                    asset_id: "asset-1".to_string(),
+                    condition: PriceAlertCondition::Above,
+                    target_price: "100".to_string(),
+                },
+                "USD".to_string(),
+                original_market_date,
+            )
+            .await
+            .expect("create alert");
+
+        let paused = repository
+            .set_status(
+                &alert.id,
+                PriceAlertStatus::Paused,
+                Some("USER_PAUSED".to_string()),
+                None,
+            )
+            .await
+            .expect("pause alert");
+        assert_eq!(paused.status, PriceAlertStatus::Paused);
+        assert_eq!(paused.armed_market_date, original_market_date);
+        assert_eq!(paused.pause_reason.as_deref(), Some("USER_PAUSED"));
+
+        let rearmed_market_date = chrono::NaiveDate::from_ymd_opt(2026, 8, 18).unwrap();
+        let rearmed = repository
+            .set_status(
+                &alert.id,
+                PriceAlertStatus::Active,
+                None,
+                Some(rearmed_market_date),
+            )
+            .await
+            .expect("rearm alert");
+        assert_eq!(rearmed.status, PriceAlertStatus::Active);
+        assert_eq!(rearmed.armed_market_date, rearmed_market_date);
+        assert!(rearmed.pause_reason.is_none());
+    }
+
+    #[tokio::test]
+    async fn acknowledges_selected_events_without_marking_others_read() {
+        let repository = setup_repository();
+        let market_date = chrono::NaiveDate::from_ymd_opt(2026, 8, 16).unwrap();
+
+        for (target, quote_id) in [("100", "quote-1"), ("110", "quote-2")] {
+            let alert = repository
+                .create_alert(
+                    NewPriceAlert {
+                        asset_id: "asset-1".to_string(),
+                        condition: PriceAlertCondition::Above,
+                        target_price: target.to_string(),
+                    },
+                    "USD".to_string(),
+                    market_date,
+                )
+                .await
+                .expect("create alert");
+            repository
+                .trigger_alert(
+                    &alert.id,
+                    NewPriceAlertEvent {
+                        id: format!("{}:{quote_id}", alert.id),
+                        alert_id: alert.id.clone(),
+                        asset_id: alert.asset_id,
+                        quote_id: quote_id.to_string(),
+                        target_price: target.to_string(),
+                        observed_close: target.to_string(),
+                        observed_high: target.to_string(),
+                        observed_low: target.to_string(),
+                        currency: "USD".to_string(),
+                        quote_timestamp: Utc.with_ymd_and_hms(2026, 8, 17, 20, 0, 0).unwrap(),
+                        triggered_at: Utc.with_ymd_and_hms(2026, 8, 17, 20, 1, 0).unwrap(),
+                    },
+                )
+                .await
+                .expect("trigger alert");
+        }
+
+        let unread = repository.list_events(true).expect("list unread events");
+        assert_eq!(unread.len(), 2);
+        assert_eq!(
+            repository
+                .acknowledge_events(Some(vec![unread[0].id.clone()]))
+                .await
+                .expect("acknowledge selected"),
+            1
+        );
+        assert_eq!(repository.count_unacknowledged_events().unwrap(), 1);
+        assert_eq!(
+            repository
+                .acknowledge_events(None)
+                .await
+                .expect("acknowledge remaining"),
+            1
+        );
+        assert_eq!(repository.count_unacknowledged_events().unwrap(), 0);
+    }
+}

--- a/crates/storage-sqlite/src/schema.rs
+++ b/crates/storage-sqlite/src/schema.rs
@@ -439,6 +439,39 @@ diesel::table! {
 }
 
 diesel::table! {
+    price_alert_events (id) {
+        id -> Text,
+        alert_id -> Text,
+        asset_id -> Text,
+        quote_id -> Text,
+        target_price -> Text,
+        observed_close -> Text,
+        observed_high -> Text,
+        observed_low -> Text,
+        currency -> Text,
+        quote_timestamp -> Text,
+        triggered_at -> Text,
+        acknowledged_at -> Nullable<Text>,
+    }
+}
+
+diesel::table! {
+    price_alerts (id) {
+        id -> Text,
+        asset_id -> Text,
+        condition -> Text,
+        target_price -> Text,
+        currency -> Text,
+        status -> Text,
+        armed_at -> Text,
+        armed_market_date -> Text,
+        pause_reason -> Nullable<Text>,
+        created_at -> Text,
+        updated_at -> Text,
+    }
+}
+
+diesel::table! {
     quotes (id) {
         id -> Text,
         asset_id -> Text,
@@ -738,6 +771,9 @@ diesel::table! {
 
 diesel::joinable!(portfolio_accounts -> portfolios (portfolio_id));
 diesel::joinable!(portfolio_accounts -> accounts (account_id));
+diesel::joinable!(price_alert_events -> assets (asset_id));
+diesel::joinable!(price_alert_events -> price_alerts (alert_id));
+diesel::joinable!(price_alerts -> assets (asset_id));
 
 diesel::table! {
     allocation_targets (id) {
@@ -899,6 +935,8 @@ diesel::allow_tables_to_appear_in_same_query!(
     lots,
     market_data_providers,
     platforms,
+    price_alert_events,
+    price_alerts,
     quote_sync_state,
     quotes,
     snapshot_positions,

--- a/packages/ui/src/components/common/searchable-select.tsx
+++ b/packages/ui/src/components/common/searchable-select.tsx
@@ -45,10 +45,12 @@ export function SearchableSelect({
           variant="outline"
           role="combobox"
           aria-expanded={open}
-          className={cn("w-full justify-between rounded-md font-normal", className)}
+          className={cn("min-w-0 max-w-full justify-between rounded-md font-normal", className)}
           disabled={disabled}
         >
-          <span className="truncate">{selectedOption ? selectedOption.label : placeholder}</span>
+          <span className="min-w-0 flex-1 truncate text-left">
+            {selectedOption ? selectedOption.label : placeholder}
+          </span>
           <Icons.ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
       </PopoverTrigger>

--- a/packages/ui/src/components/ui/icons.tsx
+++ b/packages/ui/src/components/ui/icons.tsx
@@ -15,6 +15,7 @@ import {
   BadgeDollarSign,
   BarChart,
   Baseline,
+  Bell,
   Bitcoin,
   Blocks,
   Brain,
@@ -77,6 +78,7 @@ import {
   List,
   Lock,
   LockOpen,
+  Pause,
   ListChecks,
   ListCollapse,
   ListFilter,
@@ -334,6 +336,7 @@ const IconsInternal = {
   Settings2: Settings2,
   // Additional icons for UI components
   Baseline: Baseline,
+  Bell: Bell,
   CalendarIcon: Calendar,
   CaseSensitive: CaseSensitive,
   CheckSquare: CheckSquare,
@@ -348,6 +351,7 @@ const IconsInternal = {
   List: List,
   Lock: Lock,
   LockOpen: LockOpen,
+  Pause: Pause,
   Pin: Pin,
   PinOff: PinOff,
   Presentation: Presentation,
@@ -817,6 +821,7 @@ const IconsInternal = {
  * All available icon names
  */
 export type IconName =
+  | "Bell"
   | "AlertCircle"
   | "AlertTriangle"
   | "DatabaseBackup"
@@ -881,6 +886,7 @@ export type IconName =
   | "Minus"
   | "MinusCircle"
   | "PauseCircle"
+  | "Pause"
   | "PlayCircle"
   | "Monitor"
   | "QrCode"


### PR DESCRIPTION
## Summary

- add persistent asset price alerts with `ABOVE` and `BELOW` thresholds
- evaluate alerts after quote sync, manual quote updates, CSV imports, resyncs, and periodic desktop sync
- provide one-shot trigger events, unread state, acknowledgement, pause, re-arm, delete, and duplicate protection
- add an Alerts page, asset-profile creation flow, percentage presets, responsive tables, and in-app trigger notifications
- expose matching Tauri commands and Axum REST endpoints

## Behavior

- alerts remain active indefinitely until triggered, paused, or deleted
- the armed market day uses the closing price; subsequent market days use the daily high or low according to direction
- alerts trigger only once and retain durable event history
- identical asset, direction, and normalized target combinations are rejected and protected by a database unique index

## Testing

- `cargo test --workspace`
- `cargo fmt --all -- --check`
- `pnpm format:check`
- `pnpm lint`
- `pnpm type-check`
- focused Vitest suite: 35 tests passed
- `git diff --check`

**Manual end-to-end simulation was also completed with AAPL:**

1. Created active alerts at or below `$180` and at or above `$300`.
2. Imported a simulated quote with open `$295`, high `$330`, low `$294`, and close `$325`.
3. Verified the `$300` alert transitioned from `ACTIVE` to `TRIGGERED` while the `$180` alert remained active.
4. Verified the durable trigger event, unread badge/toast, acknowledgement, pause, re-arm, duplicate rejection, and deletion flows.

**Screenshots for reference:**

Setup price alert from asset screen:
<img width="1512" height="948" alt="price-alert-screenshot" src="https://github.com/user-attachments/assets/7a36fcc7-ce75-48d9-86e5-69a874ef6e1c" />

Active alerts and create-alert dialog:
<img width="3024" height="1478" alt="price_alerts_verified" src="https://github.com/user-attachments/assets/914b4822-b396-4411-8159-8777990beaf4" />

Triggered alert, unread toast, and acknowledgement/re-arm actions:
<img width="3024" height="1478" alt="price_alert_triggered_scenario" src="https://github.com/user-attachments/assets/646812f0-d3f9-4501-9197-86072146383f" />

## Notes

- operating-system notifications and device-sync replication are outside this change; notifications are currently delivered in-app
- by submitting this pull request, I confirm that I have read and agree to the repository CLA
