### PR TITLE
feat(accounts): add annual interest rate field

### DIFF
--- a/apps/frontend/src/i18n/locales/de/account.json
+++ b/apps/frontend/src/i18n/locales/de/account.json
@@ -153,5 +153,6 @@
   "to_this_account_in": "auf dieses Konto in",
   "your_total_is": "Ihr Gesamtbetrag beträgt",
   "more_count_one": "+{{count}} weitere",
-  "more_count_other": "+{{count}} weitere"
+  "more_count_other": "+{{count}} weitere",
+  "interest_rate": "Zinssatz"
 }

--- a/apps/frontend/src/i18n/locales/de/settings.json
+++ b/apps/frontend/src/i18n/locales/de/settings.json
@@ -82,6 +82,7 @@
   "accounts_form_name_label": "Kontoname",
   "accounts_form_name_placeholder": "Anzeigename des Kontos",
   "accounts_form_group_label": "Kontogruppe",
+  "accounts_form_interest_rate_label": "Zinssatz",
   "accounts_form_group_placeholder": "Broker, Festgeld, Rente, AHV, …",
   "accounts_form_type_label": "Kontotyp",
   "accounts_form_type_placeholder": "Kontotyp wählen",

--- a/apps/frontend/src/i18n/locales/en/account.json
+++ b/apps/frontend/src/i18n/locales/en/account.json
@@ -153,5 +153,6 @@
     "irr_hover_hint": " Hover the value to see the selected-period IRR."
   },
   "more_count_one": "+{{count}} more",
-  "more_count_other": "+{{count}} more"
+  "more_count_other": "+{{count}} more",
+  "interest_rate": "Interest Rate"
 }

--- a/apps/frontend/src/i18n/locales/en/settings.json
+++ b/apps/frontend/src/i18n/locales/en/settings.json
@@ -118,6 +118,7 @@
   "accounts_form_name_label": "Account Name",
   "accounts_form_name_placeholder": "Account display name",
   "accounts_form_group_label": "Account Group",
+  "accounts_form_interest_rate_label": "Interest Rate",
   "accounts_form_group_placeholder": "Retirement, 401K, RRSP, TFSA,...",
   "accounts_form_type_label": "Account Type",
   "accounts_form_type_placeholder": "Select an account type",

--- a/apps/frontend/src/i18n/locales/es/account.json
+++ b/apps/frontend/src/i18n/locales/es/account.json
@@ -153,5 +153,6 @@
     "irr_hover_hint": " Pasa el cursor sobre el valor para ver la IRR del periodo seleccionado."
   },
   "more_count_one": "+{{count}} más",
-  "more_count_other": "+{{count}} más"
+  "more_count_other": "+{{count}} más",
+  "interest_rate": "Tasa de interés"
 }

--- a/apps/frontend/src/i18n/locales/es/settings.json
+++ b/apps/frontend/src/i18n/locales/es/settings.json
@@ -118,6 +118,7 @@
   "accounts_form_name_label": "Nombre de la cuenta",
   "accounts_form_name_placeholder": "Nombre visible de la cuenta",
   "accounts_form_group_label": "Grupo de cuentas",
+  "accounts_form_interest_rate_label": "Tasa de interés",
   "accounts_form_group_placeholder": "Jubilación, 401K, RRSP, TFSA,...",
   "accounts_form_type_label": "Tipo de cuenta",
   "accounts_form_type_placeholder": "Selecciona un tipo de cuenta",

--- a/apps/frontend/src/i18n/locales/fr/account.json
+++ b/apps/frontend/src/i18n/locales/fr/account.json
@@ -153,5 +153,6 @@
     "irr_hover_hint": " Survolez la valeur pour voir le TRI de la période sélectionnée."
   },
   "more_count_one": "+{{count}} de plus",
-  "more_count_other": "+{{count}} de plus"
+  "more_count_other": "+{{count}} de plus",
+  "interest_rate": "Taux d'intérêt"
 }

--- a/apps/frontend/src/i18n/locales/fr/settings.json
+++ b/apps/frontend/src/i18n/locales/fr/settings.json
@@ -118,6 +118,7 @@
   "accounts_form_name_label": "Nom du compte",
   "accounts_form_name_placeholder": "Nom d'affichage du compte",
   "accounts_form_group_label": "Groupe de compte",
+  "accounts_form_interest_rate_label": "Taux d'intérêt",
   "accounts_form_group_placeholder": "Retraite, 401K, REER, CELI,...",
   "accounts_form_type_label": "Type de compte",
   "accounts_form_type_placeholder": "Sélectionner un type de compte",

