### PR TITLE
feat(addon-sdk): scoped translation API for addon strings

### DIFF
--- a/apps/frontend/src/addons/iframe/addon-sandbox-entry.tsx
+++ b/apps/frontend/src/addons/iframe/addon-sandbox-entry.tsx
@@ -17,7 +17,11 @@ import { SandboxAddonAssetRegistry, type SandboxAddonAsset } from "./addon-sandb
 import { applyHostTheme, type AddonThemeSnapshot } from "./addon-sandbox-theme";
 import { rewriteModuleSpecifiers } from "./addon-module-rewriter";
 import type { AddonLocalizationSnapshot } from "./addon-sandbox-localization";
-import { initSandboxI18n, setSandboxLanguage } from "./addon-sandbox-i18n";
+import {
+  initSandboxI18n,
+  installAddonTranslationRuntime,
+  setSandboxLanguage,
+} from "./addon-sandbox-i18n";
 
 const CHANNEL = "wealthfolio:addon-sandbox:v1";
 const RUNTIME_PROTOCOL_VERSION = 1;
@@ -101,6 +105,7 @@ const root = rootElement;
 // Bootstrap i18next before any addon (and its `@wealthfolio/ui` components)
 // render, seeded from the bootstrap params so there is no flash of raw keys.
 initSandboxI18n(sandboxLocalization.uiLocale);
