### PR TITLE
Add closed positions and cash to holdings

### DIFF
--- a/apps/frontend/src/adapters/adapter-command-parity.test.ts
+++ b/apps/frontend/src/adapters/adapter-command-parity.test.ts
@@ -267,6 +267,17 @@ describe("scope-based routing — get_holdings_list", () => {
     expect(method).toBe("GET");
   });
 
+  it("account with closed positions → GET with includeClosed", async () => {
+    const mock = stubFetch();
+    await invoke("get_holdings_list", {
+      filter: { type: "account", accountId: "acc_1" },
+      includeClosed: true,
+    });
+    const { url, method } = lastCall(mock);
+    expect(url).toBe("/api/v1/holdings/list?accountId=acc_1&includeClosed=true");
+    expect(method).toBe("GET");
+  });
+
   it("portfolio → POST /holdings/list/query", async () => {
     const mock = stubFetch();
     await invoke("get_holdings_list", { filter: { type: "portfolio", portfolioId: "pf_1" } });
@@ -288,6 +299,21 @@ describe("scope-based routing — get_holdings_list", () => {
     expect(method).toBe("POST");
     expect(JSON.parse(body as string)).toEqual({
       filter: { type: "accounts", accountIds: ["acc_1", "acc_2"] },
+    });
+  });
+
+  it("all with closed positions → POST with includeClosed", async () => {
+    const mock = stubFetch();
+    await invoke("get_holdings_list", {
+      filter: { type: "all" },
+      includeClosed: true,
+    });
+    const { url, method, body } = lastCall(mock);
+    expect(url).toBe("/api/v1/holdings/list/query");
+    expect(method).toBe("POST");
+    expect(JSON.parse(body as string)).toEqual({
+      filter: { type: "all" },
+      includeClosed: true,
     });
   });
 });

--- a/apps/frontend/src/adapters/shared/portfolio.ts
+++ b/apps/frontend/src/adapters/shared/portfolio.ts
@@ -33,8 +33,14 @@ export const getHoldings = async (filter: AccountScope): Promise<Holding[]> => {
   return invoke<Holding[]>("get_holdings", { filter });
 };
 
