### PR TITLE
Add custom cover images for savings goals

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -78,6 +78,7 @@
     "react": "^19.2.8",
     "react-day-picker": "^9.13.2",
     "react-dom": "^19.2.8",
+    "react-easy-crop": "^6.2.3",
     "react-hook-form": "^7.71.1",
     "react-i18next": "^16.0.0",
     "react-router-dom": "^7.18.2",

--- a/apps/frontend/src/adapters/shared/goals.ts
+++ b/apps/frontend/src/adapters/shared/goals.ts
@@ -58,6 +58,28 @@ export const deleteGoal = async (goalId: string): Promise<void> => {
   }
 };
 
+export const setGoalCoverImage = async (
+  goalId: string,
+  contentBase64: string,
+  fileExtension: string,
+): Promise<Goal> => {
+  try {
+    return await invoke<Goal>("save_goal_cover_image", { goalId, contentBase64, fileExtension });
+  } catch (error) {
+    logger.error("Error saving goal cover image.");
+    throw error;
+  }
+};
+
+export const removeGoalCoverImage = async (goalId: string): Promise<Goal> => {
+  try {
+    return await invoke<Goal>("remove_goal_cover_image", { goalId });
+  } catch (error) {
+    logger.error("Error removing goal cover image.");
+    throw error;
+  }
+};
+
 export const getGoalFunding = async (goalId: string): Promise<GoalFundingRule[]> => {
   try {
     return await invoke<GoalFundingRule[]>("get_goal_funding", { goalId });

--- a/apps/frontend/src/adapters/tauri/goals.ts
+++ b/apps/frontend/src/adapters/tauri/goals.ts
@@ -1,0 +1,8 @@
+// Goal Commands (platform-specific)
+import { tauriInvoke } from "./core";
+
+export const loadGoalCoverImage = async (goalId: string, mimeType?: string): Promise<Blob> => {
+  const response = await tauriInvoke<ArrayBuffer | number[]>("load_goal_cover_image", { goalId });
+  const bytes = response instanceof ArrayBuffer ? response : new Uint8Array(response);
+  return new Blob([bytes], { type: mimeType || "application/octet-stream" });
+};

--- a/apps/frontend/src/adapters/tauri/index.ts
+++ b/apps/frontend/src/adapters/tauri/index.ts
@@ -104,6 +104,7 @@ export * from "../shared/custom-provider";
 
 // Goal Commands
 export * from "../shared/goals";
+export { loadGoalCoverImage } from "./goals";
 
 // Taxonomy Commands
 export * from "../shared/taxonomies";

--- a/apps/frontend/src/adapters/web/core.ts
+++ b/apps/frontend/src/adapters/web/core.ts
@@ -74,6 +74,8 @@ export const COMMANDS: CommandMap = {
   create_goal: { method: "POST", path: "/goals" },
   update_goal: { method: "PUT", path: "/goals" },
   delete_goal: { method: "DELETE", path: "/goals" },
+  save_goal_cover_image: { method: "POST", path: "/goals" },
+  remove_goal_cover_image: { method: "DELETE", path: "/goals" },
   get_goal_funding: { method: "GET", path: "/goals" },
   save_goal_funding: { method: "PUT", path: "/goals" },
   get_goal_plan: { method: "GET", path: "/goals" },
@@ -763,6 +765,21 @@ export const invoke = async <T>(command: string, payload?: Record<string, unknow
     case "delete_goal": {
       const { goalId } = payload as { goalId: string };
       url += `/${encodeURIComponent(goalId)}`;
+      break;
+    }
+    case "save_goal_cover_image": {
+      const { goalId, contentBase64, fileExtension } = payload as {
+        goalId: string;
+        contentBase64: string;
+        fileExtension: string;
+      };
+      url += `/${encodeURIComponent(goalId)}/cover-image`;
+      body = JSON.stringify({ contentBase64, fileExtension });
+      break;
+    }
+    case "remove_goal_cover_image": {
+      const { goalId } = payload as { goalId: string };
+      url += `/${encodeURIComponent(goalId)}/cover-image`;
       break;
     }
     case "get_goal_funding": {

--- a/apps/frontend/src/adapters/web/goals.ts
+++ b/apps/frontend/src/adapters/web/goals.ts
@@ -1,0 +1,26 @@
+// Web adapter - Goal Commands (platform-specific)
+import { API_PREFIX } from "./core";
+import { notifyUnauthorized } from "@/lib/auth-token";
+
+export const loadGoalCoverImage = async (goalId: string): Promise<Blob> => {
+  const response = await fetch(`${API_PREFIX}/goals/${encodeURIComponent(goalId)}/cover-image`, {
+    credentials: "same-origin",
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (response.status === 401) {
+    notifyUnauthorized();
+  }
+  if (!response.ok) {
+    let message = response.statusText || "Failed to load goal cover image";
+    try {
+      const body = (await response.json()) as { message?: unknown };
+      if (typeof body.message === "string") {
+        message = body.message;
+      }
+    } catch {
+      // Keep the HTTP status text for non-JSON errors.
+    }
+    throw new Error(message);
+  }
+  return response.blob();
+};

--- a/apps/frontend/src/adapters/web/index.ts
+++ b/apps/frontend/src/adapters/web/index.ts
@@ -135,10 +135,13 @@ export {
   previewSaveUpOverview,
   refreshAllGoalSummaries,
   refreshGoalSummary,
+  removeGoalCoverImage,
   saveGoalFunding,
   saveGoalPlan,
+  setGoalCoverImage,
   updateGoal,
 } from "../shared/goals";
+export { loadGoalCoverImage } from "./goals";
 
 // Secrets Commands
 export {

--- a/apps/frontend/src/features/goals/components/cover-image-field.tsx
+++ b/apps/frontend/src/features/goals/components/cover-image-field.tsx
@@ -1,0 +1,253 @@
+import {
+  bakeCroppedCoverImage,
+  COVER_IMAGE_ASPECT_PRESETS,
+  useGoalCoverImageSrc,
+} from "@/features/goals/lib/cover-image";
+import { useGoalMutations } from "@/features/goals/hooks/use-goals";
+import type { Goal, GoalType } from "@/lib/types";
+import { Button, Label } from "@wealthfolio/ui";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@wealthfolio/ui/components/ui/dialog";
+import { Icons } from "@wealthfolio/ui/components/ui/icons";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@wealthfolio/ui/components/ui/select";
+import { useRef, useState } from "react";
+import Cropper, { type Area, type Point } from "react-easy-crop";
+import "react-easy-crop/react-easy-crop.css";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+
+type CoverImageFieldProps =
+  | { mode: "edit"; goal: Goal }
+  | {
+      mode: "staged";
+      value: string | null;
+      onStagedChange: (base64: string | null) => void;
+      goalType: GoalType;
+    };
+
+// Zoom can go below 1x (image smaller than the crop frame) so the whole
+// motif can be kept in frame, with the uncovered margins baked transparent
+// (see restrictPosition={false} below and bakeCroppedCoverImage).
+const COVER_IMAGE_ZOOM_MIN = 0.25;
+const COVER_IMAGE_ZOOM_MAX = 3;
+
+export function CoverImageField(props: CoverImageFieldProps) {
+  const { t } = useTranslation();
+  const { setCoverImageMutation, removeCoverImageMutation } = useGoalMutations();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [pickedImageSrc, setPickedImageSrc] = useState<string | null>(null);
+  const [presetIndex, setPresetIndex] = useState(0);
+  const [crop, setCrop] = useState<Point>({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
+  const [isBaking, setIsBaking] = useState(false);
+
+  // Hooks must run unconditionally: in "staged" mode there's no real Goal
+  // yet, so build a minimal stand-in that resolves to the static fallback
+  // image (coverImagePath is always undefined for it).
+  const pseudoGoal =
+    props.mode === "edit"
+      ? props.goal
+      : { id: "", goalType: props.goalType, coverImagePath: undefined, updatedAt: "" };
+  const resolvedSrc = useGoalCoverImageSrc(pseudoGoal);
+
+  const hasCustomImage =
+    props.mode === "edit" ? Boolean(props.goal.coverImagePath) : Boolean(props.value);
+  const displaySrc =
+    props.mode === "staged" && props.value ? `data:image/png;base64,${props.value}` : resolvedSrc;
+
+  const preset = COVER_IMAGE_ASPECT_PRESETS[presetIndex];
+
+  const openCropper = (file: File) => {
+    setPickedImageSrc(URL.createObjectURL(file));
+    setPresetIndex(0);
+    setCrop({ x: 0, y: 0 });
+    setZoom(1);
+    setCroppedAreaPixels(null);
+  };
+
+  const closeCropper = () => {
+    if (pickedImageSrc) URL.revokeObjectURL(pickedImageSrc);
+    setPickedImageSrc(null);
+  };
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = "";
+    if (file) openCropper(file);
+  };
+
+  const handleCropSave = async () => {
+    if (!pickedImageSrc || !croppedAreaPixels) return;
+    setIsBaking(true);
+    try {
+      const { base64 } = await bakeCroppedCoverImage(pickedImageSrc, croppedAreaPixels, preset);
+      if (props.mode === "edit") {
+        setCoverImageMutation.mutate({
+          goalId: props.goal.id,
+          contentBase64: base64,
+          fileExtension: "png",
+        });
+      } else {
+        props.onStagedChange(base64);
+      }
+      closeCropper();
+    } catch {
+      toast.error(t("goals:cover_image.resize_failed"));
+    } finally {
+      setIsBaking(false);
+    }
+  };
+
+  const handleRemove = () => {
+    if (props.mode === "edit") {
+      removeCoverImageMutation.mutate(props.goal.id);
+    } else {
+      props.onStagedChange(null);
+    }
+  };
+
+  const isBusy =
+    props.mode === "edit"
+      ? setCoverImageMutation.isPending || removeCoverImageMutation.isPending
+      : false;
+
+  return (
+    <div className="space-y-2">
+      <Label>{t("goals:cover_image.label")}</Label>
+      <div className="group relative h-32 w-full overflow-hidden rounded-xl border">
+        <img src={displaySrc} alt="" className="h-full w-full object-cover" />
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={isBusy}
+          className="absolute inset-0 flex items-center justify-center bg-black/0 text-white opacity-0 transition-opacity disabled:cursor-not-allowed group-hover:bg-black/40 group-hover:opacity-100"
+        >
+          {isBusy ? (
+            <Icons.Spinner className="h-5 w-5 animate-spin" />
+          ) : (
+            <span className="flex flex-col items-center gap-1 text-xs font-medium">
+              <Icons.Import className="h-5 w-5" />
+              {t(hasCustomImage ? "goals:cover_image.change" : "goals:cover_image.upload")}
+            </span>
+          )}
+        </button>
+        {hasCustomImage && (
+          <Button
+            type="button"
+            size="icon-xs"
+            variant="destructive"
+            className="absolute right-2 top-2"
+            onClick={handleRemove}
+            disabled={isBusy}
+          >
+            <Icons.Trash className="h-3.5 w-3.5" />
+          </Button>
+        )}
+      </div>
+      <input
+        type="file"
+        ref={fileInputRef}
+        accept="image/png,image/jpeg,image/webp"
+        className="hidden"
+        onChange={handleFileChange}
+      />
+
+      <Dialog open={pickedImageSrc !== null} onOpenChange={(open) => !open && closeCropper()}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{t("goals:cover_image.crop_title")}</DialogTitle>
+          </DialogHeader>
+
+          {pickedImageSrc && (
+            <div className="space-y-4">
+              <div
+                className="relative h-64 w-full overflow-hidden rounded-lg"
+                style={{
+                  // Checkerboard so zoomed-out margins read as "transparent",
+                  // matching what actually gets baked into the PNG.
+                  backgroundImage:
+                    "conic-gradient(#80808033 25%, transparent 0 50%, #80808033 0 75%, transparent 0)",
+                  backgroundSize: "16px 16px",
+                }}
+              >
+                <Cropper
+                  image={pickedImageSrc}
+                  crop={crop}
+                  zoom={zoom}
+                  aspect={preset.ratio}
+                  minZoom={COVER_IMAGE_ZOOM_MIN}
+                  maxZoom={COVER_IMAGE_ZOOM_MAX}
+                  restrictPosition={false}
+                  onCropChange={setCrop}
+                  onZoomChange={setZoom}
+                  onCropComplete={(_area, pixels) => setCroppedAreaPixels(pixels)}
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="cover-image-aspect">{t("goals:cover_image.aspect_label")}</Label>
+                <Select
+                  value={preset.id}
+                  onValueChange={(id) =>
+                    setPresetIndex(COVER_IMAGE_ASPECT_PRESETS.findIndex((p) => p.id === id))
+                  }
+                >
+                  <SelectTrigger id="cover-image-aspect">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {COVER_IMAGE_ASPECT_PRESETS.map((p) => (
+                      <SelectItem key={p.id} value={p.id}>
+                        {t(p.labelKey)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="cover-image-zoom">{t("goals:cover_image.zoom_label")}</Label>
+                <input
+                  id="cover-image-zoom"
+                  type="range"
+                  min={COVER_IMAGE_ZOOM_MIN}
+                  max={COVER_IMAGE_ZOOM_MAX}
+                  step={0.01}
+                  value={zoom}
+                  onChange={(event) => setZoom(Number(event.target.value))}
+                  className="w-full"
+                />
+              </div>
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={closeCropper}>
+              {t("goals:cover_image.cancel")}
+            </Button>
+            <Button
+              type="button"
+              onClick={handleCropSave}
+              disabled={isBaking || !croppedAreaPixels}
+            >
+              {isBaking ? t("goals:cover_image.saving") : t("goals:cover_image.save")}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/frontend/src/features/goals/components/goal-card.tsx
+++ b/apps/frontend/src/features/goals/components/goal-card.tsx
@@ -1,3 +1,4 @@
+import { useGoalCoverImageSrc } from "@/features/goals/lib/cover-image";
 import { useBalancePrivacy } from "@/hooks/use-balance-privacy";
 import { useSettingsContext } from "@/lib/settings-provider";
 import type { Goal } from "@/lib/types";
@@ -24,10 +25,6 @@ function defaultQuote(goalType: string, t: TFn): string {
     custom_save_up: t("goals:card.quote_custom_save_up"),
   };
   return quotes[goalType] ?? "";
-}
-
-function coverImageSrc(goalType: string): string {
-  return `/goals/${goalType}.png`;
 }
 
 function formatTimeLeft(t: TFn, targetDate?: string): string {
@@ -89,7 +86,7 @@ export function GoalCard({ goal }: { goal: Goal }) {
   const progress = goal.summaryProgress ?? 0;
   const rawQuote = goal.description?.trim() || defaultQuote(goal.goalType, t) || "";
   const quote = rawQuote.length > 58 ? `${rawQuote.slice(0, 55).trimEnd()}…` : rawQuote;
-  const coverImage = coverImageSrc(goal.coverImageKey ?? goal.goalType);
+  const coverImage = useGoalCoverImageSrc(goal);
 
   const isOnTrack = goal.statusHealth === "on_track";
   const isAtRisk = goal.statusHealth === "at_risk";
@@ -163,7 +160,7 @@ export function GoalCard({ goal }: { goal: Goal }) {
             src={coverImage}
             alt=""
             className="h-full w-full object-cover transition-all duration-500 group-hover:scale-[1.06] dark:brightness-[0.78] dark:contrast-[1.08] dark:saturate-[0.9]"
-            style={{ objectPosition: "70% 50%" }}
+            style={{ objectPosition: goal.coverImagePath ? "50% 50%" : "70% 50%" }}
             onError={(e) => {
               e.currentTarget.style.display = "none";
             }}

--- a/apps/frontend/src/features/goals/components/goal-edit-dialog.tsx
+++ b/apps/frontend/src/features/goals/components/goal-edit-dialog.tsx
@@ -1,3 +1,4 @@
+import { CoverImageField } from "@/features/goals/components/cover-image-field";
 import type { Goal } from "@/lib/types";
 import { cn } from "@/lib/utils";
 import { Button, Input, Label } from "@wealthfolio/ui";
@@ -132,6 +133,8 @@ export function GoalEditDialog({ goal, open, onClose }: Props) {
                 <Badge variant="secondary">{goalTypeLabels[goal.goalType]}</Badge>
               </div>
             </div>
+
+            {goal.goalType === "custom_save_up" && <CoverImageField mode="edit" goal={goal} />}
 
             <div className="space-y-2">
               <Label htmlFor="goal-title">{t("goals:edit.title_label")}</Label>

--- a/apps/frontend/src/features/goals/hooks/use-goals.ts
+++ b/apps/frontend/src/features/goals/hooks/use-goals.ts
@@ -1,4 +1,11 @@
-import { createGoal, deleteGoal, getGoals, updateGoal } from "@/adapters";
+import {
+  createGoal,
+  deleteGoal,
+  getGoals,
+  removeGoalCoverImage,
+  setGoalCoverImage,
+  updateGoal,
+} from "@/adapters";
 import { QueryKeys } from "@/lib/query-keys";
 import type { Goal, NewGoal } from "@/lib/types";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -66,5 +73,39 @@ export function useGoalMutations() {
     onError: () => toast.error("Failed to delete goal."),
   });
 
-  return { createMutation, updateMutation, deleteMutation };
+  const setCoverImageMutation = useMutation({
+    mutationFn: ({
+      goalId,
+      contentBase64,
+      fileExtension,
+    }: {
+      goalId: string;
+      contentBase64: string;
+      fileExtension: string;
+    }) => setGoalCoverImage(goalId, contentBase64, fileExtension),
+    onSuccess: (_, { goalId }) => {
+      invalidate();
+      queryClient.invalidateQueries({ queryKey: QueryKeys.goal(goalId) });
+      toast.success("Cover image updated.");
+    },
+    onError: () => toast.error("Failed to update cover image."),
+  });
+
+  const removeCoverImageMutation = useMutation({
+    mutationFn: (goalId: string) => removeGoalCoverImage(goalId),
+    onSuccess: (_, goalId) => {
+      invalidate();
+      queryClient.invalidateQueries({ queryKey: QueryKeys.goal(goalId) });
+      toast.success("Cover image removed.");
+    },
+    onError: () => toast.error("Failed to remove cover image."),
+  });
+
+  return {
+    createMutation,
+    updateMutation,
+    deleteMutation,
+    setCoverImageMutation,
+    removeCoverImageMutation,
+  };
 }

--- a/apps/frontend/src/features/goals/lib/cover-image.ts
+++ b/apps/frontend/src/features/goals/lib/cover-image.ts
@@ -1,0 +1,168 @@
+import { loadGoalCoverImage } from "@/adapters";
+import type { Goal } from "@/lib/types";
+import type { Area } from "react-easy-crop";
+import { useEffect, useState } from "react";
+
+/** Cover image by convention: /goals/{goalType}.png */
+function staticCoverImageSrc(goalType: string): string {
+  return `/goals/${goalType}.png`;
+}
+
+const MIME_BY_EXTENSION: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  webp: "image/webp",
+};
+
+function mimeTypeForPath(path: string): string {
+  const extension = path.split(".").pop()?.toLowerCase() ?? "";
+  return MIME_BY_EXTENSION[extension] ?? "application/octet-stream";
+}
+
+export interface CoverImageAspectPreset {
+  id: "card" | "wide" | "tall";
+  labelKey: string;
+  /** width / height */
+  ratio: number;
+  outputWidth: number;
+  outputHeight: number;
+}
+
+/**
+ * Crop aspect ratios offered in the cover-image cropper. The goal card is
+ * the only place this image renders today (`goal-card.tsx`, `h-[156px]`,
+ * `object-cover`), but its width is responsive (1/2/3 grid columns), so no
+ * single ratio is pixel-perfect everywhere — "Card" is tuned for the common
+ * 2-3 column desktop width; "Wide"/"Tall" are offered as alternate framings.
+ */
+export const COVER_IMAGE_ASPECT_PRESETS: CoverImageAspectPreset[] = [
+  {
+    id: "card",
+    labelKey: "goals:cover_image.aspect_card",
+    ratio: 2.35,
+    outputWidth: 940,
+    outputHeight: 400,
+  },
+  {
+    id: "wide",
+    labelKey: "goals:cover_image.aspect_wide",
+    ratio: 3,
+    outputWidth: 960,
+    outputHeight: 320,
+  },
+  {
+    id: "tall",
+    labelKey: "goals:cover_image.aspect_tall",
+    ratio: 16 / 9,
+    outputWidth: 960,
+    outputHeight: 540,
+  },
+];
+
+/**
+ * Draws the cropped region (in source-image pixel coordinates, as reported
+ * by react-easy-crop's `onCropComplete`) onto a canvas at the preset's fixed
+ * output dimensions and re-encodes as PNG, returning a base64 payload ready
+ * for `setGoalCoverImage`. What the cropper previews is exactly what gets
+ * baked — no separate resize step.
+ *
+ * The crop window can extend beyond the image's natural bounds (the user
+ * zoomed out below 1x to fit the whole motif in frame instead of cropping
+ * it): the source read is clamped to the image and placed at the matching
+ * scaled position in the output, so uncovered margins stay transparent
+ * (PNG, not JPEG, to preserve that) rather than being stretched or filled.
+ */
+export async function bakeCroppedCoverImage(
+  imageSrc: string,
+  croppedAreaPixels: Area,
+  preset: CoverImageAspectPreset,
+): Promise<{ base64: string }> {
+  const image = new Image();
+  image.src = imageSrc;
+  await new Promise<void>((resolve, reject) => {
+    image.onload = () => resolve();
+    image.onerror = () => reject(new Error("Failed to load image for cropping."));
+  });
+
+  const canvas = document.createElement("canvas");
+  canvas.width = preset.outputWidth;
+  canvas.height = preset.outputHeight;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    throw new Error("Failed to get canvas context for image crop.");
+  }
+
+  const scaleX = preset.outputWidth / croppedAreaPixels.width;
+  const scaleY = preset.outputHeight / croppedAreaPixels.height;
+  const srcX = Math.max(0, croppedAreaPixels.x);
+  const srcY = Math.max(0, croppedAreaPixels.y);
+  const srcRight = Math.min(image.naturalWidth, croppedAreaPixels.x + croppedAreaPixels.width);
+  const srcBottom = Math.min(image.naturalHeight, croppedAreaPixels.y + croppedAreaPixels.height);
+  const srcWidth = srcRight - srcX;
+  const srcHeight = srcBottom - srcY;
+
+  if (srcWidth > 0 && srcHeight > 0) {
+    ctx.drawImage(
+      image,
+      srcX,
+      srcY,
+      srcWidth,
+      srcHeight,
+      (srcX - croppedAreaPixels.x) * scaleX,
+      (srcY - croppedAreaPixels.y) * scaleY,
+      srcWidth * scaleX,
+      srcHeight * scaleY,
+    );
+  }
+
+  const dataUrl = canvas.toDataURL("image/png");
+  const base64 = dataUrl.split(",")[1] ?? "";
+  return { base64 };
+}
+
+/**
+ * Resolves the `<img>` src for a goal card: the user's custom cover image if
+ * set (loaded asynchronously as a blob URL), otherwise the static
+ * per-goal-type stock image.
+ */
+export function useGoalCoverImageSrc(
+  goal: Pick<Goal, "id" | "goalType" | "coverImagePath" | "updatedAt">,
+) {
+  const { coverImagePath, updatedAt } = goal;
+  const [customUrl, setCustomUrl] = useState<string>();
+
+  useEffect(() => {
+    if (!coverImagePath) {
+      setCustomUrl(undefined);
+      return;
+    }
+
+    let cancelled = false;
+    let objectUrl: string | undefined;
+    setCustomUrl(undefined);
+
+    void (async () => {
+      try {
+        const blob = await loadGoalCoverImage(goal.id, mimeTypeForPath(coverImagePath));
+        if (cancelled) return;
+        objectUrl = URL.createObjectURL(blob);
+        setCustomUrl(objectUrl);
+      } catch {
+        // Fall back to the static stock image below.
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      if (objectUrl) {
+        URL.revokeObjectURL(objectUrl);
+      }
+    };
+    // `updatedAt` is included so replacing an image (same filename, since we
+    // always write `{goalId}.png`) still triggers a re-fetch — otherwise the
+    // blob URL from the previous upload would keep showing stale bytes.
+  }, [goal.id, coverImagePath, updatedAt]);
+
+  return customUrl ?? staticCoverImageSrc(goal.goalType);
+}

--- a/apps/frontend/src/features/goals/pages/goal-new-page.tsx
+++ b/apps/frontend/src/features/goals/pages/goal-new-page.tsx
@@ -1,3 +1,4 @@
+import { CoverImageField } from "@/features/goals/components/cover-image-field";
 import type { Goal, GoalType, PlannerMode } from "@/lib/types";
 import { useSettingsContext } from "@/lib/settings-provider";
 import { formatDateISO } from "@/lib/utils";
@@ -24,7 +25,7 @@ import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate } from "react-router-dom";
 import { useCreateGoalFlow } from "../hooks/use-create-goal-flow";
-import { useGoals } from "../hooks/use-goals";
+import { useGoalMutations, useGoals } from "../hooks/use-goals";
 import { toast } from "sonner";
 import {
   DEFAULT_RETIREMENT_PLAN,
@@ -63,6 +64,7 @@ export default function GoalNewPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const createGoalFlow = useCreateGoalFlow();
+  const { setCoverImageMutation } = useGoalMutations();
   const { goals } = useGoals();
   const { settings } = useSettingsContext();
   const [selectedType, setSelectedType] = useState<GoalType | null>(null);
@@ -77,6 +79,8 @@ export default function GoalNewPage() {
   const [retirementTargetAge, setRetirementTargetAge] = useState(
     DEFAULT_TRADITIONAL_RETIREMENT_AGE,
   );
+  const [stagedCoverImage, setStagedCoverImage] = useState<string | null>(null);
+  const [isUploadingCoverImage, setIsUploadingCoverImage] = useState(false);
 
   const goalTemplates = useMemo<GoalTemplate[]>(
     () => [
@@ -211,7 +215,22 @@ export default function GoalNewPage() {
         initialPlan,
       },
       {
-        onSuccess: ({ goal }) => {
+        onSuccess: async ({ goal }) => {
+          if (stagedCoverImage) {
+            setIsUploadingCoverImage(true);
+            try {
+              await setCoverImageMutation.mutateAsync({
+                goalId: goal.id,
+                contentBase64: stagedCoverImage,
+                fileExtension: "png",
+              });
+            } catch {
+              // setCoverImageMutation's own onError already toasts; the goal
+              // itself was created successfully either way.
+            } finally {
+              setIsUploadingCoverImage(false);
+            }
+          }
           navigate(`/goals/${goal.id}`);
         },
       },
@@ -314,6 +333,17 @@ export default function GoalNewPage() {
                       rows={3}
                     />
                   </div>
+
+                  {selectedType === "custom_save_up" && (
+                    <div className="sm:col-span-2">
+                      <CoverImageField
+                        mode="staged"
+                        value={stagedCoverImage}
+                        onStagedChange={setStagedCoverImage}
+                        goalType="custom_save_up"
+                      />
+                    </div>
+                  )}
 
                   {template?.requiresPlannerMode && (
                     <div className="border-border/60 space-y-3 border-t pt-4 sm:col-span-2">
@@ -447,6 +477,7 @@ export default function GoalNewPage() {
                   setPlannerMode("traditional");
                   setRetirementBirthYearMonth(DEFAULT_RETIREMENT_BIRTH_YEAR_MONTH);
                   setRetirementTargetAge(DEFAULT_TRADITIONAL_RETIREMENT_AGE);
+                  setStagedCoverImage(null);
                 }}
               >
                 {t("common:back")}
@@ -454,9 +485,11 @@ export default function GoalNewPage() {
               <Button
                 className="flex-1"
                 onClick={handleCreate}
-                disabled={createGoalFlow.isPending || !trimmedTitle}
+                disabled={createGoalFlow.isPending || isUploadingCoverImage || !trimmedTitle}
               >
-                {createGoalFlow.isPending ? t("goals:new.creating") : t("goals:new.create_goal")}
+                {createGoalFlow.isPending || isUploadingCoverImage
+                  ? t("goals:new.creating")
+                  : t("goals:new.create_goal")}
               </Button>
             </div>
           </div>

--- a/apps/frontend/src/i18n/locales/en/goals.json
+++ b/apps/frontend/src/i18n/locales/en/goals.json
@@ -410,6 +410,21 @@
     "saving": "Saving...",
     "save_changes": "Save changes"
   },
+  "cover_image": {
+    "label": "Cover image",
+    "upload": "Upload image",
+    "change": "Change image",
+    "crop_title": "Adjust cover image",
+    "aspect_label": "Dimensions",
+    "aspect_card": "Card (recommended)",
+    "aspect_wide": "Wide",
+    "aspect_tall": "Tall",
+    "zoom_label": "Zoom",
+    "cancel": "Cancel",
+    "save": "Save",
+    "saving": "Saving...",
+    "resize_failed": "Failed to process that image. Please try a different file."
+  },
   "new": {
     "create_goal": "Create Goal",
     "subtitle": "Choose what you want to plan for",

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -888,6 +888,8 @@ export interface Goal {
   statusHealth: GoalHealth;
   priority: number;
   coverImageKey?: string;
+  /** Filename of a user-uploaded custom cover image (custom_save_up goals only). */
+  coverImagePath?: string;
   currency?: string;
   startDate?: string;
   targetDate?: string;

--- a/apps/server/src/api/goals.rs
+++ b/apps/server/src/api/goals.rs
@@ -6,11 +6,14 @@ use crate::{
     main_lib::AppState,
 };
 use axum::{
+    body::Body,
     extract::{Path, State},
-    http::StatusCode,
+    http::{header, StatusCode},
+    response::Response,
     routing::{get, post},
     Json, Router,
 };
+use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use rust_decimal::prelude::ToPrimitive;
 use serde::Deserialize;
 use wealthfolio_core::{
@@ -64,8 +67,113 @@ async fn delete_goal(
     Path(id): Path<String>,
     State(state): State<Arc<AppState>>,
 ) -> ApiResult<StatusCode> {
+    remove_goal_cover_image_files(&state, &id)?;
     let _ = state.goal_service.delete_goal(id).await?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+const ALLOWED_GOAL_IMAGE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "webp"];
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SetGoalCoverImageBody {
+    content_base64: String,
+    file_extension: String,
+}
+
+fn goal_images_dir(state: &AppState) -> std::path::PathBuf {
+    std::path::Path::new(&state.data_root).join("goal-images")
+}
+
+/// Removes any existing cover image file for a goal, regardless of extension
+/// (a prior upload may have used a different format).
+fn remove_goal_cover_image_files(state: &AppState, goal_id: &str) -> ApiResult<()> {
+    let dir = goal_images_dir(state);
+    for extension in ALLOWED_GOAL_IMAGE_EXTENSIONS {
+        let path = dir.join(format!("{}.{}", goal_id, extension));
+        if path.exists() {
+            std::fs::remove_file(&path).map_err(|e| {
+                ApiError::Internal(format!("Failed to remove {}: {}", path.display(), e))
+            })?;
+        }
+    }
+    Ok(())
+}
+
+async fn set_goal_cover_image(
+    Path(id): Path<String>,
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<SetGoalCoverImageBody>,
+) -> ApiResult<Json<Goal>> {
+    let extension = body.file_extension.to_ascii_lowercase();
+    if !ALLOWED_GOAL_IMAGE_EXTENSIONS.contains(&extension.as_str()) {
+        return Err(ApiError::BadRequest(format!(
+            "Unsupported image format: {}",
+            body.file_extension
+        )));
+    }
+    let content = BASE64
+        .decode(&body.content_base64)
+        .map_err(|e| ApiError::BadRequest(format!("Failed to decode cover image: {}", e)))?;
+
+    let dir = goal_images_dir(&state);
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| ApiError::Internal(format!("Failed to create {}: {}", dir.display(), e)))?;
+    remove_goal_cover_image_files(&state, &id)?;
+
+    let filename = format!("{}.{}", id, extension);
+    let path = dir.join(&filename);
+    std::fs::write(&path, content)
+        .map_err(|e| ApiError::Internal(format!("Failed to write {}: {}", path.display(), e)))?;
+
+    let mut goal = state.goal_service.get_goal(&id)?;
+    goal.cover_image_path = Some(filename);
+    let g = state.goal_service.update_goal(goal).await?;
+    Ok(Json(g))
+}
+
+async fn remove_goal_cover_image(
+    Path(id): Path<String>,
+    State(state): State<Arc<AppState>>,
+) -> ApiResult<Json<Goal>> {
+    remove_goal_cover_image_files(&state, &id)?;
+    let mut goal = state.goal_service.get_goal(&id)?;
+    goal.cover_image_path = None;
+    let g = state.goal_service.update_goal(goal).await?;
+    Ok(Json(g))
+}
+
+async fn get_goal_cover_image(
+    Path(id): Path<String>,
+    State(state): State<Arc<AppState>>,
+) -> ApiResult<Response> {
+    let goal = state.goal_service.get_goal(&id)?;
+    let filename = goal.cover_image_path.ok_or(ApiError::NotFound)?;
+    let path = goal_images_dir(&state).join(&filename);
+    let content_type = match std::path::Path::new(&filename)
+        .extension()
+        .and_then(|e| e.to_str())
+    {
+        Some("png") => "image/png",
+        Some("jpg") | Some("jpeg") => "image/jpeg",
+        Some("webp") => "image/webp",
+        _ => "application/octet-stream",
+    };
+
+    let bytes = tokio::task::spawn_blocking(move || std::fs::read(&path))
+        .await
+        .map_err(|e| ApiError::Internal(format!("Cover image read task failed: {e}")))?
+        .map_err(|_| ApiError::NotFound)?;
+
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, content_type)
+        .header(
+            header::CACHE_CONTROL,
+            "private, max-age=31536000, immutable",
+        )
+        .body(Body::from(bytes))
+        .map_err(|e| ApiError::Internal(format!("Failed to build cover image response: {e}")))
 }
 
 async fn get_goal_funding(
@@ -483,6 +591,12 @@ pub fn router() -> Router<Arc<AppState>> {
     Router::new()
         .route("/goals", get(get_goals).post(create_goal).put(update_goal))
         .route("/goals/{id}", get(get_goal).delete(delete_goal))
+        .route(
+            "/goals/{id}/cover-image",
+            get(get_goal_cover_image)
+                .post(set_goal_cover_image)
+                .delete(remove_goal_cover_image),
+        )
         .route(
             "/goals/{id}/funding",
             get(get_goal_funding).put(save_goal_funding),

--- a/apps/tauri/src/commands/goal.rs
+++ b/apps/tauri/src/commands/goal.rs
@@ -1,9 +1,11 @@
+use std::fs;
+use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::context::ServiceContext;
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use log::{debug, warn};
 use rust_decimal::prelude::ToPrimitive;
-use tauri::State;
+use tauri::{AppHandle, Manager, State};
 use wealthfolio_core::goals::{
     Goal, GoalFundingRule, GoalFundingRuleInput, GoalPlan, NewGoal, SaveGoalPlan,
 };
@@ -13,6 +15,8 @@ use wealthfolio_core::planning::{
 use wealthfolio_core::portfolio::fire::RetirementOverview;
 use wealthfolio_core::portfolio::valuation::CurrentAccountValuationService;
 use wealthfolio_core::utils::time_utils::{parse_user_timezone_or_default, user_today};
+
+use crate::context::ServiceContext;
 
 #[tauri::command]
 pub async fn get_goals(state: State<'_, Arc<ServiceContext>>) -> Result<Vec<Goal>, String> {
@@ -62,13 +66,120 @@ pub async fn update_goal(
 
 #[tauri::command]
 pub async fn delete_goal(
+    app_handle: AppHandle,
     goal_id: String,
     state: State<'_, Arc<ServiceContext>>,
 ) -> Result<usize, String> {
     debug!("Deleting goal...");
+    remove_goal_cover_image_files(&app_handle, &goal_id)?;
     state
         .goal_service()
         .delete_goal(goal_id)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+const GOAL_IMAGES_DIR: &str = "goal-images";
+const ALLOWED_GOAL_IMAGE_EXTENSIONS: &[&str] = &["png", "jpg", "jpeg", "webp"];
+
+fn goal_images_dir(app_handle: &AppHandle) -> Result<PathBuf, String> {
+    let app_data_dir_path = app_handle
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("Failed to get app data dir: {}", e))?;
+    Ok(app_data_dir_path.join(GOAL_IMAGES_DIR))
+}
+
+/// Removes any existing cover image file for a goal, regardless of extension
+/// (a prior upload may have used a different format).
+fn remove_goal_cover_image_files(app_handle: &AppHandle, goal_id: &str) -> Result<(), String> {
+    let dir = goal_images_dir(app_handle)?;
+    for extension in ALLOWED_GOAL_IMAGE_EXTENSIONS {
+        let path = dir.join(format!("{}.{}", goal_id, extension));
+        if path.exists() {
+            fs::remove_file(&path)
+                .map_err(|e| format!("Failed to remove {}: {}", path.display(), e))?;
+        }
+    }
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn save_goal_cover_image(
+    app_handle: AppHandle,
+    goal_id: String,
+    content_base64: String,
+    file_extension: String,
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<Goal, String> {
+    debug!("Saving cover image for goal {}...", goal_id);
+    let extension = file_extension.to_ascii_lowercase();
+    if !ALLOWED_GOAL_IMAGE_EXTENSIONS.contains(&extension.as_str()) {
+        return Err(format!("Unsupported image format: {}", file_extension));
+    }
+
+    let content = BASE64_STANDARD
+        .decode(content_base64)
+        .map_err(|e| format!("Failed to decode cover image: {}", e))?;
+
+    let dir = goal_images_dir(&app_handle)?;
+    fs::create_dir_all(&dir).map_err(|e| format!("Failed to create {}: {}", dir.display(), e))?;
+    remove_goal_cover_image_files(&app_handle, &goal_id)?;
+
+    let filename = format!("{}.{}", goal_id, extension);
+    let path = dir.join(&filename);
+    fs::write(&path, content).map_err(|e| format!("Failed to write {}: {}", path.display(), e))?;
+
+    let mut goal = state
+        .goal_service()
+        .get_goal(&goal_id)
+        .map_err(|e| e.to_string())?;
+    goal.cover_image_path = Some(filename);
+    state
+        .goal_service()
+        .update_goal(goal)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn load_goal_cover_image(
+    app_handle: AppHandle,
+    goal_id: String,
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<tauri::ipc::Response, String> {
+    let goal = state
+        .goal_service()
+        .get_goal(&goal_id)
+        .map_err(|e| e.to_string())?;
+    let filename = goal
+        .cover_image_path
+        .ok_or_else(|| "Goal has no cover image".to_string())?;
+    let path = goal_images_dir(&app_handle)?.join(filename);
+    let bytes = tokio::task::spawn_blocking(move || fs::read(&path))
+        .await
+        .map_err(|e| format!("Cover image read task failed: {}", e))?
+        .map_err(|e| format!("Failed to read cover image: {}", e))?;
+    Ok(tauri::ipc::Response::new(bytes))
+}
+
+#[tauri::command]
+pub async fn remove_goal_cover_image(
+    app_handle: AppHandle,
+    goal_id: String,
+    state: State<'_, Arc<ServiceContext>>,
+) -> Result<Goal, String> {
+    debug!("Removing cover image for goal {}...", goal_id);
+    remove_goal_cover_image_files(&app_handle, &goal_id)?;
+
+    let mut goal = state
+        .goal_service()
+        .get_goal(&goal_id)
+        .map_err(|e| e.to_string())?;
+    goal.cover_image_path = None;
+    state
+        .goal_service()
+        .update_goal(goal)
         .await
         .map_err(|e| e.to_string())
 }

--- a/apps/tauri/src/lib.rs
+++ b/apps/tauri/src/lib.rs
@@ -511,6 +511,9 @@ pub fn run() {
             commands::goal::get_retirement_overview,
             commands::goal::get_save_up_overview,
             commands::goal::preview_save_up_overview,
+            commands::goal::save_goal_cover_image,
+            commands::goal::load_goal_cover_image,
+            commands::goal::remove_goal_cover_image,
             // Portfolios (saved reporting scopes)
             commands::portfolios::get_portfolios,
             commands::portfolios::get_portfolio,

--- a/crates/core/src/goals/goals_model.rs
+++ b/crates/core/src/goals/goals_model.rs
@@ -27,6 +27,10 @@ pub struct Goal {
     pub created_at: String,
     pub updated_at: String,
     pub summary_target_amount: Option<f64>,
+    /// Path to a user-uploaded custom cover image file (custom_save_up goals
+    /// only). Set/cleared via dedicated cover-image commands, not the
+    /// regular goal edit form.
+    pub cover_image_path: Option<String>,
 }
 
 /// Input model for creating a new goal

--- a/crates/core/src/goals/goals_service.rs
+++ b/crates/core/src/goals/goals_service.rs
@@ -949,6 +949,7 @@ mod tests {
             created_at: String::new(),
             updated_at: String::new(),
             summary_target_amount: None,
+            cover_image_path: None,
         }
     }
 
@@ -1023,6 +1024,7 @@ mod tests {
             created_at: String::new(),
             updated_at: String::new(),
             summary_target_amount: None,
+            cover_image_path: None,
         }
     }
 
@@ -1094,6 +1096,7 @@ mod tests {
                 created_at: new_goal.created_at.unwrap_or_default(),
                 updated_at: new_goal.updated_at.unwrap_or_default(),
                 summary_target_amount: None,
+                cover_image_path: None,
             };
             self.goals
                 .lock()

--- a/crates/storage-sqlite/migrations/2026-08-22-000001_goal_cover_image_path/down.sql
+++ b/crates/storage-sqlite/migrations/2026-08-22-000001_goal_cover_image_path/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE goals DROP COLUMN cover_image_path;

--- a/crates/storage-sqlite/migrations/2026-08-22-000001_goal_cover_image_path/up.sql
+++ b/crates/storage-sqlite/migrations/2026-08-22-000001_goal_cover_image_path/up.sql
@@ -1,0 +1,5 @@
+-- Path to a user-uploaded custom cover image file for a goal (custom_save_up
+-- goals only, set/cleared via dedicated cover-image commands, not part of
+-- the regular goal edit form). NULL = no custom image, falls back to the
+-- static per-goal-type stock image.
+ALTER TABLE goals ADD COLUMN cover_image_path TEXT;

--- a/crates/storage-sqlite/src/goals/model.rs
+++ b/crates/storage-sqlite/src/goals/model.rs
@@ -40,6 +40,7 @@ pub struct GoalDB {
     pub created_at: String,
     pub updated_at: String,
     pub summary_target_amount: Option<f64>,
+    pub cover_image_path: Option<String>,
 }
 
 /// Database model for creating a new goal
@@ -192,6 +193,7 @@ impl From<GoalDB> for wealthfolio_core::goals::Goal {
             created_at: db.created_at,
             updated_at: db.updated_at,
             summary_target_amount: db.summary_target_amount,
+            cover_image_path: db.cover_image_path,
         }
     }
 }

--- a/crates/storage-sqlite/src/goals/repository.rs
+++ b/crates/storage-sqlite/src/goals/repository.rs
@@ -206,6 +206,7 @@ impl GoalRepositoryTrait for GoalRepository {
             created_at: goal_update.created_at,
             updated_at: chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string(),
             summary_target_amount: goal_update.summary_target_amount,
+            cover_image_path: goal_update.cover_image_path,
         };
 
         self.writer

--- a/crates/storage-sqlite/src/schema.rs
+++ b/crates/storage-sqlite/src/schema.rs
@@ -243,6 +243,7 @@ diesel::table! {
         created_at -> Text,
         updated_at -> Text,
         summary_target_amount -> Nullable<Double>,
+        cover_image_path -> Nullable<Text>,
     }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
       react-dom:
         specifier: ^19.2.8
         version: 19.2.8(react@19.2.8)
+      react-easy-crop:
+        specifier: ^6.2.3
+        version: 6.2.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-hook-form:
         specifier: ^7.71.1
         version: 7.71.2(react@19.2.8)
@@ -5201,6 +5204,9 @@ packages:
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
+  normalize-wheel@1.0.1:
+    resolution: {integrity: sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==}
+
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
@@ -5573,6 +5579,12 @@ packages:
     engines: {node: '>= 10.13'}
     peerDependencies:
       react: '>= 16.8 || 18.0.0'
+
+  react-easy-crop@6.2.3:
+    resolution: {integrity: sha512-ebimG3OGlzizjxEZ77Cj9CVLcg5vDZ6QVz8ud1rx4WmsCDWHIROEhgMi0GpJ/jKAuwHrH0M+QZUK4hyvxbYhOA==}
+    peerDependencies:
+      react: '>=16.4.0'
+      react-dom: '>=16.4.0'
 
   react-hook-form@7.71.2:
     resolution: {integrity: sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==}
@@ -12001,6 +12013,8 @@ snapshots:
 
   node-releases@2.0.27: {}
 
+  normalize-wheel@1.0.1: {}
+
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
@@ -12399,6 +12413,12 @@ snapshots:
       file-selector: 2.1.2
       prop-types: 15.8.1
       react: 19.2.8
+
+  react-easy-crop@6.2.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+    dependencies:
+      normalize-wheel: 1.0.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   react-hook-form@7.71.2(react@19.2.8):
     dependencies:


### PR DESCRIPTION
## Summary

`custom_save_up` goals (the catch-all savings-goal type) currently all share one generic stock photo, regardless of what the goal is actually for. This adds the ability to set a personal cover image for these goals, with an interactive crop tool so the framing matches what actually renders on the goal card.

- Upload/replace/remove available from both the goal-creation wizard and the edit dialog.
- New `set_goal_cover_image` / `remove_goal_cover_image` / `load_goal_cover_image` commands on the Tauri app and the Axum web server. Images are stored as files (desktop: app data dir; server: alongside the DB) rather than DB blobs, referenced by a new `cover_image_path` column on `goals` (existing `cover_image_key` — the stock-photo-by-type lookup — is untouched).
- Crop tool (`react-easy-crop`) with a few preset aspect ratios so the crop preview is a true "what you see is what you get" match for the card. Zoom can go below 1x to keep a photo's full subject in frame instead of forcing a tight crop; anything left uncovered bakes transparent (PNG) rather than being stretched or filled.
- Image loading goes through the same command-based blob-fetch pattern already used for addon assets in this codebase (`loadAddonAsset`), rather than introducing Tauri's asset protocol — keeps this consistent with existing conventions and avoids new capability/config surface.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p wealthfolio-core -p wealthfolio-storage-sqlite` — 246 passed, 0 failed
- [x] `pnpm type-check` — clean
- [x] `pnpm --filter frontend exec eslint .` — clean (no new warnings/errors introduced)
- [x] Manual: create a `custom_save_up` goal with an image via the wizard, confirm it renders on the dashboard card
- [x] Manual: edit an existing goal's image, confirm the card/preview updates (not stale)
- [x] Manual: remove an image, confirm fallback to the stock photo
- [x] Manual: crop with zoom below 1x, confirm transparent margins render correctly against the card background

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqtuCFd8xieWR7A3VPp449