### PR TITLE
feat(goals): make the pension fund payout rate configurable

### DIFF
--- a/apps/frontend/src/features/goals/retirement-planner/components/sidebar-configurator.tsx
+++ b/apps/frontend/src/features/goals/retirement-planner/components/sidebar-configurator.tsx
@@ -58,9 +58,11 @@ const MAX_RETIREMENT_FEE = 0.1;
 const MAX_RETIREMENT_VOLATILITY = 1;
 const MAX_RETIREMENT_CONTRIBUTION_GROWTH = 0.25;
 const MAX_RETIREMENT_INCOME_GROWTH = 0.2;
+const MAX_RETIREMENT_DC_PAYOUT_RATE = 0.25;
 const FEE_SLIDER_INCREMENT = 0.01;
 const VOLATILITY_SLIDER_INCREMENT = 0.1;
 const CONTRIBUTION_GROWTH_SLIDER_INCREMENT = 0.05;
+const DEFAULT_DC_PAYOUT_SLIDER_MAX = 0.1;
 const HIGH_INFLATION_WARNING_THRESHOLD = DEFAULT_INFLATION_SLIDER_MAX;
 const HIGH_FEE_WARNING_THRESHOLD = DEFAULT_FEE_SLIDER_MAX;
 const HIGH_VOLATILITY_WARNING_THRESHOLD = DEFAULT_VOLATILITY_SLIDER_MAX;
@@ -1277,6 +1279,22 @@ export function SidebarConfigurator({
                                 s.accumulationReturn ?? draft.investment.preRetirementAnnualReturn,
                               )}
                             />
