### PR TITLE
Exclude draft activities from contribution limits

### DIFF
--- a/crates/core/src/activities/activities_traits.rs
+++ b/crates/core/src/activities/activities_traits.rs
@@ -142,8 +142,9 @@ pub trait ActivityRepositoryTrait: Send + Sync {
     }
     fn get_trading_activities(&self) -> Result<Vec<Activity>>;
     fn get_income_activities(&self) -> Result<Vec<Activity>>;
-    /// Fetches contribution-eligible activities (DEPOSIT, TRANSFER_IN, TRANSFER_OUT, CREDIT)
-    /// for the given accounts within the date range. Filtering logic applied in service layer.
+    /// Fetches posted contribution candidates (DEPOSIT, TRANSFER_IN, TRANSFER_OUT, CREDIT)
+    /// for the given accounts within the date range. Contribution classification is applied in
+    /// the service layer.
     fn get_contribution_activities(
         &self,
         account_ids: &[String],

--- a/crates/storage-sqlite/src/activities/repository.rs
+++ b/crates/storage-sqlite/src/activities/repository.rs
@@ -1960,7 +1960,7 @@ impl ActivityRepositoryTrait for ActivityRepository {
             .await
     }
 
-    /// Fetches contribution-eligible activities (DEPOSIT, TRANSFER_IN, TRANSFER_OUT, CREDIT)
+    /// Fetches posted contribution candidates (DEPOSIT, TRANSFER_IN, TRANSFER_OUT, CREDIT)
     /// for the given accounts within the date range.
     fn get_contribution_activities(
         &self,
@@ -1993,6 +1993,7 @@ impl ActivityRepositoryTrait for ActivityRepository {
             .inner_join(accounts::table.on(activities::account_id.eq(accounts::id)))
             .filter(accounts::id.eq_any(eligible_account_ids))
             .filter(accounts::is_archived.eq(false))
+            .filter(activities::status.eq("POSTED"))
             .filter(activities::activity_type.eq_any(CONTRIBUTION_TYPES))
             .filter(activities::activity_date.ge(start_utc.to_rfc3339()))
             .filter(activities::activity_date.lt(end_exclusive_utc.to_rfc3339()))
@@ -2974,6 +2975,59 @@ mod tests {
             .map(|activity| activity.id.as_str())
             .collect();
         assert_eq!(ids, HashSet::from(["split-1", "split-2", "archived-split"]));
+    }
+
+    #[tokio::test]
+    async fn contribution_activity_query_excludes_draft_mapping_evidence() {
+        let (pool, writer) = setup_db();
+        let repo = ActivityRepository::new(pool.clone(), writer);
+
+        {
+            let mut conn = get_connection(&pool).expect("conn");
+            insert_account(&mut conn, "registered-account");
+            diesel::update(accounts::table.filter(accounts::id.eq("registered-account")))
+                .set(accounts::account_type.eq("SECURITIES"))
+                .execute(&mut conn)
+                .expect("set securities account type");
+            diesel::sql_query(
+                "INSERT INTO activities
+                 (id, account_id, activity_type, subtype, status, activity_date, amount, currency,
+                  metadata, source_system, is_user_modified, needs_review, created_at, updated_at)
+                 VALUES
+                 ('posted-deposit', 'registered-account', 'DEPOSIT', NULL, 'POSTED',
+                  '2025-06-15T12:00:00Z', '100', 'USD', NULL, 'MANUAL', 0, 0,
+                  CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                 ('draft-deposit', 'registered-account', 'DEPOSIT', NULL, 'DRAFT',
+                  '2025-06-16T12:00:00Z', '200', 'USD', NULL, 'SNAPTRADE', 0, 1,
+                  CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                 ('draft-transfer', 'registered-account', 'TRANSFER_IN', NULL, 'DRAFT',
+                  '2025-06-17T12:00:00Z', '300', 'USD',
+                  '{\"flow\":{\"is_external\":true}}', 'SNAPTRADE', 0, 1,
+                  CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+                 ('draft-bonus', 'registered-account', 'CREDIT', 'BONUS', 'DRAFT',
+                  '2025-06-18T12:00:00Z', '400', 'USD',
+                  '{\"flow\":{\"is_external\":true}}', 'SNAPTRADE', 0, 1,
+                  CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)",
+            )
+            .execute(&mut conn)
+            .expect("insert posted and draft contribution candidates");
+        }
+
+        let activities = repo
+            .get_contribution_activities(
+                &["registered-account".to_string()],
+                DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+                DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+            )
+            .expect("load contribution candidates");
+
+        assert_eq!(activities.len(), 1);
+        assert_eq!(activities[0].activity_type, "DEPOSIT");
+        assert_eq!(activities[0].amount, Some(Decimal::from(100)));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- restrict contribution-limit candidates to `POSTED` activities at the SQLite repository boundary
- keep canonical activity types, subtypes, and review evidence unchanged
- cover Draft `DEPOSIT`, `TRANSFER_IN`, and `CREDIT/BONUS` rows with a repository regression test

## Why

Broker mappings that require confirmation are intentionally persisted as `DRAFT` while retaining their proposed canonical mapping. Performance, valuation, holdings, transfer pairing, and health calculations already gate their activity inputs on posted status, but the contribution-limit query selected canonical contribution types without checking status.

That allowed a review-required `DEPOSIT` to consume registered-account contribution room before approval. The bug belongs in the calculation input boundary; changing the mapped activity to `UNKNOWN` would discard useful mapping evidence and spread lifecycle policy into the mapper.

## Contract

- mapping evidence remains intact on Draft activities
- Draft activities remain visible for review
- only approval and transition to `POSTED` makes them eligible for contribution calculations
- no contribution classification rules change for posted activities

## Validation

- `cargo test -p wealthfolio-storage-sqlite contribution` — 2 passed
- `cargo test -p wealthfolio-core limits::limits_service` — 24 passed
- `cargo fmt --all -- --check`
- `git diff --check`
- GitHub PR Check — Rust, Frontend, and Build Status passed

## Related

- wealthfolio/wealthfolio#1403
- companion cloud contract hardening: afadil/wealthfolio-cloud#96
