### PR TITLE
fix(i18n): drop the sharpe_ratio label for a metric nothing computes

### DIFF
--- a/apps/frontend/src/i18n/locales/de/performance.json
+++ b/apps/frontend/src/i18n/locales/de/performance.json
@@ -38,7 +38,6 @@
   "select_benchmark": "Benchmark wählen",
   "no_benchmark": "Keine Benchmark",
   "volatility": "Volatilität",
-  "sharpe_ratio": "Sharpe-Ratio",
   "max_drawdown": "Max. Drawdown",
   "best_day": "Bester Tag",
   "worst_day": "Schlechtester Tag",

--- a/apps/frontend/src/i18n/locales/en/performance.json
+++ b/apps/frontend/src/i18n/locales/en/performance.json
@@ -38,7 +38,6 @@
   "select_benchmark": "Select Benchmark",
   "no_benchmark": "No Benchmark",
   "volatility": "Volatility",
-  "sharpe_ratio": "Sharpe Ratio",
   "max_drawdown": "Max Drawdown",
   "best_day": "Best Day",
   "worst_day": "Worst Day",

--- a/apps/frontend/src/i18n/locales/es/performance.json
+++ b/apps/frontend/src/i18n/locales/es/performance.json
@@ -38,7 +38,6 @@
   "select_benchmark": "Seleccionar índice de referencia",
   "no_benchmark": "Sin índice de referencia",
   "volatility": "Volatilidad",
-  "sharpe_ratio": "Ratio de Sharpe",
   "max_drawdown": "Caída máxima",
   "best_day": "Mejor día",
   "worst_day": "Peor día",

--- a/apps/frontend/src/i18n/locales/fr/performance.json
+++ b/apps/frontend/src/i18n/locales/fr/performance.json
@@ -38,7 +38,6 @@
   "select_benchmark": "Sélectionner un indice",
   "no_benchmark": "Aucun indice",
   "volatility": "Volatilité",
-  "sharpe_ratio": "Ratio de Sharpe",
   "max_drawdown": "Perte maximale",
   "best_day": "Meilleur jour",
   "worst_day": "Pire jour",

--- a/apps/frontend/src/i18n/locales/ja/performance.json
+++ b/apps/frontend/src/i18n/locales/ja/performance.json
@@ -38,7 +38,6 @@
   "select_benchmark": "ベンチマークを選択",
   "no_benchmark": "ベンチマークなし",
   "volatility": "ボラティリティ",
-  "sharpe_ratio": "シャープレシオ",
   "max_drawdown": "最大ドローダウン",
   "best_day": "最高日",
   "worst_day": "最低日",

--- a/apps/frontend/src/i18n/locales/ko/performance.json
+++ b/apps/frontend/src/i18n/locales/ko/performance.json
@@ -38,7 +38,6 @@
   "select_benchmark": "벤치마크 선택",
   "no_benchmark": "벤치마크 없음",
   "volatility": "변동성",
-  "sharpe_ratio": "샤프 비율",
   "max_drawdown": "최대 낙폭",
   "best_day": "최고 수익일",
   "worst_day": "최저 수익일",

--- a/apps/frontend/src/i18n/locales/zh/performance.json
+++ b/apps/frontend/src/i18n/locales/zh/performance.json
@@ -38,7 +38,6 @@
   "select_benchmark": "选择基准",
   "no_benchmark": "无基准",
   "volatility": "波动率",
-  "sharpe_ratio": "夏普比率",
   "max_drawdown": "最大回撤",
   "best_day": "最佳单日",
   "worst_day": "最差单日",


### PR DESCRIPTION
## The problem

`performance:sharpe_ratio` is translated in **all seven shipped locales** and
referenced **nowhere**:

```
$ git grep -in sharpe -- '*.rs' '*.ts' '*.tsx'
(no output)
```

It has been that way since the key was created. `3259cd31d`
(*feat(i18n): translate dashboard, holdings, account and portfolio pages*,
2026-07-03) added `performance.json` with the label already in it — so this is
not the leftover of a Sharpe implementation that was later removed. There has
never been one.

Nothing could render it even if a component asked for it:

- `PerformanceRisk` in
  `crates/core/src/portfolio/performance/performance_model.rs` carries
  `volatility`, `max_drawdown`, and the three drawdown dates. No Sharpe field,
  and no risk-free rate anywhere in the model to derive one from — Sharpe needs
  an input the app has no representation of, per-currency at that.
- The Risk strip in `apps/frontend/src/pages/performance/performance-page.tsx`
  renders exactly two metrics, both from the nested `metric.*` block:

  ```tsx
  <StripSection title={t("performance:section.risk")} className="w-[19rem]">
    <div className="grid grid-cols-2 gap-5">
      <StripMetric label={t("performance:metric.volatility")} ... />
      <StripMetric label={t("performance:metric.max_drawdown_short")} ... />
    </div>
  </StripSection>
  ```

  So the flat `sharpe_ratio` is not even a duplicate of a live key the way flat
  `volatility` and `max_drawdown` are.

`removeUnusedKeys: false` in `apps/frontend/i18next.config.ts` is deliberate and
right — an extract run should not drop a community translation for a key that
is not yet wired. The consequence is that a key like this one stays translated
forever unless it is removed by hand. Seven translators have rendered "Sharpe
Ratio" into their language for a number the application has never produced.

## The change

Remove the `sharpe_ratio` line from the seven `performance.json` files. Seven
deletions, nothing else.

## Scope

Other flat keys in this namespace are unreferenced too — `best_day`,
`chart_value`, `print_report`, and around two dozen more, all from that same
commit. Those are labels for **copy**: wiring them is a UI decision, and the
translations are worth keeping until that decision is made, which is exactly
what `removeUnusedKeys: false` protects.

`sharpe_ratio` is different in kind. It labels a **computed metric**, and
computing it requires a configurable risk-free rate the model does not have.
That is a feature, not a label change. When the feature lands the key comes back
with it — and having it absent in the meantime means whoever adds Sharpe writes
one implementation, rather than finding a translated label and wondering what
happened to the code behind it.

Happy to fold in the wider cleanup, or to close this if you would rather the key
stayed as a placeholder.

## Tests

No behaviour to test — the key has no reader. Verified mechanically:

- all seven files still parse as JSON, and each lost exactly one key (58
  top-level keys remain in each)
- `git grep -in sharpe` over `*.rs`, `*.ts`, `*.tsx` is empty before and after
- the key cannot be reached by construction either: there is no
  ``t(`performance:${...}`)`` anywhere, so no dynamically built key can land on
  it

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