-export const getHoldingsList = async (filter: AccountScope): Promise<Holding[]> => {
-  return invoke<Holding[]>("get_holdings_list", { filter });
+export const getHoldingsList = async (
+  filter: AccountScope,
+  options: { includeClosed?: boolean } = {},
+): Promise<Holding[]> => {
+  return invoke<Holding[]>("get_holdings_list", {
+    filter,
+    ...(options.includeClosed ? { includeClosed: true } : {}),
+  });
 };
 
 export const getIncomeSummary = async (filter?: AccountScope): Promise<IncomeSummary[]> => {

--- a/apps/frontend/src/adapters/web/core.ts
+++ b/apps/frontend/src/adapters/web/core.ts
@@ -505,13 +505,21 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
     }
     case "get_holdings":
     case "get_holdings_list": {
-      const p = payload as { filter: { type: string; accountId?: string } };
+      const p = payload as {
+        filter: { type: string; accountId?: string };
+        includeClosed?: boolean;
+      };
       if (p.filter?.type === "account" && p.filter.accountId) {
         const path = command === "get_holdings_list" ? "/holdings/list" : "/holdings";
-        url = `${API_PREFIX}${path}?accountId=${encodeURIComponent(p.filter.accountId)}`;
+        const params = new URLSearchParams({ accountId: p.filter.accountId });
+        if (p.includeClosed) params.set("includeClosed", "true");
+        url = `${API_PREFIX}${path}?${params.toString()}`;
         method = "GET";
       } else {
-        body = JSON.stringify({ filter: p.filter });
+        body = JSON.stringify({
+          filter: p.filter,
+          ...(p.includeClosed ? { includeClosed: true } : {}),
+        });
       }
       break;
     }

--- a/apps/frontend/src/hooks/use-holdings.test.tsx
+++ b/apps/frontend/src/hooks/use-holdings.test.tsx
@@ -1,0 +1,157 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AccountScope, Holding } from "@/lib/types";
+import { useHoldings, useHoldingsWithClosedProbe } from "./use-holdings";
+
+const mocks = vi.hoisted(() => ({
+  getHoldingsList: vi.fn(),
+}));
+
+vi.mock("@/adapters", () => ({
+  getHoldingsList: mocks.getHoldingsList,
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe("useHoldingsWithClosedProbe", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not load closed positions when the open query has holdings", async () => {
+    const openHolding = { id: "open" } as Holding;
+    mocks.getHoldingsList.mockResolvedValue([openHolding]);
+
+    const { result } = renderHook(
+      () =>
+        useHoldingsWithClosedProbe(
+          { type: "account", accountId: "account-1" },
+          { includeClosed: false, probeClosedWhenEmpty: true },
+        ),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.holdings).toEqual([openHolding]));
+
+    expect(mocks.getHoldingsList).toHaveBeenCalledTimes(1);
+    expect(mocks.getHoldingsList).toHaveBeenCalledWith(
+      { type: "account", accountId: "account-1" },
+      { includeClosed: false },
+    );
+    expect(result.current.hasHiddenClosedPositions).toBe(false);
+  });
+
+  it("probes closed positions after an empty open query", async () => {
+    const closedHolding = { id: "closed", isClosed: true } as Holding;
+    mocks.getHoldingsList.mockImplementation((_filter, options: { includeClosed?: boolean }) =>
+      Promise.resolve(options.includeClosed ? [closedHolding] : []),
+    );
+
+    const { result } = renderHook(
+      () =>
+        useHoldingsWithClosedProbe(
+          { type: "account", accountId: "account-1" },
+          { includeClosed: false, probeClosedWhenEmpty: true },
+        ),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.hasHiddenClosedPositions).toBe(true));
+
+    expect(mocks.getHoldingsList).toHaveBeenCalledTimes(2);
+    expect(mocks.getHoldingsList).toHaveBeenCalledWith(
+      { type: "account", accountId: "account-1" },
+      { includeClosed: true },
+    );
+  });
+});
+
+describe("useHoldings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("keeps open positions visible while closed positions load", async () => {
+    const openHolding = { id: "open" } as Holding;
+    const closedHolding = { id: "closed", isClosed: true } as Holding;
+    let resolveClosedQuery: ((holdings: Holding[]) => void) | undefined;
+
+    mocks.getHoldingsList.mockImplementation((_filter, options: { includeClosed?: boolean }) => {
+      if (!options.includeClosed) {
+        return Promise.resolve([openHolding]);
+      }
+
+      return new Promise<Holding[]>((resolve) => {
+        resolveClosedQuery = resolve;
+      });
+    });
+
+    const { result, rerender } = renderHook(
+      ({ includeClosed }) =>
+        useHoldings({ type: "account", accountId: "account-1" }, { includeClosed }),
+      {
+        initialProps: { includeClosed: false },
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => expect(result.current.holdings).toEqual([openHolding]));
+
+    rerender({ includeClosed: true });
+
+    expect(result.current.holdings).toEqual([openHolding]);
+    expect(result.current.isLoading).toBe(false);
+
+    act(() => {
+      resolveClosedQuery?.([openHolding, closedHolding]);
+    });
+
+    await waitFor(() => expect(result.current.holdings).toEqual([openHolding, closedHolding]));
+  });
+
+  it("does not retain positions when the account scope changes", async () => {
+    const firstAccountHolding = { id: "first-account" } as Holding;
+    let resolveSecondAccount: ((holdings: Holding[]) => void) | undefined;
+
+    mocks.getHoldingsList.mockImplementation((filter: AccountScope) => {
+      if (filter.type === "account" && filter.accountId === "account-1") {
+        return Promise.resolve([firstAccountHolding]);
+      }
+
+      return new Promise<Holding[]>((resolve) => {
+        resolveSecondAccount = resolve;
+      });
+    });
+
+    const { result, rerender } = renderHook(
+      ({ accountId }) => useHoldings({ type: "account", accountId }),
+      {
+        initialProps: { accountId: "account-1" },
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => expect(result.current.holdings).toEqual([firstAccountHolding]));
+
+    rerender({ accountId: "account-2" });
+
+    expect(result.current.holdings).toEqual([]);
+    expect(result.current.isLoading).toBe(true);
+
+    act(() => {
+      resolveSecondAccount?.([]);
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+  });
+});

--- a/apps/frontend/src/hooks/use-holdings.ts
+++ b/apps/frontend/src/hooks/use-holdings.ts
@@ -5,11 +5,36 @@ import { QueryKeys } from "@/lib/query-keys";
 
 interface UseHoldingsOptions {
   includeClosed?: boolean;
+  enabled?: boolean;
+}
+
+interface UseHoldingsWithClosedProbeOptions {
+  includeClosed: boolean;
+  probeClosedWhenEmpty: boolean;
+}
+
+function accountScopesEqual(left: AccountScope, right: AccountScope): boolean {
+  if (left.type !== right.type) return false;
+
+  switch (left.type) {
+    case "account":
+      return right.type === "account" && left.accountId === right.accountId;
+    case "accounts":
+      return (
+        right.type === "accounts" &&
+        left.accountIds.length === right.accountIds.length &&
+        left.accountIds.every((accountId, index) => accountId === right.accountIds[index])
+      );
+    case "portfolio":
+      return right.type === "portfolio" && left.portfolioId === right.portfolioId;
+    case "all":
+      return right.type === "all";
+  }
 }
 
 export function useHoldings(accountFilter: AccountScope, options: UseHoldingsOptions = {}) {
   const includeClosed = options.includeClosed ?? false;
-  const isEnabled = (() => {
+  const hasValidScope = (() => {
     switch (accountFilter.type) {
       case "account":
         return accountFilter.accountId.trim().length > 0;
@@ -23,6 +48,7 @@ export function useHoldings(accountFilter: AccountScope, options: UseHoldingsOpt
         return false;
     }
   })();
+  const isEnabled = hasValidScope && (options.enabled ?? true);
 
   const {
     data: holdings = [],
@@ -34,7 +60,35 @@ export function useHoldings(accountFilter: AccountScope, options: UseHoldingsOpt
     queryKey: [QueryKeys.HOLDINGS, accountFilter, { includeClosed }],
     queryFn: () => getHoldingsList(accountFilter, { includeClosed }),
     enabled: isEnabled,
+    placeholderData: (previousData, previousQuery) => {
+      const previousScope = previousQuery?.queryKey[1] as AccountScope | undefined;
+      return previousScope && accountScopesEqual(previousScope, accountFilter)
+        ? previousData
+        : undefined;
+    },
   });
 
   return { holdings, dataUpdatedAt, isLoading, isError, error };
+}
+
+export function useHoldingsWithClosedProbe(
+  accountFilter: AccountScope,
+  options: UseHoldingsWithClosedProbeOptions,
+) {
+  const primaryQuery = useHoldings(accountFilter, { includeClosed: options.includeClosed });
+  const shouldProbeClosedPositions =
+    options.probeClosedWhenEmpty &&
+    !options.includeClosed &&
+    !primaryQuery.isLoading &&
+    primaryQuery.holdings.length === 0;
+  const closedProbeQuery = useHoldings(accountFilter, {
+    includeClosed: true,
+    enabled: shouldProbeClosedPositions,
+  });
+
+  return {
+    ...primaryQuery,
+    isLoading: primaryQuery.isLoading || (shouldProbeClosedPositions && closedProbeQuery.isLoading),
+    hasHiddenClosedPositions: shouldProbeClosedPositions && closedProbeQuery.holdings.length > 0,
+  };
 }

--- a/apps/frontend/src/hooks/use-holdings.ts
+++ b/apps/frontend/src/hooks/use-holdings.ts
@@ -3,7 +3,12 @@ import { AccountScope, Holding } from "@/lib/types";
 import { getHoldingsList } from "@/adapters";
 import { QueryKeys } from "@/lib/query-keys";
 
-export function useHoldings(accountFilter: AccountScope) {
+interface UseHoldingsOptions {
+  includeClosed?: boolean;
+}
+
+export function useHoldings(accountFilter: AccountScope, options: UseHoldingsOptions = {}) {
+  const includeClosed = options.includeClosed ?? false;
   const isEnabled = (() => {
     switch (accountFilter.type) {
       case "account":
@@ -26,8 +31,8 @@ export function useHoldings(accountFilter: AccountScope) {
     isError,
     error,
   } = useQuery<Holding[], Error>({
-    queryKey: [QueryKeys.HOLDINGS, accountFilter],
-    queryFn: () => getHoldingsList(accountFilter),
+    queryKey: [QueryKeys.HOLDINGS, accountFilter, { includeClosed }],
+    queryFn: () => getHoldingsList(accountFilter, { includeClosed }),
     enabled: isEnabled,
   });
 

--- a/apps/frontend/src/i18n/locales/de/holdings.json
+++ b/apps/frontend/src/i18n/locales/de/holdings.json
@@ -13,6 +13,7 @@
   "gain_loss_percent": "Gewinn/Verlust %",
   "today_gain": "Heutiger Gewinn",
   "weight": "Gewichtung",
+  "weight_value": "Gewichtung {{value}}",
   "sector": "Sektor",
   "asset_class": "Anlageklasse",
   "sort_by": "Sortieren nach",

--- a/apps/frontend/src/i18n/locales/de/holdings.json
+++ b/apps/frontend/src/i18n/locales/de/holdings.json
@@ -125,6 +125,8 @@
   "asset_currency": "Vermögenswährung",
   "base_currency": "Basiswährung",
   "manual": "Manuell",
+  "open": "Offen",
+  "closed": "Geschlossen",
   "qty": "Anz.",
   "contracts": "Kontrakte",
   "bonds": "Anleihen",

--- a/apps/frontend/src/i18n/locales/en/holdings.json
+++ b/apps/frontend/src/i18n/locales/en/holdings.json
@@ -13,6 +13,7 @@
   "gain_loss_percent": "Gain/Loss %",
   "today_gain": "Today's Gain",
   "weight": "Weight",
+  "weight_value": "Weight {{value}}",
   "sector": "Sector",
   "asset_class": "Asset Class",
   "sort_by": "Sort by",

--- a/apps/frontend/src/i18n/locales/en/holdings.json
+++ b/apps/frontend/src/i18n/locales/en/holdings.json
@@ -125,6 +125,8 @@
   "asset_currency": "Asset Currency",
   "base_currency": "Base Currency",
   "manual": "Manual",
+  "open": "Open",
+  "closed": "Closed",
   "qty": "Qty",
   "contracts": "contracts",
   "bonds": "bonds",

--- a/apps/frontend/src/i18n/locales/es/holdings.json
+++ b/apps/frontend/src/i18n/locales/es/holdings.json
@@ -125,6 +125,8 @@
   "asset_currency": "Divisa del activo",
   "base_currency": "Divisa base",
   "manual": "Manual",
+  "open": "Abierta",
+  "closed": "Cerrada",
   "qty": "Cant.",
   "contracts": "contratos",
   "bonds": "bonos",

--- a/apps/frontend/src/i18n/locales/es/holdings.json
+++ b/apps/frontend/src/i18n/locales/es/holdings.json
@@ -13,6 +13,7 @@
   "gain_loss_percent": "Ganancia/Pérdida %",
   "today_gain": "Ganancia de hoy",
   "weight": "Peso",
+  "weight_value": "Peso {{value}}",
   "sector": "Sector",
   "asset_class": "Clase de activo",
   "sort_by": "Ordenar por",

--- a/apps/frontend/src/i18n/locales/fr/holdings.json
+++ b/apps/frontend/src/i18n/locales/fr/holdings.json
@@ -13,6 +13,7 @@
   "gain_loss_percent": "Gain/Perte %",
   "today_gain": "Gain du jour",
   "weight": "Poids",
+  "weight_value": "Poids {{value}}",
   "sector": "Secteur",
   "asset_class": "Classe d'actifs",
   "sort_by": "Trier par",

--- a/apps/frontend/src/i18n/locales/fr/holdings.json
+++ b/apps/frontend/src/i18n/locales/fr/holdings.json
@@ -125,6 +125,8 @@
   "asset_currency": "Devise de l'actif",
   "base_currency": "Devise de base",
   "manual": "Manuel",
+  "open": "Ouverte",
+  "closed": "Clôturée",
   "qty": "Qté",
   "contracts": "contrats",
   "bonds": "obligations",

--- a/apps/frontend/src/i18n/locales/ja/holdings.json
+++ b/apps/frontend/src/i18n/locales/ja/holdings.json
@@ -13,6 +13,7 @@
   "gain_loss_percent": "損益率",
   "today_gain": "本日の損益",
   "weight": "構成比",
+  "weight_value": "構成比 {{value}}",
   "sector": "セクター",
   "asset_class": "資産クラス",
   "sort_by": "並び替え",

--- a/apps/frontend/src/i18n/locales/ja/holdings.json
+++ b/apps/frontend/src/i18n/locales/ja/holdings.json
@@ -125,6 +125,8 @@
   "asset_currency": "資産通貨",
   "base_currency": "基準通貨",
   "manual": "手動",
+  "open": "保有中",
+  "closed": "決済済み",
   "qty": "数量",
   "contracts": "枚",
   "bonds": "口",

--- a/apps/frontend/src/i18n/locales/ko/holdings.json
+++ b/apps/frontend/src/i18n/locales/ko/holdings.json
@@ -13,6 +13,7 @@
   "gain_loss_percent": "손익률",
   "today_gain": "오늘의 손익",
   "weight": "비중",
+  "weight_value": "비중 {{value}}",
   "sector": "섹터",
   "asset_class": "자산군",
   "sort_by": "정렬 기준",

--- a/apps/frontend/src/i18n/locales/ko/holdings.json
+++ b/apps/frontend/src/i18n/locales/ko/holdings.json
@@ -125,6 +125,8 @@
   "asset_currency": "자산 통화",
   "base_currency": "기준 통화",
   "manual": "수동",
+  "open": "보유 중",
+  "closed": "청산됨",
   "qty": "수량",
   "contracts": "계약",
   "bonds": "채권",

--- a/apps/frontend/src/i18n/locales/zh/holdings.json
+++ b/apps/frontend/src/i18n/locales/zh/holdings.json
@@ -13,6 +13,7 @@
   "gain_loss_percent": "盈亏 %",
   "today_gain": "今日盈亏",
   "weight": "权重",
+  "weight_value": "权重 {{value}}",
   "sector": "行业",
   "asset_class": "资产类别",
   "sort_by": "排序方式",

--- a/apps/frontend/src/i18n/locales/zh/holdings.json
+++ b/apps/frontend/src/i18n/locales/zh/holdings.json
@@ -125,6 +125,8 @@
   "asset_currency": "资产货币",
   "base_currency": "基准货币",
   "manual": "手动",
+  "open": "持仓中",
+  "closed": "已平仓",
   "qty": "数量",
   "contracts": "份合约",
   "bonds": "份债券",

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -703,6 +703,8 @@ export interface CashHolding {
 export interface Holding {
   id: string;
   holdingType: HoldingType;
+  /** Explicit lifecycle state; aggregate quantity alone may net to zero. */
+  isClosed?: boolean;
   accountId: string;
   instrument?: Instrument | null;
   assetKind?: AssetKind | null;

--- a/apps/frontend/src/pages/account/account-holdings.test.tsx
+++ b/apps/frontend/src/pages/account/account-holdings.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AccountType } from "@/lib/constants";
+import type { Account, Holding } from "@/lib/types";
+import AccountHoldings from "./account-holdings";
+
+const mocks = vi.hoisted(() => ({
+  useHoldingsWithClosedProbe: vi.fn(),
+  useAccounts: vi.fn(),
+  setVisibilityFilters: vi.fn(),
+  isMobile: false,
+}));
+
+vi.mock("@/hooks/use-holdings", () => ({
+  useHoldingsWithClosedProbe: mocks.useHoldingsWithClosedProbe,
+}));
+
+const account: Account = {
+  id: "account-1",
+  name: "Brokerage",
+  accountType: AccountType.SECURITIES,
+  balance: 0,
+  currency: "USD",
+  isDefault: false,
+  isActive: true,
+  isArchived: false,
+  trackingMode: "TRANSACTIONS",
+  createdAt: new Date("2026-01-01"),
+  updatedAt: new Date("2026-01-01"),
+};
+
+vi.mock("@/hooks/use-accounts", () => ({
+  useAccounts: mocks.useAccounts,
+}));
+
+vi.mock("@/hooks/use-platform", () => ({
+  useIsMobileViewport: () => mocks.isMobile,
+}));
+
+vi.mock("@/hooks/use-persistent-state", () => ({
+  usePersistentState: () => [["open"], mocks.setVisibilityFilters],
+}));
+
+vi.mock("react-router-dom", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-router-dom")>()),
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@/pages/holdings/components/holdings-table", () => ({
+  HoldingsTable: () => <div data-testid="holdings-table" />,
+}));
+
+vi.mock("@/pages/holdings/components/holdings-table-mobile", () => ({
+  HoldingsTableMobile: ({ hasHiddenPositions }: { hasHiddenPositions?: boolean }) => (
+    <div data-testid="holdings-table-mobile" data-hidden-positions={String(hasHiddenPositions)} />
+  ),
+}));
+
+describe("AccountHoldings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isMobile = false;
+    mocks.useAccounts.mockReturnValue({ accounts: [account] });
+  });
+
+  it("keeps the visibility table available when only closed positions exist", () => {
+    mocks.useHoldingsWithClosedProbe.mockReturnValue({
+      holdings: [],
+      isLoading: false,
+      hasHiddenClosedPositions: true,
+    });
+
+    render(<AccountHoldings accountId={account.id} showTitle={false} />);
+
+    expect(screen.getByTestId("holdings-table")).toBeInTheDocument();
+  });
+
+  it("preserves the onboarding state for an account with no positions", () => {
+    mocks.useHoldingsWithClosedProbe.mockReturnValue({
+      holdings: [],
+      isLoading: false,
+      hasHiddenClosedPositions: false,
+    });
+
+    render(<AccountHoldings accountId={account.id} showTitle={false} />);
+
+    expect(screen.queryByTestId("holdings-table")).not.toBeInTheDocument();
+  });
+
+  it("marks cash-only results as hidden by the default visibility filter", () => {
+    const cashHolding = {
+      id: "cash-usd",
+      holdingType: "cash",
+    } as Holding;
+    mocks.isMobile = true;
+    mocks.useHoldingsWithClosedProbe.mockReturnValue({
+      holdings: [cashHolding],
+      isLoading: false,
+      hasHiddenClosedPositions: false,
+    });
+
+    render(<AccountHoldings accountId={account.id} showTitle={false} />);
+
+    expect(screen.getByTestId("holdings-table-mobile")).toHaveAttribute(
+      "data-hidden-positions",
+      "true",
+    );
+  });
+});

--- a/apps/frontend/src/pages/account/account-holdings.tsx
+++ b/apps/frontend/src/pages/account/account-holdings.tsx
@@ -22,6 +22,7 @@ import {
   DEFAULT_HOLDINGS_VISIBILITY,
   HOLDINGS_VISIBILITY_STORAGE_KEY,
   filterHoldingsByVisibility,
+  getEffectiveHoldingsVisibility,
   type HoldingsVisibilityFilter,
 } from "@/pages/holdings/components/holdings-visibility";
 
@@ -47,14 +48,6 @@ const AccountHoldings = ({
     [...DEFAULT_HOLDINGS_VISIBILITY],
   );
 
-  const { holdings, isLoading } = useHoldings(
-    {
-      type: "account",
-      accountId,
-    },
-    { includeClosed: true },
-  );
-
   const { accounts } = useAccounts();
 
   const selectedAccount = useMemo(() => {
@@ -66,6 +59,20 @@ const AccountHoldings = ({
     if (!selectedAccount) return false;
     return selectedAccount.trackingMode === "HOLDINGS";
   }, [selectedAccount]);
+
+  const showClosedPositions = !isHoldingsMode;
+  const effectiveVisibilityFilters = useMemo(
+    () => getEffectiveHoldingsVisibility(visibilityFilters, showClosedPositions),
+    [showClosedPositions, visibilityFilters],
+  );
+
+  const { holdings, isLoading } = useHoldings(
+    {
+      type: "account",
+      accountId,
+    },
+    { includeClosed: effectiveVisibilityFilters.includes("closed") },
+  );
 
   // Check if user can directly edit holdings (manual HOLDINGS-mode accounts only)
   const canEditHoldingsDirectly = useMemo(() => {
@@ -79,7 +86,7 @@ const AccountHoldings = ({
     return accountType === AccountType.CASH || isLiabilityAccountType(accountType);
   }, [selectedAccount]);
 
-  const filteredHoldings = filterHoldingsByVisibility(holdings ?? [], visibilityFilters);
+  const filteredHoldings = filterHoldingsByVisibility(holdings ?? [], effectiveVisibilityFilters);
 
   const typeOptions = useMemo(() => {
     const seen = new Set<string>();
@@ -246,15 +253,17 @@ const AccountHoldings = ({
           portfolios={[]}
           showAccountScope={false}
           typeOptions={typeOptions}
-          visibilityFilters={visibilityFilters}
+          visibilityFilters={effectiveVisibilityFilters}
           setVisibilityFilters={setVisibilityFilters}
+          showClosedPositions={showClosedPositions}
         />
       ) : (
         <HoldingsTable
           holdings={filteredHoldings ?? []}
           isLoading={isLoading}
-          visibilityFilters={visibilityFilters}
+          visibilityFilters={effectiveVisibilityFilters}
           setVisibilityFilters={setVisibilityFilters}
+          showClosedPositions={showClosedPositions}
         />
       )}
     </div>

--- a/apps/frontend/src/pages/account/account-holdings.tsx
+++ b/apps/frontend/src/pages/account/account-holdings.tsx
@@ -1,5 +1,5 @@
 import { useAccounts } from "@/hooks/use-accounts";
-import { useHoldings } from "@/hooks/use-holdings";
+import { useHoldingsWithClosedProbe } from "@/hooks/use-holdings";
 import { useIsMobileViewport } from "@/hooks/use-platform";
 import { AccountType, isLiabilityAccountType } from "@/lib/constants";
 import { canAddHoldings } from "@/lib/activity-restrictions";
@@ -66,12 +66,16 @@ const AccountHoldings = ({
     [showClosedPositions, visibilityFilters],
   );
 
-  const { holdings, isLoading } = useHoldings(
+  const includeClosed = effectiveVisibilityFilters.includes("closed");
+  const { holdings, isLoading, hasHiddenClosedPositions } = useHoldingsWithClosedProbe(
     {
       type: "account",
       accountId,
     },
-    { includeClosed: effectiveVisibilityFilters.includes("closed") },
+    {
+      includeClosed,
+      probeClosedWhenEmpty: showClosedPositions,
+    },
   );
 
   // Check if user can directly edit holdings (manual HOLDINGS-mode accounts only)
@@ -79,14 +83,15 @@ const AccountHoldings = ({
     return canAddHoldings(selectedAccount ?? undefined);
   }, [selectedAccount]);
 
-  // Cash and credit-card accounts hold no investments, so a "no holdings"
-  // empty state never applies — they only track activity / cash balance.
+  // Cash and credit-card accounts track activity and cash rather than investments.
   const isCashOrCreditAccount = useMemo(() => {
     const accountType = selectedAccount?.accountType;
     return accountType === AccountType.CASH || isLiabilityAccountType(accountType);
   }, [selectedAccount]);
 
   const filteredHoldings = filterHoldingsByVisibility(holdings ?? [], effectiveVisibilityFilters);
+  const hasHiddenPositions =
+    hasHiddenClosedPositions || (holdings.length > 0 && filteredHoldings.length === 0);
 
   const typeOptions = useMemo(() => {
     const seen = new Set<string>();
@@ -107,15 +112,13 @@ const AccountHoldings = ({
   }
 
   // Show empty state when there are no holdings
-  if (holdings.length === 0) {
+  if (holdings.length === 0 && !hasHiddenClosedPositions) {
     if (!showEmptyState) {
       return null;
     }
 
-    // Cash / credit-card accounts have no investment holdings by nature. When
-    // the account already has activity (a cash balance), show nothing here —
-    // the balance lives in the metrics panel. Only prompt to add an activity
-    // when there is no activity at all.
+    // For cash / credit-card accounts, an empty holdings response means there
+    // is no activity-derived cash position to display yet.
     if (isCashOrCreditAccount) {
       return (
         <div className="flex items-center justify-center py-16">
@@ -256,6 +259,7 @@ const AccountHoldings = ({
           visibilityFilters={effectiveVisibilityFilters}
           setVisibilityFilters={setVisibilityFilters}
           showClosedPositions={showClosedPositions}
+          hasHiddenPositions={hasHiddenPositions}
         />
       ) : (
         <HoldingsTable

--- a/apps/frontend/src/pages/account/account-holdings.tsx
+++ b/apps/frontend/src/pages/account/account-holdings.tsx
@@ -14,7 +14,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@wealthfolio/ui";
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { usePersistentState } from "@/hooks/use-persistent-state";
@@ -23,6 +23,7 @@ import {
   HOLDINGS_VISIBILITY_STORAGE_KEY,
   filterHoldingsByVisibility,
   getEffectiveHoldingsVisibility,
+  mergeHoldingsVisibilitySelection,
   type HoldingsVisibilityFilter,
 } from "@/pages/holdings/components/holdings-visibility";
 
@@ -64,6 +65,14 @@ const AccountHoldings = ({
   const effectiveVisibilityFilters = useMemo(
     () => getEffectiveHoldingsVisibility(visibilityFilters, showClosedPositions),
     [showClosedPositions, visibilityFilters],
+  );
+  const handleVisibilityFiltersChange = useCallback(
+    (nextFilters: HoldingsVisibilityFilter[]) => {
+      setVisibilityFilters((currentFilters) =>
+        mergeHoldingsVisibilitySelection(currentFilters, nextFilters, showClosedPositions),
+      );
+    },
+    [setVisibilityFilters, showClosedPositions],
   );
 
   const includeClosed = effectiveVisibilityFilters.includes("closed");
@@ -257,7 +266,7 @@ const AccountHoldings = ({
           showAccountScope={false}
           typeOptions={typeOptions}
           visibilityFilters={effectiveVisibilityFilters}
-          setVisibilityFilters={setVisibilityFilters}
+          setVisibilityFilters={handleVisibilityFiltersChange}
           showClosedPositions={showClosedPositions}
           hasHiddenPositions={hasHiddenPositions}
         />
@@ -266,7 +275,7 @@ const AccountHoldings = ({
           holdings={filteredHoldings ?? []}
           isLoading={isLoading}
           visibilityFilters={effectiveVisibilityFilters}
-          setVisibilityFilters={setVisibilityFilters}
+          setVisibilityFilters={handleVisibilityFiltersChange}
           showClosedPositions={showClosedPositions}
         />
       )}

--- a/apps/frontend/src/pages/account/account-holdings.tsx
+++ b/apps/frontend/src/pages/account/account-holdings.tsx
@@ -1,7 +1,6 @@
 import { useAccounts } from "@/hooks/use-accounts";
 import { useHoldings } from "@/hooks/use-holdings";
 import { useIsMobileViewport } from "@/hooks/use-platform";
-import { HoldingType } from "@/lib/types";
 import { AccountType, isLiabilityAccountType } from "@/lib/constants";
 import { canAddHoldings } from "@/lib/activity-restrictions";
 import { HoldingsTable } from "@/pages/holdings/components/holdings-table";
@@ -18,6 +17,13 @@ import {
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
+import { usePersistentState } from "@/hooks/use-persistent-state";
+import {
+  DEFAULT_HOLDINGS_VISIBILITY,
+  HOLDINGS_VISIBILITY_STORAGE_KEY,
+  filterHoldingsByVisibility,
+  type HoldingsVisibilityFilter,
+} from "@/pages/holdings/components/holdings-visibility";
 
 interface AccountHoldingsProps {
   accountId: string;
@@ -36,11 +42,18 @@ const AccountHoldings = ({
   const isMobile = useIsMobileViewport();
   const navigate = useNavigate();
   const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
+  const [visibilityFilters, setVisibilityFilters] = usePersistentState<HoldingsVisibilityFilter[]>(
+    HOLDINGS_VISIBILITY_STORAGE_KEY,
+    [...DEFAULT_HOLDINGS_VISIBILITY],
+  );
 
-  const { holdings, isLoading } = useHoldings({
-    type: "account",
-    accountId,
-  });
+  const { holdings, isLoading } = useHoldings(
+    {
+      type: "account",
+      accountId,
+    },
+    { includeClosed: true },
+  );
 
   const { accounts } = useAccounts();
 
@@ -66,13 +79,12 @@ const AccountHoldings = ({
     return accountType === AccountType.CASH || isLiabilityAccountType(accountType);
   }, [selectedAccount]);
 
-  const filteredHoldings = holdings?.filter((holding) => holding.holdingType !== HoldingType.CASH);
+  const filteredHoldings = filterHoldingsByVisibility(holdings ?? [], visibilityFilters);
 
   const typeOptions = useMemo(() => {
-    if (!filteredHoldings) return [];
     const seen = new Set<string>();
     const options: { value: string; label: string }[] = [];
-    for (const h of filteredHoldings) {
+    for (const h of holdings ?? []) {
       const name = h.instrument?.classifications?.assetType?.name;
       if (name && !seen.has(name)) {
         seen.add(name);
@@ -80,7 +92,7 @@ const AccountHoldings = ({
       }
     }
     return options;
-  }, [filteredHoldings]);
+  }, [holdings]);
 
   // Show loading state while data is being fetched
   if (isLoading) {
@@ -88,7 +100,7 @@ const AccountHoldings = ({
   }
 
   // Show empty state when there are no holdings
-  if (!filteredHoldings || filteredHoldings.length === 0) {
+  if (holdings.length === 0) {
     if (!showEmptyState) {
       return null;
     }
@@ -98,10 +110,6 @@ const AccountHoldings = ({
     // the balance lives in the metrics panel. Only prompt to add an activity
     // when there is no activity at all.
     if (isCashOrCreditAccount) {
-      if (holdings && holdings.length > 0) {
-        return null;
-      }
-
       return (
         <div className="flex items-center justify-center py-16">
           <EmptyPlaceholder
@@ -238,9 +246,16 @@ const AccountHoldings = ({
           portfolios={[]}
           showAccountScope={false}
           typeOptions={typeOptions}
+          visibilityFilters={visibilityFilters}
+          setVisibilityFilters={setVisibilityFilters}
         />
       ) : (
-        <HoldingsTable holdings={filteredHoldings ?? []} isLoading={isLoading} />
+        <HoldingsTable
+          holdings={filteredHoldings ?? []}
+          isLoading={isLoading}
+          visibilityFilters={visibilityFilters}
+          setVisibilityFilters={setVisibilityFilters}
+        />
       )}
     </div>
   );

--- a/apps/frontend/src/pages/account/account-page.tsx
+++ b/apps/frontend/src/pages/account/account-page.tsx
@@ -70,7 +70,6 @@ import { useActivityActionDialogs } from "@/pages/activity/hooks/use-activity-ac
 import { useActivitySearch } from "@/pages/activity/hooks/use-activity-search";
 import { PortfolioUpdateTrigger } from "@/pages/dashboard/portfolio-update-trigger";
 import { HoldingsEditMode } from "@/pages/holdings/components/holdings-edit-mode";
-import { isClosedPosition } from "@/pages/holdings/components/holdings-visibility";
 import { useCalculatePerformanceHistory } from "@/pages/performance/hooks/use-performance-data";
 import { useQuery } from "@tanstack/react-query";
 import type { SortingState } from "@tanstack/react-table";
@@ -249,22 +248,15 @@ const AccountPage = () => {
     return canAddHoldings(account);
   }, [account]);
 
-  const { holdings, isLoading: isHoldingsLoading } = useHoldings(
-    {
-      type: "account",
-      accountId: id,
-    },
-    { includeClosed: true },
-  );
-  const activeHoldings = useMemo(
-    () => holdings.filter((holding) => !isClosedPosition(holding)),
-    [holdings],
-  );
+  const { holdings, isLoading: isHoldingsLoading } = useHoldings({
+    type: "account",
+    accountId: id,
+  });
 
   // Check if account has any holdings (including cash)
   const hasHoldings = useMemo(() => {
-    return activeHoldings.length > 0;
-  }, [activeHoldings]);
+    return holdings.length > 0;
+  }, [holdings]);
 
   const hasNonCashHoldings = useMemo(() => {
     if (!holdings) return false;
@@ -1180,7 +1172,7 @@ const AccountPage = () => {
             </SheetHeader>
             <div className="flex-1 overflow-hidden px-6">
               <HoldingsEditMode
-                holdings={activeHoldings}
+                holdings={holdings}
                 account={account}
                 isLoading={isHoldingsLoading}
                 onClose={() => {

--- a/apps/frontend/src/pages/account/account-page.tsx
+++ b/apps/frontend/src/pages/account/account-page.tsx
@@ -70,6 +70,7 @@ import { useActivityActionDialogs } from "@/pages/activity/hooks/use-activity-ac
 import { useActivitySearch } from "@/pages/activity/hooks/use-activity-search";
 import { PortfolioUpdateTrigger } from "@/pages/dashboard/portfolio-update-trigger";
 import { HoldingsEditMode } from "@/pages/holdings/components/holdings-edit-mode";
+import { isClosedPosition } from "@/pages/holdings/components/holdings-visibility";
 import { useCalculatePerformanceHistory } from "@/pages/performance/hooks/use-performance-data";
 import { useQuery } from "@tanstack/react-query";
 import type { SortingState } from "@tanstack/react-table";
@@ -248,16 +249,22 @@ const AccountPage = () => {
     return canAddHoldings(account);
   }, [account]);
 
-  const { holdings, isLoading: isHoldingsLoading } = useHoldings({
-    type: "account",
-    accountId: id,
-  });
+  const { holdings, isLoading: isHoldingsLoading } = useHoldings(
+    {
+      type: "account",
+      accountId: id,
+    },
+    { includeClosed: true },
+  );
+  const activeHoldings = useMemo(
+    () => holdings.filter((holding) => !isClosedPosition(holding)),
+    [holdings],
+  );
 
   // Check if account has any holdings (including cash)
   const hasHoldings = useMemo(() => {
-    if (!holdings) return false;
-    return holdings.length > 0;
-  }, [holdings]);
+    return activeHoldings.length > 0;
+  }, [activeHoldings]);
 
   const hasNonCashHoldings = useMemo(() => {
     if (!holdings) return false;
@@ -1173,7 +1180,7 @@ const AccountPage = () => {
             </SheetHeader>
             <div className="flex-1 overflow-hidden px-6">
               <HoldingsEditMode
-                holdings={holdings ?? []}
+                holdings={activeHoldings}
                 account={account}
                 isLoading={isHoldingsLoading}
                 onClose={() => {

--- a/apps/frontend/src/pages/asset/asset-lots-table.test.tsx
+++ b/apps/frontend/src/pages/asset/asset-lots-table.test.tsx
@@ -71,4 +71,38 @@ describe("AssetLotsTable", () => {
 
     expect(screen.getAllByText("£288.15").length).toBeGreaterThan(0);
   });
+
+  it("shows disposed cost basis and realized gain for closed lots", () => {
+    render(
+      <AssetLotsTable
+        lots={[
+          {
+            ...ctyLot,
+            id: "closed-cty-lot",
+            quantity: 0,
+            remainingQuantity: 0,
+            costBasis: 0,
+            valuationCostBasis: 0,
+            isClosed: true,
+            closeDate: "2026-04-10",
+            disposalCostBasis: 28395.015,
+            disposalCostBasisBase: 283.95015,
+            realizedPnl: 2604.985,
+            realizedPnlBase: 26.04985,
+            valuationDisposalCostBasis: 283.95015,
+            valuationRealizedPnl: 26.04985,
+          },
+        ]}
+        currency="GBP"
+        marketPrice={5.65}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /expand all/i }));
+
+    expect(screen.getByText("Gain/Loss")).toBeInTheDocument();
+    expect(screen.getAllByText("£283.95").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("+26.05").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("+9.17%").length).toBeGreaterThan(0);
+  });
 });

--- a/apps/frontend/src/pages/asset/asset-lots-table.tsx
+++ b/apps/frontend/src/pages/asset/asset-lots-table.tsx
@@ -241,16 +241,24 @@ function computeLot(
   const marketValue = effectiveQuantity * marketPrice * rowContractMultiplier;
   const valuationCurrency = lot.valuationCurrency || currency;
   const valuationUnitCost = finiteAmount(lot.valuationUnitCost);
-  const valuationCostBasis = finiteAmount(lot.valuationCostBasis);
+  const openCostBasis = finiteAmount(lot.valuationCostBasis);
+  const disposedCostBasis = finiteAmount(lot.valuationDisposalCostBasis);
+  const realizedGainLoss = finiteAmount(lot.valuationRealizedPnl);
+  const valuationCostBasis = lot.isClosed ? disposedCostBasis : openCostBasis;
   const canAggregate =
-    isValuable && valuationCostBasis != null && sameCurrency(valuationCurrency, currency);
+    isValuable && openCostBasis != null && sameCurrency(valuationCurrency, currency);
   const aggregateMarketValue = canAggregate ? marketValue : 0;
-  const gainLossAmount =
-    canAggregate && valuationCostBasis != null ? marketValue - valuationCostBasis : null;
+  const gainLossAmount = lot.isClosed
+    ? realizedGainLoss
+    : canAggregate && openCostBasis != null
+      ? marketValue - openCostBasis
+      : null;
   const gainLossPercent =
     gainLossAmount != null && valuationCostBasis != null && valuationCostBasis !== 0
-      ? gainLossAmount / valuationCostBasis
-      : null;
+      ? gainLossAmount / Math.abs(valuationCostBasis)
+      : gainLossAmount === 0
+        ? 0
+        : null;
   const hasPartialSell =
     !isSnapshot && lot.originalQuantity > 0 && lot.remainingQuantity < lot.originalQuantity;
 
@@ -558,7 +566,7 @@ function AccountLotGroup({
                       {t("asset:lots.market_value_col")}
                     </TableHead>
                     <TableHead className="text-right text-[10px] uppercase tracking-[0.1em]">
-                      {t("asset:lots.unrealized")}
+                      {t("holdings:gain_loss")}
                     </TableHead>
                   </TableRow>
                 </TableHeader>
@@ -651,8 +659,14 @@ function AssetLotTableRow({ item, currency }: { item: ComputedLot; currency: str
       <TableCell className="text-right">
         {item.gainLossAmount != null ? (
           <div className="flex flex-col items-end">
-            <GainAmount value={item.gainLossAmount} currency={currency} displayCurrency={false} />
-            <GainPercent value={item.gainLossPercent ?? 0} className="text-[11px]" />
+            <GainAmount
+              value={item.gainLossAmount}
+              currency={item.valuationCurrency}
+              displayCurrency={false}
+            />
+            {item.gainLossPercent != null && (
+              <GainPercent value={item.gainLossPercent} className="text-[11px]" />
+            )}
           </div>
         ) : (
           "—"
@@ -683,8 +697,14 @@ function AssetLotMobileRow({ item, currency }: { item: ComputedLot; currency: st
         </div>
         {item.gainLossAmount != null && (
           <div className="flex shrink-0 flex-col items-end">
-            <GainAmount value={item.gainLossAmount} currency={currency} displayCurrency={false} />
-            <GainPercent value={item.gainLossPercent ?? 0} className="text-[11px]" />
+            <GainAmount
+              value={item.gainLossAmount}
+              currency={item.valuationCurrency}
+              displayCurrency={false}
+            />
+            {item.gainLossPercent != null && (
+              <GainPercent value={item.gainLossPercent} className="text-[11px]" />
+            )}
           </div>
         )}
       </div>

--- a/apps/frontend/src/pages/holdings/components/holdings-mobile-filter-sheet.test.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-mobile-filter-sheet.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { HoldingsMobileFilterSheet } from "./holdings-mobile-filter-sheet";
+
+vi.mock("@wealthfolio/ui", () => ({
+  AnimatedToggleGroup: () => null,
+  ScrollArea: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Separator: () => <hr />,
+}));
+
+vi.mock("@wealthfolio/ui/components/ui/button", () => ({
+  Button: ({ children }: { children: ReactNode }) => <button>{children}</button>,
+}));
+
+vi.mock("@wealthfolio/ui/components/ui/icons", () => ({
+  Icons: {
+    Check: () => <span />,
+    CreditCard: () => <span />,
+    Folder: () => <span />,
+    Wallet: () => <span />,
+  },
+}));
+
+vi.mock("@wealthfolio/ui/components/ui/sheet", () => ({
+  Sheet: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetClose: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SheetTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}));
+
+describe("HoldingsMobileFilterSheet", () => {
+  it("hides closed positions when the account cannot provide closed history", () => {
+    render(
+      <HoldingsMobileFilterSheet
+        open
+        onOpenChange={vi.fn()}
+        accountFilter={{ type: "all" }}
+        onAccountScopeChange={vi.fn()}
+        accounts={[]}
+        portfolios={[]}
+        selectedTypes={[]}
+        setSelectedTypes={vi.fn()}
+        showAccountScope={false}
+        sortBy="marketValue"
+        setSortBy={vi.fn()}
+        performanceMode="pnl"
+        setPerformanceMode={vi.fn()}
+        visibilityFilters={["open"]}
+        setVisibilityFilters={vi.fn()}
+        showClosedPositions={false}
+      />,
+    );
+
+    expect(screen.getByText("Open")).toBeInTheDocument();
+    expect(screen.getByText("Cash")).toBeInTheDocument();
+    expect(screen.queryByText("Closed")).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/pages/holdings/components/holdings-mobile-filter-sheet.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-mobile-filter-sheet.tsx
@@ -13,6 +13,7 @@ import { Account, AccountScope, HoldingCategoryFilterId } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { AnimatedToggleGroup, ScrollArea, Separator } from "@wealthfolio/ui";
 import { useTranslation } from "react-i18next";
+import { DEFAULT_HOLDINGS_VISIBILITY, type HoldingsVisibilityFilter } from "./holdings-visibility";
 
 type PerformanceMode = "daily" | "pnl" | "return";
 
@@ -40,6 +41,8 @@ interface HoldingsMobileFilterSheetProps {
   categoryFilter?: HoldingCategoryFilterId;
   setCategoryFilter?: (value: HoldingCategoryFilterId) => void;
   typeOptions?: { value: string; label: string }[];
+  visibilityFilters?: HoldingsVisibilityFilter[];
+  setVisibilityFilters?: (value: HoldingsVisibilityFilter[]) => void;
 }
 
 export const HoldingsMobileFilterSheet = ({
@@ -59,6 +62,8 @@ export const HoldingsMobileFilterSheet = ({
   categoryFilter = "investments",
   setCategoryFilter,
   typeOptions,
+  visibilityFilters = DEFAULT_HOLDINGS_VISIBILITY,
+  setVisibilityFilters,
 }: HoldingsMobileFilterSheetProps) => {
   const { t } = useTranslation();
   return (
@@ -109,6 +114,50 @@ export const HoldingsMobileFilterSheet = ({
             </div>
 
             <Separator />
+
+            {/* Position visibility */}
+            {setVisibilityFilters && (
+              <div className="space-y-3">
+                <h4 className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
+                  {t("common:view")}
+                </h4>
+                <div className="overflow-hidden rounded-lg border">
+                  {(
+                    [
+                      { value: "open", label: t("holdings:open") },
+                      { value: "closed", label: t("holdings:closed") },
+                      { value: "cash", label: t("holdings:cash") },
+                    ] as const
+                  ).map((option, index) => {
+                    const isSelected = visibilityFilters.includes(option.value);
+                    return (
+                      <button
+                        key={option.value}
+                        type="button"
+                        className={cn(
+                          "flex w-full items-center justify-between p-3 text-left text-sm transition-colors",
+                          index > 0 && "border-t",
+                          isSelected ? "bg-accent/50 font-medium" : "hover:bg-muted/50",
+                        )}
+                        onClick={() => {
+                          const nextValues = isSelected
+                            ? visibilityFilters.filter((value) => value !== option.value)
+                            : [...visibilityFilters, option.value];
+                          setVisibilityFilters(
+                            nextValues.length > 0 ? nextValues : [...DEFAULT_HOLDINGS_VISIBILITY],
+                          );
+                        }}
+                      >
+                        <span>{option.label}</span>
+                        {isSelected && <Icons.Check className="text-primary h-4 w-4" />}
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            {setVisibilityFilters && <Separator />}
 
             {/* Category Filter Section */}
             {setCategoryFilter && (
@@ -228,7 +277,7 @@ export const HoldingsMobileFilterSheet = ({
             )}
 
             {/* Asset Type Filter Section */}
-            {typeOptions && typeOptions.length > 0 && (
+            {((typeOptions?.length ?? 0) > 0 || selectedTypes.length > 0) && (
               <div className="space-y-3">
                 <h4 className="text-muted-foreground text-xs font-medium uppercase tracking-wider">
                   {t("holdings:asset_type")}
@@ -247,7 +296,7 @@ export const HoldingsMobileFilterSheet = ({
                     <span>{t("holdings:all_types")}</span>
                     {selectedTypes.length === 0 && <Icons.Check className="text-primary h-4 w-4" />}
                   </div>
-                  {typeOptions.map((type) => (
+                  {(typeOptions ?? []).map((type) => (
                     <div
                       key={type.value}
                       className={cn(

--- a/apps/frontend/src/pages/holdings/components/holdings-mobile-filter-sheet.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-mobile-filter-sheet.tsx
@@ -43,6 +43,7 @@ interface HoldingsMobileFilterSheetProps {
   typeOptions?: { value: string; label: string }[];
   visibilityFilters?: HoldingsVisibilityFilter[];
   setVisibilityFilters?: (value: HoldingsVisibilityFilter[]) => void;
+  showClosedPositions?: boolean;
 }
 
 export const HoldingsMobileFilterSheet = ({
@@ -64,8 +65,15 @@ export const HoldingsMobileFilterSheet = ({
   typeOptions,
   visibilityFilters = DEFAULT_HOLDINGS_VISIBILITY,
   setVisibilityFilters,
+  showClosedPositions = true,
 }: HoldingsMobileFilterSheetProps) => {
   const { t } = useTranslation();
+  const visibilityOptions: { value: HoldingsVisibilityFilter; label: string }[] = [
+    { value: "open", label: t("holdings:open") },
+    ...(showClosedPositions ? [{ value: "closed" as const, label: t("holdings:closed") }] : []),
+    { value: "cash", label: t("holdings:cash") },
+  ];
+
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
@@ -122,13 +130,7 @@ export const HoldingsMobileFilterSheet = ({
                   {t("common:view")}
                 </h4>
                 <div className="overflow-hidden rounded-lg border">
-                  {(
-                    [
-                      { value: "open", label: t("holdings:open") },
-                      { value: "closed", label: t("holdings:closed") },
-                      { value: "cash", label: t("holdings:cash") },
-                    ] as const
-                  ).map((option, index) => {
+                  {visibilityOptions.map((option, index) => {
                     const isSelected = visibilityFilters.includes(option.value);
                     return (
                       <button

--- a/apps/frontend/src/pages/holdings/components/holdings-table-mobile.test.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table-mobile.test.tsx
@@ -43,6 +43,27 @@ const cashHolding: Holding = {
 };
 
 describe("HoldingsTableMobile", () => {
+  it("keeps its controls available while holdings load", () => {
+    render(
+      <HoldingsTableMobile
+        holdings={[]}
+        isLoading
+        selectedTypes={[]}
+        setSelectedTypes={vi.fn()}
+        accountFilter={{ type: "all" }}
+        onAccountScopeChange={vi.fn()}
+        accounts={[]}
+        portfolios={[]}
+        toolbarActions={<button type="button">Open actions</button>}
+      />,
+    );
+
+    expect(screen.getByPlaceholderText("Search...")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open holdings filters" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Open actions" })).toBeInTheDocument();
+    expect(screen.queryByText("No positions found")).not.toBeInTheDocument();
+  });
+
   it("shows portfolio weight below a cash balance", () => {
     render(
       <HoldingsTableMobile

--- a/apps/frontend/src/pages/holdings/components/holdings-table-mobile.test.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table-mobile.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { HoldingType, QuoteMode } from "@/lib/constants";
+import type { Holding } from "@/lib/types";
+
+import { HoldingsTableMobile } from "./holdings-table-mobile";
+
+vi.mock("@/components/ticker-avatar", () => ({
+  TickerAvatar: () => <div data-testid="ticker-avatar" />,
+}));
+
+vi.mock("@/hooks/use-balance-privacy", () => ({
+  useBalancePrivacy: () => ({ isBalanceHidden: false }),
+}));
+
+vi.mock("react-router-dom", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-router-dom")>()),
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("./holdings-mobile-filter-sheet", () => ({
+  HoldingsMobileFilterSheet: () => null,
+}));
+
+const cashHolding: Holding = {
+  id: "cash-usd",
+  accountId: "account-1",
+  holdingType: HoldingType.CASH,
+  instrument: {
+    id: "cash:USD",
+    symbol: "USD",
+    name: "Cash (USD)",
+    currency: "USD",
+    quoteMode: QuoteMode.MANUAL,
+  },
+  quantity: 250,
+  localCurrency: "USD",
+  baseCurrency: "USD",
+  marketValue: { local: 250, base: 250 },
+  weight: 0.25,
+  asOfDate: "2026-08-18",
+};
+
+describe("HoldingsTableMobile", () => {
+  it("shows portfolio weight below a cash balance", () => {
+    render(
+      <HoldingsTableMobile
+        holdings={[cashHolding]}
+        isLoading={false}
+        selectedTypes={[]}
+        setSelectedTypes={vi.fn()}
+        accountFilter={{ type: "all" }}
+        onAccountScopeChange={vi.fn()}
+        accounts={[]}
+        portfolios={[]}
+        showSearch={false}
+        showFilterButton={false}
+      />,
+    );
+
+    expect(screen.getByText("Weight 25.00%")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/pages/holdings/components/holdings-table-mobile.test.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table-mobile.test.tsx
@@ -61,4 +61,25 @@ describe("HoldingsTableMobile", () => {
 
     expect(screen.getByText("Weight 25.00%")).toBeInTheDocument();
   });
+
+  it("suggests changing filters when closed positions are hidden", () => {
+    render(
+      <HoldingsTableMobile
+        holdings={[]}
+        isLoading={false}
+        selectedTypes={[]}
+        setSelectedTypes={vi.fn()}
+        accountFilter={{ type: "all" }}
+        onAccountScopeChange={vi.fn()}
+        accounts={[]}
+        portfolios={[]}
+        hasHiddenPositions
+      />,
+    );
+
+    expect(screen.getByText("Try adjusting your search or filter criteria.")).toBeInTheDocument();
+    expect(
+      screen.queryByText("Add activities to see your positions here."),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
@@ -4,7 +4,14 @@ import { HoldingType } from "@/lib/constants";
 import { parseOccSymbol } from "@/lib/occ-symbol";
 import { Account, AccountScope, Holding } from "@/lib/types";
 import { cn } from "@/lib/utils";
-import { AmountDisplay, Badge, GainPercent, Input, Separator } from "@wealthfolio/ui";
+import {
+  AmountDisplay,
+  Badge,
+  formatPercent,
+  GainPercent,
+  Input,
+  Separator,
+} from "@wealthfolio/ui";
 import { Button } from "@wealthfolio/ui/components/ui/button";
 import { Card } from "@wealthfolio/ui/components/ui/card";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
@@ -241,6 +248,11 @@ export const HoldingsTableMobile = ({
                         isHidden={isBalanceHidden}
                         className="font-medium"
                       />
+                    )}
+                    {isCash && (
+                      <p className="text-muted-foreground text-xs">
+                        {t("holdings:weight")} {formatPercent(holding.weight ?? 0)}
+                      </p>
                     )}
                     {!isCash &&
                       (isClosed && performanceMode === "daily" ? (

--- a/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
@@ -50,6 +50,7 @@ interface HoldingsTableMobileProps {
   visibilityFilters?: HoldingsVisibilityFilter[];
   setVisibilityFilters?: (value: HoldingsVisibilityFilter[]) => void;
   showClosedPositions?: boolean;
+  hasHiddenPositions?: boolean;
   toolbarActions?: ReactNode;
 }
 
@@ -73,6 +74,7 @@ export const HoldingsTableMobile = ({
   visibilityFilters = DEFAULT_HOLDINGS_VISIBILITY,
   setVisibilityFilters,
   showClosedPositions = true,
+  hasHiddenPositions = false,
   toolbarActions,
 }: HoldingsTableMobileProps) => {
   const { t } = useTranslation();
@@ -253,7 +255,9 @@ export const HoldingsTableMobile = ({
                     )}
                     {isCash && (
                       <p className="text-muted-foreground text-xs">
-                        {t("holdings:weight")} {formatPercent(holding.weight ?? 0)}
+                        {t("holdings:weight_value", {
+                          value: formatPercent(holding.weight ?? 0),
+                        })}
                       </p>
                     )}
                     {!isCash &&
@@ -296,7 +300,7 @@ export const HoldingsTableMobile = ({
           <div className="flex h-48 flex-col items-center justify-center rounded-lg border border-dashed p-8 text-center">
             <h3 className="text-lg font-medium">{t("holdings:no_positions_found")}</h3>
             <p className="text-muted-foreground text-sm">
-              {holdings.length === 0
+              {holdings.length === 0 && !hasHiddenPositions
                 ? t("holdings:add_activities_prompt")
                 : t("holdings:try_adjusting_filters")}
             </p>

--- a/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
@@ -49,6 +49,7 @@ interface HoldingsTableMobileProps {
   typeOptions?: { value: string; label: string }[];
   visibilityFilters?: HoldingsVisibilityFilter[];
   setVisibilityFilters?: (value: HoldingsVisibilityFilter[]) => void;
+  showClosedPositions?: boolean;
   toolbarActions?: ReactNode;
 }
 
@@ -71,6 +72,7 @@ export const HoldingsTableMobile = ({
   typeOptions,
   visibilityFilters = DEFAULT_HOLDINGS_VISIBILITY,
   setVisibilityFilters,
+  showClosedPositions = true,
   toolbarActions,
 }: HoldingsTableMobileProps) => {
   const { t } = useTranslation();
@@ -320,6 +322,7 @@ export const HoldingsTableMobile = ({
         typeOptions={typeOptions}
         visibilityFilters={visibilityFilters}
         setVisibilityFilters={setVisibilityFilters}
+        showClosedPositions={showClosedPositions}
       />
     </div>
   );

--- a/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
@@ -4,15 +4,22 @@ import { HoldingType } from "@/lib/constants";
 import { parseOccSymbol } from "@/lib/occ-symbol";
 import { Account, AccountScope, Holding } from "@/lib/types";
 import { cn } from "@/lib/utils";
-import { AmountDisplay, GainPercent, Input, Separator } from "@wealthfolio/ui";
+import { AmountDisplay, Badge, GainPercent, Input, Separator } from "@wealthfolio/ui";
 import { Button } from "@wealthfolio/ui/components/ui/button";
 import { Card } from "@wealthfolio/ui/components/ui/card";
 import { Icons } from "@wealthfolio/ui/components/ui/icons";
 import { Skeleton } from "@wealthfolio/ui/components/ui/skeleton";
-import { useMemo, useState } from "react";
+import { type ReactNode, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { HoldingsMobileFilterSheet } from "./holdings-mobile-filter-sheet";
+import {
+  compareCashFirst,
+  DEFAULT_HOLDINGS_VISIBILITY,
+  hasNonDefaultHoldingsVisibility,
+  isClosedPosition,
+  type HoldingsVisibilityFilter,
+} from "./holdings-visibility";
 
 type PerformanceMode = "daily" | "pnl" | "return";
 
@@ -33,6 +40,9 @@ interface HoldingsTableMobileProps {
   performanceMode?: PerformanceMode;
   setPerformanceMode?: (value: PerformanceMode) => void;
   typeOptions?: { value: string; label: string }[];
+  visibilityFilters?: HoldingsVisibilityFilter[];
+  setVisibilityFilters?: (value: HoldingsVisibilityFilter[]) => void;
+  toolbarActions?: ReactNode;
 }
 
 export const HoldingsTableMobile = ({
@@ -52,6 +62,9 @@ export const HoldingsTableMobile = ({
   performanceMode: controlledPerformanceMode,
   setPerformanceMode: controlledSetPerformanceMode,
   typeOptions,
+  visibilityFilters = DEFAULT_HOLDINGS_VISIBILITY,
+  setVisibilityFilters,
+  toolbarActions,
 }: HoldingsTableMobileProps) => {
   const { t } = useTranslation();
   const { isBalanceHidden } = useBalancePrivacy();
@@ -71,8 +84,9 @@ export const HoldingsTableMobile = ({
   const hasActiveFilters = useMemo(() => {
     const hasAccountScope = showAccountScope && accountFilter.type !== "all";
     const hasTypeFilter = selectedTypes.length > 0;
-    return hasAccountScope || hasTypeFilter;
-  }, [accountFilter, selectedTypes, showAccountScope]);
+    const hasVisibilityFilter = hasNonDefaultHoldingsVisibility(visibilityFilters);
+    return hasAccountScope || hasTypeFilter || hasVisibilityFilter;
+  }, [accountFilter, selectedTypes, showAccountScope, visibilityFilters]);
 
   const filteredHoldings = useMemo(() => {
     let result = [...holdings];
@@ -95,6 +109,9 @@ export const HoldingsTableMobile = ({
     }
 
     return result.sort((a, b) => {
+      const cashOrder = compareCashFirst(a, b);
+      if (cashOrder !== 0) return cashOrder;
+
       if (sortBy === "marketValue") {
         const valA = a.marketValue?.base ?? 0;
         const valB = b.marketValue?.base ?? 0;
@@ -144,15 +161,16 @@ export const HoldingsTableMobile = ({
               placeholder={t("holdings:search_placeholder")}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="bg-secondary/30 h-10 flex-1 rounded-full border-none"
+              className="bg-secondary/30 h-10 min-w-0 flex-1 rounded-full border-none"
             />
           )}
           {showFilterButton && (
             <Button
               variant="outline"
               size="icon"
-              className="relative size-9 shrink-0"
+              className="relative size-10 shrink-0 rounded-full"
               onClick={() => setIsFilterSheetOpen(true)}
+              aria-label={t("holdings:open_holdings_filters")}
             >
               <Icons.ListFilter className="h-4 w-4" />
               {hasActiveFilters && (
@@ -160,6 +178,7 @@ export const HoldingsTableMobile = ({
               )}
             </Button>
           )}
+          {toolbarActions}
         </div>
       )}
       <div className="space-y-2">
@@ -167,6 +186,7 @@ export const HoldingsTableMobile = ({
           filteredHoldings.map((holding) => {
             const symbol = holding.instrument?.symbol ?? holding.id;
             const isCash = holding.holdingType === HoldingType.CASH || symbol.startsWith("$CASH");
+            const isClosed = isClosedPosition(holding);
             const parsedOption = isCash ? null : parseOccSymbol(symbol);
             const avatarSymbol = isCash
               ? `CASH:${holding.localCurrency}`
@@ -178,9 +198,11 @@ export const HoldingsTableMobile = ({
               : parsedOption
                 ? parsedOption.underlying
                 : symbol;
-            const subtitle = parsedOption
-              ? `${new Date(parsedOption.expiration + "T12:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" })} $${parsedOption.strikePrice} ${parsedOption.optionType}`
-              : (holding.instrument?.name ?? null);
+            const subtitle = isCash
+              ? t("holdings:cash_balance")
+              : parsedOption
+                ? `${new Date(parsedOption.expiration + "T12:00:00").toLocaleDateString("en-US", { month: "short", day: "numeric" })} $${parsedOption.strikePrice} ${parsedOption.optionType}`
+                : (holding.instrument?.name ?? null);
             const isNavigable = !isCash && holding.instrument?.symbol;
 
             return (
@@ -198,6 +220,11 @@ export const HoldingsTableMobile = ({
                     <div className="flex-1 overflow-hidden">
                       <div className="flex items-center gap-1.5">
                         <p className="truncate font-semibold">{displaySymbol}</p>
+                        {isClosed && (
+                          <Badge variant="outline" className="h-4 px-1 py-0 text-[10px]">
+                            {t("holdings:closed")}
+                          </Badge>
+                        )}
                       </div>
                       {subtitle && (
                         <p className="text-muted-foreground truncate text-sm">{subtitle}</p>
@@ -205,38 +232,47 @@ export const HoldingsTableMobile = ({
                     </div>
                   </div>
                   <div className="ml-2 text-right">
-                    <AmountDisplay
-                      value={holding.marketValue?.local ?? 0}
-                      currency={holding.localCurrency}
-                      isHidden={isBalanceHidden}
-                      className="font-medium"
-                    />
-                    <div className="flex items-center justify-end gap-1">
+                    {isClosed ? (
+                      <p className="text-muted-foreground font-medium">—</p>
+                    ) : (
                       <AmountDisplay
-                        value={
-                          performanceMode === "return"
-                            ? (holding.totalReturn?.local ?? holding.totalGain?.local ?? 0)
-                            : performanceMode === "pnl"
-                              ? (holding.totalGain?.local ?? 0)
-                              : (holding.dayChange?.local ?? 0)
-                        }
+                        value={holding.marketValue?.local ?? 0}
                         currency={holding.localCurrency}
                         isHidden={isBalanceHidden}
-                        colorFormat
-                        className="text-xs"
+                        className="font-medium"
                       />
-                      <Separator orientation="vertical" className="mx-1 h-4" />
-                      <GainPercent
-                        value={
-                          performanceMode === "return"
-                            ? (holding.totalReturnPct ?? holding.totalGainPct ?? 0)
-                            : performanceMode === "pnl"
-                              ? (holding.totalGainPct ?? 0)
-                              : (holding.dayChangePct ?? 0)
-                        }
-                        className="text-xs"
-                      />
-                    </div>
+                    )}
+                    {!isCash &&
+                      (isClosed && performanceMode === "daily" ? (
+                        <p className="text-muted-foreground text-xs">—</p>
+                      ) : (
+                        <div className="flex items-center justify-end gap-1">
+                          <AmountDisplay
+                            value={
+                              performanceMode === "return"
+                                ? (holding.totalReturn?.local ?? holding.totalGain?.local ?? 0)
+                                : performanceMode === "pnl"
+                                  ? (holding.totalGain?.local ?? 0)
+                                  : (holding.dayChange?.local ?? 0)
+                            }
+                            currency={holding.localCurrency}
+                            isHidden={isBalanceHidden}
+                            colorFormat
+                            className="text-xs"
+                          />
+                          <Separator orientation="vertical" className="mx-1 h-4" />
+                          <GainPercent
+                            value={
+                              performanceMode === "return"
+                                ? (holding.totalReturnPct ?? holding.totalGainPct ?? 0)
+                                : performanceMode === "pnl"
+                                  ? (holding.totalGainPct ?? 0)
+                                  : (holding.dayChangePct ?? 0)
+                            }
+                            className="text-xs"
+                          />
+                        </div>
+                      ))}
                   </div>
                 </div>
               </Card>
@@ -270,6 +306,8 @@ export const HoldingsTableMobile = ({
         performanceMode={performanceMode}
         setPerformanceMode={setPerformanceMode}
         typeOptions={typeOptions}
+        visibilityFilters={visibilityFilters}
+        setVisibilityFilters={setVisibilityFilters}
       />
     </div>
   );

--- a/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table-mobile.tsx
@@ -152,17 +152,6 @@ export const HoldingsTableMobile = ({
     }
   };
 
-  if (isLoading) {
-    return (
-      <div className="space-y-2">
-        <Skeleton className="h-20 w-full rounded-lg" />
-        <Skeleton className="h-20 w-full rounded-lg" />
-        <Skeleton className="h-20 w-full rounded-lg" />
-        <Skeleton className="h-20 w-full rounded-lg" />
-      </div>
-    );
-  }
-
   return (
     <div className="space-y-3">
       {(showSearch || showFilterButton) && (
@@ -193,7 +182,14 @@ export const HoldingsTableMobile = ({
         </div>
       )}
       <div className="space-y-2">
-        {filteredHoldings.length > 0 ? (
+        {isLoading ? (
+          <>
+            <Skeleton className="h-20 w-full rounded-lg" />
+            <Skeleton className="h-20 w-full rounded-lg" />
+            <Skeleton className="h-20 w-full rounded-lg" />
+            <Skeleton className="h-20 w-full rounded-lg" />
+          </>
+        ) : filteredHoldings.length > 0 ? (
           filteredHoldings.map((holding) => {
             const symbol = holding.instrument?.symbol ?? holding.id;
             const isCash = holding.holdingType === HoldingType.CASH || symbol.startsWith("$CASH");

--- a/apps/frontend/src/pages/holdings/components/holdings-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table.tsx
@@ -27,6 +27,9 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { useNavigate } from "react-router-dom";
+import { HoldingsVisibilityFacet } from "./holdings-visibility-filter";
+import { isCashHolding, isClosedPosition } from "./holdings-visibility";
+import type { HoldingsVisibilityFilter } from "./holdings-visibility";
 
 // Helper function to get display value and currency based on toggle state
 const getDisplayValueAndCurrency = (
@@ -54,7 +57,7 @@ const getDisplayValueAndCurrency = (
 
 const getAveragePrice = (holding: Holding): number | null => {
   const costBasis = holding.costBasis?.local;
-  if (costBasis == null || holding.quantity === 0) {
+  if (isCashHolding(holding) || costBasis == null || holding.quantity === 0) {
     return null;
   }
 
@@ -71,10 +74,14 @@ export const HoldingsTable = ({
   holdings,
   isLoading,
   onClassify,
+  visibilityFilters,
+  setVisibilityFilters,
 }: {
   holdings: Holding[];
   isLoading: boolean;
   onClassify?: (holding: Holding) => void;
+  visibilityFilters?: HoldingsVisibilityFilter[];
+  setVisibilityFilters?: (value: HoldingsVisibilityFilter[]) => void;
 }) => {
   const { t } = useTranslation();
   const { isBalanceHidden } = useBalancePrivacy();
@@ -147,6 +154,12 @@ export const HoldingsTable = ({
         }}
         defaultSorting={[{ id: "symbol", desc: false }]}
         scrollable={true}
+        pinRowsToTop={isCashHolding}
+        toolbarFilters={
+          visibilityFilters && setVisibilityFilters ? (
+            <HoldingsVisibilityFacet value={visibilityFilters} onChange={setVisibilityFilters} />
+          ) : undefined
+        }
         toolbarActions={
           <div className="mr-2 flex items-center gap-2">
             {hasMultipleCurrencies && (
@@ -205,6 +218,7 @@ const getColumns = (
       const holding = row.original;
       const symbol = holding.instrument?.symbol ?? holding.id;
       const isCash = holding.holdingType === HoldingType.CASH;
+      const isClosed = isClosedPosition(holding);
 
       // Parse OCC symbol for options
       const parsedOption = isCash ? null : parseOccSymbol(symbol);
@@ -233,21 +247,31 @@ const getColumns = (
           <div className="flex flex-col">
             <div className="flex items-center gap-1.5">
               <span className="font-medium">{displaySymbol}</span>
-              {isManual && (
+              {isManual && !isCash && (
                 <Badge variant="secondary" className="h-4 px-1 py-0 text-[10px]">
                   {t("holdings:manual")}
                 </Badge>
               )}
+              {isClosed && (
+                <Badge variant="outline" className="h-4 px-1 py-0 text-[10px]">
+                  {t("holdings:closed")}
+                </Badge>
+              )}
             </div>
             <span className="text-muted-foreground line-clamp-1 text-xs">
-              {optionSubtitle ?? holding.instrument?.name ?? null}
+              {optionSubtitle ??
+                (isCash ? t("holdings:cash_balance") : holding.instrument?.name) ??
+                null}
             </span>
           </div>
         </div>
       );
 
       return (
-        <div className="-m-1 cursor-pointer p-1" onClick={handleNavigate}>
+        <div
+          className={isCash ? "-m-1 p-1" : "-m-1 cursor-pointer p-1"}
+          onClick={isCash ? undefined : handleNavigate}
+        >
           {content}
         </div>
       );
@@ -294,16 +318,21 @@ const getColumns = (
       label: t("common:quantity"),
     },
     cell: ({ row }) => {
-      const symbol = row.original.instrument?.symbol ?? row.original.id;
+      const holding = row.original;
+      if (isCashHolding(holding)) {
+        return <div className="text-muted-foreground px-4 text-right">—</div>;
+      }
+
+      const symbol = holding.instrument?.symbol ?? holding.id;
       const isOption = !!parseOccSymbol(symbol);
-      const assetTypeKey = row.original.instrument?.classifications?.assetType?.key ?? "";
+      const assetTypeKey = holding.instrument?.classifications?.assetType?.key ?? "";
       const isBond =
         assetTypeKey.startsWith("BOND_") ||
         assetTypeKey === "DEBT_SECURITY" ||
         assetTypeKey === "MONEY_MARKET_DEBT";
       return (
         <div className="flex min-h-[40px] flex-col items-end justify-center px-4">
-          <QuantityDisplay value={row.original.quantity} isHidden={isHidden} />
+          <QuantityDisplay value={holding.quantity} isHidden={isHidden} />
           <span className="text-muted-foreground text-xs">
             {isOption
               ? t("holdings:contracts")
@@ -333,6 +362,9 @@ const getColumns = (
     },
     cell: ({ row }) => {
       const holding = row.original;
+      if (isCashHolding(holding) || isClosedPosition(holding)) {
+        return <div className="text-muted-foreground px-4 text-right">—</div>;
+      }
       const price = holding.price ?? 0;
       const currency = holding.localCurrency;
       return (
@@ -398,6 +430,9 @@ const getColumns = (
     },
     cell: ({ row }) => {
       const holding = row.original;
+      if (isCashHolding(holding) || isClosedPosition(holding)) {
+        return <div className="text-muted-foreground px-4 text-right">—</div>;
+      }
       const value = holding.costBasis?.local ?? 0;
       const currency = holding.localCurrency;
 
@@ -430,6 +465,14 @@ const getColumns = (
     },
     cell: ({ row }) => {
       const holding = row.original;
+      if (isClosedPosition(holding)) {
+        return (
+          <div className="flex min-h-[40px] flex-col items-end justify-center px-4">
+            <span className="text-muted-foreground">—</span>
+            <span className="text-muted-foreground text-xs">{t("holdings:closed")}</span>
+          </div>
+        );
+      }
       const { value, currency } = getDisplayValueAndCurrency(
         holding,
         holding.marketValue.base,
@@ -469,12 +512,17 @@ const getColumns = (
     meta: {
       label: t("holdings:weight"),
     },
-    cell: ({ row }) => (
-      <div className="flex min-h-[40px] flex-col items-end justify-center px-4">
-        <span className="font-medium tabular-nums">{formatPercent(row.original.weight ?? 0)}</span>
-        <div className="text-xs text-transparent">-</div>
-      </div>
-    ),
+    cell: ({ row }) =>
+      isClosedPosition(row.original) ? (
+        <div className="text-muted-foreground px-4 text-right">—</div>
+      ) : (
+        <div className="flex min-h-[40px] flex-col items-end justify-center px-4">
+          <span className="font-medium tabular-nums">
+            {formatPercent(row.original.weight ?? 0)}
+          </span>
+          <div className="text-xs text-transparent">-</div>
+        </div>
+      ),
     sortingFn: (rowA, rowB) => (rowA.original.weight ?? 0) - (rowB.original.weight ?? 0),
   },
   {
@@ -493,6 +541,9 @@ const getColumns = (
     },
     cell: ({ row }) => {
       const holding = row.original;
+      if (isCashHolding(holding)) {
+        return <div className="text-muted-foreground px-4 text-right">—</div>;
+      }
       const value = showConvertedValues
         ? (holding.totalGain?.base ?? 0)
         : (holding.totalGain?.local ?? 0);
@@ -535,6 +586,9 @@ const getColumns = (
     },
     cell: ({ row }) => {
       const holding = row.original;
+      if (isCashHolding(holding)) {
+        return <div className="text-muted-foreground px-4 text-right">—</div>;
+      }
       const value = showConvertedValues
         ? (holding.totalReturn?.base ?? 0)
         : (holding.totalReturn?.local ?? 0);
@@ -572,6 +626,9 @@ const getColumns = (
     },
     cell: ({ row }) => {
       const holding = row.original;
+      if (isCashHolding(holding) || isClosedPosition(holding)) {
+        return <div className="text-muted-foreground px-4 text-right">—</div>;
+      }
       const value = showConvertedValues
         ? (holding.dayChange?.base ?? 0)
         : (holding.dayChange?.local ?? 0);
@@ -606,6 +663,9 @@ const getColumns = (
     },
     cell: ({ row }) => {
       const holding = row.original;
+      if (isCashHolding(holding) || isClosedPosition(holding)) {
+        return <div className="text-muted-foreground px-4 text-right">—</div>;
+      }
       const value = showConvertedValues
         ? (holding.unrealizedGain?.base ?? 0)
         : (holding.unrealizedGain?.local ?? 0);
@@ -643,6 +703,9 @@ const getColumns = (
     },
     cell: ({ row }) => {
       const holding = row.original;
+      if (isCashHolding(holding)) {
+        return <div className="text-muted-foreground px-4 text-right">—</div>;
+      }
       const value = showConvertedValues
         ? (holding.realizedGain?.base ?? 0)
         : (holding.realizedGain?.local ?? 0);
@@ -676,6 +739,9 @@ const getColumns = (
     },
     cell: ({ row }) => {
       const holding = row.original;
+      if (isCashHolding(holding)) {
+        return <div className="text-muted-foreground px-4 text-right">—</div>;
+      }
       const value = showConvertedValues
         ? (holding.income?.base ?? 0)
         : (holding.income?.local ?? 0);
@@ -726,7 +792,9 @@ const getColumns = (
     cell: ({ row }) => {
       const navigate = useNavigate();
       const holding = row.original;
-      const hasInstrument = !!holding.instrument;
+      const hasInstrument = holding.holdingType !== HoldingType.CASH && !!holding.instrument;
+
+      if (!hasInstrument) return null;
 
       const handleNavigate = () => {
         // Use instrument.id (asset ID) for navigation, not symbol (which may be stripped)
@@ -745,7 +813,7 @@ const getColumns = (
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              {hasInstrument && onClassify && (
+              {onClassify && (
                 <DropdownMenuItem onClick={() => onClassify(holding)}>
                   <Icons.Tag className="mr-2 h-4 w-4" />
                   {t("holdings:classify")}

--- a/apps/frontend/src/pages/holdings/components/holdings-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table.tsx
@@ -76,12 +76,14 @@ export const HoldingsTable = ({
   onClassify,
   visibilityFilters,
   setVisibilityFilters,
+  showClosedPositions = true,
 }: {
   holdings: Holding[];
   isLoading: boolean;
   onClassify?: (holding: Holding) => void;
   visibilityFilters?: HoldingsVisibilityFilter[];
   setVisibilityFilters?: (value: HoldingsVisibilityFilter[]) => void;
+  showClosedPositions?: boolean;
 }) => {
   const { t } = useTranslation();
   const { isBalanceHidden } = useBalancePrivacy();
@@ -157,7 +159,11 @@ export const HoldingsTable = ({
         pinRowsToTop={isCashHolding}
         toolbarFilters={
           visibilityFilters && setVisibilityFilters ? (
-            <HoldingsVisibilityFacet value={visibilityFilters} onChange={setVisibilityFilters} />
+            <HoldingsVisibilityFacet
+              value={visibilityFilters}
+              onChange={setVisibilityFilters}
+              showClosedPositions={showClosedPositions}
+            />
           ) : undefined
         }
         toolbarActions={

--- a/apps/frontend/src/pages/holdings/components/holdings-visibility-facet.test.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-visibility-facet.test.tsx
@@ -1,0 +1,25 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { HoldingsVisibilityFacet } from "./holdings-visibility-filter";
+
+vi.mock("@wealthfolio/ui", () => ({
+  FacetedFilter: ({ options }: { options: { value: string; label: string }[] }) => (
+    <div>
+      {options.map((option) => (
+        <span key={option.value}>{option.label}</span>
+      ))}
+    </div>
+  ),
+}));
+
+describe("HoldingsVisibilityFacet", () => {
+  it("hides closed positions when the account cannot provide closed history", () => {
+    render(
+      <HoldingsVisibilityFacet value={["open"]} onChange={vi.fn()} showClosedPositions={false} />,
+    );
+
+    expect(screen.getByText("Open")).toBeInTheDocument();
+    expect(screen.getByText("Cash")).toBeInTheDocument();
+    expect(screen.queryByText("Closed")).not.toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/pages/holdings/components/holdings-visibility-filter.test.ts
+++ b/apps/frontend/src/pages/holdings/components/holdings-visibility-filter.test.ts
@@ -5,6 +5,7 @@ import {
   compareCashFirst,
   DEFAULT_HOLDINGS_VISIBILITY,
   filterHoldingsByVisibility,
+  getEffectiveHoldingsVisibility,
   hasNonDefaultHoldingsVisibility,
   isClosedPosition,
 } from "./holdings-visibility";
@@ -56,6 +57,15 @@ describe("holdings visibility filters", () => {
     expect(hasNonDefaultHoldingsVisibility(["open"])).toBe(false);
     expect(hasNonDefaultHoldingsVisibility(["closed"])).toBe(true);
     expect(hasNonDefaultHoldingsVisibility(["open", "cash"])).toBe(true);
+  });
+
+  it("removes unsupported closed visibility for snapshot accounts", () => {
+    expect(getEffectiveHoldingsVisibility(["open", "closed", "cash"], false)).toEqual([
+      "open",
+      "cash",
+    ]);
+    expect(getEffectiveHoldingsVisibility(["closed"], false)).toEqual(["open"]);
+    expect(getEffectiveHoldingsVisibility(["closed"], true)).toEqual(["closed"]);
   });
 
   it("does not classify a zero cash balance as a closed position", () => {

--- a/apps/frontend/src/pages/holdings/components/holdings-visibility-filter.test.ts
+++ b/apps/frontend/src/pages/holdings/components/holdings-visibility-filter.test.ts
@@ -8,6 +8,7 @@ import {
   getEffectiveHoldingsVisibility,
   hasNonDefaultHoldingsVisibility,
   isClosedPosition,
+  mergeHoldingsVisibilitySelection,
 } from "./holdings-visibility";
 
 function holding(
@@ -66,6 +67,21 @@ describe("holdings visibility filters", () => {
     ]);
     expect(getEffectiveHoldingsVisibility(["closed"], false)).toEqual(["open"]);
     expect(getEffectiveHoldingsVisibility(["closed"], true)).toEqual(["closed"]);
+  });
+
+  it("preserves a hidden closed preference when supported filters change", () => {
+    expect(mergeHoldingsVisibilitySelection(["open", "closed"], ["open", "cash"], false)).toEqual([
+      "open",
+      "cash",
+      "closed",
+    ]);
+  });
+
+  it("allows closed to be removed where the filter is supported", () => {
+    expect(mergeHoldingsVisibilitySelection(["open", "closed"], ["open", "cash"], true)).toEqual([
+      "open",
+      "cash",
+    ]);
   });
 
   it("does not classify a zero cash balance as a closed position", () => {

--- a/apps/frontend/src/pages/holdings/components/holdings-visibility-filter.test.ts
+++ b/apps/frontend/src/pages/holdings/components/holdings-visibility-filter.test.ts
@@ -1,0 +1,82 @@
+import { HoldingType } from "@/lib/constants";
+import type { Holding } from "@/lib/types";
+import { describe, expect, it } from "vitest";
+import {
+  compareCashFirst,
+  DEFAULT_HOLDINGS_VISIBILITY,
+  filterHoldingsByVisibility,
+  hasNonDefaultHoldingsVisibility,
+  isClosedPosition,
+} from "./holdings-visibility";
+
+function holding(
+  id: string,
+  holdingType: Holding["holdingType"],
+  quantity: number,
+  isClosed?: boolean,
+): Holding {
+  return {
+    id,
+    holdingType,
+    isClosed,
+    accountId: "account-1",
+    quantity,
+    localCurrency: "USD",
+    baseCurrency: "USD",
+    marketValue: { local: quantity * 100, base: quantity * 100 },
+    weight: quantity === 0 ? 0 : 1,
+    asOfDate: "2026-08-17",
+  };
+}
+
+const openPosition = holding("open", HoldingType.SECURITY, 1);
+const closedPosition = holding("closed", HoldingType.SECURITY, 0);
+const cashBalance = holding("cash", HoldingType.CASH, 100);
+const allHoldings = [openPosition, closedPosition, cashBalance];
+
+describe("holdings visibility filters", () => {
+  it("shows open positions by default", () => {
+    expect(
+      filterHoldingsByVisibility(allHoldings, DEFAULT_HOLDINGS_VISIBILITY).map(({ id }) => id),
+    ).toEqual(["open"]);
+  });
+
+  it("can focus on open, closed, or cash holdings independently", () => {
+    expect(filterHoldingsByVisibility(allHoldings, ["open"]).map(({ id }) => id)).toEqual(["open"]);
+    expect(filterHoldingsByVisibility(allHoldings, ["closed"]).map(({ id }) => id)).toEqual([
+      "closed",
+    ]);
+    expect(filterHoldingsByVisibility(allHoldings, ["cash"]).map(({ id }) => id)).toEqual(["cash"]);
+    expect(
+      filterHoldingsByVisibility(allHoldings, ["open", "closed", "cash"]).map(({ id }) => id),
+    ).toEqual(["open", "closed", "cash"]);
+  });
+
+  it("only marks non-default visibility selections as active", () => {
+    expect(hasNonDefaultHoldingsVisibility(["open"])).toBe(false);
+    expect(hasNonDefaultHoldingsVisibility(["closed"])).toBe(true);
+    expect(hasNonDefaultHoldingsVisibility(["open", "cash"])).toBe(true);
+  });
+
+  it("does not classify a zero cash balance as a closed position", () => {
+    expect(isClosedPosition(holding("zero-cash", HoldingType.CASH, 0))).toBe(false);
+    expect(isClosedPosition(closedPosition)).toBe(true);
+  });
+
+  it("uses the explicit lifecycle state when an open aggregate nets to zero", () => {
+    const openNetZero = holding("open-net-zero", HoldingType.SECURITY, 0, false);
+
+    expect(isClosedPosition(openNetZero)).toBe(false);
+    expect(filterHoldingsByVisibility([openNetZero], ["open"])).toEqual([openNetZero]);
+    expect(filterHoldingsByVisibility([openNetZero], ["closed"])).toEqual([]);
+  });
+
+  it("orders cash before open and closed security positions", () => {
+    const anotherCashBalance = holding("cash-eur", HoldingType.CASH, 50);
+    const sorted = [openPosition, cashBalance, closedPosition, anotherCashBalance].sort(
+      compareCashFirst,
+    );
+
+    expect(sorted.map(({ id }) => id)).toEqual(["cash", "cash-eur", "open", "closed"]);
+  });
+});

--- a/apps/frontend/src/pages/holdings/components/holdings-visibility-filter.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-visibility-filter.tsx
@@ -6,17 +6,23 @@ import type { HoldingsVisibilityFilter } from "./holdings-visibility";
 interface HoldingsVisibilityFacetProps {
   value: HoldingsVisibilityFilter[];
   onChange: (value: HoldingsVisibilityFilter[]) => void;
+  showClosedPositions?: boolean;
 }
 
-export function HoldingsVisibilityFacet({ value, onChange }: HoldingsVisibilityFacetProps) {
+export function HoldingsVisibilityFacet({
+  value,
+  onChange,
+  showClosedPositions = true,
+}: HoldingsVisibilityFacetProps) {
   const { t } = useTranslation();
   const options = useMemo(
-    () => [
-      { value: "open", label: t("holdings:open") },
-      { value: "closed", label: t("holdings:closed") },
-      { value: "cash", label: t("holdings:cash") },
-    ],
-    [t],
+    () =>
+      [
+        { value: "open", label: t("holdings:open") },
+        ...(showClosedPositions ? [{ value: "closed", label: t("holdings:closed") }] : []),
+        { value: "cash", label: t("holdings:cash") },
+      ] as { value: HoldingsVisibilityFilter; label: string }[],
+    [showClosedPositions, t],
   );
 
   return (

--- a/apps/frontend/src/pages/holdings/components/holdings-visibility-filter.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-visibility-filter.tsx
@@ -1,0 +1,33 @@
+import { FacetedFilter } from "@wealthfolio/ui";
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import type { HoldingsVisibilityFilter } from "./holdings-visibility";
+
+interface HoldingsVisibilityFacetProps {
+  value: HoldingsVisibilityFilter[];
+  onChange: (value: HoldingsVisibilityFilter[]) => void;
+}
+
+export function HoldingsVisibilityFacet({ value, onChange }: HoldingsVisibilityFacetProps) {
+  const { t } = useTranslation();
+  const options = useMemo(
+    () => [
+      { value: "open", label: t("holdings:open") },
+      { value: "closed", label: t("holdings:closed") },
+      { value: "cash", label: t("holdings:cash") },
+    ],
+    [t],
+  );
+
+  return (
+    <FacetedFilter
+      title={t("common:view")}
+      options={options}
+      selectedValues={new Set(value)}
+      onFilterChange={(values) => {
+        const nextValues = Array.from(values) as HoldingsVisibilityFilter[];
+        onChange(nextValues.length > 0 ? nextValues : ["open"]);
+      }}
+    />
+  );
+}

--- a/apps/frontend/src/pages/holdings/components/holdings-visibility.ts
+++ b/apps/frontend/src/pages/holdings/components/holdings-visibility.ts
@@ -1,0 +1,41 @@
+import { HoldingType } from "@/lib/constants";
+import type { Holding } from "@/lib/types";
+
+export type HoldingsVisibilityFilter = "open" | "closed" | "cash";
+
+export const DEFAULT_HOLDINGS_VISIBILITY: HoldingsVisibilityFilter[] = ["open"];
+export const HOLDINGS_VISIBILITY_STORAGE_KEY = "holdings-visibility-filters-v2";
+
+export function isCashHolding(holding: Holding): boolean {
+  return holding.holdingType === HoldingType.CASH;
+}
+
+export function isClosedPosition(holding: Holding): boolean {
+  return !isCashHolding(holding) && (holding.isClosed ?? holding.quantity === 0);
+}
+
+export function compareCashFirst(a: Holding, b: Holding): number {
+  const aIsCash = isCashHolding(a);
+  const bIsCash = isCashHolding(b);
+  if (aIsCash === bIsCash) return 0;
+  return aIsCash ? -1 : 1;
+}
+
+export function filterHoldingsByVisibility(
+  holdings: Holding[],
+  filters: HoldingsVisibilityFilter[],
+): Holding[] {
+  const showOpen = filters.includes("open");
+  const showClosed = filters.includes("closed");
+  const showCash = filters.includes("cash");
+
+  return holdings.filter((holding) => {
+    if (isCashHolding(holding)) return showCash;
+    if (isClosedPosition(holding)) return showClosed;
+    return showOpen;
+  });
+}
+
+export function hasNonDefaultHoldingsVisibility(filters: HoldingsVisibilityFilter[]): boolean {
+  return filters.length !== 1 || filters[0] !== "open";
+}

--- a/apps/frontend/src/pages/holdings/components/holdings-visibility.ts
+++ b/apps/frontend/src/pages/holdings/components/holdings-visibility.ts
@@ -17,6 +17,22 @@ export function getEffectiveHoldingsVisibility(
   return supportedFilters.length > 0 ? supportedFilters : [...DEFAULT_HOLDINGS_VISIBILITY];
 }
 
+export function mergeHoldingsVisibilitySelection(
+  currentFilters: HoldingsVisibilityFilter[],
+  nextFilters: HoldingsVisibilityFilter[],
+  allowClosedPositions: boolean,
+): HoldingsVisibilityFilter[] {
+  if (
+    allowClosedPositions ||
+    !currentFilters.includes("closed") ||
+    nextFilters.includes("closed")
+  ) {
+    return nextFilters;
+  }
+
+  return [...nextFilters, "closed"];
+}
+
 export function isCashHolding(holding: Holding): boolean {
   return holding.holdingType === HoldingType.CASH;
 }

--- a/apps/frontend/src/pages/holdings/components/holdings-visibility.ts
+++ b/apps/frontend/src/pages/holdings/components/holdings-visibility.ts
@@ -6,6 +6,17 @@ export type HoldingsVisibilityFilter = "open" | "closed" | "cash";
 export const DEFAULT_HOLDINGS_VISIBILITY: HoldingsVisibilityFilter[] = ["open"];
 export const HOLDINGS_VISIBILITY_STORAGE_KEY = "holdings-visibility-filters-v2";
 
+export function getEffectiveHoldingsVisibility(
+  filters: HoldingsVisibilityFilter[],
+  allowClosedPositions: boolean,
+): HoldingsVisibilityFilter[] {
+  const supportedFilters = allowClosedPositions
+    ? filters
+    : filters.filter((filter) => filter !== "closed");
+
+  return supportedFilters.length > 0 ? supportedFilters : [...DEFAULT_HOLDINGS_VISIBILITY];
+}
+
 export function isCashHolding(holding: Holding): boolean {
   return holding.holdingType === HoldingType.CASH;
 }

--- a/apps/frontend/src/pages/holdings/holdings-page.tsx
+++ b/apps/frontend/src/pages/holdings/holdings-page.tsx
@@ -32,12 +32,18 @@ import {
 } from "@/lib/types";
 import { canAddHoldings } from "@/lib/activity-restrictions";
 import { useIsMobileViewport } from "@/hooks/use-platform";
-import { HoldingsMobileFilterSheet } from "./components/holdings-mobile-filter-sheet";
 import { HoldingsTable } from "./components/holdings-table";
 import { HoldingsTableMobile } from "./components/holdings-table-mobile";
 import { AlternativeHoldingsTable } from "./components/alternative-holdings-table";
 import { AlternativeHoldingsListMobile } from "./components/alternative-holdings-list-mobile";
 import { HoldingsEditMode } from "./components/holdings-edit-mode";
+import {
+  DEFAULT_HOLDINGS_VISIBILITY,
+  HOLDINGS_VISIBILITY_STORAGE_KEY,
+  filterHoldingsByVisibility,
+  isClosedPosition,
+  type HoldingsVisibilityFilter,
+} from "./components/holdings-visibility";
 import {
   AlternativeAssetQuickAddModal,
   AssetDetailsSheet,
@@ -66,12 +72,17 @@ export const HoldingsPage = () => {
   const { settings } = useSettingsContext();
   const baseCurrency = settings?.baseCurrency ?? "USD";
 
+  const [visibilityFilters, setVisibilityFilters] = usePersistentState<HoldingsVisibilityFilter[]>(
+    HOLDINGS_VISIBILITY_STORAGE_KEY,
+    [...DEFAULT_HOLDINGS_VISIBILITY],
+  );
+
   const [accountFilter, setAccountScope] = useState<AccountScope>({ type: "all" });
 
   // Keep selectedAccount for edit/add functionality when a specific account is selected.
   const [selectedAccount, setSelectedAccount] = useState<Account | null>(null);
 
-  const { holdings, isLoading } = useHoldings(accountFilter);
+  const { holdings, isLoading } = useHoldings(accountFilter, { includeClosed: true });
   const { accounts, isLoading: isAccountsLoading } = useAccounts({
     accountPurpose: AccountPurpose.HOLDINGS,
   });
@@ -81,7 +92,6 @@ export const HoldingsPage = () => {
 
   // Mobile filter state
   const [selectedTypes, setSelectedTypes] = useState<string[]>([]);
-  const [isFilterSheetOpen, setIsFilterSheetOpen] = useState(false);
   const [isAlternativeAssetModalOpen, setIsAlternativeAssetModalOpen] = useState(false);
   const [sortBy, setSortBy] = usePersistentState<"symbol" | "marketValue">(
     "holdings-sort-by",
@@ -321,28 +331,32 @@ export const HoldingsPage = () => {
   );
 
   // Process investment holdings
-  const { nonCashHoldings, filteredHoldings, availableTypeOptions } = useMemo(() => {
-    const nonCash =
-      holdings?.filter((holding) => holding.holdingType?.toLowerCase() !== HoldingType.CASH) ?? [];
+  const { filteredHoldings, availableTypeOptions } = useMemo(() => {
+    const allHoldings = holdings ?? [];
 
-    let filtered = nonCash;
+    let scopedHoldings = allHoldings;
     if (investmentsFilter?.assetKinds) {
       const allowedKinds = investmentsFilter.assetKinds as readonly string[];
-      filtered = nonCash.filter((holding) => {
-        return holding.assetKind && allowedKinds.includes(holding.assetKind);
+      scopedHoldings = allHoldings.filter((holding) => {
+        return (
+          holding.holdingType?.toLowerCase() === HoldingType.CASH ||
+          (holding.assetKind && allowedKinds.includes(holding.assetKind))
+        );
       });
     }
 
     // Build available type options from taxonomy classifications
     const typeSet = new Set<string>();
     const typeOptions: { value: string; label: string }[] = [];
-    for (const h of filtered) {
+    for (const h of scopedHoldings) {
       const name = h.instrument?.classifications?.assetType?.name;
       if (name && !typeSet.has(name)) {
         typeSet.add(name);
         typeOptions.push({ value: name, label: name });
       }
     }
+
+    let filtered = filterHoldingsByVisibility(scopedHoldings, visibilityFilters);
 
     if (selectedTypes.length > 0) {
       filtered = filtered.filter((holding) => {
@@ -359,19 +373,55 @@ export const HoldingsPage = () => {
     }
 
     return {
-      nonCashHoldings: nonCash,
       filteredHoldings: filtered,
       availableTypeOptions: typeOptions,
     };
-  }, [holdings, selectedTypes, investmentsFilter, healthFilter]);
+  }, [holdings, visibilityFilters, selectedTypes, investmentsFilter, healthFilter]);
 
   // Combined loading state
   const isDataLoading = isLoading || isAccountsLoading || isAlternativeHoldingsLoading;
 
   // Empty state checks
-  const hasNoInvestments = !isDataLoading && (!nonCashHoldings || nonCashHoldings.length === 0);
+  const hasNoInvestments = !isDataLoading && holdings.length === 0;
   const hasNoAssets = !isDataLoading && assetsHoldings.length === 0;
   const hasNoLiabilities = !isDataLoading && liabilitiesHoldings.length === 0;
+
+  // Action palette groups
+  const actionPaletteGroups: ActionPaletteGroup[] = useMemo(
+    () => [
+      {
+        items: [
+          {
+            icon: Icons.Wallet,
+            label: t("holdings:add_asset"),
+            onClick: () => {
+              setModalDefaultKind(undefined);
+              setIsAlternativeAssetModalOpen(true);
+            },
+          },
+          {
+            icon: Icons.CreditCard,
+            label: t("holdings:add_liability"),
+            onClick: () => {
+              setModalDefaultKind(AlternativeAssetKind.LIABILITY);
+              setIsAlternativeAssetModalOpen(true);
+            },
+          },
+          {
+            icon: Icons.Plus,
+            label: t("holdings:add_activity"),
+            onClick: () => navigate("/activities/manage"),
+          },
+          {
+            icon: Icons.Refresh,
+            label: t("holdings:update_prices"),
+            onClick: () => updatePortfolioMutation.mutate(),
+          },
+        ],
+      },
+    ],
+    [navigate, updatePortfolioMutation, t],
+  );
 
   // Investments content
   const investmentsContent = (
@@ -391,7 +441,7 @@ export const HoldingsPage = () => {
       {/* Edit Mode for HOLDINGS-mode accounts */}
       {isEditMode && selectedAccount && canEditHoldings ? (
         <HoldingsEditMode
-          holdings={holdings ?? []}
+          holdings={(holdings ?? []).filter((holding) => !isClosedPosition(holding))}
           account={selectedAccount}
           isLoading={isDataLoading}
           onClose={() => setIsEditMode(false)}
@@ -441,6 +491,8 @@ export const HoldingsPage = () => {
             <HoldingsTable
               holdings={filteredHoldings ?? []}
               isLoading={isDataLoading}
+              visibilityFilters={visibilityFilters}
+              setVisibilityFilters={setVisibilityFilters}
               onClassify={(holding) =>
                 setClassifyAsset({
                   id: holding.instrument?.id ?? holding.id,
@@ -454,7 +506,7 @@ export const HoldingsPage = () => {
           {/* Mobile View */}
           <div className="block md:hidden">
             <HoldingsTableMobile
-              holdings={nonCashHoldings ?? []}
+              holdings={filteredHoldings ?? []}
               isLoading={isDataLoading}
               selectedTypes={selectedTypes}
               setSelectedTypes={setSelectedTypes}
@@ -463,11 +515,33 @@ export const HoldingsPage = () => {
               accounts={accounts ?? []}
               portfolios={portfolios}
               showSearch={true}
-              showFilterButton={false}
+              showFilterButton={true}
               sortBy={sortBy}
+              setSortBy={setSortBy}
               performanceMode={performanceMode}
               setPerformanceMode={setPerformanceMode}
               typeOptions={availableTypeOptions}
+              visibilityFilters={visibilityFilters}
+              setVisibilityFilters={setVisibilityFilters}
+              toolbarActions={
+                isMobileViewport && currentTab === "investments" ? (
+                  <ActionPalette
+                    open={isActionPaletteOpen}
+                    onOpenChange={setIsActionPaletteOpen}
+                    groups={actionPaletteGroups}
+                    trigger={
+                      <Button
+                        variant="outline"
+                        size="icon"
+                        className="size-10 shrink-0 rounded-full"
+                        aria-label={t("holdings:open_actions")}
+                      >
+                        <Icons.DotsThreeVertical className="h-5 w-5" weight="fill" />
+                      </Button>
+                    }
+                  />
+                ) : undefined
+              }
             />
           </div>
         </>
@@ -567,58 +641,11 @@ export const HoldingsPage = () => {
     </>
   );
 
-  // Action palette groups
-  const actionPaletteGroups: ActionPaletteGroup[] = useMemo(
-    () => [
-      {
-        items: [
-          {
-            icon: Icons.Wallet,
-            label: t("holdings:add_asset"),
-            onClick: () => {
-              setModalDefaultKind(undefined);
-              setIsAlternativeAssetModalOpen(true);
-            },
-          },
-          {
-            icon: Icons.CreditCard,
-            label: t("holdings:add_liability"),
-            onClick: () => {
-              setModalDefaultKind(AlternativeAssetKind.LIABILITY);
-              setIsAlternativeAssetModalOpen(true);
-            },
-          },
-          {
-            icon: Icons.Plus,
-            label: t("holdings:add_activity"),
-            onClick: () => navigate("/activities/manage"),
-          },
-          {
-            icon: Icons.Refresh,
-            label: t("holdings:update_prices"),
-            onClick: () => updatePortfolioMutation.mutate(),
-          },
-        ],
-      },
-    ],
-    [navigate, updatePortfolioMutation, t],
-  );
-
   // Shared actions for header
   const sharedActions = useMemo(
     () => (
       <>
-        {isMobileViewport && currentTab === "investments" ? (
-          <Button
-            size="icon-sm"
-            variant="outline"
-            className="h-9 w-9 rounded-full"
-            onClick={() => setIsFilterSheetOpen(true)}
-            aria-label={t("holdings:open_holdings_filters")}
-          >
-            <Icons.ListFilter className="h-4 w-4" />
-          </Button>
-        ) : (
+        {!(isMobileViewport && currentTab === "investments") && (
           <AccountScopeSelector value={accountFilter} onChange={handleAccountScopeChange} />
         )}
         {/* Show Update button for HOLDINGS-mode manual accounts (only on investments tab) */}
@@ -628,16 +655,17 @@ export const HoldingsPage = () => {
             {t("holdings:update")}
           </Button>
         )}
-        <ActionPalette
-          open={isActionPaletteOpen}
-          onOpenChange={setIsActionPaletteOpen}
-          groups={actionPaletteGroups}
-        />
+        {!(isMobileViewport && currentTab === "investments") && (
+          <ActionPalette
+            open={isActionPaletteOpen}
+            onOpenChange={setIsActionPaletteOpen}
+            groups={actionPaletteGroups}
+          />
+        )}
       </>
     ),
     [
       isMobileViewport,
-      setIsFilterSheetOpen,
       accountFilter,
       handleAccountScopeChange,
       canEditHoldings,
@@ -687,23 +715,6 @@ export const HoldingsPage = () => {
   return (
     <>
       <SwipablePage views={views} defaultView="investments" />
-
-      {/* Mobile Filter Sheet */}
-      <HoldingsMobileFilterSheet
-        open={isFilterSheetOpen}
-        onOpenChange={setIsFilterSheetOpen}
-        accountFilter={accountFilter}
-        onAccountScopeChange={handleAccountScopeChange}
-        accounts={accounts ?? []}
-        portfolios={portfolios}
-        selectedTypes={selectedTypes}
-        setSelectedTypes={setSelectedTypes}
-        sortBy={sortBy}
-        setSortBy={setSortBy}
-        performanceMode={performanceMode}
-        setPerformanceMode={setPerformanceMode}
-        typeOptions={availableTypeOptions}
-      />
 
       {/* Alternative Asset Quick Add Modal */}
       <AlternativeAssetQuickAddModal

--- a/apps/frontend/src/pages/holdings/holdings-page.tsx
+++ b/apps/frontend/src/pages/holdings/holdings-page.tsx
@@ -9,7 +9,7 @@ import { SwipablePage, SwipablePageView } from "@/components/page";
 import { AccountScopeSelector } from "@/components/account-filter-selector";
 import { ActionPalette, type ActionPaletteGroup } from "@/components/action-palette";
 import { useAccounts } from "@/hooks/use-accounts";
-import { useHoldings } from "@/hooks/use-holdings";
+import { useHoldingsWithClosedProbe } from "@/hooks/use-holdings";
 import { usePortfolios } from "@/hooks/use-portfolios";
 import {
   useAlternativeHoldings,
@@ -89,9 +89,14 @@ export const HoldingsPage = () => {
     [showClosedPositions, visibilityFilters],
   );
 
-  const { holdings, isLoading } = useHoldings(accountFilter, {
-    includeClosed: effectiveVisibilityFilters.includes("closed"),
-  });
+  const includeClosed = effectiveVisibilityFilters.includes("closed");
+  const { holdings, isLoading, hasHiddenClosedPositions } = useHoldingsWithClosedProbe(
+    accountFilter,
+    {
+      includeClosed,
+      probeClosedWhenEmpty: showClosedPositions,
+    },
+  );
   const { accounts, isLoading: isAccountsLoading } = useAccounts({
     accountPurpose: AccountPurpose.HOLDINGS,
   });
@@ -389,9 +394,11 @@ export const HoldingsPage = () => {
 
   // Combined loading state
   const isDataLoading = isLoading || isAccountsLoading || isAlternativeHoldingsLoading;
+  const hasHiddenInvestmentPositions =
+    hasHiddenClosedPositions || (holdings.length > 0 && filteredHoldings.length === 0);
 
   // Empty state checks
-  const hasNoInvestments = !isDataLoading && holdings.length === 0;
+  const hasNoInvestments = !isDataLoading && holdings.length === 0 && !hasHiddenClosedPositions;
   const hasNoAssets = !isDataLoading && assetsHoldings.length === 0;
   const hasNoLiabilities = !isDataLoading && liabilitiesHoldings.length === 0;
   const hasMobileInvestmentsToolbar =
@@ -536,6 +543,7 @@ export const HoldingsPage = () => {
               visibilityFilters={effectiveVisibilityFilters}
               setVisibilityFilters={setVisibilityFilters}
               showClosedPositions={showClosedPositions}
+              hasHiddenPositions={hasHiddenInvestmentPositions}
               toolbarActions={
                 isMobileViewport && currentTab === "investments" ? (
                   <ActionPalette

--- a/apps/frontend/src/pages/holdings/holdings-page.tsx
+++ b/apps/frontend/src/pages/holdings/holdings-page.tsx
@@ -41,6 +41,7 @@ import {
   DEFAULT_HOLDINGS_VISIBILITY,
   HOLDINGS_VISIBILITY_STORAGE_KEY,
   filterHoldingsByVisibility,
+  getEffectiveHoldingsVisibility,
   isClosedPosition,
   type HoldingsVisibilityFilter,
 } from "./components/holdings-visibility";
@@ -82,7 +83,15 @@ export const HoldingsPage = () => {
   // Keep selectedAccount for edit/add functionality when a specific account is selected.
   const [selectedAccount, setSelectedAccount] = useState<Account | null>(null);
 
-  const { holdings, isLoading } = useHoldings(accountFilter, { includeClosed: true });
+  const showClosedPositions = selectedAccount?.trackingMode !== "HOLDINGS";
+  const effectiveVisibilityFilters = useMemo(
+    () => getEffectiveHoldingsVisibility(visibilityFilters, showClosedPositions),
+    [showClosedPositions, visibilityFilters],
+  );
+
+  const { holdings, isLoading } = useHoldings(accountFilter, {
+    includeClosed: effectiveVisibilityFilters.includes("closed"),
+  });
   const { accounts, isLoading: isAccountsLoading } = useAccounts({
     accountPurpose: AccountPurpose.HOLDINGS,
   });
@@ -356,7 +365,7 @@ export const HoldingsPage = () => {
       }
     }
 
-    let filtered = filterHoldingsByVisibility(scopedHoldings, visibilityFilters);
+    let filtered = filterHoldingsByVisibility(scopedHoldings, effectiveVisibilityFilters);
 
     if (selectedTypes.length > 0) {
       filtered = filtered.filter((holding) => {
@@ -376,7 +385,7 @@ export const HoldingsPage = () => {
       filteredHoldings: filtered,
       availableTypeOptions: typeOptions,
     };
-  }, [holdings, visibilityFilters, selectedTypes, investmentsFilter, healthFilter]);
+  }, [holdings, effectiveVisibilityFilters, selectedTypes, investmentsFilter, healthFilter]);
 
   // Combined loading state
   const isDataLoading = isLoading || isAccountsLoading || isAlternativeHoldingsLoading;
@@ -493,8 +502,9 @@ export const HoldingsPage = () => {
             <HoldingsTable
               holdings={filteredHoldings ?? []}
               isLoading={isDataLoading}
-              visibilityFilters={visibilityFilters}
+              visibilityFilters={effectiveVisibilityFilters}
               setVisibilityFilters={setVisibilityFilters}
+              showClosedPositions={showClosedPositions}
               onClassify={(holding) =>
                 setClassifyAsset({
                   id: holding.instrument?.id ?? holding.id,
@@ -523,8 +533,9 @@ export const HoldingsPage = () => {
               performanceMode={performanceMode}
               setPerformanceMode={setPerformanceMode}
               typeOptions={availableTypeOptions}
-              visibilityFilters={visibilityFilters}
+              visibilityFilters={effectiveVisibilityFilters}
               setVisibilityFilters={setVisibilityFilters}
+              showClosedPositions={showClosedPositions}
               toolbarActions={
                 isMobileViewport && currentTab === "investments" ? (
                   <ActionPalette

--- a/apps/frontend/src/pages/holdings/holdings-page.tsx
+++ b/apps/frontend/src/pages/holdings/holdings-page.tsx
@@ -43,6 +43,7 @@ import {
   filterHoldingsByVisibility,
   getEffectiveHoldingsVisibility,
   isClosedPosition,
+  mergeHoldingsVisibilitySelection,
   type HoldingsVisibilityFilter,
 } from "./components/holdings-visibility";
 import {
@@ -87,6 +88,14 @@ export const HoldingsPage = () => {
   const effectiveVisibilityFilters = useMemo(
     () => getEffectiveHoldingsVisibility(visibilityFilters, showClosedPositions),
     [showClosedPositions, visibilityFilters],
+  );
+  const handleVisibilityFiltersChange = useCallback(
+    (nextFilters: HoldingsVisibilityFilter[]) => {
+      setVisibilityFilters((currentFilters) =>
+        mergeHoldingsVisibilitySelection(currentFilters, nextFilters, showClosedPositions),
+      );
+    },
+    [setVisibilityFilters, showClosedPositions],
   );
 
   const includeClosed = effectiveVisibilityFilters.includes("closed");
@@ -510,7 +519,7 @@ export const HoldingsPage = () => {
               holdings={filteredHoldings ?? []}
               isLoading={isDataLoading}
               visibilityFilters={effectiveVisibilityFilters}
-              setVisibilityFilters={setVisibilityFilters}
+              setVisibilityFilters={handleVisibilityFiltersChange}
               showClosedPositions={showClosedPositions}
               onClassify={(holding) =>
                 setClassifyAsset({
@@ -541,7 +550,7 @@ export const HoldingsPage = () => {
               setPerformanceMode={setPerformanceMode}
               typeOptions={availableTypeOptions}
               visibilityFilters={effectiveVisibilityFilters}
-              setVisibilityFilters={setVisibilityFilters}
+              setVisibilityFilters={handleVisibilityFiltersChange}
               showClosedPositions={showClosedPositions}
               hasHiddenPositions={hasHiddenInvestmentPositions}
               toolbarActions={

--- a/apps/frontend/src/pages/holdings/holdings-page.tsx
+++ b/apps/frontend/src/pages/holdings/holdings-page.tsx
@@ -385,6 +385,8 @@ export const HoldingsPage = () => {
   const hasNoInvestments = !isDataLoading && holdings.length === 0;
   const hasNoAssets = !isDataLoading && assetsHoldings.length === 0;
   const hasNoLiabilities = !isDataLoading && liabilitiesHoldings.length === 0;
+  const hasMobileInvestmentsToolbar =
+    isMobileViewport && currentTab === "investments" && !hasNoInvestments;
 
   // Action palette groups
   const actionPaletteGroups: ActionPaletteGroup[] = useMemo(
@@ -645,7 +647,7 @@ export const HoldingsPage = () => {
   const sharedActions = useMemo(
     () => (
       <>
-        {!(isMobileViewport && currentTab === "investments") && (
+        {!hasMobileInvestmentsToolbar && (
           <AccountScopeSelector value={accountFilter} onChange={handleAccountScopeChange} />
         )}
         {/* Show Update button for HOLDINGS-mode manual accounts (only on investments tab) */}
@@ -655,7 +657,7 @@ export const HoldingsPage = () => {
             {t("holdings:update")}
           </Button>
         )}
-        {!(isMobileViewport && currentTab === "investments") && (
+        {!hasMobileInvestmentsToolbar && (
           <ActionPalette
             open={isActionPaletteOpen}
             onOpenChange={setIsActionPaletteOpen}
@@ -665,7 +667,7 @@ export const HoldingsPage = () => {
       </>
     ),
     [
-      isMobileViewport,
+      hasMobileInvestmentsToolbar,
       accountFilter,
       handleAccountScopeChange,
       canEditHoldings,

--- a/apps/server/src/api/holdings/dto.rs
+++ b/apps/server/src/api/holdings/dto.rs
@@ -6,6 +6,8 @@ use wealthfolio_core::portfolios::AccountScope;
 #[derive(Deserialize)]
 pub struct FilterBody {
     pub filter: AccountScope,
+    #[serde(rename = "includeClosed", default)]
+    pub include_closed: bool,
 }
 
 #[derive(Deserialize)]
@@ -21,6 +23,8 @@ pub struct AllocationFilterBody {
 pub struct AccountIdQuery {
     #[serde(rename = "accountId")]
     pub account_id: String,
+    #[serde(rename = "includeClosed", default)]
+    pub include_closed: bool,
 }
 
 #[derive(Deserialize)]

--- a/apps/server/src/api/holdings/handlers.rs
+++ b/apps/server/src/api/holdings/handlers.rs
@@ -92,7 +92,8 @@ pub async fn get_holdings(
     State(state): State<Arc<AppState>>,
     Json(body): Json<FilterBody>,
 ) -> ApiResult<Json<Vec<Holding>>> {
-    let holdings = load_holdings_for_filter(state.as_ref(), &body.filter).await?;
+    let holdings =
+        load_holdings_for_filter(state.as_ref(), &body.filter, body.include_closed).await?;
     Ok(Json(holdings))
 }
 
@@ -100,7 +101,8 @@ pub async fn get_holdings_list(
     State(state): State<Arc<AppState>>,
     Json(body): Json<FilterBody>,
 ) -> ApiResult<Json<Vec<HoldingListItem>>> {
-    let holdings = load_holdings_for_filter(state.as_ref(), &body.filter).await?;
+    let holdings =
+        load_holdings_for_filter(state.as_ref(), &body.filter, body.include_closed).await?;
     Ok(Json(
         holdings.into_iter().map(HoldingListItem::from).collect(),
     ))
@@ -109,6 +111,7 @@ pub async fn get_holdings_list(
 async fn load_holdings_for_filter(
     state: &AppState,
     filter: &AccountScope,
+    include_closed: bool,
 ) -> ApiResult<Vec<Holding>> {
     let base = state.base_currency.read().unwrap().clone();
     let resolved = resolve_scope(filter, state)?;
@@ -118,12 +121,17 @@ async fn load_holdings_for_filter(
     } else if account_ids.len() == 1 {
         state
             .holdings_service
-            .get_holdings(&account_ids[0], &base)
+            .get_holdings_with_options(&account_ids[0], &base, include_closed)
             .await?
     } else {
         state
             .holdings_service
-            .get_holdings_for_accounts(&account_ids, &base, &resolved.scope_id)
+            .get_holdings_for_accounts_with_options(
+                &account_ids,
+                &base,
+                &resolved.scope_id,
+                include_closed,
+            )
             .await?
     };
     Ok(holdings)
@@ -141,7 +149,7 @@ pub async fn get_holdings_for_account(
     }
     let holdings = state
         .holdings_service
-        .get_holdings(&account_ids[0], &base)
+        .get_holdings_with_options(&account_ids[0], &base, q.include_closed)
         .await?;
     Ok(Json(holdings))
 }
@@ -158,7 +166,7 @@ pub async fn get_holdings_list_for_account(
     }
     let holdings = state
         .holdings_service
-        .get_holdings(&account_ids[0], &base)
+        .get_holdings_with_options(&account_ids[0], &base, q.include_closed)
         .await?;
     Ok(Json(
         holdings.into_iter().map(HoldingListItem::from).collect(),

--- a/apps/tauri/src/commands/portfolio.rs
+++ b/apps/tauri/src/commands/portfolio.rs
@@ -235,23 +235,30 @@ pub async fn get_holdings(
 ) -> Result<Vec<Holding>, String> {
     debug!("Get holdings...");
     let filter = filter.into_account_filter()?;
-    get_holdings_for_filter(state.inner().as_ref(), filter).await
+    get_holdings_for_filter(state.inner().as_ref(), filter, false).await
 }
 
 #[tauri::command]
 pub async fn get_holdings_list(
     state: State<'_, Arc<ServiceContext>>,
     filter: AccountScopeInput,
+    include_closed: Option<bool>,
 ) -> Result<Vec<HoldingListItem>, String> {
     debug!("Get holdings list...");
     let filter = filter.into_account_filter()?;
-    let holdings = get_holdings_for_filter(state.inner().as_ref(), filter).await?;
+    let holdings = get_holdings_for_filter(
+        state.inner().as_ref(),
+        filter,
+        include_closed.unwrap_or(false),
+    )
+    .await?;
     Ok(holdings.into_iter().map(HoldingListItem::from).collect())
 }
 
 async fn get_holdings_for_filter(
     state: &ServiceContext,
     filter: AccountScope,
+    include_closed: bool,
 ) -> Result<Vec<Holding>, String> {
     let base_currency = state.get_base_currency();
     let resolved = resolve_scope(&filter, state).await?;
@@ -262,13 +269,18 @@ async fn get_holdings_for_filter(
     if account_ids.len() == 1 {
         state
             .holdings_service()
-            .get_holdings(&account_ids[0], &base_currency)
+            .get_holdings_with_options(&account_ids[0], &base_currency, include_closed)
             .await
             .map_err(|e| e.to_string())
     } else {
         state
             .holdings_service()
-            .get_holdings_for_accounts(&account_ids, &base_currency, &resolved.scope_id)
+            .get_holdings_for_accounts_with_options(
+                &account_ids,
+                &base_currency,
+                &resolved.scope_id,
+                include_closed,
+            )
             .await
             .map_err(|e| e.to_string())
     }
@@ -1685,6 +1697,7 @@ pub async fn get_snapshot_by_date(
             id: format!("{}-{}-{}", id_prefix, account_id, position.asset_id),
             account_id: account_id.clone(),
             holding_type,
+            is_closed: false,
             instrument: Some(instrument),
             asset_kind: Some(asset.kind.clone()),
             quantity: position.quantity,
@@ -1732,6 +1745,7 @@ pub async fn get_snapshot_by_date(
             id: format!("CASH-{}-{}", account_id, currency),
             account_id: account_id.clone(),
             holding_type: wealthfolio_core::holdings::HoldingType::Cash,
+            is_closed: false,
             instrument: None,
             asset_kind: None, // Cash holdings have no asset
             quantity: amount,

--- a/crates/agent-tools/src/tools/holdings.rs
+++ b/crates/agent-tools/src/tools/holdings.rs
@@ -294,6 +294,7 @@ mod tests {
             id: "holding-1".to_string(),
             account_id: "account-1".to_string(),
             holding_type: HoldingType::Security,
+            is_closed: false,
             instrument: None,
             asset_kind: None,
             quantity: Decimal::ONE,

--- a/crates/core/src/exports.rs
+++ b/crates/core/src/exports.rs
@@ -450,6 +450,7 @@ mod tests {
             id: "AGG-AAPL".to_string(),
             account_id: "all".to_string(),
             holding_type: HoldingType::Security,
+            is_closed: false,
             instrument: Some(crate::portfolio::holdings::HoldingListInstrument {
                 id: "asset-aapl".to_string(),
                 symbol: "AAPL".to_string(),

--- a/crates/core/src/portfolio/allocation/allocation_service.rs
+++ b/crates/core/src/portfolio/allocation/allocation_service.rs
@@ -1568,6 +1568,7 @@ mod tests {
             id: asset_id.to_string(),
             account_id: "acc".to_string(),
             holding_type: HoldingType::Security,
+            is_closed: false,
             instrument: Some(Instrument {
                 id: asset_id.to_string(),
                 symbol: asset_id.to_string(),
@@ -1619,6 +1620,7 @@ mod tests {
             id: format!("cash_{currency}"),
             account_id: "acc".to_string(),
             holding_type: HoldingType::Cash,
+            is_closed: false,
             instrument: None,
             asset_kind: None,
             quantity: base_value,

--- a/crates/core/src/portfolio/allocation_targets/drift_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/drift_service.rs
@@ -537,6 +537,7 @@ mod tests {
             id: "cash".to_string(),
             account_id: "acc".to_string(),
             holding_type: HoldingType::Cash,
+            is_closed: false,
             instrument: None,
             asset_kind: None,
             quantity: amount,

--- a/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
+++ b/crates/core/src/portfolio/allocation_targets/rebalance_service.rs
@@ -709,6 +709,7 @@ mod tests {
             id: id.to_string(),
             account_id: "acc-1".to_string(),
             holding_type: HoldingType::Security,
+            is_closed: false,
             instrument: Some(Instrument {
                 id: id.to_string(),
                 symbol: symbol.to_string(),
@@ -760,6 +761,7 @@ mod tests {
             id: "cash".to_string(),
             account_id: "acc-1".to_string(),
             holding_type: HoldingType::Cash,
+            is_closed: false,
             instrument: None,
             asset_kind: None,
             quantity: amount,

--- a/crates/core/src/portfolio/holdings/holdings_model.rs
+++ b/crates/core/src/portfolio/holdings/holdings_model.rs
@@ -82,6 +82,11 @@ pub struct Holding {
 
     // Position type and instrument info
     pub holding_type: HoldingType,
+    /// Whether the underlying account position has been fully closed.
+    /// This cannot be inferred from the aggregate quantity because open long
+    /// and short positions across accounts may net to zero.
+    #[serde(default)]
+    pub is_closed: bool,
     pub instrument: Option<Instrument>,
 
     /// The asset kind classification (Security, Crypto, Property, Vehicle, etc.)
@@ -168,6 +173,7 @@ pub struct HoldingListItem {
     pub id: String,
     pub account_id: String,
     pub holding_type: HoldingType,
+    pub is_closed: bool,
     pub instrument: Option<HoldingListInstrument>,
     pub asset_kind: Option<AssetKind>,
     pub quantity: Decimal,
@@ -229,6 +235,7 @@ impl From<Holding> for HoldingListItem {
             id: holding.id,
             account_id: holding.account_id,
             holding_type: holding.holding_type,
+            is_closed: holding.is_closed,
             instrument,
             asset_kind: holding.asset_kind,
             quantity: holding.quantity,

--- a/crates/core/src/portfolio/holdings/holdings_service.rs
+++ b/crates/core/src/portfolio/holdings/holdings_service.rs
@@ -28,6 +28,15 @@ use super::HoldingsValuationServiceTrait;
 pub trait HoldingsServiceTrait: Send + Sync {
     async fn get_holdings(&self, account_id: &str, base_currency: &str) -> Result<Vec<Holding>>;
 
+    async fn get_holdings_with_options(
+        &self,
+        account_id: &str,
+        base_currency: &str,
+        _include_closed: bool,
+    ) -> Result<Vec<Holding>> {
+        self.get_holdings(account_id, base_currency).await
+    }
+
     /// Aggregates holdings from multiple accounts into a single merged list.
     /// Holdings with the same asset are merged by summing MonetaryValue fields.
     /// Lots are concatenated. Weights are recomputed over the full merged set.
@@ -38,6 +47,17 @@ pub trait HoldingsServiceTrait: Send + Sync {
         base_currency: &str,
         aggregated_account_id: &str,
     ) -> Result<Vec<Holding>>;
+
+    async fn get_holdings_for_accounts_with_options(
+        &self,
+        account_ids: &[String],
+        base_currency: &str,
+        aggregated_account_id: &str,
+        _include_closed: bool,
+    ) -> Result<Vec<Holding>> {
+        self.get_holdings_for_accounts(account_ids, base_currency, aggregated_account_id)
+            .await
+    }
 
     /// Retrieves a specific holding for an account, calculates its valuation, and includes lot details.
     async fn get_holding(
@@ -236,13 +256,14 @@ impl HoldingsService {
         latest_snapshot: &snapshot::AccountStateSnapshot,
         base_currency: &str,
         lots_asset_id: Option<&str>,
+        include_closed: bool,
         skip_expired_options: bool,
     ) -> Vec<Holding> {
         let today = self.today_in_user_timezone();
         let snapshot_positions: Vec<snapshot::Position> = latest_snapshot
             .positions
             .values()
-            .filter(|p| p.quantity != Decimal::ZERO)
+            .filter(|p| include_closed || p.quantity != Decimal::ZERO)
             .cloned()
             .collect();
         let cash_balances_map: &HashMap<String, Decimal> = &latest_snapshot.cash_balances;
@@ -310,6 +331,7 @@ impl HoldingsService {
             };
 
             if skip_expired_options
+                && snapshot_pos.quantity != Decimal::ZERO
                 && is_expired_option(
                     asset_info.is_option,
                     asset_info.metadata.as_ref(),
@@ -356,6 +378,7 @@ impl HoldingsService {
                 id: format!("{}-{}-{}", id_prefix, account_id, snapshot_pos.asset_id),
                 account_id: account_id.to_string(),
                 holding_type,
+                is_closed: snapshot_pos.quantity == Decimal::ZERO,
                 instrument: Some(asset_info.instrument.clone()),
                 asset_kind: Some(asset_info.kind.clone()),
                 quantity: snapshot_pos.quantity,
@@ -414,6 +437,7 @@ impl HoldingsService {
                 id: format!("CASH-{}-{}", account_id, currency),
                 account_id: account_id.to_string(),
                 holding_type: HoldingType::Cash,
+                is_closed: false,
                 instrument: Some(cash_instrument),
                 asset_kind: None,
                 quantity: amount,
@@ -1231,6 +1255,16 @@ mod expired_option_metadata_tests {
 #[async_trait]
 impl HoldingsServiceTrait for HoldingsService {
     async fn get_holdings(&self, account_id: &str, base_currency: &str) -> Result<Vec<Holding>> {
+        self.get_holdings_with_options(account_id, base_currency, false)
+            .await
+    }
+
+    async fn get_holdings_with_options(
+        &self,
+        account_id: &str,
+        base_currency: &str,
+        include_closed: bool,
+    ) -> Result<Vec<Holding>> {
         debug!(
             "Getting holdings for account {} in base currency {}",
             account_id, base_currency
@@ -1263,6 +1297,7 @@ impl HoldingsServiceTrait for HoldingsService {
                 &latest_snapshot,
                 base_currency,
                 None,
+                include_closed,
                 true,
             )
             .await;
@@ -1316,6 +1351,22 @@ impl HoldingsServiceTrait for HoldingsService {
         base_currency: &str,
         aggregated_account_id: &str,
     ) -> Result<Vec<Holding>> {
+        self.get_holdings_for_accounts_with_options(
+            account_ids,
+            base_currency,
+            aggregated_account_id,
+            false,
+        )
+        .await
+    }
+
+    async fn get_holdings_for_accounts_with_options(
+        &self,
+        account_ids: &[String],
+        base_currency: &str,
+        aggregated_account_id: &str,
+        include_closed: bool,
+    ) -> Result<Vec<Holding>> {
         if account_ids.is_empty() {
             return Ok(Vec::new());
         }
@@ -1323,20 +1374,31 @@ impl HoldingsServiceTrait for HoldingsService {
         // Collect all holdings from each member account.
         let mut all_holdings: Vec<Holding> = Vec::new();
         for account_id in account_ids {
-            let holdings = self.get_holdings(account_id, base_currency).await?;
+            let holdings = self
+                .get_holdings_with_options(account_id, base_currency, include_closed)
+                .await?;
             all_holdings.extend(holdings);
         }
 
-        // Merge by key: securities/alternatives → asset id; cash → local_currency.
+        // Merge by key: securities/alternatives → lifecycle + asset id; cash → local_currency.
+        // Open and closed positions for the same asset must remain distinct, and
+        // open long/short positions across accounts may legitimately net to zero.
         let mut merged: HashMap<String, Holding> = HashMap::new();
         for holding in all_holdings {
             let key = match &holding.holding_type {
                 HoldingType::Cash => format!("CASH-{}", holding.local_currency),
-                _ => holding
-                    .instrument
-                    .as_ref()
-                    .map(|i| i.id.clone())
-                    .unwrap_or_else(|| holding.id.clone()),
+                _ => {
+                    let asset_id = holding
+                        .instrument
+                        .as_ref()
+                        .map(|i| i.id.clone())
+                        .unwrap_or_else(|| holding.id.clone());
+                    if holding.is_closed {
+                        format!("CLOSED-{}", asset_id)
+                    } else {
+                        asset_id
+                    }
+                }
             };
 
             match merged.entry(key.clone()) {
@@ -1485,6 +1547,7 @@ impl HoldingsServiceTrait for HoldingsService {
                 &latest_snapshot,
                 base_currency,
                 Some(asset_id),
+                false,
                 true,
             )
             .await;
@@ -1620,6 +1683,7 @@ impl HoldingsServiceTrait for HoldingsService {
                 ),
                 account_id: snapshot.account_id.clone(),
                 holding_type,
+                is_closed: false,
                 instrument: Some(instrument),
                 asset_kind: Some(asset.kind.clone()),
                 quantity: position.quantity,
@@ -1667,6 +1731,7 @@ impl HoldingsServiceTrait for HoldingsService {
                 id: format!("CASH-{}-{}", snapshot.account_id, currency),
                 account_id: snapshot.account_id.clone(),
                 holding_type: HoldingType::Cash,
+                is_closed: false,
                 instrument: None,
                 asset_kind: None,
                 quantity: amount,
@@ -1851,6 +1916,7 @@ mod tests {
 
     struct MockSnapshotService {
         snapshot: AccountStateSnapshot,
+        snapshots_by_account: HashMap<String, AccountStateSnapshot>,
     }
 
     #[async_trait::async_trait]
@@ -1883,9 +1949,14 @@ mod tests {
 
         fn get_latest_holdings_snapshot(
             &self,
-            _account_id: &str,
+            account_id: &str,
         ) -> Result<Option<AccountStateSnapshot>> {
-            Ok(Some(self.snapshot.clone()))
+            Ok(Some(
+                self.snapshots_by_account
+                    .get(account_id)
+                    .unwrap_or(&self.snapshot)
+                    .clone(),
+            ))
         }
 
         async fn save_manual_snapshot(
@@ -2815,7 +2886,10 @@ mod tests {
     ) -> HoldingsService {
         HoldingsService::new(
             Arc::new(MockAssetService::new(assets)),
-            Arc::new(MockSnapshotService { snapshot }),
+            Arc::new(MockSnapshotService {
+                snapshot,
+                snapshots_by_account: HashMap::new(),
+            }),
             Arc::new(MockValuationService { values }),
             Arc::new(AssetClassificationService::new(Arc::new(
                 EmptyTaxonomyService,
@@ -2873,6 +2947,79 @@ mod tests {
             .unwrap()
             .expect("active holding should exist");
         assert_eq!(holding.weight, dec!(1));
+    }
+
+    #[tokio::test]
+    async fn get_holdings_includes_closed_positions_only_when_requested() {
+        let account_id = "acc-1";
+        let active_asset_id = "AAPL";
+        let closed_asset_id = "MSFT";
+        let mut closed_position = test_position(account_id, closed_asset_id);
+        closed_position.quantity = Decimal::ZERO;
+        closed_position.average_cost = Decimal::ZERO;
+        closed_position.total_cost_basis = Decimal::ZERO;
+
+        let snapshot = AccountStateSnapshot {
+            account_id: account_id.to_string(),
+            currency: "USD".to_string(),
+            positions: HashMap::from([
+                (
+                    active_asset_id.to_string(),
+                    test_position(account_id, active_asset_id),
+                ),
+                (closed_asset_id.to_string(), closed_position),
+            ]),
+            ..Default::default()
+        };
+        let service = test_service(
+            snapshot,
+            vec![
+                test_asset(active_asset_id, active_asset_id, InstrumentType::Equity),
+                test_asset(closed_asset_id, closed_asset_id, InstrumentType::Equity),
+            ],
+            HashMap::from([
+                (active_asset_id.to_string(), dec!(100)),
+                (closed_asset_id.to_string(), Decimal::ZERO),
+            ]),
+        )
+        .with_lot_repository(Arc::new(MockLotRepository::new(Vec::new()).with_disposals(
+            vec![test_lot_disposal(
+                account_id,
+                closed_asset_id,
+                dec!(100),
+                dec!(100),
+                dec!(25),
+                dec!(25),
+            )],
+        )));
+
+        let current_holdings = service.get_holdings(account_id, "USD").await.unwrap();
+        assert_eq!(current_holdings.len(), 1);
+        assert_eq!(
+            current_holdings[0].instrument.as_ref().unwrap().id,
+            active_asset_id
+        );
+
+        let holdings_with_closed = service
+            .get_holdings_with_options(account_id, "USD", true)
+            .await
+            .unwrap();
+        assert_eq!(holdings_with_closed.len(), 2);
+        let closed_holding = holdings_with_closed
+            .iter()
+            .find(|holding| holding.instrument.as_ref().unwrap().id == closed_asset_id)
+            .expect("closed holding should be included");
+        assert!(closed_holding.is_closed);
+        assert_eq!(closed_holding.quantity, Decimal::ZERO);
+        assert_eq!(closed_holding.market_value.base, Decimal::ZERO);
+        assert_eq!(closed_holding.weight, Decimal::ZERO);
+        assert_eq!(
+            closed_holding.realized_gain.as_ref().unwrap().base,
+            dec!(25)
+        );
+        assert_eq!(closed_holding.total_gain.as_ref().unwrap().base, dec!(25));
+        assert_eq!(closed_holding.total_gain_pct, Some(dec!(0.25)));
+        assert_eq!(closed_holding.total_return.as_ref().unwrap().base, dec!(25));
     }
 
     #[tokio::test]
@@ -3675,6 +3822,98 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn multi_account_aggregation_keeps_open_and_closed_positions_separate() {
+        let asset_id = "AAPL";
+        let long_account = "long";
+        let short_account = "short";
+        let closed_account = "closed";
+
+        let mut long_position = test_position(long_account, asset_id);
+        long_position.quantity = dec!(5);
+        let mut short_position = test_position(short_account, asset_id);
+        short_position.quantity = dec!(-5);
+        let mut closed_position = test_position(closed_account, asset_id);
+        closed_position.quantity = Decimal::ZERO;
+        closed_position.average_cost = Decimal::ZERO;
+        closed_position.total_cost_basis = Decimal::ZERO;
+
+        let snapshots_by_account = HashMap::from([
+            (
+                long_account.to_string(),
+                AccountStateSnapshot {
+                    account_id: long_account.to_string(),
+                    currency: "USD".to_string(),
+                    positions: HashMap::from([(asset_id.to_string(), long_position)]),
+                    ..Default::default()
+                },
+            ),
+            (
+                short_account.to_string(),
+                AccountStateSnapshot {
+                    account_id: short_account.to_string(),
+                    currency: "USD".to_string(),
+                    positions: HashMap::from([(asset_id.to_string(), short_position)]),
+                    ..Default::default()
+                },
+            ),
+            (
+                closed_account.to_string(),
+                AccountStateSnapshot {
+                    account_id: closed_account.to_string(),
+                    currency: "USD".to_string(),
+                    positions: HashMap::from([(asset_id.to_string(), closed_position)]),
+                    ..Default::default()
+                },
+            ),
+        ]);
+        let service = HoldingsService::new(
+            Arc::new(MockAssetService::new(vec![test_asset(
+                asset_id,
+                asset_id,
+                InstrumentType::Equity,
+            )])),
+            Arc::new(MockSnapshotService {
+                snapshot: snapshots_by_account[long_account].clone(),
+                snapshots_by_account,
+            }),
+            Arc::new(MockValuationService {
+                values: HashMap::new(),
+            }),
+            Arc::new(AssetClassificationService::new(Arc::new(
+                EmptyTaxonomyService,
+            ))),
+        );
+
+        let holdings = service
+            .get_holdings_for_accounts_with_options(
+                &[
+                    long_account.to_string(),
+                    short_account.to_string(),
+                    closed_account.to_string(),
+                ],
+                "USD",
+                "portfolio",
+                true,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(holdings.len(), 2);
+        let open = holdings
+            .iter()
+            .find(|holding| !holding.is_closed)
+            .expect("open aggregate should remain visible");
+        let closed = holdings
+            .iter()
+            .find(|holding| holding.is_closed)
+            .expect("closed aggregate should remain separate");
+        assert_eq!(open.quantity, Decimal::ZERO);
+        assert_eq!(open.source_account_ids.len(), 2);
+        assert_eq!(closed.quantity, Decimal::ZERO);
+        assert_eq!(closed.source_account_ids, vec![closed_account.to_string()]);
+    }
+
+    #[tokio::test]
     async fn multi_account_aggregation_reports_zero_percent_for_zero_basis_and_gain() {
         let account_one = "acc-1";
         let account_two = "acc-2";
@@ -3716,6 +3955,7 @@ mod tests {
             id: "SEC-TEST-GBp".to_string(),
             account_id: "TEST".to_string(),
             holding_type: HoldingType::Security,
+            is_closed: false,
             instrument: Some(Instrument {
                 id: "TEST".to_string(),
                 symbol: "TEST".to_string(),
@@ -3841,6 +4081,7 @@ mod tests {
             id: "CASH-TEST-GBp".to_string(),
             account_id: "TEST".to_string(),
             holding_type: HoldingType::Cash,
+            is_closed: false,
             instrument: None,
             asset_kind: None,
             quantity: dec!(1000),

--- a/crates/core/src/portfolio/holdings/holdings_service.rs
+++ b/crates/core/src/portfolio/holdings/holdings_service.rs
@@ -1,6 +1,6 @@
 use crate::activities::{
-    Activity, ActivityRepositoryTrait, ACTIVITY_TYPE_BUY, ACTIVITY_TYPE_DIVIDEND,
-    ACTIVITY_TYPE_INTEREST, ACTIVITY_TYPE_SELL,
+    Activity, ActivityRepositoryTrait, ACTIVITY_SUBTYPE_OPTION_EXPIRY, ACTIVITY_TYPE_ADJUSTMENT,
+    ACTIVITY_TYPE_BUY, ACTIVITY_TYPE_DIVIDEND, ACTIVITY_TYPE_INTEREST, ACTIVITY_TYPE_SELL,
 };
 use crate::assets::{
     Asset, AssetClassificationService, AssetKind, AssetServiceTrait, InstrumentType,
@@ -777,7 +777,13 @@ impl HoldingsService {
                     .filter(|activity| activity.is_posted())
                     .filter(|activity| {
                         let activity_type = activity.effective_type();
-                        activity_type == ACTIVITY_TYPE_SELL || activity_type == ACTIVITY_TYPE_BUY
+                        let is_trade = activity_type == ACTIVITY_TYPE_SELL
+                            || activity_type == ACTIVITY_TYPE_BUY;
+                        let is_option_expiry = activity_type == ACTIVITY_TYPE_ADJUSTMENT
+                            && activity.subtype.as_deref().is_some_and(|subtype| {
+                                subtype.eq_ignore_ascii_case(ACTIVITY_SUBTYPE_OPTION_EXPIRY)
+                            });
+                        is_trade || is_option_expiry
                     })
                     .map(|activity| activity.id)
                     .collect(),
@@ -3620,6 +3626,69 @@ mod tests {
         assert_eq!(holding.return_basis.as_ref().unwrap().base, dec!(175));
         assert_eq!(holding.total_gain.as_ref().unwrap().base, dec!(60));
         assert_eq!(holding.total_gain_pct, Some(dec!(0.34285714)));
+    }
+
+    #[tokio::test]
+    async fn closed_option_realized_gain_includes_option_expiry_disposal() {
+        let account_id = "acc-1";
+        let asset_id = "AAPL260821C00200000";
+        let mut position = test_position(account_id, asset_id);
+        position.quantity = Decimal::ZERO;
+        position.average_cost = Decimal::ZERO;
+        position.total_cost_basis = Decimal::ZERO;
+
+        let snapshot = AccountStateSnapshot {
+            account_id: account_id.to_string(),
+            currency: "USD".to_string(),
+            positions: HashMap::from([(asset_id.to_string(), position)]),
+            ..Default::default()
+        };
+
+        let mut expiry_disposal = test_lot_disposal(
+            account_id,
+            asset_id,
+            dec!(100),
+            dec!(100),
+            dec!(-100),
+            dec!(-100),
+        );
+        expiry_disposal.id = "expiry-disposal".to_string();
+        expiry_disposal.disposal_activity_id = "expiry-1".to_string();
+
+        let activity_date = NaiveDate::from_ymd_opt(2026, 8, 21).unwrap();
+        let mut expiry_activity = test_income_activity(
+            "expiry-1",
+            account_id,
+            Some(asset_id),
+            ACTIVITY_TYPE_ADJUSTMENT,
+            Decimal::ZERO,
+            "USD",
+            activity_date,
+        );
+        expiry_activity.subtype = Some(ACTIVITY_SUBTYPE_OPTION_EXPIRY.to_string());
+
+        let mut service = test_service(
+            snapshot,
+            vec![test_asset(asset_id, asset_id, InstrumentType::Option)],
+            HashMap::from([(asset_id.to_string(), Decimal::ZERO)]),
+        )
+        .with_lot_repository(Arc::new(
+            MockLotRepository::new(Vec::new()).with_disposals(vec![expiry_disposal]),
+        ));
+        service.activity_repository =
+            Some(Arc::new(MockActivityRepository::new(vec![expiry_activity])));
+
+        let holdings = service
+            .get_holdings_with_options(account_id, "USD", true)
+            .await
+            .unwrap();
+
+        assert_eq!(holdings.len(), 1);
+        let holding = &holdings[0];
+        assert!(holding.is_closed);
+        assert_eq!(holding.realized_gain.as_ref().unwrap().base, dec!(-100));
+        assert_eq!(holding.realized_gain_pct, Some(dec!(-1)));
+        assert_eq!(holding.total_gain.as_ref().unwrap().base, dec!(-100));
     }
 
     #[tokio::test]

--- a/crates/core/src/portfolio/holdings/holdings_valuation_service.rs
+++ b/crates/core/src/portfolio/holdings/holdings_valuation_service.rs
@@ -101,6 +101,7 @@ impl HoldingsValuationService {
         // Asset ID is the unique identifier matching quotes table (e.g., "SHOP:XTSE", "BTC:USD")
         let required_asset_ids: Vec<String> = holdings
             .iter()
+            .filter(|holding| holding.quantity != Decimal::ZERO)
             .filter_map(|holding| {
                 // Include both Security and AlternativeAsset holdings
                 match holding.holding_type {
@@ -241,7 +242,6 @@ impl HoldingsValuationService {
 
         // --- Handle Zero Quantity ---
         if quantity == Decimal::ZERO {
-            warn!("{}: Skipping valuation for zero quantity.", context_msg);
             holding.market_value = MonetaryValue::zero();
             holding.price = None;
             holding.unrealized_gain = None;
@@ -480,7 +480,6 @@ impl HoldingsValuationService {
 
         // --- Handle Zero Quantity ---
         if quantity == Decimal::ZERO {
-            warn!("{}: Skipping valuation for zero quantity.", context_msg);
             holding.market_value = MonetaryValue::zero();
             holding.price = None;
             holding.unrealized_gain = None;

--- a/crates/core/src/portfolio/holdings/holdings_valuation_service_tests.rs
+++ b/crates/core/src/portfolio/holdings/holdings_valuation_service_tests.rs
@@ -2085,14 +2085,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_zero_quantity_security() {
+    async fn test_zero_quantity_security_does_not_fetch_quotes() {
         let (_fx_service, market_data_service, valuation_service) = setup_test_env();
 
-        market_data_service.add_quote_pair(
-            "XYZ.TO",
-            create_quote("2024-01-10", dec!(150.0), "CAD"),
-            Some(create_quote("2024-01-09", dec!(145.0), "CAD")),
-        );
+        *market_data_service.should_fail.lock().unwrap() = true;
 
         let mut holdings = vec![create_holding(
             "h_zero",

--- a/crates/core/src/portfolio/holdings/holdings_valuation_service_tests.rs
+++ b/crates/core/src/portfolio/holdings/holdings_valuation_service_tests.rs
@@ -512,6 +512,7 @@ mod tests {
             id: id.to_string(),
             account_id: "acc_1".to_string(),
             holding_type,
+            is_closed: false,
             quantity,
             local_currency: local_currency.to_string(),
             base_currency: base_currency.to_string(),

--- a/packages/ui/src/components/ui/data-table/data-table-toolbar.tsx
+++ b/packages/ui/src/components/ui/data-table/data-table-toolbar.tsx
@@ -16,6 +16,7 @@ interface DataTableToolbarProps<TData> {
   table: Table<TData>;
   searchBy?: string;
   filters?: DataTableFacetedFilterProps<TData, unknown>[];
+  additionalFilters?: React.ReactNode;
   showColumnToggle?: boolean;
   actions?: React.ReactNode;
 }
@@ -24,6 +25,7 @@ export function DataTableToolbar<TData>({
   table,
   searchBy,
   filters,
+  additionalFilters,
   showColumnToggle = false,
   actions,
 }: DataTableToolbarProps<TData>) {
@@ -51,6 +53,7 @@ export function DataTableToolbar<TData>({
             options={filter.options}
           />
         ))}
+        {additionalFilters}
         {isFiltered && (
           <Button
             variant="ghost"

--- a/packages/ui/src/components/ui/data-table/index.tsx
+++ b/packages/ui/src/components/ui/data-table/index.tsx
@@ -36,7 +36,9 @@ interface DataTableProps<TData, TValue> {
   manualPagination?: boolean;
   scrollable?: boolean;
   showColumnToggle?: boolean;
+  toolbarFilters?: React.ReactNode;
   toolbarActions?: React.ReactNode;
+  pinRowsToTop?: (row: TData) => boolean;
 }
 
 export function DataTable<TData, TValue>({
@@ -51,7 +53,9 @@ export function DataTable<TData, TValue>({
   storageKey,
   scrollable = false,
   showColumnToggle = false,
+  toolbarFilters,
   toolbarActions,
+  pinRowsToTop,
 }: DataTableProps<TData, TValue>) {
   const [rowSelection, setRowSelection] = React.useState({});
   const [storedColumnVisibility, setColumnVisibility] = storageKey
@@ -98,6 +102,11 @@ export function DataTable<TData, TValue>({
     getFacetedUniqueValues: getFacetedUniqueValues(),
   });
 
+  const rows = table.getRowModel().rows;
+  const displayRows = pinRowsToTop
+    ? [...rows.filter((row) => pinRowsToTop(row.original)), ...rows.filter((row) => !pinRowsToTop(row.original))]
+    : rows;
+
   return (
     <div className="flex h-full flex-col">
       <div className="mb-2 shrink-0">
@@ -105,6 +114,7 @@ export function DataTable<TData, TValue>({
           table={table}
           searchBy={searchBy}
           filters={filters}
+          additionalFilters={toolbarFilters}
           showColumnToggle={showColumnToggle}
           actions={toolbarActions}
         />
@@ -125,8 +135,8 @@ export function DataTable<TData, TValue>({
             ))}
           </TableHeader>
           <TableBody>
-            {table.getRowModel().rows?.length ? (
-              table.getRowModel().rows.map((row) => (
+            {displayRows.length ? (
+              displayRows.map((row) => (
                 <TableRow key={row.id} data-state={row.getIsSelected() && "selected"}>
                   {row.getVisibleCells().map((cell) => (
                     <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>


### PR DESCRIPTION
## Summary

- add a responsive holdings visibility facet filter for Open, Closed, and Cash, defaulting to Open
- expose closed positions through the desktop and web APIs and preserve explicit lifecycle state during multi-account aggregation
- keep cash balances first and present only cash-relevant values without the manual badge
- show cash portfolio weight on desktop and mobile
- align the mobile search, filter, and actions controls in one row while preserving account scope controls for empty accounts
- calculate and display realized gain for closed lots, including option-expiry disposals

## Why

Closed positions were excluded before reaching the UI, cash could not be included from the holdings view, and a zero aggregate quantity was not a reliable indicator that a position was closed. Closed lots also lacked a useful realized-gain value, and option expiries were incorrectly filtered out of realized results.

## User impact

Users can focus on open positions, closed positions, cash, or any combination from the same familiar faceted-filter pattern on desktop and mobile. Open remains the default. Closed positions remain distinct from open positions for the same asset, even when open long and short positions net to zero. Mobile users retain account selection when the chosen account is empty.

<img width="2548" height="928" alt="CleanShot 2026-08-18 at 11 05 12@2x" src="https://github.com/user-attachments/assets/9a998c04-34ce-47d6-8762-f2f0c9c57a77" />


## Validation

- `pnpm --filter frontend type-check`
- `pnpm --filter @wealthfolio/ui type-check`
- `pnpm --filter frontend test` — 149 files, 1,241 tests passed
- focused mobile holdings tests — 2 files, 7 tests passed
- focused option-expiry realized-gain regression test
- `cargo check --workspace`
- `cargo test -p wealthfolio-core closed_positions --lib`
- `cargo fmt --all -- --check`
- Prettier, targeted ESLint, and `git diff --check`

Fixes #1417
