### PR TITLE
fix(holdings): normalize quantity label case

### DIFF
--- a/apps/frontend/src/i18n/locales/de/holdings.json
+++ b/apps/frontend/src/i18n/locales/de/holdings.json
@@ -129,6 +129,7 @@
   "open": "Offen",
   "closed": "Geschlossen",
   "qty": "Anz.",
+  "shares_label": "Stücke",
   "contracts": "Kontrakte",
   "bonds": "Anleihen",
   "units": "Anteile",

--- a/apps/frontend/src/i18n/locales/en/holdings.json
+++ b/apps/frontend/src/i18n/locales/en/holdings.json
@@ -129,6 +129,7 @@
   "open": "Open",
   "closed": "Closed",
   "qty": "Qty",
+  "shares_label": "shares",
   "contracts": "contracts",
   "bonds": "bonds",
   "units": "units",

--- a/apps/frontend/src/i18n/locales/es/holdings.json
+++ b/apps/frontend/src/i18n/locales/es/holdings.json
@@ -129,6 +129,7 @@
   "open": "Abierta",
   "closed": "Cerrada",
   "qty": "Cant.",
+  "shares_label": "acciones",
   "contracts": "contratos",
   "bonds": "bonos",
   "units": "participaciones",

--- a/apps/frontend/src/i18n/locales/fr/holdings.json
+++ b/apps/frontend/src/i18n/locales/fr/holdings.json
@@ -129,6 +129,7 @@
   "open": "Ouverte",
   "closed": "Clôturée",
   "qty": "Qté",
+  "shares_label": "actions",
   "contracts": "contrats",
   "bonds": "obligations",
   "units": "parts",

--- a/apps/frontend/src/i18n/locales/ja/holdings.json
+++ b/apps/frontend/src/i18n/locales/ja/holdings.json
@@ -129,6 +129,7 @@
   "open": "保有中",
   "closed": "決済済み",
   "qty": "数量",
+  "shares_label": "株数",
   "contracts": "枚",
   "bonds": "口",
   "units": "口",

--- a/apps/frontend/src/i18n/locales/ko/holdings.json
+++ b/apps/frontend/src/i18n/locales/ko/holdings.json
@@ -129,6 +129,7 @@
   "open": "보유 중",
   "closed": "청산됨",
   "qty": "수량",
+  "shares_label": "주식 수",
   "contracts": "계약",
   "bonds": "채권",
   "units": "좌",

--- a/apps/frontend/src/i18n/locales/zh/holdings.json
+++ b/apps/frontend/src/i18n/locales/zh/holdings.json
@@ -129,6 +129,7 @@
   "open": "持仓中",
   "closed": "已平仓",
   "qty": "数量",
+  "shares_label": "股数",
   "contracts": "份合约",
   "bonds": "份债券",
   "units": "份",

--- a/apps/frontend/src/pages/holdings/components/holdings-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table.tsx
@@ -347,7 +347,7 @@ const getColumns = (
                 ? t("holdings:bonds")
                 : isEtfOrFund
                   ? t("holdings:units")
-                  : t("holdings:shares")}
+                  : t("holdings:shares_label")}
           </span>
         </div>
       );


### PR DESCRIPTION
## Summary

- add a dedicated `shares_label` translation for holdings quantity sub-labels
- keep inline quantity descriptors lowercase where appropriate (`shares`, `units`, `contracts`, and `bonds`)
- preserve the existing title-cased `shares` translation for the edit-mode column heading
- cover all seven supported locales with locale-appropriate casing

## Why

Follow-up to #1480 and #1474. The holdings table reused the title-cased `shares` heading translation as an inline unit label, while the other quantity labels were lowercase. Separating the inline label keeps the visual hierarchy consistent without forcing casing through CSS or breaking locale grammar.

## Validation

- `pnpm --filter frontend exec vitest run` — 1,262 tests passed
- `pnpm --filter frontend type-check`
- `pnpm build`
- Prettier check on all changed files
- ESLint on `holdings-table.tsx` — 0 errors (5 pre-existing warnings on untouched lines)