### PR TITLE
fix(net-worth): drop phantom cash rows from trade residue

### DIFF
--- a/crates/core/src/portfolio/net_worth/net_worth_service.rs
+++ b/crates/core/src/portfolio/net_worth/net_worth_service.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use chrono::NaiveDate;
 use log::{debug, warn};
-use rust_decimal::Decimal;
+use rust_decimal::{Decimal, RoundingStrategy};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, RwLock};
 
@@ -14,7 +14,7 @@ use super::net_worth_model::{
 use super::net_worth_traits::NetWorthServiceTrait;
 use crate::accounts::{account_types, is_liability_account_type, AccountRepositoryTrait};
 use crate::assets::{Asset, AssetKind, AssetRepositoryTrait};
-use crate::constants::DECIMAL_PRECISION;
+use crate::constants::{DECIMAL_PRECISION, DISPLAY_DECIMAL_PRECISION};
 use crate::errors::Result;
 use crate::fx::currency::normalize_amount;
 use crate::fx::FxServiceTrait;
@@ -24,6 +24,32 @@ use crate::quotes::QuoteServiceTrait;
 
 /// Number of days after which a valuation is considered stale.
 const STALENESS_THRESHOLD_DAYS: i64 = 90;
+
+/// True when a cash amount rounds away at the precision the UI renders.
+///
+/// Liquidated accounts keep residual cash balances far larger than
+/// `DECIMAL_PRECISION` (1e-8): `unit_price` is stored as a total divided by
+/// quantity and rounded to 8dp, so recomputing the cash effect as
+/// `quantity * unit_price` misses the original whole-cent total by ~1e-8 per
+/// trade. The sum scales with trade count, reaching 1e-5..1e-4 over a few
+/// hundred trades — emitting breakdown rows that carry no visible value. Gating
+/// on display precision is the only bound that does not drift as history grows.
+///
+/// This drops residue only. Real sub-dollar balances survive and are the
+/// frontend's to render: `formatCompactAmount` currently gives amounts under
+/// $1,000 zero fraction digits, so a genuine $0.33 still shows as $0.
+///
+/// Rounds half away from zero to match `Intl.NumberFormat` in the UI, rather
+/// than `round_dp`'s banker's rounding, so a balance the UI would show as
+/// $0.01 is never dropped.
+fn is_display_zero(value: Decimal) -> bool {
+    value
+        .round_dp_with_strategy(
+            DISPLAY_DECIMAL_PRECISION,
+            RoundingStrategy::MidpointAwayFromZero,
+        )
+        .is_zero()
+}
 
 /// Service for calculating net worth.
 pub struct NetWorthService {
@@ -413,11 +439,11 @@ impl NetWorthServiceTrait for NetWorthService {
                 }
 
                 // Round before the zero check: activity replay leaves residual
-                // balances around 1e-15 that are non-zero but display as $0.
+                // balances that are non-zero but display as $0.
                 let cash_base = account_valuation
                     .cash_balance_base
                     .round_dp(DECIMAL_PRECISION);
-                if !cash_base.is_zero() {
+                if !is_display_zero(cash_base) {
                     valuations.push(ValuationInfo {
                         asset_id: format!("CASH:{}", account.id),
                         name: Some(account.name.clone()),
@@ -549,6 +575,10 @@ impl NetWorthServiceTrait for NetWorthService {
                     })
                     .round_dp(DECIMAL_PRECISION);
 
+                if is_display_zero(cash_base_total) {
+                    continue;
+                }
+
                 if cash_base_total < Decimal::ZERO {
                     valuations.push(ValuationInfo {
                         asset_id: format!("CREDIT_CARD:{}", account.id),
@@ -558,7 +588,7 @@ impl NetWorthServiceTrait for NetWorthService {
                         category: AssetCategory::Liability,
                         is_cash_like: true,
                     });
-                } else if cash_base_total > Decimal::ZERO {
+                } else {
                     valuations.push(ValuationInfo {
                         asset_id: format!("CASH:{}", account.id),
                         name: Some(account.name.clone()),
@@ -584,10 +614,10 @@ impl NetWorthServiceTrait for NetWorthService {
                     .convert_cash_balance_to_base(amount, currency, &base_currency, date)
                     .round_dp(DECIMAL_PRECISION);
 
-                // Long-closed accounts keep residual balances around 1e-15 that
-                // are non-zero yet round to nothing; skip them so the Cash
-                // drill-down does not fill up with $0 rows.
-                if cash_base.is_zero() {
+                // Long-closed accounts keep residual balances that are non-zero
+                // yet round to nothing; skip them so the Cash drill-down does
+                // not fill up with $0 rows.
+                if is_display_zero(cash_base) {
                     continue;
                 }
 

--- a/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
+++ b/crates/core/src/portfolio/net_worth/net_worth_service_tests.rs
@@ -1426,6 +1426,110 @@ async fn test_dust_credit_card_balance_produces_no_liability_row() {
 }
 
 #[tokio::test]
+async fn test_sub_cent_snapshot_cash_excluded_from_cash_breakdown() {
+    let dusty = create_test_account("acc1", "SECURITIES", "USD");
+    let funded = create_test_account("acc2", "SECURITIES", "USD");
+    // Real-world residue from `quantity * unit_price` reconstruction: survives
+    // 1e-8 rounding but carries no value the UI can show.
+    let mut dust = HashMap::new();
+    dust.insert("USD".to_string(), dec!(0.00001));
+    let mut funds = HashMap::new();
+    funds.insert("USD".to_string(), dec!(2500));
+
+    let service = create_net_worth_service(
+        vec![dusty, funded],
+        vec![],
+        vec![
+            create_test_snapshot("acc1", vec![], dust),
+            create_test_snapshot("acc2", vec![], funds),
+        ],
+        vec![],
+    );
+
+    let date = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
+    let result = service.get_net_worth(date).await.unwrap();
+
+    assert_eq!(get_category_value(&result, "cash"), dec!(2500));
+
+    let cash = result
+        .assets
+        .breakdown
+        .iter()
+        .find(|b| b.category == "cash")
+        .unwrap();
+    assert_eq!(cash.children.len(), 1);
+    assert_eq!(cash.children[0].name, "Test Account acc2 (USD)");
+}
+
+#[tokio::test]
+async fn test_sub_cent_stored_valuation_cash_excluded_from_cash_breakdown() {
+    let dusty = create_test_account("acc1", "SECURITIES", "USD");
+    let funded = create_test_account("acc2", "SECURITIES", "USD");
+    let date = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
+
+    let service = create_net_worth_service_with_valuations(
+        vec![dusty, funded],
+        vec![],
+        vec![
+            create_test_snapshot("acc1", vec![], HashMap::new()),
+            create_test_snapshot("acc2", vec![], HashMap::new()),
+        ],
+        vec![],
+        vec![
+            create_account_valuation("acc1", date, dec!(-0.00001358)),
+            create_account_valuation("acc2", date, dec!(2500)),
+        ],
+    );
+
+    let result = service.get_net_worth(date).await.unwrap();
+
+    assert_eq!(get_category_value(&result, "cash"), dec!(2500));
+
+    let cash = result
+        .assets
+        .breakdown
+        .iter()
+        .find(|b| b.category == "cash")
+        .unwrap();
+    assert_eq!(cash.children.len(), 1);
+    assert_eq!(cash.children[0].name, "Test Account acc2");
+}
+
+#[tokio::test]
+async fn test_sub_cent_credit_card_balance_produces_no_liability_row() {
+    let account = create_test_account("card1", "CREDIT_CARD", "USD");
+    let mut cash = HashMap::new();
+    cash.insert("USD".to_string(), dec!(-0.00022048));
+    let snapshot = create_test_snapshot("card1", vec![], cash);
+
+    let service = create_net_worth_service(vec![account], vec![], vec![snapshot], vec![]);
+
+    let date = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
+    let result = service.get_net_worth(date).await.unwrap();
+
+    assert!(result.liabilities.breakdown.is_empty());
+    assert_eq!(result.liabilities.total, Decimal::ZERO);
+    assert_eq!(result.net_worth, Decimal::ZERO);
+}
+
+#[tokio::test]
+async fn test_half_cent_cash_balance_still_included() {
+    // The cut is at the displayed cent: 0.005 rounds up to a visible cent, so it
+    // stays. Whether the UI then renders it as $0.01 is the formatter's business.
+    let account = create_test_account("acc1", "SECURITIES", "USD");
+    let mut cash = HashMap::new();
+    cash.insert("USD".to_string(), dec!(0.005));
+    let snapshot = create_test_snapshot("acc1", vec![], cash);
+
+    let service = create_net_worth_service(vec![account], vec![], vec![snapshot], vec![]);
+
+    let date = NaiveDate::from_ymd_opt(2024, 1, 15).unwrap();
+    let result = service.get_net_worth(date).await.unwrap();
+
+    assert_eq!(get_category_value(&result, "cash"), dec!(0.005));
+}
+
+#[tokio::test]
 async fn test_staleness_detection() {
     let account = create_test_account("acc1", "SECURITIES", "USD");
     let asset = create_test_asset("AAPL", AssetKind::Investment, "USD");


### PR DESCRIPTION
Refs #1459

## Problem

The Cash drill-down fills up with rows showing no value. #1459 was closed by b715b204, but that patch only drops residues below `1e-8`, and real residues are four to seven orders larger. On a portfolio with a few hundred trades, most of the rows in the drawer are residue.

## Cause

b715b204's commit message misattributes this, so correcting the record:

- **Not** f64 noise from `serde-float` snapshot persistence.
- **Not** compounding across incremental recalc runs — a rebuild from inception reproduces the residues byte-identically.

It is deterministic. `unit_price` is stored as a total divided by quantity, rounded to 8dp; the cash effect is then recomputed as `quantity * unit_price`, which no longer lands on the original whole-cent total.

Because the error grows with history, **any fixed absolute threshold below a cent is fragile**. That is the real lesson from b715b204: `1e-8` was not merely too tight, it was the wrong *kind* of bound.

## Change

Gate row inclusion on `DISPLAY_DECIMAL_PRECISION` instead of `DECIMAL_PRECISION`, at all three cash-like emit sites (stored valuation, liability net total, snapshot fallback). Emitted values keep their 8dp rounding — only inclusion changes.

`is_display_zero` rounds half away from zero rather than reusing `round_dp`, whose banker's rounding disagrees with `Intl.NumberFormat` at exactly the half-cent: `round_dp(2)` sends `0.005` to `0.00` and would drop a balance the UI would otherwise show. This was caught by a failing boundary test, not by inspection.


## This does not empty the drawer on its own

There will still be row that show `$0` after this change, and they are **real money** — balances like `$0.33` and `$0.02`. That is a separate frontend issue. `formatCompactAmount` gives amounts under $1,000 zero fraction digits.

Deliberately **not** done by raising this PR's threshold to `0.5`. That would empty the drawer in one line, but silently discard real balances that still count toward the total — a worse bug than an ugly row. The threshold should track residue; the formatter should track display.

## Tradeoff

Genuine sub-cent balances no longer appear in the drill-down, which b715b204 deliberately preserved, and category totals shift by the dropped residue. Invisible at two decimals, but it is a behavior change rather than a pure display fix.

The root-cause repair is to store the authoritative total at import instead of a derived `unit_price`. Not attempted here as it is a much larger change.

## Checklist

- [x] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