--- a/apps/frontend/src/i18n/locales/ja/account.json
+++ b/apps/frontend/src/i18n/locales/ja/account.json
@@ -152,5 +152,6 @@
     "twr_hover_hint": " 数値にカーソルを合わせると累積TWRを表示します。",
     "irr_hover_hint": " 数値にカーソルを合わせると選択期間のIRRを表示します。"
   },
-  "more_count_other": "他{{count}}件"
+  "more_count_other": "他{{count}}件",
+  "interest_rate": "金利"
 }

--- a/apps/frontend/src/i18n/locales/ja/settings.json
+++ b/apps/frontend/src/i18n/locales/ja/settings.json
@@ -118,6 +118,7 @@
   "accounts_form_name_label": "口座名",
   "accounts_form_name_placeholder": "表示する口座名",
   "accounts_form_group_label": "口座グループ",
+  "accounts_form_interest_rate_label": "金利",
   "accounts_form_group_placeholder": "退職資金、401K、RRSP、TFSAなど",
   "accounts_form_type_label": "口座タイプ",
   "accounts_form_type_placeholder": "口座タイプを選択",

--- a/apps/frontend/src/i18n/locales/ko/account.json
+++ b/apps/frontend/src/i18n/locales/ko/account.json
@@ -152,5 +152,6 @@
     "twr_hover_hint": " 값 위에 마우스를 올리면 누적 TWR을 볼 수 있습니다.",
     "irr_hover_hint": " 값 위에 마우스를 올리면 선택한 기간의 IRR을 볼 수 있습니다."
   },
-  "more_count_other": "+{{count}}개 더보기"
+  "more_count_other": "+{{count}}개 더보기",
+  "interest_rate": "이자율"
 }

--- a/apps/frontend/src/i18n/locales/ko/settings.json
+++ b/apps/frontend/src/i18n/locales/ko/settings.json
@@ -118,6 +118,7 @@
   "accounts_form_name_label": "계좌 이름",
   "accounts_form_name_placeholder": "계좌 표시 이름",
   "accounts_form_group_label": "계좌 그룹",
+  "accounts_form_interest_rate_label": "이자율",
   "accounts_form_group_placeholder": "퇴직연금, 401K, RRSP, TFSA 등",
   "accounts_form_type_label": "계좌 유형",
   "accounts_form_type_placeholder": "계좌 유형을 선택하세요",

--- a/apps/frontend/src/i18n/locales/zh/account.json
+++ b/apps/frontend/src/i18n/locales/zh/account.json
@@ -152,5 +152,6 @@
     "twr_hover_hint": " 将鼠标悬停在该值上以查看累计 TWR。",
     "irr_hover_hint": " 将鼠标悬停在该值上以查看所选期间的 IRR。"
   },
-  "more_count_other": "+{{count}} 更多"
+  "more_count_other": "+{{count}} 更多",
+  "interest_rate": "利率"
 }

--- a/apps/frontend/src/i18n/locales/zh/settings.json
+++ b/apps/frontend/src/i18n/locales/zh/settings.json
@@ -118,6 +118,7 @@
   "accounts_form_name_label": "账户名称",
   "accounts_form_name_placeholder": "账户显示名称",
   "accounts_form_group_label": "账户分组",
+  "accounts_form_interest_rate_label": "利率",
   "accounts_form_group_placeholder": "退休、401K、RRSP、TFSA……",
   "accounts_form_type_label": "账户类型",
   "accounts_form_type_placeholder": "选择账户类型",

--- a/apps/frontend/src/lib/schemas.ts
+++ b/apps/frontend/src/lib/schemas.ts
@@ -102,6 +102,7 @@ export const newAccountSchema = z
     currency: z.string({ required_error: "Please select a currency." }),
     trackingMode: trackingModeSchema.optional().default("NOT_SET"),
     meta: z.string().nullable().optional(),
