### PR TITLE
fix: honor holdings column sorting for cash

### DIFF
--- a/apps/frontend/src/pages/holdings/components/holdings-table.test.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table.test.tsx
@@ -12,6 +12,7 @@ vi.mock("@wealthfolio/ui/components/ui/data-table", () => ({
     columns,
     data,
     defaultColumnVisibility,
+    pinRowsToTop,
   }: {
     columns: {
       id?: string;
@@ -26,6 +27,7 @@ vi.mock("@wealthfolio/ui/components/ui/data-table", () => ({
     }[];
     data: Holding[];
     defaultColumnVisibility?: Record<string, boolean>;
+    pinRowsToTop?: (row: Holding) => boolean;
   }) => {
     const getValue = (id: string) =>
       data[0] == null
@@ -67,6 +69,7 @@ vi.mock("@wealthfolio/ui/components/ui/data-table", () => ({
         <div data-testid="exact-type-match">
           {matchesHoldingType("FUND_MUTUAL") ? "true" : "false"}
         </div>
+        <div data-testid="cash-pinning">{String(data[0] && pinRowsToTop?.(data[0]))}</div>
       </div>
     );
   },
@@ -203,5 +206,25 @@ describe("HoldingsTable columns", () => {
     expect(screen.getByTestId("holding-type-cell")).toHaveTextContent("Mutual Fund");
     expect(screen.getByTestId("parent-type-match")).toHaveTextContent("false");
     expect(screen.getByTestId("exact-type-match")).toHaveTextContent("true");
+  });
+
+  it("does not pin cash rows above an explicit column sort", () => {
+    const cashHolding: Holding = {
+      id: "cash-usd",
+      accountId: "account-1",
+      holdingType: HoldingType.CASH,
+      quantity: 100,
+      localCurrency: "USD",
+      baseCurrency: "USD",
+      marketValue: { local: 100, base: 100 },
+      weight: 0.1,
+      asOfDate: "2026-08-20",
+    };
+
+    render(
+      <HoldingsTable holdings={[cashHolding]} isLoading={false} visibilityFilters={["open"]} />,
+    );
+
+    expect(screen.getByTestId("cash-pinning")).toHaveTextContent("undefined");
   });
 });

--- a/apps/frontend/src/pages/holdings/components/holdings-table.tsx
+++ b/apps/frontend/src/pages/holdings/components/holdings-table.tsx
@@ -240,7 +240,6 @@ export const HoldingsTable = ({
         }
         defaultSorting={[{ id: "symbol", desc: false }]}
         scrollable={true}
-        pinRowsToTop={isCashHolding}
         toolbarView={
           visibilityFilters && setVisibilityFilters ? (
             <HoldingsStatusSegmentedControl


### PR DESCRIPTION
## Description

Fixes #1505. Removes desktop cash-row pinning so the selected column sort, including Weight, applies to cash and non-cash holdings consistently. Mobile behavior is unchanged.

## Validation

- Focused holdings-table test: 6 passed
- Frontend lint, type check, and production build: passed
- Full suite: 7 unrelated addon-iframe failures in asset/Blob sandbox fixtures, outside this diff

## Checklist

- [x] I have read and agree to the Contributor License Agreement.

By submitting this PR, I agree to the CLA.