### PR TITLE
feat: distinguish ETF/fund units from stock shares in holdings table

### DIFF
--- a/apps/frontend/src/i18n/locales/de/holdings.json
+++ b/apps/frontend/src/i18n/locales/de/holdings.json
@@ -128,6 +128,7 @@
   "qty": "Anz.",
   "contracts": "Kontrakte",
   "bonds": "Anleihen",
+  "units": "Anteile",
   "avg_price": "Ø-Preis",
   "total_pnl": "Gesamt-G&V",
   "total_return": "Gesamtrendite",

--- a/apps/frontend/src/i18n/locales/en/holdings.json
+++ b/apps/frontend/src/i18n/locales/en/holdings.json
@@ -128,6 +128,7 @@
   "qty": "Qty",
   "contracts": "contracts",
   "bonds": "bonds",
+  "units": "units",
   "avg_price": "Avg Price",
   "total_pnl": "Total P&L",
   "total_return": "Total Return",

--- a/apps/frontend/src/i18n/locales/es/holdings.json
+++ b/apps/frontend/src/i18n/locales/es/holdings.json
@@ -128,6 +128,7 @@
   "qty": "Cant.",
   "contracts": "contratos",
   "bonds": "bonos",
+  "units": "participaciones",
   "avg_price": "Precio medio",
   "total_pnl": "P&L total",
   "total_return": "Rentabilidad total",

--- a/apps/frontend/src/i18n/locales/fr/holdings.json
+++ b/apps/frontend/src/i18n/locales/fr/holdings.json
@@ -128,6 +128,7 @@
   "qty": "Qté",
   "contracts": "contrats",
   "bonds": "obligations",
+  "units": "parts",
   "avg_price": "Prix moyen",
   "total_pnl": "P&L total",
   "total_return": "Rendement total",

--- a/apps/frontend/src/i18n/locales/ja/holdings.json
+++ b/apps/frontend/src/i18n/locales/ja/holdings.json
@@ -128,6 +128,7 @@
   "qty": "数量",
   "contracts": "枚",
   "bonds": "口",
+  "units": "口",
   "avg_price": "平均単価",
   "total_pnl": "損益合計",
   "total_return": "トータルリターン",

--- a/apps/frontend/src/i18n/locales/ko/holdings.json
+++ b/apps/frontend/src/i18n/locales/ko/holdings.json
@@ -128,6 +128,7 @@
   "qty": "수량",
   "contracts": "계약",
   "bonds": "채권",
+  "units": "좌",
   "avg_price": "평균가",
   "total_pnl": "총 손익",
   "total_return": "총 수익률",

--- a/apps/frontend/src/i18n/locales/zh/holdings.json
+++ b/apps/frontend/src/i18n/locales/zh/holdings.json
@@ -128,6 +128,7 @@
   "qty": "数量",
   "contracts": "份合约",
   "bonds": "份债券",
+  "units": "份",
   "avg_price": "平均价格",
   "total_pnl": "总盈亏",
   "total_return": "总回报",

--- a/apps/frontend/src/pages/holdings/components/holdings-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table.tsx
@@ -301,6 +301,7 @@ const getColumns = (
         assetTypeKey.startsWith("BOND_") ||
         assetTypeKey === "DEBT_SECURITY" ||
         assetTypeKey === "MONEY_MARKET_DEBT";
+      const isEtfOrFund = assetTypeKey === "ETF" || assetTypeKey === "FUND_MUTUAL";
       return (
         <div className="flex min-h-[40px] flex-col items-end justify-center px-4">
           <QuantityDisplay value={row.original.quantity} isHidden={isHidden} />
@@ -309,7 +310,9 @@ const getColumns = (
               ? t("holdings:contracts")
               : isBond
                 ? t("holdings:bonds")
-                : t("holdings:shares")}
+                : isEtfOrFund
+                  ? t("holdings:units")
+                  : t("holdings:shares")}
           </span>
         </div>
       );


### PR DESCRIPTION
fixes  https://github.com/wealthfolio/wealthfolio/issues/1474

The quantity sub-label in the holdings table previously showed "Shares" for every instrument type. ETFs and mutual funds are denominated in units (or "parts" in French financial terminology), not shares — this distinction is standard in financial reporting and relevant for users who hold both equities and funds.

## Changes

### `holdings-table.tsx`
Added an `isEtfOrFund` check using the existing
`instrument.classifications.assetType.key` field, which the auto-classification pipeline already sets to `"ETF"` or `"FUND_MUTUAL"` for the relevant instruments. The quantity sub-label now resolves to four distinct values:

| Condition | i18n key | EN |
|-----------|----------|----|
| Option (OCC symbol) | `holdings:contracts` | contracts | | Bond (`BOND_*`, `DEBT_SECURITY`, …) | `holdings:bonds` | bonds | | ETF / Mutual fund (`ETF`, `FUND_MUTUAL`) | `holdings:units` | units | | Stock or unclassified (fallback) | `holdings:shares` | shares |

Assets without classification data (manually created or never auto-classified) fall back to `holdings:shares` — no breaking change.

### i18n — new `"units"` key in 7 locales

| Locale | Translation |
|--------|-------------|
| en | units |
| fr | parts |
| de | Anteile |
| es | participaciones |
| ja | 口 |
| ko | 좌 |
| zh | 份 |

## Validation

- `cargo test -p wealthfolio-core`    → 1,839 passed (82 unit + 1,745 prop + 12 integration), 0 failed
- `cargo test -p wealthfolio-spending` → 102 passed, 0 failed
- `cargo test -p wealthfolio-connect` → 0 passed, 3 ignored (doc-tests only), 0 failed
- Prettier                            → all modified files conform

## Description

<!-- Describe your changes -->

## Checklist

- [X] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
