### PR TITLE
Fix mobile finance views and patch nanoid

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -73,7 +73,7 @@
     "i18next-resources-to-backend": "^1.2.1",
     "lucide-react": "^0.561.0",
     "motion": "^12.34.0",
-    "nanoid": "^5.1.6",
+    "nanoid": "^5.1.16",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.8",
     "react-day-picker": "^9.13.2",

--- a/apps/frontend/src/features/spending/components/budget-line-chart-card.tsx
+++ b/apps/frontend/src/features/spending/components/budget-line-chart-card.tsx
@@ -533,7 +533,7 @@ export function BudgetLineChartCard({
         ) : (
           <div
             data-no-swipe-drag
-            className="-mx-1 flex min-w-0 touch-pan-x gap-3 overflow-x-auto overscroll-x-contain px-1 pb-1 [-webkit-overflow-scrolling:touch] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+            className="-mx-1 flex min-w-0 touch-pan-x gap-3 !overflow-x-auto overscroll-x-contain px-1 pb-1 [-webkit-overflow-scrolling:touch] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
             style={{
               maskImage: "linear-gradient(to right, black calc(100% - 32px), transparent 100%)",
               WebkitMaskImage:

--- a/apps/frontend/src/i18n/locales/de/asset.json
+++ b/apps/frontend/src/i18n/locales/de/asset.json
@@ -666,7 +666,11 @@
     "date": "Datum",
     "balance": "Saldo",
     "value": "Wert",
-    "notes": "Notizen"
+    "notes": "Notizen",
+    "edit_entry_aria": "Eintrag vom {{date}} bearbeiten, {{value}}",
+    "delete_entry_aria": "Eintrag vom {{date}} löschen, {{value}}",
+    "delete_title": "Verlaufseintrag löschen?",
+    "delete_description": "Dieser Verlaufseintrag wird dauerhaft gelöscht."
   },
   "valueToolbar": {
     "add_balance": "Saldo hinzufügen",

--- a/apps/frontend/src/i18n/locales/de/asset.json
+++ b/apps/frontend/src/i18n/locales/de/asset.json
@@ -670,7 +670,8 @@
     "edit_entry_aria": "Eintrag vom {{date}} bearbeiten, {{value}}",
     "delete_entry_aria": "Eintrag vom {{date}} löschen, {{value}}",
     "delete_title": "Verlaufseintrag löschen?",
-    "delete_description": "Dieser Verlaufseintrag wird dauerhaft gelöscht."
+    "delete_description": "Dieser Verlaufseintrag wird dauerhaft gelöscht.",
+    "duplicate_date_error": "Jeder Verlaufseintrag muss ein eindeutiges Datum haben."
   },
   "valueToolbar": {
     "add_balance": "Saldo hinzufügen",

--- a/apps/frontend/src/i18n/locales/en/asset.json
+++ b/apps/frontend/src/i18n/locales/en/asset.json
@@ -670,7 +670,8 @@
     "edit_entry_aria": "Edit {{date}}, {{value}}",
     "delete_entry_aria": "Delete {{date}}, {{value}}",
     "delete_title": "Delete history entry?",
-    "delete_description": "This historical entry will be permanently deleted."
+    "delete_description": "This historical entry will be permanently deleted.",
+    "duplicate_date_error": "Each history entry must use a unique date."
   },
   "valueToolbar": {
     "add_balance": "Add Balance",

--- a/apps/frontend/src/i18n/locales/en/asset.json
+++ b/apps/frontend/src/i18n/locales/en/asset.json
@@ -666,7 +666,11 @@
     "date": "Date",
     "balance": "Balance",
     "value": "Value",
-    "notes": "Notes"
+    "notes": "Notes",
+    "edit_entry_aria": "Edit {{date}}, {{value}}",
+    "delete_entry_aria": "Delete {{date}}, {{value}}",
+    "delete_title": "Delete history entry?",
+    "delete_description": "This historical entry will be permanently deleted."
   },
   "valueToolbar": {
     "add_balance": "Add Balance",

--- a/apps/frontend/src/i18n/locales/es/asset.json
+++ b/apps/frontend/src/i18n/locales/es/asset.json
@@ -670,7 +670,8 @@
     "edit_entry_aria": "Editar la entrada del {{date}}, {{value}}",
     "delete_entry_aria": "Eliminar la entrada del {{date}}, {{value}}",
     "delete_title": "¿Eliminar entrada del historial?",
-    "delete_description": "Esta entrada del historial se eliminará de forma permanente."
+    "delete_description": "Esta entrada del historial se eliminará de forma permanente.",
+    "duplicate_date_error": "Cada entrada del historial debe usar una fecha única."
   },
   "valueToolbar": {
     "add_balance": "Añadir saldo",

--- a/apps/frontend/src/i18n/locales/es/asset.json
+++ b/apps/frontend/src/i18n/locales/es/asset.json
@@ -666,7 +666,11 @@
     "date": "Fecha",
     "balance": "Saldo",
     "value": "Valor",
-    "notes": "Notas"
+    "notes": "Notas",
+    "edit_entry_aria": "Editar la entrada del {{date}}, {{value}}",
+    "delete_entry_aria": "Eliminar la entrada del {{date}}, {{value}}",
+    "delete_title": "¿Eliminar entrada del historial?",
+    "delete_description": "Esta entrada del historial se eliminará de forma permanente."
   },
   "valueToolbar": {
     "add_balance": "Añadir saldo",

--- a/apps/frontend/src/i18n/locales/fr/asset.json
+++ b/apps/frontend/src/i18n/locales/fr/asset.json
@@ -666,7 +666,11 @@
     "date": "Date",
     "balance": "Solde",
     "value": "Valeur",
-    "notes": "Notes"
+    "notes": "Notes",
+    "edit_entry_aria": "Modifier l’entrée du {{date}}, {{value}}",
+    "delete_entry_aria": "Supprimer l’entrée du {{date}}, {{value}}",
+    "delete_title": "Supprimer cette entrée d’historique ?",
+    "delete_description": "Cette entrée d’historique sera définitivement supprimée."
   },
   "valueToolbar": {
     "add_balance": "Ajouter un solde",

--- a/apps/frontend/src/i18n/locales/fr/asset.json
+++ b/apps/frontend/src/i18n/locales/fr/asset.json
@@ -670,7 +670,8 @@
     "edit_entry_aria": "Modifier l’entrée du {{date}}, {{value}}",
     "delete_entry_aria": "Supprimer l’entrée du {{date}}, {{value}}",
     "delete_title": "Supprimer cette entrée d’historique ?",
-    "delete_description": "Cette entrée d’historique sera définitivement supprimée."
+    "delete_description": "Cette entrée d’historique sera définitivement supprimée.",
+    "duplicate_date_error": "Chaque entrée d’historique doit utiliser une date unique."
   },
   "valueToolbar": {
     "add_balance": "Ajouter un solde",

--- a/apps/frontend/src/i18n/locales/ja/asset.json
+++ b/apps/frontend/src/i18n/locales/ja/asset.json
@@ -669,7 +669,8 @@
     "edit_entry_aria": "{{date}}、{{value}}の履歴を編集",
     "delete_entry_aria": "{{date}}、{{value}}の履歴を削除",
     "delete_title": "履歴エントリを削除しますか？",
-    "delete_description": "この履歴エントリは完全に削除されます。"
+    "delete_description": "この履歴エントリは完全に削除されます。",
+    "duplicate_date_error": "各履歴エントリには重複しない日付を使用してください。"
   },
   "valueToolbar": {
     "add_balance": "残高を追加",

--- a/apps/frontend/src/i18n/locales/ja/asset.json
+++ b/apps/frontend/src/i18n/locales/ja/asset.json
@@ -665,7 +665,11 @@
     "date": "日付",
     "balance": "残高",
     "value": "評価額",
-    "notes": "メモ"
+    "notes": "メモ",
+    "edit_entry_aria": "{{date}}、{{value}}の履歴を編集",
+    "delete_entry_aria": "{{date}}、{{value}}の履歴を削除",
+    "delete_title": "履歴エントリを削除しますか？",
+    "delete_description": "この履歴エントリは完全に削除されます。"
   },
   "valueToolbar": {
     "add_balance": "残高を追加",

--- a/apps/frontend/src/i18n/locales/ko/asset.json
+++ b/apps/frontend/src/i18n/locales/ko/asset.json
@@ -666,7 +666,11 @@
     "date": "날짜",
     "balance": "잔액",
     "value": "가치",
-    "notes": "메모"
+    "notes": "메모",
+    "edit_entry_aria": "{{date}}, {{value}} 기록 편집",
+    "delete_entry_aria": "{{date}}, {{value}} 기록 삭제",
+    "delete_title": "기록 항목을 삭제할까요?",
+    "delete_description": "이 기록 항목은 영구적으로 삭제됩니다."
   },
   "valueToolbar": {
     "add_balance": "잔액 추가",

--- a/apps/frontend/src/i18n/locales/ko/asset.json
+++ b/apps/frontend/src/i18n/locales/ko/asset.json
@@ -670,7 +670,8 @@
     "edit_entry_aria": "{{date}}, {{value}} 기록 편집",
     "delete_entry_aria": "{{date}}, {{value}} 기록 삭제",
     "delete_title": "기록 항목을 삭제할까요?",
-    "delete_description": "이 기록 항목은 영구적으로 삭제됩니다."
+    "delete_description": "이 기록 항목은 영구적으로 삭제됩니다.",
+    "duplicate_date_error": "각 기록 항목에는 중복되지 않는 날짜를 사용해야 합니다."
   },
   "valueToolbar": {
     "add_balance": "잔액 추가",

--- a/apps/frontend/src/i18n/locales/zh/asset.json
+++ b/apps/frontend/src/i18n/locales/zh/asset.json
@@ -670,7 +670,8 @@
     "edit_entry_aria": "编辑 {{date}}，{{value}}",
     "delete_entry_aria": "删除 {{date}}，{{value}}",
     "delete_title": "删除历史记录？",
-    "delete_description": "此历史记录将被永久删除。"
+    "delete_description": "此历史记录将被永久删除。",
+    "duplicate_date_error": "每条历史记录必须使用唯一日期。"
   },
   "valueToolbar": {
     "add_balance": "添加余额",

--- a/apps/frontend/src/i18n/locales/zh/asset.json
+++ b/apps/frontend/src/i18n/locales/zh/asset.json
@@ -666,7 +666,11 @@
     "date": "日期",
     "balance": "余额",
     "value": "价值",
-    "notes": "备注"
+    "notes": "备注",
+    "edit_entry_aria": "编辑 {{date}}，{{value}}",
+    "delete_entry_aria": "删除 {{date}}，{{value}}",
+    "delete_title": "删除历史记录？",
+    "delete_description": "此历史记录将被永久删除。"
   },
   "valueToolbar": {
     "add_balance": "添加余额",

--- a/apps/frontend/src/pages/asset/alternative-asset-content.tsx
+++ b/apps/frontend/src/pages/asset/alternative-asset-content.tsx
@@ -83,7 +83,10 @@ export const AlternativeAssetContent: React.FC<AlternativeAssetContentProps> = (
   }, [holding.linkedAssetId, allHoldings]);
 
   // Quote mutations for history grid
-  const { saveQuoteMutation, deleteQuoteMutation } = useQuoteMutations(assetId);
+  const { saveQuoteMutation, deleteQuoteMutation, invalidateQuoteQueries } = useQuoteMutations(
+    assetId,
+    { invalidateOnSuccess: false },
+  );
 
   // Filter chart data by date range
   const filteredChartData = useMemo(() => {
@@ -323,6 +326,7 @@ export const AlternativeAssetContent: React.FC<AlternativeAssetContentProps> = (
       isLiability={isLiability}
       onSaveQuote={(quote: Quote) => saveQuoteMutation.mutateAsync(quote)}
       onDeleteQuote={(id: string) => deleteQuoteMutation.mutateAsync(id)}
+      onPersistComplete={invalidateQuoteQueries}
     />
   );
 };

--- a/apps/frontend/src/pages/asset/alternative-asset-content.tsx
+++ b/apps/frontend/src/pages/asset/alternative-asset-content.tsx
@@ -318,10 +318,11 @@ export const AlternativeAssetContent: React.FC<AlternativeAssetContentProps> = (
   return (
     <ValueHistoryDataGrid
       data={quoteHistory}
+      assetId={assetId}
       currency={holding.currency}
       isLiability={isLiability}
-      onSaveQuote={(quote: Quote) => saveQuoteMutation.mutate(quote)}
-      onDeleteQuote={(id: string) => deleteQuoteMutation.mutate(id)}
+      onSaveQuote={(quote: Quote) => saveQuoteMutation.mutateAsync(quote)}
+      onDeleteQuote={(id: string) => deleteQuoteMutation.mutateAsync(id)}
     />
   );
 };

--- a/apps/frontend/src/pages/asset/alternative-asset-content.tsx
+++ b/apps/frontend/src/pages/asset/alternative-asset-content.tsx
@@ -320,6 +320,7 @@ export const AlternativeAssetContent: React.FC<AlternativeAssetContentProps> = (
   // History tab
   return (
     <ValueHistoryDataGrid
+      key={assetId}
       data={quoteHistory}
       assetId={assetId}
       currency={holding.currency}

--- a/apps/frontend/src/pages/asset/alternative-assets/components/value-history-data-grid.test.tsx
+++ b/apps/frontend/src/pages/asset/alternative-assets/components/value-history-data-grid.test.tsx
@@ -1,11 +1,12 @@
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { format } from "date-fns";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useDataGrid } from "@wealthfolio/ui";
 
 import { useIsMobileViewport } from "@/hooks/use-platform";
 import type { Quote } from "@/lib/types";
 
-import { ValueHistoryDataGrid } from "./value-history-data-grid";
+import { ValueHistoryDataGrid, type ValueHistoryEntry } from "./value-history-data-grid";
 
 vi.mock("@/hooks/use-platform", () => ({
   useIsMobileViewport: vi.fn(),
@@ -15,21 +16,23 @@ vi.mock("@wealthfolio/ui", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@wealthfolio/ui")>();
   return {
     ...actual,
-    useDataGrid: () => ({
+    DataGrid: () => <div data-testid="data-grid" />,
+    useDataGrid: vi.fn(() => ({
       table: {
         getSelectedRowModel: () => ({ rows: [] }),
         resetRowSelection: vi.fn(),
       },
       onRowAdd: vi.fn(),
-    }),
+    })),
   };
 });
 
 const mockUseIsMobileViewport = vi.mocked(useIsMobileViewport);
+const mockUseDataGrid = vi.mocked(useDataGrid);
 const assetId = "asset-home-mortgage";
 
-const createQuote = (date: string, value: number): Quote => ({
-  id: `${assetId}_${date}_MANUAL`,
+const createQuote = (date: string, value: number, id = `${assetId}_${date}_MANUAL`): Quote => ({
+  id,
   createdAt: `${date}T00:00:00.000Z`,
   dataSource: "MANUAL",
   timestamp: `${date}T00:00:00Z`,
@@ -48,12 +51,14 @@ interface RenderGridOptions {
   data?: Quote[];
   onSaveQuote?: (quote: Quote) => Promise<void>;
   onDeleteQuote?: (quoteId: string) => Promise<void>;
+  onPersistComplete?: () => Promise<void>;
 }
 
 const renderGrid = ({
   data = [createQuote("2026-08-17", 495_000)],
   onSaveQuote = vi.fn().mockResolvedValue(undefined),
   onDeleteQuote = vi.fn().mockResolvedValue(undefined),
+  onPersistComplete = vi.fn().mockResolvedValue(undefined),
 }: RenderGridOptions = {}) => {
   render(
     <ValueHistoryDataGrid
@@ -63,9 +68,28 @@ const renderGrid = ({
       isLiability
       onSaveQuote={onSaveQuote}
       onDeleteQuote={onDeleteQuote}
+      onPersistComplete={onPersistComplete}
     />,
   );
 };
+
+interface CapturedDataGridOptions {
+  data: ValueHistoryEntry[];
+  readOnly?: boolean;
+  onDataChange: (entries: ValueHistoryEntry[]) => void;
+  onRowAdd: () => unknown;
+  onRowsDelete: (rows: ValueHistoryEntry[], rowIndices: number[]) => void;
+}
+
+const getDataGridOptions = (): CapturedDataGridOptions => {
+  const call = mockUseDataGrid.mock.calls.at(-1);
+  if (!call) throw new Error("useDataGrid was not called");
+  return call[0] as unknown as CapturedDataGridOptions;
+};
+
+beforeEach(() => {
+  mockUseDataGrid.mockClear();
+});
 
 describe("ValueHistoryDataGrid mobile", () => {
   beforeEach(() => {
@@ -87,9 +111,10 @@ describe("ValueHistoryDataGrid mobile", () => {
     expect(screen.getByLabelText("Notes")).toBeInTheDocument();
   });
 
-  it("persists a canonical manual quote before committing the edited row", async () => {
+  it("preserves an existing quote ID so the backend can move or canonicalize it", async () => {
+    const existingId = "6f5a0b1e-3e6d-4b17-8824-6247b036e123";
     const onSaveQuote = vi.fn().mockResolvedValue(undefined);
-    renderGrid({ onSaveQuote });
+    renderGrid({ data: [createQuote("2026-08-17", 495_000, existingId)], onSaveQuote });
 
     fireEvent.click(screen.getByRole("button", { name: "Edit 2026-08-17, $495,000.00" }));
     fireEvent.change(screen.getByRole("textbox", { name: "Balance" }), {
@@ -100,7 +125,7 @@ describe("ValueHistoryDataGrid mobile", () => {
     await waitFor(() => expect(onSaveQuote).toHaveBeenCalledTimes(1));
     expect(onSaveQuote).toHaveBeenCalledWith(
       expect.objectContaining({
-        id: `${assetId}_2026-08-17_MANUAL`,
+        id: existingId,
         assetId,
         close: 510_000,
       }),
@@ -174,5 +199,115 @@ describe("ValueHistoryDataGrid mobile", () => {
       await screen.findByRole("button", { name: `Edit ${today}, $490,000.00` }),
     ).toBeInTheDocument();
     expect(screen.getAllByRole("button", { name: new RegExp(`^Edit ${today},`) })).toHaveLength(1);
+  });
+});
+
+describe("ValueHistoryDataGrid desktop persistence", () => {
+  beforeEach(() => {
+    mockUseIsMobileViewport.mockReturnValue(false);
+  });
+
+  it("keeps the complete retry set when a later batch save fails", async () => {
+    const onSaveQuote = vi
+      .fn<(quote: Quote) => Promise<void>>()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("save failed"));
+    const onPersistComplete = vi.fn().mockResolvedValue(undefined);
+    renderGrid({
+      data: [createQuote("2026-08-17", 495_000), createQuote("2026-06-07", 500_000)],
+      onSaveQuote,
+      onPersistComplete,
+    });
+
+    const grid = getDataGridOptions();
+    act(() => {
+      grid.onDataChange(grid.data.map((entry) => ({ ...entry, value: entry.value - 1_000 })));
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => expect(onSaveQuote).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save Changes" })).toBeEnabled());
+    expect(onPersistComplete).not.toHaveBeenCalled();
+    expect(screen.getByText("2 modified")).toBeInTheDocument();
+  });
+
+  it("makes the data grid read-only while the saved snapshot is in flight", async () => {
+    let resolveSave: (() => void) | undefined;
+    const onSaveQuote = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+    const onPersistComplete = vi.fn().mockResolvedValue(undefined);
+    renderGrid({ onSaveQuote, onPersistComplete });
+
+    const grid = getDataGridOptions();
+    act(() => {
+      grid.onDataChange(grid.data.map((entry) => ({ ...entry, value: 490_000 })));
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => expect(getDataGridOptions().readOnly).toBe(true));
+    act(() => resolveSave?.());
+    await waitFor(() => expect(onPersistComplete).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(getDataGridOptions().readOnly).toBe(false));
+  });
+
+  it("rejects multiple entries with the same calendar date", () => {
+    const onSaveQuote = vi.fn().mockResolvedValue(undefined);
+    const onPersistComplete = vi.fn().mockResolvedValue(undefined);
+    renderGrid({
+      data: [createQuote("2026-08-17", 495_000), createQuote("2026-06-07", 500_000)],
+      onSaveQuote,
+      onPersistComplete,
+    });
+
+    const grid = getDataGridOptions();
+    act(() => {
+      grid.onDataChange(
+        grid.data.map((entry, index) =>
+          index === 1 ? { ...entry, date: new Date("2026-08-17T00:00:00") } : entry,
+        ),
+      );
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    expect(onSaveQuote).not.toHaveBeenCalled();
+    expect(onPersistComplete).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Save Changes" })).toBeEnabled();
+  });
+
+  it("deletes an existing same-day entry before saving its replacement", async () => {
+    const events: string[] = [];
+    const onDeleteQuote = vi.fn(() => {
+      events.push("delete");
+      return Promise.resolve();
+    });
+    const onSaveQuote = vi.fn(() => {
+      events.push("save");
+      return Promise.resolve();
+    });
+    const onPersistComplete = vi.fn().mockResolvedValue(undefined);
+    const today = format(new Date(), "yyyy-MM-dd");
+    renderGrid({
+      data: [createQuote(today, 495_000, "legacy-quote-id")],
+      onSaveQuote,
+      onDeleteQuote,
+      onPersistComplete,
+    });
+
+    const grid = getDataGridOptions();
+    act(() => {
+      grid.onRowsDelete([grid.data[0]], [0]);
+      grid.onRowAdd();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
+
+    await waitFor(() => expect(onPersistComplete).toHaveBeenCalledTimes(1));
+    expect(events).toEqual(["delete", "save"]);
+    expect(onSaveQuote).toHaveBeenCalledWith(
+      expect.objectContaining({ id: `${assetId}_${today}_MANUAL` }),
+    );
   });
 });

--- a/apps/frontend/src/pages/asset/alternative-assets/components/value-history-data-grid.test.tsx
+++ b/apps/frontend/src/pages/asset/alternative-assets/components/value-history-data-grid.test.tsx
@@ -61,7 +61,7 @@ const renderGrid = ({
   onDeleteQuote = vi.fn().mockResolvedValue(undefined),
   onPersistComplete = vi.fn().mockResolvedValue(undefined),
 }: RenderGridOptions = {}) => {
-  render(
+  return render(
     <ValueHistoryDataGrid
       data={data}
       assetId={assetId}
@@ -155,6 +155,32 @@ describe("ValueHistoryDataGrid mobile", () => {
     expect(screen.getByRole("textbox", { name: "Balance" })).toHaveValue("510,000.00");
   });
 
+  it("preserves an open draft when external data refreshes", () => {
+    const onSaveQuote = vi.fn().mockResolvedValue(undefined);
+    const onDeleteQuote = vi.fn().mockResolvedValue(undefined);
+    const onPersistComplete = vi.fn().mockResolvedValue(undefined);
+    const view = renderGrid({ onSaveQuote, onDeleteQuote, onPersistComplete });
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit 2026-08-17, $495,000.00" }));
+    fireEvent.change(screen.getByRole("textbox", { name: "Balance" }), {
+      target: { value: "510000" },
+    });
+
+    view.rerender(
+      <ValueHistoryDataGrid
+        data={[createQuote("2026-08-17", 500_000)]}
+        assetId={assetId}
+        currency="USD"
+        isLiability
+        onSaveQuote={onSaveQuote}
+        onDeleteQuote={onDeleteQuote}
+        onPersistComplete={onPersistComplete}
+      />,
+    );
+
+    expect(screen.getByRole("textbox", { name: "Balance" })).toHaveValue("510,000.00");
+  });
+
   it("keeps the row and confirmation open when deletion fails", async () => {
     const onDeleteQuote = vi.fn().mockRejectedValue(new Error("delete failed"));
     renderGrid({ onDeleteQuote });
@@ -234,6 +260,33 @@ describe("ValueHistoryDataGrid desktop persistence", () => {
     await waitFor(() => expect(screen.getByRole("button", { name: "Save Changes" })).toBeEnabled());
     expect(onPersistComplete).not.toHaveBeenCalled();
     expect(screen.getByText("2 modified")).toBeInTheDocument();
+  });
+
+  it("preserves unsaved edits when external data refreshes", () => {
+    const onSaveQuote = vi.fn().mockResolvedValue(undefined);
+    const onDeleteQuote = vi.fn().mockResolvedValue(undefined);
+    const onPersistComplete = vi.fn().mockResolvedValue(undefined);
+    const view = renderGrid({ onSaveQuote, onDeleteQuote, onPersistComplete });
+
+    const grid = getDataGridOptions();
+    act(() => {
+      grid.onDataChange(grid.data.map((entry) => ({ ...entry, value: 490_000 })));
+    });
+
+    view.rerender(
+      <ValueHistoryDataGrid
+        data={[createQuote("2026-08-17", 500_000)]}
+        assetId={assetId}
+        currency="USD"
+        isLiability
+        onSaveQuote={onSaveQuote}
+        onDeleteQuote={onDeleteQuote}
+        onPersistComplete={onPersistComplete}
+      />,
+    );
+
+    expect(getDataGridOptions().data[0].value).toBe(490_000);
+    expect(screen.getByText("1 modified")).toBeInTheDocument();
   });
 
   it("makes the data grid read-only while the saved snapshot is in flight", async () => {

--- a/apps/frontend/src/pages/asset/alternative-assets/components/value-history-data-grid.test.tsx
+++ b/apps/frontend/src/pages/asset/alternative-assets/components/value-history-data-grid.test.tsx
@@ -1,0 +1,178 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { format } from "date-fns";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useIsMobileViewport } from "@/hooks/use-platform";
+import type { Quote } from "@/lib/types";
+
+import { ValueHistoryDataGrid } from "./value-history-data-grid";
+
+vi.mock("@/hooks/use-platform", () => ({
+  useIsMobileViewport: vi.fn(),
+}));
+
+vi.mock("@wealthfolio/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@wealthfolio/ui")>();
+  return {
+    ...actual,
+    useDataGrid: () => ({
+      table: {
+        getSelectedRowModel: () => ({ rows: [] }),
+        resetRowSelection: vi.fn(),
+      },
+      onRowAdd: vi.fn(),
+    }),
+  };
+});
+
+const mockUseIsMobileViewport = vi.mocked(useIsMobileViewport);
+const assetId = "asset-home-mortgage";
+
+const createQuote = (date: string, value: number): Quote => ({
+  id: `${assetId}_${date}_MANUAL`,
+  createdAt: `${date}T00:00:00.000Z`,
+  dataSource: "MANUAL",
+  timestamp: `${date}T00:00:00Z`,
+  assetId,
+  open: value,
+  high: value,
+  low: value,
+  volume: 0,
+  close: value,
+  adjclose: value,
+  currency: "USD",
+  notes: undefined,
+});
+
+interface RenderGridOptions {
+  data?: Quote[];
+  onSaveQuote?: (quote: Quote) => Promise<void>;
+  onDeleteQuote?: (quoteId: string) => Promise<void>;
+}
+
+const renderGrid = ({
+  data = [createQuote("2026-08-17", 495_000)],
+  onSaveQuote = vi.fn().mockResolvedValue(undefined),
+  onDeleteQuote = vi.fn().mockResolvedValue(undefined),
+}: RenderGridOptions = {}) => {
+  render(
+    <ValueHistoryDataGrid
+      data={data}
+      assetId={assetId}
+      currency="USD"
+      isLiability
+      onSaveQuote={onSaveQuote}
+      onDeleteQuote={onDeleteQuote}
+    />,
+  );
+};
+
+describe("ValueHistoryDataGrid mobile", () => {
+  beforeEach(() => {
+    mockUseIsMobileViewport.mockReturnValue(true);
+  });
+
+  it("provides contextual row actions and a labelled notes field", () => {
+    renderGrid();
+
+    expect(
+      screen.getByRole("button", { name: "Edit 2026-08-17, $495,000.00" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Delete 2026-08-17, $495,000.00" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit 2026-08-17, $495,000.00" }));
+
+    expect(screen.getByLabelText("Notes")).toBeInTheDocument();
+  });
+
+  it("persists a canonical manual quote before committing the edited row", async () => {
+    const onSaveQuote = vi.fn().mockResolvedValue(undefined);
+    renderGrid({ onSaveQuote });
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit 2026-08-17, $495,000.00" }));
+    fireEvent.change(screen.getByRole("textbox", { name: "Balance" }), {
+      target: { value: "510000" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(onSaveQuote).toHaveBeenCalledTimes(1));
+    expect(onSaveQuote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: `${assetId}_2026-08-17_MANUAL`,
+        assetId,
+        close: 510_000,
+      }),
+    );
+    expect(
+      await screen.findByRole("button", { name: "Edit 2026-08-17, $510,000.00" }),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the draft open when saving fails", async () => {
+    const onSaveQuote = vi.fn().mockRejectedValue(new Error("save failed"));
+    renderGrid({ onSaveQuote });
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit 2026-08-17, $495,000.00" }));
+    fireEvent.change(screen.getByRole("textbox", { name: "Balance" }), {
+      target: { value: "510000" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(onSaveQuote).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: "Balance" })).toHaveValue("510,000.00");
+  });
+
+  it("keeps the row and confirmation open when deletion fails", async () => {
+    const onDeleteQuote = vi.fn().mockRejectedValue(new Error("delete failed"));
+    renderGrid({ onDeleteQuote });
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete 2026-08-17, $495,000.00" }));
+    const dialog = screen.getByRole("alertdialog", { name: "Delete history entry?" });
+    fireEvent.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => expect(onDeleteQuote).toHaveBeenCalledTimes(1));
+    const openDialog = screen.getByRole("alertdialog", { name: "Delete history entry?" });
+    expect(openDialog).toBeInTheDocument();
+    fireEvent.click(within(openDialog).getByRole("button", { name: "Cancel" }));
+    expect(
+      screen.getByRole("button", { name: "Edit 2026-08-17, $495,000.00" }),
+    ).toBeInTheDocument();
+  });
+
+  it("uses the explicit asset ID when saving the first history entry", async () => {
+    const onSaveQuote = vi.fn().mockResolvedValue(undefined);
+    renderGrid({ data: [], onSaveQuote });
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Balance" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(onSaveQuote).toHaveBeenCalledTimes(1));
+    const today = format(new Date(), "yyyy-MM-dd");
+    expect(onSaveQuote).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: `${assetId}_${today}_MANUAL`,
+        assetId,
+      }),
+    );
+  });
+
+  it("replaces an existing entry when adding another balance for the same day", async () => {
+    const today = format(new Date(), "yyyy-MM-dd");
+    const onSaveQuote = vi.fn().mockResolvedValue(undefined);
+    renderGrid({ data: [createQuote(today, 495_000)], onSaveQuote });
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Balance" }));
+    fireEvent.change(screen.getByRole("textbox", { name: "Balance" }), {
+      target: { value: "490000" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(
+      await screen.findByRole("button", { name: `Edit ${today}, $490,000.00` }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: new RegExp(`^Edit ${today},`) })).toHaveLength(1);
+  });
+});

--- a/apps/frontend/src/pages/asset/alternative-assets/components/value-history-data-grid.test.tsx
+++ b/apps/frontend/src/pages/asset/alternative-assets/components/value-history-data-grid.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { format } from "date-fns";
+import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useDataGrid } from "@wealthfolio/ui";
 
@@ -79,6 +80,10 @@ interface CapturedDataGridOptions {
   onDataChange: (entries: ValueHistoryEntry[]) => void;
   onRowAdd: () => unknown;
   onRowsDelete: (rows: ValueHistoryEntry[], rowIndices: number[]) => void;
+  columns: {
+    id?: string;
+    cell?: (context: unknown) => ReactNode;
+  }[];
 }
 
 const getDataGridOptions = (): CapturedDataGridOptions => {
@@ -249,6 +254,16 @@ describe("ValueHistoryDataGrid desktop persistence", () => {
     fireEvent.click(screen.getByRole("button", { name: "Save Changes" }));
 
     await waitFor(() => expect(getDataGridOptions().readOnly).toBe(true));
+    const lockedGrid = getDataGridOptions();
+    const actionsColumn = lockedGrid.columns.find((column) => column.id === "actions");
+    if (typeof actionsColumn?.cell !== "function") {
+      throw new Error("actions column was not configured");
+    }
+    const actionCell = actionsColumn.cell({ row: { original: lockedGrid.data[0] } });
+    const action = render(<>{actionCell}</>);
+    expect(within(action.container).getByRole("button")).toBeDisabled();
+    action.unmount();
+
     act(() => resolveSave?.());
     await waitFor(() => expect(onPersistComplete).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(getDataGridOptions().readOnly).toBe(false));

--- a/apps/frontend/src/pages/asset/alternative-assets/components/value-history-data-grid.tsx
+++ b/apps/frontend/src/pages/asset/alternative-assets/components/value-history-data-grid.tsx
@@ -25,6 +25,7 @@ import { useTranslation } from "react-i18next";
 import { createColumnHelper } from "@tanstack/react-table";
 import type { Quote } from "@/lib/types";
 import { useIsMobileViewport } from "@/hooks/use-platform";
+import { toast } from "@wealthfolio/ui/components/ui/use-toast";
 import { ValueHistoryToolbar } from "./value-history-toolbar";
 import { format } from "date-fns";
 
@@ -80,6 +81,8 @@ interface ValueHistoryDataGridProps {
   onSaveQuote: (quote: Quote) => Promise<void>;
   /** Callback to delete a quote */
   onDeleteQuote: (quoteId: string) => Promise<void>;
+  /** Refresh quote-dependent queries after a complete persistence operation */
+  onPersistComplete: () => Promise<void>;
 }
 
 // Generate a temporary ID for new entries
@@ -95,11 +98,17 @@ const toValueHistoryEntry = (quote: Quote): ValueHistoryEntry => ({
   isNew: false,
 });
 
+const canonicalQuoteId = (entry: ValueHistoryEntry, assetId: string): string => {
+  const datePart = format(entry.date, "yyyy-MM-dd");
+  return `${assetId}_${datePart}_MANUAL`;
+};
+
 // Convert ValueHistoryEntry back to Quote for saving
 const toQuote = (entry: ValueHistoryEntry, assetId: string): Quote => {
-  const datePart = format(entry.date, "yyyy-MM-dd");
+  const id =
+    entry.isNew || entry.id.startsWith("temp-") ? canonicalQuoteId(entry, assetId) : entry.id;
   return {
-    id: `${assetId}_${datePart}_MANUAL`,
+    id,
     createdAt: new Date().toISOString(),
     dataSource: "MANUAL",
     timestamp: format(entry.date, "yyyy-MM-dd'T'00:00:00'Z'"),
@@ -113,6 +122,16 @@ const toQuote = (entry: ValueHistoryEntry, assetId: string): Quote => {
     currency: entry.currency,
     notes: entry.notes || undefined,
   };
+};
+
+const hasDuplicateDates = (entries: ValueHistoryEntry[]): boolean => {
+  const dates = new Set<string>();
+  return entries.some((entry) => {
+    const date = format(entry.date, "yyyy-MM-dd");
+    if (dates.has(date)) return true;
+    dates.add(date);
+    return false;
+  });
 };
 
 // Create draft entry
@@ -132,6 +151,7 @@ export function ValueHistoryDataGrid({
   isLiability = false,
   onSaveQuote,
   onDeleteQuote,
+  onPersistComplete,
 }: ValueHistoryDataGridProps) {
   const { t } = useTranslation();
   const isMobile = useIsMobileViewport();
@@ -166,21 +186,26 @@ export function ValueHistoryDataGrid({
   const columnHelper = createColumnHelper<ValueHistoryEntry>();
 
   // Delete a single row
-  const handleDeleteRow = useCallback((entry: ValueHistoryEntry) => {
-    if (entry.isNew) {
-      // Remove new entries immediately
-      setLocalEntries((prev) => prev.filter((e) => e.id !== entry.id));
-      setDirtyIds((prev) => {
-        const next = new Set(prev);
-        next.delete(entry.id);
-        return next;
-      });
-    } else {
-      // Mark existing entries for deletion
-      setDeletedIds((prev) => new Set(prev).add(entry.id));
-      setLocalEntries((prev) => prev.filter((e) => e.id !== entry.id));
-    }
-  }, []);
+  const handleDeleteRow = useCallback(
+    (entry: ValueHistoryEntry) => {
+      if (isPersisting) return;
+
+      if (entry.isNew) {
+        // Remove new entries immediately
+        setLocalEntries((prev) => prev.filter((e) => e.id !== entry.id));
+        setDirtyIds((prev) => {
+          const next = new Set(prev);
+          next.delete(entry.id);
+          return next;
+        });
+      } else {
+        // Mark existing entries for deletion
+        setDeletedIds((prev) => new Set(prev).add(entry.id));
+        setLocalEntries((prev) => prev.filter((e) => e.id !== entry.id));
+      }
+    },
+    [isPersisting],
+  );
 
   const columns = useMemo(
     () => [
@@ -213,6 +238,7 @@ export function ValueHistoryDataGrid({
               variant="ghost"
               size="icon"
               className="text-muted-foreground hover:text-destructive h-7 w-7"
+              disabled={isPersisting}
               onClick={() => handleDeleteRow(row.original)}
             >
               <Icons.X className="h-4 w-4" />
@@ -221,7 +247,7 @@ export function ValueHistoryDataGrid({
         ),
       }),
     ],
-    [columnHelper, isLiability, handleDeleteRow, t],
+    [columnHelper, isLiability, handleDeleteRow, isPersisting, t],
   );
 
   // Handle data changes from the grid
@@ -329,6 +355,7 @@ export function ValueHistoryDataGrid({
     enableSorting: true,
     enableSearch: true,
     enablePaste: true,
+    readOnly: isPersisting,
     onDataChange,
     onRowAdd,
     onRowsAdd,
@@ -351,26 +378,68 @@ export function ValueHistoryDataGrid({
   // Save all changes
   const handleSave = useCallback(async () => {
     if (isPersisting) return;
+    if (hasDuplicateDates(localEntries)) {
+      toast({
+        title: t("asset:valueHistory.duplicate_date_error"),
+        variant: "destructive",
+      });
+      return;
+    }
 
-    const quotesToSave = localEntries
-      .filter((entry) => dirtyIds.has(entry.id))
-      .map((entry) => toQuote(entry, assetId));
-    const idsToDelete = [...deletedIds].filter((id) => !id.startsWith("temp-"));
+    const dirtyIdsSnapshot = new Set(dirtyIds);
+    const deletedIdsSnapshot = new Set(deletedIds);
+    const entriesToSave = localEntries.filter((entry) => dirtyIdsSnapshot.has(entry.id));
+    const quotesToSave = entriesToSave.map((entry) => toQuote(entry, assetId));
+    const idsToDelete = [...deletedIdsSnapshot].filter((id) => !id.startsWith("temp-"));
 
     setIsPersisting(true);
     try {
-      await Promise.all([
-        ...quotesToSave.map((quote) => onSaveQuote(quote)),
-        ...idsToDelete.map((id) => onDeleteQuote(id)),
-      ]);
-      setDirtyIds(new Set());
-      setDeletedIds(new Set());
+      // Delete first so a same-day replacement cannot be removed after it is saved.
+      for (const id of idsToDelete) {
+        await onDeleteQuote(id);
+      }
+      for (const quote of quotesToSave) {
+        await onSaveQuote(quote);
+      }
+
+      const savedEntries = new Map(
+        entriesToSave.map((entry) => [
+          entry.id,
+          { ...entry, id: canonicalQuoteId(entry, assetId), isNew: false },
+        ]),
+      );
+      setLocalEntries((current) => current.map((entry) => savedEntries.get(entry.id) ?? entry));
+      setDirtyIds((current) => {
+        const next = new Set(current);
+        dirtyIdsSnapshot.forEach((id) => next.delete(id));
+        return next;
+      });
+      setDeletedIds((current) => {
+        const next = new Set(current);
+        deletedIdsSnapshot.forEach((id) => next.delete(id));
+        return next;
+      });
+      try {
+        await onPersistComplete();
+      } catch {
+        // Persistence succeeded; a later query refresh can recover from a transient refetch error.
+      }
     } catch {
       // Mutation callbacks surface their own error notifications. Keep edits for retry.
     } finally {
       setIsPersisting(false);
     }
-  }, [assetId, deletedIds, dirtyIds, isPersisting, localEntries, onDeleteQuote, onSaveQuote]);
+  }, [
+    assetId,
+    deletedIds,
+    dirtyIds,
+    isPersisting,
+    localEntries,
+    onDeleteQuote,
+    onPersistComplete,
+    onSaveQuote,
+    t,
+  ]);
 
   // Cancel changes
   const handleCancel = useCallback(() => {
@@ -416,7 +485,7 @@ export function ValueHistoryDataGrid({
     const quote = toQuote(mobileDraft, assetId);
     const savedEntry: ValueHistoryEntry = {
       ...mobileDraft,
-      id: quote.id,
+      id: canonicalQuoteId(mobileDraft, assetId),
       isNew: false,
     };
 
@@ -431,12 +500,17 @@ export function ValueHistoryDataGrid({
         ),
       ]);
       setMobileDraft(null);
+      try {
+        await onPersistComplete();
+      } catch {
+        // Persistence succeeded; a later query refresh can recover from a transient refetch error.
+      }
     } catch {
       // Mutation callback surfaces the error. Keep the draft open for retry.
     } finally {
       setIsPersisting(false);
     }
-  }, [assetId, isPersisting, mobileDraft, onSaveQuote]);
+  }, [assetId, isPersisting, mobileDraft, onPersistComplete, onSaveQuote]);
 
   const handleMobileDelete = useCallback(async () => {
     if (!mobileDeleteEntry || isPersisting) return;
@@ -448,12 +522,17 @@ export function ValueHistoryDataGrid({
       setLocalEntries((prev) => prev.filter((entry) => entry.id !== entryToDelete.id));
       setMobileDraft((draft) => (draft?.id === entryToDelete.id ? null : draft));
       setMobileDeleteEntry(null);
+      try {
+        await onPersistComplete();
+      } catch {
+        // Persistence succeeded; a later query refresh can recover from a transient refetch error.
+      }
     } catch {
       // Mutation callback surfaces the error. Keep the dialog open for retry.
     } finally {
       setIsPersisting(false);
     }
-  }, [isPersisting, mobileDeleteEntry, onDeleteQuote]);
+  }, [isPersisting, mobileDeleteEntry, onDeleteQuote, onPersistComplete]);
 
   if (isMobile) {
     const valueLabel = isLiability

--- a/apps/frontend/src/pages/asset/alternative-assets/components/value-history-data-grid.tsx
+++ b/apps/frontend/src/pages/asset/alternative-assets/components/value-history-data-grid.tsx
@@ -1,13 +1,36 @@
-import { Button, DataGrid, Icons, useDataGrid } from "@wealthfolio/ui";
-import { useCallback, useMemo, useState } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  Button,
+  DataGrid,
+  DatePickerInput,
+  formatAmount,
+  formatCurrencySymbol,
+  Icons,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupText,
+  MoneyInput,
+  Textarea,
+  useDataGrid,
+} from "@wealthfolio/ui";
+import { useCallback, useEffect, useId, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { createColumnHelper } from "@tanstack/react-table";
 import type { Quote } from "@/lib/types";
+import { useIsMobileViewport } from "@/hooks/use-platform";
 import { ValueHistoryToolbar } from "./value-history-toolbar";
 import { format } from "date-fns";
 
 const DATE_ONLY_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 const UTC_MIDNIGHT_REGEX = /^\d{4}-\d{2}-\d{2}T00:00:00(?:\.\d+)?Z$/;
+const MOBILE_PAGE_SIZE = 20;
 
 // Parse YYYY-MM-DD as local midnight to avoid timezone shifts in date-only values.
 const parseLocalDate = (dateOnly: string): Date => new Date(dateOnly + "T00:00:00");
@@ -47,14 +70,16 @@ export interface ValueHistoryEntry {
 interface ValueHistoryDataGridProps {
   /** Quote data from the backend */
   data: Quote[];
+  /** Asset identifier used for canonical manual quote IDs */
+  assetId: string;
   /** Currency for the asset */
   currency: string;
   /** Whether this is a liability (changes "Value" to "Balance" label) */
   isLiability?: boolean;
   /** Callback to save a quote */
-  onSaveQuote: (quote: Quote) => void;
+  onSaveQuote: (quote: Quote) => Promise<void>;
   /** Callback to delete a quote */
-  onDeleteQuote: (quoteId: string) => void;
+  onDeleteQuote: (quoteId: string) => Promise<void>;
 }
 
 // Generate a temporary ID for new entries
@@ -71,14 +96,14 @@ const toValueHistoryEntry = (quote: Quote): ValueHistoryEntry => ({
 });
 
 // Convert ValueHistoryEntry back to Quote for saving
-const toQuote = (entry: ValueHistoryEntry, symbol: string): Quote => {
-  const datePart = format(entry.date, "yyyy-MM-dd").replace(/-/g, "");
+const toQuote = (entry: ValueHistoryEntry, assetId: string): Quote => {
+  const datePart = format(entry.date, "yyyy-MM-dd");
   return {
-    id: entry.id.startsWith("temp-") ? `${datePart}_${symbol.toUpperCase()}` : entry.id,
+    id: `${assetId}_${datePart}_MANUAL`,
     createdAt: new Date().toISOString(),
     dataSource: "MANUAL",
     timestamp: format(entry.date, "yyyy-MM-dd'T'00:00:00'Z'"),
-    assetId: symbol,
+    assetId,
     open: entry.value,
     high: entry.value,
     low: entry.value,
@@ -102,12 +127,14 @@ const createDraftEntry = (currency: string): ValueHistoryEntry => ({
 
 export function ValueHistoryDataGrid({
   data,
+  assetId,
   currency,
   isLiability = false,
   onSaveQuote,
   onDeleteQuote,
 }: ValueHistoryDataGridProps) {
   const { t } = useTranslation();
+  const isMobile = useIsMobileViewport();
   // Convert quotes to local entries
   const initialEntries = useMemo(
     () => data.map(toValueHistoryEntry).sort((a, b) => b.date.getTime() - a.date.getTime()),
@@ -117,19 +144,23 @@ export function ValueHistoryDataGrid({
   const [localEntries, setLocalEntries] = useState<ValueHistoryEntry[]>(initialEntries);
   const [dirtyIds, setDirtyIds] = useState<Set<string>>(new Set());
   const [deletedIds, setDeletedIds] = useState<Set<string>>(new Set());
+  const [mobilePage, setMobilePage] = useState(0);
+  const [mobileDraft, setMobileDraft] = useState<ValueHistoryEntry | null>(null);
+  const [mobileDeleteEntry, setMobileDeleteEntry] = useState<ValueHistoryEntry | null>(null);
+  const [isPersisting, setIsPersisting] = useState(false);
+  const mobileNotesId = useId();
 
   // Sync with external data changes
-  useMemo(() => {
+  useEffect(() => {
     setLocalEntries(initialEntries);
     setDirtyIds(new Set());
     setDeletedIds(new Set());
+    setMobileDraft(null);
+    setMobileDeleteEntry(null);
   }, [initialEntries]);
 
   // Track if there are unsaved changes
   const hasUnsavedChanges = dirtyIds.size > 0 || deletedIds.size > 0;
-
-  // Get assetId from first quote or use empty string
-  const symbol = data[0]?.assetId ?? "";
 
   // Column definitions
   const columnHelper = createColumnHelper<ValueHistoryEntry>();
@@ -318,26 +349,28 @@ export function ValueHistoryDataGrid({
   }, [dataGrid.table, onRowsDelete]);
 
   // Save all changes
-  const handleSave = useCallback(() => {
-    // Save dirty entries
-    for (const entry of localEntries) {
-      if (dirtyIds.has(entry.id)) {
-        const quote = toQuote(entry, symbol);
-        onSaveQuote(quote);
-      }
-    }
+  const handleSave = useCallback(async () => {
+    if (isPersisting) return;
 
-    // Delete marked entries
-    for (const id of deletedIds) {
-      if (!id.startsWith("temp-")) {
-        onDeleteQuote(id);
-      }
-    }
+    const quotesToSave = localEntries
+      .filter((entry) => dirtyIds.has(entry.id))
+      .map((entry) => toQuote(entry, assetId));
+    const idsToDelete = [...deletedIds].filter((id) => !id.startsWith("temp-"));
 
-    // Reset state
-    setDirtyIds(new Set());
-    setDeletedIds(new Set());
-  }, [localEntries, dirtyIds, deletedIds, symbol, onSaveQuote, onDeleteQuote]);
+    setIsPersisting(true);
+    try {
+      await Promise.all([
+        ...quotesToSave.map((quote) => onSaveQuote(quote)),
+        ...idsToDelete.map((id) => onDeleteQuote(id)),
+      ]);
+      setDirtyIds(new Set());
+      setDeletedIds(new Set());
+    } catch {
+      // Mutation callbacks surface their own error notifications. Keep edits for retry.
+    } finally {
+      setIsPersisting(false);
+    }
+  }, [assetId, deletedIds, dirtyIds, isPersisting, localEntries, onDeleteQuote, onSaveQuote]);
 
   // Cancel changes
   const handleCancel = useCallback(() => {
@@ -346,6 +379,299 @@ export function ValueHistoryDataGrid({
     setDeletedIds(new Set());
     dataGrid.table.resetRowSelection();
   }, [initialEntries, dataGrid.table]);
+
+  const sortedEntries = useMemo(
+    () => [...localEntries].sort((a, b) => b.date.getTime() - a.date.getTime()),
+    [localEntries],
+  );
+  const mobilePageCount = Math.max(1, Math.ceil(sortedEntries.length / MOBILE_PAGE_SIZE));
+  const mobilePageEntries = sortedEntries.slice(
+    mobilePage * MOBILE_PAGE_SIZE,
+    (mobilePage + 1) * MOBILE_PAGE_SIZE,
+  );
+
+  useEffect(() => {
+    setMobilePage((page) => Math.min(page, mobilePageCount - 1));
+  }, [mobilePageCount]);
+
+  const handleMobileAdd = useCallback(() => {
+    setMobilePage(0);
+    setMobileDraft(createDraftEntry(currency));
+  }, [currency]);
+
+  const handleMobileFieldChange = useCallback(
+    (field: "date" | "value" | "notes", value: Date | number | string) => {
+      setMobileDraft((draft) => (draft ? { ...draft, [field]: value } : draft));
+    },
+    [],
+  );
+
+  const handleMobileEdit = useCallback((entry: ValueHistoryEntry) => {
+    setMobileDraft({ ...entry, date: new Date(entry.date) });
+  }, []);
+
+  const handleMobileSave = useCallback(async () => {
+    if (!mobileDraft || isPersisting) return;
+
+    const quote = toQuote(mobileDraft, assetId);
+    const savedEntry: ValueHistoryEntry = {
+      ...mobileDraft,
+      id: quote.id,
+      isNew: false,
+    };
+
+    setIsPersisting(true);
+    try {
+      await onSaveQuote(quote);
+      const savedDay = format(savedEntry.date, "yyyy-MM-dd");
+      setLocalEntries((prev) => [
+        savedEntry,
+        ...prev.filter(
+          (entry) => entry.id !== mobileDraft.id && format(entry.date, "yyyy-MM-dd") !== savedDay,
+        ),
+      ]);
+      setMobileDraft(null);
+    } catch {
+      // Mutation callback surfaces the error. Keep the draft open for retry.
+    } finally {
+      setIsPersisting(false);
+    }
+  }, [assetId, isPersisting, mobileDraft, onSaveQuote]);
+
+  const handleMobileDelete = useCallback(async () => {
+    if (!mobileDeleteEntry || isPersisting) return;
+
+    const entryToDelete = mobileDeleteEntry;
+    setIsPersisting(true);
+    try {
+      await onDeleteQuote(entryToDelete.id);
+      setLocalEntries((prev) => prev.filter((entry) => entry.id !== entryToDelete.id));
+      setMobileDraft((draft) => (draft?.id === entryToDelete.id ? null : draft));
+      setMobileDeleteEntry(null);
+    } catch {
+      // Mutation callback surfaces the error. Keep the dialog open for retry.
+    } finally {
+      setIsPersisting(false);
+    }
+  }, [isPersisting, mobileDeleteEntry, onDeleteQuote]);
+
+  if (isMobile) {
+    const valueLabel = isLiability
+      ? t("asset:valueHistory.balance")
+      : t("asset:valueHistory.value");
+    const mobileEntries = mobileDraft?.isNew
+      ? [mobileDraft, ...mobilePageEntries]
+      : mobilePageEntries;
+
+    return (
+      <div className="flex flex-col space-y-3">
+        <div>
+          <Button
+            className="h-11"
+            onClick={handleMobileAdd}
+            disabled={mobileDraft !== null || isPersisting}
+          >
+            <Icons.Plus className="mr-2 h-4 w-4" aria-hidden="true" />
+            {isLiability ? t("asset:valueToolbar.add_balance") : t("asset:valueToolbar.add_value")}
+          </Button>
+        </div>
+
+        <div className="bg-background isolate divide-y overflow-hidden rounded-xl border">
+          {mobileEntries.length === 0 ? (
+            <p className="text-muted-foreground p-6 text-center text-sm">
+              {t("asset:altContent.no_valuation_data")}
+            </p>
+          ) : (
+            mobileEntries.map((entry) => {
+              const isEditing = mobileDraft?.id === entry.id;
+
+              if (isEditing && mobileDraft) {
+                const draft = mobileDraft;
+
+                return (
+                  <div key={draft.id} className="bg-background w-full space-y-3 p-3">
+                    <div>
+                      <span className="text-xs font-medium uppercase tracking-wide">
+                        {draft.isNew
+                          ? isLiability
+                            ? t("asset:valueToolbar.add_balance")
+                            : t("asset:valueToolbar.add_value")
+                          : t("common:edit")}
+                      </span>
+                    </div>
+
+                    <div className="space-y-2.5">
+                      <div>
+                        <label className="text-muted-foreground mb-1 block text-xs">
+                          {t("asset:valueHistory.date")}
+                        </label>
+                        <DatePickerInput
+                          value={draft.date}
+                          disabled={isPersisting}
+                          onChange={(date) => date && handleMobileFieldChange("date", date)}
+                        />
+                      </div>
+                      <div>
+                        <label className="text-muted-foreground mb-1 block text-xs">
+                          {valueLabel}
+                        </label>
+                        <InputGroup className="bg-input-bg h-10 rounded-md">
+                          <InputGroupAddon align="inline-start">
+                            <InputGroupText>{formatCurrencySymbol(draft.currency)}</InputGroupText>
+                          </InputGroupAddon>
+                          <MoneyInput
+                            data-slot="input-group-control"
+                            className="min-w-0 flex-1 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0"
+                            value={draft.value}
+                            maxDecimalPlaces={2}
+                            fixedDecimalScale
+                            thousandSeparator
+                            disabled={isPersisting}
+                            aria-label={valueLabel}
+                            onValueChange={(value) => handleMobileFieldChange("value", value ?? 0)}
+                          />
+                        </InputGroup>
+                      </div>
+                      <div>
+                        <label
+                          htmlFor={mobileNotesId}
+                          className="text-muted-foreground mb-1 block text-xs"
+                        >
+                          {t("asset:valueHistory.notes")}
+                        </label>
+                        <Textarea
+                          id={mobileNotesId}
+                          rows={2}
+                          className="min-h-16 resize-none"
+                          value={draft.notes}
+                          disabled={isPersisting}
+                          onChange={(event) => handleMobileFieldChange("notes", event.target.value)}
+                        />
+                      </div>
+                    </div>
+
+                    <div className="flex justify-end gap-2 pt-1">
+                      <Button
+                        variant="outline"
+                        className="h-11"
+                        disabled={isPersisting}
+                        onClick={() => setMobileDraft(null)}
+                      >
+                        {t("common:cancel")}
+                      </Button>
+                      <Button className="h-11" disabled={isPersisting} onClick={handleMobileSave}>
+                        <Icons.Save className="mr-2 h-4 w-4" aria-hidden="true" />
+                        {t("common:save")}
+                      </Button>
+                    </div>
+                  </div>
+                );
+              }
+
+              return (
+                <div key={entry.id} className="flex items-center p-1.5">
+                  <button
+                    type="button"
+                    className="active:bg-muted/40 grid min-h-11 min-w-0 flex-1 grid-cols-[minmax(0,1fr)_auto_auto] items-center gap-x-2 rounded-md px-1.5 py-2 text-left disabled:opacity-50"
+                    aria-label={t("asset:valueHistory.edit_entry_aria", {
+                      date: format(entry.date, "yyyy-MM-dd"),
+                      value: formatAmount(entry.value, entry.currency),
+                    })}
+                    disabled={isPersisting}
+                    onClick={() => handleMobileEdit(entry)}
+                  >
+                    <span className="text-muted-foreground truncate text-sm">
+                      {format(entry.date, "yyyy-MM-dd")}
+                    </span>
+                    <span className="text-foreground text-base font-semibold tabular-nums">
+                      {formatAmount(entry.value, entry.currency)}
+                    </span>
+                    <Icons.Pencil className="text-muted-foreground h-4 w-4" aria-hidden="true" />
+                    {entry.notes && (
+                      <span className="text-muted-foreground col-span-3 mt-1 line-clamp-2 text-xs">
+                        {entry.notes}
+                      </span>
+                    )}
+                  </button>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="text-muted-foreground hover:text-destructive h-11 w-11 shrink-0"
+                    aria-label={t("asset:valueHistory.delete_entry_aria", {
+                      date: format(entry.date, "yyyy-MM-dd"),
+                      value: formatAmount(entry.value, entry.currency),
+                    })}
+                    disabled={isPersisting}
+                    onClick={() => setMobileDeleteEntry(entry)}
+                  >
+                    <Icons.Trash className="h-4 w-4" aria-hidden="true" />
+                  </Button>
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        {mobilePageCount > 1 && (
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">
+              {t("asset:quoteGrid.page_of", {
+                page: mobilePage + 1,
+                total: mobilePageCount,
+              })}
+            </span>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-11"
+                onClick={() => setMobilePage((page) => page - 1)}
+                disabled={mobilePage === 0 || mobileDraft !== null || isPersisting}
+              >
+                {t("common:previous")}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-11"
+                onClick={() => setMobilePage((page) => page + 1)}
+                disabled={mobilePage >= mobilePageCount - 1 || mobileDraft !== null || isPersisting}
+              >
+                {t("common:next")}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        <AlertDialog
+          open={mobileDeleteEntry !== null}
+          onOpenChange={(open) => !open && !isPersisting && setMobileDeleteEntry(null)}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>{t("asset:valueHistory.delete_title")}</AlertDialogTitle>
+              <AlertDialogDescription>
+                {t("asset:valueHistory.delete_description")}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isPersisting}>{t("common:cancel")}</AlertDialogCancel>
+              <AlertDialogAction
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                disabled={isPersisting}
+                onClick={(event) => {
+                  event.preventDefault();
+                  void handleMobileDelete();
+                }}
+              >
+                {t("common:delete")}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-h-0 flex-1 flex-col space-y-3">
@@ -358,6 +684,7 @@ export function ValueHistoryDataGrid({
         onDeleteSelected={handleDeleteSelected}
         onSave={handleSave}
         onCancel={handleCancel}
+        isSaving={isPersisting}
         isLiability={isLiability}
       />
 

--- a/apps/frontend/src/pages/asset/alternative-assets/components/value-history-data-grid.tsx
+++ b/apps/frontend/src/pages/asset/alternative-assets/components/value-history-data-grid.tsx
@@ -20,7 +20,7 @@ import {
   Textarea,
   useDataGrid,
 } from "@wealthfolio/ui";
-import { useCallback, useEffect, useId, useMemo, useState } from "react";
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { createColumnHelper } from "@tanstack/react-table";
 import type { Quote } from "@/lib/types";
@@ -169,18 +169,20 @@ export function ValueHistoryDataGrid({
   const [mobileDeleteEntry, setMobileDeleteEntry] = useState<ValueHistoryEntry | null>(null);
   const [isPersisting, setIsPersisting] = useState(false);
   const mobileNotesId = useId();
-
-  // Sync with external data changes
-  useEffect(() => {
-    setLocalEntries(initialEntries);
-    setDirtyIds(new Set());
-    setDeletedIds(new Set());
-    setMobileDraft(null);
-    setMobileDeleteEntry(null);
-  }, [initialEntries]);
+  const lastSyncedEntriesRef = useRef(initialEntries);
 
   // Track if there are unsaved changes
   const hasUnsavedChanges = dirtyIds.size > 0 || deletedIds.size > 0;
+  const hasPendingEdits = hasUnsavedChanges || mobileDraft !== null;
+
+  // Sync with external data changes
+  useEffect(() => {
+    if (initialEntries === lastSyncedEntriesRef.current) return;
+    if (isPersisting || hasPendingEdits) return;
+    setLocalEntries(initialEntries);
+    setMobileDeleteEntry(null);
+    lastSyncedEntriesRef.current = initialEntries;
+  }, [hasPendingEdits, initialEntries, isPersisting]);
 
   // Column definitions
   const columnHelper = createColumnHelper<ValueHistoryEntry>();

--- a/apps/frontend/src/pages/asset/alternative-assets/components/value-history-toolbar.tsx
+++ b/apps/frontend/src/pages/asset/alternative-assets/components/value-history-toolbar.tsx
@@ -10,6 +10,7 @@ interface ValueHistoryToolbarProps {
   onDeleteSelected: () => void;
   onSave: () => void;
   onCancel: () => void;
+  isSaving?: boolean;
   isLiability?: boolean;
 }
 
@@ -22,6 +23,7 @@ export function ValueHistoryToolbar({
   onDeleteSelected,
   onSave,
   onCancel,
+  isSaving = false,
   isLiability = false,
 }: ValueHistoryToolbarProps) {
   const { t } = useTranslation();
@@ -29,13 +31,13 @@ export function ValueHistoryToolbar({
   return (
     <div className="flex items-center justify-between">
       <div className="flex items-center gap-2">
-        <Button variant="default" size="sm" onClick={onAddRow}>
+        <Button variant="default" size="sm" onClick={onAddRow} disabled={isSaving}>
           <Icons.Plus className="mr-2 h-4 w-4" />
           {isLiability ? t("asset:valueToolbar.add_balance") : t("asset:valueToolbar.add_value")}
         </Button>
 
         {selectedRowCount > 0 && (
-          <Button variant="outline" size="sm" onClick={onDeleteSelected}>
+          <Button variant="outline" size="sm" onClick={onDeleteSelected} disabled={isSaving}>
             <Icons.Trash className="mr-2 h-4 w-4" />
             {t("asset:valueToolbar.delete_count", { count: selectedRowCount })}
           </Button>
@@ -50,10 +52,10 @@ export function ValueHistoryToolbar({
               {dirtyCount > 0 && deletedCount > 0 && ", "}
               {deletedCount > 0 && t("asset:valueToolbar.to_delete", { count: deletedCount })}
             </span>
-            <Button variant="ghost" size="sm" onClick={onCancel}>
+            <Button variant="ghost" size="sm" onClick={onCancel} disabled={isSaving}>
               {t("common:cancel")}
             </Button>
-            <Button variant="default" size="sm" onClick={onSave}>
+            <Button variant="default" size="sm" onClick={onSave} disabled={isSaving}>
               <Icons.Save className="mr-2 h-4 w-4" />
               {t("asset:valueToolbar.save_changes")}
             </Button>

--- a/apps/frontend/src/pages/asset/hooks/use-quote-mutations.test.tsx
+++ b/apps/frontend/src/pages/asset/hooks/use-quote-mutations.test.tsx
@@ -1,0 +1,84 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Quote } from "@/lib/types";
+import { QueryKeys } from "@/lib/query-keys";
+
+import { useQuoteMutations } from "./use-quote-mutations";
+
+const adapterMocks = vi.hoisted(() => ({
+  updateQuote: vi.fn(),
+  deleteQuote: vi.fn(),
+  logger: { error: vi.fn() },
+}));
+const performanceMocks = vi.hoisted(() => ({
+  invalidatePerformanceCaches: vi.fn(),
+}));
+
+vi.mock("@/adapters", () => adapterMocks);
+vi.mock("@/lib/performance-cache", () => performanceMocks);
+vi.mock("@wealthfolio/ui/components/ui/use-toast", () => ({ toast: vi.fn() }));
+
+const assetId = "asset-home-mortgage";
+const quote: Quote = {
+  id: `${assetId}_2026-08-17_MANUAL`,
+  createdAt: "2026-08-17T00:00:00.000Z",
+  dataSource: "MANUAL",
+  timestamp: "2026-08-17T00:00:00Z",
+  assetId,
+  open: 495_000,
+  high: 495_000,
+  low: 495_000,
+  volume: 0,
+  close: 495_000,
+  adjclose: 495_000,
+  currency: "USD",
+};
+
+const createHarness = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+};
+
+describe("useQuoteMutations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    adapterMocks.updateQuote.mockResolvedValue(undefined);
+  });
+
+  it("defers invalidation until the batch boundary when requested", async () => {
+    const { queryClient, wrapper } = createHarness();
+    const invalidateQueries = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(
+      () => useQuoteMutations(assetId, { invalidateOnSuccess: false }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.saveQuoteMutation.mutateAsync(quote);
+    });
+
+    expect(invalidateQueries).not.toHaveBeenCalled();
+    expect(performanceMocks.invalidatePerformanceCaches).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await result.current.invalidateQuoteQueries();
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: [QueryKeys.QUOTE_HISTORY, assetId],
+    });
+    expect(invalidateQueries).toHaveBeenCalledTimes(3);
+    expect(performanceMocks.invalidatePerformanceCaches).toHaveBeenCalledWith(queryClient);
+  });
+});

--- a/apps/frontend/src/pages/asset/hooks/use-quote-mutations.ts
+++ b/apps/frontend/src/pages/asset/hooks/use-quote-mutations.ts
@@ -4,15 +4,31 @@ import { QueryKeys } from "@/lib/query-keys";
 import { invalidatePerformanceCaches } from "@/lib/performance-cache";
 import { Quote } from "@/lib/types";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
 
-export const useQuoteMutations = (assetId: string) => {
+interface UseQuoteMutationsOptions {
+  invalidateOnSuccess?: boolean;
+}
+
+export const useQuoteMutations = (
+  assetId: string,
+  { invalidateOnSuccess = true }: UseQuoteMutationsOptions = {},
+) => {
   const queryClient = useQueryClient();
 
-  const handleSuccess = (message: string) => {
-    queryClient.invalidateQueries({ queryKey: [QueryKeys.ASSET_DATA, assetId] });
-    queryClient.invalidateQueries({ queryKey: [QueryKeys.QUOTE_HISTORY, assetId] });
-    queryClient.invalidateQueries({ queryKey: [QueryKeys.LATEST_QUOTES] });
+  const invalidateQuoteQueries = useCallback(async () => {
     invalidatePerformanceCaches(queryClient);
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.ASSET_DATA, assetId] }),
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.QUOTE_HISTORY, assetId] }),
+      queryClient.invalidateQueries({ queryKey: [QueryKeys.LATEST_QUOTES] }),
+    ]);
+  }, [assetId, queryClient]);
+
+  const handleSuccess = (message: string) => {
+    if (invalidateOnSuccess) {
+      void invalidateQuoteQueries();
+    }
     toast({
       title: message,
       variant: "success",
@@ -59,5 +75,6 @@ export const useQuoteMutations = (assetId: string) => {
   return {
     saveQuoteMutation,
     deleteQuoteMutation,
+    invalidateQuoteQueries,
   };
 };

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -95,7 +95,7 @@
     "input-otp": "^1.4.2",
     "lucide-react": "^0.561.0",
     "motion": "^12.34.0",
-    "nanoid": "^5.1.6",
+    "nanoid": "^5.1.16",
     "react-aria-components": "^1.15.1",
     "react-day-picker": "^9.13.2",
     "react-dropzone": "^14.4.1",

--- a/packages/ui/src/components/financial/money-input.tsx
+++ b/packages/ui/src/components/financial/money-input.tsx
@@ -20,6 +20,8 @@ export interface MoneyInputProps {
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   /** Maximum decimal places (default: 8) */
   maxDecimalPlaces?: number;
+  /** Always display the configured number of decimal places */
+  fixedDecimalScale?: boolean;
   /** Use thousand separators (default: false) */
   thousandSeparator?: boolean;
   /** Placeholder text */
@@ -49,6 +51,7 @@ const MoneyInput = React.forwardRef<HTMLInputElement, MoneyInputProps>(
       onValueChange,
       onChange,
       maxDecimalPlaces = DECIMAL_PRECISION,
+      fixedDecimalScale = false,
       thousandSeparator = false,
       placeholder = "0.00",
       className,
@@ -80,6 +83,7 @@ const MoneyInput = React.forwardRef<HTMLInputElement, MoneyInputProps>(
         onKeyDown={onKeyDown}
         allowNegative={false}
         decimalScale={maxDecimalPlaces}
+        fixedDecimalScale={fixedDecimalScale}
         thousandSeparator={thousandSeparator}
         allowedDecimalSeparators={[".", ","]}
         valueIsNumericString={false}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -176,8 +176,8 @@ importers:
         specifier: ^12.34.0
         version: 12.34.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       nanoid:
-        specifier: ^5.1.6
-        version: 5.1.6
+        specifier: ^5.1.16
+        version: 5.1.16
       qrcode.react:
         specifier: ^4.2.0
         version: 4.2.0(react@19.2.8)
@@ -442,8 +442,8 @@ importers:
         specifier: ^12.34.0
         version: 12.34.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       nanoid:
-        specifier: ^5.1.6
-        version: 5.1.6
+        specifier: ^5.1.16
+        version: 5.1.16
       react:
         specifier: ^19.2.4
         version: 19.2.8
@@ -5162,13 +5162,13 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.6:
-    resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -6650,7 +6650,7 @@ snapshots:
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.8)
       assistant-cloud: 0.1.17
       assistant-stream: 0.2.47
-      nanoid: 5.1.6
+      nanoid: 5.1.16
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       react-textarea-autosize: 8.5.9(@types/react@19.2.14)(react@19.2.8)
@@ -9868,13 +9868,13 @@ snapshots:
   assistant-stream@0.2.47:
     dependencies:
       '@standard-schema/spec': 1.1.0
-      nanoid: 5.1.6
+      nanoid: 5.1.16
       secure-json-parse: 4.1.0
 
   assistant-stream@0.3.2:
     dependencies:
       '@standard-schema/spec': 1.1.0
-      nanoid: 5.1.6
+      nanoid: 5.1.16
       secure-json-parse: 4.1.0
 
   ast-types@0.16.1:
@@ -11975,9 +11975,9 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
-  nanoid@5.1.6: {}
+  nanoid@5.1.16: {}
 
   natural-compare@1.4.0: {}
 
@@ -12223,7 +12223,7 @@ snapshots:
 
   postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Summary

- restore horizontal touch scrolling for spending categories on mobile
- replace the liability value-history DataGrid with a responsive mobile list and inline editor while preserving the desktop grid
- preserve existing quote identities, retain retryable edits after partial failures, and refresh quote history once per completed batch
- lock desktop editing during persistence, reject duplicate dates, and serialize same-day replacements as delete-then-save
- improve mobile accessibility and update nanoid to patched 3.3.18 and 5.1.16 releases

## Root cause

A global flex overflow rule overrode the spending category scroller on mobile. The liability history reused a desktop-focused DataGrid, canonicalized existing quote IDs before the backend could move them, and allowed per-item refetches and concurrent edits during batch persistence.

## Validation

- `pnpm type-check`
- `pnpm test` — 148 files, 1,230 tests passed
- `pnpm build`
- live verification at 320px mobile and desktop widths