+                            <LeverRow
+                              label={t("goals:sidebar.income.fund_payout_rate")}
+                              value={s.payoutRate ?? DEFAULT_DC_PAYOUT_ESTIMATE_RATE}
+                              onChange={(v) => updateStream(s.id, { payoutRate: v })}
+                              min={0}
+                              max={rateSliderMaxFor(
+                                s.payoutRate ?? DEFAULT_DC_PAYOUT_ESTIMATE_RATE,
+                                DEFAULT_DC_PAYOUT_SLIDER_MAX,
+                                RATE_SLIDER_INCREMENT,
+                                MAX_RETIREMENT_DC_PAYOUT_RATE,
+                              )}
+                              inputMax={MAX_RETIREMENT_DC_PAYOUT_RATE}
+                              step={0.001}
+                              suffix="%"
+                              format={(v) => (v * 100).toFixed(1)}
+                            />
                             {s.startAge <= draft.personal.currentAge && (
                               <LeverRow
                                 label={t("goals:sidebar.income.monthly_payout_after_tax")}
@@ -1294,7 +1312,7 @@ export function SidebarConfigurator({
                             <p className="text-muted-foreground px-1 text-[11px] leading-relaxed">
                               {t("goals:sidebar.income.payout_estimate_note", {
                                 pct: numberFormatting.formatDecimal(
-                                  DEFAULT_DC_PAYOUT_ESTIMATE_RATE * 100,
+                                  (s.payoutRate ?? DEFAULT_DC_PAYOUT_ESTIMATE_RATE) * 100,
                                   { minimumFractionDigits: 1, maximumFractionDigits: 1 },
                                 ),
                               })}

--- a/apps/frontend/src/features/goals/retirement-planner/lib/dashboard-math.test.ts
+++ b/apps/frontend/src/features/goals/retirement-planner/lib/dashboard-math.test.ts
@@ -1,10 +1,32 @@
 import { describe, expect, it } from "vitest";
+import type { RetirementIncomeStream, RetirementPlan } from "../types";
 import {
   deriveRetirementReadiness,
+  projectedAnnualIncomeNominalAtAge,
   resolveCoverageAnnualNominalValues,
   resolveFundedProgress,
   resolvePortfolioDrawRate,
 } from "./dashboard-math";
+import { DEFAULT_RETIREMENT_PLAN } from "./plan-adapter";
+
+function planWithFund(stream: Partial<RetirementIncomeStream>): RetirementPlan {
+  return {
+    ...DEFAULT_RETIREMENT_PLAN,
+    personal: { ...DEFAULT_RETIREMENT_PLAN.personal, currentAge: 45, targetRetirementAge: 65 },
+    incomeStreams: [
+      {
+        id: "fund",
+        label: "Pension fund",
+        streamType: "dc",
+        startAge: 65,
+        adjustForInflation: false,
+        currentValue: 120_000,
+        accumulationReturn: 0,
+        ...stream,
+      },
+    ],
+  };
+}
 
 describe("retirement dashboard math", () => {
   it("does not inflate backend nominal budget fallback values again", () => {
@@ -95,6 +117,13 @@ describe("retirement dashboard math", () => {
         horizonAge: 90,
       }),
     ).toMatchObject({ tone: "bad", problem: "portfolio-depletion" });
+  });
+
+  it("draws fund income at the stream's payout rate, defaulting to 3.5%/yr", () => {
+    expect(projectedAnnualIncomeNominalAtAge(planWithFund({}), 65, 65)).toBeCloseTo(4_200, 6);
+    expect(
+      projectedAnnualIncomeNominalAtAge(planWithFund({ payoutRate: 0.06 }), 65, 65),
+    ).toBeCloseTo(7_200, 6);
   });
 
   it("shows portfolio draw rate only when meaningful", () => {

--- a/apps/frontend/src/features/goals/retirement-planner/lib/dashboard-math.ts
+++ b/apps/frontend/src/features/goals/retirement-planner/lib/dashboard-math.ts
@@ -36,8 +36,9 @@ function projectedDcMonthlyPayout(
   retirementAge: number,
   defaultAccumulationReturn: number,
 ) {
+  const payoutRate = Math.max(0, stream.payoutRate ?? DEFAULT_DC_PAYOUT_ESTIMATE_RATE);
   if (stream.startAge <= currentAge) {
-    const fallback = (Math.max(0, stream.currentValue ?? 0) * DEFAULT_DC_PAYOUT_ESTIMATE_RATE) / 12;
+    const fallback = (Math.max(0, stream.currentValue ?? 0) * payoutRate) / 12;
     return Math.max(0, stream.monthlyAmount ?? fallback);
   }
   const totalYears = Math.max(0, stream.startAge - currentAge);
@@ -58,7 +59,7 @@ function projectedDcMonthlyPayout(
       ? (annualContributionEndValue * (Math.pow(1 + r, contribYears) - 1)) / r
       : monthly * 12 * contribYears;
   const fvAnnuity = fvAnnuityAtStop * Math.pow(1 + r, growthOnlyYears);
-  return ((fvLump + fvAnnuity) * DEFAULT_DC_PAYOUT_ESTIMATE_RATE) / 12;
+  return ((fvLump + fvAnnuity) * payoutRate) / 12;
 }
 
 export function projectedAnnualIncomeNominalAtAge(

--- a/apps/frontend/src/features/goals/retirement-planner/types.ts
+++ b/apps/frontend/src/features/goals/retirement-planner/types.ts
@@ -209,6 +209,8 @@ export interface RetirementIncomeStream {
   currentValue?: number;
   monthlyContribution?: number;
   accumulationReturn?: number;
+  /** Annual draw rate applied to the projected fund balance once payouts start. */
+  payoutRate?: number;
 }
 
 export interface InvestmentAssumptions {

--- a/apps/frontend/src/i18n/locales/de/goals.json
+++ b/apps/frontend/src/i18n/locales/de/goals.json
@@ -318,6 +318,7 @@
       "current_fund_balance": "Aktueller Fondssaldo",
       "monthly_fund_contribution": "Monatlicher Fondsbeitrag",
       "fund_return_before_payout": "Fondsrendite vor Auszahlung",
+      "fund_payout_rate": "Auszahlungsrate",
       "monthly_payout_after_tax": "Monatliche Auszahlung nach Steuern",
       "payout_estimate_note": "Die geschätzte Auszahlung verwendet {{pct}} %/Jahr des prognostizierten Fondssaldos, sofern Sie keine monatliche Auszahlung eingeben.",
       "start_age": "Startalter",

--- a/apps/frontend/src/i18n/locales/en/goals.json
+++ b/apps/frontend/src/i18n/locales/en/goals.json
@@ -318,6 +318,7 @@
       "current_fund_balance": "Current fund balance",
       "monthly_fund_contribution": "Monthly fund contribution",
       "fund_return_before_payout": "Fund return before payout",
+      "fund_payout_rate": "Payout rate",
       "monthly_payout_after_tax": "Monthly payout after tax",
       "payout_estimate_note": "Estimated payout uses {{pct}}%/yr of the projected fund balance unless you enter a monthly payout.",
       "start_age": "Start age",

--- a/apps/frontend/src/i18n/locales/es/goals.json
+++ b/apps/frontend/src/i18n/locales/es/goals.json
@@ -318,6 +318,7 @@
       "current_fund_balance": "Saldo actual del fondo",
       "monthly_fund_contribution": "Aportación mensual al fondo",
       "fund_return_before_payout": "Rentabilidad del fondo antes del pago",
+      "fund_payout_rate": "Tasa de pago",
       "monthly_payout_after_tax": "Pago mensual después de impuestos",
       "payout_estimate_note": "El pago estimado utiliza el {{pct}}%/año del saldo proyectado del fondo salvo que introduzcas un pago mensual.",
       "start_age": "Edad de inicio",

--- a/apps/frontend/src/i18n/locales/fr/goals.json
+++ b/apps/frontend/src/i18n/locales/fr/goals.json
@@ -318,6 +318,7 @@
       "current_fund_balance": "Solde actuel du fonds",
       "monthly_fund_contribution": "Cotisation mensuelle au fonds",
       "fund_return_before_payout": "Rendement du fonds avant versement",
+      "fund_payout_rate": "Taux de versement",
       "monthly_payout_after_tax": "Versement mensuel après impôt",
       "payout_estimate_note": "Le versement estimé utilise {{pct}} %/an du solde projeté du fonds, sauf si vous saisissez un versement mensuel.",
       "start_age": "Âge de début",

--- a/apps/frontend/src/i18n/locales/ja/goals.json
+++ b/apps/frontend/src/i18n/locales/ja/goals.json
@@ -318,6 +318,7 @@
       "current_fund_balance": "現在のファンド残高",
       "monthly_fund_contribution": "毎月のファンド拠出額",
       "fund_return_before_payout": "受取開始前のファンドリターン",
+      "fund_payout_rate": "受取率",
       "monthly_payout_after_tax": "税引後の毎月の受取額",
       "payout_estimate_note": "毎月の受取額を入力しない場合、予想ファンド残高の{{pct}}%/年を推定受取額として使用します。",
       "start_age": "開始年齢",

--- a/apps/frontend/src/i18n/locales/ko/goals.json
+++ b/apps/frontend/src/i18n/locales/ko/goals.json
@@ -318,6 +318,7 @@
       "current_fund_balance": "현재 펀드 잔액",
       "monthly_fund_contribution": "월 펀드 납입액",
       "fund_return_before_payout": "지급 전 펀드 수익률",
+      "fund_payout_rate": "지급률",
       "monthly_payout_after_tax": "세후 월 지급액",
       "payout_estimate_note": "월 지급액을 직접 입력하지 않으면 예상 지급액은 예측된 펀드 잔액의 연 {{pct}}%로 계산됩니다.",
       "start_age": "시작 연령",

--- a/apps/frontend/src/i18n/locales/zh/goals.json
+++ b/apps/frontend/src/i18n/locales/zh/goals.json
@@ -318,6 +318,7 @@
       "current_fund_balance": "当前基金余额",
       "monthly_fund_contribution": "每月基金供款",
       "fund_return_before_payout": "支付前基金收益率",
+      "fund_payout_rate": "支付比率",
       "monthly_payout_after_tax": "税后每月支付额",
       "payout_estimate_note": "除非您输入每月支付额，否则估算支付额按预计基金余额的 {{pct}}%/年计算。",
       "start_age": "起始年龄",

--- a/crates/core/src/goals/goals_service.rs
+++ b/crates/core/src/goals/goals_service.rs
@@ -22,6 +22,7 @@ const GOAL_LIFECYCLE_ARCHIVED: &str = "archived";
 const RETIREMENT_MIN_ANNUAL_RETURN: f64 = -0.20;
 const RETIREMENT_MAX_ANNUAL_RETURN: f64 = 0.50;
 const RETIREMENT_MAX_ANNUAL_INVESTMENT_FEE: f64 = 0.10;
+const RETIREMENT_MAX_DC_PAYOUT_RATE: f64 = 0.25;
 const RETIREMENT_MAX_ANNUAL_VOLATILITY: f64 = 1.0;
 
 // ─── Shared helpers ──────────────────────────────────────────────────────────
@@ -320,6 +321,14 @@ pub fn validate_retirement_plan(plan: &RetirementPlan) -> Result<()> {
                 value,
                 RETIREMENT_MIN_ANNUAL_RETURN,
                 RETIREMENT_MAX_ANNUAL_RETURN,
+            )?;
+        }
+        if let Some(value) = stream.payout_rate {
+            validate_finite_range(
+                "Defined-contribution payout rate",
+                value,
+                0.0,
+                RETIREMENT_MAX_DC_PAYOUT_RATE,
             )?;
         }
     }
@@ -1489,6 +1498,7 @@ mod tests {
             current_value: None,
             monthly_contribution: None,
             accumulation_return: None,
+            payout_rate: None,
         });
         assert!(validate_retirement_plan(&plan)
             .expect_err("negative income should be rejected")
@@ -1530,6 +1540,7 @@ mod tests {
             current_value: Some(10_000.0),
             monthly_contribution: Some(100.0),
             accumulation_return: Some(RETIREMENT_MAX_ANNUAL_RETURN),
+            payout_rate: None,
         });
 
         validate_retirement_plan(&plan).expect("frontend caps should validate");

--- a/crates/core/src/planning/retirement/dto.rs
+++ b/crates/core/src/planning/retirement/dto.rs
@@ -1039,6 +1039,7 @@ mod tests {
             current_value: None,
             monthly_contribution: None,
             accumulation_return: None,
+            payout_rate: None,
         });
 
         let budget = compute_budget_breakdown(&plan, 65);

--- a/crates/core/src/planning/retirement/engine.rs
+++ b/crates/core/src/planning/retirement/engine.rs
@@ -279,10 +279,12 @@ pub(crate) fn resolve_plan_dc_payouts(
         .iter()
         .filter(|s| s.stream_type == StreamKind::DefinedContribution)
         .map(|s| {
+            let payout_rate = s
+                .payout_rate
+                .unwrap_or(DEFAULT_DC_PAYOUT_ESTIMATE_RATE)
+                .max(0.0);
             if s.start_age <= current_age {
-                let fallback = s.current_value.unwrap_or(0.0).max(0.0)
-                    * DEFAULT_DC_PAYOUT_ESTIMATE_RATE
-                    / 12.0;
+                let fallback = s.current_value.unwrap_or(0.0).max(0.0) * payout_rate / 12.0;
                 return (s.id.clone(), s.monthly_amount.unwrap_or(fallback).max(0.0));
             }
             let total_years = (s.start_age as i32 - current_age as i32).max(0) as u32;
@@ -304,7 +306,7 @@ pub(crate) fn resolve_plan_dc_payouts(
                 monthly_contrib * 12.0 * contrib_years as f64
             };
             let fv_annuity = fv_annuity_at_stop * (1.0 + r).powi(growth_only_years as i32);
-            let monthly_payout = (fv_lump + fv_annuity) * DEFAULT_DC_PAYOUT_ESTIMATE_RATE / 12.0;
+            let monthly_payout = (fv_lump + fv_annuity) * payout_rate / 12.0;
             (s.id.clone(), monthly_payout)
         })
         .collect()
@@ -941,6 +943,7 @@ mod tests {
             current_value: None,
             monthly_contribution: None,
             accumulation_return: None,
+            payout_rate: None,
         });
         let target_at_50 = compute_required_capital(&p, 50).expect("target should be reachable");
         let target_at_60 = compute_required_capital(&p, 60).expect("target should be reachable");
@@ -966,6 +969,7 @@ mod tests {
             current_value: Some(10_000.0),
             monthly_contribution: Some(200.0),
             accumulation_return: Some(0.04),
+            payout_rate: None,
         };
         // Retiring at 50: contributions stop at 50, 15 years of growth-only until 65
         let payouts_at_50 = resolve_plan_dc_payouts(std::slice::from_ref(&dc), 35, 50, 0.04);
@@ -996,6 +1000,7 @@ mod tests {
             current_value: Some(100_000.0),
             monthly_contribution: None,
             accumulation_return: None,
+            payout_rate: None,
         };
 
         let low = resolve_plan_dc_payouts(std::slice::from_ref(&dc), 45, 65, 0.02);
@@ -1018,6 +1023,7 @@ mod tests {
             current_value: Some(120_000.0),
             monthly_contribution: None,
             accumulation_return: Some(0.0),
+            payout_rate: None,
         };
 
         let payouts = resolve_plan_dc_payouts(&[dc], 65, 65, 0.04);
@@ -1025,6 +1031,56 @@ mod tests {
         assert!(
             (payouts.get("dc").copied().unwrap() - 350.0).abs() < 0.01,
             "120k fund should estimate 3.5%/yr / 12 as monthly payout"
+        );
+    }
+
+    #[test]
+    fn dc_payout_uses_stream_payout_rate_override() {
+        let dc = RetirementIncomeStream {
+            id: "dc".into(),
+            label: "RRSP".into(),
+            stream_type: StreamKind::DefinedContribution,
+            start_age: 65,
+            adjust_for_inflation: false,
+            annual_growth_rate: None,
+            monthly_amount: None,
+            linked_account_id: None,
+            current_value: Some(120_000.0),
+            monthly_contribution: None,
+            accumulation_return: Some(0.0),
+            payout_rate: Some(0.06),
+        };
+
+        let payouts = resolve_plan_dc_payouts(&[dc], 45, 65, 0.04);
+
+        assert!(
+            (payouts.get("dc").copied().unwrap() - 600.0).abs() < 0.01,
+            "120k fund at a 6%/yr payout rate should pay 600/mo"
+        );
+    }
+
+    #[test]
+    fn already_started_dc_fallback_uses_stream_payout_rate_override() {
+        let dc = RetirementIncomeStream {
+            id: "dc".into(),
+            label: "Active RRIF".into(),
+            stream_type: StreamKind::DefinedContribution,
+            start_age: 60,
+            adjust_for_inflation: false,
+            annual_growth_rate: None,
+            monthly_amount: None,
+            linked_account_id: None,
+            current_value: Some(120_000.0),
+            monthly_contribution: None,
+            accumulation_return: None,
+            payout_rate: Some(0.06),
+        };
+
+        let payouts = resolve_plan_dc_payouts(&[dc], 65, 65, 0.04);
+
+        assert!(
+            (payouts.get("dc").copied().unwrap() - 600.0).abs() < 0.01,
+            "already-started fund should fall back to its own payout rate"
         );
     }
 
@@ -1042,6 +1098,7 @@ mod tests {
             current_value: Some(500_000.0),
             monthly_contribution: Some(500.0),
             accumulation_return: Some(0.04),
+            payout_rate: None,
         };
 
         let payouts = resolve_plan_dc_payouts(&[dc], 65, 65, 0.04);
@@ -1068,6 +1125,7 @@ mod tests {
             current_value: Some(100_000.0),
             monthly_contribution: Some(500.0),
             accumulation_return: Some(0.04),
+            payout_rate: None,
         });
 
         let projection = project_retirement(&plan, 500_000.0);
@@ -1104,6 +1162,7 @@ mod tests {
             current_value: None,
             monthly_contribution: None,
             accumulation_return: None,
+            payout_rate: None,
         });
         let target_at_60 = compute_required_capital(&p, 60).expect("target should be reachable");
         let target_at_35 = compute_required_capital(&p, 35).expect("target should be reachable");
@@ -1299,6 +1358,7 @@ mod tests {
             current_value: None,
             monthly_contribution: None,
             accumulation_return: None,
+            payout_rate: None,
         });
         let proj = project_retirement(&plan, 800_000.0);
         let at_60 = proj

--- a/crates/core/src/planning/retirement/model.rs
+++ b/crates/core/src/planning/retirement/model.rs
@@ -213,6 +213,9 @@ pub struct RetirementIncomeStream {
     pub current_value: Option<f64>,
     pub monthly_contribution: Option<f64>,
     pub accumulation_return: Option<f64>,
+    /// Annual draw rate applied to the projected fund balance once payouts start.
+    /// Falls back to `DEFAULT_DC_PAYOUT_ESTIMATE_RATE` when unset.
+    pub payout_rate: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
## Description

Defined-contribution ("Fund") income streams in the retirement planner turn a
projected fund balance into a monthly payout at a fixed 3.5%/yr —
`DEFAULT_DC_PAYOUT_ESTIMATE_RATE`, declared in
`crates/core/src/planning/retirement/model.rs` and mirrored in
`apps/frontend/src/features/goals/retirement-planner/lib/constants.ts`. Nothing
in the UI can change it.

For a fund that is already paying out, the "Monthly payout after tax" lever is an
escape hatch. For a fund that starts in the future it is not: that lever only
renders when `startAge <= currentAge` (`sidebar-configurator.tsx`), and
`resolve_plan_dc_payouts` ignores `monthly_amount` on the projection branch
(`crates/core/src/planning/retirement/engine.rs`). A plan whose pension
annuitises at, say, 6% has no way to say so.

This adds an optional per-stream payout rate:

- `RetirementIncomeStream.payout_rate: Option<f64>` — `None` falls back to the
  3.5% constant, so stored plans project exactly as before.
- Both payout resolvers read it: `resolve_plan_dc_payouts` (projection branch and
  already-started fallback) and `projectedDcMonthlyPayout` in `dashboard-math.ts`.
- New "Payout rate" lever in the sidebar's income section, beside "Fund return
  before payout". Slider to 10%, typed input to 25%.
- `validate_retirement_plan` bounds the field to 0–25%, matching the frontend cap.
- The note under the fund levers now quotes that fund's effective rate instead of
  the constant. Label added to all seven locales.

The collapsed stream summary and the monthly-payout lever both read
`incomeStreamMonthlyAmount`, so the estimate on screen tracks the rate as it
moves, and an explicitly entered monthly payout still takes precedence.

## Tests

- `cargo test -p wealthfolio-core planning::retirement` — 74 passed, including two
  new cases: the override on a future-start fund, and the override as the
  already-started fallback.
- `vitest run src/features/goals/retirement-planner/lib` — 11 passed, including a
  new case covering the 3.5% default against a 6% override.
- `cargo check --workspace --all-targets` clean.

## Checklist

- [x] I have read and agree to the
      [Contributor License Agreement](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).

By submitting this PR, I agree to the
[CLA](https://github.com/wealthfolio/wealthfolio/blob/main/CLA.md).