+installAddonTranslationRuntime(ADDON_ID);
 
 function post(type: string, payload: Record<string, unknown> = {}) {
   parent.postMessage({ channel: CHANNEL, addonId: ADDON_ID, nonce: NONCE, type, ...payload }, "*");

--- a/apps/frontend/src/addons/iframe/addon-sandbox-i18n.ts
+++ b/apps/frontend/src/addons/iframe/addon-sandbox-i18n.ts
@@ -1,5 +1,7 @@
 import i18next from "i18next";
-import { initReactI18next } from "react-i18next";
+import { useMemo } from "react";
+import { initReactI18next, useTranslation } from "react-i18next";
+import type { AddonTranslationApi, AddonTranslationResources } from "@wealthfolio/addon-sdk";
 
 import { DEFAULT_LOCALE, SUPPORTED_LOCALE_CODES, type LocaleCode } from "@/i18n/locales";
 import deUi from "@/i18n/locales/de/ui.json";
@@ -34,8 +36,10 @@ const resources: Record<LocaleCode, { ui: Record<string, unknown> }> = {
 };
 
 // Map regional codes (e.g. `fr-CA`) to the base language, matching the host.
+// Lowercased: i18next stores resource bundles case-sensitively but resolves
+// lowercase codes, so an uppercase key would be stored yet never resolve.
 function normalizeLanguage(language: string) {
-  return language.split("-")[0];
+  return language.split("-")[0].toLowerCase();
 }
 
 function applyDocumentLanguage(language: string) {
@@ -88,10 +92,119 @@ export function setSandboxLanguage(language?: string) {
   }
 
   const normalized = normalizeLanguage(language);
-  if (sandboxI18n.language === normalized) {
-    return;
+  // Each instance is synced independently and idempotently — returning early
+  // because one of them already matches could leave the other out of sync.
+  if (sandboxI18n.language !== normalized) {
+    void sandboxI18n.changeLanguage(normalized);
+  }
+  if (addonI18n.isInitialized && addonI18n.language !== normalized) {
+    void addonI18n.changeLanguage(normalized);
+  }
+  applyDocumentLanguage(normalized);
+}
+
+// Addon translations live on their OWN i18next instance. The host `ui`
+// catalog exists only on `sandboxI18n`, so no t() option, key shape, or
+// registered value can read or write host strings — there is no path to
+// them, rather than a list of blocked paths. Deliberately NOT registered as
+// the react-i18next default (that stays `sandboxI18n` for `@wealthfolio/ui`);
+// the hook passes it explicitly via `useTranslation(ns, { i18n })`.
+const addonI18n = i18next.createInstance();
+
+/**
+ * Install the `@wealthfolio/addon-sdk` translation runtime for this iframe's
+ * addon. One iframe hosts exactly one addon; its resources live on the
+ * dedicated `addonI18n` instance (the host "ui" catalog is not present there
+ * at all), and the language always follows the host — the runtime exposes no
+ * way to change it.
+ */
+export function installAddonTranslationRuntime(addonId: string) {
+  const namespace = `addon/${addonId}`;
+
+  if (!addonI18n.isInitialized) {
+    void addonI18n.init({
+      lng: sandboxI18n.language || DEFAULT_LOCALE,
+      fallbackLng: DEFAULT_LOCALE,
+      ns: [namespace],
+      defaultNS: namespace,
+      resources: {},
+      // Synchronous init — registerTranslations and t may run in the same tick.
+      initImmediate: false,
+      interpolation: {
+        // React already escapes values.
+        escapeValue: false,
+      },
+      // Read by the stock react-i18next hook (passed this instance via its
+      // `i18n` option) even though the instance is not the react-i18next
+      // default: resources are synchronous, and consumers re-render on
+      // language changes and on (late) registerTranslations calls.
+      react: {
+        useSuspense: false,
+        bindI18n: "languageChanged",
+        bindI18nStore: "added removed",
+      },
+    });
   }
 
-  void sandboxI18n.changeLanguage(normalized);
-  applyDocumentLanguage(normalized);
+  function registerTranslations(resources: AddonTranslationResources) {
+    for (const [language, bundle] of Object.entries(resources ?? {})) {
+      if (!bundle) {
+        continue;
+      }
+      const normalized = normalizeLanguage(language);
+      // Only plain base codes may reach i18next: addResourceBundle
+      // reinterprets a dotted lng argument as a resource path, and anything
+      // else would be stored under a key that never resolves.
+      if (!/^[a-z]{2,3}$/.test(normalized)) {
+        console.warn(
+          `[addon-sandbox] ignoring translations for invalid language code "${language}"`,
+        );
+        continue;
+      }
+      addonI18n.addResourceBundle(
+        normalized,
+        namespace,
+        bundle,
+        /* deep */ true,
+        /* overwrite */ true,
+      );
+    }
+  }
+
+  function useAddonTranslation(): AddonTranslationApi {
+    // Stock react-i18next hook bound to the dedicated instance; re-render
+    // wiring comes from the instance's react options above. `t` changes
+    // identity when the language or the registered resources change.
+    const { t } = useTranslation(namespace, { i18n: addonI18n });
+    const language = addonI18n.language || DEFAULT_LOCALE;
+    // Memoized so the returned `t` keeps a stable identity across unrelated
+    // renders (safe in effect deps / React.memo props).
+    return useMemo(
+      () => ({
+        t: (key, options) => {
+          const translated: unknown = t(key, {
+            ...(options ?? {}),
+            // Defense in depth and a stable contract on top of the instance
+            // isolation: lookups stay in the addon namespace ("ui:key" keys
+            // are literal, `ns` overrides are ignored), `$t()` nesting in
+            // registered values is disabled, and language resolution always
+            // follows the host setting.
+            ns: namespace,
+            nsSeparator: false,
+            nest: false,
+            lng: undefined,
+            lngs: undefined,
+            fallbackLng: undefined,
+          } as unknown as Record<string, never>);
+          // The SDK contract is string-only; non-string results (returnObjects)
+          // fall back to the key rather than stringifying an object.
+          return typeof translated === "string" ? translated : key;
+        },
+        language,
+      }),
+      [t, language],
+    );
+  }
+
+  globalThis.__wealthfolioAddonI18n = { registerTranslations, useAddonTranslation };
 }

--- a/apps/frontend/src/addons/iframe/addon-translations.test.tsx
+++ b/apps/frontend/src/addons/iframe/addon-translations.test.tsx
@@ -1,0 +1,242 @@
+import { registerTranslations, useAddonTranslation } from "@wealthfolio/addon-sdk";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The sandbox i18n module owns a singleton instance, so every case gets a
+// fresh module graph; the SDK wrappers read the runtime from globalThis at
+// call time, so their module identity does not matter.
+async function loadSandbox() {
+  vi.resetModules();
+  delete globalThis.__wealthfolioAddonI18n;
+  return import("./addon-sandbox-i18n");
+}
+
+function AddonGreeting({ name }: { name: string }) {
+  const { t } = useAddonTranslation();
+  return <span>{t("greeting", { name })}</span>;
+}
+
+describe("addon translation runtime", () => {
+  beforeEach(() => {
+    delete globalThis.__wealthfolioAddonI18n;
+  });
+
+  it("translates addon strings through the SDK and follows host language changes", async () => {
+    const { initSandboxI18n, installAddonTranslationRuntime, setSandboxLanguage } =
+      await loadSandbox();
+    initSandboxI18n("en");
+    installAddonTranslationRuntime("sample-addon");
+
+    registerTranslations({
+      en: { greeting: "Hello {{name}}" },
+      fr: { greeting: "Bonjour {{name}}" },
+    });
+
+    function LanguageBadge() {
+      const { language } = useAddonTranslation();
+      return <span data-testid="language">{language}</span>;
+    }
+    render(
+      <>
+        <AddonGreeting name="Aziz" />
+        <LanguageBadge />
+      </>,
+    );
+    expect(await screen.findByText("Hello Aziz")).toBeInTheDocument();
+    expect(screen.getByTestId("language")).toHaveTextContent(/^en$/);
+
+    setSandboxLanguage("fr");
+    expect(await screen.findByText("Bonjour Aziz")).toBeInTheDocument();
+    expect(screen.getByTestId("language")).toHaveTextContent(/^fr$/);
+  });
+
+  it("cannot read or overwrite the host ui namespace", async () => {
+    const { initSandboxI18n, installAddonTranslationRuntime } = await loadSandbox();
+    const i18n = initSandboxI18n("en");
+    installAddonTranslationRuntime("sample-addon");
+
+    // A hostile or careless addon registering ui-shaped keys only writes into
+    // its own namespace — the host ui bundle is untouched...
+    registerTranslations({ en: { sheet: { close: "HACKED" } } });
+    expect(i18n.t("ui:sheet.close")).toBe("Close");
+    expect(i18n.getResource("en", "ui", "sheet.close")).toBe("Close");
+
+    // Structural isolation: addon resources live on a separate i18next
+    // instance — the host instance never even holds an addon namespace.
+    expect(i18n.hasResourceBundle("en", "addon/sample-addon")).toBe(false);
+
+    // ...and the addon's own lookups can never reach ui keys: not by
+    // fallthrough, not by a "ui:"-prefixed key, not by an options ns override.
+    // Nested lookups inside the addon's own bundle still work.
+    const runtime = globalThis.__wealthfolioAddonI18n;
+    function UiProbe() {
+      const { t } = runtime!.useAddonTranslation();
+      return (
+        <>
+          <span data-testid="fallthrough">{t("dialog.close")}</span>
+          <span data-testid="key-embedded">{t("ui:sheet.close")}</span>
+          <span data-testid="options-ns">{t("sheet.close", { ns: "ui" })}</span>
+          <span data-testid="own-nested">{t("sheet.close")}</span>
+        </>
+      );
+    }
+    render(<UiProbe />);
+    expect(await screen.findByTestId("fallthrough")).toHaveTextContent(/^dialog.close$/);
+    expect(screen.getByTestId("key-embedded")).toHaveTextContent(/^ui:sheet.close$/);
+    expect(screen.getByTestId("options-ns")).toHaveTextContent(/^HACKED$/);
+    expect(screen.getByTestId("own-nested")).toHaveTextContent(/^HACKED$/);
+  });
+
+  it("seals nesting, language overrides, and malformed language keys", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      const { initSandboxI18n, installAddonTranslationRuntime, setSandboxLanguage } =
+        await loadSandbox();
+      const i18n = initSandboxI18n("en");
+      installAddonTranslationRuntime("sample-addon");
+
+      registerTranslations({
+        en: { own: "Own EN", esc: '$t(sheet.close, {"ns": "ui"})' },
+        // Uppercase and regional codes must land on the resolvable base code.
+        "FR-CA": { own: "Own FR" },
+      });
+
+      // A dotted language key must never reach i18next: addResourceBundle
+      // reinterprets it as a resource path into the host en/ui tree.
+      const uiKeysBefore = Object.keys(i18n.getResourceBundle("en", "ui")).sort();
+      registerTranslations({ "en.ui": { sheet: { close: "PWNED" } } });
+      expect(warn).toHaveBeenCalledOnce();
+      expect(Object.keys(i18n.getResourceBundle("en", "ui")).sort()).toEqual(uiKeysBefore);
+      expect(i18n.getResource("en", "ui", "sheet.close")).toBe("Close");
+
+      function Probe() {
+        const { t } = useAddonTranslation();
+        return (
+          <>
+            {/* $t() nesting is disabled: rendered literally, no ns escape */}
+            <span data-testid="nested">{t("esc")}</span>
+            {/* language resolution options are stripped: host language wins */}
+            <span data-testid="lng-override">{t("own", { lng: "fr" })}</span>
+            {/* "FR-CA" registration resolves once the host language is fr */}
+            <span data-testid="own">{t("own")}</span>
+          </>
+        );
+      }
+      render(<Probe />);
+      expect(await screen.findByTestId("nested")).toHaveTextContent(
+        '$t(sheet.close, {"ns": "ui"})',
+      );
+      expect(screen.getByTestId("lng-override")).toHaveTextContent(/^Own EN$/);
+
+      setSandboxLanguage("fr");
+      await vi.waitFor(() => {
+        expect(screen.getByTestId("own")).toHaveTextContent(/^Own FR$/);
+      });
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("falls back to the addon's en bundle for untranslated languages", async () => {
+    const { initSandboxI18n, installAddonTranslationRuntime } = await loadSandbox();
+    initSandboxI18n("de");
+    installAddonTranslationRuntime("sample-addon");
+
+    registerTranslations({ en: { greeting: "Hello {{name}}" } });
+
+    render(<AddonGreeting name="Aziz" />);
+    expect(await screen.findByText("Hello Aziz")).toBeInTheDocument();
+  });
+
+  it("keeps t identity stable across unrelated re-renders, changing it on language or resource changes", async () => {
+    const { initSandboxI18n, installAddonTranslationRuntime, setSandboxLanguage } =
+      await loadSandbox();
+    initSandboxI18n("en");
+    installAddonTranslationRuntime("sample-addon");
+    registerTranslations({
+      en: { greeting: "Hello {{name}}" },
+      fr: { greeting: "Bonjour {{name}}" },
+    });
+
+    const identities: unknown[] = [];
+    function Probe({ tick }: { tick: number }) {
+      const { t } = useAddonTranslation();
+      identities.push(t);
+      return (
+        <span data-testid="probe">
+          {tick}:{t("greeting", { name: "A" })}
+        </span>
+      );
+    }
+
+    const { rerender } = render(<Probe tick={1} />);
+    rerender(<Probe tick={2} />);
+    // An unrelated parent re-render must not produce a new t.
+    expect(identities[1]).toBe(identities[0]);
+
+    setSandboxLanguage("fr");
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("probe")).toHaveTextContent("Bonjour A");
+    });
+    const afterLanguageChange = identities[identities.length - 1];
+    expect(afterLanguageChange).not.toBe(identities[0]);
+
+    // Late resource registration must also invalidate t.
+    registerTranslations({ fr: { greeting: "Salut {{name}}" } });
+    await vi.waitFor(() => {
+      expect(screen.getByTestId("probe")).toHaveTextContent("Salut A");
+    });
+    expect(identities[identities.length - 1]).not.toBe(afterLanguageChange);
+  });
+
+  it("resolves i18next plurals through the SDK t", async () => {
+    const { initSandboxI18n, installAddonTranslationRuntime } = await loadSandbox();
+    initSandboxI18n("en");
+    installAddonTranslationRuntime("sample-addon");
+
+    registerTranslations({
+      en: { holdings_one: "{{count}} holding", holdings_other: "{{count}} holdings" },
+    });
+
+    function Holdings({ count }: { count: number }) {
+      const { t } = useAddonTranslation();
+      return <span>{t("holdings", { count })}</span>;
+    }
+    render(
+      <>
+        <Holdings count={1} />
+        <Holdings count={3} />
+      </>,
+    );
+    expect(await screen.findByText("1 holding")).toBeInTheDocument();
+    expect(await screen.findByText("3 holdings")).toBeInTheDocument();
+  });
+
+  it("re-renders consumers when translations are registered after mount", async () => {
+    const { initSandboxI18n, installAddonTranslationRuntime } = await loadSandbox();
+    initSandboxI18n("en");
+    installAddonTranslationRuntime("sample-addon");
+
+    render(<AddonGreeting name="Aziz" />);
+    expect(await screen.findByText("greeting")).toBeInTheDocument();
+
+    registerTranslations({ en: { greeting: "Hello {{name}}" } });
+    expect(await screen.findByText("Hello Aziz")).toBeInTheDocument();
+  });
+
+  it("degrades outside the sandbox: register warns and no-ops, the hook throws", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      registerTranslations({ en: { greeting: "Hello" } });
+      expect(warn).toHaveBeenCalledOnce();
+
+      function Broken() {
+        useAddonTranslation();
+        return null;
+      }
+      expect(() => render(<Broken />)).toThrowError(/only available inside/);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/docs/addons/addon-localization.md
+++ b/docs/addons/addon-localization.md
@@ -1,0 +1,124 @@
+# Addon Localization
+
+Wealthfolio addons run inside a sandboxed iframe that follows the host app's
+language and regional formatting settings. This page covers the two halves of
+localization: **formatting** (numbers, currencies, dates — region-driven) and
+**translation** (your addon's own strings — language-driven).
+
+Both follow the user's settings automatically and update live when the user
+changes them — no reload, no listeners to wire up.
+
+## Region formatting (numbers, currencies, dates)
+
+The host separates the UI **language** from the **formatting region**: a user
+may read the UI in French while formatting amounts as `en-US`. Never hardcode
+`toLocaleString()` locales or format patterns — use the formatting hooks from
+`@wealthfolio/ui`, which are wired to the user's settings inside the sandbox:
+
+```tsx
+import {
+  useAmountFormatting,
+  useDateFormatting,
+  useNumberFormatting,
+  useLocalizationSettings,
+} from "@wealthfolio/ui";
+
+function HoldingRow({ value, currency, asOf }: Props) {
+  const { formatAmount } = useAmountFormatting();
+  const { formatDate } = useDateFormatting();
+  const { formatPercent } = useNumberFormatting();
+
+  return (
+    <div>
+      {formatAmount(value, currency)} — {formatDate(asOf)} —{" "}
+      {formatPercent(0.042)}
+    </div>
+  );
+}
+```
+
+Highlights of the API:
+
+- `useAmountFormatting()` — `formatAmount`, `formatPrice`,
+  `formatCompactAmount`, `formatRoundedAmount`, `formatCurrencySymbol`,
+  `currencyFractionDigits`
+- `useNumberFormatting()` — `formatPercent`, `formatQuantity`, `formatDecimal`,
+  `decimalSeparator`, `groupSeparator`, and locale-aware `parseNumber` for
+  inputs
+- `useDateFormatting()` — `formatDate`, `formatDateTime`, `formatTime`,
+  calendar-date and range variants, and locale-aware `parseDate`
+- `useLocalizationSettings()` — the raw `{ locale, uiLocale, timezone }` if you
+  need to make a decision yourself
+
+## Translating your addon's strings
+
+Register your translations once in `enable()`, then use the hook in components:
+
+```tsx
+import {
+  registerTranslations,
+  useAddonTranslation,
+} from "@wealthfolio/addon-sdk";
+
+export default function enable(ctx: AddonContext) {
+  registerTranslations({
+    en: {
+      title: "Dividend Forecast",
+      greeting: "Hello {{name}}",
+      holdings_one: "{{count}} holding",
+      holdings_other: "{{count}} holdings",
+    },
+    fr: {
+      title: "Prévision de dividendes",
+      greeting: "Bonjour {{name}}",
+    },
+  });
+
+  // ... register routes / sidebar items
+}
+
+function Title() {
+  const { t, language } = useAddonTranslation();
+  return <h1 lang={language}>{t("title")}</h1>;
+}
+```
+
+Behavior and rules:
+
+- **Keys are private to your addon.** Your resources live in an addon-scoped
+  namespace; you cannot read or overwrite the host's strings, and other addons
+  cannot see yours.
+- **Language follows the host.** There is no API to change the language from an
+  addon — the UI language is a user setting. `language` from the hook tells you
+  the current base code (`en`, `fr`, `de`, `es`, `zh`, `ja`, `ko`).
+- **Fallback is your `en` bundle.** If the current language is missing a key (or
+  the whole bundle), lookup falls back to your `en` resources; if that is
+  missing too, the key itself is rendered. Always ship a complete `en` bundle.
+- **Interpolation and plurals** use standard i18next syntax: `{{name}}`
+  placeholders, and `_one` / `_other` plural suffixes driven by
+  `t('holdings', { count })`. `$t()` nesting inside translation values is
+  disabled, and language-resolution options (`lng`, `fallbackLng`) are ignored —
+  the host language always wins.
+- Components re-render automatically on language changes and on (late)
+  `registerTranslations` calls, but registering in `enable()` before the first
+  render avoids a flash of untranslated keys.
+
+### Languages beyond the host's set
+
+Registering languages the host does not support is harmless — they are stored
+but never resolved, because the sandbox language can only ever be one of the
+host-supported codes above.
+
+If your addon genuinely needs its own localization stack (ICU messages, its own
+language switcher, a language the host lacks), bundle your own copy of
+`i18next` + `react-i18next` inside the addon instead of using this API. That is
+fully supported: your bundled instance is private to your addon's iframe. Note
+that the sandbox blocks network requests, so lazy-loading backends will not work
+— bundle your resources statically.
+
+## What the host does NOT provide
+
+- `react-i18next` / `i18next` are not host dependencies — do not add them to
+  your build's `external` list; bundle them if you need them directly.
+- There is no way to read the host's translation catalog (`ui:*` keys) or to
+  change the app language from an addon.

--- a/docs/addons/index.md
+++ b/docs/addons/index.md
@@ -14,6 +14,8 @@
   architecture.
 - [Addon API Reference](./addon-api-reference.md) — Complete API documentation
   for addon development.
+- [Addon Localization](./addon-localization.md) — Formatting and translating
+  addon UI for the user's language and region
 - [Addon Packages](./addon-packages.md) — List of available packages and
   dependencies for addon development.
 - [Addon Migration Guide v2 to v3](./addon-migration-guide-v2-to-v3.md) —
@@ -32,6 +34,7 @@
 
 ## 🛠️ Other Resources
 
+- [Addon Localization](./addon-localization.md)
 - [Addon Packages](./addon-packages.md)
 - [Addon Migration Guide v2 to v3](./addon-migration-guide-v2-to-v3.md)
 - [Addon Migration Guide v3.6 to v3.7](./addon-migration-guide-v3.6-to-v3.7.md)

--- a/packages/addon-sdk/CHANGELOG.md
+++ b/packages/addon-sdk/CHANGELOG.md
@@ -4,6 +4,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `registerTranslations()` and `useAddonTranslation()` for translating addon UI
+  strings. Resources live on a dedicated i18next instance inside the addon
+  sandbox, isolated from the host catalog; the language follows the host
+  setting. Requires a Wealthfolio release that ships this sandbox runtime
+  (unreleased at the time of writing). See the
+  [Addon Localization guide](../../docs/addons/addon-localization.md).
+
 ## [3.7.0] - 2026-08-10
 
 Wealthfolio 3.7 adds private packaged assets while preserving the documented

--- a/packages/addon-sdk/src/i18n.ts
+++ b/packages/addon-sdk/src/i18n.ts
@@ -1,0 +1,79 @@
+/**
+ * Addon translation API.
+ *
+ * The implementation lives in the Wealthfolio addon sandbox, which installs a
+ * runtime on `globalThis` before any addon code runs. Addon resources live on
+ * a dedicated i18next instance, separate from the one serving the host's `ui`
+ * catalog, so addons can never read or overwrite the host's strings, and the
+ * language always follows the host setting — addons cannot change it.
+ *
+ * Outside the sandbox (e.g. unit tests of addon code) `registerTranslations`
+ * is a warning no-op and `useAddonTranslation` throws.
+ */
+
+/** A nested map of translation keys to strings, i18next resource shape. */
+export interface AddonTranslationBundle {
+  [key: string]: string | AddonTranslationBundle;
+}
+
+/**
+ * Translations keyed by base language code (`en`, `fr`, `de`, ...).
+ * Regional codes (`fr-CA`) are normalized to their base language; keys that
+ * are not plain language codes are ignored with a warning.
+ * Languages the host does not support are stored but never resolved.
+ */
+export type AddonTranslationResources = Record<string, AddonTranslationBundle>;
+
+export interface AddonTranslationApi {
+  /**
+   * Translate a key from this addon's registered resources. Supports i18next
+   * interpolation and plurals. Lookups are locked to this addon's own
+   * namespace and the host language: `ns`, `nsSeparator`, `lng`, `lngs`, and
+   * `fallbackLng` options are ignored, `:`-prefixed keys are treated
+   * literally, and `$t()` nesting inside translation values is disabled.
+   */
+  t: (key: string, options?: Record<string, unknown>) => string;
+  /** Current UI language as a base code (`en`, `fr`, ...). Follows the host setting. */
+  language: string;
+}
+
+/** Implemented and installed by the host sandbox; addons never construct this. */
+export interface AddonTranslationRuntime {
+  registerTranslations: (resources: AddonTranslationResources) => void;
+  useAddonTranslation: () => AddonTranslationApi;
+}
+
+declare global {
+  // Installed by the Wealthfolio addon sandbox before any addon code runs.
+  var __wealthfolioAddonI18n: AddonTranslationRuntime | undefined;
+}
+
+/**
+ * Register this addon's translations. Call once, in `enable()`, before the
+ * first render. Merges per language into the addon's private namespace;
+ * missing languages fall back to the addon's `en` bundle.
+ */
+export function registerTranslations(resources: AddonTranslationResources): void {
+  const runtime = globalThis.__wealthfolioAddonI18n;
+  if (!runtime) {
+    console.warn(
+      '[wealthfolio-sdk] registerTranslations is only available inside the Wealthfolio addon sandbox; ignoring call.',
+    );
+    return;
+  }
+  runtime.registerTranslations(resources);
+}
+
+/**
+ * React hook returning a `t` bound to this addon's registered translations.
+ * Re-renders when the host language changes.
+ */
+export function useAddonTranslation(): AddonTranslationApi {
+  const runtime = globalThis.__wealthfolioAddonI18n;
+  if (!runtime) {
+    throw new Error(
+      'useAddonTranslation is only available inside the Wealthfolio addon sandbox',
+    );
+  }
+  return runtime.useAddonTranslation();
+}

--- a/packages/addon-sdk/src/index.ts
+++ b/packages/addon-sdk/src/index.ts
@@ -113,6 +113,15 @@ export { HOST_DEPENDENCIES } from './host-dependencies';
 export { ADDON_ICON_NAMES } from './icons';
 export type { AddonIconName } from './icons';
 
+// Addon translations (implemented by the host sandbox)
+export { registerTranslations, useAddonTranslation } from './i18n';
+export type {
+  AddonTranslationApi,
+  AddonTranslationBundle,
+  AddonTranslationResources,
+  AddonTranslationRuntime,
+} from './i18n';
+
 /**
  * Addons receive their context as a parameter to the enable() function.
  * Each addon gets its own isolated iframe context with scoped host APIs.


### PR DESCRIPTION
## Description

Gives addon authors a first-class way to translate their own UI strings, riding on the sandbox i18next instance introduced in #1511 (merged):

```tsx
import { registerTranslations, useAddonTranslation } from '@wealthfolio/addon-sdk';

export default function enable(ctx: AddonContext) {
  registerTranslations({
    en: { greeting: 'Hello {{name}}' },
    fr: { greeting: 'Bonjour {{name}}' },
  });
}

function Title() {
  const { t, language } = useAddonTranslation();
  return <h1>{t('greeting', { name: 'Aziz' })}</h1>;
}
```

### Design: a narrow SDK waist, not a react-i18next host dependency

The tempting alternative — adding `react-i18next` to `HOST_DEPENDENCIES` — was evaluated and rejected:

- **The live instance can't be withheld.** `useTranslation()` returns the `i18n` object, with `changeLanguage`, `addResourceBundle` (which shallow-merges — one call replaces a whole top-level `ui:*` subtree), and `removeResourceBundle`. Curation of exports can't produce a read-only surface.
- **Config becomes public API.** `defaultNS`, `fallbackLng`, `supportedLngs` on the shared instance would freeze the moment addons depend on them; `changeLanguage` to an unsupported code leaves i18next in a half-switched state (`language` reports it, resolution silently falls back).
- **Registration is a four-list trap.** A host dependency must be added to frontend `HOST_DEPENDENCIES`, `HOST_DEPENDENCY_VERSION_RANGES`, the SDK's `HOST_DEPENDENCIES` map, and the dev-tools template externals — missing the SDK one makes `validateManifest` actively tell authors to bundle the package.

The SDK API avoids all of it by construction:

- Addon resources live on a **dedicated i18next instance**, separate from the one serving the host `ui` catalog — host strings are not merely sealed off, they are absent from the instance addons can address, in both directions and regardless of `t()` options (regression-tested). The option seals (`ns`, `nsSeparator: false`, `nest: false`, `lng`/`lngs`/`fallbackLng` stripped) remain as contract enforcement: keys are literal and the language always follows the host setting.
- No instance escapes: `t` and `language` only. Language always follows the host setting.
- Ships through `@wealthfolio/addon-sdk`, which is **already bridged** — zero changes to dependency lists or the build template.
- Failure ownership is right: the worst a bug can do is mistranslate the addon's own strings.

Addons with needs beyond this (ICU, their own language switcher, languages the host lacks) bundle their own `i18next` — realm-safe, fully supported, now documented.

### Mechanics

- `packages/addon-sdk/src/i18n.ts` — types + thin wrappers reading `globalThis.__wealthfolioAddonI18n` at call time (so the API also works if an addon bundles the SDK instead of externalizing it). Outside the sandbox: `registerTranslations` warns + no-ops, `useAddonTranslation` throws.
- Sandbox (`addon-sandbox-i18n.ts`) implements the runtime; the entry installs it right after `initSandboxI18n`, before any addon code runs.
- `useAddonTranslation` uses the stock react-i18next hook bound explicitly to the dedicated instance (`useTranslation(ns, { i18n })`); the instance is deliberately not registered as react-i18next's default, which stays the `ui` instance for `@wealthfolio/ui`. Its react options (`bindI18n`, `bindI18nStore: "added removed"`, `useSuspense: false`) drive re-renders on language changes and late registration.
- The hook memoizes its result on `[t, language]`, so the SDK `t` has a stable identity across unrelated renders (safe in effect deps / `React.memo`) and changes exactly when language or resources change — covered by a dedicated identity test.
- `deep: true, overwrite: true` on registration, so repeated calls merge predictably.

### Docs

New [Addon Localization](https://github.com/wealthfolio/wealthfolio/blob/feature/addon-sdk-translations/docs/addons/addon-localization.md) page covering both halves: the **formatting hooks that already exist** (`useAmountFormatting` / `useNumberFormatting` / `useDateFormatting` / `useLocalizationSettings` — previously undocumented) and the new translation API, plus the bundle-your-own escape hatch and its CSP constraint. Linked from the docs index, and noted in the SDK changelog under Unreleased.

### Review

Two adversarial review passes ran on this branch; everything they confirmed is fixed and regression-tested:

- **Namespace escape (found by probe test):** the initially shipped `t` could read host `ui:*` strings via a `"ui:"`-prefixed key or an `{ ns }` option override — i18next's key parsing and `options.ns` beat the `useTranslation` binding. Sealed in the wrapper; a 4-way assertion now locks fallthrough, key-embedded ns, options-ns override, and own-namespace nested lookup.
- **Unstable `t` identity:** fixed with the memoization above.
- **`language` contract untested:** now asserted exactly `en` → `fr` across a host language switch.
- A suspected stale-translations path on in-place addon reload was **refuted**: `loadAddon` is only ever posted after a fresh-realm `ready`, so every delivery lands on a brand-new i18next instance.

A calibration note on the rounds below: with one iframe per addon, the realm is the actual security boundary and host `ui` strings are public — so these were API-contract escapes with a self-contained blast radius, not vulnerabilities. They were still fixed and regression-tested; a final round then moved addon resources onto a dedicated instance (structural isolation) while keeping the option seals as contract enforcement.

A third, independent review round found three further escapes, each reproduced against the installed i18next and now sealed with regression tests:

- **`$t()` nesting escape:** a registered value like `$t(sheet.close, {"ns": "ui"})` resolved the host catalog — nested-call options merge over the sealed top-level options. Nesting is now disabled (`nest: false`).
- **Dotted language key write-escape (the serious one):** `registerTranslations({ "en.ui": ... })` hit i18next's argument-shifting path for dotted `lng` values and mutated the host `en/ui` resource tree (injected junk keys). Language keys are now validated to plain base codes; anything else is ignored with a warning.
- **Language-policy overrides:** `t(key, { lng: "fr" })` diverged from the host language and `{ fallbackLng: false }` could drop the documented `en` fallback. `lng`/`lngs`/`fallbackLng` are now stripped.

### Testing

8 tests in `addon-translations.test.tsx`, exercising the full chain through the real SDK exports:

- interpolation + live re-render + `language` value on host language change
- `ui:` namespace sealed in both directions (4-way assertion described above)
- nesting, language-override, and malformed-language-key escapes sealed (third review round)
- `t` identity: stable across unrelated re-renders, invalidated by language and resource changes
- structural isolation: the host instance never holds an addon namespace
- fallback to the addon's `en` bundle
- i18next plurals (`_one`/`_other`) through the SDK `t`
- late registration re-renders mounted consumers
- outside-sandbox degradation (warn/no-op + throw)

`vitest run src/addons`: **126 passed** · frontend `tsc` clean · eslint clean on changed files · SDK `build`/`type-check`/`lint` clean · `build:addon-sandbox-runtime` succeeds (+0.4 KB gzip).

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).


