### PR TITLE
fix(addons): keep permission controls reachable

### DIFF
--- a/apps/frontend/src/pages/settings/addons/components/addon-permission-dialog.tsx
+++ b/apps/frontend/src/pages/settings/addons/components/addon-permission-dialog.tsx
@@ -110,7 +110,7 @@ export function PermissionDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="flex max-h-[90vh] max-w-4xl flex-col overflow-hidden">
-        <DialogHeader>
+        <DialogHeader className="shrink-0">
           <DialogTitle className="flex flex-col gap-3 md:flex-row md:items-center">
             <Icons.Settings className="hidden h-5 w-5 md:block" />
             <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
@@ -129,7 +129,7 @@ export function PermissionDialog({
           <DialogDescription>{manifest.description}</DialogDescription>
         </DialogHeader>
 
-        <div className="flex-1 space-y-6 overflow-hidden">
+        <div className="min-h-0 flex-1 space-y-6 overflow-y-auto pr-1">
           {/* Function Count Warning */}
           <div className="pt-8">
             <AlertFeedback variant={getWarningVariantByFunctionCount(totalFunctionCount)}>
@@ -141,8 +141,8 @@ export function PermissionDialog({
             </AlertFeedback>
           </div>
 
-          {/* Data Access Permissions using shared component - Make scrollable */}
-          <div className="flex-1 overflow-auto">
+          {/* Data Access Permissions */}
+          <div>
             <PermissionCategoriesDisplay permissions={permissionsToDisplay} />
           </div>
 
@@ -183,7 +183,7 @@ export function PermissionDialog({
           )}
         </div>
 
-        <DialogFooter className="gap-3">
+        <DialogFooter className="shrink-0 gap-3">
           {isViewOnly ? (
             canManageNetworkHosts ? (
               <>

--- a/apps/frontend/src/pages/settings/addons/components/permission-categories-display.tsx
+++ b/apps/frontend/src/pages/settings/addons/components/permission-categories-display.tsx
@@ -63,7 +63,7 @@ export function PermissionCategoriesDisplay({ permissions }: PermissionCategorie
     <div className="space-y-4">
       <div className="space-y-3">
         <h4 className="font-medium">{t("settings:addon_permission_list_title")}</h4>
-        <div className="max-h-[400px] space-y-2 overflow-y-auto pr-2">
+        <div className="space-y-2">
           {displayPermissions.map((permission) => (
             <div
               key={permission.category}


### PR DESCRIPTION
## Summary

- make the add-on permission dialog body the single constrained scroll region
- keep the dialog header and action footer visible at constrained viewport heights
- remove the nested permission-list scrollbar so network-host controls remain reachable

## Reproduction

At the default 1280x720 viewport, the permission body was shorter than its content and overflow-hidden clipped the network-host approval controls. Zooming out made the controls appear only because more effective viewport space became available.

## Verification

- reproduced with a temporary add-on declaring multiple permissions and network hosts
- verified at 1280x720, 1024x500, 1600x900, and mobile 390x844 viewports
- pnpm type-check
- Prettier and ESLint on the changed files
- pnpm --filter frontend test --run (187 files, 1495 tests)

Closes #1245