+    interestRate: z.string().optional(),
   })
   .refine(
     (data) => data.accountType !== AccountType.CREDIT_CARD || data.trackingMode !== "HOLDINGS",

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -91,6 +91,7 @@ export interface Account {
   meta?: string; // Optional - additional metadata as JSON string
   provider?: string; // Optional - sync provider (e.g., 'SNAPTRADE', 'PLAID', 'MANUAL')
   providerAccountId?: string; // Optional - account ID in the provider's system
+  interestRate?: string; // Optional - annual interest rate (e.g. "1.7" for 1.7%)
 }
 
 /**

--- a/apps/frontend/src/pages/account/account-page.tsx
+++ b/apps/frontend/src/pages/account/account-page.tsx
@@ -981,11 +981,17 @@ const AccountPage = () => {
                 </Sheet>
               </div>
             </div>
-            {!account?.group && account?.currency && (
-              <p className="text-muted-foreground text-xs leading-tight md:text-sm">
-                {account?.currency}
-              </p>
-            )}
+            <p className="text-muted-foreground flex items-center gap-1.5 text-xs leading-tight md:text-sm">
+              {!account?.group && account?.currency && <span>{account.currency}</span>}
+              {account?.interestRate && (
+                <span className="text-muted-foreground text-xs">
+                  {t("account:interest_rate")}:{" "}
+                  <span className="bg-primary/10 text-primary rounded-sm px-1.5 py-px font-medium">
+                    {parseFloat(account.interestRate).toFixed(2)}%
+                  </span>
+                </span>
+              )}
+            </p>
           </div>
         </div>
       </PageHeader>

--- a/apps/frontend/src/pages/settings/accounts/components/account-edit-modal.tsx
+++ b/apps/frontend/src/pages/settings/accounts/components/account-edit-modal.tsx
@@ -29,6 +29,7 @@ export function AccountEditModal({ account, open, onClose }: AccountEditModalPro
     isArchived: account?.isArchived ?? false,
     trackingMode: account?.trackingMode,
     meta: account?.meta,
+    interestRate: account?.interestRate ?? undefined,
   };
 
   return (

--- a/apps/frontend/src/pages/settings/accounts/components/account-form.tsx
+++ b/apps/frontend/src/pages/settings/accounts/components/account-form.tsx
@@ -291,6 +291,31 @@ export function AccountForm({ defaultValues, onSuccess = () => undefined }: Acco
 
               <FormField
                 control={form.control}
+                name="interestRate"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t("settings:accounts_form_interest_rate_label")}</FormLabel>
+                    <FormControl>
+                      <div className="relative">
+                        <Input
+                          type="text"
+                          inputMode="decimal"
+                          placeholder="0.00"
+                          {...field}
+                          value={field.value ?? ""}
+                        />
+                        <span className="text-muted-foreground pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-sm">
+                          %
+                        </span>
+                      </div>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
                 name="accountType"
                 render={({ field }) => (
                   <FormItem className="flex flex-col">

--- a/apps/server/src/models.rs
+++ b/apps/server/src/models.rs
@@ -73,6 +73,7 @@ pub struct NewAccount {
     pub meta: Option<String>,
     pub provider: Option<String>,
     pub provider_account_id: Option<String>,
+    pub interest_rate: Option<String>,
 }
 
 fn default_tracking_mode() -> String {
@@ -104,6 +105,7 @@ impl From<NewAccount> for core_accounts::NewAccount {
             meta: a.meta,
             provider: a.provider,
             provider_account_id: a.provider_account_id,
+            interest_rate: a.interest_rate,
         }
     }
 }
@@ -124,6 +126,7 @@ pub struct AccountUpdate {
     pub meta: Option<String>,
     pub provider: Option<String>,
     pub provider_account_id: Option<String>,
+    pub interest_rate: Option<String>,
 }
 
 impl From<AccountUpdate> for core_accounts::AccountUpdate {
@@ -142,6 +145,7 @@ impl From<AccountUpdate> for core_accounts::AccountUpdate {
             meta: a.meta,
             provider: a.provider,
             provider_account_id: a.provider_account_id,
+            interest_rate: a.interest_rate,
         }
     }
 }

--- a/crates/ai/tests/tool_outputs_parity.rs
+++ b/crates/ai/tests/tool_outputs_parity.rs
@@ -58,6 +58,7 @@ fn fixture_account(id: &str, name: &str, account_type: &str, currency: &str) -> 
         provider_account_id: None,
         is_archived: false,
         tracking_mode: TrackingMode::Transactions,
+        interest_rate: None,
     }
 }
 

--- a/crates/connect/src/broker/service.rs
+++ b/crates/connect/src/broker/service.rs
@@ -433,6 +433,7 @@ impl BrokerSyncServiceTrait for BrokerSyncService {
                 provider_account_id: Some(provider_account_id.clone()),
                 is_archived: false,
                 tracking_mode,
+                interest_rate: None,
             };
 
             // Create the account via AccountService (handles FX rate registration)

--- a/crates/core/src/accounts/accounts_model.rs
+++ b/crates/core/src/accounts/accounts_model.rs
@@ -248,6 +248,8 @@ pub struct Account {
     pub is_archived: bool,
     /// Tracking mode for the account
     pub tracking_mode: TrackingMode,
+    /// Annual interest rate (e.g. "1.7" for 1.7%)
+    pub interest_rate: Option<String>,
 }
 
 impl Account {
@@ -287,6 +289,7 @@ pub struct NewAccount {
     pub is_archived: bool,
     #[serde(default)]
     pub tracking_mode: TrackingMode,
+    pub interest_rate: Option<String>,
 }
 
 impl NewAccount {
@@ -330,6 +333,7 @@ pub struct AccountUpdate {
     pub provider_account_id: Option<String>,
     pub is_archived: Option<bool>,
     pub tracking_mode: Option<TrackingMode>,
+    pub interest_rate: Option<String>,
 }
 
 impl AccountUpdate {

--- a/crates/storage-sqlite/migrations/2026-08-20-000001_add_interest_rate_to_accounts/down.sql
+++ b/crates/storage-sqlite/migrations/2026-08-20-000001_add_interest_rate_to_accounts/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE accounts DROP COLUMN interest_rate;

--- a/crates/storage-sqlite/migrations/2026-08-20-000001_add_interest_rate_to_accounts/up.sql
+++ b/crates/storage-sqlite/migrations/2026-08-20-000001_add_interest_rate_to_accounts/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE accounts ADD COLUMN interest_rate TEXT;

--- a/crates/storage-sqlite/src/accounts/model.rs
+++ b/crates/storage-sqlite/src/accounts/model.rs
@@ -48,6 +48,7 @@ pub struct AccountDB {
     pub provider_account_id: Option<String>,
     pub is_archived: bool,
     pub tracking_mode: String,
+    pub interest_rate: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -199,6 +200,7 @@ impl From<AccountDB> for Account {
             provider_account_id: db.provider_account_id,
             is_archived: db.is_archived,
             tracking_mode,
+            interest_rate: db.interest_rate,
         }
     }
 }
@@ -229,6 +231,7 @@ impl From<NewAccount> for AccountDB {
             provider_account_id: domain.provider_account_id,
             is_archived: domain.is_archived,
             tracking_mode,
+            interest_rate: domain.interest_rate,
         }
     }
 }
@@ -261,6 +264,7 @@ impl From<AccountUpdate> for AccountDB {
             provider_account_id: domain.provider_account_id,
             is_archived: domain.is_archived.unwrap_or(false),
             tracking_mode,
+            interest_rate: domain.interest_rate,
         }
     }
 }

--- a/crates/storage-sqlite/src/schema.rs
+++ b/crates/storage-sqlite/src/schema.rs
@@ -18,6 +18,7 @@ diesel::table! {
         provider_account_id -> Nullable<Text>,
         is_archived -> Bool,
         tracking_mode -> Text,
+        interest_rate -> Nullable<Text>,
     }
 }
 


### PR DESCRIPTION
Allows users to enter and display an annual interest rate on cash accounts (e.g. French Livret A / LDDS at 1.7%).

## Changes

### Database
- Migration `2026-08-20-000001`: adds `interest_rate TEXT` column to `accounts` table
- Diesel schema updated accordingly

### Backend (Rust)
- `Account`, `NewAccount`, `AccountUpdate` in `wealthfolio-core` carry `interest_rate: Option<String>`
- `AccountDB` (storage-sqlite) maps the field through all three `From` conversions
- `wealthfolio-server` REST models (`NewAccount`, `AccountUpdate`) and their `From` impls updated
- `wealthfolio-connect` broker sync: `interest_rate: None` added to `NewAccount` initializer

### Frontend (TypeScript / React)
- `Account` type and `newAccountSchema` (Zod) include `interestRate?: string`
- Account form: new "Interest Rate" field (`type="text" inputMode="decimal"`) with `%` suffix
- Account edit modal: `interestRate` included in `defaultValues` so the saved value is restored on re-open
- Account detail page header: badge displays `Interest Rate: X.XX%` when set

### i18n
- `settings.json` key `accounts_form_interest_rate_label` — 7 locales (en/fr/de/es/ja/ko/zh)
- `account.json` key `interest_rate` — 7 locales

## Test plan
- [X] Create a Cash account, enter `1.7` as interest rate → save → badge `Interest Rate: 1.70%` visible on account page
- [X] Re-open the account form → field pre-filled with `1.7`
- [X] Save without touching the field → value preserved
- [X] Clear the field → badge no longer shown on account page
- [X] Accounts without an interest rate unaffected

## Description

<!-- Describe your changes -->

<img width="322" height="64" alt="image" src="https://github.com/user-attachments/assets/9c1339e4-e31c-41c4-bdc6-939ff139ad7f" />


## Checklist

- [X] I have read and agree to the [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the [CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
